### PR TITLE
fix(host): resolve peers through the registry, not config.yaml alone

### DIFF
--- a/src/scitex_agent_container/_state/_peer_resolve.py
+++ b/src/scitex_agent_container/_state/_peer_resolve.py
@@ -1,0 +1,122 @@
+"""Peer resolution: config.yaml peers UNION the scitex-dev host registry.
+
+Why this module exists (measured 2026-08-12 on scitex-compute-04)
+-----------------------------------------------------------------
+``sac host probe`` / ``sac host exec`` / ``sac --on <peer>`` all gated on
+``peer in cfg.peers`` — the ``peers:`` block of
+``~/.scitex/agent-container/config.yaml``. That file is OPTIONAL and
+:func:`.host_config.load` is explicitly missing-tolerant, so on a host
+with no config.yaml ``cfg.peers`` is ``{}`` and **every** peer name was
+rejected with ``exit 2``::
+
+    $ sac host list          # prints 6 registry rows with ssh aliases
+    peers: []
+    $ sac host probe mba
+    error: peer 'mba' is not defined in config.yaml
+
+That is the whole reachability surface refusing every host sac had just
+finished listing. The consequence was fleet-wide: nothing could answer
+"which hosts are reachable?" through the supported CLI, so every caller
+hand-rolled ssh instead — which is exactly the bypass a supported surface
+exists to prevent.
+
+The registry already had the answer. :mod:`.host_registry` reads
+``scitex_dev.hosts`` (SSOT ``$SCITEX_DIR/dev/hosts.yaml``) and exposes
+:func:`~.host_registry.registry_ssh_alias` — *"the ~/.ssh/config Host
+alias to reach this machine"* — which had **zero** call sites. sac was
+resolving the registry for ``scitex_root`` (where a peer writes state)
+while ignoring it for ``ssh_alias`` (how to reach that peer at all).
+
+Precedence — config.yaml ALWAYS wins
+------------------------------------
+A config entry carries things the registry deliberately does not model:
+``via:`` ProxyJump chains, ``env_preamble`` (Lmod on HPC), ``reverse_ssh``.
+Letting a registry row shadow one of those would silently drop a jump
+chain, so the registry only ever FILLS GAPS.
+
+The membership test is ``name in peers``, not ``name in peers.keys()``,
+and the difference is load-bearing: :class:`~.host_config.PeersMap`
+resolves glob keys in ``__contains__``. With a config entry
+``spartan*: {via: [spartan], env_preamble: [...]}``, the name ``spartan``
+is ALREADY resolvable by pattern; adding an exact registry row for it
+would pre-empt the pattern (exact match wins in ``PeersMap``) and strip
+the env_preamble that makes ``apptainer`` reachable there.
+
+Rows with no ``ssh_alias`` (``ywata-note-win`` — inbound ssh to it times
+out, so the registry records ``null`` deliberately) are NOT routable and
+are skipped: offering a peer whose route is ``None`` would render an ssh
+argv with an empty host and fail unreadably.
+
+Not fixed here — a stale route is still a stale route
+-----------------------------------------------------
+This module hands the registry's declared ``ssh_alias`` to ssh verbatim.
+If the registry declares a name ``~/.ssh/config`` does not define, the
+dispatch still fails — correctly, and now with the alias visible in the
+error rather than hidden behind "not defined in config.yaml". Measured on
+this host: ``scitex-nas-01`` / ``scitex-nas-02`` do not resolve, while the
+``nas-01`` / ``nas-02`` aliases the ssh config actually defines do. That
+is a DATA defect in the registry (scitex-dev owns hosts.yaml), and sac
+must not paper over it by guessing at a different name.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .host_registry import registry_hosts
+
+if TYPE_CHECKING:
+    from .host_config import PeerSpec
+
+__all__ = ["peers_with_registry", "registry_peer_names"]
+
+
+def peers_with_registry(peers: dict[str, "PeerSpec"]) -> dict[str, "PeerSpec"]:
+    """``peers`` plus a routable entry for every registry host it lacks.
+
+    The return value is a :class:`~.host_config.PeersMap`, so glob keys
+    from config.yaml keep resolving exactly as before and the result can
+    be handed straight to :func:`~._host_ssh.build_ssh_argv` (which does
+    ``peers[peer_name]`` and walks ``via:`` through the same mapping).
+
+    Pure and side-effect free; safe to call per dispatch. The registry
+    read itself degrades to ``[]`` on a box with no scitex-dev and no
+    hosts.yaml, in which case the input mapping is returned unchanged in
+    content.
+    """
+    # Imported here rather than at module scope: ``host_config`` re-exports
+    # ``_host_ssh`` at its bottom, and that module imports ``host_registry``
+    # — a module-level import of ``host_config`` from here would join that
+    # cycle and break whichever of the three is imported first.
+    from .host_config import PeersMap, PeerSpec
+
+    merged = PeersMap()
+    # Config entries FIRST so their insertion order (which is also the
+    # glob-match order in PeersMap) is preserved exactly.
+    for name, spec in peers.items():
+        merged[name] = spec
+    for row in registry_hosts():
+        if not row.ssh_alias:
+            continue
+        if row.name in peers:
+            # Exact key OR a config glob pattern that already covers it.
+            continue
+        merged[row.name] = PeerSpec(name=row.name, ssh=row.ssh_alias)
+    return merged
+
+
+def registry_peer_names(peers: dict[str, "PeerSpec"]) -> set[str]:
+    """Names in :func:`peers_with_registry` that came from the registry.
+
+    Lets a caller label its output ("where did this route come from?")
+    without re-deriving the precedence rule — the one place that rule is
+    written down is :func:`peers_with_registry`.
+    """
+    return {
+        row.name
+        for row in registry_hosts()
+        if row.ssh_alias and row.name not in peers
+    }
+
+
+# EOF

--- a/src/scitex_agent_container/cli_pkg/_host_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_host_list_cmd.py
@@ -42,10 +42,14 @@ def _filter_interfaces(ifaces: list, include_virtual: bool) -> list:
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
 @click.pass_context
 def host_list(ctx: click.Context, all_interfaces: bool, as_json: bool) -> None:
-    """Local host + peers configured under config.yaml's ``peers:`` block.
+    """Local host + every peer sac can reach.
 
     The first row is always the local host (the machine running
-    ``sac``); peers under ``config.yaml``'s ``peers:`` block follow.
+    ``sac``). The ``peers`` block that follows is the exact set of names
+    ``sac host probe`` / ``sac host exec`` / ``sac --on`` accept:
+    ``config.yaml``'s ``peers:`` entries UNION the scitex-dev registry's
+    hosts that declare an ``ssh_alias``, config winning on a collision.
+    Each row is tagged with the source its route came from.
     Virtual / container-managed interfaces (docker, br-*, veth, ...)
     are hidden by default — pass ``--all-interfaces`` to include them.
 
@@ -56,6 +60,7 @@ def host_list(ctx: click.Context, all_interfaces: bool, as_json: bool) -> None:
       $ sac host list --all-interfaces   # include docker0, br-*, etc.
     """
     from .._state._host_ssh import resolve_peer_scitex_root
+    from .._state._peer_resolve import peers_with_registry, registry_peer_names
     from .._state.host_registry import registry_hosts
 
     cfg = load()
@@ -67,21 +72,33 @@ def host_list(ctx: click.Context, all_interfaces: bool, as_json: bool) -> None:
         "aliases": cfg.host.aliases,
         "interfaces": _filter_interfaces(host_interfaces(), all_interfaces),
     }
+    # Every name ``sac host probe/exec`` and ``sac --on`` will accept —
+    # config.yaml peers UNION the registry's routable hosts. Listing only
+    # the config half is what made this command print six registry rows
+    # above an empty ``peers:`` and left "which hosts are reachable?"
+    # unanswerable on any box without a config.yaml.
+    all_peers = peers_with_registry(cfg.peers)
+    from_registry = registry_peer_names(cfg.peers)
     peers = []
-    for name, peer in sorted(cfg.peers.items()):
+    for name, peer in sorted(all_peers.items()):
         peers.append(
             {
                 "name": name,
                 "scope": "peer",
                 "ssh": peer.ssh,
                 "via": list(peer.via),
+                # Which of the two sources supplied this route. Without it
+                # the operator cannot tell a hand-configured peer (whose
+                # via/env_preamble they own) from a registry row sac filled
+                # in for them.
+                "source": "registry" if name in from_registry else "config",
                 # Where a remote sac WILL write its state — resolved through
                 # the scitex-dev registry (SSOT), inheriting through ``via:``
                 # for glob compute nodes. None = home-relative default on the
                 # peer (the registry root is ``~/.scitex``, or the host is
                 # unregistered). Surfaced so the operator can SEE the answer
                 # rather than discover it from a misplaced 1.4GB SIF.
-                "scitex_root": resolve_peer_scitex_root(name, cfg.peers),
+                "scitex_root": resolve_peer_scitex_root(name, all_peers),
             }
         )
     registry = [
@@ -122,10 +139,11 @@ def host_list(ctx: click.Context, all_interfaces: bool, as_json: bool) -> None:
         console.print(f"  {iface['iface']:<11} {iface['family']:<6} {iface['addr']}")
     # Peers.
     if peers:
-        console.print("[bold]peers[/bold]")
+        console.print("[bold]peers[/bold] [dim](every name probe/exec/--on accepts)[/dim]")
         for r in peers:
             via = f"  via={','.join(r['via'])}" if r["via"] else ""
-            console.print(f"  {r['name']:<11} ssh={r['ssh']}{via}")
+            origin = "  [dim](registry)[/dim]" if r["source"] == "registry" else ""
+            console.print(f"  {r['name']:<11} ssh={r['ssh']}{via}{origin}")
             if r["scitex_root"]:
                 console.print(
                     f"              scitex_root={r['scitex_root']} [dim](registry)[/dim]"

--- a/src/scitex_agent_container/cli_pkg/host_group.py
+++ b/src/scitex_agent_container/cli_pkg/host_group.py
@@ -17,7 +17,9 @@ import subprocess
 
 import click
 
+from .._state._peer_resolve import peers_with_registry
 from .._state.host_config import (
+    Config,
     build_ssh_argv,
     load,
     ssh_control_options_str,
@@ -63,6 +65,26 @@ def host_group() -> None:
 # probe / ssh-opts / peer CRUD).
 register_list_command(host_group)
 register_validate_command(host_group)
+
+
+def _unknown_peer_error(peer: str, cfg: Config) -> str:
+    """The message for a peer neither config.yaml nor the registry knows.
+
+    Names BOTH sources, because "not defined in config.yaml" was actively
+    misleading once the registry became a route source: on a host with no
+    config.yaml at all it pointed the operator at a file that does not
+    exist and never mentioned the registry that lists the host they asked
+    for. Ends with the one command that enumerates every name that WOULD
+    have worked.
+    """
+    where = str(cfg.source_path) if cfg.source_path else "config.yaml"
+    return (
+        f"error: peer '{peer}' is not defined in {where} and is not a "
+        f"routable host in the scitex-dev registry (a registry host is "
+        f"routable when it declares an ssh_alias).\n"
+        f"Add it under peers: in config.yaml or to the registry, then "
+        f"re-run. See: sac host list"
+    )
 
 
 def split_on_flag(argv: list[str]) -> tuple[str | None, list[str]]:
@@ -114,18 +136,15 @@ def dispatch_remote(peer: str, argv: list[str], ssh_argv0: str = "sac") -> int:
     ``remote=True``.
     """
     cfg = load()
-    if peer not in cfg.peers:
-        click.echo(
-            f"error: --on peer '{peer}' is not defined in {cfg.source_path}.\n"
-            f"Add it under peers: in config.yaml, then re-run.",
-            err=True,
-        )
+    peers = peers_with_registry(cfg.peers)
+    if peer not in peers:
+        click.echo(_unknown_peer_error(peer, cfg), err=True)
         return 2
     from ._on_start_propagate import is_agents_start_argv, propagate_remote_start
 
     if is_agents_start_argv(argv):
         return propagate_remote_start(peer, argv, ssh_argv0=ssh_argv0)
-    ssh_argv = build_ssh_argv(peer, [ssh_argv0, *argv], cfg.peers)
+    ssh_argv = build_ssh_argv(peer, [ssh_argv0, *argv], peers)
     proc = subprocess.run(ssh_argv)
     return proc.returncode
 
@@ -147,24 +166,23 @@ def host_exec(peer: str, argv: tuple[str, ...]) -> None:
       $ sac host exec spartan -- agent list --json
       $ sac host exec bm198 -- sac db export --since 2026-05-01
 
-    PEER must be defined under config.yaml's ``peers:`` block. The peer's
-    ``via:`` chain renders into ssh's ``-J`` flag automatically; sac
-    never opens a port. Stdio is inherited so streaming output works.
+    PEER may be a ``peers:`` entry in config.yaml or any host in the
+    scitex-dev registry that declares an ``ssh_alias``; config.yaml wins
+    when both define it. The peer's ``via:`` chain renders into ssh's
+    ``-J`` flag automatically; sac never opens a port. Stdio is inherited
+    so streaming output works.
     """
     cfg = load()
-    if peer not in cfg.peers:
-        click.echo(
-            f"error: peer '{peer}' is not defined in {cfg.source_path}.\n"
-            f"Add it under peers: in config.yaml, then re-run.",
-            err=True,
-        )
+    peers = peers_with_registry(cfg.peers)
+    if peer not in peers:
+        click.echo(_unknown_peer_error(peer, cfg), err=True)
         raise SystemExit(2)
     if not argv:
         click.echo(
             "error: no command supplied. Try: sac host exec PEER -- <cmd>", err=True
         )
         raise SystemExit(2)
-    ssh_argv = build_ssh_argv(peer, list(argv), cfg.peers)
+    ssh_argv = build_ssh_argv(peer, list(argv), peers)
     proc = subprocess.run(ssh_argv)
     raise SystemExit(proc.returncode)
 
@@ -190,8 +208,9 @@ def host_probe(ctx: click.Context, peer: str, timeout: int, as_json: bool) -> No
     import time
 
     cfg = load()
-    if peer not in cfg.peers:
-        msg = f"peer '{peer}' is not defined in config.yaml"
+    peers = peers_with_registry(cfg.peers)
+    if peer not in peers:
+        msg = _unknown_peer_error(peer, cfg)
         if _json_flag(ctx, as_json):
             click.echo(json.dumps({"peer": peer, "reachable": False, "error": msg}))
         else:
@@ -202,7 +221,7 @@ def host_probe(ctx: click.Context, peer: str, timeout: int, as_json: bool) -> No
     ssh_argv = build_ssh_argv(
         peer,
         remote_argv,
-        cfg.peers,
+        peers,
         extra_opts=["-o", f"ConnectTimeout={timeout}"],
     )
     started = time.monotonic()

--- a/tests/scitex_agent_container/_state/test__peer_resolve.py
+++ b/tests/scitex_agent_container/_state/test__peer_resolve.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for peer resolution — config.yaml UNION the host registry.
+
+NO MOCKS. Every test drives the real seam: a real ``hosts.yaml`` written
+to a real ``tmp_path`` and read through the real ``$SCITEX_DIR/dev/``
+cascade, real ``PeerSpec`` / ``PeersMap`` objects, and the real
+``build_ssh_argv`` renderer.
+
+The regression under test was MEASURED on scitex-compute-04 (2026-08-12).
+``sac host list`` printed six registry hosts with ssh aliases above an
+empty ``peers: []``, and every reachability verb then refused all six::
+
+    $ sac host probe mba
+    error: peer 'mba' is not defined in config.yaml
+
+config.yaml does not exist on that host — :func:`host_config.load` is
+missing-tolerant by design — so ``cfg.peers`` was ``{}`` and the gate
+``peer not in cfg.peers`` rejected everything. sac was reading the
+registry for ``scitex_root`` while ignoring the ``ssh_alias`` sitting in
+the same row; ``registry_ssh_alias`` had zero call sites. The practical
+cost: nothing could answer "which hosts are reachable?" through the
+supported CLI, so callers hand-rolled ssh instead.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# Import via ``host_config`` (the established public re-export path), not
+# the private siblings: ``host_config`` and ``_host_ssh`` form a
+# deliberate import cycle, so importing the sibling FIRST hits a
+# partially initialized module.
+from scitex_agent_container._state._peer_resolve import (
+    peers_with_registry,
+    registry_peer_names,
+)
+from scitex_agent_container._state.host_config import (
+    PeersMap,
+    PeerSpec,
+    build_ssh_argv,
+)
+
+_HOSTS_YAML = textwrap.dedent(
+    """\
+    hosts:
+      spartan:
+        kind: hpc-login
+        ssh_alias: spartan
+        scitex_root: "/data/gpfs/projects/punim0264/ywatanabe/.scitex"
+      mba:
+        kind: workstation
+        ssh_alias: mba
+        scitex_root: "~/.scitex"
+      scitex-nas-03:
+        kind: storage
+        ssh_alias: scitex-nas-03
+        scitex_root: "~/.scitex"
+      ywata-note-win:
+        kind: workstation
+        ssh_alias: null
+        scitex_root: "~/.scitex"
+    """
+)
+
+_SPARTAN_PREAMBLE = ("module load Apptainer/1.3.3",)
+
+
+def _set_scitex_dir(value: str) -> Iterator[None]:
+    """Set $SCITEX_DIR for the test, restoring the prior value on teardown."""
+    sentinel = object()
+    previous: object = os.environ.get("SCITEX_DIR", sentinel)
+    os.environ["SCITEX_DIR"] = value
+    try:
+        yield
+    finally:
+        if previous is sentinel:
+            os.environ.pop("SCITEX_DIR", None)
+        else:
+            os.environ["SCITEX_DIR"] = str(previous)
+
+
+@pytest.fixture()
+def registry(tmp_path: Path) -> Iterator[Path]:
+    """A real hosts.yaml at the real resolved location ($SCITEX_DIR/dev/)."""
+    hosts_dir = tmp_path / "dev"
+    hosts_dir.mkdir(parents=True)
+    (hosts_dir / "hosts.yaml").write_text(_HOSTS_YAML)
+    yield from _set_scitex_dir(str(tmp_path))
+
+
+@pytest.fixture()
+def empty_registry(tmp_path: Path) -> Iterator[Path]:
+    """A registry file that exists but declares no hosts at all."""
+    hosts_dir = tmp_path / "dev"
+    hosts_dir.mkdir(parents=True)
+    (hosts_dir / "hosts.yaml").write_text("hosts: {}\n")
+    yield from _set_scitex_dir(str(tmp_path))
+
+
+@pytest.fixture()
+def glob_peers() -> PeersMap:
+    """The two-tier HPC config shape: one pattern key, blank ssh."""
+    peers = PeersMap()
+    peers["spartan*"] = PeerSpec(
+        name="spartan*", ssh="", env_preamble=_SPARTAN_PREAMBLE
+    )
+    return peers
+
+
+def test_registry_host_is_routable_with_no_config_peers(registry: Path) -> None:
+    """THE bug: no config.yaml must not mean no reachable hosts."""
+    # Arrange
+    configured: dict[str, PeerSpec] = {}
+    # Act
+    merged = peers_with_registry(configured)
+    # Assert
+    assert "mba" in merged
+
+
+def test_registry_peer_carries_the_declared_ssh_alias(registry: Path) -> None:
+    """The route comes from the registry's ``ssh_alias``, verbatim."""
+    # Arrange
+    configured: dict[str, PeerSpec] = {}
+    # Act
+    merged = peers_with_registry(configured)
+    # Assert
+    assert merged["scitex-nas-03"].ssh == "scitex-nas-03"
+
+
+def test_registry_peer_renders_a_real_ssh_argv(registry: Path) -> None:
+    """The resolved peer must be usable by the unmodified ssh renderer."""
+    # Arrange
+    merged = peers_with_registry({})
+    # Act
+    argv = build_ssh_argv("mba", ["sac", "host", "list", "--json"], merged)
+    # Assert
+    assert argv[argv.index("--") + 1 :] == ["sac", "host", "list", "--json"]
+
+
+def test_registry_peer_ssh_argv_targets_the_alias(registry: Path) -> None:
+    """The ssh host word is the alias, not the registry row name."""
+    # Arrange
+    merged = peers_with_registry({})
+    # Act
+    argv = build_ssh_argv("spartan", ["hostname"], merged)
+    # Assert
+    assert argv[argv.index("--") - 1] == "spartan"
+
+
+def test_config_peer_ssh_wins_over_registry_row(registry: Path) -> None:
+    """A config entry is explicit operator intent; the registry fills gaps."""
+    # Arrange
+    configured = {
+        "spartan": PeerSpec(name="spartan", ssh="ywatanabe@spartan-login1")
+    }
+    # Act
+    merged = peers_with_registry(configured)
+    # Assert
+    assert merged["spartan"].ssh == "ywatanabe@spartan-login1"
+
+
+def test_config_peer_env_preamble_survives_the_merge(registry: Path) -> None:
+    """Shadowing a config peer would silently drop its Lmod preamble."""
+    # Arrange
+    configured = {
+        "spartan": PeerSpec(
+            name="spartan", ssh="spartan", env_preamble=_SPARTAN_PREAMBLE
+        )
+    }
+    # Act
+    merged = peers_with_registry(configured)
+    # Assert
+    assert merged["spartan"].env_preamble == _SPARTAN_PREAMBLE
+
+
+def test_config_glob_pattern_is_not_preempted(
+    registry: Path, glob_peers: PeersMap
+) -> None:
+    """A registry exact row must not steal a name a config glob covers.
+
+    ``PeersMap`` prefers an exact key over a pattern, so injecting an
+    exact ``spartan`` row would strip the ``spartan*`` entry's
+    env_preamble — the ``module load`` that puts ``apptainer`` on
+    Spartan's PATH.
+    """
+    # Arrange
+    expected = _SPARTAN_PREAMBLE
+    # Act
+    merged = peers_with_registry(glob_peers)
+    # Assert
+    assert merged["spartan"].env_preamble == expected
+
+
+def test_glob_matched_peer_still_fills_ssh_from_the_queried_name(
+    registry: Path, glob_peers: PeersMap
+) -> None:
+    """The pattern's blank ssh keeps resolving to the queried name."""
+    # Arrange
+    expected = "spartan"
+    # Act
+    merged = peers_with_registry(glob_peers)
+    # Assert
+    assert merged["spartan"].ssh == expected
+
+
+def test_row_without_ssh_alias_is_not_routable(registry: Path) -> None:
+    """``ywata-note-win`` records ``ssh_alias: null`` deliberately.
+
+    Inbound ssh to it times out, so it has no route; offering it would
+    render an ssh argv with an empty host and fail unreadably.
+    """
+    # Arrange
+    configured: dict[str, PeerSpec] = {}
+    # Act
+    merged = peers_with_registry(configured)
+    # Assert
+    assert "ywata-note-win" not in merged
+
+
+def test_registry_peer_names_reports_the_filled_gaps(registry: Path) -> None:
+    # Arrange
+    configured = {"mba": PeerSpec(name="mba", ssh="mba.local")}
+    # Act
+    names = registry_peer_names(configured)
+    # Assert
+    assert {"spartan", "scitex-nas-03"} <= names
+
+
+def test_registry_peer_names_excludes_configured_peers(registry: Path) -> None:
+    """A name the operator configured is labelled config, not registry."""
+    # Arrange
+    configured = {"mba": PeerSpec(name="mba", ssh="mba.local")}
+    # Act
+    names = registry_peer_names(configured)
+    # Assert
+    assert "mba" not in names
+
+
+def test_config_peer_survives_when_registry_is_empty(empty_registry: Path) -> None:
+    """A box with no registry hosts keeps its pre-existing config peers."""
+    # Arrange
+    configured = {"bm198": PeerSpec(name="bm198", ssh="bm198", via=("spartan",))}
+    # Act
+    merged = peers_with_registry(configured)
+    # Assert
+    assert merged["bm198"].ssh == "bm198"
+
+
+def test_config_peer_via_chain_survives_when_registry_is_empty(
+    empty_registry: Path,
+) -> None:
+    """The ProxyJump chain is part of that peer and must not be rebuilt."""
+    # Arrange
+    configured = {"bm198": PeerSpec(name="bm198", ssh="bm198", via=("spartan",))}
+    # Act
+    merged = peers_with_registry(configured)
+    # Assert
+    assert merged["bm198"].via == ("spartan",)
+
+
+# EOF

--- a/tests/scitex_agent_container/_state/test_host_config.py
+++ b/tests/scitex_agent_container/_state/test_host_config.py
@@ -82,6 +82,24 @@ def cfg_path(tmp_path: Path, env_save_restore) -> Path:
     return p
 
 
+@pytest.fixture
+def empty_registry(tmp_path: Path, env_save_restore) -> Path:
+    """A real, EMPTY scitex-dev host registry at $SCITEX_DIR/dev/hosts.yaml.
+
+    ``sac host list`` reports config peers UNION the registry's routable
+    hosts, so a test that asserts on the ``peers`` list has to pin BOTH
+    sources. Leaving the registry ambient makes the assertion depend on
+    the operator's real hosts.yaml — on scitex-compute-04 that is five
+    extra rows, so the test's outcome was a property of the machine, not
+    of the code.
+    """
+    hosts_dir = tmp_path / "registry" / "dev"
+    hosts_dir.mkdir(parents=True)
+    (hosts_dir / "hosts.yaml").write_text("hosts: {}\n")
+    env_save_restore.set("SCITEX_DIR", str(tmp_path / "registry"))
+    return hosts_dir / "hosts.yaml"
+
+
 # ---------------------------------------------------------------------------
 # load()
 # ---------------------------------------------------------------------------
@@ -296,7 +314,15 @@ peers:
 # ---------------------------------------------------------------------------
 
 
-def test_host_list_returns_empty_peers_with_no_config(cfg_path: Path):
+def test_host_list_returns_empty_peers_with_no_config_and_no_registry(
+    cfg_path: Path, empty_registry: Path
+):
+    """Peers is empty only when NEITHER route source offers anything.
+
+    The registry half is pinned explicitly: with a populated registry
+    this list is correctly non-empty, which is the whole point of the
+    change — a host with no config.yaml can still reach its peers.
+    """
     # Arrange
     from scitex_agent_container.cli_pkg.host_group import host_list
 
@@ -306,7 +332,7 @@ def test_host_list_returns_empty_peers_with_no_config(cfg_path: Path):
     assert json.loads(result.stdout)["peers"] == []
 
 
-def test_host_list_renders_configured_peers(cfg_path: Path):
+def test_host_list_renders_configured_peers(cfg_path: Path, empty_registry: Path):
     # Arrange
     cfg_path.write_text(
         """

--- a/tests/scitex_agent_container/cli_pkg/test_host_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_host_group.py
@@ -39,6 +39,44 @@ def cfg_path(tmp_path: Path, env_save_restore) -> Path:
     return p
 
 
+@pytest.fixture
+def empty_registry(tmp_path: Path, env_save_restore) -> Path:
+    """A real, EMPTY scitex-dev host registry at $SCITEX_DIR/dev/hosts.yaml.
+
+    ``sac host list`` now reports config peers UNION the registry's
+    routable hosts, so any test asserting on the peers block has to pin
+    the registry half. Without this the assertions read the OPERATOR's
+    real hosts.yaml and their outcome depends on which machine CI runs
+    on — the suite passed here only because the ambient registry happened
+    to be empty in the environment where these tests were written.
+    """
+    hosts_dir = tmp_path / "registry" / "dev"
+    hosts_dir.mkdir(parents=True)
+    (hosts_dir / "hosts.yaml").write_text("hosts: {}\n")
+    env_save_restore.set("SCITEX_DIR", str(tmp_path / "registry"))
+    return hosts_dir / "hosts.yaml"
+
+
+@pytest.fixture
+def registry_with_one_host(tmp_path: Path, env_save_restore) -> Path:
+    """A registry declaring exactly one routable host and one unroutable."""
+    hosts_dir = tmp_path / "registry" / "dev"
+    hosts_dir.mkdir(parents=True)
+    (hosts_dir / "hosts.yaml").write_text(
+        "hosts:\n"
+        "  mba:\n"
+        "    kind: workstation\n"
+        "    ssh_alias: mba\n"
+        '    scitex_root: "~/.scitex"\n'
+        "  ywata-note-win:\n"
+        "    kind: workstation\n"
+        "    ssh_alias: null\n"
+        '    scitex_root: "~/.scitex"\n'
+    )
+    env_save_restore.set("SCITEX_DIR", str(tmp_path / "registry"))
+    return hosts_dir / "hosts.yaml"
+
+
 # ---------------------------------------------------------------------------
 # `sac host list` — rich (non-JSON) renders.
 # ---------------------------------------------------------------------------
@@ -96,13 +134,63 @@ peers:
     assert "via=mba" in result.output
 
 
-def test_host_list_rich_states_no_peers_when_empty(cfg_path: Path):
+def test_host_list_rich_states_no_peers_when_nothing_is_routable(
+    cfg_path: Path, empty_registry: Path
+):
+    """"No peers" now means neither source offered a route.
+
+    Before the registry became a route source this only had to check
+    config.yaml. A host with an empty ``peers:`` block but a populated
+    registry is NOT peerless — it can reach every registry host — so the
+    registry has to be empty too for this message to be truthful.
+    """
     # Arrange
     cfg_path.write_text("peers: {}\n")
     # Act
     result = CliRunner().invoke(host_list, [])
     # Assert
     assert "no peers configured" in result.output
+
+
+def test_host_list_rich_lists_a_registry_host_as_a_peer(
+    cfg_path: Path, registry_with_one_host: Path
+):
+    """THE fix: a registry host is reachable without any config.yaml.
+
+    Measured on scitex-compute-04 (2026-08-12): this command printed six
+    registry rows above ``peers: []`` and ``sac host probe`` then refused
+    every one of them.
+    """
+    # Arrange
+    cfg_path.write_text("peers: {}\n")
+    # Act
+    result = CliRunner().invoke(host_list, [])
+    # Assert
+    assert "ssh=mba" in result.output
+
+
+def test_host_list_rich_labels_a_registry_sourced_route(
+    cfg_path: Path, registry_with_one_host: Path
+):
+    """The operator must be able to tell a filled-in route from their own."""
+    # Arrange
+    cfg_path.write_text("peers: {}\n")
+    # Act
+    result = CliRunner().invoke(host_list, [])
+    # Assert
+    assert "(registry)" in result.output
+
+
+def test_host_list_omits_a_registry_host_with_no_ssh_alias(
+    cfg_path: Path, registry_with_one_host: Path
+):
+    """``ssh_alias: null`` means no route — offering it would fail blankly."""
+    # Arrange
+    cfg_path.write_text("peers: {}\n")
+    # Act
+    result = CliRunner().invoke(host_list, ["--json"])
+    # Assert
+    assert "ywata-note-win" not in [p["name"] for p in json.loads(result.stdout)["peers"]]
 
 
 def test_host_list_rich_renders_alias_arrow_for_local(cfg_path: Path):
@@ -269,7 +357,7 @@ _RETIRED_ALIAS_WARNING = (
 
 
 @pytest.fixture
-def json_run_with_library_warning(cfg_path: Path):
+def json_run_with_library_warning(cfg_path: Path, empty_registry: Path):
     """Run sac's real ``host list --json`` while a library logs a WARNING.
 
     Reproduces the condition that took ``pytest-matrix`` red across 18 open
@@ -286,8 +374,10 @@ def json_run_with_library_warning(cfg_path: Path):
 
     Everything is real (PA-306, no mocks): a real ``logging`` logger, a real
     click command, and sac's real ``host list`` callback reached through
-    ``ctx.invoke``. ``cfg_path`` names a file that is never written, so the
-    payload's ``peers`` list is legitimately empty.
+    ``ctx.invoke``. ``cfg_path`` names a file that is never written and
+    ``empty_registry`` pins the OTHER route source, so the payload's
+    ``peers`` list is legitimately empty on any machine — this fixture
+    used to read whatever hosts.yaml the host it ran on happened to have.
     """
 
     @click.command("warn-then-list")


### PR DESCRIPTION
## The bug

`sac host probe` / `sac host exec` / `sac --on` all gated on `peer in cfg.peers` — the `peers:` block of `~/.scitex/agent-container/config.yaml`. That file is **optional** and `host_config.load` is missing-tolerant by design, so on a host without one `cfg.peers` is `{}` and **every** peer name was refused with exit 2.

Measured on scitex-compute-04, where config.yaml does not exist:

```
$ sac host list          # prints 6 registry hosts, each with an ssh alias
peers: []
$ sac host probe mba
error: peer 'mba' is not defined in config.yaml
```

One command listed the hosts; the next refused all of them. Nothing could answer *"which hosts are reachable?"* through the supported surface, so every caller that needed it tonight hand-rolled ssh instead — the exact bypass a supported surface exists to prevent.

## Why it is sac's own bug

sac already had the answer and was ignoring it. `_state/host_registry.py` reads scitex-dev's SSOT (`$SCITEX_DIR/dev/hosts.yaml`) and exposes `registry_ssh_alias` — *"the `~/.ssh/config` Host alias to reach this machine"* — which had **zero call sites**. sac was resolving the registry for `scitex_root` (where a peer writes state) while ignoring the `ssh_alias` sitting in the same row (how to reach that peer at all).

## The fix

`_state/_peer_resolve.py::peers_with_registry()` unions the two sources, **config.yaml always winning** on a collision — a config entry carries `via:` chains, `env_preamble` and `reverse_ssh` that the registry deliberately does not model, so the registry only ever fills gaps.

Two details that are load-bearing:

- The membership test is `name in peers`, which routes through `PeersMap.__contains__` and therefore its **glob** resolution. An exact registry row for `spartan` would otherwise pre-empt a `spartan*` config pattern (exact beats pattern) and silently strip the `module load` that puts apptainer on PATH there.
- Rows with `ssh_alias: null` — `ywata-note-win`, whose inbound ssh times out, so the registry records `null` on purpose — are **not** routable and are skipped. Offering one would render an ssh argv with an empty host and fail unreadably.

The result is a `PeersMap`, so it drops straight into the unmodified `build_ssh_argv` (which does `peers[name]` and walks `via:` through the same mapping). No renderer changes.

`sac host list` now lists the union — the exact set of names the verbs accept — tagging each row with the source its route came from.

## Verified against the real fleet, from this host

| probe | result |
|---|---|
| `scitex-nas-03` | `reachable=true`, `remote_canonical=DXP480TPLUS-994`, 4894ms |
| `mba` | ssh succeeded; remote sac 0.10.7 has no `host` verb (honest, and a different failure from "unreachable") |
| `scitex-nas-01` | exit 255, `ssh: Could not resolve hostname scitex-nas-01` |
| `nonsense-host` | the new error naming **both** sources |

Every one of those exited 2 with "not defined in config.yaml" before this change.

**The `scitex-nas-01` case is deliberate, not a miss.** sac hands the registry's declared alias to ssh verbatim; when hosts.yaml declares a name `~/.ssh/config` does not define, the dispatch still fails — correctly, and now with the alias *visible* rather than hidden behind "not defined in config.yaml". That is a **data** defect in scitex-dev's hosts.yaml: the 2026-08-07 rename to `scitex-nas-0X` landed in the registry, but the ssh-config generator (whose managed block says "Generated from ~/.scitex/dev/hosts.yaml") still emits `nas-0X`, so the registry's declared route is dead for 2 of 3 NAS hosts. hosts.yaml also carries **no rows at all** for `scitex-compute-01..04`. Tracked separately on card `registry-nas-ssh-alias-unreachable`; sac must not paper over it by guessing a different name.

## On the four tests this changes

They asserted the old outcome *and* read the operator's real hosts.yaml, so their result was a property of the machine they ran on rather than of the code — on compute-04 the ambient registry contributed five extra rows. They now pin the registry half explicitly with a `tmp_path` fixture (`empty_registry` / `registry_with_one_host`).

**Expiry note**, since this is the shape that took the fleet's CI red tonight: these tests no longer assert *"capability X is absent"*. They pin the union rule with both inputs controlled, so they do not expire when a host's registry gains rows — which is exactly what broke them before. The one thing that would legitimately expire them is a change to the precedence rule itself, and that rule lives in exactly one function.

## Scope

Reachability only. **Nothing here wires any host to replicate.** scitex-dev PR #584 fixes a real eviction defect in the replication applier and has not landed; the capability is being propagated across the fleet unused until it does.

## Context: what "7 hosts on 0.48.0" does and does not mean

This PR ships alongside a fleet propagation of `scitex-dev` 0.48.0, which is what makes the per-host store protocol (`Store.origins` / `Store.changes_since`) available to sac and cards at all. Three claims that are routinely conflated, stated separately because tonight produced four separate incidents from exactly that conflation:

- **7 BARE HOSTS are on 0.48.0.** compute-01/02/03/04, nas-03, mba, spartan — each verified by importing `Store` on a fresh interpreter over a fresh ssh, not by reading `__version__`.
- **CONTAINERS ARE NOT.** They take `scitex-dev` from the SIF image. The container this was developed in is on **0.47.0** (`/opt/venv-sac`). 0.47.0 already carries the protocol, so nothing is blocked — but bare-host and container versions now differ by one, and **no agent restart substitutes for an image rebuild and redistribution.** That gap is real and remains open.
- **NOTHING REPLICATES.** See Scope above.

So: *the fleet's bare hosts* are on 0.48.0. *The fleet* is not. Excluded hosts, each on a measurement: **nas-01** (armv7l, no python3 at all — only `/usr/local/bin/python2.7`), **nas-02** (x86_64, same — no python3; the missing interpreter is the blocker, not the missing apptainer), **ywata-note-win** (`ssh_alias: null`, no inbound route).

Note the irony worth flagging: `develop` currently carries an interim `scitex-dev<0.48` ceiling, i.e. this branch is capped *below* the version now installed on every capable host. That ceiling is deliberate and temporary and is not this PR's concern, but it means CI here does not exercise the version the fleet actually runs.

## Tests

**4047 passed, 4 skipped, 16 deselected, 0 failed** — the full `_state/` and `cli_pkg/` suites, run against this branch *after* merging `develop`. 13 of those are new (`test__peer_resolve.py`).

### Why this branch was rebased onto current develop before asking for a verdict

This PR was opened from a base 4 commits behind `develop`, predating `15b0515` (#1000) — the commit that fixed develop's five failures with an interim `scitex-dev<0.48` ceiling. Left alone, CI here would have run against the **unfixed** baseline, and the standing guidance for that situation is "those five are inherited, ignore them".

That guidance is correct and would have been actively harmful here, for a reason worth writing down:

> The two `pytest-matrix` legs are the **only** checks that exercise this change. They were also the exact two that would have come back red for reasons having nothing to do with it. Six green checks around two red ones I had been pre-authorised to dismiss is not a verdict — it is a coin flip with a story attached.

A pre-authorised dismissal is a licence to ignore the only evidence that counts, and it makes a PR unfalsifiable rather than merely noisy. So the branch was updated to the fixed base (clean merge, no conflicts) and the verdict below is against a baseline that is green on its own.

**If you are ever told "ignore that failure, it is inherited", the follow-up question is: which checks are left that could still disagree with me?** If the answer is none, the run proves nothing regardless of how much green surrounds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
