### PR TITLE
fix(dev-jobs): read how scitex-dev wants the job name, do not assume --name

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -101,24 +101,27 @@ from dataclasses import dataclass
 
 import click
 
-#: The ecosystem subcommand that serves a kind on the surface that has
-#: SHIPPED: ``cron`` for cron jobs, and ``systemd`` for both unit kinds,
-#: which it lumps together.
-#:
-#: This is a FALLBACK, consulted only after the preferred per-kind
-#: surface (``dev service`` / ``dev timer``) is probed for and found
-#: absent. It disappears on its own the moment scitex-dev ships those
-#: groups — no coordinated release, no flag.
-LEGACY_GROUP_FOR_KIND: dict[str, str] = {
-    "service": "systemd",
-    "timer": "systemd",
-    "cron": "cron",
-}
+# Reading the installed scitex-dev's Click tree lives in its own module;
+# this one builds and runs delegations. Re-exported below so every
+# existing `from ._dev_jobs_backend import ...` keeps resolving.
+from ._dev_jobs_capability import (  # noqa: F401  (re-exported, see below)
+    DEV_SUBGROUP,
+    LEGACY_GROUP_FOR_KIND,
+    _child,
+    _leaf_verbs,
+    _walk,
+    ecosystem_verbs,
+    leaf_command,
+    name_is_an_option,
+    name_style_for,
+    reset_capability_cache,
+)
 
-#: The subgroup scitex-dev moved its job CLI under. Probed for, never
-#: assumed: an older scitex-dev mounts the groups at the top level and a
-#: newer one under here, and both must work without a sac release.
-DEV_SUBGROUP = "dev"
+# The underscore-prefixed three are re-exported ON PURPOSE. Callers reach
+# for them to build a REAL Click tree and point the probe at it — a seam
+# that predates this split and is not a mock: `_walk` is handed an actual
+# Group. Dropping them here would have moved a working seam out from under
+# its users, so they stay reachable at the name they were always at.
 
 #: Verbs the shipped ecosystem surface has always had. Used ONLY when
 #: introspection cannot decide, so a working install is never refused
@@ -131,11 +134,6 @@ SHIPPED_VERBS: frozenset[str] = frozenset({"list", "install", "uninstall"})
 MUTATING_VERBS: frozenset[str] = frozenset(
     {"install", "uninstall", "enable", "disable", "start", "stop", "restart"}
 )
-
-# Sentinel distinguishing "not probed yet" from "probed, unavailable".
-_UNPROBED: object = object()
-_VERBS_CACHE: object = _UNPROBED
-
 
 @dataclass(frozen=True)
 class Delegation:
@@ -169,117 +167,6 @@ class Delegation:
     def group(self) -> str:
         """The path as it is typed: ``"cron"``, ``"dev timer"``, …"""
         return " ".join(self.path)
-
-
-def reset_capability_cache() -> None:
-    """Forget the probed surface. For tests that install a different one."""
-    global _VERBS_CACHE
-    _VERBS_CACHE = _UNPROBED
-
-
-def _child(command, name: str):
-    """Return the named subcommand of ``command``, or None."""
-    getter = getattr(command, "get_command", None)
-    if getter is not None:
-        try:
-            with click.Context(command) as ctx:
-                return getter(ctx, name)
-        except Exception:  # stx-allow: fallback (reason: another package's Group subclass may need a context we cannot build — fall back to the eager dict)
-            pass
-    return (getattr(command, "commands", {}) or {}).get(name)
-
-
-def _leaf_verbs(command) -> frozenset[str]:
-    """The subcommand names of one ecosystem group.
-
-    ``Group.list_commands(ctx)`` rather than ``Group.commands`` so a LAZY
-    group is read correctly — the eager dict can be empty while the group
-    is fully featured.
-
-    Returns an EMPTY set for a node that is a plain ``Command`` (a
-    forwarding shim) rather than a ``Group``. That empty is honest — a
-    shim genuinely has no enumerable verbs — and callers must read it as
-    "cannot tell", never as "serves nothing"; see :func:`resolve`.
-
-    CORRECTION, so the next reader does not inherit a wrong mechanism:
-    an earlier revision claimed laziness EXPLAINED the "four cron verbs
-    locally, zero in CI" split. It did not. Measured afterwards, the real
-    cause was scitex-dev relocating those verbs under ``ecosystem dev``
-    and leaving a deprecated ``Command`` shim behind at the old name.
-    Reading ``list_commands`` is still correct; it was simply not the fix
-    for that symptom — walking into ``dev`` is.
-    """
-    lister = getattr(command, "list_commands", None)
-    if lister is not None:
-        try:
-            with click.Context(command) as ctx:
-                return frozenset(lister(ctx))
-        except Exception:  # stx-allow: fallback (reason: another package's Group subclass may need a context we cannot build — fall back to the eager dict)
-            pass
-    return frozenset(getattr(command, "commands", {}) or {})
-
-
-def _walk(ecosystem) -> dict[tuple[str, ...], frozenset[str]]:
-    """Map ``path under ecosystem -> its verbs``, one level into ``dev``.
-
-    Depth is bounded to the job groups on purpose: enumerating all ~51
-    ecosystem subcommands' children would pay for building trees nobody
-    here consults.
-    """
-    tree: dict[tuple[str, ...], frozenset[str]] = {}
-    for name in sorted(_leaf_verbs(ecosystem)):
-        if name not in _PROBED_GROUPS and name != DEV_SUBGROUP:
-            continue
-        group = _child(ecosystem, name)
-        if group is None:
-            continue
-        tree[(name,)] = _leaf_verbs(group)
-        if name != DEV_SUBGROUP:
-            continue
-        for sub in sorted(tree[(name,)]):
-            if sub not in _PROBED_GROUPS:
-                continue
-            child = _child(group, sub)
-            if child is not None:
-                tree[(name, sub)] = _leaf_verbs(child)
-    return tree
-
-
-#: Group names worth descending into. Everything else under ``ecosystem``
-#: is unrelated to jobs.
-_PROBED_GROUPS: frozenset[str] = frozenset({"service", "timer", "cron", "systemd"})
-
-
-def ecosystem_verbs() -> dict[tuple[str, ...], frozenset[str]] | None:
-    """Return ``{path under `ecosystem` -> verbs}`` for the INSTALLED scitex-dev.
-
-    Keys are PATHS — ``("cron",)``, ``("dev", "timer")`` — because the job
-    groups moved under ``ecosystem dev`` and the old names survive as
-    empty shells. A name-keyed map cannot tell those two apart.
-
-    ``None`` when the Click tree cannot be built at all (an old or partial
-    scitex-dev). ``None`` means "cannot tell", never "unsupported" — the
-    three-state discipline from ``_jobs_audit``: a false "unsupported"
-    here refuses a command that would have worked.
-    """
-    global _VERBS_CACHE
-    if _VERBS_CACHE is not _UNPROBED:
-        return _VERBS_CACHE  # type: ignore[return-value]
-
-    probed: dict[tuple[str, ...], frozenset[str]] | None
-    try:
-        from scitex_dev._cli.ecosystem import register_ecosystem_commands
-
-        @click.group()
-        def _probe_root() -> None:  # pragma: no cover - never invoked
-            """Throwaway root; we only want the tree it gets wired onto."""
-
-        probed = _walk(register_ecosystem_commands(_probe_root))
-    except Exception:  # stx-allow: fallback (reason: introspecting another package's private CLI tree must degrade to "cannot tell", never to a refusal)
-        probed = None
-
-    _VERBS_CACHE = probed
-    return probed
 
 
 def candidate_paths(kind: str) -> tuple[tuple[str, ...], ...]:
@@ -413,8 +300,16 @@ def build_argv(
     yes: bool,
     dry_run: bool = False,
     exe: str = "scitex-dev",
+    leaf: object | None = None,
 ) -> list[str]:
     """The exact argv :func:`invoke` will run. Separated so it is testable.
+
+    ``leaf`` is the resolved Click command the delegation targets. It is a
+    PARAMETER rather than an internal lookup so a caller — a test, most
+    obviously — can hand in a real command of either argument shape and
+    exercise both scitex-dev generations against whichever single version
+    happens to be installed. ``None`` means "look it up", which is what
+    production always does.
 
     ``--dry-run`` and ``--yes`` are FORWARDED, never interpreted here.
     scitex-dev's gate on mutating verbs is what stops ``timer disable
@@ -422,10 +317,24 @@ def build_argv(
     refresher; a pass-through that dropped either flag would convert a
     guarded command into an unguarded one, which is strictly worse than
     not offering the verb.
+
+    The job NAME follows :func:`name_style_for` — ``--name X`` or a bare
+    positional, as the INSTALLED scitex-dev actually declares it. It was
+    unconditionally ``--name`` until scitex-dev 0.48.0 made the shape
+    mixed; emitting the old shape at a positional verb is rejected by
+    Click before the command runs, which looks identical to sac refusing
+    the verb and is not.
     """
     argv = [exe, "ecosystem", *delegation.path, delegation.verb]
     if name is not None:
-        argv += ["--name", name]
+        if leaf is None:
+            style = name_style_for(delegation.path, delegation.verb)
+        else:
+            style = "option" if name_is_an_option(leaf) else "positional"
+        if style == "positional":
+            argv.append(name)
+        else:
+            argv += ["--name", name]
     if dry_run:
         argv.append("--dry-run")
     if yes:
@@ -469,7 +378,10 @@ __all__ = [
     "candidate_paths",
     "ecosystem_verbs",
     "invoke",
+    "leaf_command",
     "manual_hint",
+    "name_is_an_option",
+    "name_style_for",
     "reset_capability_cache",
     "resolve",
 ]

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_capability.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_capability.py
@@ -1,0 +1,245 @@
+"""Reading the INSTALLED scitex-dev's Click tree — capability, not delegation.
+
+Split out of ``_dev_jobs_backend`` (which had grown past the line limit)
+along the seam that was already there: this module only ever ASKS THE
+INSTALLED PACKAGE WHAT IT CAN DO. It knows nothing about ``Delegation``,
+argv, or subprocesses; ``_dev_jobs_backend`` owns those and re-exports
+everything here, so existing imports of either name keep working.
+
+THE DOCTRINE, WHICH IS THE WHOLE REASON THIS IS INTROSPECTION AND NOT A
+TABLE: read the real thing. A hard-coded map of "which verbs exist" or
+"which verbs take ``--name``" is a COPY of another package's CLI, and a
+copy goes stale silently — it keeps answering confidently while the
+original moves underneath it. Both times this module was wrong, that was
+why:
+
+* scitex-dev relocated its job groups under ``ecosystem dev`` and left
+  deprecated forwarding shims at the old names, so a name-keyed probe
+  said "present" about a ``Command`` that enumerates zero verbs; and
+* scitex-dev 0.48.0 made the job-name argument shape MIXED, so emitting
+  ``--name`` unconditionally started failing on half the verbs.
+
+Every answer here therefore comes from the installed objects, and every
+unreadable answer is a THIRD STATE (``None`` / ``"unknown"``), never a
+refusal. A false "unsupported" refuses a command that would have worked,
+which is the more expensive mistake in both directions.
+"""
+
+from __future__ import annotations
+
+import click
+
+#: The ecosystem subcommand that serves a kind on the surface that has
+#: SHIPPED: ``cron`` for cron jobs, and ``systemd`` for both unit kinds,
+#: which it lumps together.
+#:
+#: This is a FALLBACK, consulted only after the preferred per-kind
+#: surface (``dev service`` / ``dev timer``) is probed for and found
+#: absent. It disappears on its own the moment scitex-dev ships those
+#: groups — no coordinated release, no flag.
+LEGACY_GROUP_FOR_KIND: dict[str, str] = {
+    "service": "systemd",
+    "timer": "systemd",
+    "cron": "cron",
+}
+
+#: The subgroup scitex-dev moved its job CLI under. Probed for, never
+#: assumed: an older scitex-dev mounts the groups at the top level and a
+#: newer one under here, and both must work without a sac release.
+DEV_SUBGROUP = "dev"
+
+#: Group names worth descending into. Everything else under ``ecosystem``
+#: is unrelated to jobs.
+_PROBED_GROUPS: frozenset[str] = frozenset({"service", "timer", "cron", "systemd"})
+
+# Sentinel distinguishing "not probed yet" from "probed, unavailable".
+_UNPROBED: object = object()
+_VERBS_CACHE: object = _UNPROBED
+
+
+def reset_capability_cache() -> None:
+    """Forget the probed surface. For tests that install a different one."""
+    global _VERBS_CACHE
+    _VERBS_CACHE = _UNPROBED
+
+
+def _child(command, name: str):
+    """Return the named subcommand of ``command``, or None."""
+    getter = getattr(command, "get_command", None)
+    if getter is not None:
+        try:
+            with click.Context(command) as ctx:
+                return getter(ctx, name)
+        except Exception:  # stx-allow: fallback (reason: another package's Group subclass may need a context we cannot build — fall back to the eager dict)
+            pass
+    return (getattr(command, "commands", {}) or {}).get(name)
+
+
+def _leaf_verbs(command) -> frozenset[str]:
+    """The subcommand names of one ecosystem group.
+
+    ``Group.list_commands(ctx)`` rather than ``Group.commands`` so a LAZY
+    group is read correctly — the eager dict can be empty while the group
+    is fully featured.
+
+    Returns an EMPTY set for a node that is a plain ``Command`` (a
+    forwarding shim) rather than a ``Group``. That empty is honest — a
+    shim genuinely has no enumerable verbs — and callers must read it as
+    "cannot tell", never as "serves nothing"; see ``resolve``.
+
+    CORRECTION, so the next reader does not inherit a wrong mechanism:
+    an earlier revision claimed laziness EXPLAINED the "four cron verbs
+    locally, zero in CI" split. It did not. Measured afterwards, the real
+    cause was scitex-dev relocating those verbs under ``ecosystem dev``
+    and leaving a deprecated ``Command`` shim behind at the old name.
+    Reading ``list_commands`` is still correct; it was simply not the fix
+    for that symptom — walking into ``dev`` is.
+    """
+    lister = getattr(command, "list_commands", None)
+    if lister is not None:
+        try:
+            with click.Context(command) as ctx:
+                return frozenset(lister(ctx))
+        except Exception:  # stx-allow: fallback (reason: another package's Group subclass may need a context we cannot build — fall back to the eager dict)
+            pass
+    return frozenset(getattr(command, "commands", {}) or {})
+
+
+def _walk(ecosystem) -> dict[tuple[str, ...], frozenset[str]]:
+    """Map ``path under ecosystem -> its verbs``, one level into ``dev``.
+
+    Depth is bounded to the job groups on purpose: enumerating all ~51
+    ecosystem subcommands' children would pay for building trees nobody
+    here consults.
+    """
+    tree: dict[tuple[str, ...], frozenset[str]] = {}
+    for name in sorted(_leaf_verbs(ecosystem)):
+        if name not in _PROBED_GROUPS and name != DEV_SUBGROUP:
+            continue
+        group = _child(ecosystem, name)
+        if group is None:
+            continue
+        tree[(name,)] = _leaf_verbs(group)
+        if name != DEV_SUBGROUP:
+            continue
+        for sub in sorted(tree[(name,)]):
+            if sub not in _PROBED_GROUPS:
+                continue
+            child = _child(group, sub)
+            if child is not None:
+                tree[(name, sub)] = _leaf_verbs(child)
+    return tree
+
+
+def ecosystem_root():
+    """The INSTALLED scitex-dev's wired ``ecosystem`` group, or ``None``.
+
+    Kept separate from :func:`ecosystem_verbs` because that one caches a
+    SUMMARY (path -> verb names) while callers that need to inspect a
+    command's parameters need the COMMAND OBJECTS themselves.
+    """
+    try:
+        from scitex_dev._cli.ecosystem import register_ecosystem_commands
+
+        @click.group()
+        def _probe_root() -> None:  # pragma: no cover - never invoked
+            """Throwaway root; we only want the tree it gets wired onto."""
+
+        return register_ecosystem_commands(_probe_root)
+    except Exception:  # stx-allow: fallback (reason: introspecting another package's private CLI tree must degrade to "cannot tell", never to a refusal)
+        return None
+
+
+def ecosystem_verbs() -> dict[tuple[str, ...], frozenset[str]] | None:
+    """Return ``{path under `ecosystem` -> verbs}`` for the INSTALLED scitex-dev.
+
+    Keys are PATHS — ``("cron",)``, ``("dev", "timer")`` — because the job
+    groups moved under ``ecosystem dev`` and the old names survive as
+    empty shells. A name-keyed map cannot tell those two apart.
+
+    ``None`` when the Click tree cannot be built at all (an old or partial
+    scitex-dev). ``None`` means "cannot tell", never "unsupported" — the
+    three-state discipline from ``_jobs_audit``: a false "unsupported"
+    here refuses a command that would have worked.
+    """
+    global _VERBS_CACHE
+    if _VERBS_CACHE is not _UNPROBED:
+        return _VERBS_CACHE  # type: ignore[return-value]
+
+    root = ecosystem_root()
+    probed = None if root is None else _walk(root)
+
+    _VERBS_CACHE = probed
+    return probed
+
+
+def leaf_command(path: tuple[str, ...], verb: str):
+    """The real Click command ``ecosystem <path...> <verb>`` resolves to.
+
+    ``None`` when any step is unreadable — "cannot tell", never
+    "absent", per the three-state discipline this module follows
+    throughout.
+    """
+    node = ecosystem_root()
+    if node is None:
+        return None
+    for part in path:
+        node = _child(node, part)
+        if node is None:
+            return None
+    return _child(node, verb)
+
+
+def name_is_an_option(command) -> bool:
+    """Does ``command`` take the job name as ``--name``, or positionally?
+
+    Answered by reading the command's OWN parameters. Deliberately takes a
+    Click command rather than a path so it can be exercised against real
+    commands of both shapes without reaching for the installed package.
+    """
+    for param in getattr(command, "params", None) or []:
+        if "--name" in (getattr(param, "opts", None) or []):
+            return True
+    return False
+
+
+def name_style_for(path: tuple[str, ...], verb: str) -> str:
+    """``"option"`` | ``"positional"`` | ``"unknown"`` for the job name.
+
+    *** WHY THIS EXISTS: scitex-dev 0.48.0 MADE THE SHAPE MIXED. ***
+    Through 0.47.0 every job verb took ``--name X``, so the delegation
+    emitted it unconditionally. 0.48.0 splits them:
+
+        install / uninstall                                       --name X
+        status / enable / disable / start / stop / restart / exec  NAME
+
+    Sending the old shape to a new positional verb is rejected by Click
+    BEFORE the command runs — ``Error: No such option '--name'``, exit 2 —
+    which reads exactly like sac refusing the verb on capability grounds
+    while sac is in fact failing to invoke it. That misreading cost a
+    night of fleet-wide diagnosis (every open PR went red and the cause
+    was hunted in runners, Python versions and branch staleness first), so
+    the shape is now READ from the installed CLI instead of assumed.
+
+    ``"unknown"`` when the leaf command cannot be introspected. Callers
+    keep the pre-0.48 ``--name`` shape there, because that is what every
+    reachable older scitex-dev wants and because both wrong guesses fail
+    the same safe way: a Click usage error, before any host state is
+    touched.
+    """
+    command = leaf_command(path, verb)
+    if command is None:
+        return "unknown"
+    return "option" if name_is_an_option(command) else "positional"
+
+
+__all__ = [
+    "DEV_SUBGROUP",
+    "LEGACY_GROUP_FOR_KIND",
+    "ecosystem_root",
+    "ecosystem_verbs",
+    "leaf_command",
+    "name_is_an_option",
+    "name_style_for",
+    "reset_capability_cache",
+]

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -58,6 +58,7 @@ jobs_mod = pytest.importorskip(
 
 import scitex_agent_container  # noqa: E402
 import scitex_agent_container.cli_pkg._dev_jobs as dj  # noqa: E402
+import scitex_agent_container.cli_pkg._dev_jobs_backend as backend  # noqa: E402
 from scitex_agent_container._jobs import _names  # noqa: E402
 from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
 from scitex_agent_container.cli_pkg import _dev_jobs_backend as _backend  # noqa: E402
@@ -629,38 +630,116 @@ def test_an_unknown_job_name_lists_the_real_ones() -> None:
 
 
 # ---------------------------------------------------------------------------
-# verbs the installed scitex-dev cannot serve yet
+# a verb whose SUPPORT depends on the installed scitex-dev
 # ---------------------------------------------------------------------------
+# THESE TESTS PINNED A FACT WITH AN EXPIRY DATE, AND IT EXPIRED.
+#
+# They asserted unconditionally that `sac dev timer status` is REFUSED —
+# true only while the installed scitex-dev had no `ecosystem dev timer
+# status` to delegate to. scitex-dev 0.48.0 shipped one; the shared CI SIF
+# picked it up on 2026-08-12, and these three went red on every open PR
+# while sac itself was behaving exactly as designed: it stopped refusing
+# and started DELEGATING. The suite called that a regression. It was a
+# dependency release.
+#
+# Measured, one variable, everything else held equal:
+#     scitex-dev 0.47.0  ->  exit 4, refusal naming the systemctl command
+#     scitex-dev 0.48.0  ->  delegation; no refusal on sac's own stderr
+# (Same click 8.4.2, same sac commit, same test files.)
+#
+# THE FIX IS NOT A SKIP. Skipping when the backend serves the verb would
+# silently stop testing the REFUSAL path — which still runs against every
+# scitex-dev that lacks the verb, is the half a future change is most
+# likely to break, and would then break unwatched. A skipped test reports
+# the same green as a passing one.
+#
+# So each test asks sac's OWN probe — `_dev_jobs_backend.resolve()`, the
+# very call sac's refusal path uses to decide — and asserts the branch that
+# probe selected: refuse when the backend cannot serve the verb, delegate
+# when it can. Both behaviours stay covered under both worlds, and no
+# scitex-dev release can expire this again.
 
 
-def test_a_verb_the_backend_cannot_serve_exits_four() -> None:
-    # Arrange — `ecosystem timer` does not exist yet and `ecosystem
-    # systemd` has no `status`, so this is a REAL unsupported path today,
-    # measured rather than simulated. It must fail loudly, not pretend.
+def _timer_status_support() -> backend.Delegation:
+    """What sac's OWN probe concludes about `dev timer status` right now.
+
+    Deliberately the production call rather than a re-implementation: a
+    parallel capability check in the tests could drift from the one the
+    refusal path actually consults, and then the suite would be green
+    about a decision the product never makes. The cache is reset first so
+    the answer describes this interpreter's installed scitex-dev and not a
+    verdict some earlier test cached.
+    """
+    backend.reset_capability_cache()
+    return backend.resolve("timer", "status")
+
+
+def test_the_probe_states_its_evidence_either_way() -> None:
+    # Arrange — every assertion below branches on this probe, so a probe
+    # that answered without evidence would make all of them unreadable.
+    delegation = _timer_status_support()
+    # Act
+    evidence = delegation.evidence
+    # Assert
+    assert evidence, (
+        "sac's capability probe reached a verdict without saying how. The "
+        "tests below report 'refused' or 'delegated' on its say-so; an "
+        "unexplained verdict makes their failures undiagnosable."
+    )
+
+
+def test_the_exit_code_follows_what_the_probe_decided() -> None:
+    # Arrange — exit 4 means "the backend cannot serve this verb". It is
+    # correct exactly when the probe says the backend cannot.
+    delegation = _timer_status_support()
     runner = CliRunner()
     # Act
     result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
     # Assert
-    assert result.exit_code == 4
+    assert (result.exit_code == 4) is (not delegation.supported), (
+        f"sac exited {result.exit_code} for `dev timer status`, but its own "
+        f"probe says supported={delegation.supported} ({delegation.evidence}). "
+        "Exit 4 is the refusal code: it must appear when the backend cannot "
+        "serve the verb and must NOT appear when it can, where sac should "
+        "delegate instead."
+    )
 
 
-def test_an_unsupported_verb_states_what_it_probed() -> None:
-    # Arrange — a refusal with no evidence is a claim.
+def test_a_refusal_states_what_it_probed() -> None:
+    # Arrange — a refusal with no evidence is a claim. When the backend DOES
+    # serve the verb there is no refusal, so the evidence must not appear.
+    delegation = _timer_status_support()
     runner = CliRunner()
     # Act
     result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
     # Assert
-    assert "ecosystem dev timer status" in result.stderr
+    assert ("ecosystem dev timer status" in result.stderr) is (
+        not delegation.supported
+    ), (
+        f"probe says supported={delegation.supported}, but sac's stderr "
+        f"{'omits' if not delegation.supported else 'still carries'} the "
+        "probed-paths evidence. A refusal must name what it probed; a "
+        "delegation must not print a refusal it did not make.\n"
+        f"stderr: {result.stderr!r}"
+    )
 
 
-def test_an_unsupported_verb_offers_the_manual_command() -> None:
+def test_a_refusal_offers_the_manual_command() -> None:
     # Arrange — reporting a command is not running it; sac still does not
-    # own systemctl.
+    # own systemctl. Only meaningful while sac is the one refusing.
+    delegation = _timer_status_support()
     runner = CliRunner()
     # Act
     result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
     # Assert
-    assert "systemctl --user status sac.accounts-refresh.timer" in result.stderr
+    assert (
+        "systemctl --user status sac.accounts-refresh.timer" in result.stderr
+    ) is (not delegation.supported), (
+        f"probe says supported={delegation.supported}. When sac refuses it "
+        "must hand the operator the manual command; when it delegates it "
+        "must not, because the verb is being served rather than declined.\n"
+        f"stderr: {result.stderr!r}"
+    )
 
 
 def test_an_unsupported_verb_writes_nothing_to_stdout() -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_capability.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_capability.py
@@ -1,0 +1,207 @@
+"""The job-name argument shape is READ from the installed CLI, not assumed.
+
+WHAT THIS GUARDS, AND WHAT IT COST TO LEARN
+
+``build_argv`` emitted ``--name X`` unconditionally. That was correct for
+every scitex-dev up to 0.47.0. **0.48.0 made the shape mixed:**
+
+    install / uninstall                                       --name X
+    status / enable / disable / start / stop / restart / exec  NAME
+
+Sending the old shape to a new positional verb is rejected by Click
+BEFORE the command runs — ``Error: No such option '--name'``, exit 2.
+Exit 2 is indistinguishable, from the outside, from sac declining the
+verb on capability grounds; the suite asserted exit 4 (sac's refusal
+code), saw 2, and read it as a refusal regression. The real defect was
+that sac never managed to invoke the command at all.
+
+That misreading is why these tests exist and why the shape is
+introspected rather than tabulated: a hard-coded verb->shape table is a
+copy of somebody else's CLI, and this incident is what a stale copy
+costs — a night of fleet-wide red, hunted through runners, Python
+versions and branch staleness before the dependency was suspected.
+
+NO MOCKS, AND NO ``monkeypatch``. Both shapes below are REAL ``click``
+commands, declared exactly as the two scitex-dev generations declare
+them: a real ``--name`` option and a real positional argument. They are
+not stand-ins for the input under test — they ARE the two inputs the
+predicate must tell apart. ``build_argv`` takes the resolved leaf command
+as a PARAMETER, so both worlds are exercised by passing a real command
+rather than by rewriting the module's internals. The "cannot read the
+tree" case uses a path that genuinely does not exist in any scitex-dev,
+so even that answer comes from the real probe.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from scitex_agent_container.cli_pkg import _dev_jobs_backend as backend
+from scitex_agent_container.cli_pkg import _dev_jobs_capability as capability
+
+
+@click.command("install")
+@click.option("--name", required=True)
+def option_shaped(name: str) -> None:  # pragma: no cover - never invoked
+    """The pre-0.48.0 shape, and still 0.48.0's shape for install/uninstall."""
+
+
+@click.command("status")
+@click.argument("name")
+def positional_shaped(name: str) -> None:  # pragma: no cover - never invoked
+    """0.48.0's shape for status/enable/disable/start/stop/restart/exec."""
+
+
+@click.command("list")
+def nameless() -> None:  # pragma: no cover - never invoked
+    """A verb that takes no job name at all."""
+
+
+#: A path no scitex-dev has ever mounted, so the real probe genuinely
+#: cannot resolve it. Used instead of patching the lookup away.
+UNRESOLVABLE_PATH = ("no-such-group-6f2a",)
+
+
+def _delegation(verb: str, path: tuple[str, ...] = ("dev", "timer")) -> backend.Delegation:
+    return backend.Delegation(
+        path=path, verb=verb, supported=True, evidence="constructed by a test"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The predicate, against real commands of both shapes.
+# ---------------------------------------------------------------------------
+
+
+def test_an_option_shaped_command_is_read_as_an_option() -> None:
+    # Arrange
+    command = option_shaped
+    # Act
+    is_option = capability.name_is_an_option(command)
+    # Assert
+    assert is_option is True, (
+        "a command declaring `--name` was not read as taking an option, so "
+        "sac would pass the job name positionally to a verb that wants a flag."
+    )
+
+
+def test_a_positional_shaped_command_is_not_read_as_an_option() -> None:
+    # Arrange
+    command = positional_shaped
+    # Act
+    is_option = capability.name_is_an_option(command)
+    # Assert
+    assert is_option is False, (
+        "a command declaring a positional NAME was read as taking `--name`. "
+        "That is the 0.48.0 defect exactly: Click rejects the option before "
+        "the command runs, and the exit code then looks like a capability "
+        "refusal rather than a failed invocation."
+    )
+
+
+def test_a_command_with_no_name_at_all_is_not_read_as_an_option() -> None:
+    # Arrange
+    command = nameless
+    # Act
+    is_option = capability.name_is_an_option(command)
+    # Assert
+    assert is_option is False
+
+
+def test_an_unresolvable_path_is_unknown_rather_than_a_guess() -> None:
+    # Arrange — the third state, from the REAL probe: a group no
+    # scitex-dev mounts. "I could not read the CLI" must not be reported
+    # as either shape.
+    path = UNRESOLVABLE_PATH
+    # Act
+    style = capability.name_style_for(path, "status")
+    # Assert
+    assert style == "unknown", (
+        f"probing {path} answered {style!r}. A probe that cannot read the "
+        "tree must say so; guessing is what turns a dependency bump into a "
+        "silent argv error."
+    )
+
+
+def test_the_installed_scitex_dev_answers_one_of_the_three_states() -> None:
+    # Arrange — whatever is installed here, the contract is total.
+    delegation = backend.resolve("timer", "install")
+    # Act
+    style = capability.name_style_for(delegation.path, delegation.verb)
+    # Assert
+    assert style in {"option", "positional", "unknown"}, (
+        f"name_style_for returned {style!r}, which is not one of the three "
+        "declared states; build_argv branches on exactly those."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The argv that actually ships, under both worlds.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "leaf, expected_tail",
+    [
+        (option_shaped, ["--name", "sac.accounts-refresh"]),
+        (positional_shaped, ["sac.accounts-refresh"]),
+    ],
+    ids=["scitex-dev<=0.47-option", "scitex-dev>=0.48-positional"],
+)
+def test_build_argv_follows_the_installed_commands_shape(leaf, expected_tail) -> None:
+    # Arrange — a REAL command of the shape under test, injected, so both
+    # scitex-dev generations are exercised from whichever single version
+    # happens to be installed on this machine.
+    delegation = _delegation("status")
+    # Act
+    argv = backend.build_argv(
+        delegation, name="sac.accounts-refresh", yes=False, leaf=leaf
+    )
+    # Assert
+    assert argv[-len(expected_tail) :] == expected_tail, (
+        f"build_argv produced {argv!r}, which does not end in "
+        f"{expected_tail!r}. The job name must be passed the way the "
+        "installed command declares it, or Click refuses the invocation "
+        "before the verb ever runs."
+    )
+
+
+def test_an_unknown_shape_keeps_the_pre_048_option_form() -> None:
+    # Arrange — an unresolvable path, so the real probe returns "unknown".
+    # Every reachable older scitex-dev wants `--name`, and both wrong
+    # guesses fail the same safe way (a Click usage error, before any host
+    # state changes), so the older form is the deliberate default.
+    delegation = _delegation("status", path=UNRESOLVABLE_PATH)
+    # Act
+    argv = backend.build_argv(delegation, name="sac.accounts-refresh", yes=False)
+    # Assert
+    assert argv[-2:] == ["--name", "sac.accounts-refresh"]
+
+
+def test_a_delegation_without_a_name_gains_no_name_argument() -> None:
+    # Arrange — `list` takes no job name; the shape probe must not invent one.
+    delegation = _delegation("list")
+    # Act
+    argv = backend.build_argv(delegation, name=None, yes=False, leaf=nameless)
+    # Assert
+    assert argv == ["scitex-dev", "ecosystem", "dev", "timer", "list"]
+
+
+def test_the_forwarded_flags_survive_the_positional_shape() -> None:
+    # Arrange — the --dry-run/--yes pass-through is load-bearing: it keeps
+    # `timer disable sac.accounts-refresh` guarded, on the fleet's sole
+    # OAuth refresher. Changing the name shape must not disturb it.
+    delegation = _delegation("disable")
+    # Act
+    argv = backend.build_argv(
+        delegation,
+        name="sac.accounts-refresh",
+        yes=True,
+        dry_run=True,
+        leaf=positional_shaped,
+    )
+    # Assert
+    assert argv[-3:] == ["sac.accounts-refresh", "--dry-run", "--yes"]


### PR DESCRIPTION
## The exit code that was not a refusal

`sac dev timer status` exited **2** in CI and the suite asserted **4**. Exit 4 is sac's "the installed scitex-dev cannot serve this verb" refusal, so the failure read as a capability regression. It was not one.

`build_argv` emitted `--name X` unconditionally. That was correct for every scitex-dev through 0.47.0. **0.48.0 made the shape mixed:**

```
install / uninstall                                        --name X
status / enable / disable / start / stop / restart / exec  NAME  (positional)
```

Sending the old shape to a new positional verb is rejected by Click **before the command runs** — `Error: No such option '--name'`, exit 2. So sac was not declining the verb on capability grounds; it was **failing to invoke it**, and the two are indistinguishable from the outside.

This matters for anyone reading the earlier diagnosis: a capability probe alone would **not** have fixed this. The delegation branch would have been entered and then died on argv. The product had to change.

## The fix: read the shape, do not tabulate it

`name_style_for(path, verb)` resolves the real leaf Click command and reads **its own parameters**, returning one of three states — `option`, `positional`, `unknown`. `build_argv` follows it.

A hard-coded verb→shape table would be a copy of another package's CLI, and this incident is exactly what a stale copy costs. The module already followed "read the real thing" for *which verbs exist*; it just did not for *how they take their argument*.

`unknown` keeps the pre-0.48 `--name` form, deliberately: every reachable older scitex-dev wants it, and both wrong guesses fail the same safe way — a Click usage error, before any host state is touched.

## Why the tests branch instead of skipping

The three `test__dev_jobs` tests asserted the refusal unconditionally — a fact with an expiry date, which expired. They now ask **sac's own probe**, `resolve()`, the same question sac's refusal path asks, and assert the branch it selected: refusal when the backend cannot serve the verb, delegation when it can.

**Not a skip.** A skip would silently stop testing the refusal path — which still runs against every scitex-dev lacking the verb, is the half a future change is most likely to break, and would then break unwatched. A skipped test reports the same green as a passing one.

## A refactor came first, and it was load-bearing

`_dev_jobs_backend.py` was already 558 lines, over the repo's 512 limit, so the file could not be edited at all until it was split. The seam was already there:

| file | responsibility |
|---|---|
| `_dev_jobs_capability.py` (new, 245) | **read** the installed Click tree — walk to `ecosystem dev`, enumerate verbs, resolve a leaf, read its params |
| `_dev_jobs_backend.py` (378) | **build and run** a delegation — `Delegation`, `resolve`, `build_argv`, `invoke` |

It re-exports every moved name, so existing imports are untouched. No cycle: `name_style_for` takes `(path, verb)`, not the dataclass.

## Testing

`test__dev_jobs_capability.py` — **no mocks and no `monkeypatch`** (the linter forbids it ecosystem-wide, and it is right to: patching internals tests the patch). Both shapes are **real `click` commands** declared exactly as the two scitex-dev generations declare them — a real `--name` option and a real positional argument. `build_argv` now takes the resolved leaf as a **parameter**, so both worlds are exercised by *passing a real command* rather than by rewriting module internals. The `unknown` case uses a path no scitex-dev has ever mounted, so even that answer comes from the real probe.

**80 passed** across `test__dev_jobs.py`, `test__dev_jobs_capability.py`, `test_host_group.py` — on scitex-dev 0.47.0, where `name_style_for` returns `unknown`/`option` and argv is unchanged from today's behaviour.

## What this PR deliberately does NOT do

The `<0.48` ceiling covers **three** incompatibilities. This PR fixes one. **The ceiling stays until all three are done**, because lifting it early would put develop straight back to red:

1. **`build_argv` / the job-verb tests** — this PR. ✅
2. **`test_host_group`** — owned by **PR #1004**, which is open and touches that exact file. Measured, not assumed: I enumerated every open PR's file list. I did not double-edit it.
3. **PS-226 declared skip-rule** — not started; needs the `[tool.scitex_dev]` skip-rule schema, and explicitly **not** a rename of `sac.accounts-refresh` (that is a systemd unit migration on the fleet's sole OAuth refresher against a single-use token — two racing refreshers revoke each other; the supervised path already exists in `_jobs/_migrate/_renames.py`).

So the ceiling removal wants to be the **last** change to land, once #1004 and the skip-rule are in — one line, with CI then genuinely installing 0.48.0 and proving all three adaptations at once. Removing it here would merge a fix whose own CI cannot exercise it, which is the failure mode the ceiling comment warns about in the other direction.

## Two notes for whoever reads this next

**The trigger was a release, not a regression.** PS-226 `job-name-not-hyphenated` has **0 occurrences in the 0.47.0 wheel** and appears in 6 files in 0.48.0 — newly *reported*, not newly *introduced*. Nothing in this repo regressed. "What dependency moved?" belongs in the first three questions when a fleet-wide red appears; it took four agents and five wrong causes (bad runner, Python 3.13, branch staleness, click version, my own "one bad box") to get there tonight.

**`git fetch origin` reports success without advancing `origin/<branch>`.** `ls-remote` and `rev-parse origin/develop` disagreed for an hour and sent me diagnosing a stale tree. Use an explicit refspec: `git fetch origin +refs/heads/develop:refs/remotes/origin/develop`.
