### PR TITLE
fix(ci): ask the kernel which CPUs we may use, not nproc

### DIFF
--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -269,9 +269,26 @@ done
 # The kernel will schedule this process on 48 CPUs. Only `nproc` disagreed, so
 # the suite ran on the FLOOR of 4 workers inside a 48-CPU allocation the fleet
 # was already paying for — 15282 passed in 532s where it had 12x the cores
-# available. coreutils `nproc` honours OMP_NUM_THREADS / OMP_THREAD_LIMIT AHEAD
-# of the affinity mask, and HPC sites commonly default OMP_NUM_THREADS=1 to stop
-# naive threaded code oversubscribing a shared node.
+# available.
+#
+# CAUSE, MEASURED RATHER THAN MATCHED. coreutils `nproc` honours
+# OMP_NUM_THREADS / OMP_THREAD_LIMIT AHEAD of the affinity mask. On that runner:
+#
+#     OMP_NUM_THREADS        1
+#     nproc (as-is)          1
+#     nproc (OMP_* cleared)  48
+#     sched_getaffinity      48
+#
+# Clearing the variable moves nproc from 1 to 48, which establishes the cause
+# instead of merely fitting it.
+#
+# DO NOT "FIX" THIS BY UNSETTING OMP_NUM_THREADS. It is set to 1 on purpose and
+# it is CORRECT: each xdist worker is a separate process, and BLAS/OpenMP inside
+# numpy will happily start one thread per core in EVERY one of them. 48 workers
+# x 48 OMP threads is 2304 threads on 48 CPUs. OMP_NUM_THREADS=1 with 48
+# PROCESSES is exactly the right shape — one thread per core, no oversubscription.
+# The bug was never the variable; it was reading a THREAD-BUDGET knob as a
+# CPU-COUNT fact.
 #
 # `Cpus_allowed_list` in /proc/self/status is exactly "the CPUs the kernel will
 # schedule THIS process on". It needs no python and no taskset (neither is

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -253,10 +253,66 @@ done
 # node is ever shared" concern instead of statically reserving half the CPUs.
 # Floor 4. pyproject addopts carries `-v`; override to `-q` here — 2460 verbose
 # lines x workers bloats the CI log and adds measurable overhead.
+#
+# ASK THE KERNEL WHAT THIS PROCESS MAY RUN ON — DO NOT ASK `nproc`.
+#
+# `nproc` was the obvious source and it is wrong on the Spartan runners.
+# Measured on spartan-bm153 inside SLURM job 29015324, which holds 48 CPUs:
+#
+#     nproc                      1     <- what this line used to read
+#     nproc --all              128
+#     sched_getaffinity         48
+#     taskset -pc self          48     (listed explicitly)
+#     cpuset.cpus.effective  0-127     (no cgroup confinement)
+#     SLURM_CPUS_PER_TASK       48
+#
+# The kernel will schedule this process on 48 CPUs. Only `nproc` disagreed, so
+# the suite ran on the FLOOR of 4 workers inside a 48-CPU allocation the fleet
+# was already paying for — 15282 passed in 532s where it had 12x the cores
+# available. coreutils `nproc` honours OMP_NUM_THREADS / OMP_THREAD_LIMIT AHEAD
+# of the affinity mask, and HPC sites commonly default OMP_NUM_THREADS=1 to stop
+# naive threaded code oversubscribing a shared node.
+#
+# `Cpus_allowed_list` in /proc/self/status is exactly "the CPUs the kernel will
+# schedule THIS process on". It needs no python and no taskset (neither is
+# guaranteed on a bare HPC node — that is why the SIF exists), and no OpenMP
+# variable can override it. Fall back to SLURM_CPUS_PER_TASK, then to `nproc`,
+# so a host without /proc/self/status behaves exactly as before.
+#
+# The echo prints EVERY source, not just the winner. When these disagree again
+# — and they will, on some host nobody has met yet — the disagreement is the
+# finding, and it should be in the log rather than requiring a special trip.
+_cpus_from_affinity() {
+    local list part lo hi n=0
+    list=$(awk '/^Cpus_allowed_list:/ {print $2; exit}' /proc/self/status 2>/dev/null)
+    [ -n "$list" ] || return 1
+    local IFS=','
+    for part in $list; do
+        case "$part" in
+            *-*)
+                lo=${part%%-*}; hi=${part##*-}
+                case "$lo$hi" in *[!0-9]*) return 1 ;; esac
+                n=$(( n + hi - lo + 1 ))
+                ;;
+            *)
+                case "$part" in *[!0-9]*) return 1 ;; esac
+                n=$(( n + 1 ))
+                ;;
+        esac
+    done
+    [ "$n" -gt 0 ] || return 1
+    printf '%s\n' "$n"
+}
+
 NPROC="$(nproc 2>/dev/null || echo 4)"
-WORKERS=$NPROC
+AFFINITY="$(_cpus_from_affinity || true)"
+DETECTED="${AFFINITY:-${SLURM_CPUS_PER_TASK:-}}"
+case "$DETECTED" in
+    ''|*[!0-9]*) DETECTED="$NPROC" ;;
+esac
+WORKERS="$DETECTED"
 [ "$WORKERS" -lt 4 ] && WORKERS=4
-echo "xdist workers=$WORKERS (nproc=$NPROC)"
+echo "xdist workers=$WORKERS (affinity=${AFFINITY:-<unreadable>} nproc=$NPROC SLURM_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK:-<unset>})"
 
 # Warm the matplotlib font cache ONCE, single-process, before xdist forks the
 # workers. This builds $MPLCONFIGDIR/fontlist-*.json a single time so every


### PR DESCRIPTION
## The suite has been running on 4 workers inside a 48-CPU allocation

Measured on `spartan-bm153`, inside SLURM job `29015324`:

```
nproc                      1     <- what this line read
nproc --all              128
sched_getaffinity         48
taskset -pc self          48     (listed explicitly)
cpuset.cpus.effective  0-127     (no cgroup confinement)
SLURM_CPUS_PER_TASK       48
scontrol NumCPUs          48
```

**The kernel will schedule this process on 48 CPUs.** No cgroup narrows it,
SLURM gave exactly what was asked for, and not being inside an `srun` step
turned out not to matter — the batch shell inherited the full mask anyway.
Every candidate was eliminated by a positive measurement rather than an absence.

Only `nproc` disagreed. And `nproc` is what this line fed to `xdist -n`, so the
suite ran on the **floor of 4 workers** with 12x the cores idle: `15282 passed
in 532s`. Every timing conclusion drawn from those runs — including my own
"Spartan is too slow for the heavy lane" — described the wrong machine.

## The fix

`Cpus_allowed_list` in `/proc/self/status` is exactly *"the CPUs the kernel will
schedule THIS process on"*. It needs no python and no `taskset` — neither is
guaranteed on a bare HPC node, which is the whole reason the SIF exists — and
**no OpenMP variable can override it.** Falls back to `SLURM_CPUS_PER_TASK`,
then `nproc`, so a host without `/proc/self/status` behaves exactly as before.

### Why this is safe to land now

**It is a no-op wherever `nproc` is already correct.** On a 32-core compute host
the parser computes 32, matching `nproc` exactly. It changes behaviour only
where the current behaviour is provably wrong.

That is also why it does not wait on the open question of *why* `nproc` lies.
coreutils `nproc` honours `OMP_NUM_THREADS`/`OMP_THREAD_LIMIT` ahead of the
affinity mask, and a canary is testing that specifically — but the affinity mask
is the right source regardless of the answer. The verdict changes what this PR
can *claim*, not whether it should land.

### Tested for rejection, not just acceptance

```
"0-127"                -> 128      "0"          -> 1
"0-47"                 ->  48      "1,2,6,10"   -> 4
"1,2,6,10,13-14,17"    ->   7
""                     -> fail closed to the fallback chain
"garbage"              -> fail closed to the fallback chain
```

A parser that returns a plausible number from malformed input is how a wrong
worker count becomes invisible again.

### It now prints every source, not the winner

```
xdist workers=48 (affinity=48 nproc=1 SLURM_CPUS_PER_TASK=48)
```

When these disagree on some host nobody has met yet, the disagreement is already
in the log instead of costing someone a probe run.

## What it buys

This **converts already-allocated, already-paid-for capacity into throughput.**
No new hardware, no new lease, no change to the SLURM job — that allocation has
been up 2d10h and holds its 48 CPUs whether or not we use them. Nothing here
resizes or resubmits it.

**Conditional worth recording for whoever reads this later:** if this lands and
the Spartan runners start using their full allocation, #992 (unpinning `main`'s
SIF shim from Spartan's filesystem) moves from *desirable* to *urgent*, because
the heavy lane then has somewhere real to go. Today `tests` and the release gate
stay on `scitex-org-cpu` precisely because Spartan looked too slow — and that
was an artifact of this bug.

Also relevant to the constitution rewrite: **Spartan does not fail this suite.**
`15282 passed, 65 skipped, 0 failed` on green develop. "Too slow for CI" was
measured against a 4-worker run of a 48-core allocation.

## Composes with #881 — please keep both

#881 (`fix/xdist-worker-cap`) adds a `CI_XDIST_WORKERS` **override**. This fixes
the **default derivation**. They are complements, not alternatives:

- an override with a broken default is still broken for everyone who does not
  set it;
- a good default with no override is inflexible.

Whoever lands second should keep both rather than pick. The textual conflict is
a few lines around `WORKERS=`.
