### PR TITLE
feat(ci-rail): a push writes a card, CI's verdict writes back, the agent hears it

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -71,13 +71,40 @@ if [ -z "$RUFF" ] && command -v ruff >/dev/null 2>&1; then
   RUFF="$(command -v ruff)"
 fi
 
+# LAST RESORT: let uv fetch ruff on demand. Measured 2026-08-12 — the agent
+# containers ship NO ruff at any of the paths above and none on PATH, so this
+# gate could not run in the very environment most pushes come from. A gate
+# that cannot run has exactly two outcomes, and both are bad: it blocks every
+# push, or it teaches everyone to reach for --no-verify, which disarms the
+# protected-branch guard above at the same time. Resolving ruff through uv
+# keeps the check STRICT (same ruff, same rules) instead of trading strictness
+# for availability. Declared as an array because it is a multi-word command.
+RUFF_ARGV=()
+if [ -n "$RUFF" ]; then
+  RUFF_ARGV=("$RUFF")
+else
+  for uv_bin in "${SAC_PRE_PUSH_UV:-}" "/uvwork/bin/uv" "$HOME/.local/bin/uv"; do
+    if [ -n "$uv_bin" ] && [ -x "$uv_bin" ]; then
+      RUFF_ARGV=("$uv_bin" tool run ruff)
+      RUFF="$uv_bin tool run ruff"
+      break
+    fi
+  done
+  if [ -z "$RUFF" ] && command -v uv >/dev/null 2>&1; then
+    RUFF_ARGV=("$(command -v uv)" tool run ruff)
+    RUFF="uv tool run ruff"
+  fi
+fi
+
 if [ -z "$RUFF" ]; then
   # Loud failure — never silently skip the gate (handoff Q3). If a
   # genuine emergency requires bypass, --no-verify is documented as
   # the explicit override and shows up in the audit log.
   echo "PRE-PUSH BLOCKED: ruff binary not found." >&2
   echo "  Searched: \$SAC_PRE_PUSH_RUFF, .venv/bin/ruff, /opt/venv-agent/bin/ruff," >&2
-  echo "           /opt/venv-sac/bin/ruff, \$HOME/.local/bin/ruff, PATH." >&2
+  echo "           /opt/venv-sac/bin/ruff, \$HOME/.local/bin/ruff, PATH," >&2
+  echo "           and 'uv tool run ruff' (\$SAC_PRE_PUSH_UV, /uvwork/bin/uv," >&2
+  echo "           \$HOME/.local/bin/uv, PATH)." >&2
   echo "  Install ruff via: pip install -e .[dev]" >&2
   echo "  Or point the hook at an existing ruff: export SAC_PRE_PUSH_RUFF=/path/to/ruff" >&2
   echo "  Or bypass once (emergency only): git push --no-verify" >&2
@@ -88,7 +115,7 @@ fi
 # the unused-import slip-through that motivated this hook.
 # --extend-per-file-ignores excludes __init__.py re-export shims (the
 # standard idiom — imports there *are* the public surface, not dead code).
-if ! "$RUFF" check \
+if ! "${RUFF_ARGV[@]}" check \
       --select F401,F811 \
       --extend-per-file-ignores "**/__init__.py:F401" \
       src/ tests/; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,7 +30,16 @@ cd "$(git rev-parse --show-toplevel)"
 #
 # git feeds pre-push one line per ref on stdin:
 #   <local ref> <local sha1> <remote ref> <remote sha1>
+#
+# READ IT ONCE, INTO A VARIABLE. stdin is a stream: whoever consumes it
+# first consumes it for everyone. The branch guard below and the card
+# record at the bottom of this file both need these refs, and before
+# ADR-0024 the guard's `while read` swallowed them. Capturing up front is
+# what lets a second consumer exist at all.
+PUSHED_REFS="$(cat)"
+
 while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  [ -n "${remote_ref:-}" ] || continue
   case "${remote_ref##refs/heads/}" in
     main|master)
       echo "PRE-PUSH BLOCKED: refusing to push directly to '${remote_ref##refs/heads/}'." >&2
@@ -39,7 +48,7 @@ while read -r _local_ref _local_sha remote_ref _remote_sha; do
       exit 1
       ;;
   esac
-done
+done <<< "$PUSHED_REFS"
 
 # Locate ruff. Search order matches the venvs the SciTeX harness
 # typically installs into; falls back to whatever ruff is on PATH.
@@ -89,4 +98,58 @@ if ! "$RUFF" check \
   echo "  $RUFF check --select F401,F811 --extend-per-file-ignores '**/__init__.py:F401' --fix src/ tests/" >&2
   echo "Or skip the hook (only when truly needed) with --no-verify." >&2
   exit 1
+fi
+
+# --- Register the push on its card (ADR-0024, the rail's first leg) ---------
+#
+# The operator's requirement, verbatim (2026-08-12): 「プッシュに連動して、
+# 必ずフックでカードにその情報を書かないといけない」— a push must register
+# itself on a card, and it must be a HOOK that does it.
+#
+# This card is the rail's ROUTING TABLE, which is the part worth
+# understanding: it records WHO pushed, so when CI's verdict comes back
+# the runner delivers it to that agent instead of inferring an owner from
+# the repo name. That inference is genuinely ambiguous here — two agent
+# specs declare `project: scitex-agent-container`, and sac's own
+# resolve_owner() takes the one that sorts first, which is the one with
+# zero inbox subscribers since 2026-08-10.
+#
+# LAST, and deliberately so: everything above can still block the push, and
+# a card claiming a push that ruff then rejected is a lie on the board.
+#
+# NEVER BLOCKS. A card-store hiccup must not cost an engineer their push,
+# and it need not: the CI half creates the card when it finds none, so the
+# worst case here is a verdict routed by spec instead of by recorded fact.
+# The failure is still printed — silence is what this whole rail exists to
+# remove — it just does not change the exit status.
+RAIL="$(git rev-parse --show-toplevel)/.github/ci/ci_card_rail.py"
+RAIL_PY=""
+for candidate in \
+    "${SAC_RAIL_PYTHON:-}" \
+    "/opt/venv-sac/bin/python3" \
+    ".venv/bin/python" \
+; do
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    RAIL_PY="$candidate"
+    break
+  fi
+done
+if [ -z "$RAIL_PY" ] && command -v python3 >/dev/null 2>&1; then
+  RAIL_PY="$(command -v python3)"
+fi
+
+if [ -n "$RAIL_PY" ] && [ -f "$RAIL" ]; then
+  REPO_SLUG="$(git remote get-url origin 2>/dev/null | sed -e 's#\.git$##' -e 's#^.*[:/]\([^/]*/[^/]*\)$#\1#')"
+  while read -r local_ref local_sha _remote_ref _remote_sha; do
+    case "$local_ref" in refs/heads/*) : ;; *) continue ;; esac
+    # All-zero local sha is git's sentinel for a branch DELETION.
+    case "$local_sha" in 0000000000000000000000000000000000000000) continue ;; esac
+    [ -n "$local_sha" ] || continue
+    "$RAIL_PY" "$RAIL" push \
+      --repo "${REPO_SLUG:-scitex-ai/scitex-agent-container}" \
+      --branch "${local_ref#refs/heads/}" \
+      --sha "$local_sha" \
+      --subject "$(git log -1 --format='%s' "$local_sha" 2>/dev/null)" \
+      || echo "PRE-PUSH: card record failed (push continues)." >&2
+  done <<< "$PUSHED_REFS"
 fi

--- a/.github/ci/ci_card_rail.py
+++ b/.github/ci/ci_card_rail.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""The CI feedback rail: a push registers a card, CI's verdict is written
+onto that card, and the update is delivered to the agent that pushed.
+
+ADR-0024 is the design. The operator's words (2026-08-12) describe a
+MECHANISM rather than a wish —
+
+    プッシュに連動して、必ずフックでカードにその情報を書かないといけない
+    …GitHub から信号が帰ってきたときに、フックでカードに書き込む、
+    それがエージェントに通知が行く
+
+— so there are exactly two entry points, sharing exactly one card:
+
+    push     ← the git ``pre-push`` hook, in the pushing agent's container
+    verdict  ← a job on the runner that sits on the control-plane host
+
+This file orchestrates. :mod:`ci_rail_cards` owns the card contract and
+the store guard; :mod:`ci_rail_listen` owns delivery. The split is by
+failure domain, not by size: a store that is silently the wrong database
+and a bus that silently reaches nobody are different bugs with different
+evidence, and each module carries the measurements for its own.
+
+DEPENDENCIES ARE DELIBERATELY THIN — standard library, plus a lazy
+``scitex_cards`` import for the card write. No ``scitex_agent_container``
+import: this runs under ``uv run --with scitex-cards`` on a runner with
+no sac installed, and from a git hook inside an agent container. Every
+sac fact is fetched over its loopback HTTP control plane instead.
+
+FAILING LOUDLY IS THE FEATURE. On the ``verdict`` path every
+unrecoverable condition — unreachable daemon, non-2xx, unresolvable
+recipient, refused card write, wrong store — exits non-zero and turns the
+step red, because a notification rail that fails quietly is the original
+defect wearing a fix. The single deliberate non-failure is a delivered
+count of zero: the event is already persisted and will replay, so that is
+a warning naming the RECIPIENT as the fault rather than a red step
+blaming the rail. The ``push`` path inverts the trade-off and never
+blocks a push — a card-store hiccup must not cost an engineer their work,
+and the verdict half creates the card when it finds none.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.error
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from ci_rail_cards import (  # noqa: E402 — sibling module, path fixed up above
+    STATUS_FOR_CONCLUSION,
+    card_id_for,
+    card_title,
+    cards,
+    get_card,
+    now_stamp,
+    record_push,
+    repo_basename,
+    resolved_store_dsn,
+    upsert_card,
+)
+from ci_rail_failure import summarize_failures  # noqa: E402 — sibling module
+from ci_rail_listen import (  # noqa: E402 — sibling module, path fixed up above
+    TOKEN_DIR,
+    fleet_agents,
+    listen_base_url,
+    listen_token,
+    notify_agent,
+    reachability_of,
+)
+
+# A verdict is only reported for conclusions that ARE a verdict. A
+# cancelled run means a newer push superseded this one (the gate sets
+# ``cancel-in-progress``), not a statement about the code; reporting it
+# would train the fleet to ignore this rail.
+TERMINAL_CONCLUSIONS = frozenset({"success", "failure"})
+
+# The identity of the pushing agent, in precedence order.
+# ``$SCITEX_TODO_AGENT_ID`` is the card package's own canonical variable
+# and so leads — but it is NOT reliably present: measured unset in this
+# container's shell, and present in the cards MCP server process as the
+# literal, unexpanded string ``${SCITEX_TODO_AGENT_ID}``. The sac-side
+# names are set by the runtime that launched the container and were
+# measured correct, so they are working fallbacks rather than decoration.
+# An owner-less card is REJECTED by the store — there is no silent
+# fallback there — so resolving this is what makes the push half work.
+AGENT_ID_ENV_VARS = (
+    "SCITEX_TODO_AGENT_ID",
+    "SAC_NAME",
+    "SCITEX_AGENT_CONTAINER_AGENT",
+    "CLAUDE_AGENT_ID",
+)
+
+__all__ = [
+    "TERMINAL_CONCLUSIONS",
+    "main",
+    "pushing_agent",
+    "record_verdict",
+    "resolve_recipient",
+    "verdict_text",
+]
+
+
+def pushing_agent() -> str | None:
+    """First non-empty, non-template agent identity from the environment."""
+    for var in AGENT_ID_ENV_VARS:
+        value = (os.environ.get(var) or "").strip()
+        # Reject an unexpanded shell template rather than filing cards
+        # owned by an agent literally named "${SCITEX_TODO_AGENT_ID}".
+        if value and not value.startswith("${"):
+            return value
+    return None
+
+
+def _warn(msg: str) -> None:
+    """A GitHub warning annotation that stays readable off-CI."""
+    print(f"::warning::{msg}", flush=True)
+
+
+def _die(msg: str, code: int = 1) -> int:
+    """Fail loudly: an error annotation AND a non-zero exit — both.
+
+    The annotation is what a human sees on the run page; the exit code is
+    what turns the step red so the run page gets looked at at all.
+    """
+    print(f"::error::{msg}", file=sys.stderr, flush=True)
+    print(f"::error::{msg}", flush=True)
+    return code
+
+
+def resolve_recipient(
+    *, card: dict[str, Any] | None, repo: str, agents: list[dict[str, Any]]
+) -> tuple[str | None, str]:
+    """Who should hear this verdict? Returns ``(name, how_it_was_decided)``.
+
+    Precedence, and the reason for each step:
+
+    1. **The card's own agent**, set by ``pre-push`` to whoever actually
+       pushed. A verdict belongs to the pusher, and no inference beats a
+       record of the fact.
+    2. **An agent spec whose ``project`` matches the repo, PREFERRING one
+       that is reachable right now.** sac's ``_ci_owner.resolve_owner``
+       makes the same match but takes the first hit in sorted filename
+       order, which on this very repo deterministically selects
+       ``scitex-agent-container-04`` — zero inbox subscribers since
+       2026-08-10. Sorting reachable candidates first is the whole
+       difference between a delivered verdict and a silent one, and is
+       why this does not simply call that function.
+
+    ``None`` means nobody could be resolved; the caller must treat that
+    as an error, never as a quiet skip.
+    """
+    if card:
+        named = card.get("agent") or card.get("assignee")
+        if isinstance(named, str) and named.strip():
+            return named.strip(), "card"
+
+    base = repo_basename(repo)
+    matches = [a for a in agents if str(a.get("project", "")).strip() == base]
+    if not matches:
+        return None, "unresolved"
+    matches.sort(
+        key=lambda a: (
+            a.get("inbox_reachable") != "reachable",
+            -int(a.get("inbox_subscribers") or 0),
+            str(a.get("started_at") or ""),
+        )
+    )
+    name = matches[0].get("name")
+    return (str(name) if name else None), "spec"
+
+
+def verdict_text(
+    *,
+    repo: str,
+    branch: str,
+    sha: str,
+    conclusion: str,
+    leg: str,
+    run_url: str,
+    detail: str = "",
+) -> str:
+    """The message a woken human reads.
+
+    ``detail`` names what broke. It is not decoration: a notification
+    that arrives and says only "Red" has solved half the problem, and
+    half is measurable here — seven consecutive red nights on this fleet
+    reached nobody, and the fix for that is not merely arriving, it is
+    arriving with the failing test named.
+
+    Deliberately NO attribution. The rail reports the verdict and quotes
+    the log; it does not say WHY, because it cannot know, and a rail that
+    guesses causes teaches people to distrust the ones it gets right.
+    """
+    head = f"CI {conclusion.upper()} — {repo_basename(repo)} `{branch}` ({sha[:8]})"
+    if leg:
+        head += f" [{leg}]"
+    tail = (
+        "Green. Self-merge if you own it — do NOT poll `gh pr checks`."
+        if conclusion == "success"
+        else "Red. Fix and push; this rail re-fires on your next push."
+    )
+    parts = [f"{head}.", tail]
+    if detail.strip():
+        parts.append(detail.strip())
+    parts.append(f"Run: {run_url}")
+    parts.append(f"Card: {card_id_for(repo, sha)}")
+    return "\n".join(parts)
+
+
+def record_verdict(
+    *,
+    repo: str,
+    branch: str,
+    sha: str,
+    conclusion: str,
+    leg: str,
+    run_url: str,
+    token: str,
+    run_id: str = "",
+) -> int:
+    """Write the verdict onto the card, then deliver it. Returns an exit code."""
+    pkg = cards()
+    card_id = card_id_for(repo, sha)
+    # Print the store BEFORE writing. Two databases on this host answer
+    # to the same store_uuid, so "which one did CI write to" is a real
+    # question a reader will have, and the run log is the only place it
+    # can be answered after the fact.
+    print(f"card store: {resolved_store_dsn()}", flush=True)
+
+    agents = fleet_agents(token)
+    card = get_card(pkg, card_id)
+    if card is None:
+        _warn(
+            f"no card for {card_id} — the pre-push hook did not run for "
+            f"{sha[:8]}. Creating one now so the verdict is still recorded."
+        )
+    recipient, how = resolve_recipient(card=card, repo=repo, agents=agents)
+    if not recipient:
+        return _die(
+            f"no recipient for {repo}@{sha[:8]}: the card names no agent and no "
+            f"agent spec declares project={repo_basename(repo)!r}. A verdict "
+            "with no addressee is exactly the silent-nobody failure this rail "
+            "exists to remove, so this step fails instead of dropping it."
+        )
+
+    # RECORD FIRST, DELIVER SECOND. The card is the durable statement of
+    # what CI decided; the notification is a courtesy copy. If delivery
+    # fails, the verdict is still on the board — which is not true in the
+    # other order.
+    # Only a red verdict needs the log read; a green one has nothing to
+    # name and the API call would be pure latency.
+    detail = summarize_failures(repo, run_id) if conclusion == "failure" else ""
+    body = verdict_text(
+        repo=repo,
+        branch=branch,
+        sha=sha,
+        conclusion=conclusion,
+        leg=leg,
+        run_url=run_url,
+        detail=detail,
+    )
+    upsert_card(
+        pkg,
+        card_id,
+        title=card_title(repo, branch, sha, conclusion),
+        status=STATUS_FOR_CONCLUSION[conclusion],
+        kind="task",
+        repo=repo_basename(repo),
+        project=repo_basename(repo),
+        agent=recipient,
+        assignee=recipient,
+        note=(
+            f"CI {conclusion} for {sha[:8]} ({leg or 'gate'}) at {now_stamp()} "
+            f"— {run_url}"
+        ),
+        last_activity=now_stamp(),
+    )
+    pkg.comment_task(task_id=card_id, text=body, by="ci")
+    print(
+        f"card {card_id}: recorded {conclusion} "
+        f"(status={STATUS_FOR_CONCLUSION[conclusion]})",
+        flush=True,
+    )
+
+    reach, subs = reachability_of(agents, recipient)
+    print(
+        f"recipient {recipient} (via {how}); inbox_reachable={reach} subscribers={subs}",
+        flush=True,
+    )
+
+    try:
+        result = notify_agent(token, agent=recipient, body=body, card_id=card_id)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:400]
+        return _die(f"POST /v1/notify -> HTTP {exc.code}: {detail}")
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return _die(f"POST /v1/notify to {listen_base_url()} failed: {exc}")
+
+    delivered = int(result.get("delivered_subscriber_count") or 0)
+    print(
+        f"notified {recipient}: msg_id={result.get('msg_id')} "
+        f"delivered_subscriber_count={delivered}",
+        flush=True,
+    )
+    if delivered == 0:
+        # NOT an error, and the distinction is the entire point. The event
+        # is already persisted in ``channel_events``; a zero count means
+        # the RECIPIENT is deaf right now, not that the RAIL is broken.
+        # Name which, so nobody spends a night debugging the other one.
+        _warn(
+            f"{recipient} has no live inbox subscriber (inbox_reachable={reach}). "
+            "The verdict is persisted and replays on its next connect, but it "
+            "did NOT reach a live session. This is a RECIPIENT fault, not a rail "
+            "fault: the card and the channel_events row both exist."
+        )
+    return 0
+
+
+def _cmd_push(args: argparse.Namespace) -> int:
+    """Never blocks a push: loud on stderr, exit 0 regardless.
+
+    A push must not fail because a card store hiccupped, and it need not
+    — the verdict half creates the card when it finds none, so the worst
+    case here is a verdict routed by agent spec instead of recorded fact.
+    """
+    try:
+        record_push(
+            repo=args.repo,
+            branch=args.branch,
+            sha=args.sha,
+            agent=args.agent.strip() or pushing_agent(),
+            subject=args.subject or "",
+        )
+    except Exception as exc:  # noqa: BLE001 — see the docstring
+        print(
+            f"ci_card_rail: push NOT recorded on a card ({exc}); the push "
+            "itself is unaffected and CI will create the card instead.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 0
+    print(
+        f"ci_card_rail: recorded push {args.sha[:8]} on "
+        f"{card_id_for(args.repo, args.sha)}"
+    )
+    return 0
+
+
+def _cmd_verdict(args: argparse.Namespace) -> int:
+    conclusion = (args.conclusion or "").strip().lower()
+    if conclusion not in TERMINAL_CONCLUSIONS:
+        print(
+            f"ci_card_rail: conclusion {conclusion!r} is not a verdict "
+            "(cancelled/skipped means a superseded push) — nothing reported.",
+            flush=True,
+        )
+        return 0
+    token = listen_token()
+    if not token:
+        return _die(
+            "no sac listen bearer token: set $SAC_LISTEN_BEARER, or provide "
+            f"~/{TOKEN_DIR}/listen-<host>.token. Refusing to skip delivery "
+            "silently."
+        )
+    try:
+        return record_verdict(
+            repo=args.repo,
+            branch=args.branch,
+            sha=args.sha,
+            conclusion=conclusion,
+            leg=args.leg or "",
+            run_url=args.run_url or "",
+            token=token,
+            run_id=args.run_id or "",
+        )
+    except ImportError as exc:
+        return _die(f"scitex_cards is not importable on this runner: {exc}")
+    except Exception as exc:  # noqa: BLE001 — a rail that fails quietly is the bug
+        return _die(f"verdict for {args.repo}@{args.sha[:8]} not recorded: {exc}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ci_card_rail", description="push -> card -> CI verdict -> agent"
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    push = sub.add_parser("push", help="record a push on its card (git pre-push hook)")
+    push.add_argument("--repo", required=True)
+    push.add_argument("--branch", required=True)
+    push.add_argument("--sha", required=True)
+    push.add_argument("--agent", default="")
+    push.add_argument("--subject", default="")
+    push.set_defaults(func=_cmd_push)
+
+    verdict = sub.add_parser(
+        "verdict", help="write CI's verdict to the card and notify the agent"
+    )
+    verdict.add_argument("--repo", required=True)
+    verdict.add_argument("--branch", required=True)
+    verdict.add_argument("--sha", required=True)
+    verdict.add_argument("--conclusion", required=True)
+    verdict.add_argument("--leg", default="")
+    verdict.add_argument("--run-url", dest="run_url", default="")
+    verdict.add_argument("--run-id", dest="run_id", default="")
+    verdict.set_defaults(func=_cmd_verdict)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# EOF

--- a/.github/ci/ci_card_rail.py
+++ b/.github/ci/ci_card_rail.py
@@ -51,6 +51,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from ci_rail_cards import (  # noqa: E402 — sibling module, path fixed up above
     BLOCKER_CLEARED,
     STATUS_FOR_CONCLUSION,
+    VERDICT_ACTOR,
     card_id_for,
     card_title,
     cards,
@@ -279,6 +280,13 @@ def record_verdict(
     upsert_card(
         pkg,
         card_id,
+        # A runner's `run:` step carries NO agent identity, and the store
+        # refuses to invent a creator. Without this the verdict half
+        # cannot create a card -- the path taken whenever the pre-push
+        # hook did not run, i.e. every human push and every repo where
+        # the hook is not installed. The rail would fail precisely where
+        # it is meant to be the safety net.
+        create_only={"created_by": VERDICT_ACTOR},
         title=card_title(repo, branch, sha, conclusion),
         status=STATUS_FOR_CONCLUSION[conclusion],
         # CLOSE THE LOOP. The push half parked this card as blocked on

--- a/.github/ci/ci_card_rail.py
+++ b/.github/ci/ci_card_rail.py
@@ -49,6 +49,7 @@ from typing import Any
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from ci_rail_cards import (  # noqa: E402 — sibling module, path fixed up above
+    BLOCKER_CLEARED,
     STATUS_FOR_CONCLUSION,
     card_id_for,
     card_title,
@@ -266,6 +267,12 @@ def record_verdict(
         card_id,
         title=card_title(repo, branch, sha, conclusion),
         status=STATUS_FOR_CONCLUSION[conclusion],
+        # CLOSE THE LOOP. The push half parked this card as blocked on
+        # `compute` (waiting for a machine). If the verdict did not clear
+        # that, every pushed commit would leave behind a card blocked
+        # forever on a gate that has already opened -- this rail's own
+        # failure mode, reproduced one level up and at one card per push.
+        blocker=BLOCKER_CLEARED,
         kind="task",
         repo=repo_basename(repo),
         project=repo_basename(repo),

--- a/.github/ci/ci_card_rail.py
+++ b/.github/ci/ci_card_rail.py
@@ -197,8 +197,22 @@ def verdict_text(
     head = f"CI {conclusion.upper()} — {repo_basename(repo)} `{branch}` ({sha[:8]})"
     if leg:
         head += f" [{leg}]"
+    # THE GREEN MESSAGE MUST NOT CLAIM MERGEABILITY. This rail sees ONE
+    # workflow -- the pytest gate -- because `needs:` cannot reach across
+    # workflow files. lint, quality-audit, import-smoke and the
+    # hosted-runner guard all report separately and are invisible here.
+    #
+    # This said "Green. Self-merge if you own it." That was a verdict
+    # computed over the checks that happen to be in view, presented as a
+    # verdict over the checks that should have run -- the same shape as
+    # reading a queued check as green, which is the bug this whole rail
+    # exists to answer. Reproducing it inside the fix would be the worst
+    # possible place for it. So: state the scope, and let the reader own
+    # the merge decision.
     tail = (
-        "Green. Self-merge if you own it — do NOT poll `gh pr checks`."
+        "The pytest gate is green for this commit. It is NOT a merge signal: "
+        "lint, quality, import-smoke and the runner guard report separately "
+        "and this rail cannot see them."
         if conclusion == "success"
         else "Red. Fix and push; this rail re-fires on your next push."
     )

--- a/.github/ci/ci_card_rail.py
+++ b/.github/ci/ci_card_rail.py
@@ -63,6 +63,10 @@ from ci_rail_cards import (  # noqa: E402 — sibling module, path fixed up abov
     upsert_card,
 )
 from ci_rail_failure import summarize_failures  # noqa: E402 — sibling module
+from ci_rail_message import (  # noqa: E402 — sibling module
+    sibling_workflow_names,
+    verdict_text,
+)
 from ci_rail_listen import (  # noqa: E402 — sibling module, path fixed up above
     TOKEN_DIR,
     fleet_agents,
@@ -173,57 +177,6 @@ def resolve_recipient(
     return (str(name) if name else None), "spec"
 
 
-def verdict_text(
-    *,
-    repo: str,
-    branch: str,
-    sha: str,
-    conclusion: str,
-    leg: str,
-    run_url: str,
-    detail: str = "",
-) -> str:
-    """The message a woken human reads.
-
-    ``detail`` names what broke. It is not decoration: a notification
-    that arrives and says only "Red" has solved half the problem, and
-    half is measurable here — seven consecutive red nights on this fleet
-    reached nobody, and the fix for that is not merely arriving, it is
-    arriving with the failing test named.
-
-    Deliberately NO attribution. The rail reports the verdict and quotes
-    the log; it does not say WHY, because it cannot know, and a rail that
-    guesses causes teaches people to distrust the ones it gets right.
-    """
-    head = f"CI {conclusion.upper()} — {repo_basename(repo)} `{branch}` ({sha[:8]})"
-    if leg:
-        head += f" [{leg}]"
-    # THE GREEN MESSAGE MUST NOT CLAIM MERGEABILITY. This rail sees ONE
-    # workflow -- the pytest gate -- because `needs:` cannot reach across
-    # workflow files. lint, quality-audit, import-smoke and the
-    # hosted-runner guard all report separately and are invisible here.
-    #
-    # This said "Green. Self-merge if you own it." That was a verdict
-    # computed over the checks that happen to be in view, presented as a
-    # verdict over the checks that should have run -- the same shape as
-    # reading a queued check as green, which is the bug this whole rail
-    # exists to answer. Reproducing it inside the fix would be the worst
-    # possible place for it. So: state the scope, and let the reader own
-    # the merge decision.
-    tail = (
-        "The pytest gate is green for this commit. It is NOT a merge signal: "
-        "lint, quality, import-smoke and the runner guard report separately "
-        "and this rail cannot see them."
-        if conclusion == "success"
-        else "Red. Fix and push; this rail re-fires on your next push."
-    )
-    parts = [f"{head}.", tail]
-    if detail.strip():
-        parts.append(detail.strip())
-    parts.append(f"Run: {run_url}")
-    parts.append(f"Card: {card_id_for(repo, sha)}")
-    return "\n".join(parts)
-
 
 def record_verdict(
     *,
@@ -235,6 +188,7 @@ def record_verdict(
     run_url: str,
     token: str,
     run_id: str = "",
+    workflow: str = "",
 ) -> int:
     """Write the verdict onto the card, then deliver it. Returns an exit code."""
     pkg = cards()
@@ -276,6 +230,10 @@ def record_verdict(
         leg=leg,
         run_url=run_url,
         detail=detail,
+        card_id=card_id,
+        # Derived from the checkout at verdict time, so a workflow added
+        # later cannot silently drop out of the disclaimer.
+        unobserved=sibling_workflow_names(workflow),
     )
     upsert_card(
         pkg,
@@ -307,11 +265,48 @@ def record_verdict(
         last_activity=now_stamp(),
     )
     pkg.comment_task(task_id=card_id, text=body, by="ci")
-    print(
-        f"card {card_id}: recorded {conclusion} "
-        f"(status={STATUS_FOR_CONCLUSION[conclusion]})",
-        flush=True,
-    )
+    # READ BACK THE FIELD, NOT THE CARD'S EXISTENCE. A presence check
+    # passes straight through the failure this guards against.
+    #
+    # The shared board takes its mutex as an flock on a file INSIDE each
+    # container, while the cards live in one shared postgres. Two agents
+    # each lock their own copy, both succeed instantly, and both do
+    # read-whole-store -> mutate -> write-whole-store. Last writer wins
+    # and silently reverts the other -- measured on the live store, where
+    # a `complete_task` that RETURNED done was later found blocked,
+    # undone by writes to entirely unrelated cards. The store's own
+    # shrink guard compares the set of IDS, so it sees a card VANISH but
+    # never a card REGRESS, and the confirmed loss passed it cleanly.
+    #
+    # That failure is this rail's thesis turned against it: a verdict
+    # written and silently reverted is INDISTINGUISHABLE from a verdict
+    # never written -- the card exists, looks like ours, and says the
+    # wrong thing. So verify the VALUE, rewrite once, and if the store
+    # still disagrees, fail loudly rather than notify anyone about a
+    # record that has already evaporated.
+    expected = STATUS_FOR_CONCLUSION[conclusion]
+    stored = (get_card(pkg, card_id) or {}).get("status")
+    if stored != expected:
+        _warn(
+            f"card {card_id}: wrote status={expected!r} but the store reads "
+            f"{stored!r} — a concurrent writer clobbered it. Rewriting once."
+        )
+        upsert_card(
+            pkg,
+            card_id,
+            title=card_title(repo, branch, sha, conclusion),
+            status=expected,
+            blocker=BLOCKER_CLEARED,
+            last_activity=now_stamp(),
+        )
+        stored = (get_card(pkg, card_id) or {}).get("status")
+        if stored != expected:
+            return _die(
+                f"card {card_id}: status reads {stored!r} after writing "
+                f"{expected!r} twice. The verdict is NOT durably recorded, so "
+                "this fails rather than announcing a record that does not exist."
+            )
+    print(f"card {card_id}: recorded {conclusion} (status={expected}, read back)")
 
     reach, subs = reachability_of(agents, recipient)
     print(
@@ -403,6 +398,7 @@ def _cmd_verdict(args: argparse.Namespace) -> int:
             run_url=args.run_url or "",
             token=token,
             run_id=args.run_id or "",
+            workflow=args.workflow or "",
         )
     except ImportError as exc:
         return _die(f"scitex_cards is not importable on this runner: {exc}")
@@ -434,6 +430,9 @@ def build_parser() -> argparse.ArgumentParser:
     verdict.add_argument("--leg", default="")
     verdict.add_argument("--run-url", dest="run_url", default="")
     verdict.add_argument("--run-id", dest="run_id", default="")
+    # The workflow this rail OBSERVES; every other workflow in the
+    # checkout becomes the "cannot see" list on a green verdict.
+    verdict.add_argument("--workflow", default="")
     verdict.set_defaults(func=_cmd_verdict)
     return parser
 

--- a/.github/ci/ci_rail_cards.py
+++ b/.github/ci/ci_rail_cards.py
@@ -97,6 +97,63 @@ def card_id_for(repo: str, sha: str) -> str:
     return f"ci-{repo_basename(repo)}-{sha[:12]}"
 
 
+def card_scope(repo: str, branch: str) -> str:
+    """The queryable key for "all CI cards on this branch".
+
+    Exists so :func:`supersede_older` can ask the store a question
+    instead of parsing card titles. A branch is the unit that advances,
+    so it is the unit superseding is scoped to.
+    """
+    return f"ci:{repo_basename(repo)}:{branch}"
+
+
+def supersede_older(pkg: Any, *, repo: str, branch: str, sha: str) -> list[str]:
+    """Close pending cards on this branch left behind by an older commit.
+
+    THE ORPHAN THIS FIXES. A card is opened per pushed SHA and settled by
+    that SHA's verdict. When the branch advances -- a follow-up commit, a
+    force-push, a rebase -- the older run is cancelled by
+    `cancel-in-progress`, and a cancelled run is deliberately NOT a
+    verdict. So the older card could never settle by any event: closing
+    it `done` would assert a green nobody measured, and leaving it parks
+    a card forever on a gate that will never open. On a busy branch that
+    is MOST cards, and the rail would bury its own signal under its own
+    debris.
+
+    `cancelled` is the honest terminal state: the question was withdrawn,
+    not answered. The superseding SHA is named so the trail is walkable.
+
+    Best-effort by contract -- it runs inside the push hook, where
+    nothing may block a push. Returns the ids it closed.
+    """
+    closed: list[str] = []
+    keep = card_id_for(repo, sha)
+    for task in pkg.list_tasks(scope=card_scope(repo, branch)):
+        task_id = str(task.get("id") or "")
+        if task_id == keep or not task_id.startswith("ci-"):
+            continue
+        if task.get("status") != PENDING_STATUS:
+            continue
+        pkg.update_task(
+            task_id=task_id,
+            status="cancelled",
+            blocker=BLOCKER_CLEARED,
+            note=(
+                f"Superseded by {sha[:8]} on {branch} at {now_stamp()}. Its gate "
+                "run was cancelled by cancel-in-progress, and a cancelled run is "
+                "not a verdict — so no event could ever settle this card."
+            ),
+            last_activity=now_stamp(),
+        )
+        pkg.comment_task(
+            task_id=task_id,
+            text=f"Superseded by `{sha[:8]}`. Closing: no verdict is owed for this sha.",
+            by="ci",
+        )
+        closed.append(task_id)
+    return closed
+
+
 def card_title(repo: str, branch: str, sha: str, verdict: str = "") -> str:
     """A title legible on a phone at 4am, which is where this lands.
 
@@ -212,6 +269,7 @@ def record_push(
     fields: dict[str, Any] = {
         "status": PENDING_STATUS,
         "blocker": PENDING_BLOCKER,
+        "scope": card_scope(repo, branch),
         "kind": "task",
         "repo": repo_basename(repo),
         "project": repo_basename(repo),
@@ -227,6 +285,15 @@ def record_push(
     if subject.strip():
         line += f" — {subject.strip().splitlines()[0][:120]}"
     pkg.comment_task(task_id=card_id, text=line, by=agent or "ci")
+
+    # The branch has just advanced, so this is the moment older pending
+    # cards on it became unanswerable. Doing it HERE rather than at
+    # verdict time means the board is correct immediately, and stays
+    # correct even when the superseded run's verdict job never runs at
+    # all -- which is the usual case, since cancel-in-progress kills it.
+    superseded = supersede_older(pkg, repo=repo, branch=branch, sha=sha)
+    if superseded:
+        print(f"ci_card_rail: superseded {', '.join(superseded)}")
     return card
 
 

--- a/.github/ci/ci_rail_cards.py
+++ b/.github/ci/ci_rail_cards.py
@@ -35,6 +35,34 @@ from typing import Any
 # which is what makes ``failed`` both terminal and honest here.
 STATUS_FOR_CONCLUSION = {"success": "done", "failure": "failed"}
 
+# A pushed commit awaiting CI is BLOCKED ON COMPUTE, and both halves of
+# that phrase are load-bearing.
+#
+# Not ``in_progress``: nobody is doing it. A pending card in the runnable
+# set is indistinguishable from a stalled one to every reader and every
+# stop hook, and with queue p90 at ~902 s it would sit there looking
+# abandoned for a quarter of an hour on a healthy day. One card per push
+# per repo in that state is not a board, it is a log wearing a board's
+# clothes -- and it blocked a peer's board three times in an hour before
+# this changed.
+#
+# But ALSO not a bare ``blocked``: a blocked card with no named gate
+# nudges nobody and leaves the runnable count, which is how 21 operator
+# decisions sat invisible for weeks. ``compute`` is the store's own word
+# for "waiting on a machine", which is precisely and literally what a
+# queued CI run is. So the card is out of the runnable set AND says why.
+#
+# The verdict half MUST clear this blocker (see ``BLOCKER_CLEARED``). A
+# pending card whose verdict never arrives is this rail's own failure
+# mode reproduced one level up.
+PENDING_STATUS = "blocked"
+PENDING_BLOCKER = "compute"
+
+# The card package clears a field when handed an empty string. Named,
+# because ``blocker=""`` at a call site reads like an oversight and is
+# in fact the whole close-the-loop step.
+BLOCKER_CLEARED = ""
+
 __all__ = [
     "STATUS_FOR_CONCLUSION",
     "card_id_for",
@@ -170,15 +198,20 @@ def record_push(
 ) -> Any:
     """Register a push on its card. Driven by the ``pre-push`` hook.
 
-    ``agent`` is whoever actually pushed, and recording it is the whole
-    reason the verdict half can address the right agent later. Status is
-    ``in_progress``: a pushed commit awaiting CI is work in flight, and
-    the owner is the person who can act on it.
+    ``agent`` is whoever actually PUSHED -- resolved from the pushing
+    process's own environment, never from the repo's owning agent. The
+    distinction matters the moment this leaves one repo: the pusher is
+    who can act on a red verdict, whereas a repo-level identity simply
+    accumulates everybody's pushes onto one board.
+
+    Status is ``blocked``/``compute`` -- waiting on a machine, with the
+    gate named. See ``PENDING_STATUS``.
     """
     pkg = cards()
     card_id = card_id_for(repo, sha)
     fields: dict[str, Any] = {
-        "status": "in_progress",
+        "status": PENDING_STATUS,
+        "blocker": PENDING_BLOCKER,
         "kind": "task",
         "repo": repo_basename(repo),
         "project": repo_basename(repo),

--- a/.github/ci/ci_rail_cards.py
+++ b/.github/ci/ci_rail_cards.py
@@ -1,0 +1,200 @@
+"""The card half of the CI feedback rail: the card contract, and safe
+access to the one store that is actually the fleet's board.
+
+Companion to :mod:`ci_card_rail` (orchestration + CLI) and
+:mod:`ci_rail_listen` (delivery). This module owns the shape of the card
+a push and a verdict share, and the guard that decides whether the store
+in front of us is the real one.
+
+THE CARD IS THE RAIL'S ROUTING TABLE, not merely its output. ``pre-push``
+records WHO pushed; the verdict half reads that back and delivers to that
+agent instead of inferring an owner from the repo name. On this repo the
+inference is genuinely wrong: two agent specs declare
+``project: scitex-agent-container`` and sac's own ``resolve_owner`` takes
+the one that sorts first, which is the one with no inbox subscriber.
+
+WHY THE STORE GUARD EXISTS — measured, not hypothetical. See
+:func:`cards`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+# CI outcome -> card status. ``failed``, deliberately NOT ``blocked``, and
+# the difference is not cosmetic. A ``blocked`` card must name the gate
+# holding it, and this store's blockers are ('compute', 'dependency',
+# 'dep', 'operator-decision', 'agent-wait', 'none') — none of which
+# describes a red test suite. A red gate waits on nobody; it is a finished
+# run with a bad result that its owner can act on immediately. Filing it
+# as ``blocked`` with no gate would drop it into exactly the state this
+# fleet spent 2026-08-11 paying for: cards that nudge nobody and are
+# excluded from the runnable count, invisible until someone goes looking.
+# A fix arrives as a NEW push with a NEW sha and therefore a NEW card,
+# which is what makes ``failed`` both terminal and honest here.
+STATUS_FOR_CONCLUSION = {"success": "done", "failure": "failed"}
+
+__all__ = [
+    "STATUS_FOR_CONCLUSION",
+    "card_id_for",
+    "card_title",
+    "cards",
+    "get_card",
+    "now_stamp",
+    "record_push",
+    "repo_basename",
+    "upsert_card",
+]
+
+
+def now_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def repo_basename(repo: str) -> str:
+    return repo.rstrip("/").split("/")[-1].strip()
+
+
+def card_id_for(repo: str, sha: str) -> str:
+    """The card id both halves of the rail derive independently.
+
+    Twelve hex characters of the head sha: long enough that a collision
+    is not a practical concern, short enough to stay readable. Keyed on
+    the HEAD SHA rather than the branch because a branch is reused across
+    pushes while a verdict belongs to the commit it judged. Deriving it
+    on both sides is what removes the need for any channel between a git
+    hook and a runner job that starts minutes later.
+    """
+    return f"ci-{repo_basename(repo)}-{sha[:12]}"
+
+
+def card_title(repo: str, branch: str, sha: str, verdict: str = "") -> str:
+    """A title legible on a phone at 4am, which is where this lands.
+
+    The verdict leads, because that is the one word a woken reader needs.
+    Repo and branch follow, because a bare short sha identifies nothing
+    to a human. The id is for the two halves of the rail to agree on; the
+    title is for the person.
+    """
+    tag = f"ci {verdict}".strip().upper() if verdict else "ci"
+    return f"[{tag}] {repo_basename(repo)} {branch} {sha[:8]}"
+
+
+def cards() -> Any:
+    """The card package, with the store it resolved to CHECKED, not assumed.
+
+    This guard is not defensive padding; every clause is a measured
+    failure on this host.
+
+    * ``127.0.0.1:5442`` and ``127.0.0.1:55432`` BOTH answer, BOTH report
+      ``store_uuid`` ``1d55dd6e-…``, and hold 3496 vs 3793 cards. Two
+      divergent databases wearing one identity — so the field designed to
+      detect a split is precisely the field that cannot detect this one.
+      The cause is now traced: an MCP entry pinned the DSN literally to
+      ``:5442`` (an SSH tunnel to another box's postgres) while every
+      shell reads ``:55432``, so a process's card writes and its own
+      read-back can land in different databases with nothing saying so.
+    * An UNSET ``$SCITEX_CARDS_DB`` does not fail. It silently resolves to
+      a local ``cards.db`` FILE that no board reads. A runner's ``run:``
+      step gets a non-interactive shell sourcing no profile, so unset is
+      exactly what it sees unless the workflow passes the DSN explicitly.
+
+    Writing a verdict into a store nobody reads is the same silent-nobody
+    failure as delivering to a deaf agent. So: resolve, check, and refuse
+    — and RETURN the resolved target so the caller can print it, because
+    a rail that cannot say which database it wrote to cannot be audited.
+    """
+    import scitex_cards
+
+    resolved = scitex_cards.resolve_store() or {}
+    backend = str(resolved.get("backend") or "").lower()
+    if backend not in ("postgresql", "postgres"):
+        raise RuntimeError(
+            f"card store resolved to {resolved.get('resolved')!r} "
+            f"(backend={backend!r}), not the fleet's postgres store. Set "
+            "$SCITEX_CARDS_DB explicitly — an unset DSN falls back to a "
+            "local file that no board reads."
+        )
+    return scitex_cards
+
+
+def resolved_store_dsn() -> str:
+    """The DSN actually in force, for logging. Never raises."""
+    try:
+        import scitex_cards
+
+        return str((scitex_cards.resolve_store() or {}).get("resolved") or "?")
+    except Exception:  # noqa: BLE001 — a logging aid must not break the rail
+        return "?"
+
+
+def get_card(pkg: Any, card_id: str) -> dict[str, Any] | None:
+    """The card, or ``None`` if it genuinely does not exist yet.
+
+    ONLY ``TaskNotFoundError`` means "not there"; everything else is
+    re-raised, and that narrowness is a scar. This began as a bare
+    ``except Exception: return None``, which turned a keyword-argument
+    mistake (``get_task`` takes ``task_id=``, not a positional) into a
+    phantom "no such card" — so the caller went on to ``add_task`` and
+    hit a duplicate-id error one layer away from the cause. A read fault
+    dressed as absence is exactly the silent failure this rail exists to
+    delete; it must not live inside the rail itself.
+
+    A caution for whoever debugs this next: the not-found error text
+    names ``~/.scitex/cards/tasks.yaml``, which is neither the resolved
+    DSN nor the ``user_store`` path. Do not read that string as evidence
+    of which store was queried — it names one that was not.
+    """
+    try:
+        return pkg.get_task(task_id=card_id)
+    except pkg.TaskNotFoundError:
+        return None
+
+
+def upsert_card(pkg: Any, card_id: str, *, title: str, **fields: Any) -> Any:
+    """Create the card, or update it when this rail already made one.
+
+    ``add_task`` raises on an existing id, so the read decides. No lock
+    spans the two halves of the rail and none is needed: the push half
+    runs minutes ahead of the verdict half, and even a genuine race
+    converges, because both sides write the same derived id.
+    """
+    if get_card(pkg, card_id) is None:
+        return pkg.add_task(id=card_id, title=title, **fields)
+    return pkg.update_task(task_id=card_id, title=title, **fields)
+
+
+def record_push(
+    *, repo: str, branch: str, sha: str, agent: str | None, subject: str = ""
+) -> Any:
+    """Register a push on its card. Driven by the ``pre-push`` hook.
+
+    ``agent`` is whoever actually pushed, and recording it is the whole
+    reason the verdict half can address the right agent later. Status is
+    ``in_progress``: a pushed commit awaiting CI is work in flight, and
+    the owner is the person who can act on it.
+    """
+    pkg = cards()
+    card_id = card_id_for(repo, sha)
+    fields: dict[str, Any] = {
+        "status": "in_progress",
+        "kind": "task",
+        "repo": repo_basename(repo),
+        "project": repo_basename(repo),
+        "note": f"pushed {sha[:8]} on {branch} at {now_stamp()}; CI verdict pending.",
+        "last_activity": now_stamp(),
+    }
+    if agent:
+        fields.update(agent=agent, assignee=agent, created_by=agent)
+    card = upsert_card(
+        pkg, card_id, title=card_title(repo, branch, sha, "pending"), **fields
+    )
+    line = f"pushed `{sha[:8]}` to `{branch}`"
+    if subject.strip():
+        line += f" — {subject.strip().splitlines()[0][:120]}"
+    pkg.comment_task(task_id=card_id, text=line, by=agent or "ci")
+    return card
+
+
+# EOF

--- a/.github/ci/ci_rail_cards.py
+++ b/.github/ci/ci_rail_cards.py
@@ -63,6 +63,24 @@ PENDING_BLOCKER = "compute"
 # in fact the whole close-the-loop step.
 BLOCKER_CLEARED = ""
 
+# Who the store records as having filed a CI-created card.
+#
+# The store demands a creator AND an assignee and refuses to invent
+# either -- correctly, since an owner-less card is nobody's. The verdict
+# half always resolves an assignee (the pusher, or the reachable owning
+# agent), but on a GitHub runner there is no agent identity in the
+# environment AT ALL: a job's `run:` step has no $SCITEX_TODO_AGENT_ID,
+# no $SAC_NAME, nothing. Measured by running the real command under the
+# runner's exact environment (`env -i` + the runner service's PATH),
+# which is the only way this surfaces -- from a container shell every
+# identity variable is populated and the call succeeds.
+#
+# It matters on the path that MATTERS: the verdict half creates the card
+# whenever the pre-push hook did not run, which is every human push and
+# every repo where the hook is not installed. Without this the rail
+# fails exactly where it was supposed to be the safety net.
+VERDICT_ACTOR = "ci"
+
 __all__ = [
     "STATUS_FOR_CONCLUSION",
     "card_id_for",
@@ -237,16 +255,29 @@ def get_card(pkg: Any, card_id: str) -> dict[str, Any] | None:
         return None
 
 
-def upsert_card(pkg: Any, card_id: str, *, title: str, **fields: Any) -> Any:
+def upsert_card(
+    pkg: Any,
+    card_id: str,
+    *,
+    title: str,
+    create_only: dict[str, Any] | None = None,
+    **fields: Any,
+) -> Any:
     """Create the card, or update it when this rail already made one.
 
     ``add_task`` raises on an existing id, so the read decides. No lock
     spans the two halves of the rail and none is needed: the push half
     runs minutes ahead of the verdict half, and even a genuine race
     converges, because both sides write the same derived id.
+
+    ``create_only`` carries fields the store accepts at CREATION and
+    rejects on update -- ``created_by`` above all. Splitting them is not
+    tidiness: passing ``created_by`` to ``update_task`` is an error, and
+    omitting it from ``add_task`` is also an error, so one dict cannot
+    serve both calls.
     """
     if get_card(pkg, card_id) is None:
-        return pkg.add_task(id=card_id, title=title, **fields)
+        return pkg.add_task(id=card_id, title=title, **fields, **(create_only or {}))
     return pkg.update_task(task_id=card_id, title=title, **fields)
 
 

--- a/.github/ci/ci_rail_failure.py
+++ b/.github/ci/ci_rail_failure.py
@@ -1,0 +1,169 @@
+"""What actually broke: pulling the first useful failure lines out of a
+run's logs so a red verdict names something to look at.
+
+WHY THIS EXISTS. A notification that reaches a human and says only "Red.
+Fix and push" has solved half the problem. Seven consecutive red nights
+on this fleet reached nobody; the cure for that is not merely arriving,
+it is arriving with the failing test named. Tonight's own red would have
+read as "Red." when the useful content was five tests asserting a
+capability that a dependency release had just added.
+
+WHY IT READS THE **JOB** LOG, NOT THE RUN LOG. The verdict job runs while
+its own run is still in progress, and ``/runs/{id}/logs`` returns an
+EMPTY archive for an in-progress run. A completed job's log is available
+immediately, so this walks the run's jobs and reads the logs of the ones
+that already failed.
+
+THE 0-BYTE TRAP, WHICH IS THE REASON THIS MODULE IS CAREFUL. An empty log
+greps exactly like a clean one: both yield no matches and exit 0. So does
+a log that could not be fetched at all. Every one of those is reported
+here as an explicit statement about the LOG rather than as silence about
+the CODE — see :func:`summarize_failures`. A "no failures found" that is
+indistinguishable from "never looked" is the bug this rail exists to
+delete, and it would be especially perverse to reintroduce it in the code
+whose job is to say what went wrong.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+import zipfile
+
+GITHUB_API = "https://api.github.com"
+
+# Ordered by how much a reader learns from a hit. pytest's own summary
+# line names the test; the `E ` lines carry the assertion; a traceback's
+# last line names the exception. Collection errors and import failures
+# come last because they are usually consequences of the first three.
+FAILURE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^FAILED\s+\S+.*$"),
+    re.compile(r"^ERROR\s+\S+.*$"),
+    re.compile(r"^E\s{3}\s*\S.*$"),
+    re.compile(r"^\s*(?:[A-Za-z_.]+)?(?:Error|Exception|AssertionError):.*$"),
+)
+
+# GitHub prefixes every log line with an ISO timestamp and a space.
+_TS = re.compile(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s")
+
+MAX_LINES = 4
+MAX_LINE_CHARS = 200
+
+__all__ = ["extract_failure_lines", "summarize_failures"]
+
+
+def _token() -> str | None:
+    for var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        value = (os.environ.get(var) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _api(path: str, token: str, *, raw: bool = False, timeout: float = 20.0):
+    req = urllib.request.Request(f"{GITHUB_API}{path}")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        payload = resp.read()
+        if resp.info().get("Content-Encoding") == "gzip":
+            payload = gzip.decompress(payload)
+        if raw:
+            return payload
+        return json.loads(payload.decode("utf-8") or "{}")
+
+
+def _decode_log(payload: bytes) -> str:
+    """Job logs arrive as plain text, or occasionally as a zip archive."""
+    if payload[:2] == b"PK":
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            names = archive.namelist()
+            if not names:
+                return ""
+            return "\n".join(
+                archive.read(name).decode("utf-8", "replace") for name in names[:4]
+            )
+    return payload.decode("utf-8", "replace")
+
+
+def extract_failure_lines(log_text: str, *, limit: int = MAX_LINES) -> list[str]:
+    """The most informative distinct failure lines, in priority order.
+
+    Deduplicated because a parametrized test failing forty times produces
+    forty near-identical lines, and a notification that is forty copies
+    of one assertion is no more useful than one copy.
+    """
+    seen: set[str] = set()
+    picked: list[str] = []
+    for pattern in FAILURE_PATTERNS:
+        for raw_line in log_text.splitlines():
+            line = _TS.sub("", raw_line).strip()
+            if not line or not pattern.match(line):
+                continue
+            line = line[:MAX_LINE_CHARS]
+            if line in seen:
+                continue
+            seen.add(line)
+            picked.append(line)
+            if len(picked) >= limit:
+                return picked
+    return picked
+
+
+def summarize_failures(repo: str, run_id: str) -> str:
+    """One short block naming what failed, or WHY nothing could be named.
+
+    Never returns an empty string. Every path -- no token, API refusal,
+    a zero-byte log, a log with no recognisable failure line -- produces a
+    sentence about the LOG. Silence here would read as "nothing was
+    wrong", which is exactly the confusion that lets a red night pass
+    unnoticed.
+    """
+    if not run_id:
+        return "(no run id; cannot name the failure)"
+    token = _token()
+    if not token:
+        return "(no GITHUB_TOKEN in the verdict job; cannot read the run's logs)"
+
+    try:
+        jobs = _api(f"/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100", token)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return f"(could not list the run's jobs: {exc})"
+
+    failed = [
+        job
+        for job in (jobs.get("jobs") or [])
+        if job.get("conclusion") in ("failure", "timed_out")
+    ]
+    if not failed:
+        return "(no failed job in this run reported a log to read)"
+
+    names = ", ".join(str(job.get("name")) for job in failed[:3])
+    for job in failed:
+        try:
+            payload = _api(
+                f"/repos/{repo}/actions/jobs/{job.get('id')}/logs", token, raw=True
+            )
+        except (urllib.error.URLError, OSError) as exc:
+            return f"failed: {names} (log fetch failed: {exc})"
+        # THE BYTE COUNT IS CHECKED BEFORE THE GREP, not after. An empty
+        # log and a clean log are indistinguishable downstream.
+        if not payload:
+            continue
+        lines = extract_failure_lines(_decode_log(payload))
+        if lines:
+            body = "\n".join(f"  {line}" for line in lines)
+            return f"failed: {names}\n{body}"
+    return (
+        f"failed: {names} (logs were empty or held no recognisable failure "
+        "line — open the run to see why)"
+    )
+
+
+# EOF

--- a/.github/ci/ci_rail_failure.py
+++ b/.github/ci/ci_rail_failure.py
@@ -65,12 +65,40 @@ def _token() -> str | None:
     return None
 
 
+class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
+    """Drop the Authorization header when a redirect crosses hosts.
+
+    THE JOB-LOG ENDPOINT IS A REDIRECT, and that is what makes this
+    necessary rather than fussy. ``/actions/jobs/{id}/logs`` answers 302
+    with a Location on Azure blob storage, where the log actually lives.
+    urllib follows redirects by default and, by default, REPLAYS every
+    header -- including ``Authorization: Bearer <github token>``. Azure
+    has no idea what a GitHub token is and rejects the request:
+
+        HTTP Error 401: Server failed to authenticate the request.
+
+    So the header that authenticates the first hop breaks the second.
+    The blob URL carries its own signature in the query string and needs
+    no header at all. Measured against a real failed run -- from the API
+    shape alone this looks like it should work, and it does not.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new is not None:
+            for header in ("Authorization", "authorization"):
+                new.headers.pop(header, None)
+                new.unredirected_hdrs.pop(header, None)
+        return new
+
+
 def _api(path: str, token: str, *, raw: bool = False, timeout: float = 20.0):
     req = urllib.request.Request(f"{GITHUB_API}{path}")
     req.add_header("Authorization", f"Bearer {token}")
     req.add_header("Accept", "application/vnd.github+json")
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+    opener = urllib.request.build_opener(_StripAuthOnRedirect)
+    with opener.open(req, timeout=timeout) as resp:  # noqa: S310
         payload = resp.read()
         if resp.info().get("Content-Encoding") == "gzip":
             payload = gzip.decompress(payload)

--- a/.github/ci/ci_rail_listen.py
+++ b/.github/ci/ci_rail_listen.py
@@ -1,0 +1,171 @@
+"""The ``sac listen`` half of the CI feedback rail: how a verdict reaches
+a running agent, and how this rail knows whether anyone is listening.
+
+Companion to :mod:`ci_card_rail`, which owns the card contract and the
+CLI. This module owns exactly one thing: talking to the ``sac listen``
+control plane over loopback.
+
+WHY THERE IS NO WEBHOOK HERE (ADR-0024 §4.1). ``sac listen`` binds
+``127.0.0.1`` only, and that is policy rather than accident — the CLI
+refuses a non-loopback bind without an explicit override. So there is no
+public route for GitHub to POST to, and the two mechanisms usually
+reached for are both wrong here: a webhook cannot arrive, and a poller
+is what you build when the signal cannot reach you. It can. The
+self-hosted runner long-polls OUTWARD to GitHub and then executes the
+job ON THIS HOST, where loopback is reachable and the bearer token is a
+local file. The GitHub → host path already exists and is already
+trusted; this module just uses it.
+
+WHY DELIVERY GOES OVER THIS RAIL AND NOT THE CARD SIDECAR (ADR-0024 §2).
+There are two notification rails in this fleet with opposite health. The
+card package's file sidecar was measured frozen — 149 unseen events,
+nothing moving since 07:05. sac's ``channel_events`` + a2a bus was
+measured live, durable and replayable. Routing over the live one also
+decouples this rail from the sidecar's unfinished retirement, so neither
+piece of work blocks the other.
+
+DEPENDENCIES: standard library only. This runs under ``uv run --with
+scitex-cards`` on a runner that has no ``scitex_agent_container``
+install, so every sac fact is fetched over HTTP rather than imported.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LISTEN_BASE_URL = "http://127.0.0.1:7878"
+TOKEN_DIR = Path(".scitex") / "agent-container" / "tokens"
+
+__all__ = [
+    "DEFAULT_LISTEN_BASE_URL",
+    "TOKEN_DIR",
+    "fleet_agents",
+    "listen_base_url",
+    "listen_token",
+    "notify_agent",
+    "reachability_of",
+]
+
+
+def listen_base_url() -> str:
+    return (os.environ.get("SAC_LISTEN_BASE_URL") or DEFAULT_LISTEN_BASE_URL).rstrip(
+        "/"
+    )
+
+
+def listen_token() -> str | None:
+    """The host-wide ``sac listen`` bearer, from env or its canonical file.
+
+    Mirrors ``scitex_agent_container._listen.tokens.default_token_path``
+    by construction rather than by import, because the runner's Python
+    has no sac install. The env override exists so the same script works
+    from a container that mounts the token elsewhere.
+    """
+    env = os.environ.get("SAC_LISTEN_BEARER") or os.environ.get("SAC_LISTEN_TOKEN")
+    if env and env.strip():
+        return env.strip()
+    host = os.environ.get("SAC_LISTEN_TOKEN_HOST") or socket.gethostname()
+    path = Path.home() / TOKEN_DIR / f"listen-{host}.token"
+    if not path.is_file():
+        return None
+    try:
+        return path.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def _request(
+    path: str,
+    *,
+    token: str,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 15.0,
+) -> Any:
+    url = f"{listen_base_url()}{path}"
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(url, data=data, method="POST" if data else "GET")
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8") or "{}")
+
+
+def fleet_agents(token: str) -> list[dict[str, Any]]:
+    """``GET /agents`` — every registered agent WITH its live reachability.
+
+    The ``inbox_subscribers`` / ``inbox_reachable`` fields are the whole
+    reason this call exists. REGISTERED IS NOT REACHABLE: an agent row
+    can carry a pid, an a2a port and an ``active`` group while holding
+    zero inbox subscribers, in which case a message to it lands on an
+    empty bus and NO ERROR IS RAISED ANYWHERE. Measured on this host
+    2026-08-12: 9 of 15 registered agents were in exactly that state,
+    and every reachable one had been started within the previous eight
+    hours — subscription reach decays with uptime. Choosing a recipient
+    without reading this field is how a rail gets declared working while
+    delivering to nobody.
+    """
+    body = _request("/agents", token=token)
+    if isinstance(body, dict):
+        agents = body.get("agents")
+        if isinstance(agents, list):
+            return [a for a in agents if isinstance(a, dict)]
+    return []
+
+
+def reachability_of(agents: list[dict[str, Any]], name: str) -> tuple[str, int]:
+    """``(inbox_reachable, inbox_subscribers)`` for ``name``.
+
+    ``("unknown", 0)`` when the name is not in the roster at all — which
+    is a different fact from "known and deaf", and the caller reports it
+    differently.
+    """
+    for agent in agents:
+        if agent.get("name") == name:
+            return (
+                str(agent.get("inbox_reachable") or "unknown"),
+                int(agent.get("inbox_subscribers") or 0),
+            )
+    return "unknown", 0
+
+
+def notify_agent(
+    token: str, *, agent: str, body: str, card_id: str | None = None
+) -> dict[str, Any]:
+    """``POST /v1/notify`` — persist to ``channel_events``, then publish.
+
+    DURABLE BEFORE LIVE, and that ordering is the reason this endpoint is
+    the right seam. The daemon writes the event to ``channel_events``
+    BEFORE publishing it to the in-memory bus, and the persisted row id
+    becomes the SSE ``id:`` line — so an agent that happens to be
+    disconnected at this instant replays the event from its
+    ``Last-Event-ID`` cursor on reconnect instead of losing it. The bus
+    is a fan-out in front of a durable log, not the log itself.
+
+    Delivery is also OUTBOUND-SUBSCRIPTION, never an inbound POST: a
+    containerized agent's own ``turn_url`` is unreachable from outside
+    its container, so it subscribes outward and the daemon publishes
+    down that stream.
+
+    Returns the daemon's JSON, including ``delivered_subscriber_count``.
+    Raises ``urllib`` errors, which the caller must surface loudly.
+    """
+    return _request(
+        "/v1/notify",
+        token=token,
+        payload={
+            "agent": agent,
+            "body": body,
+            "card_id": card_id,
+            "from_agent": "ci",
+        },
+    )
+
+
+# EOF

--- a/.github/ci/ci_rail_message.py
+++ b/.github/ci/ci_rail_message.py
@@ -1,0 +1,124 @@
+"""What the verdict actually SAYS, and the limits it admits to.
+
+Companion to :mod:`ci_card_rail` (orchestration), :mod:`ci_rail_cards`
+(the card contract) and :mod:`ci_rail_listen` (delivery). This module
+owns one thing: turning a conclusion into the sentence a woken human
+reads.
+
+That deserves its own module because the message is where this rail's
+sharpest defect lived. It once ended a green verdict with "Self-merge if
+you own it" -- advice drawn from ONE workflow's result, because `needs:`
+cannot reach across workflow files and lint, quality, import-smoke and
+the runner guard are all invisible from here. That is a verdict computed
+over the checks in view, presented as a verdict over the gate: the exact
+shape of queued-reads-as-green, reproduced inside the fix for it.
+
+The rule this module exists to hold: **say what was observed, say what
+was not, and decline to draw the conclusion the reader wants.**
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["sibling_workflow_names", "verdict_text"]
+
+
+def sibling_workflow_names(this_workflow: str, workflows_dir: str | None = None) -> list[str]:
+    """PR-triggering workflows in the repo EXCEPT the one this rail sees.
+
+    DERIVED, NOT HARDCODED, and the difference has a failure mode. A list
+    written by hand is a snapshot of today's workflow set: add a workflow
+    next month and it silently drops out of the disclaimer, so the
+    message quietly resumes overclaiming while still LOOKING careful. A
+    disclaimer that decays is worse than none, because it keeps buying
+    trust it no longer earns.
+
+    Filtered to workflows a PULL REQUEST can trigger. Listing every file
+    would name the release, nightly and autobump workflows -- accurate
+    about the repo, misleading about this commit, since none of them will
+    ever report on a PR. A disclaimer that overstates what is pending is
+    its own small dishonesty.
+
+    Scans for a top-level ``name:`` instead of parsing YAML: this runs
+    under ``uv run --with scitex-cards`` and must not assume a YAML
+    library is present. Returns ``[]`` when the directory is unreadable,
+    which the caller renders as an UNNAMED disclaimer -- never a stale
+    list, and never silence.
+    """
+    directory = Path(workflows_dir) if workflows_dir else Path(".github/workflows")
+    if not directory.is_dir():
+        return []
+    names: list[str] = []
+    for path in sorted(directory.glob("*.y*ml")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        # Split at `jobs:` so a `pull_request` appearing in a step or a
+        # comment cannot be mistaken for a trigger declaration.
+        head = text.split("\njobs:", 1)[0]
+        if "pull_request" not in head:
+            continue
+        for line in text.splitlines():
+            if line.startswith("name:"):
+                name = line.split(":", 1)[1].strip().strip("\"'")
+                if name and name != this_workflow:
+                    names.append(name)
+                break
+    return sorted(set(names))
+
+
+def _repo_basename(repo: str) -> str:
+    return repo.rstrip("/").split("/")[-1].strip()
+
+
+def verdict_text(
+    *,
+    repo: str,
+    branch: str,
+    sha: str,
+    conclusion: str,
+    leg: str,
+    run_url: str,
+    card_id: str,
+    detail: str = "",
+    unobserved: list[str] | None = None,
+) -> str:
+    """The message a woken human reads.
+
+    ``detail`` names what broke, and is not decoration: a notification
+    that arrives saying only "Red" has solved half the problem, and half
+    is measurable here -- seven consecutive red nights on this fleet
+    reached nobody. Arriving is not the fix; arriving with the failing
+    test named is.
+
+    Deliberately NO attribution. The rail reports the verdict and quotes
+    the log; it never says WHY, because it cannot know, and a rail that
+    guesses causes teaches people to distrust the ones it gets right.
+    """
+    head = f"CI {conclusion.upper()} — {_repo_basename(repo)} `{branch}` ({sha[:8]})"
+    if leg:
+        head += f" [{leg}]"
+
+    if conclusion == "success":
+        tail = "The pytest gate is green for this commit. It is NOT a merge signal: "
+        if unobserved:
+            tail += (
+                f"this rail cannot see {len(unobserved)} other PR workflows — "
+                f"{', '.join(unobserved)}."
+            )
+        else:
+            tail += "other workflows report separately and this rail cannot see them."
+    else:
+        tail = "Red. Fix and push; this rail re-fires on your next push."
+
+    parts = [f"{head}.", tail]
+    if detail.strip():
+        parts.append(detail.strip())
+    parts.append(f"Run: {run_url}")
+    parts.append(f"Card: {card_id}")
+    return "\n".join(parts)
+
+
+# EOF

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -301,11 +301,26 @@ jobs:
   # rail's own premise true instead of assumed. The label was added to that
   # runner and to no other; no other workflow names it, so it widens nothing.
   #
-  # THE COST, STATED HONESTLY: this is a separate job, so it pays a queue
-  # admission (measured median ~706 s on this pool, p90 ~2325 s). ADR-0024's
-  # cheaper in-job placement was only available under the false premise above.
-  # Correct-and-late beats fast-and-delivered-to-nobody; revisit if a
-  # control-plane-local runner is ever added to the gate pool itself.
+  # THE COST, STATED HONESTLY, IN TWO PARTS. This is a deliberate trade, not
+  # a side effect of solving the loopback problem.
+  #
+  # 1. LATENCY. A separate job pays a queue admission (measured median ~706 s
+  #    on this pool, p90 ~2325 s). ADR-0024's cheaper in-job placement was
+  #    only available under the false premise above.
+  # 2. AVAILABILITY. Pinning makes THE RAIL EXACTLY AS AVAILABLE AS THIS ONE
+  #    HOST. Exactly one runner advertises `sac-control-plane` (verified
+  #    online at merge time, not merely written here). If that machine is
+  #    down, verdicts stop -- and they stop SILENTLY, because a queued job
+  #    reports nothing and "still queued after 15 minutes" is normal here
+  #    (p90 ~902 s). A job pinned to a label nobody carries is
+  #    indistinguishable from a saturated pool, which is why the label must
+  #    be verified as ADVERTISED BY A LIVE RUNNER, never merely as named in
+  #    YAML. `verdict_delivered` reconciliation is the intended backstop and
+  #    does not exist yet.
+  #
+  # Correct-and-late beats fast-and-delivered-to-nobody, so the trade is
+  # taken; revisit if a control-plane-local runner joins the gate pool, or
+  # if a second machine is ever given the control plane.
   verdict:
     name: ci-verdict-to-pushing-agent
     needs: [test]

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -149,6 +149,12 @@ env:
 permissions:
   contents: read
   id-token: write
+  # `actions: read` lets the verdict job read the FAILED JOBS' logs so a red
+  # notification can name the failing test instead of saying only "Red".
+  # A workflow that withholds a permission its own job needs is one of the
+  # inert-but-configured shapes this fleet keeps rediscovering, so it is
+  # declared here rather than assumed from the default token.
+  actions: read
 
 jobs:
   test:
@@ -263,3 +269,86 @@ jobs:
       - name: Remove this leg's CI scratch (persistent runner — nothing else reclaims it)
         if: always()
         run: bash .github/ci/clean-tmpdir.sh run-in-sif.sh ${{ matrix.python-version }}
+
+  # THE CI FEEDBACK RAIL (ADR-0024). The operator asked for this mechanism by
+  # name on 2026-08-12: 「GitHub から信号が帰ってきたときに、フックでカードに
+  # 書き込む、それがエージェントに通知が行く」— when GitHub's signal comes
+  # back, write it to the card, and that reaches the agent. This job is that
+  # return path. `pre-push` already registered the commit on a card; this
+  # writes the verdict onto the SAME card and delivers it to whoever pushed.
+  #
+  # WHY NOT A WEBHOOK. `sac listen` binds 127.0.0.1 only, and that is policy,
+  # not accident — so there is no public route for GitHub to POST to. A
+  # self-hosted runner, however, long-polls OUTWARD to GitHub and then
+  # executes ON OUR HARDWARE, where loopback is reachable and the bearer is a
+  # local file. The GitHub -> host path already exists and is already trusted.
+  # That is nearer the operator's 「フック」 than the two existing pollers: it
+  # fires ON the event rather than noticing it up to 300 s later, and it drops
+  # the `gh`-auth dependency that made both of them fail closed. Neither has
+  # ever delivered a verdict on this host — the `verdict_delivered` table has
+  # never even been created.
+  #
+  # `runs-on: sac-control-plane` IS THE LOAD-BEARING LINE, and it is the one
+  # thing ADR-0024 got wrong. That ADR reasoned "the self-hosted runners
+  # execute on this host", but `vars.CI_RUNS_ON` is `scitex-org-cpu`, which is
+  # FOUR runners on FOUR DIFFERENT MACHINES (scitex-01..04). Only
+  # scitex-04-org-cpu-01 sits on the box that runs `sac listen` and the card
+  # store. So the premise holds for 25% of jobs, and on the other 75% both
+  # `127.0.0.1:7878` and `127.0.0.1:55432` resolve to a DIFFERENT machine's
+  # daemon and a DIFFERENT postgres — writing the verdict somewhere nobody
+  # reads and delivering it to nobody, with nothing raising an error. Pinning
+  # the job to a label carried by exactly that one machine is what makes the
+  # rail's own premise true instead of assumed. The label was added to that
+  # runner and to no other; no other workflow names it, so it widens nothing.
+  #
+  # THE COST, STATED HONESTLY: this is a separate job, so it pays a queue
+  # admission (measured median ~706 s on this pool, p90 ~2325 s). ADR-0024's
+  # cheaper in-job placement was only available under the false premise above.
+  # Correct-and-late beats fast-and-delivered-to-nobody; revisit if a
+  # control-plane-local runner is ever added to the gate pool itself.
+  verdict:
+    name: ci-verdict-to-pushing-agent
+    needs: [test]
+    # `always()` so RED reports AT ALL — a rail that only fires on green is
+    # not a feedback rail, it is a congratulations service. The script skips
+    # `cancelled` itself (a superseded push is not a verdict about the code).
+    if: always()
+    runs-on: [self-hosted, Linux, X64, sac-control-plane]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # $SCITEX_CARDS_DB IS PASSED EXPLICITLY, and that is load-bearing too. A
+      # `run:` step gets a NON-INTERACTIVE shell which sources no profile, so
+      # an unset DSN does not fail — it silently resolves to a local
+      # `cards.db` FILE that no board reads. Worse, this host answers on BOTH
+      # :5442 and :55432 with the same `store_uuid` but different row counts
+      # (3496 vs 3793) — two divergent databases wearing one identity, so the
+      # field meant to detect a split cannot detect this one. The script
+      # re-checks the resolved backend and refuses to write rather than
+      # guessing. `vars.SCITEX_CARDS_DB` overrides without a workflow edit.
+      #
+      # uv BY ABSOLUTE PATH: the runner service's PATH is the system default
+      # and does NOT include ~/.local/bin, so a bare `uv` is not found here
+      # even though it is on the operator's interactive PATH.
+      - name: Write the CI verdict to the card and notify the pushing agent
+        env:
+          SCITEX_CARDS_DB: ${{ vars.SCITEX_CARDS_DB || 'postgresql://scitex_cards@127.0.0.1:55432/scitex_cards' }}
+          TEST_RESULT: ${{ needs.test.result }}
+          # Reads the FAILED JOBS' logs so a red verdict names the failing
+          # test. Deliberately the per-JOB log endpoint: this job is itself
+          # running, so the whole-RUN log archive is still empty and would
+          # grep exactly like a clean one.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          UV="$(command -v uv || echo "$HOME/.local/bin/uv")"
+          "$UV" run --quiet --with scitex-cards \
+            python .github/ci/ci_card_rail.py verdict \
+              --repo "${{ github.repository }}" \
+              --branch "${{ github.head_ref || github.ref_name }}" \
+              --sha "${{ github.event.pull_request.head.sha || github.sha }}" \
+              --conclusion "$TEST_RESULT" \
+              --leg "pytest-matrix" \
+              --run-id "${{ github.run_id }}" \
+              --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -366,4 +366,5 @@ jobs:
               --conclusion "$TEST_RESULT" \
               --leg "pytest-matrix" \
               --run-id "${{ github.run_id }}" \
+              --workflow "${{ github.workflow }}" \
               --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -38,6 +38,88 @@ audit:
           a security regression, not a compliance win. Kept hosted until an
           ephemeral/isolated runner exists for untrusted-trigger workflows.
 
+    # PS-224, second entry — the ADR-0024 CI feedback rail's `verdict` job.
+    #
+    # THE FINDING IS LITERALLY TRUE AND ITS HAZARD IS EMPIRICALLY FALSE, and
+    # the gap between those two is the whole reason this entry exists rather
+    # than a re-point.
+    #
+    # What PS-224 asserts: `sac-control-plane` is not in the destination
+    # registry. Correct. scitex-dev's registry — the packaged seed in
+    # `scitex_dev/hosts/_seed.py`, which is the FLOOR PS-224 validates
+    # against when a host has no `~/.scitex/dev/hosts.yaml` (runners do not)
+    # — carries exactly two label sets, both spartan's. Verified present in
+    # 0.47.0 (what CI runs) AND in 0.48.0 (current PyPI).
+    #
+    # What PS-224 INFERS from that, and why it does not hold here: "a
+    # SELF-HOSTED label no runner advertises queues indefinitely (never
+    # fails, never runs)". Measured against the live org runner list on
+    # 2026-08-12, `sac-control-plane` IS advertised, by exactly one runner:
+    #
+    #   scitex-04-org-cpu-01  online
+    #     self-hosted, Linux, X64, scitex-org-cpu, sac-control-plane
+    #
+    # and the job it gates DISPATCHED AND SUCCEEDED — run 31572329783, job
+    # `ci-verdict-to-pushing-agent` (94039063012), conclusion `success`,
+    # which is how the red this entry fixes was reported in the first place.
+    # So the registry is BEHIND REALITY, not ahead of a mistake. It knows
+    # none of scitex-01..04: `scitex-org-cpu` is missing too, and every
+    # workflow naming that pool passes PS-224 only because it reaches it
+    # through a `vars.CI_RUNS_ON` expression whose literal FALLBACK
+    # (`scitex-ci`) is what the rule statically sees. This job names its
+    # label directly, so it is the one place the lag is visible. Hiding it
+    # behind the same expression would silence the rule while changing
+    # nothing real — that is a string trick, not a fix, and is not done here.
+    #
+    # THE EXEMPTION'S OWN PRECONDITION IS SATISFIED EXACTLY. PS-224 admits a
+    # per-job exemption when "this job genuinely cannot run on any registered
+    # machine", and that is the literal situation: no registered machine
+    # carries `sac-control-plane`, and spartan — the only registered
+    # destination — is the WRONG machine on purpose. The rail writes to
+    # `127.0.0.1:7878` (`sac listen`, bound to loopback by policy) and
+    # `127.0.0.1:55432` (the card postgres). On any other box both resolve to
+    # a different daemon and a different database, so the job would report
+    # `success` while writing the verdict where nobody reads it. Loopback
+    # locality to the control plane is the job's correctness condition, not a
+    # preference; see the block comment above `verdict:` in the workflow.
+    #
+    # THIS IS A DEFERRAL, NOT A WAIVER. The real fix is in scitex-dev:
+    # register scitex-01..04 and their labels in the packaged seed, which
+    # closes this AND the wider `scitex-org-cpu` blind spot. Filed as
+    # scitex-ai/scitex-dev#588 with the live runner table. It cannot green
+    # this branch today — it needs a scitex-dev release and a CI SIF rebuild
+    # before sac's audit would see it. This entry comes off in the change
+    # that adopts that release.
+    #
+    # NOTE THE AVAILABILITY COST THIS ENTRY NOW MASKS. One runner advertises
+    # this label, so the rail is exactly as available as scitex-04, and a
+    # down machine stops verdicts SILENTLY (a queued job reports nothing, and
+    # this pool's p90 queue is ~902 s, so "still queued" looks normal). That
+    # trade is argued in the workflow comment and accepted there; PS-224 was
+    # the only thing that would have shouted about it, so re-verify the label
+    # is live — `gh api orgs/scitex-ai/actions/runners` — rather than trusting
+    # this comment, whenever the rail goes quiet.
+      - path: .github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml::verdict
+        line: 0
+        reason: >-
+          Registry lag, not a mis-routed job, and deferred rather than waived.
+          `sac-control-plane` is advertised by exactly one LIVE runner
+          (scitex-04-org-cpu-01, online 2026-08-12) and the job dispatched and
+          succeeded there — run 31572329783 job `ci-verdict-to-pushing-agent`
+          — so PS-224's "queues indefinitely" hazard does not apply. What is
+          true is that scitex-dev's packaged seed (`hosts/_seed.py`, the floor
+          PS-224 validates against on runners, which have no
+          `~/.scitex/dev/hosts.yaml`) knows only spartan in both 0.47.0 and
+          0.48.0 — it knows none of scitex-01..04, `scitex-org-cpu` included.
+          The job cannot be re-pointed: it writes to `sac listen` on
+          127.0.0.1:7878 and the card postgres on 127.0.0.1:55432, so on any
+          other machine it would report success while writing the verdict to a
+          different daemon and a different database that nobody reads —
+          loopback locality to the control plane is its correctness condition.
+          Real fix is registering scitex-01..04 in scitex-dev's seed, filed as
+          scitex-ai/scitex-dev#588; this entry is removed by the change that
+          adopts that release.
+
   # PS-226 (job-name-not-hyphenated), introduced by scitex-dev 0.48.0.
   #
   # THIS IS A DEFERRAL, NOT A WAIVER, AND THE FINDING IS CORRECT.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,14 @@ scitex-agent-container = "scitex_agent_container._jobs._jobs_plugin:provide_jobs
 # — this key replaces them, it does not extend them, and dropping one would
 # silently start demanding @stx.session of every module under it.
 [tool.scitex-linter]
-library_dirs = ["src", "tests", "apps", "config", "docs", ".github/ci"]
+# ".github", not ".github/ci": the linter's is_script() tests `lib_dir in
+# path.parts`, so an entry with a separator in it is never a single path
+# COMPONENT and can never match. ".github/ci" sat here as a silent no-op —
+# it looked configured and exempted nothing, which is the same shape of bug
+# as a hooksPath pointing at a directory that does not exist. Nothing under
+# .github is a SciTeX session script, so the component-level entry is also
+# the honest one.
+library_dirs = ["src", "tests", "apps", "config", "docs", ".github"]
 
 # sac's SYSTEM (apt) dependency declarations, aggregated by
 # scitex_dev.system_deps.discover_system_deps. sac registered NOTHING here

--- a/tests/integration/test_ci_card_rail.py
+++ b/tests/integration/test_ci_card_rail.py
@@ -398,6 +398,7 @@ def test_a_green_verdict_does_not_claim_mergeability(rail) -> None:
         conclusion="success",
         leg="pytest-matrix",
         run_url="https://example.test/1",
+        card_id="ci-sac-abcdef123456",
     )
     # Act
     text = rail.verdict_text(**kwargs)
@@ -414,6 +415,7 @@ def test_a_green_verdict_names_what_it_did_not_see(rail) -> None:
         conclusion="success",
         leg="pytest-matrix",
         run_url="https://example.test/1",
+        card_id="ci-sac-abcdef123456",
     )
     # Act
     text = rail.verdict_text(**kwargs)
@@ -569,6 +571,7 @@ def test_verdict_text_states_the_conclusion(rail, conclusion: str) -> None:
         conclusion=conclusion,
         leg="pytest-matrix",
         run_url=run_url,
+        card_id="ci-sac-abcdef123456",
     )
     # Assert
     assert conclusion.upper() in text
@@ -585,6 +588,7 @@ def test_verdict_text_links_the_run(rail) -> None:
         conclusion="failure",
         leg="pytest-matrix",
         run_url=run_url,
+        card_id="ci-sac-abcdef123456",
     )
     # Assert
     assert run_url in text
@@ -602,6 +606,7 @@ def test_a_red_verdict_names_what_broke(rail) -> None:
         conclusion="failure",
         leg="pytest-matrix",
         run_url="https://example.test/1",
+        card_id="ci-sac-abcdef123456",
         detail=detail,
     )
     # Assert

--- a/tests/integration/test_ci_card_rail.py
+++ b/tests/integration/test_ci_card_rail.py
@@ -248,6 +248,132 @@ def test_clearing_a_field_means_the_empty_string(rail_cards) -> None:
     assert sentinel == expected
 
 
+class _FakeStore:
+    """A minimal card store: enough to drive superseding, no postgres."""
+
+    def __init__(self, tasks: list[dict]) -> None:
+        self.tasks = {t["id"]: t for t in tasks}
+        self.comments: list[str] = []
+
+    def list_tasks(self, scope: str = "", **_kw) -> list[dict]:
+        return [t for t in self.tasks.values() if t.get("scope") == scope]
+
+    def update_task(self, task_id: str, **fields) -> dict:
+        self.tasks[task_id].update(fields)
+        return self.tasks[task_id]
+
+    def comment_task(self, task_id: str, text: str, by: str = "") -> None:
+        self.comments.append(f"{task_id}:{text}")
+
+
+def _pending(card_id: str, scope: str) -> dict:
+    return {"id": card_id, "scope": scope, "status": "blocked", "blocker": "compute"}
+
+
+def test_superseding_closes_the_stale_pending_card(rail_cards) -> None:
+    """A branch that advances orphans its older card.
+
+    The older run is killed by `cancel-in-progress`, and a cancelled run
+    is deliberately not a verdict -- so no event can ever settle that
+    card. Closing it `done` would assert a green nobody measured.
+    """
+    # Arrange
+    scope = rail_cards.card_scope("o/sac", "feat/x")
+    old_id = rail_cards.card_id_for("o/sac", "a" * 40)
+    store = _FakeStore([_pending(old_id, scope)])
+    # Act
+    rail_cards.supersede_older(store, repo="o/sac", branch="feat/x", sha="b" * 40)
+    # Assert
+    assert store.tasks[old_id]["status"] == "cancelled"
+
+
+def test_superseding_clears_the_stale_gate(rail_cards) -> None:
+    # Arrange
+    scope = rail_cards.card_scope("o/sac", "feat/x")
+    old_id = rail_cards.card_id_for("o/sac", "a" * 40)
+    store = _FakeStore([_pending(old_id, scope)])
+    # Act
+    rail_cards.supersede_older(store, repo="o/sac", branch="feat/x", sha="b" * 40)
+    # Assert
+    assert store.tasks[old_id]["blocker"] == rail_cards.BLOCKER_CLEARED
+
+
+def test_superseding_never_closes_the_current_card(rail_cards) -> None:
+    """The commit that just landed is the one card still owed a verdict."""
+    # Arrange
+    scope = rail_cards.card_scope("o/sac", "feat/x")
+    current_id = rail_cards.card_id_for("o/sac", "b" * 40)
+    store = _FakeStore([_pending(current_id, scope)])
+    # Act
+    closed = rail_cards.supersede_older(store, repo="o/sac", branch="feat/x", sha="b" * 40)
+    # Assert
+    assert closed == []
+
+
+def test_superseding_leaves_settled_cards_alone(rail_cards) -> None:
+    """A card that already got its verdict is history, not debris."""
+    # Arrange
+    scope = rail_cards.card_scope("o/sac", "feat/x")
+    old_id = rail_cards.card_id_for("o/sac", "a" * 40)
+    settled = {"id": old_id, "scope": scope, "status": "failed"}
+    store = _FakeStore([settled])
+    # Act
+    rail_cards.supersede_older(store, repo="o/sac", branch="feat/x", sha="b" * 40)
+    # Assert
+    assert store.tasks[old_id]["status"] == "failed"
+
+
+def test_superseding_is_scoped_to_one_branch(rail_cards) -> None:
+    """A push to one branch says nothing about another branch's runs."""
+    # Arrange
+    other_id = rail_cards.card_id_for("o/sac", "c" * 40)
+    other = _pending(other_id, rail_cards.card_scope("o/sac", "feat/other"))
+    store = _FakeStore([other])
+    # Act
+    rail_cards.supersede_older(store, repo="o/sac", branch="feat/x", sha="b" * 40)
+    # Assert
+    assert store.tasks[other_id]["status"] == "blocked"
+
+
+def test_a_green_verdict_does_not_claim_mergeability(rail) -> None:
+    """This rail sees ONE workflow; `needs:` cannot cross workflow files.
+
+    Saying "self-merge" from the pytest gate alone is a verdict over the
+    checks that happen to be in view, dressed as a verdict over the
+    checks that should have run -- the same shape as reading a queued
+    check as green, which is the bug this rail exists to answer.
+    """
+    # Arrange
+    kwargs = dict(
+        repo="scitex-ai/sac",
+        branch="feat/x",
+        sha="abcdef1234567890",
+        conclusion="success",
+        leg="pytest-matrix",
+        run_url="https://example.test/1",
+    )
+    # Act
+    text = rail.verdict_text(**kwargs)
+    # Assert
+    assert "self-merge" not in text.lower()
+
+
+def test_a_green_verdict_names_what_it_did_not_see(rail) -> None:
+    # Arrange
+    kwargs = dict(
+        repo="scitex-ai/sac",
+        branch="feat/x",
+        sha="abcdef1234567890",
+        conclusion="success",
+        leg="pytest-matrix",
+        run_url="https://example.test/1",
+    )
+    # Act
+    text = rail.verdict_text(**kwargs)
+    # Assert
+    assert "report separately" in text
+
+
 def test_title_leads_with_the_verdict(rail_cards) -> None:
     """The one word a reader woken at 4am needs, first."""
     # Arrange

--- a/tests/integration/test_ci_card_rail.py
+++ b/tests/integration/test_ci_card_rail.py
@@ -2,23 +2,24 @@
 
 Two kinds of test live here, and the second kind is the point.
 
-**Logic tests** cover the decisions the rail makes with no store and no
+**Logic tests** cover decisions the rail makes with no store and no
 network: which card id both halves derive, who receives a verdict, what
 status a red gate produces.
 
-**Shape tests** assert facts about the WORKFLOW itself, in the spirit of
+**Shape tests** assert facts about the WORKFLOW, in the spirit of
 ``test_ci_python_matrix_shape.py``. They exist because every failure this
-rail is built to prevent is a silent one, and the two ways to re-open
-that hole are both single-line edits to YAML: unpin ``runs-on`` (the
-verdict then executes on a machine where loopback is a different host's
-daemon and a different postgres) or drop ``if: always()`` (the rail then
-only congratulates and never warns). Neither would fail any test that
-only exercised Python, and neither would look wrong in review.
+rail prevents is a silent one, and the ways to re-open that hole are all
+single-line YAML edits: unpin ``runs-on`` (the verdict then runs where
+loopback is a different host's daemon and a different postgres), drop
+``if: always()`` (the rail then only congratulates), or drop the explicit
+DSN (the store silently becomes a local file). None would fail a test
+that only exercised Python, and none would look wrong in review.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -31,20 +32,18 @@ GATE_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml"
 )
 
-# The label that must remain on the verdict job. It is carried by exactly
-# one runner in the org pool -- the one on the host that runs `sac listen`
-# and the card store.
+# Carried by exactly one runner in the org pool: the machine that runs
+# `sac listen` and the card store.
 CONTROL_PLANE_LABEL = "sac-control-plane"
+LONG_SHA = "0123456789abcdef0123456789abcdef01234567"
 
 
 def _load(module_name: str):
-    """Import a rail module by path.
+    """Import a rail module by path, the same way the runner does.
 
-    The rail deliberately is NOT an installed package: it must run under
-    ``uv run --with scitex-cards`` on a runner that has no sac install,
-    and from a git hook inside an agent container. So the tests import it
-    the same way the runner does -- by file -- rather than pretending it
-    is importable as ``scitex_agent_container.something``.
+    The rail is deliberately NOT an installed package: it runs under
+    ``uv run --with scitex-cards`` on a runner with no sac install, and
+    from a git hook inside an agent container.
     """
     sys.path.insert(0, str(CI_DIR))
     spec = importlib.util.spec_from_file_location(
@@ -71,59 +70,45 @@ def gate_workflow() -> dict:
     return yaml.safe_load(GATE_WORKFLOW.read_text(encoding="utf-8"))
 
 
-# ---------------------------------------------------------------------------
-# the card id is the ONLY channel between the two halves
-# ---------------------------------------------------------------------------
-def test_card_id_is_derived_from_repo_and_sha_only(rail_cards) -> None:
-    """Both halves must reach the same id from the same commit.
+@pytest.fixture(scope="module")
+def verdict_job(gate_workflow) -> dict:
+    return gate_workflow["jobs"]["verdict"]
 
-    There is no message passed from a developer's git hook to a runner
-    job minutes later, so the id has to be a pure function of facts both
-    sides independently hold. Anything else -- a branch name, a run id, a
-    timestamp -- would make the verdict land on a card nobody watches.
+
+@pytest.fixture(scope="module")
+def verdict_run_script(verdict_job) -> str:
+    return " ".join(step.get("run", "") for step in verdict_job["steps"])
+
+
+@pytest.fixture(scope="module")
+def verdict_env(verdict_job) -> dict:
+    return next(step["env"] for step in verdict_job["steps"] if "env" in step)
+
+
+@pytest.fixture
+def clean_agent_env():
+    """Real environment, saved and restored -- no monkeypatch.
+
+    ``pushing_agent`` reads ``os.environ`` directly, which is what it
+    does in production, so the test drives the real thing.
     """
-    long_sha = "0123456789abcdef0123456789abcdef01234567"
-    from_push = rail_cards.card_id_for("scitex-ai/scitex-agent-container", long_sha)
-    from_ci = rail_cards.card_id_for("scitex-agent-container", long_sha)
-    assert from_push == from_ci == "ci-scitex-agent-container-0123456789ab"
+    names = (
+        "SCITEX_TODO_AGENT_ID",
+        "SAC_NAME",
+        "SCITEX_AGENT_CONTAINER_AGENT",
+        "CLAUDE_AGENT_ID",
+    )
+    saved = {name: os.environ.get(name) for name in names}
+    for name in names:
+        os.environ.pop(name, None)
+    yield os.environ
+    for name, value in saved.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
 
 
-def test_card_id_distinguishes_pushes_to_the_same_branch(rail_cards) -> None:
-    a = rail_cards.card_id_for("r/x", "a" * 40)
-    b = rail_cards.card_id_for("r/x", "b" * 40)
-    assert a != b, "a verdict belongs to the commit it judged, not to the branch"
-
-
-# ---------------------------------------------------------------------------
-# a red gate must never produce a gate-less `blocked` card
-# ---------------------------------------------------------------------------
-def test_no_conclusion_maps_to_blocked(rail_cards) -> None:
-    """`blocked` without a named gate is invisible work.
-
-    Such a card nudges nobody and is excluded from the runnable count, so
-    it sits unseen until somebody goes looking -- the exact state this
-    fleet spent 2026-08-11 paying for. A red gate waits on nothing; it is
-    a finished run with a bad result, so it is `failed`.
-    """
-    assert "blocked" not in set(rail_cards.STATUS_FOR_CONCLUSION.values())
-    assert rail_cards.STATUS_FOR_CONCLUSION["failure"] == "failed"
-    assert rail_cards.STATUS_FOR_CONCLUSION["success"] == "done"
-
-
-def test_every_terminal_conclusion_has_a_status(rail, rail_cards) -> None:
-    """The two tables cannot drift apart without this failing."""
-    assert set(rail.TERMINAL_CONCLUSIONS) == set(rail_cards.STATUS_FOR_CONCLUSION)
-
-
-def test_title_leads_with_the_verdict(rail_cards) -> None:
-    title = rail_cards.card_title("scitex-ai/sac", "feat/x", "abcdef1234567890", "failure")
-    assert title.startswith("[CI FAILURE]")
-    assert "sac" in title and "feat/x" in title and "abcdef12" in title
-
-
-# ---------------------------------------------------------------------------
-# recipient resolution -- the difference between delivered and silent
-# ---------------------------------------------------------------------------
 def _agent(name: str, *, project: str, reachable: bool, started: str = "2026-08-10"):
     return {
         "name": name,
@@ -134,146 +119,443 @@ def _agent(name: str, *, project: str, reachable: bool, started: str = "2026-08-
     }
 
 
+# ---------------------------------------------------------------------------
+# the card id is the ONLY channel between the two halves
+# ---------------------------------------------------------------------------
+def test_card_id_ignores_the_repo_owner_prefix(rail_cards) -> None:
+    """Both halves must reach the same id from the same commit.
+
+    Nothing is passed from a developer's git hook to a runner job that
+    starts minutes later, so the id must be a pure function of facts both
+    sides already hold -- and the two sides spell the repo differently.
+    """
+    # Arrange
+    owner_qualified = "scitex-ai/scitex-agent-container"
+    # Act
+    from_push = rail_cards.card_id_for(owner_qualified, LONG_SHA)
+    # Assert
+    assert from_push == rail_cards.card_id_for("scitex-agent-container", LONG_SHA)
+
+
+def test_card_id_uses_twelve_sha_characters(rail_cards) -> None:
+    # Arrange
+    repo = "scitex-ai/scitex-agent-container"
+    # Act
+    card_id = rail_cards.card_id_for(repo, LONG_SHA)
+    # Assert
+    assert card_id == "ci-scitex-agent-container-0123456789ab"
+
+
+def test_card_id_distinguishes_pushes_to_the_same_branch(rail_cards) -> None:
+    """A verdict belongs to the commit it judged, not to the branch."""
+    # Arrange
+    first, second = "a" * 40, "b" * 40
+    # Act
+    ids = {rail_cards.card_id_for("r/x", first), rail_cards.card_id_for("r/x", second)}
+    # Assert
+    assert len(ids) == 2
+
+
+# ---------------------------------------------------------------------------
+# card status: never an unnamed gate, never a phantom runnable
+# ---------------------------------------------------------------------------
+def test_a_red_gate_is_never_filed_as_blocked(rail_cards) -> None:
+    """`blocked` demands a gate, and no blocker describes a red suite.
+
+    A gate-less blocked card nudges nobody and leaves the runnable count
+    -- how 21 operator decisions sat invisible for weeks.
+    """
+    # Arrange
+    statuses = rail_cards.STATUS_FOR_CONCLUSION
+    # Act
+    values = set(statuses.values())
+    # Assert
+    assert "blocked" not in values
+
+
+def test_a_failed_run_files_the_card_failed(rail_cards) -> None:
+    # Arrange
+    conclusion = "failure"
+    # Act
+    status = rail_cards.STATUS_FOR_CONCLUSION[conclusion]
+    # Assert
+    assert status == "failed"
+
+
+def test_a_successful_run_files_the_card_done(rail_cards) -> None:
+    # Arrange
+    conclusion = "success"
+    # Act
+    status = rail_cards.STATUS_FOR_CONCLUSION[conclusion]
+    # Assert
+    assert status == "done"
+
+
+def test_every_terminal_conclusion_has_a_status(rail, rail_cards) -> None:
+    """The two tables cannot drift apart without this failing."""
+    # Arrange
+    conclusions = set(rail.TERMINAL_CONCLUSIONS)
+    # Act
+    mapped = set(rail_cards.STATUS_FOR_CONCLUSION)
+    # Assert
+    assert conclusions == mapped
+
+
+def test_a_pending_card_is_out_of_the_runnable_set(rail_cards) -> None:
+    """`in_progress` would make a waiting card look like a stalled one.
+
+    Queue p90 here is ~902s, so a pending card would sit in somebody's
+    runnable work looking abandoned for a quarter of an hour.
+    """
+    # Arrange
+    expected = "blocked"
+    # Act
+    status = rail_cards.PENDING_STATUS
+    # Assert
+    assert status == expected
+
+
+def test_a_pending_card_names_compute_as_its_gate(rail_cards) -> None:
+    """`compute` is the store's own word for "waiting on a machine"."""
+    # Arrange
+    expected = "compute"
+    # Act
+    blocker = rail_cards.PENDING_BLOCKER
+    # Assert
+    assert blocker == expected
+
+
+def test_the_verdict_clears_the_pending_blocker(rail_cards) -> None:
+    """A card parked on a gate must be un-parked when the gate opens.
+
+    Otherwise the rail leaves one permanently-blocked card per push, on a
+    gate that has already opened -- its own failure mode one level up.
+    """
+    # Arrange
+    source = (CI_DIR / "ci_card_rail.py").read_text(encoding="utf-8")
+    # Act
+    verdict_half = source.split("def record_verdict", 1)[1]
+    # Assert
+    assert "blocker=BLOCKER_CLEARED" in verdict_half
+
+
+def test_clearing_a_field_means_the_empty_string(rail_cards) -> None:
+    # Arrange
+    expected = ""
+    # Act
+    sentinel = rail_cards.BLOCKER_CLEARED
+    # Assert
+    assert sentinel == expected
+
+
+def test_title_leads_with_the_verdict(rail_cards) -> None:
+    """The one word a reader woken at 4am needs, first."""
+    # Arrange
+    repo, branch, sha = "scitex-ai/sac", "feat/x", "abcdef1234567890"
+    # Act
+    title = rail_cards.card_title(repo, branch, sha, "failure")
+    # Assert
+    assert title.startswith("[CI FAILURE]")
+
+
+def test_title_identifies_the_branch_a_human_would_look_for(rail_cards) -> None:
+    # Arrange
+    repo, branch, sha = "scitex-ai/sac", "feat/x", "abcdef1234567890"
+    # Act
+    title = rail_cards.card_title(repo, branch, sha, "failure")
+    # Assert
+    assert "sac" in title and "feat/x" in title and "abcdef12" in title
+
+
+# ---------------------------------------------------------------------------
+# recipient resolution -- the difference between delivered and silent
+# ---------------------------------------------------------------------------
 def test_recipient_prefers_a_reachable_agent_over_a_deaf_one(rail) -> None:
     """The regression that motivated not reusing sac's resolve_owner.
 
-    Two agent specs declare ``project: scitex-agent-container``. sac's
-    ``_ci_owner.resolve_owner`` walks ``sorted(glob("*/spec.yaml"))`` and
-    returns the first match, and "-" sorts before "/", so
-    ``scitex-agent-container-04`` wins -- an agent measured with zero
-    inbox subscribers since 2026-08-10. Delivering there raises no error
-    anywhere; it simply reaches nobody.
+    Two specs declare ``project: scitex-agent-container``. That function
+    walks ``sorted(glob("*/spec.yaml"))`` and takes the first, and "-"
+    sorts before "/", so ``scitex-agent-container-04`` wins -- measured
+    with zero inbox subscribers since 2026-08-10. Delivering there raises
+    nothing anywhere; it simply reaches nobody.
     """
+    # Arrange
     agents = [
-        _agent("scitex-agent-container-04", project="scitex-agent-container", reachable=False),
-        _agent("scitex-agent-container", project="scitex-agent-container", reachable=True),
+        _agent("sac-04", project="sac", reachable=False),
+        _agent("sac", project="sac", reachable=True),
     ]
-    who, how = rail.resolve_recipient(card=None, repo="x/scitex-agent-container", agents=agents)
-    assert who == "scitex-agent-container"
+    # Act
+    who, _how = rail.resolve_recipient(card=None, repo="x/sac", agents=agents)
+    # Assert
+    assert who == "sac"
+
+
+def test_spec_resolution_reports_how_it_decided(rail) -> None:
+    # Arrange
+    agents = [_agent("sac", project="sac", reachable=True)]
+    # Act
+    _who, how = rail.resolve_recipient(card=None, repo="x/sac", agents=agents)
+    # Assert
     assert how == "spec"
 
 
 def test_recorded_pusher_beats_any_inference(rail) -> None:
     """A record of who pushed outranks a guess from the repo name."""
+    # Arrange
     agents = [_agent("some-other-agent", project="sac", reachable=True)]
-    who, how = rail.resolve_recipient(
+    # Act
+    who, _how = rail.resolve_recipient(
         card={"agent": "the-actual-pusher"}, repo="x/sac", agents=agents
     )
-    assert (who, how) == ("the-actual-pusher", "card")
+    # Assert
+    assert who == "the-actual-pusher"
+
+
+def test_card_resolution_reports_how_it_decided(rail) -> None:
+    # Arrange
+    agents = [_agent("some-other-agent", project="sac", reachable=True)]
+    # Act
+    _who, how = rail.resolve_recipient(
+        card={"agent": "the-actual-pusher"}, repo="x/sac", agents=agents
+    )
+    # Assert
+    assert how == "card"
 
 
 def test_unresolvable_recipient_is_reported_not_guessed(rail) -> None:
-    who, how = rail.resolve_recipient(card=None, repo="x/nobody-owns-this", agents=[])
-    assert who is None and how == "unresolved"
+    """The caller must fail loudly rather than drop the verdict."""
+    # Arrange
+    agents: list[dict] = []
+    # Act
+    who, _how = rail.resolve_recipient(card=None, repo="x/nobody", agents=agents)
+    # Assert
+    assert who is None
 
 
 def test_deaf_is_still_chosen_when_it_is_the_only_candidate(rail) -> None:
-    """A deaf owner is better than no addressee -- the event is durable.
+    """A deaf owner beats no addressee -- the event is durable.
 
-    ``publish_to_agent`` persists to ``channel_events`` BEFORE publishing,
-    so a verdict addressed to a currently-unsubscribed agent is replayed
-    on its next connect rather than lost. Refusing to address it would
-    throw away a recoverable delivery.
+    ``publish_to_agent`` persists to ``channel_events`` before it
+    publishes, so a verdict addressed to an unsubscribed agent replays on
+    its next connect. Refusing to address it would discard a recoverable
+    delivery.
     """
+    # Arrange
     agents = [_agent("only-one", project="sac", reachable=False)]
-    who, _ = rail.resolve_recipient(card=None, repo="x/sac", agents=agents)
+    # Act
+    who, _how = rail.resolve_recipient(card=None, repo="x/sac", agents=agents)
+    # Assert
     assert who == "only-one"
 
 
 # ---------------------------------------------------------------------------
 # identity resolution
 # ---------------------------------------------------------------------------
-def test_unexpanded_template_is_not_an_identity(rail, monkeypatch) -> None:
+def test_unexpanded_template_is_not_an_identity(rail, clean_agent_env) -> None:
     """``${SCITEX_TODO_AGENT_ID}`` arrives literally in some processes.
 
     Measured in the cards MCP server on this host. Accepting it would
     file cards owned by an agent whose name is a shell template.
     """
-    monkeypatch.setenv("SCITEX_TODO_AGENT_ID", "${SCITEX_TODO_AGENT_ID}")
-    monkeypatch.setenv("SAC_NAME", "real-agent")
-    assert rail.pushing_agent() == "real-agent"
+    # Arrange
+    clean_agent_env["SCITEX_TODO_AGENT_ID"] = "${SCITEX_TODO_AGENT_ID}"
+    clean_agent_env["SAC_NAME"] = "real-agent"
+    # Act
+    resolved = rail.pushing_agent()
+    # Assert
+    assert resolved == "real-agent"
 
 
-def test_no_identity_anywhere_returns_none(rail, monkeypatch) -> None:
-    for var in rail.AGENT_ID_ENV_VARS:
-        monkeypatch.delenv(var, raising=False)
-    assert rail.pushing_agent() is None
+def test_no_identity_anywhere_returns_none(rail, clean_agent_env) -> None:
+    """An owner-less card is rejected by the store, so this must be visible.
+
+    The fixture has already removed every identity variable; returning
+    None is what lets the push half report that plainly instead of
+    filing a card with no owner.
+    """
+    # Arrange
+    present = [v for v in rail.AGENT_ID_ENV_VARS if clean_agent_env.get(v)]
+    # Act
+    resolved = rail.pushing_agent() if not present else "fixture-did-not-clean"
+    # Assert
+    assert resolved is None
 
 
 # ---------------------------------------------------------------------------
 # the message a woken human reads
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize("conclusion", ["success", "failure"])
-def test_verdict_text_carries_conclusion_run_and_card(rail, conclusion: str) -> None:
+def test_verdict_text_states_the_conclusion(rail, conclusion: str) -> None:
+    # Arrange
+    run_url = "https://github.com/o/r/actions/runs/1"
+    # Act
     text = rail.verdict_text(
         repo="scitex-ai/sac",
         branch="feat/x",
         sha="abcdef1234567890",
         conclusion=conclusion,
         leg="pytest-matrix",
-        run_url="https://github.com/o/r/actions/runs/1",
+        run_url=run_url,
     )
+    # Assert
     assert conclusion.upper() in text
-    assert "https://github.com/o/r/actions/runs/1" in text
-    assert rail.card_id_for("scitex-ai/sac", "abcdef1234567890") in text
+
+
+def test_verdict_text_links_the_run(rail) -> None:
+    # Arrange
+    run_url = "https://github.com/o/r/actions/runs/1"
+    # Act
+    text = rail.verdict_text(
+        repo="scitex-ai/sac",
+        branch="feat/x",
+        sha="abcdef1234567890",
+        conclusion="failure",
+        leg="pytest-matrix",
+        run_url=run_url,
+    )
+    # Assert
+    assert run_url in text
+
+
+def test_a_red_verdict_names_what_broke(rail) -> None:
+    """Arriving without naming the failing test solves half the problem."""
+    # Arrange
+    detail = "failed: pytest-matrix\n  E   assert 2 == 4"
+    # Act
+    text = rail.verdict_text(
+        repo="scitex-ai/sac",
+        branch="feat/x",
+        sha="abcdef1234567890",
+        conclusion="failure",
+        leg="pytest-matrix",
+        run_url="https://example.test/1",
+        detail=detail,
+    )
+    # Assert
+    assert "assert 2 == 4" in text
 
 
 # ---------------------------------------------------------------------------
-# WORKFLOW SHAPE -- the two single-line edits that would silently re-break it
+# WORKFLOW SHAPE -- the single-line edits that would silently re-break it
 # ---------------------------------------------------------------------------
-def test_verdict_job_is_pinned_to_the_control_plane_host(gate_workflow) -> None:
+def test_verdict_job_is_pinned_to_the_control_plane_host(verdict_job) -> None:
     """ADR-0024 assumed "the self-hosted runners execute on this host".
 
     They do not. ``vars.CI_RUNS_ON`` is ``scitex-org-cpu``: four runners
-    on four machines (scitex-01..04), and only scitex-04-org-cpu-01 sits
-    on the box running ``sac listen`` and the card store. Unpinned, the
-    verdict job would 75% of the time POST to a different machine's
-    loopback and write to a different postgres -- delivering to nobody
-    and recording nowhere, with nothing raising an error.
+    on four machines, and only scitex-04-org-cpu-01 sits on the box
+    running ``sac listen`` and the card store. Unpinned, this job would
+    75% of the time POST to another machine's loopback and write to
+    another postgres -- delivered to nobody, recorded nowhere, silent.
     """
-    job = gate_workflow["jobs"]["verdict"]
-    runs_on = job["runs-on"]
-    assert isinstance(runs_on, list), "must be a literal label list, not vars.CI_RUNS_ON"
-    assert CONTROL_PLANE_LABEL in runs_on
-    assert "self-hosted" in runs_on
+    # Arrange
+    runs_on = verdict_job["runs-on"]
+    # Act
+    labels = set(runs_on) if isinstance(runs_on, list) else set()
+    # Assert
+    assert CONTROL_PLANE_LABEL in labels
 
 
-def test_verdict_job_reports_red(gate_workflow) -> None:
-    """Without ``always()`` the job is skipped exactly when it matters.
+def test_verdict_job_does_not_inherit_the_shared_runner_pool(verdict_job) -> None:
+    """A literal label list, never ``vars.CI_RUNS_ON``."""
+    # Arrange
+    runs_on = verdict_job["runs-on"]
+    # Act
+    is_literal_list = isinstance(runs_on, list)
+    # Assert
+    assert is_literal_list
 
-    ``needs: [test]`` alone means a failed gate skips the verdict job, so
-    the rail would deliver green verdicts and stay silent on red -- a
-    congratulations service, not a feedback rail.
+
+def test_verdict_job_reports_red(verdict_job) -> None:
+    """Without ``always()`` a failed gate SKIPS this job.
+
+    The rail would then deliver green verdicts and stay silent on red --
+    a congratulations service, not a feedback rail.
     """
-    job = gate_workflow["jobs"]["verdict"]
-    assert "always()" in str(job.get("if", ""))
-    assert "test" in job["needs"]
+    # Arrange
+    condition = str(verdict_job.get("if", ""))
+    # Act
+    fires_unconditionally = "always()" in condition
+    # Assert
+    assert fires_unconditionally
 
 
-def test_verdict_job_passes_the_card_store_explicitly(gate_workflow) -> None:
+def test_verdict_job_waits_for_the_gate(verdict_job) -> None:
+    # Arrange
+    needs = verdict_job["needs"]
+    # Act
+    waits_on_test = "test" in needs
+    # Assert
+    assert waits_on_test
+
+
+def test_verdict_job_passes_the_card_store_explicitly(verdict_env) -> None:
     """An unset DSN does not fail -- it silently picks a local file.
 
-    A ``run:`` step gets a non-interactive shell that sources no profile,
-    so the DSN must come from the workflow. Writing the verdict into a
-    store no board reads is the same silent-nobody failure as delivering
-    to a deaf agent.
+    A ``run:`` step gets a non-interactive shell sourcing no profile, so
+    the DSN must come from the workflow. Writing the verdict into a store
+    no board reads is the same silent-nobody failure as a deaf recipient.
     """
-    step = next(
-        s for s in gate_workflow["jobs"]["verdict"]["steps"] if "env" in s
-    )
-    assert "SCITEX_CARDS_DB" in step["env"]
-    assert "postgres" in step["env"]["SCITEX_CARDS_DB"]
+    # Arrange
+    keys = set(verdict_env)
+    # Act
+    declares_store = "SCITEX_CARDS_DB" in keys
+    # Assert
+    assert declares_store
 
 
-def test_verdict_step_invokes_the_rail_with_a_conclusion(gate_workflow) -> None:
-    run = " ".join(
-        s.get("run", "") for s in gate_workflow["jobs"]["verdict"]["steps"]
-    )
-    assert "ci_card_rail.py verdict" in run
-    assert "--conclusion" in run
-    # uv by absolute fallback: the runner service's PATH is the system
-    # default and does not include ~/.local/bin.
-    assert ".local/bin/uv" in run
+def test_verdict_job_points_at_a_postgres_store(verdict_env) -> None:
+    # Arrange
+    dsn = verdict_env["SCITEX_CARDS_DB"]
+    # Act
+    is_postgres = "postgres" in dsn
+    # Assert
+    assert is_postgres
+
+
+def test_verdict_job_can_read_failed_job_logs(gate_workflow) -> None:
+    """Naming the failure needs ``actions: read``.
+
+    A workflow that withholds a permission its own job needs is one of
+    the inert-but-configured shapes this fleet keeps rediscovering.
+    """
+    # Arrange
+    permissions = gate_workflow["permissions"]
+    # Act
+    granted = permissions.get("actions")
+    # Assert
+    assert granted == "read"
+
+
+def test_verdict_step_invokes_the_rail(verdict_run_script) -> None:
+    # Arrange
+    script = verdict_run_script
+    # Act
+    invokes = "ci_card_rail.py verdict" in script
+    # Assert
+    assert invokes
+
+
+def test_verdict_step_passes_the_gate_result(verdict_run_script) -> None:
+    # Arrange
+    script = verdict_run_script
+    # Act
+    passes_conclusion = "--conclusion" in script
+    # Assert
+    assert passes_conclusion
+
+
+def test_verdict_step_resolves_uv_by_absolute_path(verdict_run_script) -> None:
+    """The runner service's PATH is the system default.
+
+    It does not include ~/.local/bin, so a bare ``uv`` is not found here
+    even though it is on the operator's interactive PATH.
+    """
+    # Arrange
+    script = verdict_run_script
+    # Act
+    has_absolute_fallback = ".local/bin/uv" in script
+    # Assert
+    assert has_absolute_fallback
 
 
 # EOF

--- a/tests/integration/test_ci_card_rail.py
+++ b/tests/integration/test_ci_card_rail.py
@@ -1,0 +1,279 @@
+"""The CI feedback rail's invariants (ADR-0024).
+
+Two kinds of test live here, and the second kind is the point.
+
+**Logic tests** cover the decisions the rail makes with no store and no
+network: which card id both halves derive, who receives a verdict, what
+status a red gate produces.
+
+**Shape tests** assert facts about the WORKFLOW itself, in the spirit of
+``test_ci_python_matrix_shape.py``. They exist because every failure this
+rail is built to prevent is a silent one, and the two ways to re-open
+that hole are both single-line edits to YAML: unpin ``runs-on`` (the
+verdict then executes on a machine where loopback is a different host's
+daemon and a different postgres) or drop ``if: always()`` (the rail then
+only congratulates and never warns). Neither would fail any test that
+only exercised Python, and neither would look wrong in review.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_DIR = REPO_ROOT / ".github" / "ci"
+GATE_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml"
+)
+
+# The label that must remain on the verdict job. It is carried by exactly
+# one runner in the org pool -- the one on the host that runs `sac listen`
+# and the card store.
+CONTROL_PLANE_LABEL = "sac-control-plane"
+
+
+def _load(module_name: str):
+    """Import a rail module by path.
+
+    The rail deliberately is NOT an installed package: it must run under
+    ``uv run --with scitex-cards`` on a runner that has no sac install,
+    and from a git hook inside an agent container. So the tests import it
+    the same way the runner does -- by file -- rather than pretending it
+    is importable as ``scitex_agent_container.something``.
+    """
+    sys.path.insert(0, str(CI_DIR))
+    spec = importlib.util.spec_from_file_location(
+        module_name, CI_DIR / f"{module_name}.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rail():
+    return _load("ci_card_rail")
+
+
+@pytest.fixture(scope="module")
+def rail_cards():
+    return _load("ci_rail_cards")
+
+
+@pytest.fixture(scope="module")
+def gate_workflow() -> dict:
+    return yaml.safe_load(GATE_WORKFLOW.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# the card id is the ONLY channel between the two halves
+# ---------------------------------------------------------------------------
+def test_card_id_is_derived_from_repo_and_sha_only(rail_cards) -> None:
+    """Both halves must reach the same id from the same commit.
+
+    There is no message passed from a developer's git hook to a runner
+    job minutes later, so the id has to be a pure function of facts both
+    sides independently hold. Anything else -- a branch name, a run id, a
+    timestamp -- would make the verdict land on a card nobody watches.
+    """
+    long_sha = "0123456789abcdef0123456789abcdef01234567"
+    from_push = rail_cards.card_id_for("scitex-ai/scitex-agent-container", long_sha)
+    from_ci = rail_cards.card_id_for("scitex-agent-container", long_sha)
+    assert from_push == from_ci == "ci-scitex-agent-container-0123456789ab"
+
+
+def test_card_id_distinguishes_pushes_to_the_same_branch(rail_cards) -> None:
+    a = rail_cards.card_id_for("r/x", "a" * 40)
+    b = rail_cards.card_id_for("r/x", "b" * 40)
+    assert a != b, "a verdict belongs to the commit it judged, not to the branch"
+
+
+# ---------------------------------------------------------------------------
+# a red gate must never produce a gate-less `blocked` card
+# ---------------------------------------------------------------------------
+def test_no_conclusion_maps_to_blocked(rail_cards) -> None:
+    """`blocked` without a named gate is invisible work.
+
+    Such a card nudges nobody and is excluded from the runnable count, so
+    it sits unseen until somebody goes looking -- the exact state this
+    fleet spent 2026-08-11 paying for. A red gate waits on nothing; it is
+    a finished run with a bad result, so it is `failed`.
+    """
+    assert "blocked" not in set(rail_cards.STATUS_FOR_CONCLUSION.values())
+    assert rail_cards.STATUS_FOR_CONCLUSION["failure"] == "failed"
+    assert rail_cards.STATUS_FOR_CONCLUSION["success"] == "done"
+
+
+def test_every_terminal_conclusion_has_a_status(rail, rail_cards) -> None:
+    """The two tables cannot drift apart without this failing."""
+    assert set(rail.TERMINAL_CONCLUSIONS) == set(rail_cards.STATUS_FOR_CONCLUSION)
+
+
+def test_title_leads_with_the_verdict(rail_cards) -> None:
+    title = rail_cards.card_title("scitex-ai/sac", "feat/x", "abcdef1234567890", "failure")
+    assert title.startswith("[CI FAILURE]")
+    assert "sac" in title and "feat/x" in title and "abcdef12" in title
+
+
+# ---------------------------------------------------------------------------
+# recipient resolution -- the difference between delivered and silent
+# ---------------------------------------------------------------------------
+def _agent(name: str, *, project: str, reachable: bool, started: str = "2026-08-10"):
+    return {
+        "name": name,
+        "project": project,
+        "inbox_reachable": "reachable" if reachable else "unreachable",
+        "inbox_subscribers": 1 if reachable else 0,
+        "started_at": started,
+    }
+
+
+def test_recipient_prefers_a_reachable_agent_over_a_deaf_one(rail) -> None:
+    """The regression that motivated not reusing sac's resolve_owner.
+
+    Two agent specs declare ``project: scitex-agent-container``. sac's
+    ``_ci_owner.resolve_owner`` walks ``sorted(glob("*/spec.yaml"))`` and
+    returns the first match, and "-" sorts before "/", so
+    ``scitex-agent-container-04`` wins -- an agent measured with zero
+    inbox subscribers since 2026-08-10. Delivering there raises no error
+    anywhere; it simply reaches nobody.
+    """
+    agents = [
+        _agent("scitex-agent-container-04", project="scitex-agent-container", reachable=False),
+        _agent("scitex-agent-container", project="scitex-agent-container", reachable=True),
+    ]
+    who, how = rail.resolve_recipient(card=None, repo="x/scitex-agent-container", agents=agents)
+    assert who == "scitex-agent-container"
+    assert how == "spec"
+
+
+def test_recorded_pusher_beats_any_inference(rail) -> None:
+    """A record of who pushed outranks a guess from the repo name."""
+    agents = [_agent("some-other-agent", project="sac", reachable=True)]
+    who, how = rail.resolve_recipient(
+        card={"agent": "the-actual-pusher"}, repo="x/sac", agents=agents
+    )
+    assert (who, how) == ("the-actual-pusher", "card")
+
+
+def test_unresolvable_recipient_is_reported_not_guessed(rail) -> None:
+    who, how = rail.resolve_recipient(card=None, repo="x/nobody-owns-this", agents=[])
+    assert who is None and how == "unresolved"
+
+
+def test_deaf_is_still_chosen_when_it_is_the_only_candidate(rail) -> None:
+    """A deaf owner is better than no addressee -- the event is durable.
+
+    ``publish_to_agent`` persists to ``channel_events`` BEFORE publishing,
+    so a verdict addressed to a currently-unsubscribed agent is replayed
+    on its next connect rather than lost. Refusing to address it would
+    throw away a recoverable delivery.
+    """
+    agents = [_agent("only-one", project="sac", reachable=False)]
+    who, _ = rail.resolve_recipient(card=None, repo="x/sac", agents=agents)
+    assert who == "only-one"
+
+
+# ---------------------------------------------------------------------------
+# identity resolution
+# ---------------------------------------------------------------------------
+def test_unexpanded_template_is_not_an_identity(rail, monkeypatch) -> None:
+    """``${SCITEX_TODO_AGENT_ID}`` arrives literally in some processes.
+
+    Measured in the cards MCP server on this host. Accepting it would
+    file cards owned by an agent whose name is a shell template.
+    """
+    monkeypatch.setenv("SCITEX_TODO_AGENT_ID", "${SCITEX_TODO_AGENT_ID}")
+    monkeypatch.setenv("SAC_NAME", "real-agent")
+    assert rail.pushing_agent() == "real-agent"
+
+
+def test_no_identity_anywhere_returns_none(rail, monkeypatch) -> None:
+    for var in rail.AGENT_ID_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    assert rail.pushing_agent() is None
+
+
+# ---------------------------------------------------------------------------
+# the message a woken human reads
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("conclusion", ["success", "failure"])
+def test_verdict_text_carries_conclusion_run_and_card(rail, conclusion: str) -> None:
+    text = rail.verdict_text(
+        repo="scitex-ai/sac",
+        branch="feat/x",
+        sha="abcdef1234567890",
+        conclusion=conclusion,
+        leg="pytest-matrix",
+        run_url="https://github.com/o/r/actions/runs/1",
+    )
+    assert conclusion.upper() in text
+    assert "https://github.com/o/r/actions/runs/1" in text
+    assert rail.card_id_for("scitex-ai/sac", "abcdef1234567890") in text
+
+
+# ---------------------------------------------------------------------------
+# WORKFLOW SHAPE -- the two single-line edits that would silently re-break it
+# ---------------------------------------------------------------------------
+def test_verdict_job_is_pinned_to_the_control_plane_host(gate_workflow) -> None:
+    """ADR-0024 assumed "the self-hosted runners execute on this host".
+
+    They do not. ``vars.CI_RUNS_ON`` is ``scitex-org-cpu``: four runners
+    on four machines (scitex-01..04), and only scitex-04-org-cpu-01 sits
+    on the box running ``sac listen`` and the card store. Unpinned, the
+    verdict job would 75% of the time POST to a different machine's
+    loopback and write to a different postgres -- delivering to nobody
+    and recording nowhere, with nothing raising an error.
+    """
+    job = gate_workflow["jobs"]["verdict"]
+    runs_on = job["runs-on"]
+    assert isinstance(runs_on, list), "must be a literal label list, not vars.CI_RUNS_ON"
+    assert CONTROL_PLANE_LABEL in runs_on
+    assert "self-hosted" in runs_on
+
+
+def test_verdict_job_reports_red(gate_workflow) -> None:
+    """Without ``always()`` the job is skipped exactly when it matters.
+
+    ``needs: [test]`` alone means a failed gate skips the verdict job, so
+    the rail would deliver green verdicts and stay silent on red -- a
+    congratulations service, not a feedback rail.
+    """
+    job = gate_workflow["jobs"]["verdict"]
+    assert "always()" in str(job.get("if", ""))
+    assert "test" in job["needs"]
+
+
+def test_verdict_job_passes_the_card_store_explicitly(gate_workflow) -> None:
+    """An unset DSN does not fail -- it silently picks a local file.
+
+    A ``run:`` step gets a non-interactive shell that sources no profile,
+    so the DSN must come from the workflow. Writing the verdict into a
+    store no board reads is the same silent-nobody failure as delivering
+    to a deaf agent.
+    """
+    step = next(
+        s for s in gate_workflow["jobs"]["verdict"]["steps"] if "env" in s
+    )
+    assert "SCITEX_CARDS_DB" in step["env"]
+    assert "postgres" in step["env"]["SCITEX_CARDS_DB"]
+
+
+def test_verdict_step_invokes_the_rail_with_a_conclusion(gate_workflow) -> None:
+    run = " ".join(
+        s.get("run", "") for s in gate_workflow["jobs"]["verdict"]["steps"]
+    )
+    assert "ci_card_rail.py verdict" in run
+    assert "--conclusion" in run
+    # uv by absolute fallback: the runner service's PATH is the system
+    # default and does not include ~/.local/bin.
+    assert ".local/bin/uv" in run
+
+
+# EOF

--- a/tests/integration/test_ci_card_rail.py
+++ b/tests/integration/test_ci_card_rail.py
@@ -335,6 +335,53 @@ def test_superseding_is_scoped_to_one_branch(rail_cards) -> None:
     assert store.tasks[other_id]["status"] == "blocked"
 
 
+def test_the_verdict_half_supplies_a_creator_when_it_creates(rail_cards) -> None:
+    """A GitHub runner's `run:` step carries NO agent identity at all.
+
+    The store demands a creator and refuses to invent one, so creating a
+    card there fails unless the rail supplies it. This is the path taken
+    whenever the pre-push hook did not run -- every human push, every
+    repo without the hook -- so the rail would fail exactly where it is
+    meant to be the safety net. Found by running the real command under
+    `env -i` plus the runner service's PATH; from a container shell every
+    identity variable is populated and the call succeeds, which is why
+    this cannot be caught by testing from a shell.
+    """
+    # Arrange
+    source = (CI_DIR / "ci_card_rail.py").read_text(encoding="utf-8")
+    # Act
+    verdict_half = source.split("def record_verdict", 1)[1]
+    # Assert
+    assert 'create_only={"created_by": VERDICT_ACTOR}' in verdict_half
+
+
+def test_creator_is_only_sent_on_creation(rail_cards) -> None:
+    """`created_by` is accepted by add_task and REJECTED by update_task.
+
+    One dict cannot serve both calls, which is the whole reason
+    `create_only` exists as a separate channel.
+    """
+    # Arrange
+    calls: list[str] = []
+
+    class _Store:
+        TaskNotFoundError = KeyError
+
+        def get_task(self, task_id: str):
+            return {"id": task_id}
+
+        def update_task(self, **fields):
+            calls.append("update:" + ",".join(sorted(fields)))
+            return fields
+
+    # Act
+    rail_cards.upsert_card(
+        _Store(), "ci-x-1", title="t", create_only={"created_by": "ci"}, status="done"
+    )
+    # Assert
+    assert "created_by" not in calls[0]
+
+
 def test_a_green_verdict_does_not_claim_mergeability(rail) -> None:
     """This rail sees ONE workflow; `needs:` cannot cross workflow files.
 


### PR DESCRIPTION
## The rail the operator asked for

> プッシュに連動して、必ずフックでカードにその情報を書かないといけない…GitHubから信号が帰ってきたときに、フックでカードに書き込む、それがエージェントに通知が行く

Implements **ADR-0024**, piloted on this repo and no other.

```
push  -> .githooks/pre-push registers the commit on a card
CI    -> a job on the control-plane host writes the verdict to the SAME card
card  -> the verdict is delivered into the pushing agent's live session
```

The card id is derived from `(repo, head sha)` on both sides, which is why no
channel is needed between a git hook and a runner job that starts minutes later.

## Why a runner step and not a webhook

`sac listen` binds `127.0.0.1` only, by policy — there is no public route for
GitHub to POST to. But a self-hosted runner already long-polls **outward** to
GitHub and then executes on our hardware, where loopback is reachable and the
bearer is a local file. The GitHub→host path exists and is already trusted.
That is nearer 「フック」 than the two existing pollers: it fires *on* the event
rather than noticing it up to 300 s later, and it drops the `gh`-auth
dependency that made both fail closed. Neither has ever delivered a verdict on
this host — `verdict_delivered` has never even been created.

## The one thing ADR-0024 got wrong, measured

The ADR reasoned "the self-hosted runners execute on this host". They do not.
`vars.CI_RUNS_ON` is `scitex-org-cpu` — **four runners on four machines**, and
only `scitex-04-org-cpu-01` sits on the box running `sac listen` and the card
store. The premise holds for 25% of jobs; on the other 75% both
`127.0.0.1:7878` and `127.0.0.1:55432` are a *different* machine's daemon and a
*different* postgres — recorded nowhere, delivered to nobody, nothing raised.

So the verdict job is pinned to a `sac-control-plane` label carried by that one
runner, and `test_verdict_job_is_pinned_to_the_control_plane_host` recomputes
the pin from the workflow rather than trusting it. The cost is one queue
admission (median ~706 s here); the ADR's cheaper in-job placement was only
available under the false premise.

## Three silent failures this refuses to reproduce

| Failure | What this does |
|---|---|
| **Delivering to a deaf agent.** 9 of 15 registered agents hold zero inbox subscribers; a message lands on an empty bus and raises nothing. | Recipient resolution *prefers a reachable agent*. sac's own `resolve_owner` takes the first spec in sorted order — for this repo, deterministically the agent with no subscriber since 2026-08-10. A zero delivered-count is reported as a **recipient** fault, not a rail fault, since the event is persisted and replays. |
| **Writing to a store nobody reads.** `:5442` and `:55432` both answer, both report `store_uuid 1d55dd6e-…`, and hold **3496 vs 3793** cards — two divergent databases wearing one identity. An unset DSN silently picks a local file. | DSN passed explicitly, backend re-checked, resolved target printed so a run is auditable after the fact. |
| **Saying only "Red".** Seven consecutive red nights reached nobody; arriving without naming the failing test solves half of that. | A red verdict quotes the first failure lines from the **failed jobs'** logs — the per-job endpoint, because this job is itself running and the whole-run archive is still empty and greps exactly like a clean one. Every unreadable-log path says so explicitly. It reports the verdict and quotes the log; it does not assert a cause it cannot know. |

A red gate files the card `failed`, never `blocked`. A `blocked` card must name
its gate, none of this store's blockers describes a red suite, and a gate-less
blocked card nudges nobody and leaves the runnable count — which is how 21
operator decisions sat invisible for weeks.

## Also fixed

- `.githooks/pre-push` resolves ruff via `uv` when no venv ships it. The agent
  containers ship **no** ruff at any searched path, so this gate could not run
  in the environment most pushes come from — it either blocked every push or
  taught everyone to reach for `--no-verify`, disarming the protected-branch
  guard in the same stroke. Still strict; same ruff, same rules.
- `pyproject.toml` `library_dirs` held `".github/ci"`, but `is_script()` tests
  `lib_dir in path.parts`, so a value containing a separator can never match.
  It looked configured and exempted nothing.

## Verification

The push half fired on this very branch: a real `pre-push` hook recorded commit
`b2745405` on card `ci-scitex-agent-container-b27454051ade`. The delivery half
was proven end to end before this PR — a verdict reached a running agent's live
session, confirmed by that agent independently.

**This PR's own gate run is the acceptance test for the CI half.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
