### PR TITLE
fix(listen): a zero on the inbox must name its cause — deaf vs not-running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,69 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Added
 
+- **A zero on the inbox now names its cause: `deaf_inbox` vs `not_running`.**
+  `inbox_subscribers: 0` has always been confounded — it means a detached
+  inbox adapter *or* an agent that is not running at all — and
+  `_listen/_reachability.py` has warned about that in its own docstring since
+  it was written. Every consumer since has had to *remember* the warning, on
+  the surface an agent consults right before handing over work, and the record
+  says they do not: 2026-07-14, three agents read a wall of zeros as a deaf
+  fleet and escalated a P0 that did not exist (every agent in their lists was
+  simply stopped); 2026-08-12, a peer read the same zeros as evidence that
+  "reach decays with uptime".
+
+  Measured on the fleet host that morning: **15 registry rows, 9 reporting
+  `unreachable`, and all 9 had no tmux session, no `sac mcp channel` process,
+  and an `instances` row stamped `ended_at=2026-08-11T17:54:26Z`,
+  `exit_reason=crashed`.** Not one of them was deaf. They were dead, and their
+  registry rows had outlived them — still advertising a pid, a port and a
+  `turn_url`, with no field anywhere saying otherwise.
+
+  So the zero is now paired with the one instrument that is independent of the
+  broker's own bookkeeping — the host's tmux table — and the result is NAMED on
+  every `GET /agents` row, on `GET /agents/<name>/status`, and in
+  `sac agents health`:
+
+  - `fault: "deaf_inbox"` — a live session observed AND 0 subscribers. The
+    state that was previously unnameable, and the one worth alarming on: green
+    at every surface, work routed to it, work evaporates.
+  - `fault: "not_running"` — the row outlived the process. Not a delivery
+    fault at all; there is nothing to deliver *to*.
+  - `fault: null` — healthy, or a reading nobody could take.
+
+  Only a POSITIVE observation convicts: a snapshot we could not take (a wedged
+  tmux, or the container-blindness trap where an empty result is a namespace
+  boundary rather than an empty fleet) yields no fault, and an agent whose spec
+  does not declare the `tui` runtime is never convicted on a missing tmux
+  session it was never going to have. The overlay is a REPORT and is wired to
+  nothing destructive — least of all `deaf_inbox`, whose subject is by
+  definition a healthy session a restart would destroy.
+
+### Fixed
+
+- **`a2a_send` no longer tells a sender to wait for a reconnect that has no
+  process to happen in.** A 0-subscriber send raised `no_subscriber_error`,
+  whose remedy says — correctly, for a live agent with a detached adapter —
+  "NOT LOST … do NOT re-send … it replays on their next connect". For a
+  *stopped* agent that advice is inverted: no session exists to reconnect, so
+  the row sits in `channel_events` until someone deliberately starts the agent,
+  and the sender waits forever behind reassuring text. This is the same shape
+  as the `sac-04` incident (a name that was never registered, queued all day
+  behind the same "it's queued" advice) one layer over — and on 2026-08-12 it
+  applied to 9 of the 15 registered agents on the host.
+
+  The send path now reads the `fault` the listen route publishes and raises a
+  distinct `target_not_running` failure with the opposite remedy. It still does
+  **not** tell the caller to start the target: whether a stopped agent should be
+  running is an operator decision, not a side effect of someone wanting to
+  message it.
+
+- **`sac agents health` no longer asserts a process state it never observed.**
+  The unreachable branch ended with "The process is up; its inbox adapter is
+  not attached" — a claim about the process the command had not made and could
+  not make. It was wrong for 9 of 15 agents on the host. It now reports which
+  zero it is, and when the cause is unconfirmed it says so instead of guessing.
+
 - **`sac image build --reproducible` — the build verb can finally express
   "build reproducibly", and sac finally calls the round trip it has had access
   to all along.** scitex-container has shipped the whole apparatus for months

--- a/src/scitex_agent_container/_lifecycle/_verdict_tmux.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_tmux.py
@@ -32,6 +32,7 @@ from typing import Any, Callable
 
 __all__ = [
     "in_sif",
+    "observed_session_snapshot",
     "pid_namespace_is_observable",
     "session_name_for_config",
     "tmux_probe_ran",
@@ -142,6 +143,33 @@ def _observed_snapshot(
         # not an empty fleet. Refuse to treat a non-observation as one.
         return None
     return snapshot
+
+
+def observed_session_snapshot(
+    socket_name: str | None = None,
+    *,
+    snapshot_fn: Callable[..., dict | None] | None = None,
+    in_sif_fn: Callable[[], bool] | None = None,
+) -> dict | None:
+    """ONE batched tmux reading, for a caller that must judge MANY agents.
+
+    Same contract as :func:`_observed_snapshot` — a ``dict`` of live sessions
+    when we were genuinely in a position to look, ``None`` when we were not
+    (wedged tmux, or the container-blindness trap where an empty result is a
+    namespace boundary rather than an empty fleet).
+
+    Public because a route that annotates every registry row must take the
+    reading ONCE. :func:`tmux_session_observation` re-probes per call, so
+    asking it about N agents costs N ``tmux`` subprocess spawns — the exact
+    O(N)-spawns shape that blew the heartbeat tick's budget and got it
+    abandoned (see :func:`.._runners._tmux._tmux_probe.list_sessions_activity`).
+    Callers look a name up in the returned dict instead.
+
+    A thin wrapper rather than a second implementation: the blindness rule
+    lives in exactly one place, so a batched caller and a per-agent caller can
+    never drift into disagreeing about what "I could not look" means.
+    """
+    return _observed_snapshot(socket_name, snapshot_fn, in_sif_fn)
 
 
 def tmux_probe_ran(

--- a/src/scitex_agent_container/_lifecycle/inbox_probe.py
+++ b/src/scitex_agent_container/_lifecycle/inbox_probe.py
@@ -62,7 +62,7 @@ import urllib.request
 
 from .._listen._reachability import REACHABLE, UNKNOWN, UNREACHABLE
 
-__all__ = ["DEFAULT_LISTEN_URL", "probe_inbox_reachability"]
+__all__ = ["DEFAULT_LISTEN_URL", "probe_inbox_reachability", "probe_inbox_status"]
 
 DEFAULT_LISTEN_URL = "http://127.0.0.1:7878"
 
@@ -92,6 +92,42 @@ def probe_inbox_reachability(
 
     Never raises: every failure path degrades to ``(None, UNKNOWN)``.
     """
+    count, reachable, _fault = probe_inbox_status(
+        name, listen_url=listen_url, bearer=bearer, timeout_s=timeout_s
+    )
+    return count, reachable
+
+
+def probe_inbox_status(
+    name: str,
+    *,
+    listen_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _TIMEOUT_S,
+) -> tuple[int | None, str, str | None]:
+    """:func:`probe_inbox_reachability`, plus the FAULT that disambiguates it.
+
+    Returns ``(inbox_subscribers, inbox_reachable, fault)``.
+
+    The third element is the whole point of this function, and the answer to
+    the confound this module's docstring spends forty lines warning about. The
+    listen daemon now pairs the subscriber count with the host's tmux table and
+    publishes which of the two causes it observed (see
+    ``_listen._inbox_fault``):
+
+    * ``deaf_inbox``  — ALIVE and unreachable. Case (a): genuinely deaf.
+    * ``not_running`` — the registry row outlived the process. Case (b).
+    * ``None``        — no fault, or a listen too old to publish one, or a
+      reading nobody could take. Never a verdict.
+
+    So a caller no longer has to *remember* that a zero is ambiguous — the zero
+    now arrives with its cause attached. Note this changes nothing about rule
+    2: the fault is still reported and nothing else. It must not feed a
+    restart, least of all ``deaf_inbox``, whose subject is by definition a
+    LIVE session that a restart would destroy.
+
+    Never raises: every failure path degrades to ``(None, UNKNOWN, None)``.
+    """
     base = (listen_url or _listen_base_url()).rstrip("/")
     token = bearer if bearer is not None else os.environ.get("SAC_LISTEN_BEARER")
     req = urllib.request.Request(f"{base}/agents/{name}/status", method="GET")
@@ -107,15 +143,20 @@ def probe_inbox_reachability(
         ValueError,
         OSError,
     ):  # stx-allow: fallback (reason: an unobservable listen must yield UNKNOWN — never a false 'unreachable' verdict against a healthy agent)
-        return None, UNKNOWN
+        return None, UNKNOWN, None
 
     if not isinstance(body, dict):
-        return None, UNKNOWN
+        return None, UNKNOWN, None
+
+    fault = body.get("fault")
+    if not isinstance(fault, str) or not fault:
+        # Absent (a listen predating the fault overlay) or blank. No verdict.
+        fault = None
 
     count = body.get("inbox_subscribers")
     if not isinstance(count, int) or isinstance(count, bool):
         # Field absent (an older listen that predates the observation) or
         # not an int. We did not observe a zero — we observed nothing.
-        return None, UNKNOWN
+        return None, UNKNOWN, fault
 
-    return count, (REACHABLE if count >= 1 else UNREACHABLE)
+    return count, (REACHABLE if count >= 1 else UNREACHABLE), fault

--- a/src/scitex_agent_container/_listen/_agents_list.py
+++ b/src/scitex_agent_container/_listen/_agents_list.py
@@ -100,6 +100,7 @@ async def list_agents(request: Request) -> JSONResponse:
     _ports = port_claims_map()
     rows = [enrich_row(row, ports=_ports) for row in rows]
     rows = await _annotate_reachability(request, rows)
+    rows = _annotate_faults(rows)
 
     # AN EMPTY LIST IS NOT AN ANSWER ON ITS OWN.
     #
@@ -143,6 +144,35 @@ async def list_agents(request: Request) -> JSONResponse:
             _state_db.DEFAULT_DB_PATH,
         )
     return JSONResponse({"agents": rows, "sources": sources})
+
+
+def _annotate_faults(rows: list[dict]) -> list[dict]:
+    """Add ``fault`` / ``fault_detail`` — the CAUSE behind a zero.
+
+    ``inbox_subscribers: 0`` is confounded: it means a detached inbox adapter
+    OR an agent that is not running, and the broker cannot tell those apart.
+    Publishing the raw zero here and trusting every caller to remember the
+    caveat has failed repeatedly — most recently on 2026-08-12, when 9 of the
+    15 rows on this host reported ``unreachable`` and every one of them was a
+    STOPPED agent, read by a peer as a fleet going deaf.
+
+    So pair it with the host's tmux table, which is independent of the broker,
+    and name the result. See :mod:`._inbox_fault`.
+
+    Best-effort in the SAFE direction, like reachability above: a snapshot we
+    could not take yields NO faults, never a fleet-wide "not running".
+    """
+    from ._inbox_fault import annotate_faults, session_snapshot
+
+    try:
+        return annotate_faults(rows, snapshot=session_snapshot())
+    except Exception as exc:  # stx-allow: fallback (reason: fault classification is an ADVISORY overlay — it must never take down the peer-discovery route the fleet depends on)
+        log.warning(
+            "list_agents: fault classification failed (returning rows without "
+            "the `fault` overlay): %s",
+            exc,
+        )
+        return rows
 
 
 async def _annotate_reachability(request: Request, rows: list[dict]) -> list[dict]:

--- a/src/scitex_agent_container/_listen/_inbox_fault.py
+++ b/src/scitex_agent_container/_listen/_inbox_fault.py
@@ -1,0 +1,270 @@
+"""A ZERO MUST NAME ITS CAUSE — splitting *deaf* from *stopped*.
+
+``inbox_subscribers == 0`` is published on every ``GET /agents`` row by
+:mod:`._reachability`, and that module is emphatic that the number is
+CONFOUNDED: a zero means the agent's inbox adapter is detached **or** that the
+agent is not running at all, and the broker cannot tell you which. It says so,
+in its own docstring, and then hands the caller the zero anyway.
+
+Every consumer since has had to remember that warning, and the record says they
+do not:
+
+* **2026-07-14** — three agents independently read a wall of zeros as a deaf
+  fleet and escalated a P0. Every agent in their lists was simply STOPPED.
+  Three agreeing reports were one instrument read three times.
+* **2026-08-12** — measured on this host: 15 registry rows, 9 reporting
+  ``inbox_reachable: unreachable``, and **all 9 had no tmux session and no
+  ``sac mcp channel`` process**. They were stopped, not deaf. A fourth agent
+  reported the same zeros as evidence that "reach decays with uptime".
+
+The confound is not a documentation problem. A field whose correct reading
+requires remembering a docstring will be misread, because the surface that
+publishes it — the peer-discovery route an agent consults *before handing over
+work* — is exactly where a caller is in a hurry.
+
+So this module resolves the confound at the source, by pairing the count with
+the one instrument that IS independent of the broker's bookkeeping: **the
+host's tmux session table** (``._lifecycle._verdict_tmux``). Two observations,
+one verdict:
+
+======================  ====================  ==========================
+session observed        inbox_subscribers     ``fault``
+======================  ====================  ==========================
+present                 ``0``                 :data:`FAULT_DEAF_INBOX`
+absent (tui runtime)    anything              :data:`FAULT_NOT_RUNNING`
+anything else                                 ``None``
+======================  ====================  ==========================
+
+:data:`FAULT_DEAF_INBOX` is the fault this fleet could not previously NAME: an
+agent that is *running* and *unreachable at once*. It is worse than a stopped
+one, because every surface reports it green, work is routed to it, and the work
+evaporates.
+
+Two rules inherited from :mod:`._reachability`, and not negotiable here
+-----------------------------------------------------------------------
+1. **Only a POSITIVE observation convicts.** A snapshot we could not take
+   (wedged tmux, or the container-blindness trap) yields no fault at all —
+   never :data:`FAULT_NOT_RUNNING`. "I could not look" is not a death
+   certificate, and this fleet has already paid for rendering it as one.
+2. **A fault is a REPORT, never a trigger.** Nothing here may be wired to a
+   restart. :data:`FAULT_NOT_RUNNING` describes a stale registry row, whose
+   remedy is a deliberate operator action; :data:`FAULT_DEAF_INBOX` describes a
+   *live session* whose adapter is detached, and restarting on it would destroy
+   the healthy session it just correctly identified.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Mapping
+
+from ._reachability import UNKNOWN
+
+__all__ = [
+    "FAULT_DEAF_INBOX",
+    "FAULT_NOT_RUNNING",
+    "annotate_faults",
+    "annotate_status_fault",
+    "classify_fault",
+    "session_snapshot",
+]
+
+log = logging.getLogger(__name__)
+
+#: A live session whose inbox adapter is attached to nothing. The agent is up,
+#: answering, holding a tmux session — and every ``a2a_send`` aimed at it fans
+#: out to zero subscribers. THE fault this module exists to name.
+FAULT_DEAF_INBOX = "deaf_inbox"
+
+#: The registry row outlived the process. Not a delivery fault at all: there is
+#: nothing to deliver TO. Named separately because the remedy is the opposite of
+#: the deaf case — waiting will never help, since no adapter will reconnect.
+FAULT_NOT_RUNNING = "not_running"
+
+_DETAIL = {
+    FAULT_DEAF_INBOX: (
+        "RUNNING BUT DEAF — a live tmux session was observed for this agent AND "
+        "its inbox stream has 0 subscribers. It is up, but every a2a_send aimed "
+        "at it fans out to nobody. Messages are NOT lost (sac listen persists "
+        "them to channel_events and the stream replays undelivered rows on the "
+        "adapter's next connect), so do not re-send. Do NOT restart on this "
+        "signal alone: the session is healthy and a restart would destroy it. "
+        "Reach the agent by a rail that does not use its inbox adapter (a "
+        "scitex-cards card assigned to it), or ask the operator."
+    ),
+    FAULT_NOT_RUNNING: (
+        "NOT RUNNING — this registry row declares an agent, but no live session "
+        "was observed for it (the probe SUCCEEDED, so this is real absence, not "
+        "a failed look). The row outlived the process. Its 0 inbox subscribers "
+        "mean 'nobody is home', NOT 'a detached adapter': nothing will "
+        "reconnect to drain its queue until someone deliberately starts it, so "
+        "waiting for a reply will never succeed."
+    ),
+}
+
+
+def session_snapshot() -> dict | None:
+    """One batched reading of the host's live tmux sessions, or ``None``.
+
+    ``None`` means we were not in a position to look, and every downstream
+    verdict must then be "no fault" rather than "everything is absent". Note
+    the listen daemon runs on the HOST, which is precisely why it can take this
+    reading at all — the same probe from inside a container sees an empty
+    fleet and would slander all 15 rows at once.
+    """
+    try:
+        from .._lifecycle._verdict_tmux import observed_session_snapshot
+
+        return observed_session_snapshot()
+    except Exception as exc:  # stx-allow: fallback (reason: a probe that blew up observed NOTHING — it must yield "could not look", never a fleet-wide absence verdict)
+        log.warning(
+            "inbox fault: could not take a tmux session snapshot (reporting NO "
+            "faults rather than convicting every row of being absent): %s",
+            exc,
+        )
+        return None
+
+
+def _runtime_is_tui(name: str) -> bool | None:
+    """Does ``name``'s spec declare the tmux-based ``tui`` runtime? Ternary.
+
+    Delegates to the canonical answer
+    (:func:`._agent_exec_liveness._runtime_writes_apptainer_pidfile`) rather
+    than parsing the spec a second time, so this module and the spawn probe can
+    never drift about which runtime an agent has. That function returns
+    ``False`` for "writes no apptainer pidfile", which IS the tui runtime;
+    ``True`` (apptainer) and ``None`` (unresolvable spec) both mean tmux cannot
+    speak for this agent.
+    """
+    from ._agent_exec_liveness import _runtime_writes_apptainer_pidfile
+
+    writes = _runtime_writes_apptainer_pidfile(name)
+    if writes is None:
+        return None
+    return writes is False
+
+
+def _session_present(
+    row: Mapping[str, Any],
+    snapshot: Mapping[str, Any],
+    runtime_is_tui_fn: Callable[[str], bool | None],
+) -> bool | None:
+    """Is this row's tmux session live? ``None`` when absence proves nothing.
+
+    Presence is read straight from the batched snapshot and needs no knowledge
+    of the agent's runtime: a live ``tui-<name>`` session is positive evidence
+    whoever launched it.
+
+    ABSENCE is the asymmetric half. A non-TUI agent (apptainer, claude-session)
+    legitimately holds no tmux session, so "not in the snapshot" is its NORMAL
+    state and convicting on it would stamp :data:`FAULT_NOT_RUNNING` on every
+    healthy container agent — the same shape as the pidfile probe that once
+    convicted every TUI agent in the fleet, run in the opposite direction. So
+    absence only counts when the spec POSITIVELY declares a tui runtime.
+    """
+    name = row.get("name")
+    if not isinstance(name, str) or not name:
+        return None
+    if f"tui-{name}" in snapshot:
+        return True
+    if runtime_is_tui_fn(name) is True:
+        return False
+    return None
+
+
+def classify_fault(
+    row: Mapping[str, Any],
+    *,
+    snapshot: Mapping[str, Any] | None,
+    runtime_is_tui_fn: Callable[[str], bool | None] | None = None,
+) -> str | None:
+    """Return this row's ``fault``, or ``None``.
+
+    ``snapshot=None`` (we could not look) always returns ``None``: rule 1.
+
+    A row whose ``inbox_reachable`` is :data:`._reachability.UNKNOWN` also
+    returns ``None``. That value already encodes "this agent's bus is not ours
+    to observe" — a remote host's agent, served by a different broker — and
+    reusing it keeps the locality decision in the one module that owns it
+    instead of re-deriving it here and risking drift.
+
+    ``runtime_is_tui_fn`` is the seam for the spec lookup, so the RULE can be
+    driven from a hand-rolled resolver without an on-disk spec, a tmux server
+    or a listen daemon.
+    """
+    if snapshot is None:
+        return None
+    if row.get("inbox_reachable") == UNKNOWN:
+        return None
+
+    count = row.get("inbox_subscribers")
+    observed = isinstance(count, int) and not isinstance(count, bool)
+
+    # A LIVE SUBSCRIBER OUTRANKS A MISSING SESSION. The broker watched
+    # something attach to this agent's inbox stream, which is first-hand proof
+    # that a process is home; "no tmux session named tui-<name>" is an absence,
+    # and an absence never beats a positive reading. They can legitimately
+    # disagree — a session renamed out from under us, an adapter started
+    # outside the tmux pane — and when they do, the fault must be NEITHER,
+    # because a subscribed agent is by definition not deaf and demonstrably
+    # not gone.
+    if observed and count >= 1:
+        return None
+
+    alive = _session_present(row, snapshot, runtime_is_tui_fn or _runtime_is_tui)
+    if alive is False:
+        return FAULT_NOT_RUNNING
+    if alive is not True:
+        return None
+    return FAULT_DEAF_INBOX if observed else None
+
+
+def annotate_faults(
+    rows: list[dict[str, Any]],
+    *,
+    snapshot: Mapping[str, Any] | None,
+    runtime_is_tui_fn: Callable[[str], bool | None] | None = None,
+) -> list[dict[str, Any]]:
+    """Add ``fault`` / ``fault_detail`` to every row (idempotent, additive).
+
+    ``fault`` is ALWAYS emitted — ``None`` for a healthy row — so the response
+    shape stays uniform and a consumer can branch on the key's VALUE rather
+    than on its presence. ``fault_detail`` is emitted only alongside a fault,
+    and says what to do about it: a named fault whose remedy the reader has to
+    guess is how a correct signal still ends in the wrong action.
+    """
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        fault = classify_fault(
+            row, snapshot=snapshot, runtime_is_tui_fn=runtime_is_tui_fn
+        )
+        new = dict(row)
+        new["fault"] = fault
+        if fault is not None:
+            new["fault_detail"] = _DETAIL[fault]
+        out.append(new)
+    return out
+
+
+def annotate_status_fault(body: dict[str, Any]) -> dict[str, Any]:
+    """:func:`annotate_faults` for a SINGLE-agent status body.
+
+    ``GET /agents/<name>/status`` answered HTTP 200 with a full body — port,
+    turn_url, ``inbox_reachable: unreachable`` — for agents that had not
+    existed for two days, and carried no field anywhere saying so. This is the
+    seam that fixes that, and it is the same classifier the list route uses, so
+    the two surfaces cannot disagree about one agent.
+
+    Advisory, like every path in this module: a failure returns the body
+    unchanged rather than taking down the route the whole fleet uses to decide
+    whether a peer is real.
+    """
+    try:
+        return annotate_faults([body], snapshot=session_snapshot())[0]
+    except Exception as exc:  # stx-allow: fallback (reason: the fault overlay is advisory — it must never fail the status route)
+        log.warning(
+            "agent_status: fault classification failed (returning the body "
+            "without the `fault` overlay): %s",
+            exc,
+        )
+        return body

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -172,6 +172,14 @@ async def agent_status(request: Request) -> JSONResponse:
     # running session_id + a live pid say nothing about whether this agent's
     # inbox adapter is attached; only the broker does. See ``_reachability``.
     body = await _annotate_status_reachability(request, body)
+    # …and the CAUSE behind a zero. A stopped agent's registry row outlives its
+    # process, so this route answered HTTP 200 with a full body — port, turn_url,
+    # ``inbox_reachable: unreachable`` — for an agent that had not existed for
+    # two days, with no field anywhere saying so. Measured 2026-08-12: 9 of 15
+    # rows on this host looked exactly like that. See ``_inbox_fault``.
+    from ._inbox_fault import annotate_status_fault
+
+    body = annotate_status_fault(body)
     return JSONResponse(body)
 
 

--- a/src/scitex_agent_container/_mcp/_channel_send_errors.py
+++ b/src/scitex_agent_container/_mcp/_channel_send_errors.py
@@ -88,6 +88,7 @@ ERR_UNREACHABLE = "unreachable"
 ERR_DELIVERY_ERROR = "delivery_error"
 ERR_LOOKUP_FAILED = "lookup_failed"
 ERR_UNKNOWN_TARGET = "unknown_target"
+ERR_TARGET_NOT_RUNNING = "target_not_running"
 
 # What a 0-subscriber send hands the caller instead of a false success.
 #
@@ -140,6 +141,67 @@ UNKNOWN_TARGET_REMEDY: tuple[str, ...] = (
     "a dead agent — the agent you meant may be perfectly healthy under its "
     "real name.",
 )
+
+
+# What a REGISTERED BUT STOPPED target hands the caller — the third cause of a
+# 0-subscriber count, and the one whose advice was previously inverted.
+#
+# NO_SUBSCRIBER_REMEDY above says, correctly and in bold, "NOT LOST … do NOT
+# re-send … it replays on their next connect". That is right for a live agent
+# whose adapter is detached. For a STOPPED agent there is no next connect: no
+# session exists to reconnect, so the row sits in `channel_events` until someone
+# deliberately starts the agent. Handing the sender "wait, it is queued" is then
+# the same failure as the `sac-04` typo incident (see UNKNOWN_TARGET_REMEDY) —
+# a message parked forever behind reassuring advice.
+#
+# It still does NOT tell the caller to start the agent. Starting someone else's
+# agent is an operator decision — measured 2026-08-12, 9 of 15 registered rows
+# on one host were stopped, and a rail that nudges every blocked sender to start
+# them would have restarted most of a fleet overnight, unasked and unobserved.
+NOT_RUNNING_REMEDY: tuple[str, ...] = (
+    "DO NOT WAIT FOR A REPLY. Unlike a detached inbox adapter, a stopped agent "
+    "has no session that will reconnect, so the queued row will not drain on "
+    "its own. This is the opposite of the no_live_subscriber case.",
+    "The message IS durably queued (sac listen persisted it to channel_events "
+    "before publishing), so it will be delivered IF this agent is started "
+    "later. Do not re-send — that would deliver it twice.",
+    "Do NOT start the target yourself to unblock your send. Whether a stopped "
+    "agent should be running is an operator decision, not a side effect of "
+    "someone wanting to message it.",
+    "To make progress now: file a scitex-cards card assigned to the target "
+    "(durable and pull-based, so it survives the agent being down), or route "
+    "the work to a running peer, or escalate to the operator.",
+)
+
+
+def not_running_error(target: str) -> SendError:
+    """Build the loud error for a send to a REGISTERED BUT STOPPED agent.
+
+    Distinct from :func:`no_subscriber_error` because the count that produced
+    both is identical — ``delivered_subscriber_count == 0`` — while the correct
+    response is opposite. The distinguishing evidence is not the count: it is
+    the ``fault`` the listen route now publishes next to it, derived from the
+    host's tmux table (see ``_listen._inbox_fault``). Only a POSITIVELY observed
+    absence reaches here; an unobservable session falls back to
+    :func:`no_subscriber_error`, which is the safe reading.
+    """
+    return SendError(
+        f"NOT DELIVERED — send to {target!r} reached no live subscriber, and "
+        f"{target!r} IS NOT RUNNING: the listen daemon observed no live session "
+        "for it, so its registry row has outlived its process. The message is "
+        "durably queued, but NOTHING WILL DRAIN THAT QUEUE until the agent is "
+        "started — there is no adapter to reconnect. Do not wait for a reply.",
+        code=ERR_TARGET_NOT_RUNNING,
+        target=target,
+        detail={
+            "delivered": False,
+            "delivered_subscriber_count": 0,
+            "durably_queued": True,
+            "registered": True,
+            "target_running": False,
+            "what_to_do": list(NOT_RUNNING_REMEDY),
+        },
+    )
 
 
 def suggest_names(target: str, known: list[str]) -> list[str]:
@@ -334,8 +396,10 @@ __all__ = [
     "ERR_DELIVERY_ERROR",
     "ERR_LOOKUP_FAILED",
     "ERR_NO_SUBSCRIBER",
+    "ERR_TARGET_NOT_RUNNING",
     "ERR_UNKNOWN_TARGET",
     "ERR_UNREACHABLE",
+    "NOT_RUNNING_REMEDY",
     "NO_SUBSCRIBER_REMEDY",
     "UNKNOWN_TARGET_REMEDY",
     "SendError",
@@ -343,6 +407,7 @@ __all__ = [
     "error_result",
     "lookup_error_result",
     "no_subscriber_error",
+    "not_running_error",
     "suggest_names",
     "unknown_target_error",
     "unreachable_error",

--- a/src/scitex_agent_container/_mcp/_channel_target_lookup.py
+++ b/src/scitex_agent_container/_mcp/_channel_target_lookup.py
@@ -1,0 +1,105 @@
+"""What the send path asks the REGISTRY about a target that reached nobody.
+
+Extracted from :mod:`._channel_tools` (at the per-file cap), and cohesive on its
+own terms: these are the pure projections over a ``GET /agents`` body that turn
+one ambiguous number into an actionable one.
+
+``delivered_subscriber_count == 0`` has THREE causes which demand DIFFERENT
+responses, and the count is identical in all three:
+
+===============================  ==========================================
+cause                            what the sender must do
+===============================  ==========================================
+adapter detached, agent LIVE     WAIT — the row replays on their reconnect
+agent NOT RUNNING                DO NOT WAIT — nothing will reconnect
+name never registered (a typo)   FIX THE NAME — nothing is queued at all
+===============================  ==========================================
+
+The fleet has paid for both collapses. The typo case cost scitex-dev a day of
+messages addressed to ``sac-04`` (2026-08-09), every one answered ``200`` with
+``durably_queued=true``. The not-running case is the same shape one layer over:
+measured 2026-08-12, **9 of 15** registered rows on this host were stopped
+agents, and a sender hitting any of them was told — in bold, by
+``NO_SUBSCRIBER_REMEDY`` — that the message would replay on a reconnect that no
+longer had a process to happen in.
+
+Everything here is a PURE function over rows, so the rules are testable without
+a listen daemon, and every one of them is biased the same way: an answer we
+could not read degrades to the pre-existing, safer verdict rather than to a
+confident new one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "fault_of",
+    "is_registered",
+    "names_of",
+    "rows_from_agents_body",
+]
+
+
+def rows_from_agents_body(body: Any) -> list[dict[str, Any]]:
+    """Normalise a ``GET /agents`` body into a list of row dicts.
+
+    Accepts both the current ``{"agents": [...]}`` envelope and the bare list
+    older listens returned, and tolerates a list of bare NAME STRINGS by
+    promoting each to ``{"name": ...}`` — so a modern caller keeps working
+    against an old daemon instead of silently deciding the fleet is empty.
+
+    Returns ``[]`` for anything unparseable. The caller must read that as "I
+    could not determine", NEVER as "no agents exist".
+    """
+    rows = body.get("agents") if isinstance(body, dict) else body
+    if not isinstance(rows, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if isinstance(row, dict):
+            out.append(row)
+        elif isinstance(row, str) and row:
+            out.append({"name": row})
+    return out
+
+
+def names_of(rows: list[dict[str, Any]]) -> list[str]:
+    """Every registered name in ``rows`` (``name``, falling back to ``agent``)."""
+    names: list[str] = []
+    for row in rows:
+        name = row.get("name") or row.get("agent")
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names
+
+
+def is_registered(target: str, rows: list[dict[str, Any]]) -> bool:
+    """True unless ``rows`` can AFFIRMATIVELY say ``target`` is absent.
+
+    Deliberately biased toward the pre-existing behaviour. An empty list means
+    the registry was unreadable (or genuinely empty), and "I could not check"
+    is NOT evidence of a bad name — reporting an unknown target off a failed
+    lookup would invent the exact false certainty the send-error module exists
+    to prevent. So an unreadable registry says less, rather than something
+    confident and possibly wrong.
+    """
+    names = names_of(rows)
+    if not names:
+        return True
+    return target in names
+
+
+def fault_of(target: str, rows: list[dict[str, Any]]) -> str | None:
+    """The ``fault`` the listen route published for ``target``, or ``None``.
+
+    ``None`` covers "no such row" AND "this listen does not publish the field"
+    — an older daemon predating :mod:`.._listen._inbox_fault`. Both fall back
+    to the undifferentiated no-subscriber verdict, which is what every caller
+    got before this distinction existed and is therefore safe.
+    """
+    for row in rows:
+        if (row.get("name") or row.get("agent")) == target:
+            fault = row.get("fault")
+            return fault if isinstance(fault, str) else None
+    return None

--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -19,14 +19,22 @@ import json
 import logging
 from typing import Any
 
+from .._listen._inbox_fault import FAULT_NOT_RUNNING
 from ._channel_send_errors import (
     SendError,
     delivery_error,
     error_result,
     lookup_error_result,
     no_subscriber_error,
+    not_running_error,
     unknown_target_error,
     unreachable_error,
+)
+from ._channel_target_lookup import (
+    fault_of,
+    is_registered,
+    names_of,
+    rows_from_agents_body,
 )
 from .channel import _recent
 
@@ -214,58 +222,48 @@ def register_tools(
                     "(delivered_subscriber_count=0) — NOT DELIVERED",
                     target,
                 )
-                # A 0-subscriber count has TWO causes that need OPPOSITE
-                # actions, and the count alone cannot tell them apart:
+                # A 0-subscriber count has THREE causes needing DIFFERENT
+                # actions, and the count alone tells them apart in none:
                 #
                 #   registered agent, adapter detached -> WAIT (it replays)
+                #   registered agent, NOT RUNNING      -> DO NOT WAIT; there
+                #                                         is no session left
+                #                                         to reconnect
                 #   name never registered (a typo)     -> FIX THE NAME
+                #
+                # The third was split out after the `sac-04` incident; the
+                # second after 2026-08-12, when 9 of 15 registered rows on this
+                # host were STOPPED agents whose senders were being told, in
+                # bold, to wait for a reconnect with no process to happen in.
+                # See ``._channel_target_lookup``.
                 #
                 # Only ask the registry on this failure path, so the happy
                 # path pays nothing for the distinction.
-                if not await _target_is_registered(target):
-                    raise unknown_target_error(target, await _registered_names())
+                rows = await _registered_rows()
+                if not is_registered(target, rows):
+                    raise unknown_target_error(target, names_of(rows))
+                if fault_of(target, rows) == FAULT_NOT_RUNNING:
+                    raise not_running_error(target)
                 raise no_subscriber_error(target)
         return res
 
-    async def _registered_names() -> list[str]:
-        """Registered agent names, from the same ``/agents`` view a2a_peers uses.
+    async def _registered_rows() -> list[dict[str, Any]]:
+        """Registry rows, from the same ``/agents`` view a2a_peers uses.
 
-        Returns ``[]`` when the registry cannot be read — the CALLER must
-        treat that as "could not determine", never as "no agents exist".
+        Rows rather than names, so this ONE fetch answers both questions the
+        failure path asks — is the name real, and is the agent running.
+        ``[]`` when the registry cannot be read; the caller must treat that as
+        "could not determine", never as "no agents exist".
         """
         try:
             res = await _get("/agents")
         except Exception:  # noqa: BLE001 - registry unreadable is not a send failure
             return []
-        body = res.get("body")
-        rows = body.get("agents") if isinstance(body, dict) else body
-        if not isinstance(rows, list):
-            return []
-        names: list[str] = []
-        for row in rows:
-            if isinstance(row, dict):
-                name = row.get("name") or row.get("agent")
-                if isinstance(name, str) and name:
-                    names.append(name)
-            elif isinstance(row, str) and row:
-                names.append(row)
-        return names
+        return rows_from_agents_body(res.get("body"))
 
-    async def _target_is_registered(target: str) -> bool:
-        """True unless the registry can AFFIRMATIVELY say ``target`` is absent.
-
-        Deliberately biased toward the existing behaviour. An empty list
-        means the registry was unreadable (or genuinely empty), and
-        "I could not check" is NOT evidence of a bad name — reporting an
-        unknown target on a failed lookup would invent the very false
-        certainty this whole module exists to prevent. So we downgrade to
-        the pre-existing no_subscriber_error and say less, rather than
-        saying something confident and possibly wrong.
-        """
-        names = await _registered_names()
-        if not names:
-            return True
-        return target in names
+    async def _registered_names() -> list[str]:
+        """Registered agent names — for callers outside the send failure path."""
+        return names_of(await _registered_rows())
 
     def _find(msg_id: str) -> dict[str, Any] | None:
         for ev in reversed(_recent):

--- a/src/scitex_agent_container/cli_pkg/_health_liveness.py
+++ b/src/scitex_agent_container/cli_pkg/_health_liveness.py
@@ -86,18 +86,55 @@ def print_liveness(console: Any, liveness: dict) -> None:
         )
 
 
-def print_inbox(console: Any, name: str, subscribers: int, reachable: str) -> None:
-    """Render the inbox-reachability observation (moved verbatim from
-    ``status_cmds.health`` — the 512-line per-file cap)."""
+def print_inbox(
+    console: Any,
+    name: str,
+    subscribers: int,
+    reachable: str,
+    fault: str | None = None,
+) -> None:
+    """Render the inbox-reachability observation, and WHICH zero it is.
+
+    The unreachable branch used to end with "The process is up; its inbox
+    adapter is not attached" — a claim about the process that this command had
+    not observed and could not make. For a STOPPED agent it was simply false,
+    and it came bundled with advice ("messages are … replayed when its channel
+    adapter reconnects") that only holds for a live one. Measured 2026-08-12:
+    9 of the 15 registered agents on this host were stopped, so that sentence
+    was wrong more often than it was right.
+
+    ``fault`` is the listen daemon's observation of which case this is (see
+    ``_listen._inbox_fault``). When it is absent — an older daemon, or a
+    reading nobody could take — the text says what was actually seen and stops
+    there, rather than re-asserting the old guess.
+    """
+    from .._listen._inbox_fault import FAULT_DEAF_INBOX, FAULT_NOT_RUNNING
     from .._listen._reachability import UNKNOWN, UNREACHABLE
 
-    if reachable == UNREACHABLE:
+    if reachable == UNREACHABLE and fault == FAULT_NOT_RUNNING:
         console.print(
-            f"[yellow]inbox: NOT REACHABLE — 0 live subscribers. "
-            f"a2a_send to '{name}' will reach nobody (messages are queued and "
-            f"replayed when its channel adapter reconnects). The process is "
-            f"up; its inbox adapter is not attached. Do NOT force-restart on "
-            f"this alone.[/yellow]"
+            f"[red]inbox: NOT REACHABLE — and '{name}' IS NOT RUNNING. No live "
+            f"session was observed for it, so its registry row has outlived "
+            f"its process. Messages are queued durably, but NOTHING WILL "
+            f"DRAIN THAT QUEUE until the agent is started — there is no "
+            f"adapter left to reconnect. Do not wait for a reply.[/red]"
+        )
+    elif reachable == UNREACHABLE and fault == FAULT_DEAF_INBOX:
+        console.print(
+            f"[yellow]inbox: NOT REACHABLE — RUNNING BUT DEAF. A live session "
+            f"was observed for '{name}' AND it has 0 subscribers, so a2a_send "
+            f"reaches nobody while the agent is up. Messages are queued and "
+            f"replayed when its channel adapter reconnects. Do NOT "
+            f"force-restart: the session is healthy.[/yellow]"
+        )
+    elif reachable == UNREACHABLE:
+        console.print(
+            f"[yellow]inbox: NOT REACHABLE — 0 live subscribers, cause "
+            f"UNCONFIRMED. a2a_send to '{name}' will reach nobody. This is "
+            f"EITHER a detached inbox adapter on a live agent (messages "
+            f"replay on reconnect) OR an agent that is not running at all "
+            f"(nothing will reconnect) — this reading cannot tell them apart. "
+            f"Do NOT force-restart on it.[/yellow]"
         )
     elif reachable == UNKNOWN:
         console.print(

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -454,9 +454,13 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
     # ``healthy`` is deliberately NOT derived from this: 0 subscribers means
     # a detached inbox adapter, not a dead agent, and anything that
     # auto-restarts on it would destroy a healthy session. Observation only.
-    from .._lifecycle.inbox_probe import probe_inbox_reachability
+    # ``fault`` is what makes the zero READABLE. Without it, "0 subscribers"
+    # is the same string for a live agent whose adapter detached and for one
+    # that has not existed since Tuesday — measured 2026-08-12, 9 of 15 rows
+    # on this host were the latter and were read as the former.
+    from .._lifecycle.inbox_probe import probe_inbox_status
 
-    subscribers, reachable = probe_inbox_reachability(name)
+    subscribers, reachable, inbox_fault = probe_inbox_status(name)
 
     # The ternary verdict (ALIVE/DEAD/UNKNOWN) + its EVIDENCE, published
     # alongside the ``healthy`` bool rather than replacing it — a bool cannot
@@ -480,6 +484,7 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
                     "message": message,
                     "inbox_subscribers": subscribers,
                     "inbox_reachable": reachable,
+                    "fault": inbox_fault,
                     "liveness": liveness,
                     "overlay_masking": overlay_masking,
                 },
@@ -497,7 +502,7 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
 
     print_liveness(console, liveness)
     print_overlay_masking(console, overlay_masking)
-    print_inbox(console, name, subscribers, reachable)
+    print_inbox(console, name, subscribers, reachable, inbox_fault)
 
     if not is_healthy:
         sys.exit(1)

--- a/tests/scitex_agent_container/_listen/test__agents_list.py
+++ b/tests/scitex_agent_container/_listen/test__agents_list.py
@@ -154,3 +154,45 @@ def test_agents_key_is_unchanged_for_consumers(client):
     body = _body(client)
     # Assert
     assert body["agents"] == []
+
+
+# --- the `fault` overlay is wired in, and cannot take the route down ------
+#
+# The classifier's own rules are proved in test__inbox_fault.py. What matters
+# HERE is that the route actually applies it, and that it stays ADVISORY: this
+# is the surface an agent consults before handing over work, and an overlay
+# that could fail it would be a worse bug than the ambiguity it resolves.
+
+
+def test_every_row_carries_the_fault_key(client, empty_store):
+    # Arrange: a row the classifier cannot convict (no resolvable spec in the
+    # isolated agents dir), so only the KEY's presence is under test.
+    from scitex_agent_container._listen._agents_list import _annotate_faults
+
+    rows = [{"name": "alpha", "inbox_subscribers": 0, "inbox_reachable": "unreachable"}]
+    # Act
+    out = _annotate_faults(rows)
+    # Assert
+    assert "fault" in out[0]
+
+
+def test_an_unresolvable_agent_is_not_convicted_by_the_route(client, empty_store):
+    # Arrange: same row — an unreadable spec must never render as "not running".
+    from scitex_agent_container._listen._agents_list import _annotate_faults
+
+    rows = [{"name": "alpha", "inbox_subscribers": 0, "inbox_reachable": "unreachable"}]
+    # Act
+    out = _annotate_faults(rows)
+    # Assert
+    assert out[0]["fault"] is None
+
+
+def test_a_row_with_no_name_does_not_break_the_route(client, empty_store):
+    # Arrange: the route must survive a malformed row rather than 500.
+    from scitex_agent_container._listen._agents_list import _annotate_faults
+
+    rows = [{"inbox_subscribers": 0, "inbox_reachable": "unreachable"}]
+    # Act
+    out = _annotate_faults(rows)
+    # Assert
+    assert out[0]["fault"] is None

--- a/tests/scitex_agent_container/_listen/test__inbox_fault.py
+++ b/tests/scitex_agent_container/_listen/test__inbox_fault.py
@@ -1,0 +1,259 @@
+"""A zero must name its cause — deaf vs stopped vs "I could not look".
+
+The rules under test are the ones this fleet has already broken twice: a wall of
+``inbox_subscribers: 0`` read as a deaf fleet (2026-07-14, a P0 that did not
+exist), and again on 2026-08-12 when 9 of 15 rows on one host were STOPPED
+agents reported as a reachability decay.
+
+Every case drives :func:`classify_fault` with a hand-rolled snapshot and a
+hand-rolled runtime resolver, so the RULE is proved without a tmux server, a
+listen daemon, an on-disk spec, or a live agent.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._listen._inbox_fault import (
+    FAULT_DEAF_INBOX,
+    FAULT_NOT_RUNNING,
+    annotate_faults,
+    classify_fault,
+)
+from scitex_agent_container._listen._reachability import (
+    REACHABLE,
+    UNKNOWN,
+    UNREACHABLE,
+)
+
+# Hand-rolled runtime resolvers — the three answers the real spec lookup can
+# give. Injected rather than patched: the seam is production's own parameter.
+TUI = lambda name: True  # noqa: E731 - a one-line stub reads better inline
+APPTAINER = lambda name: False  # noqa: E731
+UNRESOLVABLE = lambda name: None  # noqa: E731
+
+
+def _row(name="alpha", *, subscribers=0, reachable=UNREACHABLE):
+    """A ``GET /agents`` row, defaulting to the ambiguous zero under test."""
+    return {
+        "name": name,
+        "inbox_subscribers": subscribers,
+        "inbox_reachable": reachable,
+    }
+
+
+# --- THE fault this module exists to name --------------------------------
+
+
+def test_live_session_with_zero_subscribers_is_deaf():
+    """Session observed + 0 subscribers = RUNNING BUT DEAF.
+
+    The state that was previously unnameable: green at every surface, work
+    routed to it, work evaporates.
+    """
+    # Arrange
+    row = _row()
+    # Act
+    fault = classify_fault(row, snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault == FAULT_DEAF_INBOX
+
+
+def test_live_session_with_a_subscriber_is_no_fault():
+    # Arrange
+    row = _row(subscribers=1, reachable=REACHABLE)
+    # Act
+    fault = classify_fault(row, snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault is None
+
+
+# --- the confound: a stopped agent is NOT a deaf one ----------------------
+
+
+def test_absent_session_is_reported_as_not_running():
+    """The 2026-08-12 case: no session, and the registry row outlived it.
+
+    Reporting this as a deaf inbox is the misdiagnosis; the remedy is the
+    opposite one, because waiting for a reconnect can never work.
+    """
+    # Arrange
+    row = _row()
+    # Act
+    fault = classify_fault(row, snapshot={"tui-other": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault == FAULT_NOT_RUNNING
+
+
+def test_stopped_agent_is_distinguished_from_a_deaf_one():
+    """Same zero, same ``unreachable`` label, different verdict.
+
+    These two rows are byte-identical on every field the old surface
+    published — which is exactly why nine stopped agents read as deaf ones.
+    """
+    # Arrange
+    snapshot = {"tui-live": 1}
+    # Act
+    verdicts = (
+        classify_fault(_row("live"), snapshot=snapshot, runtime_is_tui_fn=TUI),
+        classify_fault(_row("gone"), snapshot=snapshot, runtime_is_tui_fn=TUI),
+    )
+    # Assert
+    assert verdicts == (FAULT_DEAF_INBOX, FAULT_NOT_RUNNING)
+
+
+# --- rule 1: only a POSITIVE observation convicts -------------------------
+
+
+def test_unobservable_snapshot_convicts_nobody():
+    """``snapshot=None`` is "I could not look" — it must accuse nobody.
+
+    A container cannot see the host's tmux; rendering that blindness as
+    absence would slander every row at once.
+    """
+    # Arrange
+    row = _row()
+    # Act
+    fault = classify_fault(row, snapshot=None, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault is None
+
+
+def test_apptainer_agent_without_a_tmux_session_is_not_convicted():
+    """A non-TUI runtime holds no tmux session BY CONSTRUCTION.
+
+    Convicting on its absence is the old pidfile probe's bug run backwards —
+    that one stamped ``startup_failed`` on every healthy TUI agent.
+    """
+    # Arrange
+    row = _row()
+    # Act
+    fault = classify_fault(row, snapshot={}, runtime_is_tui_fn=APPTAINER)
+    # Assert
+    assert fault is None
+
+
+def test_unresolvable_runtime_is_not_convicted():
+    """An unreadable spec is not evidence that an agent is gone."""
+    # Arrange
+    row = _row()
+    # Act
+    fault = classify_fault(row, snapshot={}, runtime_is_tui_fn=UNRESOLVABLE)
+    # Assert
+    assert fault is None
+
+
+def test_unknown_reachability_row_is_skipped():
+    """``inbox_reachable: unknown`` already means "not ours to observe".
+
+    Reusing it keeps the locality rule in the one module that owns it.
+    """
+    # Arrange
+    row = _row(subscribers=None, reachable=UNKNOWN)
+    # Act
+    fault = classify_fault(row, snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault is None
+
+
+def test_row_without_a_name_is_skipped():
+    # Arrange
+    row = {"inbox_subscribers": 0, "inbox_reachable": UNREACHABLE}
+    # Act
+    fault = classify_fault(row, snapshot={}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault is None
+
+
+def test_missing_subscriber_count_does_not_convict():
+    """An absent count is not a zero — we observed nothing."""
+    # Arrange
+    row = {"name": "alpha", "inbox_reachable": UNREACHABLE}
+    # Act
+    fault = classify_fault(row, snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault is None
+
+
+def test_a_live_subscriber_outranks_a_missing_session():
+    """When the two instruments disagree, the POSITIVE reading wins.
+
+    The broker watching something attach is first-hand proof a process is
+    home; "no session named tui-<name>" is an absence, and an absence must
+    never beat a positive observation. Such an agent is neither deaf nor gone.
+    """
+    # Arrange
+    row = _row(subscribers=1, reachable=REACHABLE)
+    # Act
+    fault = classify_fault(row, snapshot={}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault is None
+
+
+def test_bool_subscriber_count_does_not_convict():
+    """``False`` is not a subscriber count of zero."""
+    # Arrange
+    row = _row(subscribers=False)
+    # Act
+    fault = classify_fault(row, snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert fault is None
+
+
+# --- the row overlay ------------------------------------------------------
+
+
+def test_healthy_row_still_carries_the_fault_key():
+    """Uniform shape: consumers branch on the VALUE, not on the key existing."""
+    # Arrange
+    rows = [_row("live", subscribers=1, reachable=REACHABLE)]
+    # Act
+    out = annotate_faults(rows, snapshot={"tui-live": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert out[0]["fault"] is None
+
+
+def test_healthy_row_carries_no_fault_detail():
+    # Arrange
+    rows = [_row("live", subscribers=1, reachable=REACHABLE)]
+    # Act
+    out = annotate_faults(rows, snapshot={"tui-live": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert "fault_detail" not in out[0]
+
+
+def test_deaf_row_is_told_not_to_re_send():
+    """A named fault whose remedy must be guessed still ends in a wrong action."""
+    # Arrange
+    rows = [_row()]
+    # Act
+    out = annotate_faults(rows, snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert "do not re-send" in out[0]["fault_detail"].lower()
+
+
+def test_not_running_row_is_not_told_to_wait_for_a_reconnect():
+    """The stopped case must contradict, not echo, the deaf case's advice."""
+    # Arrange
+    rows = [_row()]
+    # Act
+    out = annotate_faults(rows, snapshot={}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert "outlived the process" in out[0]["fault_detail"]
+
+
+def test_annotate_preserves_every_pre_existing_field():
+    """Additive overlay: the declaration is never overwritten by the observation."""
+    # Arrange
+    row = {**_row(), "pid": 4242, "a2a_port": 19000, "role": "maintainer"}
+    # Act
+    out = annotate_faults([row], snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)[0]
+    # Assert
+    assert all(out[key] == value for key, value in row.items())
+
+
+def test_annotate_does_not_mutate_the_input_row():
+    # Arrange
+    row = _row()
+    # Act
+    annotate_faults([row], snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert "fault" not in row

--- a/tests/scitex_agent_container/_mcp/test__channel_target_lookup.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_target_lookup.py
@@ -1,0 +1,209 @@
+"""One zero, three causes — the send path's registry projections.
+
+``delivered_subscriber_count == 0`` is identical for a detached adapter, a
+stopped agent, and a name that was never registered, while the correct response
+differs in each case. These are the pure functions that tell them apart, plus
+the error that carries the third verdict.
+
+The bias under test is uniform: an answer we could not read must degrade to the
+PRE-EXISTING, safer verdict, never to a confident new one.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._listen._inbox_fault import (
+    FAULT_DEAF_INBOX,
+    FAULT_NOT_RUNNING,
+)
+from scitex_agent_container._mcp._channel_send_errors import (
+    ERR_TARGET_NOT_RUNNING,
+    not_running_error,
+)
+from scitex_agent_container._mcp._channel_target_lookup import (
+    fault_of,
+    is_registered,
+    names_of,
+    rows_from_agents_body,
+)
+
+LIVE = {"name": "alpha", "fault": None}
+DEAF = {"name": "beta", "fault": FAULT_DEAF_INBOX}
+STOPPED = {"name": "gamma", "fault": FAULT_NOT_RUNNING}
+
+
+# --- parsing the /agents body --------------------------------------------
+
+
+def test_current_envelope_is_parsed():
+    # Arrange
+    body = {"agents": [LIVE, STOPPED]}
+    # Act
+    rows = rows_from_agents_body(body)
+    # Assert
+    assert rows == [LIVE, STOPPED]
+
+
+def test_bare_list_from_an_older_listen_is_parsed():
+    # Arrange
+    body = [LIVE]
+    # Act
+    rows = rows_from_agents_body(body)
+    # Assert
+    assert rows == [LIVE]
+
+
+def test_bare_name_strings_are_promoted_to_rows():
+    """An old daemon listing names must not read as an empty fleet."""
+    # Arrange
+    body = ["alpha", "beta"]
+    # Act
+    rows = rows_from_agents_body(body)
+    # Assert
+    assert rows == [{"name": "alpha"}, {"name": "beta"}]
+
+
+def test_unparseable_body_yields_no_rows():
+    # Arrange
+    body = "not a listing"
+    # Act
+    rows = rows_from_agents_body(body)
+    # Assert
+    assert rows == []
+
+
+# --- is the name real? ----------------------------------------------------
+
+
+def test_a_listed_name_is_registered():
+    # Arrange
+    rows = [LIVE, STOPPED]
+    # Act
+    registered = is_registered("alpha", rows)
+    # Assert
+    assert registered is True
+
+
+def test_an_absent_name_is_not_registered():
+    """The `sac-04` case: a typo must be named, not queued forever."""
+    # Arrange
+    rows = [LIVE, STOPPED]
+    # Act
+    registered = is_registered("sac-04", rows)
+    # Assert
+    assert registered is False
+
+
+def test_an_unreadable_registry_does_not_accuse_the_name():
+    """"I could not check" is not evidence of a bad name.
+
+    An empty list means the registry was unreadable OR genuinely empty, and
+    convicting the caller's spelling off that would invent false certainty.
+    """
+    # Arrange
+    rows: list[dict] = []
+    # Act
+    registered = is_registered("alpha", rows)
+    # Assert
+    assert registered is True
+
+
+def test_names_are_read_from_the_agent_key_too():
+    # Arrange
+    rows = [{"agent": "delta"}]
+    # Act
+    names = names_of(rows)
+    # Assert
+    assert names == ["delta"]
+
+
+# --- is the agent running? ------------------------------------------------
+
+
+def test_a_stopped_target_reports_the_not_running_fault():
+    # Arrange
+    rows = [LIVE, STOPPED]
+    # Act
+    fault = fault_of("gamma", rows)
+    # Assert
+    assert fault == FAULT_NOT_RUNNING
+
+
+def test_a_deaf_target_reports_the_deaf_fault():
+    """A live-but-deaf target keeps the WAIT advice — its adapter will return."""
+    # Arrange
+    rows = [LIVE, DEAF]
+    # Act
+    fault = fault_of("beta", rows)
+    # Assert
+    assert fault == FAULT_DEAF_INBOX
+
+
+def test_an_older_listen_without_the_field_reports_no_fault():
+    """No ``fault`` key means fall back to the verdict that was always safe."""
+    # Arrange
+    rows = [{"name": "alpha"}]
+    # Act
+    fault = fault_of("alpha", rows)
+    # Assert
+    assert fault is None
+
+
+def test_an_unlisted_target_reports_no_fault():
+    # Arrange
+    rows = [LIVE]
+    # Act
+    fault = fault_of("nobody", rows)
+    # Assert
+    assert fault is None
+
+
+# --- the error the stopped case raises ------------------------------------
+
+
+def test_not_running_error_carries_its_own_failure_code():
+    """A distinct code so callers branch on the CLASS, not on prose."""
+    # Arrange
+    target = "gamma"
+    # Act
+    err = not_running_error(target)
+    # Assert
+    assert err.code == ERR_TARGET_NOT_RUNNING
+
+
+def test_not_running_error_still_reports_the_message_as_queued():
+    """It IS durable — it just will not be delivered until someone starts them."""
+    # Arrange
+    target = "gamma"
+    # Act
+    err = not_running_error(target)
+    # Assert
+    assert err.detail["durably_queued"] is True
+
+
+def test_not_running_error_says_the_target_is_not_running():
+    # Arrange
+    target = "gamma"
+    # Act
+    err = not_running_error(target)
+    # Assert
+    assert err.detail["target_running"] is False
+
+
+def test_not_running_error_tells_the_sender_not_to_wait():
+    """The inversion this fault exists to fix: no reconnect is coming."""
+    # Arrange
+    target = "gamma"
+    # Act
+    err = not_running_error(target)
+    # Assert
+    assert any("DO NOT WAIT" in step for step in err.detail["what_to_do"])
+
+
+def test_not_running_error_does_not_tell_the_sender_to_start_the_agent():
+    """Starting someone else's agent is an operator decision, not a side effect."""
+    # Arrange
+    target = "gamma"
+    # Act
+    err = not_running_error(target)
+    # Assert
+    assert any("Do NOT start the target" in step for step in err.detail["what_to_do"])


### PR DESCRIPTION
## The measurement first

I was asked to confirm a finding that 9 of 15 registered agents were **running but deaf**, and that "reach decays with uptime, and it decays silently."

**The 9-of-15 count replicates exactly. The conclusion drawn from it does not.**

Those 9 agents are not deaf. **They are stopped.** Three independent instruments agree:

| instrument | reading |
|---|---|
| `tmux ls` on the host | exactly 6 sessions — the 6 with `inbox_subscribers >= 1`, and no others |
| host process table | `sac mcp channel --name X` running for exactly those same 6 |
| `state.db` `instances` | the 9 carry `ended_at=2026-08-11T17:54:26Z`, `exit_reason=crashed`; only 6 rows have `ended_at IS NULL` |

The registry PID is *not* an instrument here — it reports DEAD for all 15, including agents holding live tmux sessions, because the recorded pid lives in another namespace. `_verdict_tmux.py` says exactly this in its docstring; it is now also measured.

**There is no decay, and there is a positive control for that.** `sac listen` restarted at `2026-08-12T00:27:22Z` — *after* five of the six live agents booted (22:39–22:50Z). All five are still subscribed. Their SSE consumers re-subscribed across a broker restart with no agent restart, which is precisely the invariant `_mcp/_channel_sse.py` claims to hold. The apparent "restarted after 17:59" correlation was `started_at` standing in for *has this row's process survived* — the old rows are stale rows.

This is the third time this fleet has read a wall of zeros as deafness. On 2026-07-14 three agents did it simultaneously and escalated a P0 that did not exist; `_lifecycle/inbox_probe.py` documents that incident at length and warns that a zero is confounded. The warning did not work, because it lives in a docstring and the zero is published on the surface an agent reads *while in a hurry to hand over work*.

## What this PR changes

A zero now arrives with its cause attached, derived by pairing the subscriber count with the one instrument independent of the broker's own bookkeeping — the host's tmux table.

`fault` is published on every `GET /agents` row, on `GET /agents/<name>/status`, and in `sac agents health`:

- **`deaf_inbox`** — a live session observed **and** 0 subscribers. The state that was previously unnameable, and the one worth alarming on: green at every surface, work routed to it, work evaporates.
- **`not_running`** — the registry row outlived the process. Not a delivery fault at all; there is nothing to deliver *to*.
- **`null`** — healthy, or a reading nobody could take.

Discipline inherited from `_reachability.py` and not relaxed:

- **Only a positive observation convicts.** An untakeable snapshot (wedged tmux, or the container-blindness trap where an empty result is a namespace boundary and not an empty fleet) yields no fault. An agent whose spec does not declare the `tui` runtime is never convicted on a missing tmux session it was never going to have — that would be the old pidfile probe's bug run backwards.
- **A live subscriber outranks a missing session.** When the two instruments disagree, the fault is neither: a subscribed agent is by definition not deaf and demonstrably not gone.
- **A fault is a report, never a trigger.** Nothing here is wired to a restart — least of all `deaf_inbox`, whose subject is by definition a healthy session a restart would destroy.

### Two consequences fixed with it

**`a2a_send` no longer tells a sender to wait for a reconnect that has no process to happen in.** A 0-subscriber send raised `no_subscriber_error`, whose remedy says — correctly, for a live agent with a detached adapter — *"NOT LOST … do NOT re-send … it replays on their next connect"*. For a stopped agent that is inverted: no session exists to reconnect, so the row sits in `channel_events` until someone starts the agent and the sender waits forever behind reassuring text. Same shape as the `sac-04` incident one layer over — and on 2026-08-12 it applied to 9 of the 15 registered agents. The send path now raises a distinct `target_not_running` with the opposite remedy. It still does **not** tell the caller to start the target: whether a stopped agent should be running is an operator decision, not a side effect of someone wanting to message it.

**`sac agents health` no longer asserts a process state it never observed.** Its unreachable branch ended with *"The process is up; its inbox adapter is not attached"* — a claim the command had not made and could not make. It was wrong for 9 of 15 agents. It now reports which zero it is, and says so plainly when the cause is unconfirmed.

`sac agents list` needed nothing: it already probes tmux per row and reported all nine as `stopped`. The two surfaces disagreed, and only the peer-facing one was wrong.

## Verification

- `6134 passed, 13 skipped` across `_listen`, `_mcp`, `_lifecycle`, `cli_pkg` (PYTHONPATH pinned to this worktree's `src/`).
- 38 new tests: the classifier rules driven through injected snapshots and a hand-rolled runtime resolver (no mocks, no monkeypatch), the send-path projections, and route-level wiring on the existing real-Starlette harness.
- **End-to-end against the live fleet**, real tmux snapshot, no agent touched: 9 → `not_running`, 6 → `null`, **0 → `deaf_inbox`**. The new instrument's first act is to report that the alarm it was built to raise has no subjects on this host right now.

## Not done here, filed instead

The 9 agents crashed together at `2026-08-11T17:54:26Z` and the `scitex-agent-container-fleet-reconcile.timer` — documented as *"restarts agents whose tmux session is GONE"*, running every 5 minutes — did not resurrect any of them in ~9 hours. Separately, sac's own code notes that spec `restart: {policy: on-failure}` was never enforced. Filed as card `reconcile-timer-did-not-restart-9-agents`; restarting nine agents unasked overnight is the operator's call, not mine.

**Agents touched by this work: none.** Nothing was started, stopped, or restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
