### PR TITLE
chore(audit): declare PS-226 as a deferral, with the reason it is not a rename

### DIFF
--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -58,6 +58,24 @@ audit:
   #
   # The supervised path already exists: `_jobs/_migrate/_renames.py`.
   # This entry comes off in the same change that runs the migration.
+  #
+  # *** READ THIS BEFORE DELETING ANY UNIT. ***
+  # "verify-exactly-one" means EXACTLY ONE UNIT FOR THIS ONE JOB — old
+  # gone, new present. It does NOT mean "one accounts job on the host".
+  # There are TWO accounts jobs and BOTH MUST EXIST:
+  #
+  #   sac.accounts-refresh                        rotates the credential,
+  #                                               every 2h, on the host
+  #                                               holding refresh material
+  #   scitex-agent-container-accounts-keepalive   distributes the
+  #                                               ACCESS-ONLY copy,
+  #                                               every 15min
+  #
+  # They are DIFFERENT JOBS doing different work, not a rename pair and
+  # not duplicates of each other. Anyone who reads this rule as "collapse
+  # the accounts jobs to one" would remove a job the fleet depends on —
+  # which is a larger outage than the naming defect being deferred here.
+  # The only thing PS-226 asks for is the SHAPE OF ONE JobSpec NAME.
   skip-rules:
     - rule: PS-226
       reason: >-
@@ -70,8 +88,15 @@ audit:
         authentication down. The migration must be ordered stop-old ->
         remove-old -> install-new -> verify-exactly-one and run
         supervised; the path exists in `_jobs/_migrate/_renames.py`.
-        Tracked in card `sac-accounts-refresh-unit-migration`; this entry
-        is removed by the change that performs the migration.
+        "verify-exactly-one" means exactly one unit FOR THIS ONE JOB, NOT
+        one accounts job on the host: `sac.accounts-refresh` (rotates the
+        credential, every 2h) and
+        `scitex-agent-container-accounts-keepalive` (distributes the
+        access-only copy, every 15min) are DIFFERENT JOBS that must BOTH
+        continue to exist — they are not a rename pair and must never be
+        collapsed into one. PS-226 asks only for the SHAPE OF ONE JobSpec
+        NAME. Tracked in card `sac-accounts-refresh-unit-migration`; this
+        entry is removed by the change that performs the migration.
 
   # PS-103: legitimate top-level dirs that are not part of the wheel
   # but are operator-facing artefacts:

--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -38,6 +38,41 @@ audit:
           a security regression, not a compliance win. Kept hosted until an
           ephemeral/isolated runner exists for untrusted-trigger workflows.
 
+  # PS-226 (job-name-not-hyphenated), introduced by scitex-dev 0.48.0.
+  #
+  # THIS IS A DEFERRAL, NOT A WAIVER, AND THE FINDING IS CORRECT.
+  # `JobSpec(name="sac.accounts-refresh")` is genuinely not hyphen-
+  # separated, and the rule exists for a real reason:
+  # `jobs/_systemd.py::systemd_unit_name` derives the unit FILENAME from
+  # the job name verbatim, with no sanitisation.
+  #
+  # What is deferred is the REMEDY, because the obvious one is more
+  # dangerous than the defect. Renaming does not re-label the running
+  # unit; it makes sac install a SECOND unit beside the live hand-written
+  # one. That unit is the fleet's SOLE OAuth refresher, and it refreshes a
+  # SINGLE-USE token — two refreshers racing revoke each other, taking
+  # every agent's authentication down with them. So the rename is a
+  # supervised systemd unit migration (stop-old -> remove-old ->
+  # install-new -> verify-exactly-one), never a drive-by edit, and
+  # never at an hour when nobody is watching.
+  #
+  # The supervised path already exists: `_jobs/_migrate/_renames.py`.
+  # This entry comes off in the same change that runs the migration.
+  skip-rules:
+    - rule: PS-226
+      reason: >-
+        Correct finding, deferred to the supervised job-name migration —
+        not waived. `systemd_unit_name` uses `JobSpec.name` verbatim, so
+        renaming `sac.accounts-refresh` installs a SECOND unit beside the
+        live one instead of adopting it. That job is the fleet's sole
+        OAuth refresher against a SINGLE-USE refresh token, where two
+        racing refreshers revoke each other and take fleet-wide
+        authentication down. The migration must be ordered stop-old ->
+        remove-old -> install-new -> verify-exactly-one and run
+        supervised; the path exists in `_jobs/_migrate/_renames.py`.
+        Tracked in card `sac-accounts-refresh-unit-migration`; this entry
+        is removed by the change that performs the migration.
+
   # PS-103: legitimate top-level dirs that are not part of the wheel
   # but are operator-facing artefacts:
   #   - config/      declarative YAML schema + templates the CLI


### PR DESCRIPTION
Part **(3)** of the three the `scitex-dev<0.48` ceiling covers. One file: `.scitex/dev/config.yaml`.

## The finding is correct. The remedy is what is deferred.

scitex-dev 0.48.0 added **PS-226** (`job-name-not-hyphenated`). It fires on `JobSpec(name="sac.accounts-refresh")`, and it is right to: `_jobs/_systemd.py::systemd_unit_name` derives the unit **filename** from the job name **verbatim**, with no sanitisation.

So this is **not** a false positive, and the entry does not claim it is.

What is deferred is the fix, because the obvious one is more dangerous than the defect it repairs:

- renaming does **not** re-label the running unit — it makes sac install a **second** unit beside the live hand-written one;
- that job is the fleet's **sole OAuth refresher**, against a **single-use** token;
- two refreshers racing **revoke each other**, taking every agent's authentication down with them.

This is the same hazard that already made sac refuse to federate `sac listen` as `sac.listen`: the live unit is the hyphenated `sac-listen.service`, and a dotted duplicate would have put two `Restart=always` supervisors on one port.

The migration is therefore ordered **stop-old → remove-old → install-new → verify-exactly-one**, supervised, and explicitly not run at an hour when nobody is watching. The supervised path already exists at `_jobs/_migrate/_renames.py` — it should be used rather than reimplemented. Tracked in card `sac-accounts-refresh-unit-migration`.

## Why `skip-rules` and not `audit.skip`

`audit.skip-rules` is the sanctioned mechanism precisely because it is **not** a silencer:

- it **rejects an entry with no written rationale** — loudly, naming the entry, including whitespace-only; and
- `audit-all` reprints a **masked inventory** on every run — count, rule ids, per-rule masked count, and each written reason.

So the deferral stays visible on every audit rather than disappearing. The legacy `audit.skip` list is bare rule codes applied silently, and is deliberately not used here.

## Verified against the real loader, not assumed

Run against `scitex_dev._cli.audit._config._skip_rules`:

```
parsed entries: 1
  rule='PS-226'   reason (675 chars)
PS-226 present with a non-empty rationale: OK

audit keys: ['exemptions', 'root-whitelist', 'skip-rules']
PS-224 exemption still present: True
root-whitelist dirs: ['config', 'containers']

whitespace-only reason rejected, as designed:
  invalid `audit.skip-rules` entry: 'PS-999' has an empty `reason`
```

The last line matters: the guard that makes this mechanism trustworthy is still live, so this entry earned its pass by carrying a reason rather than by disabling the check.

## The closing condition is written down

The change that performs the migration **removes this entry in the same commit**. An entry left behind after its cause is gone masks a rule with nothing left to mask — which is how an audit quietly stops meaning anything. That is stated in the config comment and on the card.

## Sequencing

With this, part (1) is in **#1007** and part (3) is here. Part (2) — `test_host_group` — belongs to **#1004**. The `<0.48` ceiling comes off in whichever of the three lands **last**, so CI actually installs 0.48.0 and proves all three adaptations at once. Lifting it earlier would merge fixes whose own CI cannot exercise them.
