### PR TITLE
build(deps): restore the scitex-dev <0.48 ceiling — the first 0.48.0 run says two of three conditions are unmet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ dev = [
     #     masked violation in its own `project-structure: 1 error(s)`
     #     tally. A skip rule that suppresses the REPORT but not the STATUS
     #     cannot do the one job it exists for. That is a scitex-dev
-    #     defect, not a sac one, and it is filed upstream.
+    #     defect, not a sac one: scitex-ai/scitex-dev#590.
     #     (The other audit-cli warnings seen on 0.48.0 — §4b CliHelp, §13
     #     `skills` nesting — are NOT new and NOT the cause: 0.47.0 reports
     #     the same two and exits 0. §10w is an import-budget measurement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,49 +156,7 @@ dev = [
     # audit-all` and reds the `test_audit_all_clean` gate; fixed by
     # 0.17.12. Also: tests/results/ accepted as a known tests subdir
     # (PS-302).
-    #
-    # <0.48 CEILING — 2026-08-12, and it is a DEADLINE, not a preference.
-    # scitex-dev 0.48.0 took develop red on all three matrix legs with five
-    # failures that no sac commit caused. Measured by A/B on ONE commit
-    # (00f7f96, same click 8.4.2, same interpreter): 69/69 green with
-    # 0.47.0 installed, 4 failed with only scitex-dev swapped to 0.48.0.
-    # Three independent incompatibilities, none of them cosmetic:
-    #
-    #  1. 0.48.0 SHIPPED the per-kind job surface sac had been probing for
-    #     (`ecosystem dev {service,timer} <verb>`), and its name argument is
-    #     MIXED: install/uninstall take `--name X`, while
-    #     status/enable/disable/start/stop/restart/exec take a POSITIONAL
-    #     NAME. `_dev_jobs_backend.build_argv` emits `--name` unconditionally,
-    #     so nine sac commands now die on `Error: No such option '--name'`
-    #     (exit 2) instead of running. That is a REAL sac bug, not a test
-    #     artifact — it is why the three test__dev_jobs cases fail, and it
-    #     needs an introspection-driven fix, not a version bump.
-    #  2. 0.48.0 changed where `scitex_dev.hosts._retired` emits its WARNING,
-    #     so it no longer reaches click's isolated stderr under CliRunner
-    #     (test_library_warning_reaches_the_merged_cli_runner_output).
-    #  3. 0.48.0 ADDED rule PS-226 `job-name-not-hyphenated`, which does not
-    #     exist anywhere in 0.47.0 (verified: 0 occurrences in the 0.47.0
-    #     wheel, 6 files in 0.48.0, implemented in
-    #     `_cli/audit/_project/_check_job_naming.py`). It is the single
-    #     unmasked error behind `test_audit_all_clean`, and it fires on
-    #     `JobSpec(name="sac.accounts-refresh")`.
-    #
-    # THE RENAME PS-226 ASKS FOR IS DELIBERATELY NOT DONE HERE, and the
-    # ceiling exists so that decision stays ours rather than the clock's.
-    # `systemd_unit_name` derives the unit filename from the job name
-    # VERBATIM, so renaming does NOT adopt the live `sac.accounts-refresh.timer`
-    # — it INSTALLS A SECOND UNIT beside it. That job is the fleet's sole
-    # OAuth refresher against a SINGLE-USE refresh token, and two racing
-    # refreshers revoke each other fleet-wide. It is therefore a supervised
-    # UNIT MIGRATION (stop-old -> remove-old -> install-new -> verify-exactly-one),
-    # which already has its migration verb and recorded rename in
-    # `src/scitex_agent_container/_jobs/_migrate/_renames.py` and its
-    # reasoning in `_jobs/_names.py`. A red audit rule is survivable; a
-    # revoked fleet credential is not.
-    #
-    # LIFT THIS CEILING by doing the adaptation (1) and (2) and running the
-    # migration for (3) — not by widening the specifier.
-    "scitex-dev>=0.31.1,<0.48",
+    "scitex-dev>=0.31.1",
     # PS210: tests import scitex_hpc unguarded, so [dev] must include it
     # (otherwise `pip install -e .[dev]` can't run the full suite).
     "scitex-hpc>=0.6.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,76 @@ dev = [
     # audit-all` and reds the `test_audit_all_clean` gate; fixed by
     # 0.17.12. Also: tests/results/ accepted as a known tests subdir
     # (PS-302).
-    "scitex-dev>=0.31.1",
+    #
+    # <0.48 CEILING — REINSTATED 2026-08-12 by the run that tried to lift
+    # it. PR #1014 removed this line and put 0.48.0 through CI for the
+    # first time; the numbers are recorded here rather than the verdict
+    # alone, because the next person to reach for the lift deserves the
+    # measurement and not a bare "no".
+    #
+    # A/B ON ONE COMMIT (a12ea769), same tree, same `.scitex/dev` config:
+    #   0.47.0  `ecosystem audit-all` exit 0;  suite green (develop runs
+    #           31572345560 / 31570905419 on the same code)
+    #   0.48.0  `ecosystem audit-all` exit 1;  3 failed / 15415 passed
+    #           (pytest-matrix-on-ubuntu-py3.11, run 31575290345)
+    #
+    # THE THREE LIFT CONDITIONS, AND WHERE THEY ACTUALLY STAND:
+    #
+    #  1. MIXED NAME SHAPE — ADAPTED IN PRODUCTION, STALE IN ONE TEST.
+    #     `_dev_jobs_capability.name_style_for` now READS the installed
+    #     CLI (0.48.0 splits install/uninstall `--name X` from
+    #     status/enable/disable/start/stop/restart/exec POSITIONAL NAME)
+    #     and `build_argv` follows it, so the nine broken sac commands are
+    #     fixed. But `test_the_pass_through_forwards_dry_run` still
+    #     asserts the literal pre-0.48 argv with `--name`, so it reds
+    #     under 0.48.0 while the code it guards is CORRECT. The gate it
+    #     protects (`--dry-run` survives the pass-through) has to be
+    #     asserted without pinning the name shape: `build_argv(...,
+    #     leaf=...)` was added for exactly that and no test uses it yet.
+    #
+    #  2. WARNING ROUTING — NOT ADAPTED AT ALL.
+    #     0.48.0 changed where `scitex_dev.hosts._retired` emits its
+    #     WARNING. Under CliRunner it now reaches the REAL stderr (pytest
+    #     files it under "Captured stderr setup") instead of click's
+    #     isolated stream, so
+    #     `test_library_warning_reaches_the_merged_cli_runner_output`
+    #     finds nothing in `result.output`. Untouched since the ceiling
+    #     went up.
+    #
+    #  3. PS-226 — THE DECLARED SKIP DOES NOT CLEAR THE EXIT CODE.
+    #     The finding that matters most, because #1009 was meant to have
+    #     settled it. `.scitex/dev/config.yaml` declares the PS-226
+    #     deferral and 0.48.0 HONOURS it in the report:
+    #         MASKED INVENTORY: 1 violation(s) masked by 1 declared rule
+    #         summary: 0 unmasked error(s) ..., 1 masked by skip-rules
+    #     and audit-all STILL EXITS 1, because audit-project keeps the
+    #     masked violation in its own `project-structure: 1 error(s)`
+    #     tally. A skip rule that suppresses the REPORT but not the STATUS
+    #     cannot do the one job it exists for. That is a scitex-dev
+    #     defect, not a sac one, and it is filed upstream.
+    #     (The other audit-cli warnings seen on 0.48.0 — §4b CliHelp, §13
+    #     `skills` nesting — are NOT new and NOT the cause: 0.47.0 reports
+    #     the same two and exits 0. §10w is an import-budget measurement
+    #     the runner's slow I/O made unreadable; it claims no verdict.)
+    #
+    # THE RENAME PS-226 ASKS FOR IS STILL DELIBERATELY NOT DONE.
+    # `systemd_unit_name` derives the unit filename from `JobSpec.name`
+    # VERBATIM, so renaming does NOT adopt the live
+    # `sac.accounts-refresh.timer` — it INSTALLS A SECOND UNIT beside it.
+    # That job is the fleet's sole OAuth refresher against a SINGLE-USE
+    # refresh token, and two racing refreshers revoke each other
+    # fleet-wide. It is a supervised UNIT MIGRATION (stop-old ->
+    # remove-old -> install-new -> verify-exactly-one) whose verb and
+    # recorded rename live in `_jobs/_migrate/_renames.py` and whose
+    # reasoning lives in `_jobs/_names.py`. A red audit rule is
+    # survivable; a revoked fleet credential is not.
+    #
+    # LIFT THIS CEILING by finishing (1)'s test, doing (2), and taking
+    # either an upstream fix or the supervised migration for (3) — never
+    # by widening the specifier. A specifier stretched until the red goes
+    # away is a gate configured so it cannot fail, which is worse than no
+    # gate, because the config still lists it and everyone believes it.
+    "scitex-dev>=0.31.1,<0.48",
     # PS210: tests import scitex_hpc unguarded, so [dev] must include it
     # (otherwise `pip install -e .[dev]` can't run the full suite).
     "scitex-hpc>=0.6.2",


### PR DESCRIPTION
## What this PR now does

It **restores** the `scitex-dev>=0.31.1,<0.48` ceiling and rewrites the
comment above it with what the lift attempt measured.

The PR opened as a lift (`a12ea76`, 1 insertion / 43 deletions). That was
the right thing to do — it was the only way to put scitex-dev **0.48.0**
through CI for the first time, and the red it produced is the
information the PR existed to produce. Having produced it, the honest
move is the ceiling, not a wider specifier.

## What the run measured

`pytest-matrix-on-ubuntu-py3.11` (run
[31575290345](https://github.com/scitex-ai/scitex-agent-container/actions/runs/31575290345)),
scitex-dev **0.48.0** installed: **3 failed, 15415 passed**. The
`develop` baseline on the same code with the ceiling in place is green
(runs 31572345560, 31570905419).

A/B of `scitex-dev ecosystem audit-all` on the identical tree
(`a12ea769`) and identical `.scitex/dev/config.yaml`:

| scitex-dev | audit-cli | audit-project | PS-226 | exit |
|---|---|---|---|---|
| 0.47.0 | 0 err, 2 warn | **0 err**, 92 warn | rule does not exist | **0** |
| 0.48.0 | 0 err, 3 warn | **1 err**, 211 warn | 1 violation, masked | **1** |

## The three failures

**1. `test__dev_jobs_backend.py::test_the_pass_through_forwards_dry_run`
— sac test staleness, production code is already correct.**

```
At index 5 diff: 'sac.accounts-refresh' != '--name'
Right contains one more item: '--dry-run'
```

0.48.0 made the job-name argument mixed (`install`/`uninstall` take
`--name X`; `status`/`enable`/`disable`/… take a positional `NAME`).
`_dev_jobs_capability.name_style_for` already reads this off the
installed CLI and `build_argv` already follows it — the nine sac commands
0.48.0 would have broken are fine. Only the test still asserts the
literal pre-0.48 argv. `build_argv(..., leaf=...)` exists precisely so
this gate can be stated without pinning the shape, and no test uses it
yet.

**2. `test_host_group.py::test_library_warning_reaches_the_merged_cli_runner_output`
— not adapted at all.**

0.48.0 moved where `scitex_dev.hosts._retired` emits its `WARNING`. Under
`CliRunner` it now reaches the real stderr — pytest files it under
`Captured stderr setup` — instead of click's isolated stream, so nothing
is in `result.output`. This condition has been untouched since the
ceiling went up.

**3. `tests/develop/test_audit.py::test_audit_all_clean` — an upstream
defect: the declared skip rule suppresses the report but not the exit
status.**

This is the finding that matters most, because #1009 was meant to have
settled it. 0.48.0 honours the PS-226 deferral in the report:

```
MASKED INVENTORY (audit.skip-rules)
scitex-agent-container: 1 violation(s) masked by 1 declared skip rule(s).
summary: ... 0 unmasked error(s) (+3 warning/info finding(s)), 1 masked by skip-rules
```

and `audit-all` still exits **1**, because `audit-project` keeps the
masked violation in its own `project-structure: 1 error(s)` tally. A skip
rule that hides a violation from the report but not from the status
cannot do the one job it exists for.

The §4b (`CliHelp`) and §13 (`skills` nesting) warnings are red herrings
— 0.47.0 reports the same two and exits 0. §10w is an import-budget
measurement the runner's slow I/O made unreadable; it explicitly claims
no verdict.

## Why not just widen the specifier

A specifier stretched until the red goes away is a gate configured so it
cannot fail — worse than deleting it, because the config still lists it
and everyone believes it works. The PS-226 rename stays deliberately
undone for the same reason it always has: `systemd_unit_name` derives the
unit filename from `JobSpec.name` verbatim, so renaming installs a
**second** unit beside the live `sac.accounts-refresh.timer` rather than
adopting it, and that job is the fleet's sole OAuth refresher against a
single-use token.

## To lift the ceiling next time

1. Restate `test_the_pass_through_forwards_dry_run` via
   `build_argv(..., leaf=...)` so it asserts the gate, not the shape.
2. Adapt to 0.48.0's warning routing.
3. Take either an upstream fix for the skip-rule exit status, or run the
   supervised unit migration.

Card: `sac-lift-scitex-dev-048-ceiling`.
