### PR TITLE
fix(test): a psycopg guard that raised NameError instead of its own failure

### DIFF
--- a/tests/integration/test_apptainer_base_def_scitex_todo.py
+++ b/tests/integration/test_apptainer_base_def_scitex_todo.py
@@ -224,8 +224,7 @@ def test_uv_pip_install_block_can_provide_psycopg(base_def_text: str) -> None:
         "scitex-cards install must PROVIDE psycopg — via an extra "
         f"{sorted(_EXTRAS_PROVIDING_PSYCOPG)} or a floor >= "
         f"{'.'.join(map(str, _CORE_SINCE_PSYCOPG))} where it is core. "
-        f"Got {requirement!r} in:\n{block}. Old form kept for reference: "
-        f"apptainer-base.def; got extras {sorted(extras)} in:\n{block}"
+        f"Got {requirement!r} in:\n{block}"
     )
 
 


### PR DESCRIPTION
## The bug

`test_uv_pip_install_block_can_provide_psycopg` built its assert message from
`extras` — a name never bound in that function. The guard could not report a
failure; on the first real breach it raised

```
NameError: name 'extras' is not defined
```

instead of naming the requirement it rejected.

## Why it matters even though nothing is failing today

The assertion **passes** against the current `apptainer-base.def`, so a normal
run never builds the message. It would fire only the first time the psycopg
contract actually broke — precisely the moment someone needs to be told *which
pin lost the driver*.

That failure mode has already been paid for once. On 2026-08-02 site-packages
held a driverless namespace-package `psycopg`, every agent's card writes failed
against a healthy database, and three agents were sent to the wrong layer. This
guard exists to shorten exactly that diagnosis, and it would have answered with
a `NameError`.

## The fix

Drop the vestigial clause. Lines 158-164 of this file record that asserting on
the extras *spelling* was wrong three times over, and that the message was
rewritten to report the whole requirement instead. The trailing
`"Old form kept for reference:"` text is left over from that migration and kept
a dead interpolation alive. What precedes it already reports the requirement and
the block, which is strictly more informative than the extras list.

## Proof — both directions

The failure path was driven with a def block that violates the contract
(`"scitex-cards>=0.20.0"` — below the 0.31.8 where psycopg became core, naming
no providing extra), against the pre-fix source from `git show HEAD:` and the
post-fix worktree source:

```
--- BEFORE ---
  NameError -> the test CANNOT report its failure
    name 'extras' is not defined

--- AFTER ---
  AssertionError -> the test REPORTS its failure
    scitex-cards install must PROVIDE psycopg — via an extra
    ['all', 'postgres'] or a floor >= 0.31.8 where it is core.
    Got 'scitex-cards>=0.20.0' in: ...
```

`22 passed` in the file, run with `PYTHONPATH` pointed at this worktree's `src`.

## Scope

One file, two lines removed, no behaviour change to any passing assertion. Found
while surveying def-file test coverage for the staged-build split
(`sac-staged-def-split-4stage`); independent of that work, which stays blocked on
an operator decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
