### PR TITLE
fix(reconcile): N corpses with NO tmux server is one event, not N restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`sac agents reconcile` refuses a MASS restart: N corpses with no tmux
+  server at all is ONE event, not N agents dying.** The reconcile timer is
+  currently disabled and has never run; this is what has to land before it is
+  safe to arm.
+
+  `_runners/_tmux/_tmux_probe.py` treats tmux's "no server running" as a
+  CONFIRMED-empty fleet — it returns `{}`, a real observation, not `None` — and
+  `_verdict_tmux._observed_snapshot` rescues that only `if not snapshot and
+  in_sif_fn()`, i.e. only inside a container. This job runs under
+  `systemd --user` on the HOST, where `in_sif()` is `False`, so `{}` passed
+  straight through as "every session is genuinely absent".
+
+  Correct when a tmux server is normally absent. Catastrophically wrong when
+  the server dying IS the failure mode — which is what happened on 2026-08-11,
+  when the host's tmux server went away and took eleven agents with it inside a
+  two-second window. Every one of them reads as an independent corpse whose
+  spec asks to be kept running.
+
+  The existing budget does not cover this and is not the thing that fails: it
+  throttles per agent (30-min debounce, 2/agent/hour) and per pass (10), and
+  neither is fleet-wide. **10 restarts/pass x 12 passes/hour = up to 120
+  container starts an hour** on a host that just had a resource event, with 90
+  of 113 specs opted in. It does not even fail fast — `tmux new-session` spawns
+  a server, so `sac agents start` SUCCEEDS into a host that just lost one.
+
+  A pass that would restart more than one agent while **no tmux server exists**
+  now withholds every restart, spends no budget, and exits 2 (new verdict
+  `FLEET-BLACKOUT`, grouped with `UNKNOWN`/`BUDGET-UNKNOWN` because the pass
+  looked and could not resolve what it saw).
+
+  The predicate is SERVER-ABSENT, not zero-sessions, and that distinction is
+  the design. Both incidents show an empty session list and demand opposite
+  responses: a live server holding no sessions means the AGENTS died — the
+  2026-06 OAuth rotation killed 33 with tmux untouched, and recovering exactly
+  that is why this job exists — while no server at all means one thing killed
+  them together. An earlier draft keyed on zero sessions and would have blocked
+  the first; `test_whole_dead_fleet_is_recovered` caught it on the first run.
+  The fact separating them was already in the probe's hands (`rc != 0` plus a
+  no-server marker versus `rc == 0` with no rows) and was being discarded at
+  the boundary; `list_sessions_activity_detailed` now carries it, and
+  `list_sessions_activity` keeps its exact contract.
+
+  A single corpse is still restarted even with the server gone — refusing there
+  would strand a one-agent host, and one restart is a blast radius the
+  per-agent budget already bounds.
+
+- **The fleet-reconcile job description no longer promises a give-up it does
+  not implement.** It claimed an unrecoverable agent is "RECORDED as degraded
+  instead of bounced endlessly". The recording is implemented; the giving-up is
+  not. The hourly cap is a ROLLING window, so steady state for an agent that
+  can never recover is 2 restarts/hour forever (~48 container starts/day) —
+  which `_budget.py` argues deliberately, since a permanent give-up would
+  strand an agent that crashed three times last March. The behaviour is right
+  and the sentence was wrong; it now says "bounded RATE, not eventual
+  give-up". A promise nobody keeps is worse than no promise.
+
 ### Added
 
 - **A zero on the inbox now names its cause: `deaf_inbox` vs `not_running`.**

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -159,6 +159,8 @@ def provide_jobs() -> "list[JobSpec]":
     """
     from scitex_dev.jobs import JobSpec
 
+    from ._specs_liveness import liveness_jobs
+
     return [
         JobSpec(
             # THE ONE NAME STILL ON THE LEGACY PREFIX, AND IT IS ON PURPOSE.
@@ -383,76 +385,11 @@ def provide_jobs() -> "list[JobSpec]":
             # waiting on this run.
             timeout_sec=300,
         ),
-        JobSpec(
-            name="scitex-agent-container-fleet-reconcile",
-            schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
-            command="sac agents reconcile --apply",
-            description=(
-                "The enforcer of 'should be running => is running'. Restarts "
-                "agents whose tmux session is GONE while their spec asks to be "
-                "kept running AND nothing recorded a deliberate stop. Only ever "
-                "touches a CORPSE (no session => no context to lose); never a "
-                "live-but-wedged agent (auth-heal owns those) and never a "
-                "deliberately-stopped one. Rate-limited (30min/agent debounce, "
-                "<=2/agent/hour, <=10/pass); an agent it cannot recover is "
-                "RECORDED as degraded instead of bounced endlessly."
-            ),
-            kind="timer",
-            # THIS JOB IS THE MECHANISM, not an optimisation. `restart.policy`
-            # in ~93 specs is dead code — `_lifecycle/_start.py` launches the
-            # loop that reads it on a `daemon=True` thread and then returns,
-            # and `sac agents start` is a short-lived CLI, so the supervisor
-            # dies with the process that promised it. Nothing else owns fleet
-            # liveness: `sac listen`'s reconciler only alarms on stuck CARDS.
-            # An OAuth rotation killed 33 agents and they stayed dead until the
-            # operator noticed by chance. Unschedule this and that returns.
-            #
-            # 5min: the window an agent stays dead. A pass that finds nothing
-            # (the normal case) is one batched `tmux list-sessions` plus a spec
-            # read each — cheap enough to run often.
-            on_boot_sec="5min",
-            on_unit_active_sec="5min",
-            # A no-op pass takes ~seconds; this bounds the pathological one
-            # (`--limit` restarts, each a stop+settle+start). A pass killed at
-            # this timeout is SAFE: the restart history is persisted per
-            # restart, not at the end, so the next tick still honours the
-            # debounce for anything already bounced.
-            timeout_sec=300,
-        ),
-        JobSpec(
-            name="scitex-agent-container-restart-login-expired-agents",
-            schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
-            command="sac agents restart-login-expired --apply",
-            description=(
-                "Restarts LIVE agents wedged behind a frozen 'Login expired' "
-                "banner (auth-dead but tmux-alive) — the half fleet-reconcile "
-                "leaves alone. Detection is READ-ONLY + 2-run-corroborated (a "
-                "banner that moved between the two captures = working, never "
-                "restarted); the restart runs through the pool-loading start "
-                "path (cannot strip CCT tokens) and is rate-limited (30min/agent "
-                "debounce, <=2/agent/hour, <=10/pass); an agent still wedged "
-                "after the cap is RECORDED as degraded, not bounced endlessly. "
-                "DEPLOY GATE: do NOT enable until the host's auth-heal.py "
-                "scan_tui cron is retired (double-supervisor risk)."
-            ),
-            # Same taxonomy note as the jobs above: kind must be one of
-            # {"service","timer","cron"} (scitex-dev #153); a periodic
-            # systemd --user timer is ``kind="timer"`` with the cadence in
-            # ``on_unit_active_sec``. A wrong kind raises at construction and
-            # ``ecosystem up`` then silently drops sac's WHOLE provider.
-            kind="timer",
-            # 5min matched to fleet-reconcile so the two enforcers sweep on the
-            # same beat rather than harmonising into one; it is the window a
-            # wedged agent stays wedged. A no-op pass is one `tmux list-sessions`
-            # plus two pane captures ~4s apart.
-            on_boot_sec="5min",
-            on_unit_active_sec="5min",
-            # Mirrors fleet-reconcile: bounds the pathological pass (`--limit`
-            # restarts, each a stop+settle+start) plus the ~4s capture interval.
-            # A pass killed here is SAFE — history is persisted per restart, so
-            # the next tick still honours the debounce for anything bounced.
-            timeout_sec=300,
-        ),
+        # The two AGENT-LIVENESS enforcers live together in
+        # :mod:`._specs_liveness` — each one's scope is defined by what the
+        # other covers (corpses vs live-but-wedged), so they are unreadable
+        # apart. Spliced in HERE to preserve the historical order.
+        *liveness_jobs(),
         JobSpec(
             name="scitex-agent-container-heal-agent-auth",
             schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)

--- a/src/scitex_agent_container/_jobs/_specs_liveness.py
+++ b/src/scitex_agent_container/_jobs/_specs_liveness.py
@@ -1,0 +1,108 @@
+"""The two AGENT-LIVENESS enforcers, which only make sense side by side.
+
+Split out of :mod:`._jobs_plugin` (at the per-file cap). They are one concern
+divided in two, and each one's scope is defined by what the other handles:
+
+* ``fleet-reconcile`` restarts CORPSES — no tmux session, so no context to lose.
+* ``restart-login-expired-agents`` restarts the LIVE-BUT-WEDGED half — tmux is
+  up and the pane is frozen behind an auth banner — which fleet-reconcile
+  deliberately will not touch.
+
+Keeping them in one file is what makes either readable: they share a rate-limit
+vocabulary, run on the same beat by design, and a reader checking "who covers a
+wedged agent?" must see both answers at once.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.jobs import JobSpec
+
+__all__ = ["liveness_jobs"]
+
+
+def liveness_jobs() -> "list[JobSpec]":
+    """The fleet-liveness JobSpecs, in their historical order."""
+    from scitex_dev.jobs import JobSpec
+
+    return [
+        JobSpec(
+            name="scitex-agent-container-fleet-reconcile",
+            schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
+            command="sac agents reconcile --apply",
+            description=(
+                "The enforcer of 'should be running => is running'. Restarts "
+                "agents whose tmux session is GONE while their spec asks to be "
+                "kept running AND nothing recorded a deliberate stop. Only ever "
+                "touches a CORPSE (no session => no context to lose); never a "
+                "live-but-wedged agent (auth-heal owns those) and never a "
+                "deliberately-stopped one. REFUSES a mass restart: several "
+                "corpses AND no live tmux session anywhere is the SERVER dying, "
+                "not N agents dying, so the pass withholds every restart and "
+                "alarms (exit 2) instead of acting on a reading it cannot "
+                "disambiguate. Rate-limited per agent (30min debounce, "
+                "<=2/agent/hour) and per pass (<=10). NOTE that hourly cap is a "
+                "ROLLING window, NOT a give-up: an agent it can never recover "
+                "is RECORDED as degraded and retried at 2/hour indefinitely. "
+                "Bounded RATE, not eventual surrender — do not read it as one."
+            ),
+            kind="timer",
+            # THIS JOB IS THE MECHANISM, not an optimisation. `restart.policy`
+            # in ~93 specs is dead code — `_lifecycle/_start.py` launches the
+            # loop that reads it on a `daemon=True` thread and then returns,
+            # and `sac agents start` is a short-lived CLI, so the supervisor
+            # dies with the process that promised it. Nothing else owns fleet
+            # liveness: `sac listen`'s reconciler only alarms on stuck CARDS.
+            # An OAuth rotation killed 33 agents and they stayed dead until the
+            # operator noticed by chance. Unschedule this and that returns.
+            #
+            # 5min: the window an agent stays dead. A pass that finds nothing
+            # (the normal case) is one batched `tmux list-sessions` plus a spec
+            # read each — cheap enough to run often.
+            on_boot_sec="5min",
+            on_unit_active_sec="5min",
+            # A no-op pass takes ~seconds; this bounds the pathological one
+            # (`--limit` restarts, each a stop+settle+start). A pass killed at
+            # this timeout is SAFE: the restart history is persisted per
+            # restart, not at the end, so the next tick still honours the
+            # debounce for anything already bounced.
+            timeout_sec=300,
+        ),
+        JobSpec(
+            name="scitex-agent-container-restart-login-expired-agents",
+            schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
+            command="sac agents restart-login-expired --apply",
+            description=(
+                "Restarts LIVE agents wedged behind a frozen 'Login expired' "
+                "banner (auth-dead but tmux-alive) — the half fleet-reconcile "
+                "leaves alone. Detection is READ-ONLY + 2-run-corroborated (a "
+                "banner that moved between the two captures = working, never "
+                "restarted); the restart runs through the pool-loading start "
+                "path (cannot strip CCT tokens) and is rate-limited (30min/agent "
+                "debounce, <=2/agent/hour, <=10/pass). As with fleet-reconcile "
+                "that hourly cap is a ROLLING window: an agent still wedged "
+                "after it is RECORDED as degraded and retried at 2/hour, not "
+                "given up on. DEPLOY GATE: do NOT enable until the host's "
+                "auth-heal.py scan_tui cron is retired (double-supervisor risk)."
+            ),
+            # Same taxonomy note as the jobs above: kind must be one of
+            # {"service","timer","cron"} (scitex-dev #153); a periodic
+            # systemd --user timer is ``kind="timer"`` with the cadence in
+            # ``on_unit_active_sec``. A wrong kind raises at construction and
+            # ``ecosystem up`` then silently drops sac's WHOLE provider.
+            kind="timer",
+            # 5min matched to fleet-reconcile so the two enforcers sweep on the
+            # same beat rather than harmonising into one; it is the window a
+            # wedged agent stays wedged. A no-op pass is one `tmux list-sessions`
+            # plus two pane captures ~4s apart.
+            on_boot_sec="5min",
+            on_unit_active_sec="5min",
+            # Mirrors fleet-reconcile: bounds the pathological pass (`--limit`
+            # restarts, each a stop+settle+start) plus the ~4s capture interval.
+            # A pass killed here is SAFE — history is persisted per restart, so
+            # the next tick still honours the debounce for anything bounced.
+            timeout_sec=300,
+        ),
+    ]

--- a/src/scitex_agent_container/_reconcile/_blackout.py
+++ b/src/scitex_agent_container/_reconcile/_blackout.py
@@ -1,0 +1,156 @@
+"""N corpses at once is ONE event, and it is not N agents dying.
+
+THE HOLE THIS CLOSES
+--------------------
+``_runners/_tmux/_tmux_probe.py`` treats tmux's two "there is no server"
+stderrs as a **confirmed-empty fleet** — it returns ``{}``, a real
+observation, not ``None``. That is deliberate and right: a host with no tmux
+server genuinely has no sessions.
+
+``_lifecycle/_verdict_tmux._observed_snapshot`` then rescues the one case
+where an empty reading is a lie — ``if not snapshot and in_sif_fn()`` — because
+from inside a container the host's tmux lives in another mount namespace. But
+this job runs under ``systemd --user`` **on the host**, where ``in_sif()`` is
+``False``. So ``{}`` passes straight through as "every session is genuinely
+absent".
+
+Correct when a tmux server is normally absent. **Catastrophically wrong when
+the server dying IS the failure mode** — and that is exactly what happened on
+2026-08-11: the host's tmux server went away and took every pane with it,
+eleven agents in a two-second window. Every one of them would read here as an
+independent corpse with a spec asking to be kept running.
+
+WHY THE PER-AGENT BUDGET DOES NOT COVER THIS
+--------------------------------------------
+:mod:`._budget` is real and it is not the thing that fails. It throttles **per
+agent** (30-minute debounce, 2/agent/hour) and **per pass** (10). Neither is a
+FLEET-wide limit, and the distinction only matters in this one scenario:
+
+    10 restarts/pass x 12 passes/hour = up to 120 container starts per hour
+
+on a host that has just had whatever event killed its tmux server. Ninety specs
+on this fleet declare a managed restart policy, so the population is there. And
+it does not even fail fast: ``tmux new-session`` SPAWNS a server, so
+``sac agents start`` SUCCEEDS into a host that just lost one. The restarts land,
+and keep landing.
+
+THE RULE
+--------
+If a pass would restart more than one agent **and there is no tmux server on
+this host at all**, those restarts share a cause that is not the agents, and
+the reconciler must refuse and say so.
+
+The predicate is SERVER-ABSENT, not zero-sessions, and the difference is the
+whole design. Both incidents below present an empty session list, and they
+demand opposite responses:
+
+* **server alive, every agent dead** — the 2026-06 OAuth rotation killed 33
+  agents while tmux was untouched. RECOVER THEM. That incident is why this job
+  exists, and ``test_whole_dead_fleet_is_recovered`` is it written down.
+* **server itself gone** — 2026-08-11. REFUSE.
+
+An earlier draft of this module keyed on "zero live sessions" and would have
+blocked the first case. The suite caught it on the first run. The fact that
+separates them was already in the probe's hands and was being dropped at the
+boundary; :func:`.._runners._tmux._tmux_probe.list_sessions_activity_detailed`
+now carries it.
+
+Two more things this deliberately does NOT do:
+
+* A pass that would restart nothing is unaffected — an idle host reports no
+  sessions too, and there is nothing to refuse.
+* A SINGLE corpse is still restarted, even with the server gone. Refusing there
+  would strand a one-agent host, and one restart is a blast radius the
+  per-agent budget already bounds.
+
+So the threshold is where the evidence changes: **two or more corpses and no
+tmux server at all** is a statement about the host, not about the agents.
+
+This never restarts anything, and it never marks an agent dead. It withholds
+an action and raises an alarm — the strictly safer direction, because the cost
+of refusing wrongly is a delayed restart the next pass can still perform, while
+the cost of acting wrongly is a fleet-wide restart storm into an unhealthy
+host.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "FLEET_BLACKOUT_MIN_RESTARTS",
+    "blackout_detail",
+    "is_fleet_blackout",
+]
+
+#: How many would-be restarts it takes, with zero sessions observed, before a
+#: pass stops believing it is looking at independent deaths. Two: one corpse on
+#: a host with no other sessions is ordinary (and bounded by the per-agent
+#: budget), while two simultaneous corpses and no survivors anywhere is the
+#: signature of something that killed them together.
+FLEET_BLACKOUT_MIN_RESTARTS = 2
+
+
+def is_fleet_blackout(
+    *,
+    server_present: bool | None,
+    restart_count: int,
+    min_restarts: int = FLEET_BLACKOUT_MIN_RESTARTS,
+) -> bool:
+    """Is this pass looking at ONE infrastructure event rather than N deaths?
+
+    ``server_present`` comes from
+    :func:`.._runners._tmux._tmux_probe.list_sessions_activity_detailed`:
+    ``True`` a tmux server answered, ``False`` there is none, ``None`` we could
+    not tell.
+
+    ONLY ``False`` TRIPS THIS, and that is the whole correction. An earlier
+    draft keyed on "zero live sessions", which is the same reading for two
+    opposite incidents:
+
+        server alive, every agent dead   the 2026-06 OAuth rotation — 33 agents
+                                         killed, tmux untouched. RECOVER THEM;
+                                         this job exists for that case.
+        server itself gone               2026-08-11 — eleven agents in two
+                                         seconds. REFUSE; restarting here
+                                         lands on a host that just lost its
+                                         tmux server and repeats every pass.
+
+    Keying on the empty session list would have blocked the first, which the
+    suite caught immediately: ``test_whole_dead_fleet_is_recovered`` is that
+    incident written down. The distinguishing fact was already in the probe's
+    hands (``rc != 0`` + a no-server marker, versus ``rc == 0`` and no rows)
+    and was simply being discarded at the boundary.
+
+    ``None`` never trips it: an unobservable fleet is already handled upstream
+    (every agent decides ``UNKNOWN`` and nothing is restarted), and inventing
+    a blackout from a reading nobody took would be the same manufactured
+    certainty one layer along.
+
+    ``restart_count`` is how many agents this pass decided to RESTART, counted
+    BEFORE any of them is performed — which is why the caller must decide for
+    the whole fleet first and act second.
+    """
+    if server_present is not False:
+        return False
+    return restart_count >= min_restarts
+
+
+def blackout_detail(restart_count: int, names: tuple[str, ...] = ()) -> str:
+    """The operator-facing explanation. Says what was seen, what was withheld,
+    and what to check — a refusal whose reason the reader has to guess is how a
+    correct decision still ends in the wrong action.
+    """
+    listed = ", ".join(names[:10]) if names else "(none named)"
+    more = f" (+{len(names) - 10} more)" if len(names) > 10 else ""
+    return (
+        f"FLEET BLACKOUT — {restart_count} agent(s) look like corpses and "
+        f"THERE IS NO TMUX SERVER on this host at all. The server itself went "
+        f"away and took every pane with it (as on 2026-08-11, eleven agents "
+        f"in two seconds) — this is ONE event, not {restart_count} agents "
+        f"dying independently. REFUSING to restart anything: a mass restart "
+        f"here would LAND (tmux new-session spawns a fresh server), so it "
+        f"would not even fail loudly, and it would repeat every pass. "
+        f"Withheld: {listed}{more}. Find why the tmux server went away, then "
+        f"run `sac agents reconcile --apply --limit 2` by hand and watch it. "
+        f"NOTE this is specifically a MISSING SERVER — a live server holding "
+        f"zero sessions means the agents died and DOES restart them."
+    )

--- a/src/scitex_agent_container/_reconcile/_pass.py
+++ b/src/scitex_agent_container/_reconcile/_pass.py
@@ -28,10 +28,13 @@ from ._alarm import (
     record_self_recovered,
 )
 from ._budget import DEFAULT_PASS_CAP, Budget, history_path, read_history, save_history
+from ._perform import perform, resolve_pending
+from ._report import AgentReport
 from ._rule import MANAGED_POLICIES, Verdict, decide
 
 __all__ = [
     "AgentReport",
+    "perform",
     "PassOutcome",
     "fleet_agents_dir",
     "fleet_spec_paths",
@@ -41,26 +44,6 @@ __all__ = [
 #: Same override the sibling fleet-wide verb (``sac agents refresh-acl``)
 #: honours, so both point at one registry in tests and on odd install roots.
 _AGENTS_DIR_ENV = "SCITEX_AGENT_CONTAINER_AGENTS_DIR"
-
-
-@dataclass(frozen=True)
-class AgentReport:
-    """One agent's line in the report. ``detail`` is ALWAYS printed."""
-
-    name: str
-    verdict: Verdict
-    reason: str
-    detail: str
-    policy: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "verdict": self.verdict.value,
-            "reason": self.reason,
-            "detail": self.detail,
-            "policy": self.policy,
-        }
 
 
 @dataclass(frozen=True)
@@ -89,8 +72,14 @@ class PassOutcome:
         look" is not clean, and a pass that could not see the fleet — or
         could not read its own memory of what it already restarted — must
         not exit 0 and let a cron log it as a healthy tick.
+
+        FLEET_BLACKOUT joins them, and belongs in this group rather than the
+        next one for the same reason: the pass DID look and could not tell N
+        independent deaths from one event that killed them together. That is
+        an unresolved reading, not a tidy "something is down" — and it is the
+        state that most needs a human, so it must never exit 0.
         """
-        if self.of(Verdict.UNKNOWN, Verdict.BUDGET_UNKNOWN):
+        if self.of(Verdict.UNKNOWN, Verdict.BUDGET_UNKNOWN, Verdict.FLEET_BLACKOUT):
             return 2
         if self.of(
             Verdict.FAILED,
@@ -178,6 +167,32 @@ def _batched_snapshot_fn(
     return _cached
 
 
+def _server_present(snapshot_fn: Callable[..., dict | None] | None) -> bool | None:
+    """Is there a tmux SERVER on this host at all? ``None`` when we cannot say.
+
+    Separate from the session snapshot because it answers a different question,
+    and because the two empties mean opposite things: a live server holding no
+    sessions is "every agent died" (recover them — the 33-agent OAuth rotation
+    is why this job exists), while no server at all is "one thing killed them
+    together" (refuse — see :mod:`._blackout`).
+
+    An INJECTED ``snapshot_fn`` yields ``None``, deliberately. A test's fake
+    speaks for which sessions exist; it says nothing about whether a tmux
+    server does, and reading a substituted session list as evidence about the
+    server would be inventing a fact nobody supplied. ``None`` never trips the
+    breaker, so every existing pass-level test keeps its current behaviour.
+    """
+    if snapshot_fn is not None:
+        return None
+    from .._runners._tmux._tmux_probe import list_sessions_activity_detailed
+
+    # stx-allow: fallback (reason: a probe that raises observed nothing — UNKNOWN, which authorises no refusal and no restart)
+    try:
+        return list_sessions_activity_detailed()[1]
+    except Exception:
+        return None
+
+
 def _real_restart(name: str) -> bool:
     """Restart ONE local agent. ``is not False`` per the CLI's own rule.
 
@@ -238,97 +253,6 @@ def _spec_report(spec: Path, exc: Exception) -> AgentReport:
     )
 
 
-#: Which rate-limit stood in the way — and, crucially, whether it means
-#: "wait" or "a human must look". Only :attr:`Verdict.OVER_BUDGET` is
-#: carded (see :mod:`._alarm`), and the difference is not cosmetic:
-#:
-#: * ``debounce`` (COOLING-DOWN) is the NORMAL state of a healthy recovery.
-#:   The debounce is 30min and the timer ticks every 5, so a perfectly good
-#:   restart is inside its own debounce for the next five ticks. Carding
-#:   that would mint a board card for every successful heal — training the
-#:   operator to ignore the board, which is how the fleet died unnoticed in
-#:   the first place.
-#: * ``over-budget`` means we have already bounced it twice in an hour AND
-#:   waited out two debounces, and it is STILL down. Restarting is not
-#:   fixing this: that is a real, human-shaped problem, so it is carded.
-#: * ``pass-cap`` (CAPPED) is our own throttle, not the agent's fault. The
-#:   next tick picks it up 5 minutes later.
-_BUDGET_VERDICTS = {
-    "debounce": Verdict.COOLING_DOWN,
-    "over-budget": Verdict.OVER_BUDGET,
-    "pass-cap": Verdict.CAPPED,
-}
-
-#: Verdicts that mean we ATTEMPTED a restart, so the history must be
-#: persisted before we touch the next agent. FAILED counts: a restart that
-#: raised still consumed a real attempt, and forgetting it would let the
-#: next tick retry immediately.
-_SPENT = (Verdict.RESTARTED, Verdict.FAILED)
-
-
-def _perform(
-    name: str,
-    decision,
-    *,
-    budget: Budget | None,
-    apply: bool,
-    now: float,
-    restart_fn: Callable[[str], bool],
-    budget_detail: str = "",
-) -> AgentReport:
-    """Turn the rule's RESTART authorisation into what we actually did."""
-    if budget is None:
-        # We could not read our OWN restart memory, so the debounce and the
-        # hourly cap cannot be enforced. Restarting anyway would not be
-        # "trying harder" — with no memory, EVERY corpse is restartable on
-        # EVERY 5-minute tick, forever. That is the restart loop the limits
-        # exist to prevent, and it is strictly worse than a down agent.
-        return AgentReport(
-            name,
-            Verdict.BUDGET_UNKNOWN,
-            "budget-unreadable",
-            f"{decision.detail}; NOT restarted: {budget_detail}",
-        )
-    check = budget.check(name, now)
-    if not check.allowed:
-        return AgentReport(
-            name,
-            _BUDGET_VERDICTS[check.reason],
-            check.reason,
-            f"{decision.detail}; NOT restarted: {check.detail}",
-        )
-
-    if not apply:
-        return AgentReport(
-            name,
-            Verdict.WOULD_RESTART,
-            decision.reason,
-            f"{decision.detail} — would restart (dry-run: nothing was done; "
-            f"re-run with --apply to actually restart)",
-        )
-
-    # stx-allow: fallback (reason: one agent's restart raising must never abort the sweep — the rest of the fleet is still down and still needs recovering; the failure is carded and reported)
-    try:
-        ok = restart_fn(name)
-    except Exception as exc:
-        budget.record(name, now)  # a restart we ATTEMPTED still spends budget
-        return AgentReport(
-            name,
-            Verdict.FAILED,
-            "restart-raised",
-            f"{decision.detail}; restart FAILED: {exc}",
-        )
-    budget.record(name, now)
-    if ok:
-        return AgentReport(name, Verdict.RESTARTED, decision.reason, decision.detail)
-    return AgentReport(
-        name,
-        Verdict.FAILED,
-        "restart-returned-false",
-        f"{decision.detail}; restart ran but reported FAILURE — the agent is "
-        f"still down",
-    )
-
 
 def reconcile_pass(
     *,
@@ -384,6 +308,11 @@ def reconcile_pass(
     read = read_history(history_file)
     budget = Budget(read.history, pass_cap=limit) if read.enforceable else None
     reports: list[AgentReport] = []
+    # RESTART authorisations, held until the whole fleet has been decided. A
+    # corpse is only interpretable next to its neighbours: N corpses with no
+    # live session anywhere is ONE event, not N deaths, and a loop that
+    # restarts as it goes can never see that. See :mod:`._blackout`.
+    pending: list[tuple[str, Any, str]] = []
 
     for spec in fleet_spec_paths(specs_dir):
         # stx-allow: fallback (reason: a single malformed/foreign spec.yaml must NOT abort the rest of the fleet sweep — it is reported as UNKNOWN and the sweep continues, mirroring `sac agents refresh-acl`)
@@ -417,36 +346,30 @@ def reconcile_pass(
                 )
             )
             continue
-        report = _perform(
-            name,
-            decision,
+        pending.append((name, decision, policy))
+
+    # The fleet is decided; now act on it as a whole.
+    #
+    # Read the snapshot through the SAME rescue the per-agent path uses rather
+    # than calling `snapshot()` raw: `_observed_snapshot` is what turns an
+    # empty reading taken from inside a container — where the host's tmux is in
+    # another mount namespace — into ``None`` instead of "the fleet is empty".
+    # Calling the probe directly here would reintroduce exactly the
+    # blind-reads-as-absent confusion this breaker exists to catch, one level
+    # up from where it was fixed.
+    reports.extend(
+        resolve_pending(
+            pending,
+            server_present=_server_present(snapshot_fn),
             budget=budget,
             apply=apply,
             now=now,
             restart_fn=restart_fn,
             budget_detail=read.detail,
+            history_file=history_file,
+            stream=stream,
         )
-        reports.append(report)
-        # PERSIST THE MOMENT WE SPEND BUDGET, never only at the end. The
-        # scheduled form runs under a systemd timeout, and a pass killed
-        # mid-sweep with its history still in RAM would forget the agents it
-        # had just bounced — so the next tick would bounce them again,
-        # debounce and hourly cap silently disarmed. That is the restart
-        # LOOP these limits exist to prevent, re-introduced by the very
-        # timeout meant to contain the pass. One small atomic write per
-        # restart (<=`limit` per pass) buys immunity to it.
-        if apply and budget is not None and report.verdict in _SPENT:
-            # stx-allow: fallback (reason: if we can no longer RECORD restarts we must stop PERFORMING them — a restart we cannot remember is an unbounded one. Spending the pass cap halts further restarts safely; the loud print + non-zero exit carry the failure.)
-            try:
-                save_history(history_file, budget.history, now=now)
-            except OSError as exc:
-                budget.spent = budget.pass_cap  # authorise no further restarts
-                print(
-                    f"[fleet-reconcile] CANNOT RECORD restarts to "
-                    f"{history_file} ({exc}) — halting this pass's restarts. "
-                    f"An unrecordable restart is an unbounded one.",
-                    file=stream,
-                )
+    )
 
     if apply and budget is not None:
         # stx-allow: fallback (reason: the end-of-pass prune is housekeeping; its failure is already reported by the per-restart guard above and must not crash a pass that has already done its work)

--- a/src/scitex_agent_container/_reconcile/_perform.py
+++ b/src/scitex_agent_container/_reconcile/_perform.py
@@ -1,0 +1,192 @@
+"""Turning authorised restarts into what actually happened.
+
+Extracted from :mod:`._pass` (at the per-file cap) and cohesive on its own
+terms: everything here is about SPENDING — budget, the restart itself, and
+persisting the record of it before the next agent is touched.
+
+It also holds the fleet-wide gate. A corpse is only interpretable next to its
+neighbours, so :func:`resolve_pending` takes the whole pass's RESTART
+authorisations at once, asks :mod:`._blackout` whether they are N deaths or one
+event, and only then acts. That ordering is the point: a per-agent loop that
+restarts as it goes cannot see that it is the tenth corpse in a row.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from ._blackout import blackout_detail, is_fleet_blackout
+from ._budget import Budget, save_history
+from ._report import AgentReport
+from ._rule import Verdict  # noqa: F401  (re-exported for _pass's callers)
+
+__all__ = ["_BUDGET_VERDICTS", "_SPENT", "perform", "resolve_pending"]
+
+#: Verdicts that mean we ATTEMPTED a restart, so the history must be
+#: persisted before we touch the next agent. FAILED counts: a restart that
+#: raised still consumed a real attempt, and forgetting it would let the
+#: next tick retry immediately.
+_SPENT = (Verdict.RESTARTED, Verdict.FAILED)
+
+#: Which rate-limit stood in the way — and, crucially, whether it means
+#: "wait" or "a human must look". Only :attr:`Verdict.OVER_BUDGET` is
+#: carded (see :mod:`._alarm`), and the difference is not cosmetic:
+#:
+#: * ``debounce`` (COOLING-DOWN) is the NORMAL state of a healthy recovery.
+#:   The debounce is 30min and the timer ticks every 5, so a perfectly good
+#:   restart is inside its own debounce for the next five ticks. Carding
+#:   that would mint a board card for every successful heal — training the
+#:   operator to ignore the board, which is how the fleet died unnoticed in
+#:   the first place.
+#: * ``over-budget`` means we have already bounced it twice in an hour AND
+#:   waited out two debounces, and it is STILL down. Restarting is not
+#:   fixing this: that is a real, human-shaped problem, so it is carded.
+#: * ``pass-cap`` (CAPPED) is our own throttle, not the agent's fault. The
+#:   next tick picks it up 5 minutes later.
+_BUDGET_VERDICTS = {
+    "debounce": Verdict.COOLING_DOWN,
+    "over-budget": Verdict.OVER_BUDGET,
+    "pass-cap": Verdict.CAPPED,
+}
+
+
+def perform(
+    name: str,
+    decision,
+    *,
+    budget: Budget | None,
+    apply: bool,
+    now: float,
+    restart_fn: Callable[[str], bool],
+    budget_detail: str = "",
+) -> AgentReport:
+    """Turn the rule's RESTART authorisation into what we actually did."""
+    if budget is None:
+        # We could not read our OWN restart memory, so the debounce and the
+        # hourly cap cannot be enforced. Restarting anyway would not be
+        # "trying harder" — with no memory, EVERY corpse is restartable on
+        # EVERY 5-minute tick, forever. That is the restart loop the limits
+        # exist to prevent, and it is strictly worse than a down agent.
+        return AgentReport(
+            name,
+            Verdict.BUDGET_UNKNOWN,
+            "budget-unreadable",
+            f"{decision.detail}; NOT restarted: {budget_detail}",
+        )
+    check = budget.check(name, now)
+    if not check.allowed:
+        return AgentReport(
+            name,
+            _BUDGET_VERDICTS[check.reason],
+            check.reason,
+            f"{decision.detail}; NOT restarted: {check.detail}",
+        )
+
+    if not apply:
+        return AgentReport(
+            name,
+            Verdict.WOULD_RESTART,
+            decision.reason,
+            f"{decision.detail} — would restart (dry-run: nothing was done; "
+            f"re-run with --apply to actually restart)",
+        )
+
+    # stx-allow: fallback (reason: one agent's restart raising must never abort the sweep — the rest of the fleet is still down and still needs recovering; the failure is carded and reported)
+    try:
+        ok = restart_fn(name)
+    except Exception as exc:
+        budget.record(name, now)  # a restart we ATTEMPTED still spends budget
+        return AgentReport(
+            name,
+            Verdict.FAILED,
+            "restart-raised",
+            f"{decision.detail}; restart FAILED: {exc}",
+        )
+    budget.record(name, now)
+    if ok:
+        return AgentReport(name, Verdict.RESTARTED, decision.reason, decision.detail)
+    return AgentReport(
+        name,
+        Verdict.FAILED,
+        "restart-returned-false",
+        f"{decision.detail}; restart ran but reported FAILURE — the agent is "
+        f"still down",
+    )
+
+
+def resolve_pending(
+    pending: list[tuple[str, Any, str]],
+    *,
+    server_present: bool | None,
+    budget: Budget | None,
+    apply: bool,
+    now: float,
+    restart_fn: Callable[[str], bool],
+    budget_detail: str,
+    history_file: Path,
+    stream: Any = None,
+) -> list[AgentReport]:
+    """Act on every RESTART this pass authorised — or refuse them together.
+
+    The fleet-wide gate runs FIRST and applies to the whole batch, because the
+    evidence it reads is a property of the pass rather than of any one agent:
+    multiple corpses AND no live session anywhere. See :mod:`._blackout`.
+
+    A blackout refuses in the SAFE direction — it withholds restarts and spends
+    no budget, so the next pass can still recover the fleet the moment a live
+    session reappears. Nothing here marks an agent dead.
+    """
+    stream = stream if stream is not None else sys.stderr
+    names = tuple(name for name, _, _ in pending)
+
+    if is_fleet_blackout(
+        server_present=server_present, restart_count=len(pending)
+    ):
+        detail = blackout_detail(len(pending), names)
+        print(f"[fleet-reconcile] {detail}", file=stream)
+        return [
+            AgentReport(
+                name,
+                Verdict.FLEET_BLACKOUT,
+                "fleet-blackout",
+                f"{decision.detail}; NOT restarted: {detail}",
+                policy,
+            )
+            for name, decision, policy in pending
+        ]
+
+    reports: list[AgentReport] = []
+    for name, decision, _policy in pending:
+        report = perform(
+            name,
+            decision,
+            budget=budget,
+            apply=apply,
+            now=now,
+            restart_fn=restart_fn,
+            budget_detail=budget_detail,
+        )
+        reports.append(report)
+        # PERSIST THE MOMENT WE SPEND BUDGET, never only at the end. The
+        # scheduled form runs under a systemd timeout, and a pass killed
+        # mid-sweep with its history still in RAM would forget the agents it
+        # had just bounced — so the next tick would bounce them again,
+        # debounce and hourly cap silently disarmed. That is the restart
+        # LOOP these limits exist to prevent, re-introduced by the very
+        # timeout meant to contain the pass. One small atomic write per
+        # restart (<=`limit` per pass) buys immunity to it.
+        if apply and budget is not None and report.verdict in _SPENT:
+            # stx-allow: fallback (reason: if we can no longer RECORD restarts we must stop PERFORMING them — a restart we cannot remember is an unbounded one. Spending the pass cap halts further restarts safely; the loud print + non-zero exit carry the failure.)
+            try:
+                save_history(history_file, budget.history, now=now)
+            except OSError as exc:
+                budget.spent = budget.pass_cap  # authorise no further restarts
+                print(
+                    f"[fleet-reconcile] CANNOT RECORD restarts to "
+                    f"{history_file} ({exc}) — halting this pass's restarts. "
+                    f"An unrecordable restart is an unbounded one.",
+                    file=stream,
+                )
+    return reports

--- a/src/scitex_agent_container/_reconcile/_report.py
+++ b/src/scitex_agent_container/_reconcile/_report.py
@@ -1,0 +1,35 @@
+"""One agent's line in a reconcile report.
+
+Extracted from :mod:`._pass` so that :mod:`._perform` — which BUILDS these —
+can import the type without importing the pass that calls it. A shared value
+type belongs below both of its users, not inside one of them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ._rule import Verdict
+
+__all__ = ["AgentReport"]
+
+
+@dataclass(frozen=True)
+class AgentReport:
+    """One agent's line in the report. ``detail`` is ALWAYS printed."""
+
+    name: str
+    verdict: Verdict
+    reason: str
+    detail: str
+    policy: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "verdict": self.verdict.value,
+            "reason": self.reason,
+            "detail": self.detail,
+            "policy": self.policy,
+        }

--- a/src/scitex_agent_container/_reconcile/_rule.py
+++ b/src/scitex_agent_container/_reconcile/_rule.py
@@ -93,6 +93,10 @@ class Verdict(str, Enum):
     COOLING_DOWN = "COOLING-DOWN"  # inside the debounce → wait, do not card
     CAPPED = "CAPPED"  # this pass's global cap spent; next pass retries
     BUDGET_UNKNOWN = "BUDGET-UNKNOWN"  # we cannot read our OWN memory → refuse
+    # A corpse we refuse to touch because it is not ALONE: this pass saw
+    # multiple corpses and not one live session anywhere, which is the host's
+    # tmux server dying rather than N agents dying. See :mod:`._blackout`.
+    FLEET_BLACKOUT = "FLEET-BLACKOUT"
 
     # Not a thing a pass DID — a thing it could not do. An agent whose pane
     # would not capture, or that is registered with no live session at all,

--- a/src/scitex_agent_container/_runners/_tmux/_tmux_probe.py
+++ b/src/scitex_agent_container/_runners/_tmux/_tmux_probe.py
@@ -88,6 +88,45 @@ def list_sessions_activity(
 
     Never raises.
     """
+    return list_sessions_activity_detailed(
+        timeout_s=timeout_s, socket_name=socket_name
+    )[0]
+
+
+def list_sessions_activity_detailed(
+    *, timeout_s: float = BATCH_PROBE_TIMEOUT_S, socket_name: str | None = None
+) -> tuple[dict[str, int] | None, bool | None]:
+    """:func:`list_sessions_activity`, plus WHETHER A SERVER IS THERE AT ALL.
+
+    Returns ``(sessions, server_present)``:
+
+      * ``({...}, True)``  — a server answered and these are its sessions.
+      * ``({}, True)``     — a server answered and it holds NO sessions.
+      * ``({}, False)``    — there is NO tmux server on this socket.
+      * ``(None, None)``   — the probe failed. Both facts are UNKNOWN.
+
+    THE TWO EMPTIES ARE NOT THE SAME EVENT, and collapsing them is a real
+    hazard rather than a nicety. ``list_sessions_activity`` returns ``{}`` for
+    both, which is right for its own question ("which sessions are live?") and
+    wrong for anyone asking WHY the answer is empty:
+
+      * ``({}, True)``  — the server is fine and every agent died. This is the
+        2026-06 OAuth rotation: 33 agents killed, tmux untouched. The fleet
+        reconciler MUST recover them; that incident is why it exists.
+      * ``({}, False)`` — the server itself went away and took every pane with
+        it. This is 2026-08-11: eleven agents in a two-second window. Mass
+        restarts here land on a host that just lost its tmux server (``tmux
+        new-session`` spawns a fresh one), so they succeed, and repeat on every
+        pass.
+
+    Those two demand OPPOSITE responses, and the information to tell them apart
+    was already in hand — ``rc != 0`` plus a no-server marker versus ``rc == 0``
+    with no rows — and was being discarded at this boundary. This function stops
+    discarding it; :func:`list_sessions_activity` keeps its exact contract by
+    dropping the second element.
+
+    Never raises.
+    """
     argv = ["tmux"]
     if socket_name:
         argv += ["-L", socket_name]
@@ -97,14 +136,14 @@ def list_sessions_activity(
             argv, capture_output=True, text=True, timeout=timeout_s
         )
     except (OSError, subprocess.SubprocessError):  # stx-allow: fallback (a wedged/missing tmux is UNKNOWN liveness, never "all agents dead" — the caller preserves the previous data)
-        return None
+        return None, None
     if result.returncode != 0:
         # Distinguish "no tmux server" (a definitive, EMPTY fleet) from any
         # other failure (UNKNOWN). Reading a wedged probe as an empty fleet
         # is exactly the bug this contract prevents.
         if _is_no_server(result.stderr or ""):
-            return {}
-        return None
+            return {}, False
+        return None, None
     out: dict[str, int] = {}
     for line in (result.stdout or "").splitlines():
         name, sep, raw = line.partition("\t")
@@ -114,7 +153,7 @@ def list_sessions_activity(
             out[name] = int(raw.strip())
         except ValueError:  # stx-allow: fallback (one unparseable activity stamp contributes nothing — the other sessions still beat)
             continue
-    return out
+    return out, True
 
 
 def _display_field(session_name: str, fmt: str) -> str | None:

--- a/tests/scitex_agent_container/_reconcile/test__blackout.py
+++ b/tests/scitex_agent_container/_reconcile/test__blackout.py
@@ -1,0 +1,149 @@
+"""N corpses at once is ONE event, and it must not become N restarts.
+
+The hole: `_tmux_probe` treats "no server running" as a CONFIRMED-empty fleet
+(`{}`, a real observation), and `_verdict_tmux`'s blindness rescue fires only
+inside a container. Under `systemd --user` on the host that empty reading
+passes straight through as "every session is genuinely absent" — which is
+exactly what a dead tmux server looks like, and exactly what happened on
+2026-08-11 when the host's server took eleven agents with it in two seconds.
+
+Ninety specs on that fleet declare a managed restart policy, and the budget
+throttles per agent and per pass but never fleet-wide: 10/pass x 12 passes/hour
+is up to 120 container starts an hour into a host that just lost its tmux
+server — which `sac agents start` would happily recreate, so it does not even
+fail fast.
+
+These pin the predicate. Pure function, hand-built inputs, no tmux and no
+daemon.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._reconcile._blackout import (
+    FLEET_BLACKOUT_MIN_RESTARTS,
+    blackout_detail,
+    is_fleet_blackout,
+)
+
+
+# --- the incident this exists for ----------------------------------------
+
+
+def test_many_corpses_and_no_sessions_anywhere_is_a_blackout():
+    """2026-08-11, in one assertion: eleven corpses, zero live sessions."""
+    # Arrange
+    server, restarts = False, 11
+    # Act
+    blackout = is_fleet_blackout(server_present=server, restart_count=restarts)
+    # Assert
+    assert blackout is True
+
+
+def test_two_corpses_is_already_a_blackout():
+    """The threshold is where the evidence changes, not at some round number."""
+    # Arrange
+    server, restarts = False, FLEET_BLACKOUT_MIN_RESTARTS
+    # Act
+    blackout = is_fleet_blackout(server_present=server, restart_count=restarts)
+    # Assert
+    assert blackout is True
+
+
+# --- and the cases it must NOT break -------------------------------------
+
+
+def test_a_single_corpse_is_still_restarted():
+    """On a one-agent host every real death also has zero live sessions.
+
+    Refusing here would make the job useless for the case it handles best,
+    and one restart is a blast radius the per-agent budget already bounds.
+    """
+    # Arrange
+    server, restarts = False, 1
+    # Act
+    blackout = is_fleet_blackout(server_present=server, restart_count=restarts)
+    # Assert
+    assert blackout is False
+
+
+def test_a_live_server_with_every_agent_dead_is_still_recovered():
+    """THE load-bearing negative, and the case an earlier draft got wrong.
+
+    A tmux server that is up but holds no sessions means the AGENTS died, not
+    the host — the 2026-06 OAuth rotation killed 33 of them with tmux
+    untouched, and recovering exactly that is why this job exists. Keying the
+    breaker on "zero sessions" would have blocked it; `test__pass.py::
+    test_whole_dead_fleet_is_recovered` caught that on the first run.
+    """
+    # Arrange
+    server, restarts = True, 33
+    # Act
+    blackout = is_fleet_blackout(server_present=server, restart_count=restarts)
+    # Assert
+    assert blackout is False
+
+
+def test_a_host_with_nothing_to_restart_is_not_a_blackout():
+    """No server AND nothing to restart: a quiet host, not an incident."""
+    # Arrange
+    server, restarts = False, 0
+    # Act
+    blackout = is_fleet_blackout(server_present=server, restart_count=restarts)
+    # Assert
+    assert blackout is False
+
+
+def test_an_unobservable_fleet_never_trips_the_breaker():
+    """``None`` is "I could not look" — it must not manufacture a blackout.
+
+    An unobservable fleet is already handled upstream (every agent decides
+    UNKNOWN and nothing is restarted); inventing a blackout from a reading
+    nobody took would be the same manufactured certainty one layer along.
+    """
+    # Arrange
+    server, restarts = None, 11
+    # Act
+    blackout = is_fleet_blackout(server_present=server, restart_count=restarts)
+    # Assert
+    assert blackout is False
+
+
+# --- the operator-facing explanation --------------------------------------
+
+
+def test_detail_names_the_withheld_agents():
+    # Arrange
+    names = ("figrecipe", "scitex-ui")
+    # Act
+    detail = blackout_detail(2, names)
+    # Assert
+    assert "figrecipe" in detail
+
+
+def test_detail_says_it_refused_rather_than_failed():
+    """A refusal read as a failure sends the operator hunting the wrong thing."""
+    # Arrange
+    names = ("a",)
+    # Act
+    detail = blackout_detail(11, names)
+    # Assert
+    assert "REFUSING" in detail
+
+
+def test_detail_points_at_the_tmux_server():
+    """The reader needs the next action, not just the verdict."""
+    # Arrange
+    names = ("a",)
+    # Act
+    detail = blackout_detail(11, names)
+    # Assert
+    assert "tmux server" in detail
+
+
+def test_detail_truncates_a_long_withheld_list():
+    # Arrange
+    names = tuple(f"agent-{i}" for i in range(14))
+    # Act
+    detail = blackout_detail(14, names)
+    # Assert
+    assert "+4 more" in detail


### PR DESCRIPTION
The fleet-reconcile timer is currently **disabled and has never run**. This is the change that has to land before it is safe to arm, plus the correction to the promise its own unit description makes.

## The hole

`_runners/_tmux/_tmux_probe.py` treats tmux's two "there is no server" stderrs as a **confirmed-empty fleet** — it returns `{}`, a real observation, not `None`:

```python
_NO_SERVER_MARKERS = ("no server running", "no such file or directory")
```

`_lifecycle/_verdict_tmux._observed_snapshot` then rescues the one case where an empty reading is a lie — but only that one:

```python
if not snapshot and in_sif_fn():
    return None   # namespace blindness, not an empty fleet
```

This job runs under `systemd --user` **on the host**, where `in_sif()` is `False`. So `{}` passes straight through as *"every session is genuinely absent."*

That is correct when a tmux server is normally absent. It is **catastrophically wrong when the server dying is the failure mode** — which is exactly what happened on 2026-08-11: the host's tmux server went away and took every pane with it, eleven agents inside a two-second window. Every one of them reads here as an independent corpse with a spec asking to be kept running.

## Why the existing budget does not cover it

`_budget.py` is real, correct, and not the thing that fails. It throttles **per agent** (30-min debounce, 2/agent/hour) and **per pass** (10). Neither is fleet-wide, and the distinction only matters in this one scenario:

```
10 restarts/pass  ×  12 passes/hour  =  up to 120 container starts per hour
```

on a host that has just had whatever event killed its tmux server. **Ninety specs** on this fleet declare a managed restart policy (89 `on-failure` + 1 `always` of 113), so the population is there. And it does not fail fast: `tmux new-session` *spawns* a server, so `sac agents start` **succeeds** into a host that just lost one. The restarts land, and keep landing.

A fleet-wide amplifier hiding behind a correctly-implemented per-agent budget.

## The rule

If a pass would restart **more than one** agent and **there is no tmux server on this host at all**, those restarts share a cause that is not the agents. It withholds every restart, spends no budget, and alarms.

**The predicate is SERVER-ABSENT, not zero-sessions, and that distinction is the whole design.** Both incidents below present an empty session list and demand opposite responses:

- **server alive, every agent dead** — the 2026-06 OAuth rotation killed 33 agents with tmux untouched. **Recover them.** That incident is why this job exists.
- **server itself gone** — 2026-08-11, eleven agents in two seconds. **Refuse.**

My first draft keyed on "zero live sessions" and would have blocked the first case. `test_whole_dead_fleet_is_recovered` caught it on the very first run — the suite had that incident written down as an executable assertion, which is exactly what stopped a plausible-looking safety feature from disabling the safety it was protecting.

The fact that separates them was already in the probe's hands and was being thrown away at the boundary:

```python
if result.returncode != 0:
    if _is_no_server(result.stderr or ""):
        return {}            # no server  -> was indistinguishable from...
    return None
...
return out                   # rc == 0, no rows -> ...a server with 0 sessions
```

`list_sessions_activity_detailed` now returns `(sessions, server_present)`; `list_sessions_activity` keeps its exact contract by dropping the second element.

New verdict `FLEET-BLACKOUT`, exiting **2**, not 1 — it joins `UNKNOWN`/`BUDGET_UNKNOWN` because the pass *did* look and could not resolve what it saw. That is an unresolved reading, not a tidy "something is down", and it is the state that most needs a human, so it must never exit 0.

Deliberately **not** blanket refusals:

- **A pass that would restart nothing is unaffected** — a quiet host is not an incident.
- **A single corpse is still restarted**, even with the server gone. Refusing there would strand a one-agent host, and one restart is a blast radius the per-agent budget already bounds.

It refuses in the safe direction: no restarts, **no budget spent**, nothing marked dead. The next pass recovers the fleet the moment a server answers.

## The description correction

The unit's own text claimed an unrecoverable agent is *"RECORDED as degraded instead of bounced endlessly."* Recording is implemented (`_alarm.py`). **Giving up is not.** The hourly cap is a *rolling window*, so steady state for an agent that can never recover is 2 restarts/hour forever — ~48 container starts/day. `_budget.py` argues that deliberately (a permanent give-up would strand an agent that crashed three times last March), so the behaviour is right and the sentence was wrong.

It now says *"bounded RATE, not eventual give-up"* outright. A promise nobody keeps is worse than no promise.

## Refactors carried (mechanical, no behaviour change)

Both files were at or over the 512-line cap, so the edits required extraction first:

- `_reconcile/_report.py` — `AgentReport` moved out of `_pass.py` so `_perform.py`, which *builds* them, can import the type without importing the pass that calls it.
- `_reconcile/_perform.py` — the spending half (budget check, the restart, per-restart history persistence) plus the new `resolve_pending`, which is where the fleet-wide gate runs.
- `_jobs/_specs_liveness.py` — the two agent-liveness JobSpecs. They are one concern split in two (corpses vs live-but-wedged), each one's scope defined by what the other covers, so they are unreadable apart.

`reconcile_pass` is now **decide-then-act**: it collects RESTART authorisations for the whole fleet, then resolves them together. That ordering is the point — a per-agent loop that restarts as it goes cannot see that it is the tenth corpse in a row.

One subtlety worth flagging for review: `_server_present` returns `None` whenever a test injects a `snapshot_fn`. A fake speaks for which sessions exist; it says nothing about whether a tmux server does, and reading a substituted session list as evidence about the server would invent a fact nobody supplied. `None` never trips the breaker, so every existing pass-level test keeps its current behaviour unchanged.

## Not in scope

Arming the timer. That stays the operator's call, and the recommended sequence is: this fix → one watched `sac agents reconcile --apply --limit 2` → enable exactly one unit. Never a bulk `ecosystem up`: `jobs-enabled.txt` does not exist, so `is_selected` returns True for every job, and a bulk arm would also arm `restart-login-expired-agents`, which carries an explicit deploy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
