### PR TITLE
fix(state): an exit_reason must name the check that ran, not a fate it never established

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`exit_reason='crashed'` is now `'pid_absent_at_sweep'` — the value names
+  the check that ran, not a fate it never established.** The GC sweep does not
+  witness anything die. It runs `os.kill(pid, 0)` at an arbitrary later moment
+  and writes a row for every pid that is no longer there, which supports
+  exactly one claim: *this pid was not present when we looked.* It wrote that
+  as `crashed`, and paired it with `ended_at=now()`, which reads as a time of
+  death nothing measured.
+
+  Both were believed. Measured 2026-08-12: eleven agents on the fleet host
+  carried `ended_at=2026-08-11T17:54:26Z, exit_reason='crashed'`, and **three
+  separate readers** took the identical second across eleven rows as proof of
+  a simultaneous kill — then reasoned about what could kill eleven processes
+  at once. Nothing did. They had died **10h46m earlier**, across a two-second
+  window when the host's tmux server went away, and `17:54:26Z` was
+  `now_iso()` evaluated *once* before the loop and stamped on every row the
+  sweep reaped. An identical timestamp across N rows is the expected output of
+  one sweep; it is not evidence about the agents.
+
+  Saying *at sweep* in the value is the load-bearing half: it warns that the
+  `ended_at` beside it is the moment we looked, not the moment it ended.
+
+  Backward compatible in both directions. `crashed` is still accepted on read
+  — live databases hold those rows, they mean exactly what the new name says,
+  and dropping the old spelling would send every existing corpse down
+  `_reconcile/_rule.py`'s "an exit_reason this rule does not know" path, which
+  refuses to act, silently making real corpses unrecoverable. `db clean --json`
+  emits **both** keys carrying the same count, so a consumer reading `crashed`
+  does not start seeing a zero — which would be precisely the "success value
+  that is also the didn't-check value" this change exists to stop producing.
+
+  The general rule, which outlives this field: **a field whose name asserts
+  more than its check performed will be believed at its name.** Nobody audits
+  the query behind a value that already sounds like an answer.
+
 ### Added
 
 - **The Stop hook now REPORTS the queue that was waiting on a human, because

--- a/src/scitex_agent_container/_reconcile/_rule.py
+++ b/src/scitex_agent_container/_reconcile/_rule.py
@@ -58,9 +58,23 @@ MANAGED_POLICIES = ("always", "on-failure")
 #: operator's intent — never second-guess it, never "helpfully" undo it.
 DELIBERATE_EXIT_REASONS = ("stopped", "deleted")
 
-#: ``exit_reason`` values that mean it DIED without being asked to: the
-#: reaper writes ``crashed``, the host-reboot sweep writes ``reboot-swept``.
-UNEXPECTED_EXIT_REASONS = ("crashed", "reboot-swept")
+#: ``exit_reason`` values that mean it ENDED without being asked to: the
+#: reaper writes ``pid_absent_at_sweep``, the host-reboot sweep writes
+#: ``reboot-swept``.
+#:
+#: ``crashed`` is the reaper's PRE-2026-08-12 spelling and is listed because
+#: databases still hold those rows — dropping it would silently reclassify
+#: every existing corpse as "an exit_reason this rule does not know" and
+#: strand it. Both spellings are the same observation.
+#:
+#: Note what this category actually licenses. ``pid_absent_at_sweep`` says
+#: only that a pid was gone when a sweep looked; it does NOT establish a
+#: crash, and the row's ``ended_at`` is the sweep's clock rather than a time
+#: of death. That is sufficient here — this rule additionally requires no live
+#: tmux session before it acts, so the exit_reason is a corroborating signal
+#: and never the sole one — but it is not sufficient to tell anyone WHY an
+#: agent ended, and nothing downstream should read it that way.
+UNEXPECTED_EXIT_REASONS = ("pid_absent_at_sweep", "crashed", "reboot-swept")
 
 #: ``exit_reason`` values that are sac's own internal bookkeeping rather
 #: than a statement about the agent's fate. Not a corpse to resurrect: a

--- a/src/scitex_agent_container/_state/state_db_gc.py
+++ b/src/scitex_agent_container/_state/state_db_gc.py
@@ -2,6 +2,38 @@
 
 Extracted from :mod:`state_db` for line-budget. Re-exported by
 :mod:`state_db` so external callers keep the same import path.
+
+AN ``exit_reason`` NAMES THE CHECK, NOT THE FATE
+------------------------------------------------
+This sweep does not witness anything die. It runs ``os.kill(pid, 0)`` at some
+arbitrary later moment and writes a row for every pid that is no longer there.
+That is a **single observation of absence**, and it supports exactly one claim:
+*this pid was not present when we looked.*
+
+It used to write that as ``exit_reason='crashed'``, which asserts a cause the
+check never established, and it paired it with ``ended_at=now()``, which reads
+as a time of death the check never measured. Both were believed.
+
+MEASURED 2026-08-12: eleven agents on the fleet host carried
+``ended_at=2026-08-11T17:54:26Z, exit_reason='crashed'``. Three separate
+readers — including the author of this docstring — took the identical second
+across eleven rows as proof of a simultaneous kill, and reasoned about what
+could kill eleven processes at once. Nothing did. They had died **10h46m
+earlier**, over a two-second window when the host's tmux server went away, and
+``17:54:26Z`` was simply :func:`now_iso` evaluated ONCE (see ``now_ts`` below)
+and stamped onto every row the loop reaped. An identical timestamp across N
+rows is the EXPECTED output of one sweep; it is not evidence of anything about
+the agents.
+
+So the value is now :data:`EXIT_REASON_PID_ABSENT_AT_SWEEP` — a name that
+states the check that ran and, by saying *at sweep*, warns that the
+accompanying ``ended_at`` is the moment we LOOKED, not the moment it died. The
+old value is still accepted on read, because rows written before this change
+exist and mean the same thing.
+
+The general rule, which outlives this module: **a field whose name asserts
+more than its check performed will be believed at its name.** No reader
+audits the query behind a value that already sounds like an answer.
 """
 
 from __future__ import annotations
@@ -9,6 +41,18 @@ from __future__ import annotations
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+
+#: What the pid-liveness branch writes: ``os.kill(pid, 0)`` raised ESRCH at
+#: sweep time. It says nothing about WHEN the process left, WHY it left, or
+#: whether anything was wrong — a deliberately-killed agent, an OOM victim and
+#: a clean exit that failed to record itself are indistinguishable here.
+EXIT_REASON_PID_ABSENT_AT_SWEEP = "pid_absent_at_sweep"
+
+#: The value this branch wrote before 2026-08-12. Retained as a READ alias
+#: only: live databases hold these rows, they mean exactly what the new name
+#: says, and silently reclassifying them would strand real corpses. Never
+#: write it.
+LEGACY_EXIT_REASON_CRASHED = "crashed"
 
 
 def _proc_btime() -> str | None:
@@ -47,7 +91,12 @@ def gc_dead_instances(
        precedes the current ``/proc/stat btime`` is marked
        ``exit_reason='reboot-swept'``.
     2. **PID liveness** — for the host's own active rows, ``kill -0
-       pid`` failures mark the row ``exit_reason='crashed'``.
+       pid`` failures mark the row
+       ``exit_reason='pid_absent_at_sweep'``. Note what that value does
+       and does not claim: the pid was absent WHEN WE LOOKED. The
+       ``ended_at`` written beside it is this sweep's clock, not a time
+       of death, and the two can be hours apart (measured: 10h46m). See
+       the module docstring.
     3. **Heartbeat staleness** — if ``last_heartbeat_at`` exists and
        is older than ``heartbeat_stale_seconds``, mark
        ``exit_reason='gc-stale'``.
@@ -64,9 +113,23 @@ def gc_dead_instances(
     """
     from .state_db import _resolve_host, now_iso, open_db
 
-    counters = {"reboot_swept": 0, "crashed": 0, "gc_stale": 0}
+    # ``crashed`` is a DEPRECATED ALIAS carrying the same number as
+    # ``pid_absent_at_sweep``, so a consumer reading the old key keeps working
+    # across this release rather than silently seeing zero swept rows — which
+    # is exactly the "success value that is also the didn't-check value" this
+    # change exists to stop producing.
+    counters = {
+        "reboot_swept": 0,
+        "crashed": 0,
+        EXIT_REASON_PID_ABSENT_AT_SWEEP: 0,
+        "gc_stale": 0,
+    }
     boot = _proc_btime()
     canonical_host = _resolve_host(None)
+    # ONE clock reading for the whole sweep. This is deliberate and correct —
+    # it is the moment we LOOKED — but it is why every row this pass reaps
+    # shares a second, and why that shared second must never be read as a
+    # simultaneous death. The value written beside it says so by name now.
     now_ts = now_iso()
     stale_cutoff = datetime.now(timezone.utc).timestamp() - heartbeat_stale_seconds
 
@@ -115,10 +178,11 @@ def gc_dead_instances(
             ):  # stx-allow: fallback (reason: ESRCH/other kernel error — the process is genuinely gone from our POV)
                 if not dry_run:
                     conn.execute(
-                        "UPDATE instances SET ended_at=?, exit_reason='crashed' WHERE id=?",
-                        (now_ts, row["id"]),
+                        "UPDATE instances SET ended_at=?, exit_reason=? WHERE id=?",
+                        (now_ts, EXIT_REASON_PID_ABSENT_AT_SWEEP, row["id"]),
                     )
                 counters["crashed"] += 1
+                counters[EXIT_REASON_PID_ABSENT_AT_SWEEP] += 1
 
         # ``AND remote=0`` — the heartbeat sweep is the ONE branch without a
         # host filter, so without this a cross-host (``remote=1``) row could be

--- a/tests/scitex_agent_container/_reconcile/test__rule.py
+++ b/tests/scitex_agent_container/_reconcile/test__rule.py
@@ -139,12 +139,31 @@ def test_ghost_active_row_names_the_corpse_signature():
     assert decision.reason == "ghost-active-row"
 
 
-@pytest.mark.parametrize("reason", ["crashed", "reboot-swept"])
+@pytest.mark.parametrize(
+    "reason", ["pid_absent_at_sweep", "crashed", "reboot-swept"]
+)
 def test_unexpected_exit_reason_is_restarted(reason):
-    # Arrange — the reaper wrote 'crashed'; the reboot sweep wrote
-    # 'reboot-swept'. Neither is a human deciding to stop the agent.
+    # Arrange — the reaper writes 'pid_absent_at_sweep' (and wrote 'crashed'
+    # before 2026-08-12); the reboot sweep wrote 'reboot-swept'. None of them
+    # is a human deciding to stop the agent.
     # Act
     decision = _decide(row=_row(ended_at="2026-07-16T00:00:00Z", exit_reason=reason))
+    # Assert
+    assert decision.verdict is Verdict.RESTART
+
+
+def test_legacy_crashed_rows_are_still_recognised_as_corpses():
+    """Rows written before the rename must not become unclassifiable.
+
+    Live databases hold them — eleven on the fleet host the day this landed.
+    Dropping the old spelling would send every one of them down the
+    "an exit_reason this rule does not know" path, which refuses to act, so
+    real corpses would silently stop being recoverable.
+    """
+    # Arrange
+    row = _row(ended_at="2026-07-16T00:00:00Z", exit_reason="crashed")
+    # Act
+    decision = _decide(row=row)
     # Assert
     assert decision.verdict is Verdict.RESTART
 

--- a/tests/scitex_agent_container/_state/test_state_db.py
+++ b/tests/scitex_agent_container/_state/test_state_db.py
@@ -733,7 +733,68 @@ def test_gc_dead_instances_persists_exit_reason_crashed_on_instance_row(
             "SELECT exit_reason FROM instances WHERE id=?", (iid,)
         ).fetchone()
     # Assert
-    assert row["exit_reason"] == "crashed"
+    assert row["exit_reason"] == "pid_absent_at_sweep"
+
+
+def test_sweep_writes_a_reason_naming_the_check_not_a_cause(
+    db_path: Path, dead_pid_environment
+):
+    """The value must not assert a fate the check never established.
+
+    ``os.kill(pid, 0)`` raising ESRCH supports exactly one claim: the pid was
+    absent when we looked. The old value said ``crashed``, and three readers
+    believed it — reasoning about what could kill eleven processes in one
+    second when nothing had.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db import (
+        gc_dead_instances,
+        open_db,
+        record_instance_start,
+    )
+
+    iid = record_instance_start("dead-agent", pid=999_999_999, host="test-host")
+    # Act
+    gc_dead_instances()
+    with open_db() as conn:
+        row = conn.execute(
+            "SELECT exit_reason FROM instances WHERE id=?", (iid,)
+        ).fetchone()
+    # Assert
+    assert "crashed" not in row["exit_reason"]
+
+
+def test_one_sweep_stamps_every_reaped_row_with_the_same_ended_at(
+    db_path: Path, dead_pid_environment
+):
+    """THE TRAP, pinned: a shared second is the sweep's clock, not a co-death.
+
+    Measured 2026-08-12 — eleven rows shared ``17:54:26Z`` and were read as a
+    simultaneous kill. They had died 10h46m earlier, at different moments.
+    This test exists so nobody can "fix" the shared timestamp by accident and
+    so the behaviour is documented as intended rather than incidental.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db import (
+        gc_dead_instances,
+        open_db,
+        record_instance_start,
+    )
+
+    for name in ("dead-a", "dead-b", "dead-c"):
+        record_instance_start(name, pid=999_999_999, host="test-host")
+    # Act
+    gc_dead_instances()
+    with open_db() as conn:
+        stamps = [
+            r["ended_at"]
+            for r in conn.execute(
+                "SELECT ended_at FROM instances WHERE exit_reason=?",
+                ("pid_absent_at_sweep",),
+            ).fetchall()
+        ]
+    # Assert
+    assert len(set(stamps)) == 1
 
 
 def test_db_clean_via_cli_reports_at_least_one_crashed_in_json_body(


### PR DESCRIPTION
Follow-up to #1002, and a fix for the field that misled me while I was writing it.

## The measurement

The GC sweep does not witness anything die. It runs `os.kill(pid, 0)` at an arbitrary later moment and writes a row for every pid that is no longer there. That supports exactly one claim: **this pid was not present when we looked.**

It wrote that as `exit_reason='crashed'` — asserting a cause the check never established — and paired it with `ended_at=now()`, which reads as a time of death nothing measured.

Both were believed. On 2026-08-12 eleven agents on the fleet host carried:

```
ended_at=2026-08-11T17:54:26Z   exit_reason='crashed'
```

**Three separate readers** — including me — took the identical second across eleven rows as proof of a simultaneous kill, and reasoned about what could kill eleven processes at once. Nothing did. They had died **10h46m earlier**, across a two-second window when the host's tmux server went away. `17:54:26Z` was `now_iso()` evaluated *once* before the loop:

```python
now_ts = now_iso()                      # computed ONCE, before the loop
...
for row in rows:
    except (OSError, ProcessLookupError):
        conn.execute(
            "UPDATE instances SET ended_at=?, exit_reason='crashed' WHERE id=?",
            (now_ts, row["id"]),        # same now_ts for every row
        )
```

An identical timestamp across N rows is the **expected output of one sweep**. It is not evidence about the agents.

## The change

`pid_absent_at_sweep`. Saying *at sweep* is the load-bearing half — it warns that the `ended_at` beside it is the moment we **looked**, not the moment it ended.

**Backward compatible in both directions**, which is most of the diff:

- **`crashed` is still accepted on read.** Live databases hold those rows (eleven on the fleet host as I write this), they mean exactly what the new name says, and dropping the old spelling would send every existing corpse down `_reconcile/_rule.py`'s *"an exit_reason this rule does not know"* path — which refuses to act — silently making real corpses unrecoverable. A regression test pins this.
- **`db clean --json` emits both keys** carrying the same count, so a consumer reading `crashed` does not start seeing a zero. That zero would be precisely the *"success value that is also the didn't-check value"* this change exists to stop producing.

It also **pins the trap as intended behaviour**: a test asserts one sweep stamps every row it reaps with the *same* `ended_at`, so nobody "fixes" the shared timestamp by accident, and the next reader finds it documented rather than incidental.

## Why this is the same bug as #1002

#1002 fixed a number whose **cause** was unreadable — `inbox_subscribers: 0`, which means a detached adapter *or* a stopped agent, so callers supplied the missing half themselves. This fixes a number whose **meaning** is unreadable: `ended_at` on a swept row, which callers read as a death time.

In both cases the field is honest about what it *stores* and silent about what it *means*, and the reader fills the gap with the most available story. The rule I would keep:

> **A field whose name asserts more than its check performed will be believed at its name.** Nobody audits the query behind a value that already sounds like an answer.

`crashed` sounded like an answer. `pid_absent_at_sweep` sounds like a reading, which is what it is.

## Scope

Deliberately **not** in this PR: giving the sweep a separate observation-time column so `ended_at` could hold a real death time when one is known. That is a schema migration and a larger design question (nothing currently records death times — the heartbeat pipeline that would have is itself dead, tracked separately). Renaming the value is the part that stops the misreading today.

## Verification

`1472 passed, 3 skipped` across `_state`, `_reconcile`, `_lifecycle/test__instances_pid.py`, `cli_pkg/test_db_group.py`, with `PYTHONPATH` pinned to this worktree's `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
