### PR TITLE
feat(git-identity): let agents sign their own work as agent@scitex.ai

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/git_identity_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/git_identity_hooks/README.md
@@ -106,10 +106,27 @@ copy here is the source of truth; propagate it exactly like
 
 ## Provisioning side (defense in depth)
 
-This hook is the fail-loud backstop. The upstream pin still belongs to
-direnv: `~/proj/.envrc` exports `SAC_GIT_AUTHOR_EMAIL=ywatanabe@scitex.ai`
-(+ name/committer), and `runtimes/_apptainer_inner_argv.py`
-(`_GIT_ENV_ALIAS_STEPS`) mirrors `SAC_GIT_*` → `GIT_*`. If a host is
-found where that pin does not land (as reproduced above), fix the direnv
-allow / `.envrc` sourcing on that host so `GIT_AUTHOR_EMAIL` is set at
-launch — the hook then never has to fire.
+This hook is the fail-loud backstop. The upstream pin is TWO layers, both
+scoped to the agent (an agent's `$HOME` is `/home/agent`, inside its own
+apptainer overlay, so neither can reach the operator's `~/.gitconfig`):
+
+1. **The per-agent spec** — `<agents_dir>/<name>/spec.yaml` carries
+   `apptainer.raw_args: ["--env", "GIT_AUTHOR_EMAIL=agent@scitex.ai", ...]`
+   plus the agent's own id as `GIT_AUTHOR_NAME`. Env beats git config, so
+   this is what actually decides authorship.
+2. **The shared to_home baseline** — `<agents_dir>/_shared/to_home/.gitconfig`,
+   materialized into every agent's `$HOME/.gitconfig` on each start by
+   `runtimes/_to_home.py`. The fallback for when layer 1 does not land; its
+   job is to make that failure land on an allowlisted identity rather than a
+   synthesized `user@hostname`.
+
+If a host is found where the author is wrong, read layer 1 first — it wins.
+
+> **Not direnv.** This section used to name `~/proj/.envrc` exporting
+> `SAC_GIT_AUTHOR_EMAIL` as the pin. Measured on compute-04 2026-08-12:
+> that file does not exist and the variable is empty, so the
+> `_GIT_ENV_ALIAS_STEPS` mirror in `runtimes/_apptainer_inner_argv.py`
+> contributes nothing on this fleet. The mirror is values-agnostic and
+> still works if a host ever sets `SAC_GIT_*` — but documentation asserting
+> a mechanism that contributes nothing sends the next reader to fix the
+> wrong layer, so it is recorded here as inert rather than as the source.

--- a/src/scitex_agent_container/_baseline_assets/git_identity_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/git_identity_hooks/README.md
@@ -50,17 +50,24 @@ Nothing caught it until CLAssistant, after CI.
 
 | kind          | value                                     | maps to           |
 | ------------- | ----------------------------------------- | ----------------- |
-| built-in exact | `ywatanabe@scitex.ai`                    | GitHub `ywatanabe1989` |
+| built-in exact | `agent@scitex.ai`                        | GitHub `ywatanabe1989` (agent-authored) |
+| built-in exact | `ywatanabe@scitex.ai`                    | GitHub `ywatanabe1989` (operator's own) |
 | built-in glob  | `*[bot]@users.noreply.github.com`        | `bot*` authors    |
 | env extension  | `CC_CLA_ALLOWED_EMAILS="a@x,b@y"`         | LLEmacs / others  |
 
-The default is intentionally tight: the container's ONLY intended author
-is `ywatanabe@scitex.ai`, so ANY deviation (`agent@<host>`, a synthesized
-`user@hostname`, a stray override) is the bug the hook exists to catch.
-For a rare non-default-but-allowlisted identity, extend via
-`CC_CLA_ALLOWED_EMAILS` rather than loosening the default. Operator-
-supervised bypass: `CC_ALLOW_CLA_AUTHOR=1` or an inline
-`# hook-bypass: cla-author` marker.
+`cla.yml` allowlists **GitHub accounts** (`bot*,ywatanabe1989`), and
+CLAssistant reaches an account from a commit by its author email. Both
+addresses above are verified emails on `ywatanabe1989`, so both pass; they
+differ only in who `git log` credits. Since 2026-08-12 (operator-approved)
+agent-authored commits use `agent@scitex.ai`, so agent work is
+distinguishable from the operator's own without either failing the gate.
+
+The default stays intentionally tight at those two: ANY other author
+(`agent@<host>`, a synthesized `user@hostname`, a stray override) maps to
+no allowlisted account and is the bug the hook exists to catch. For a rare
+non-default-but-allowlisted identity, extend via `CC_CLA_ALLOWED_EMAILS`
+rather than loosening the default. Operator-supervised bypass:
+`CC_ALLOW_CLA_AUTHOR=1` or an inline `# hook-bypass: cla-author` marker.
 
 ## How to deploy fleet-wide
 

--- a/src/scitex_agent_container/_baseline_assets/git_identity_hooks/enforce_commit_author_allowlist.sh
+++ b/src/scitex_agent_container/_baseline_assets/git_identity_hooks/enforce_commit_author_allowlist.sh
@@ -28,12 +28,17 @@
 # CI. This hook is the fail-loud backstop that catches it at commit/push
 # time, in-place.
 #
-# The CLA maps AUTHOR -> GitHub account by email. The container's ONLY
-# intended author is the allowlisted `ywatanabe@scitex.ai`; ANY deviation
-# (`agent@<host>`, a synthesized `user@hostname`, a stray override) is the
-# bug. So the default allowlist is intentionally tight; extend it for the
-# rare non-default-but-allowlisted identity (LLEmacs / a bot) via the env
-# var below rather than loosening the default.
+# The CLA maps AUTHOR -> GitHub account by email, then checks that account
+# against `.github/workflows/cla.yml`'s `allowlist: bot*,ywatanabe1989`. So
+# what matters is whether the email is VERIFIED on `ywatanabe1989` -- not the
+# local-part. Two are: `ywatanabe@scitex.ai` (the operator's own, human work)
+# and `agent@scitex.ai` (the AGENT identity; operator-approved + verified on
+# the same account, 2026-08-12). Both pass CLAssistant and differ only in who
+# `git log` says did the work. ANY OTHER author (`agent@<host>`, a synthesized
+# `user@hostname`, a stray override) maps to no allowlisted account and is the
+# bug this hook exists to catch, so the default stays tight at those two;
+# extend it for the rare non-default-but-allowlisted identity (LLEmacs / a
+# bot) via the env var below rather than loosening the default.
 #
 # Policy:
 #   - `git commit`, effective author NOT allowlisted             -> BLOCK
@@ -43,7 +48,8 @@
 #   - non-git / non-Bash / not-in-a-repo                         -> allow
 #
 # Allowlist (case-insensitive email match):
-#   - built-in exact:  ywatanabe@scitex.ai   (= GitHub ywatanabe1989)
+#   - built-in exact:  ywatanabe@scitex.ai   (= GitHub ywatanabe1989, human)
+#   - built-in exact:  agent@scitex.ai       (= GitHub ywatanabe1989, agents)
 #   - built-in glob:   *[bot]@users.noreply.github.com   (bot* authors)
 #   - env extension:   CC_CLA_ALLOWED_EMAILS="a@x,b@y"   (comma/space list)
 #
@@ -81,13 +87,20 @@ if [[ "${1:-}" == "--self-test" ]]; then
     tmpdir=$(mktemp -d)
     trap 'rm -rf "$tmpdir"' EXIT
 
-    good_repo="$tmpdir/good"     # config author = allowlisted
+    good_repo="$tmpdir/good"     # config author = allowlisted (human)
+    agent_repo="$tmpdir/agent"   # config author = allowlisted (agent)
     bad_repo="$tmpdir/bad"       # config author = NOT allowlisted
     (
         mkdir -p "$good_repo" && cd "$good_repo" || exit
         git init -q -b feature/x
         git config user.email "ywatanabe@scitex.ai"
         git config user.name "Yusuke Watanabe"
+        git commit --allow-empty -q -m seed
+
+        mkdir -p "$agent_repo" && cd "$agent_repo" || exit
+        git init -q -b feature/x
+        git config user.email "agent@scitex.ai"
+        git config user.name "scitex-agent-container"
         git commit --allow-empty -q -m seed
 
         mkdir -p "$bad_repo" && cd "$bad_repo" || exit
@@ -120,6 +133,12 @@ if [[ "${1:-}" == "--self-test" ]]; then
     # --- commit: allowlisted config author -> ALLOW ---
     run "commit good-config author" "git commit -m x" "$good_repo" 0
     run "commit good, -C form" "git -C $good_repo commit -m x" "$tmpdir" 0
+
+    # --- the AGENT identity is allowlisted too (2026-08-12) ---
+    run "commit agent-identity author" "git commit -m x" "$agent_repo" 0
+    run "push agent-identity commit" "git push origin feature/x" "$agent_repo" 0
+    run "agent identity is case-insensitive" \
+        "git -c user.email=Agent@SciTeX.ai commit -m x" "$bad_repo" 0
 
     # --- commit: non-allowlisted config author -> BLOCK ---
     run "commit bad-config author" "git commit -m x" "$bad_repo" 2
@@ -320,7 +339,7 @@ if sh("git", "-C", repo, "rev-parse", "--git-dir")[0] != 0:
     sys.exit(0)
 
 # Allowlist (case-insensitive).
-ALLOWED_EXACT = {"ywatanabe@scitex.ai"}
+ALLOWED_EXACT = {"ywatanabe@scitex.ai", "agent@scitex.ai"}
 ALLOWED_GLOBS = ["*[[]bot[]]@users.noreply.github.com"]
 for e in re.split(r"[,\s]+", os.environ.get("CC_CLA_ALLOWED_EMAILS", "")):
     e = e.strip().lower()
@@ -428,8 +447,8 @@ if bad_src.startswith("GIT_AUTHOR_EMAIL env") or bad_src.startswith("inline GIT_
     fix = (
         "A GIT_AUTHOR_EMAIL is set to a NON-allowlisted value (it beats\n"
         "  git config). Re-point it, then re-create the commit:\n"
-        "    export GIT_AUTHOR_EMAIL=ywatanabe@scitex.ai\n"
-        "    export GIT_AUTHOR_NAME='Yusuke Watanabe'\n"
+        "    export GIT_AUTHOR_EMAIL=agent@scitex.ai\n"
+        "    export GIT_AUTHOR_NAME=\"${SAC_NAME:-agent}\"\n"
         "    git -C %s commit --amend --reset-author --no-edit" % repo
     )
 elif "pushed commit author" in bad_src:
@@ -437,8 +456,8 @@ elif "pushed commit author" in bad_src:
         "One or more commits you are pushing are authored by a\n"
         "  non-allowlisted identity. Fix identity, then rewrite them\n"
         "  (topic branch only -- never a shared branch):\n"
-        "    git -C %s config user.email ywatanabe@scitex.ai\n"
-        "    git -C %s config user.name  'Yusuke Watanabe'\n"
+        "    git -C %s config user.email agent@scitex.ai\n"
+        "    git -C %s config user.name  \"${SAC_NAME:-agent}\"\n"
         "    # last commit:\n"
         "    git -C %s commit --amend --reset-author --no-edit\n"
         "    # or a range: git -C %s rebase --exec \\\n"
@@ -446,9 +465,9 @@ elif "pushed commit author" in bad_src:
     )
 else:
     fix = (
-        "Set the CLA-allowlisted identity, then re-create the commit:\n"
-        "    git -C %s config user.email ywatanabe@scitex.ai\n"
-        "    git -C %s config user.name  'Yusuke Watanabe'\n"
+        "Set the CLA-allowlisted AGENT identity, then re-create the commit:\n"
+        "    git -C %s config user.email agent@scitex.ai\n"
+        "    git -C %s config user.name  \"${SAC_NAME:-agent}\"\n"
         "    git -C %s commit --amend --reset-author --no-edit   # if already committed"
         % (repo, repo, repo)
     )
@@ -462,7 +481,8 @@ msg = (
     ">>> GitHub account.\n"
     "\n"
     "The required 'CLAssistant' check maps each commit author to a GitHub\n"
-    "account via an allowlist (bot*, ywatanabe1989 -> ywatanabe@scitex.ai). An\n"
+    "account via an allowlist (bot*, ywatanabe1989 -> agent@scitex.ai for\n"
+    "agents / ywatanabe@scitex.ai for the operator's own commits). An\n"
     "author that maps to no allowlisted account makes CLAssistant FAIL and\n"
     "BLOCK THE MERGE -- and it only surfaces AFTER CI has already gone green.\n"
     "Because force-push is hook-blocked, the sole remedy then is re-creating\n"

--- a/tests/integration/git_identity_hooks/conftest.py
+++ b/tests/integration/git_identity_hooks/conftest.py
@@ -33,6 +33,17 @@ HOOK_SCRIPT = HOOK_DIR / "enforce_commit_author_allowlist.sh"
 
 ALLOWLISTED_EMAIL = "ywatanabe@scitex.ai"
 ALLOWLISTED_NAME = "Yusuke Watanabe"
+
+# The AGENT identity (operator-approved 2026-08-12): a SECOND verified email
+# on the same GitHub account (ywatanabe1989), so it clears the CLA gate while
+# making agent-authored commits distinguishable from the operator's own in
+# `git log`. Allowlisted alongside — NOT instead of — the human identity.
+AGENT_EMAIL = "agent@scitex.ai"
+AGENT_NAME = "scitex-agent-container"
+
+# Still NOT allowlisted: the `agent@<host>` shape from the scitex-hpc
+# 2026-07-05 incident maps to no GitHub account. Deliberately one character
+# away from AGENT_EMAIL's domain, so a regex that over-matches is caught.
 NON_ALLOWLISTED_EMAIL = "agent@scitex-hpc"
 
 # Identity/allowlist env vars that would make the hook's resolution
@@ -93,6 +104,11 @@ def run_hook(
 @pytest.fixture
 def good_repo(tmp_path: Path) -> Iterator[Path]:
     yield _make_repo(tmp_path / "good", ALLOWLISTED_EMAIL, ALLOWLISTED_NAME)
+
+
+@pytest.fixture
+def agent_repo(tmp_path: Path) -> Iterator[Path]:
+    yield _make_repo(tmp_path / "agentid", AGENT_EMAIL, AGENT_NAME)
 
 
 @pytest.fixture

--- a/tests/integration/git_identity_hooks/test_enforce_commit_author_allowlist.py
+++ b/tests/integration/git_identity_hooks/test_enforce_commit_author_allowlist.py
@@ -19,6 +19,7 @@ import subprocess
 import pytest
 
 from .conftest import (
+    AGENT_EMAIL,
     ALLOWLISTED_EMAIL,
     HOOK_SCRIPT,
     NON_ALLOWLISTED_EMAIL,
@@ -134,8 +135,60 @@ def test_commit_block_message_gives_config_fix(commit_bad_result):
     res = commit_bad_result
     # Act
     stderr = res.stderr
+    # Assert — the remediation must point at the AGENT identity. The hook
+    # only ever runs inside an agent container, so telling it to author as
+    # the operator would undo the 2026-08-12 identity split it now enforces.
+    assert f"config user.email {AGENT_EMAIL}" in stderr
+
+
+# --- the agent identity is allowlisted alongside the human one -------
+
+
+def test_commit_agent_identity_is_allowed(agent_repo):
+    # Arrange
+    cmd = "git commit -m x"
+    # Act
+    res = run_hook(cmd, agent_repo)
     # Assert
-    assert "config user.email ywatanabe@scitex.ai" in stderr
+    assert res.returncode == 0, res.stderr
+
+
+def test_push_agent_identity_commit_is_allowed(agent_repo):
+    # Arrange
+    cmd = "git push origin feature/x"
+    # Act
+    res = run_hook(cmd, agent_repo)
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+def test_agent_identity_match_is_case_insensitive(bad_repo):
+    # Arrange
+    cmd = "git -c user.email=Agent@SciTeX.ai commit -m x"
+    # Act
+    res = run_hook(cmd, bad_repo)
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+def test_human_identity_still_allowed_alongside_agent(good_repo):
+    # Arrange — the agent identity is ADDITIVE; the operator's own commits
+    # must keep passing the same gate.
+    cmd = f"git -c user.email={ALLOWLISTED_EMAIL} commit -m x"
+    # Act
+    res = run_hook(cmd, good_repo)
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+def test_agent_at_hostname_shape_is_still_blocked(bad_repo):
+    # Arrange — the incident shape (agent@<host>) must NOT be swept in by
+    # allowlisting agent@scitex.ai.
+    cmd = f"git -c user.email={NON_ALLOWLISTED_EMAIL} commit -m x"
+    # Act
+    res = run_hook(cmd, bad_repo)
+    # Assert
+    assert res.returncode == 2
 
 
 def test_commit_blocked_when_targeted_via_git_dash_c(bad_repo, tmp_path):


### PR DESCRIPTION

An agent-authored commit was indistinguishable from one the operator
typed himself: both said `Yusuke Watanabe <ywatanabe@scitex.ai>`. The
operator approved a second, separate identity for agents (2026-08-12) —
`agent@scitex.ai`, a VERIFIED email on the same GitHub account.

Verified is what makes it safe: CLAssistant allowlists ACCOUNTS
(`bot*,ywatanabe1989`) and reaches one from a commit by its author
email, so a verified alias maps to the same account and the required
check still passes. This is exactly what `agent@scitex-hpc` could not do
in the 2026-07-05 incident — that address maps to no account at all,
which is why it blocked a green PR. Distinguishable authorship, same
gate.

The allowlist here is that incident's fail-loud backstop, and it was
pinned to the single human address, so it would have blocked every agent
commit the moment the new identity landed. It now accepts both, and —
since this hook only ever runs inside an agent container — its
remediation text stops telling agents to author as the operator, which
would have quietly undone the split it is meant to enforce.

Deliberately NOT widened to `agent@*`: `agent@scitex-hpc` is one
character away and must stay blocked. A test pins that.

Host-side counterpart (not in this repo): the 95 agent specs under
~/.scitex/agent-container/agents/ now pin GIT_AUTHOR_*/GIT_COMMITTER_*
to each agent's own id, and the `_shared/to_home/.gitconfig` fallback
follows. The operator's ~/.gitconfig is untouched — an agent's $HOME is
/home/agent inside its own apptainer overlay — and no layer here sets
commit.gpgsign, so identity stays decoupled from ssh signing.

---

Verified: hook self-test 24/24, the git_identity_hooks suite 30/30, and the commit on this branch reads back `scitex-agent-container <agent@scitex.ai>`. The operator’s `~/.gitconfig` is byte-identical (same sha256 + mtime) before and after the host-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
