### PR TITLE
fix(ci): `rm -rf ""` is a silent success, so guard the scratch path with `:?`

### DIFF
--- a/.github/ci/build-in-sif.sh
+++ b/.github/ci/build-in-sif.sh
@@ -39,7 +39,11 @@ export LC_ALL=C.UTF-8 LANG=C.UTF-8
 . "$(dirname "${BASH_SOURCE[0]}")/tmpdir-lib.sh"
 TMPDIR="$(ci_tmpdir_path build "$V")"
 export TMPDIR
-rm -rf "$TMPDIR"
+# `${TMPDIR:?}` — see run-in-sif.sh for the measurement. Short version: `rm -rf ""`
+# exits 0 SILENTLY on GNU coreutils (`-f` swallows the empty operand), so an empty
+# name here would delete nothing, fail nothing, and leave the rest of the script
+# addressing paths off the filesystem root. `:?` aborts instead.
+rm -rf "${TMPDIR:?build scratch path came back empty — refusing to rm -rf it}"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 
 # The compute-node $HOME is RO inside the container — point every cache the

--- a/.github/ci/publish-in-sif.sh
+++ b/.github/ci/publish-in-sif.sh
@@ -56,7 +56,11 @@ ls -l dist
 . "$(dirname "${BASH_SOURCE[0]}")/tmpdir-lib.sh"
 TMPDIR="$(ci_tmpdir_path publish "$V")"
 export TMPDIR
-rm -rf "$TMPDIR"
+# `${TMPDIR:?}` — see run-in-sif.sh for the measurement. Short version: `rm -rf ""`
+# exits 0 SILENTLY on GNU coreutils (`-f` swallows the empty operand), so an empty
+# name here would delete nothing, fail nothing, and leave the rest of the script
+# addressing paths off the filesystem root. `:?` aborts instead.
+rm -rf "${TMPDIR:?publish scratch path came back empty — refusing to rm -rf it}"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 export UV_CACHE_DIR="$TMPDIR/uv-cache"
 export XDG_CACHE_HOME="$TMPDIR"

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -77,7 +77,21 @@ export GIT_CONFIG_VALUE_1=false
 . "$(dirname "${BASH_SOURCE[0]}")/tmpdir-lib.sh"
 TMPDIR="$(ci_tmpdir_path ci "$V")"
 export TMPDIR
-rm -rf "$TMPDIR"
+# `${TMPDIR:?}` AND NOT `$TMPDIR`, at every `rm -rf` of this path.
+#
+# The name is produced by a function in ANOTHER file, so "it is always non-empty"
+# is a property of tmpdir-lib.sh, not of this line — one refactor away from being
+# false, and nothing here would notice.
+#
+# `rm -rf ""` IS NOT THE SAFE NO-OP IT LOOKS LIKE. Measured on GNU coreutils 9.4:
+# `-f` treats the empty operand as a nonexistent file, so it exits 0 SILENTLY —
+# `set -euo pipefail` does not catch it, and the script CONTINUES with TMPDIR="".
+# Every later use is then a path off the filesystem root: `"$TMPDIR/site"` is
+# `/site`, and the sibling sweep's `! -path "$TMPDIR"` self-exclusion stops
+# matching anything. The empty value is dangerous because it is silent.
+#
+# `:?` makes the shell abort right here, naming the variable, before the deletion.
+rm -rf "${TMPDIR:?ci scratch path came back empty — refusing to rm -rf it}"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 
 # REMOVE OUR OWN SCRATCH ON THE WAY OUT. The `rm -rf` above only ever deletes a
@@ -94,7 +108,10 @@ mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 #
 # The trap preserves the script's exit status (bash re-raises it after the
 # handler), so a failing test suite still fails.
-trap 'rm -rf "$TMPDIR"' EXIT
+#
+# Same `:?` guard as above, and it matters MORE here: a trap body is evaluated at
+# EXIT, so it reads whatever TMPDIR holds then — not what it held at line 80.
+trap 'rm -rf "${TMPDIR:?exiting with an empty scratch path — refusing to rm -rf it}"' EXIT
 
 # ...and sweep SIBLINGS left behind by jobs that never reached the trap — a
 # cancelled workflow, a SIGKILL, an OOM, or any run that predates this change.

--- a/tests/integration/test_ci_tmpdir_cleanup.py
+++ b/tests/integration/test_ci_tmpdir_cleanup.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import os
 import subprocess
 import time
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -56,13 +57,15 @@ def test_ci_script_exists():
 
 def test_scratch_dir_is_removed_on_exit(script_text):
     # Arrange
-    needle = 'trap \'rm -rf "$TMPDIR"\' EXIT'
+    needle = "trap 'rm -rf \"${TMPDIR:?"
     # Act
     present = needle in script_text
     # Assert
     assert present, (
-        "run-in-sif.sh must remove its own scratch dir on EXIT. Without it each "
-        "CI leg leaks ~2G and the runner filesystem fills (measured: 290G)."
+        "run-in-sif.sh must remove its own scratch dir on EXIT, via the guarded "
+        "${TMPDIR:?} form. Without the trap each CI leg leaks ~2G and the runner "
+        "filesystem fills (measured: 290G); without the guard the trap can fire "
+        "on an empty path."
     )
 
 
@@ -99,6 +102,131 @@ def test_sibling_sweep_is_scoped_to_this_projects_dirs(script_text):
     assert present, (
         "the sweep must match only this project's scratch dirs; a wider glob "
         "would reap other tenants' data from a shared /tmp."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The scratch path may never be deleted UNGUARDED.
+#
+# `rm -rf "$TMPDIR"` is one empty variable away from `rm -rf ""`, and that is NOT
+# the harmless no-op it reads as. MEASURED on GNU coreutils 9.4: `-f` treats the
+# empty operand as a nonexistent file, so the command exits 0 SILENTLY. Under
+# `set -euo pipefail` nothing stops, and the script continues with TMPDIR="" —
+# every later `"$TMPDIR/site"` is then `/site`, off the filesystem root.
+#
+# So the fix is `${TMPDIR:?}`, and the test below does not merely assert that the
+# guarded spelling is present: it EXECUTES both spellings with the variable empty
+# and observes the difference. The unguarded control is what makes the guarded
+# case evidence rather than decoration — a guard only ever seen passing has not
+# been shown to guard anything.
+# ---------------------------------------------------------------------------
+_WRAPPERS = ("run-in-sif.sh", "build-in-sif.sh", "publish-in-sif.sh")
+
+
+def _wrapper(name: str) -> Path:
+    return _SCRIPT.parent / name
+
+
+@lru_cache(maxsize=None)
+def _run(body: str) -> tuple[int, str, str]:
+    """Run ``body`` under the wrappers' own `set -euo pipefail`, TMPDIR empty."""
+    script = f'set -euo pipefail\nTMPDIR=""\n{body}\necho REACHED-NEXT-LINE\n'
+    proc = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _rm_lines(name: str) -> list[str]:
+    """Every line of a wrapper that deletes the scratch path."""
+    text = _wrapper(name).read_text(encoding="utf-8")
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if "TMPDIR" in line and line.lstrip().startswith(("rm -rf", "trap 'rm -rf"))
+    ]
+
+
+# (wrapper, line) for every scratch deletion actually shipped, so each case below
+# executes the REAL text of the REAL script rather than a paraphrase of it.
+_DELETIONS = [(n, line) for n in _WRAPPERS for line in _rm_lines(n)]
+_PLAIN = [c for c in _DELETIONS if not c[1].startswith("trap ")]
+
+
+@pytest.mark.parametrize("name", _WRAPPERS)
+def test_every_wrapper_still_deletes_its_scratch(name):
+    # Arrange
+    wrapper = name
+    # Act
+    lines = _rm_lines(wrapper)
+    # Assert
+    assert lines, f"{wrapper} deletes no scratch path — did the lifecycle move?"
+
+
+@pytest.mark.parametrize(("name", "body"), _DELETIONS)
+def test_every_scratch_deletion_carries_the_guard(name, body):
+    # Arrange
+    expected = "${TMPDIR:?"
+    # Act
+    guarded = expected in body
+    # Assert
+    assert guarded, (
+        f"{name} deletes the scratch path without the guard: `{body}`. An empty "
+        "TMPDIR makes `rm -rf` a SILENT success, and the script then addresses "
+        "paths off the filesystem root."
+    )
+
+
+def test_unguarded_deletion_would_proceed_on_an_empty_path():
+    """The CONTROL. Without this case the guarded tests prove nothing."""
+    # Arrange
+    body = 'rm -rf "$TMPDIR"'
+    # Act
+    returncode, stdout, _ = _run(body)
+    # Assert
+    assert (returncode, "REACHED-NEXT-LINE" in stdout) == (0, True), (
+        'expected `rm -rf ""` to succeed silently and let the script carry on '
+        f"(rc={returncode}, out={stdout!r}). If this ever fails, the platform's "
+        "rm now rejects an empty operand and the hazard has changed shape — "
+        "re-measure before weakening the guard."
+    )
+
+
+@pytest.mark.parametrize(("name", "body"), _DELETIONS)
+def test_guarded_deletion_aborts_on_an_empty_path(name, body):
+    # Arrange
+    command = body
+    # Act
+    returncode, stdout, _ = _run(command)
+    # Assert
+    assert returncode != 0, (
+        f"{name}: `{command}` did NOT abort on an empty TMPDIR "
+        f"(rc=0, out={stdout!r})"
+    )
+
+
+@pytest.mark.parametrize(("name", "body"), _DELETIONS)
+def test_guarded_deletion_names_the_variable_it_refused(name, body):
+    # Arrange
+    command = body
+    # Act
+    _, _, stderr = _run(command)
+    # Assert
+    assert "TMPDIR" in stderr, (
+        f"{name}: `{command}` aborted without naming TMPDIR — whoever reads the "
+        f"CI log needs the variable in the message. stderr={stderr!r}"
+    )
+
+
+@pytest.mark.parametrize(("name", "body"), _PLAIN)
+def test_guarded_deletion_stops_execution(name, body):
+    # Arrange
+    command = body
+    # Act
+    _, stdout, _ = _run(command)
+    # Assert
+    assert "REACHED-NEXT-LINE" not in stdout, (
+        f"{name}: `{command}` reported the refusal but execution continued"
     )
 
 


### PR DESCRIPTION
## What

Four `rm -rf "$TMPDIR"` sites in the in-SIF CI wrappers now spell it
`rm -rf "${TMPDIR:?<why>}"`.

| file | site |
| --- | --- |
| `.github/ci/run-in-sif.sh` | start-of-run cleanup |
| `.github/ci/run-in-sif.sh` | `trap … EXIT` |
| `.github/ci/build-in-sif.sh` | start-of-run cleanup |
| `.github/ci/publish-in-sif.sh` | start-of-run cleanup |

Each path is produced by `ci_tmpdir_path()` in **another file**, so
"always non-empty" is a property of `tmpdir-lib.sh`, not of these lines.

## Why an empty value is worse than it looks

Measured here, GNU coreutils 9.4:

```
$ bash -c 'set -euo pipefail; V=""; rm -rf "$V"; echo REACHED'
REACHED
rc=0
```

`-f` treats the empty operand as a nonexistent file, so the command
**succeeds silently** and `set -euo pipefail` has nothing to catch. The
script then carries on with `TMPDIR=""`, and every later use is a path off
the filesystem root — `"$TMPDIR/site"` is `/site` — while the sibling
sweep's `! -path "$TMPDIR"` self-exclusion stops matching anything.

`${TMPDIR:?}` aborts at the deletion instead, names the variable, and is a
no-op on every healthy run. It matters most in the **trap**: a trap body is
evaluated at exit, so it reads whatever `TMPDIR` holds *then*.

## Deliberately not touched

- `tmpdir-lib.sh`'s two `rm -rf -- "$d"` calls. Already guarded —
  `_ci_tmpdir_is_managed` rejects an empty path, anything outside the
  scratch root, deeper nesting and any traversal. Adding `:?` there would
  imply they were unsafe.
- `enforce_force_flag.sh`. Its current behaviour is correct for what it was
  written to do (block `rm`/`cp` *missing* `-f`); `rm -rf "$VAR"` passing it
  is out of that hook's scope, not a bug in it.

## Evidence — the guard was observed refusing

The tests execute the **real line text lifted from the shipped script** with
`TMPDIR` empty, and pair every guarded case with the unguarded control. A
guard only ever seen passing has not been shown to guard anything.

- With this change: **28 passed**.
- Same tests, wrappers reverted to their pre-fix text: **16 failed**, e.g.

```
AssertionError: publish-in-sif.sh: `rm -rf "$TMPDIR"` reported the refusal
but execution continued
assert 'REACHED-NEXT-LINE' not in 'REACHED-NEXT-LINE\n'
```

which is the old behaviour stated in its own words.

## Scope

Deliberately small. Sibling sites found during the audit are **carded, not
folded in** — a safety fix that grows into a refactor is one nobody reviews
carefully:

- `src/scitex_agent_container/containers/spartan-sif-bake.sh:204` —
  `rm -rf "$CTX"` where `CTX="$WORKDIR/build-context/$LAYER"`. Both parts are
  settable from argv (`--workdir`, `--layer`) and `LAYER` defaults to empty,
  so an empty `LAYER` widens the target from one layer's context to **all** of
  them. Different shape, needs its own thought.
- `_baseline_assets/git_identity_hooks/enforce_commit_author_allowlist.sh:82`
  — `trap 'rm -rf "$tmpdir"' EXIT` on a `mktemp -d` result, self-test path.

scitex-dev's three equivalent wrappers are a separate PR.
