### PR TITLE
ci(routing): give the sub-minute single-core jobs their own lane

### DIFF
--- a/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
+++ b/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
@@ -54,7 +54,23 @@ jobs:
   install-check:
     # Kept byte-identical — see lint.yml. (Verified: not protection-pinned.)
     name: import-smoke-on-ubuntu-py3-12
-    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    #
+    # 47s median, single-core, and it never enters the CI SIF. That is the
+    # POINT of this job: it installs from source on the BARE runner precisely to
+    # check that the package imports without the SIF's baked environment, so
+    # routing it to a SIF-capable host would not help it and pinning it here
+    # costs it nothing.
+    #
+    # It was holding one of four 32-core machines per run on a pool at 93-94%
+    # utilisation, then queueing 289s median (p90 902s). The spartan-cpu runners
+    # are nproc=1 — wrong for `tests` (497s there vs 170s on 32 cores), right
+    # for this.
+    #
+    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
+    # visible in a diff and cannot reach `tests` or the release gate, which DO
+    # enter the SIF and still need #992 first.
+    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,29 @@ jobs:
     # stops reporting has already held a release hostage once. Correcting the
     # "on-ubuntu" names repo-wide is a separate, coordinated change.
     name: ruff-on-ubuntu-latest
-    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    #
+    # This repo's CI is bimodal. Over 276 self-hosted jobs (2.1 h): `tests` is
+    # 31% of jobs at 368s and uses all 32 cores (xdist runs -n $(nproc)); the
+    # other 69% — this job included — run 12-51s on about ONE core. `ruff` is
+    # the smallest of them at 12s median, and it never enters the CI SIF: no
+    # exec-in-sif.sh, no /data/gpfs bind, just checkout + uv + ruff.
+    #
+    # So a 12-second single-core job was taking one of four 32-core machines
+    # for its turn, on a pool measured at 93-94% utilisation — and then waiting
+    # 289s median (p90 902s) for the privilege.
+    #
+    # The spartan-cpu runners were sitting idle, and a canary established the
+    # fact nobody had checked: they are nproc=1. That makes them wrong for
+    # `tests` (the suite takes 497s there vs 170s on 32 cores) and correctly
+    # sized for exactly this kind of job.
+    #
+    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
+    # visible in a diff, revertible on its own, and CANNOT reach `tests` or
+    # pypi-publish-and-github-release-on-tag.yml by accident. Do not generalise
+    # it to those: both DO enter the SIF, and `main`'s exec-in-sif.sh still
+    # binds /data/gpfs/projects/punim0264 unconditionally (#992 is the fix).
+    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
+++ b/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
@@ -63,7 +63,26 @@ concurrency:
 jobs:
   no-hosted-runners:
     name: no-hosted-runners-guard-on-self-hosted
-    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    #
+    # 13s median, single-core, needs nothing but PyYAML, and never enters the
+    # CI SIF. It was holding one of four 32-core machines per run on a pool at
+    # 93-94% utilisation, then queueing 289s median (p90 902s) — a 13-second
+    # job waiting twenty times its own runtime for a machine it used 1/32 of.
+    #
+    # The spartan-cpu runners are nproc=1: wrong for `tests` (497s there vs
+    # 170s on 32 cores), right for this. And see the setup-uv note below — this
+    # job was already written for the bare Spartan node's constraints.
+    #
+    # NOTE THE SELF-REFERENCE: this guard parses every workflow's `runs-on` and
+    # fails anything it cannot prove self-hosted. The literal list below starts
+    # with "self-hosted", so it passes its own check — verified by running the
+    # guard against this tree before committing, not assumed.
+    #
+    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
+    # visible in a diff and cannot reach `tests` or the release gate, which DO
+    # enter the SIF and still need #992 first.
+    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/quality-audit-on-ubuntu-latest.yml
@@ -51,7 +51,21 @@ jobs:
     # Deliberate misnomer, kept byte-identical — see lint.yml for the full
     # reasoning. (Verified: not a protection-pinned required context.)
     name: scitex-dev-quality-audit-on-ubuntu-latest
-    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    #
+    # 44s median, single-core, and it never enters the CI SIF — the audit-*
+    # verbs are filesystem and AST analysis over the checkout, so nothing here
+    # depends on the host beyond having uv and a Python. It was holding one of
+    # four 32-core machines per run on a pool at 93-94% utilisation, then
+    # queueing 289s median (p90 902s).
+    #
+    # The spartan-cpu runners are nproc=1 — wrong for `tests` (497s there vs
+    # 170s on 32 cores), right for a job like this one.
+    #
+    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
+    # visible in a diff and cannot reach `tests` or the release gate, which DO
+    # enter the SIF and still need #992 first.
+    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
+++ b/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
@@ -40,7 +40,25 @@ jobs:
   sphinx:
     # Kept byte-identical — see lint.yml. (Verified: not protection-pinned.)
     name: rtd-sphinx-build-on-ubuntu-latest
-    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    #
+    # 51s median, single-core, and it never enters the CI SIF — checkout + uv +
+    # sphinx-build on the bare runner, no /data/gpfs bind. It was holding one of
+    # four 32-core machines per run on a pool at 93-94% utilisation, then
+    # queueing 289s median (p90 902s). The spartan-cpu runners are nproc=1:
+    # wrong for `tests` (497s there vs 170s on 32 cores), right for this.
+    #
+    # THIS JOB COMMITS, which is why the host matters beyond size. The
+    # default-branch refresh below pushes regenerated HTML, and commit signing
+    # fails 13/13 on compute-04 ("failed to write commit object" — ssh signing
+    # against a key that is not there). The canary probed `git commit` on
+    # spartan-bm153 and it succeeds with signing unset, so this move takes the
+    # refresh OFF the one host where it reliably breaks.
+    #
+    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
+    # visible in a diff and cannot reach `tests` or the release gate, which DO
+    # enter the SIF and still need #992 first.
+    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
     timeout-minutes: 20
     permissions:
       contents: write


### PR DESCRIPTION
## Two thirds of CI was queueing behind the other third for machines it could not use

Measured over 276 self-hosted jobs in 2.1 h, this repo's CI is bimodal:

| | share of jobs | median run | cores it uses |
|---|---|---|---|
| `tests` | 31 % | 368 s | all 32 (`xdist -n $(nproc)`) |
| light lane | 69 % | 12-51 s | about one |

They share one pool: four 32-core machines, one runner each, measured at
**93-94 % utilisation** with a **289 s median queue and 902 s p90**. So a
12-second `ruff` run took a whole 32-core machine for its turn and waited
roughly twenty times its own runtime to get one.

## The measurement that decided this

The three `spartan-cpu` runners were idle, and the plan on the table was to
treat them as three more machines. A canary (#1001) checked the one thing
nobody had: **`nproc = 1`**. The full suite takes **497 s** there against
**170 s** on a 32-core host.

That single fact splits the decision cleanly. One-core slots are the wrong
place for `tests` and exactly the right size for the light lane. "Three idle
machines" was really three one-core slots, which is a different plan than the
one we were about to make.

## What moved, and the property that qualifies it

| workflow | check | median | enters SIF? |
|---|---|---|---|
| `lint.yml` | `lint` | 12 s | no |
| `no-hosted-runners-guard-on-self-hosted.yml` | `no-hosted-runners` | 13 s | no |
| `quality-audit-on-ubuntu-latest.yml` | `quality` | 44 s | no |
| `import-smoke-on-ubuntu-py3-12.yml` | `import-smoke` | 47 s | no |
| `rtd-sphinx-build-on-ubuntu-latest.yml` | `docs` | 51 s | no |

The qualifying property is **not runtime — it is the SIF**. None of these calls
`exec-in-sif.sh`; they are checkout + uv on the bare runner, so none needs the
`/data/gpfs` bind. `import-smoke` installs on the bare runner *deliberately*, to
prove the package imports without the SIF's baked environment. And the guard's
own `setup-uv` step already carried the note that the bare Spartan node has no
Python and is PEP-668 externally-managed — these jobs were written for that
host's constraints.

## What did NOT move, and why the line is exactly there

`tests`, all four jobs of `pypi-publish-and-github-release-on-tag.yml`,
`autobump-release-sweep`, and `newb`. **Every one of them enters the SIF**, and
`origin/main`'s `exec-in-sif.sh` still binds `/data/gpfs/projects/punim0264`
unconditionally (line 45 `APPTAINER_TMPDIR`, line 95 `--bind`; `develop` guards
both since #880). **#992 is the precondition for moving any of them**, and
`main` was just promoted — a release path whose hardware varies silently is the
worst thing to ship tonight.

Please do not read this PR as permission to move the rest. The table above is
the whole authorised set; the SIF column is the reason.

## Why per-workflow `runs-on` and not the variable

`vars.CI_RUNS_ON` is load-bearing and it is working — measured across its
02:27:58Z change, at flat arrival (1.89 -> 2.01 jobs/min), flat service
(42 -> 41 s) and flat utilisation (93 -> 94 %), median queue fell **1197 s ->
289 s**. It is the mitigation, not the cause. It is also read by **10 workflows
/ 13 jobs including all four release jobs**, so editing it re-points release
hardware with no diff to read.

A literal list in each file keeps this routing visible in review, revertible one
workflow at a time, and structurally unable to reach the release gate.

## Verification

- The `no-hosted-runners` guard parses every `runs-on` and fails anything it
  cannot prove self-hosted — **including its own**, which this PR moved. Ran it
  against this tree before committing: **exit 0**.
- **This PR verifies itself.** Four of the five moved workflows are PR-gate
  checks, so `lint`, `quality`, `import-smoke`, `docs` and `no-hosted-runners`
  on this very PR are running on `spartan-cpu`. If a one-core slot cannot serve
  them, these checks say so directly.
- `tests` on this PR still runs on the unchanged pool, which is the control.

## Incidental fix

`rtd-sphinx` commits regenerated HTML on default-branch pushes, and commit
signing fails 13/13 on compute-04 (`fatal: failed to write commit object` — ssh
signing against a key that is not there). The canary probed `git commit` on
`spartan-bm153`: it succeeds, signing unset. So this also takes that refresh off
the one host where it reliably breaks.

## Not done

No test disabled, skipped or deselected — capacity, not coverage. No label
widened, no runner re-labelled, `CI_RUNS_ON` untouched. Per-ref `concurrency`
groups were measured at 4 of 43 active jobs (9 %) and left out on purpose:
real, but not the ceiling, and I did not want it read as one.
