### PR TITLE
feat(image-build): refuse a hand-run apptainer build of sac's own images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,20 @@ scitex-agent-container = "scitex_agent_container._system_deps:provide"
 [project.entry-points."scitex_todo.hooks"]
 scitex-agent-container = "scitex_agent_container._listen._card_event_delivery:deliver_card_event"
 
+# Claude Code hook RULES sac declares about its own surfaces. sac owns the
+# rule (they are sac's images being protected) and ships the refusal
+# script; scitex-dev discovers this provider and applies the rows
+# centrally, exactly as it does for jobs / system_deps / gate — the leaf
+# never installs anything itself, and scitex-dev never hardcodes anything
+# about apptainer.
+#
+# The provider imports scitex_dev.hooks LAZILY, so this entry point ships
+# and stays inert on a scitex-dev that predates the hooks contract instead
+# of breaking import-time metadata (same idiom + same reason as the
+# scitex_dev.jobs provider above).
+[project.entry-points."scitex_dev.hooks"]
+scitex-agent-container = "scitex_agent_container._claude_hooks_plugin:provide_hooks"
+
 [project.urls]
 Homepage = "https://github.com/ywatanabe1989/scitex-agent-container"
 Repository = "https://github.com/ywatanabe1989/scitex-agent-container.git"

--- a/src/scitex_agent_container/_baseline_assets/image_build_hooks/.gitignore
+++ b/src/scitex_agent_container/_baseline_assets/image_build_hooks/.gitignore
@@ -1,0 +1,6 @@
+# The hook writes its audit trail next to itself (THIS_DIR), which is the
+# right default once deployed to $HOME/.claude/hooks/pre-tool-use/ but
+# means running the script from a checkout drops a log into the source
+# tree. Never commit it. Override the location with
+# SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH.
+.*.sh.log

--- a/src/scitex_agent_container/_baseline_assets/image_build_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/image_build_hooks/README.md
@@ -1,0 +1,146 @@
+# image_build_hooks
+
+Claude Code PreToolUse hooks protecting **sac's own image build**.
+
+| file | role |
+|---|---|
+| `deny_raw_apptainer_build.sh` | refuses a hand-run `apptainer build` of a sac image |
+| `settings.local.json.fragment.json` | manual `PreToolUse`/`Bash` wiring (legacy path) |
+
+## Who declares, who applies
+
+sac **declares** this rule and ships the script. sac does **not** install it.
+scitex-dev discovers the declaration through the `scitex_dev.hooks`
+entry-point group and applies it centrally:
+
+```
+pyproject.toml
+  [project.entry-points."scitex_dev.hooks"]
+  scitex-agent-container = "scitex_agent_container._claude_hooks_plugin:provide_hooks"
+                                                    |
+                                                    v
+scitex_agent_container/_claude_hooks_plugin.py   -> HookRule(id="sac.no-raw-apptainer-build", ...)
+                                                    |
+                                                    v
+scitex-dev  discover_hooks()                     -> installs $HOME/.claude/hooks/pre-tool-use/
+```
+
+This is the same leaf-declares / keystone-applies split as `scitex_dev.jobs`,
+`scitex_dev.system_deps` and `scitex_dev.gate.checks`. The leaf owns the rule
+because it is sac's images being protected; scitex-dev hardcodes nothing about
+apptainer. `cli_pkg/image_group.py` already names the same doctrine in its own
+comment: *"each package owns its own surface; the aggregator never hard-codes
+package names"*.
+
+The `scitex_dev.hooks` import in the provider is **lazy**, so the entry point
+ships and stays inert on a scitex-dev that predates the contract rather than
+breaking import-time metadata — same idiom and same reason as
+`_jobs/_jobs_plugin.py`.
+
+## Why the rule exists
+
+sac's image build is **not** `apptainer build` plus arguments.
+
+`sac image build` stages a build-context directory holding the `.def`
+alongside a `scitex-agent-container-src/` copy of the installed package, and
+the `.def` resolves its `%files` sources against that staging dir.
+`apptainer-base.def` documents the contract itself:
+
+> Bundle the package's OWN source tree so the in-SIF sac is the source tree
+> that shipped this .def — never a `git+...@main` snapshot of whatever
+> happened to be on a branch at build time. […] apptainer resolves the
+> relative source path below against the build CWD, which the CLI sets to
+> that staging dir.
+
+A hand-run build skips the staging. It does **not** fail loudly — it produces
+a SIF whose in-image sac is whatever happened to be lying around, and the
+mismatch surfaces weeks later as a version that makes no sense.
+
+The build is additionally becoming **staged** (base → scitex → …), where a
+hand-run build also bypasses parent-chain resolution and staleness checking,
+silently layering a child on a stale or missing parent.
+
+### Not a duplicate of `heavy_job_hooks`
+
+`enforce_heavy_job_demotion.sh` judges only whether a heavy command was
+`nice`'d. A fully demoted
+`nice -n 19 ionice -c 2 -n 7 apptainer build … apptainer-base.def`
+sails through it today. This hook closes exactly that gap, and the self-test
+pins the case.
+
+## The discriminator, and why
+
+`apptainer build` against an unrelated image is legitimate and must keep
+working. **A guard that blocks unrelated builds gets disabled, and then the
+real rule is gone with it.** So the hook refuses only what it can prove is
+ours, keyed on the recipe's **content** — not its filename, not the output
+SIF's name:
+
+**Primary — the label key `org.scitex.layer`.** Every sac recipe declares it
+under `%labels` (`base`, `scitex`, `proxy` today). Content-keyed, so it
+survives the `.def` renames in flight, survives the recipe directory moving,
+and still catches a `.def` copied to `/tmp`. It is also the *same* notion of
+"ours" the built artifact carries — `apptainer inspect --labels x.sif` reports
+`org.scitex.layer: base` — so guard and artifact agree.
+
+The matcher is `^[ \t]*org\.scitex\.layer\b` and stops there. It matches the
+**key**, never the value set: a matcher spelled
+`org\.scitex\.layer (base|scitex|proxy)` would silently stop catching new
+stages once `system-deps` / `python-pkgs` appear, while still passing its own
+tests — a guard whose trigger condition is narrower than its stated rule. The
+self-test uses a recipe labelled `a-stage-that-does-not-exist-yet` to pin
+this.
+
+**Fallback — sac's own directories.** When the recipe cannot be read (a build
+driven over ssh on another host, or a path not yet created), the command text
+is checked for `scitex_agent_container/containers` or
+`.scitex/agent-container/containers`.
+
+**Honest limit:** a build whose recipe is unreadable *and* which names none of
+sac's directories passes through. That is the safe direction to be wrong.
+
+### Wrappers the detector must see through
+
+Two real-world spellings defeat a naive check, both taken from
+`containers/spartan-sif-bake.sh`:
+
+```sh
+:122  APPTAINER="$(command -v apptainer)"          # argv[0] is /usr/bin/apptainer
+:275  bash -c "... exec \"$APPTAINER\" build --force \"$PARTIAL_SIF\" \"$CTX/apptainer-$LAYER.def\""
+```
+
+argv[0] is an **absolute path**, and the build appears only **inside a quoted
+argument** of `bash -c` under `srun`. The detector therefore `basename()`s
+argv[0] and re-splits any token that itself mentions a builder. Both forms are
+pinned in the self-test — someone reaching for a workaround produces exactly
+these.
+
+## Deliberately allowed
+
+- `sac image build …` — the sanctioned path
+- `containers/spartan-sif-bake.sh` — the sanctioned remote bake; it does its
+  own `$CTX` staging, so it earns the exemption on merit
+- read-only verbs: `apptainer inspect --labels|--deffile`, `exec`, `run`
+- any build carrying no sac signal
+
+## Overrides
+
+```
+SAC_ALLOW_RAW_IMAGE_BUILD=1          # env
+# hook-bypass: raw-apptainer-build   # inline marker
+```
+
+The hook also **fails open**: if `python3` is unavailable or the decision
+engine errors, the command is allowed. A broken guard must not wedge the
+agent's Bash tool.
+
+## Verifying it
+
+```bash
+bash deny_raw_apptainer_build.sh --self-test
+```
+
+20 cases — nine refusals, nine allowances, two bypasses. The pytest suite in
+`tests/integration/image_build_hooks/` drives the same script by
+repo-relative path against real PreToolUse JSON, so an asset move is caught at
+collection time rather than at agent-boot time.

--- a/src/scitex_agent_container/_baseline_assets/image_build_hooks/deny_raw_apptainer_build.sh
+++ b/src/scitex_agent_container/_baseline_assets/image_build_hooks/deny_raw_apptainer_build.sh
@@ -1,0 +1,425 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# File: src/scitex_agent_container/_baseline_assets/image_build_hooks/deny_raw_apptainer_build.sh
+#
+# Description: PreToolUse hook for Bash. Refuses a HAND-RUN
+# `apptainer build` / `singularity build` of scitex-agent-container's OWN
+# images, and names `sac image build` as the command to run instead.
+#
+# DECLARED BY scitex-agent-container (the leaf owns the rule about its own
+# images), APPLIED BY scitex-dev through the `scitex_dev.hooks` entry-point
+# group -- see the sibling README.md and
+# ``scitex_agent_container._claude_hooks_plugin``. Do not hand-place this
+# file; it is deployed to $HOME/.claude/hooks/pre-tool-use/.
+#
+# WHY THIS RULE EXISTS
+# --------------------
+# sac's image build is NOT `apptainer build` plus arguments. `sac image
+# build` stages a build-context DIRECTORY holding the .def alongside a
+# `scitex-agent-container-src/` copy of the installed package, and the .def
+# resolves its `%files` sources against that staging dir. apptainer-base.def
+# documents the contract in its own %files comment:
+#
+#     # Bundle the package's OWN source tree so the in-SIF sac is the
+#     # source tree that shipped this .def -- never a `git+...@main`
+#     # snapshot of whatever happened to be on a branch at build time.
+#     ...
+#     # apptainer resolves the relative source path below against the
+#     # build CWD, which the CLI sets to that staging dir.
+#     scitex-agent-container-src /opt/scitex-agent-container-src
+#
+# A hand-run build skips the staging. It does NOT fail loudly -- it produces
+# a SIF whose in-image sac is whatever happened to be lying around, and the
+# mismatch surfaces weeks later as a version that makes no sense. That is
+# the "artifact exists, but not built from the tree you think" class.
+#
+# The build is additionally becoming STAGED (base -> scitex -> ...), where a
+# hand-run build also bypasses parent-chain resolution and staleness
+# checking, silently layering a child on a stale or missing parent.
+#
+# This is NOT a duplicate of enforce_heavy_job_demotion.sh. That hook judges
+# only whether a heavy command was NICE'd; a fully demoted
+# `nice -n 19 ionice -c 2 -n 7 apptainer build ... apptainer-base.def`
+# sails through it today. This hook closes that gap.
+#
+# THE DISCRIMINATOR, AND WHY
+# --------------------------
+# `apptainer build` against an unrelated image is legitimate and MUST keep
+# working. A guard that blocks unrelated builds gets disabled, and then the
+# real rule is gone with it. So we block only when the build is
+# demonstrably one of OURS, keyed on the recipe's CONTENT -- not on its
+# filename, not on the output SIF's name:
+#
+#   PRIMARY   a readable file argument declaring the label key
+#             `org.scitex.layer` (every sac recipe declares it under
+#             %labels). Content-keyed, so it survives the .def renames
+#             now in flight, survives the recipe directory moving, and
+#             still catches a .def copied to /tmp. It is also the SAME
+#             notion of "ours" the built artifact carries --
+#             `apptainer inspect --labels x.sif` reports
+#             `org.scitex.layer: base` -- so guard and artifact agree.
+#
+#             We match the KEY and stop. A matcher spelled
+#             `org\.scitex\.layer (base|scitex|proxy)` would silently stop
+#             catching new stages once `system-deps` / `python-pkgs`
+#             appear, while still passing its own tests -- a guard whose
+#             trigger is narrower than its stated rule.
+#
+#   FALLBACK  the command text names sac's own recipe dir
+#             (`scitex_agent_container/containers`) or sac's SIF output
+#             dir (`.scitex/agent-container/containers`). This is the only
+#             signal available when the content cannot be read: a build
+#             driven over ssh on another host, or a path not yet created.
+#
+# Honest limit: a build whose recipe is unreadable AND which names none of
+# sac's directories passes through. That is the safe direction to be wrong.
+#
+# NOT blocked, deliberately:
+#   - `sac image build ...`              -- the sanctioned path
+#   - `containers/spartan-sif-bake.sh`   -- the sanctioned remote bake. It
+#        does its OWN $CTX staging, so it earns the exemption on merit.
+#   - read-only apptainer verbs          -- inspect / exec / run / instance
+#   - any build carrying no sac signal
+#
+# Bypass (rare -- know why you are doing it):
+#   1. Append marker `hook-bypass: raw-apptainer-build` to the command.
+#   2. Or export `SAC_ALLOW_RAW_IMAGE_BUILD=1`.
+
+set -u
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_PATH="${SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH:-$THIS_DIR/.$(basename "$0").log}"
+
+# ------------------------------------------------------------------
+# Decision engine.
+#
+# Kept in python rather than grep because "is this a build?" needs a token
+# walk: `apptainer --debug build x.sif y.def` IS a build, while
+# `apptainer exec img.sif make build` is NOT, and no honest single regex
+# separates those. It must also see through two real-world wrappers --
+# an ABSOLUTE argv[0] (`/usr/bin/apptainer`, which is what
+# spartan-sif-bake.sh:275 produces via `command -v`) and a quoted
+# `bash -c "... exec \"$APPTAINER\" build ..."` under srun/ssh, where the
+# build appears only INSIDE an argument. An argv[0] match misses both;
+# re-splitting builder-bearing tokens catches them.
+#
+# Prints `<reason>|<evidence>` and exits 2 when the command must be
+# refused; exits 0 silently otherwise.
+# ------------------------------------------------------------------
+_decide() {
+    python3 -c '
+import os
+import re
+import shlex
+import sys
+
+RAW = sys.stdin.read()
+
+# The label KEY every sac recipe declares under %labels. Deliberately
+# unanchored to any value set, so a new stage is caught the day it lands.
+LABEL_KEY = re.compile(r"^[ \t]*org\.scitex\.layer\b", re.MULTILINE)
+
+# sac`s own recipe dir / SIF output dir. Used ONLY when content is unreadable.
+PATH_MARKERS = (
+    "scitex_agent_container/containers",
+    "scitex-agent-container/containers",
+    ".scitex/agent-container/containers",
+)
+
+# Sanctioned wrappers that do their own staging and are exempt on merit.
+SANCTIONED = ("spartan-sif-bake.sh",)
+
+BUILDERS = ("apptainer", "singularity")
+
+
+def tokens(text):
+    """Best-effort shell split; falls back to whitespace on unbalanced quotes."""
+    try:
+        return shlex.split(text, comments=False, posix=True)
+    except ValueError:
+        return text.split()
+
+
+def invokes_build(toks):
+    """True if an apptainer/singularity token is followed by the `build` verb.
+
+    basename() so an ABSOLUTE argv[0] (/usr/bin/apptainer) still matches.
+    Leading dashes are skipped so `apptainer --debug build` counts, while
+    `apptainer exec img.sif make build` does not (first bare word is exec).
+    """
+    for i, tok in enumerate(toks):
+        if os.path.basename(tok) not in BUILDERS:
+            continue
+        for nxt in toks[i + 1:]:
+            if nxt.startswith("-"):
+                continue
+            if nxt == "build":
+                return True
+            break
+    return False
+
+
+def _subcommands(toks, text):
+    """Tokens that are themselves commands (a quoted `bash -c` payload)."""
+    for tok in toks:
+        if tok != text and any(b in tok for b in BUILDERS):
+            yield tok
+
+
+def build_detected(text):
+    toks = tokens(text)
+    if invokes_build(toks):
+        return True
+    return any(invokes_build(tokens(sub)) for sub in _subcommands(toks, text))
+
+
+def flatten(text):
+    toks = tokens(text)
+    out = list(toks)
+    for sub in _subcommands(toks, text):
+        out.extend(tokens(sub))
+    return out
+
+
+def sac_recipe_argument(toks):
+    """First readable file argument that declares the sac layer label."""
+    for tok in toks:
+        if not tok or tok.startswith("-"):
+            continue
+        path = os.path.expanduser(tok)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                head = fh.read(200_000)
+        except OSError:
+            continue
+        if LABEL_KEY.search(head):
+            return os.path.abspath(path)
+    return None
+
+
+if any(w in RAW for w in SANCTIONED):
+    sys.exit(0)
+
+if not build_detected(RAW):
+    sys.exit(0)
+
+hit = sac_recipe_argument(flatten(RAW))
+if hit:
+    print("recipe|" + hit)
+    sys.exit(2)
+
+for marker in PATH_MARKERS:
+    if marker in RAW:
+        print("path|" + marker)
+        sys.exit(2)
+
+sys.exit(0)
+' 2>/dev/null
+}
+
+# ------------------------------------------------------------------
+# Self-test -- the measured refuse/allow pair, runnable at any time:
+#   bash deny_raw_apptainer_build.sh --self-test
+# ------------------------------------------------------------------
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "=== Self-test: $(basename "$0") ==="
+    pass=0
+    fail=0
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    # Stand-in for a sac recipe: carries the label KEY and nothing else, so
+    # the test proves we key on the key -- not on a filename, not on a
+    # known layer VALUE.
+    cat >"$tmp/some-renamed-stage.def" <<'DEF'
+Bootstrap: docker
+From: ubuntu@sha256:dead
+%labels
+    org.scitex.layer a-stage-that-does-not-exist-yet
+DEF
+    # Stand-in for somebody else's recipe: no sac label.
+    cat >"$tmp/unrelated.def" <<'DEF'
+Bootstrap: docker
+From: alpine:3.20
+%labels
+    org.example.layer whatever
+DEF
+
+    # Re-invoke through `bash "$SELF"` rather than bare `"$0"`: $0 is
+    # whatever argv[0] the caller used, and a bare relative name is not on
+    # PATH -- that spelling makes every case exit 127 and the suite reports
+    # a uniform failure that looks like a logic bug.
+    SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+
+    run() {
+        local desc="$1" cmd="$2" want="$3" rc
+        printf '%s' "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":$(printf '%s' "$cmd" |
+            python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')}}" |
+            bash "$SELF" >/dev/null 2>&1
+        rc=$?
+        if [[ "$rc" == "$want" ]]; then
+            echo "  PASS (rc=$rc) $desc"
+            pass=$((pass + 1))
+        else
+            echo "  FAIL got $rc want $want: $desc -- cmd: $cmd"
+            fail=$((fail + 1))
+        fi
+    }
+
+    echo "-- REFUSED: a sac image built by hand --"
+    run "raw build of a sac recipe" \
+        "apptainer build out.sif $tmp/some-renamed-stage.def" 2
+    run "singularity alias" \
+        "singularity build out.sif $tmp/some-renamed-stage.def" 2
+    run "global flag before the verb" \
+        "apptainer --debug build out.sif $tmp/some-renamed-stage.def" 2
+    run "sandbox form advertised in the def header" \
+        "apptainer build --sandbox base/ $tmp/some-renamed-stage.def" 2
+    run "sudo-wrapped" \
+        "sudo apptainer build --fakeroot out.sif $tmp/some-renamed-stage.def" 2
+    run "fully demoted (heavy-job hook would allow this)" \
+        "nice -n 19 ionice -c 2 -n 7 apptainer build out.sif $tmp/some-renamed-stage.def" 2
+    run "absolute argv[0] inside a quoted bash -c" \
+        "bash -c 'exec /usr/bin/apptainer build --force p.sif $tmp/some-renamed-stage.def'" 2
+    run "wheel recipe dir by path (file unreadable)" \
+        "apptainer build out.sif /opt/x/scitex_agent_container/containers/apptainer-scitex.def" 2
+    run "remote build naming sac's SIF dir" \
+        "ssh spartan 'apptainer build ~/.scitex/agent-container/containers/sac-base.sif r.def'" 2
+
+    echo "-- ALLOWED: everything else keeps working --"
+    run "unrelated recipe" \
+        "apptainer build out.sif $tmp/unrelated.def" 0
+    run "unrelated docker uri" \
+        "apptainer build myimage.sif docker://ubuntu:24.04" 0
+    run "the sanctioned CLI" \
+        "sac image build base -y" 0
+    run "the sanctioned bake wrapper" \
+        "bash src/scitex_agent_container/containers/spartan-sif-bake.sh --layer base" 0
+    run "read-only inspect of a sac SIF" \
+        "apptainer inspect --labels ~/.scitex/agent-container/containers/sac-base.sif" 0
+    run "read-only deffile of a sac SIF" \
+        "apptainer inspect --deffile ~/.scitex/agent-container/containers/sac-base.sif" 0
+    run "exec whose argv merely contains the word build" \
+        "apptainer exec img.sif make build" 0
+    run "apptainer version" "apptainer --version" 0
+    run "not the Bash tool" "" 0
+
+    echo "-- BYPASS --"
+    run "marker bypass" \
+        "apptainer build out.sif $tmp/some-renamed-stage.def # hook-bypass: raw-apptainer-build" 0
+    SAC_ALLOW_RAW_IMAGE_BUILD=1 run "env-var bypass" \
+        "apptainer build out.sif $tmp/some-renamed-stage.def" 0
+
+    echo "pass=$pass fail=$fail"
+    [[ $fail -eq 0 ]] && exit 0 || exit 1
+fi
+
+# ------------------------------------------------------------------
+# Enablement switch (centralized project-switch/switch.yaml), when present.
+# ------------------------------------------------------------------
+HELPER_SCRIPT="$(dirname "$THIS_DIR")/project-switch/hook_switch_helper.sh"
+if [[ -f "$HELPER_SCRIPT" ]]; then
+    # shellcheck source=/dev/null
+    source "$HELPER_SCRIPT"
+    if declare -f check_hook_enabled_or_exit >/dev/null 2>&1; then
+        check_hook_enabled_or_exit "$(basename "$0")"
+    fi
+fi
+
+# ------------------------------------------------------------------
+# Env-var escape
+# ------------------------------------------------------------------
+[[ "${SAC_ALLOW_RAW_IMAGE_BUILD:-}" == "1" ]] && exit 0
+
+# ------------------------------------------------------------------
+# Read input + extract command (Bash tool only)
+# ------------------------------------------------------------------
+INPUT="$(cat)"
+
+CMD=$(printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if d.get("tool_name", "") != "Bash":
+    sys.exit(0)
+print((d.get("tool_input", {}) or {}).get("command", "") or "", end="")
+' 2>/dev/null) || exit 0
+[[ -z "$CMD" ]] && exit 0
+
+# ------------------------------------------------------------------
+# String-marker escape
+# ------------------------------------------------------------------
+if printf '%s' "$CMD" | grep -qF 'hook-bypass: raw-apptainer-build'; then
+    exit 0
+fi
+
+# ------------------------------------------------------------------
+# Decide. Fail OPEN: if python3 is missing or the engine errors, a broken
+# guard must not wedge the agent's Bash tool.
+# ------------------------------------------------------------------
+VERDICT="$(printf '%s' "$CMD" | _decide)"
+[[ $? == 2 ]] || exit 0
+[[ -n "$VERDICT" ]] || exit 0
+
+REASON="${VERDICT%%|*}"
+EVIDENCE="${VERDICT#*|}"
+
+if [[ "$REASON" == "recipe" ]]; then
+    TRIGGER="Triggered by this file:
+  $EVIDENCE
+It declares the label key \`org.scitex.layer\` under %labels, which is how a
+sac recipe identifies itself — the same label \`apptainer inspect --labels\`
+reports on the built SIF."
+else
+    TRIGGER="Triggered by: the command names sac's own image directory
+  $EVIDENCE
+(the recipe itself was not readable from here — e.g. a build driven on
+another host — so the path is the only available signal.)"
+fi
+
+printf '[%s] BLOCK %s :: %s :: %s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$REASON" "$EVIDENCE" "$CMD" \
+    >>"$LOG_PATH" 2>/dev/null || true
+
+cat >&2 <<EOF
+BLOCKED by deny_raw_apptainer_build.sh: hand-run \`apptainer build\` of a sac image.
+
+$TRIGGER
+
+Build it through the CLI instead — same recipe, correct build context:
+
+  sac image build base            # or: scitex | proxy
+  sac image build base -y         # non-interactive
+  sac image build --help          # remote / reproducible options
+
+WHY THIS IS BLOCKED
+sac's image build is not \`apptainer build\` plus arguments. \`sac image build\`
+stages a build-context directory holding the .def alongside a
+\`scitex-agent-container-src/\` copy of the installed package, and the .def
+resolves its \`%files\` sources against that staging dir. apptainer-base.def
+says so itself: it bundles "the package's OWN source tree so the in-SIF sac is
+the source tree that shipped this .def — never a \`git+...@main\` snapshot".
+
+A hand-run build skips the staging and does NOT fail loudly. It produces a SIF
+whose in-image sac is whatever happened to be lying around, and you find out
+weeks later from a version that makes no sense. The build is also becoming
+staged (base → scitex → …), where a hand-run build additionally bypasses
+parent-chain resolution and staleness checking — silently layering a child on
+a stale or missing parent.
+
+STILL ALLOWED
+  - \`apptainer build\` of anything that is not ours (no \`org.scitex.layer\`)
+  - read-only verbs: \`apptainer inspect --labels|--deffile\`, exec, run
+  - \`sac image build\` and sac's own \`spartan-sif-bake.sh\` remote bake
+
+Rare override (know why you're doing it):
+  SAC_ALLOW_RAW_IMAGE_BUILD=1   or append   # hook-bypass: raw-apptainer-build
+EOF
+
+exit 2
+
+# EOF

--- a/src/scitex_agent_container/_baseline_assets/image_build_hooks/settings.local.json.fragment.json
+++ b/src/scitex_agent_container/_baseline_assets/image_build_hooks/settings.local.json.fragment.json
@@ -1,0 +1,17 @@
+{
+  "_comment_deny_raw_apptainer_build_hook": "PreToolUse Bash-matcher wiring for deny_raw_apptainer_build.sh. APPEND the single hook entry below into the EXISTING `PreToolUse` `Bash` matcher's `hooks` list in the baseline <agents_dir>/_shared/to_home/.claude/settings.json (next to enforce_heavy_job_demotion.sh, whose gap this closes) -- do NOT add a second Bash matcher block. The script body lives next to this fragment (src/scitex_agent_container/_baseline_assets/image_build_hooks/) and must be deployed to $HOME/.claude/hooks/pre-tool-use/ via to_home materialization; it has no sibling python files and FAILS OPEN (allow) if python3 is unavailable, because a broken guard must not wedge the agent's Bash tool. This fragment is the LEGACY/manual wiring path and is kept so the bundle stays installable by hand; the sanctioned path is the `scitex_dev.hooks` entry-point declared in scitex_agent_container/_claude_hooks_plugin.py, which scitex-dev discovers and applies centrally. The hook refuses ONLY builds it can prove are sac's own -- a recipe declaring the `org.scitex.layer` label key, or a command naming sac's recipe/SIF directories; unrelated apptainer builds pass through untouched. Overrides: SAC_ALLOW_RAW_IMAGE_BUILD=1 or an inline `# hook-bypass: raw-apptainer-build` marker. Rationale is documented in the sibling README.md.",
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/pre-tool-use/deny_raw_apptainer_build.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/scitex_agent_container/_claude_hooks_plugin.py
+++ b/src/scitex_agent_container/_claude_hooks_plugin.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_agent_container/_claude_hooks_plugin.py
+"""scitex-agent-container's own Claude Code hook DECLARATIONS.
+
+sac declares the rules that protect sac's own surfaces; it does not install
+them. scitex-dev discovers this provider through the ``scitex_dev.hooks``
+entry-point group and applies the rows centrally -- the same split every
+other ``scitex_dev.*`` group uses (``jobs``, ``system_deps``, ``gate``,
+``linter.plugins``), and the same one ``cli_pkg/image_group.py`` already
+names in its own comment: "each package owns its own surface; the
+aggregator never hard-codes package names".
+
+The point of a declaration is the REASON field, not the rule text. A rule
+records WHAT is refused; only the reason records WHY, and "why" is what
+lets a future reader decide whether the rule can be dropped. Each row below
+names the mechanism that breaks without it.
+
+The ``scitex_dev.hooks`` import is LAZY (inside ``provide_hooks``) so a
+scitex-dev that predates the hooks contract -- which is every released
+scitex-dev at the time this module landed -- does not break the entry
+point's import-time metadata. This mirrors ``_jobs/_jobs_plugin.py``, whose
+docstring gives the same reason for the same idiom. The entry point can
+therefore ship and stay inert until the contract exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.hooks import HookRule
+
+_PROVIDER = "scitex-agent-container"
+
+#: Bundle root for the hook scripts this module declares. Package-relative
+#: paths in the rows below are resolved against the package directory --
+#: i.e. ``importlib.resources.files("scitex_agent_container") / <script>``.
+_BUNDLE = "_baseline_assets/image_build_hooks"
+
+#: Absolute on-disk path to the same bundle, for callers that already have
+#: the package imported and do not want to go through importlib.resources.
+BUNDLE_DIR = Path(__file__).resolve().parent / "_baseline_assets" / "image_build_hooks"
+
+DENY_RAW_APPTAINER_BUILD = f"{_BUNDLE}/deny_raw_apptainer_build.sh"
+
+
+def provide_hooks() -> "tuple[HookRule, ...]":
+    """Hook rules sac declares about its own surfaces."""
+    from scitex_dev.hooks import HookRule
+
+    return (
+        HookRule(
+            id="sac.no-raw-apptainer-build",
+            rule=(
+                "Refuse a hand-run `apptainer build` / `singularity build` of "
+                "a scitex-agent-container image; build it with `sac image "
+                "build <layer>` instead."
+            ),
+            reason=(
+                "sac's image build is not `apptainer build` plus arguments. "
+                "`sac image build` stages a build-context directory holding "
+                "the .def alongside a `scitex-agent-container-src/` copy of "
+                "the installed package, and the .def resolves its `%files` "
+                "sources against that staging dir -- apptainer-base.def "
+                "documents the contract in its own %files comment, bundling "
+                "'the package's OWN source tree so the in-SIF sac is the "
+                "source tree that shipped this .def, never a git+...@main "
+                "snapshot'. A hand-run build skips the staging and does NOT "
+                "fail loudly: it produces a SIF whose in-image sac is "
+                "whatever happened to be lying around, and the mismatch "
+                "surfaces weeks later as a version that makes no sense. The "
+                "build is additionally becoming staged (base -> scitex -> "
+                "...), where a hand-run build also bypasses parent-chain "
+                "resolution and staleness checking, silently layering a "
+                "child on a stale or missing parent. The existing heavy-job "
+                "demotion hook does not cover this: it judges only whether "
+                "the command was nice'd, so a fully demoted raw build passes "
+                "it today."
+            ),
+            event="pre-tool-use",
+            severity="deny",
+            matches=("Bash",),
+            script=DENY_RAW_APPTAINER_BUILD,
+        ),
+    )
+
+
+__all__ = ["provide_hooks", "BUNDLE_DIR", "DENY_RAW_APPTAINER_BUILD"]
+
+# EOF

--- a/tests/integration/image_build_hooks/__init__.py
+++ b/tests/integration/image_build_hooks/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# File: tests/integration/image_build_hooks/__init__.py
+"""Integration tests for the image-build guard hook assets."""
+
+# EOF

--- a/tests/integration/image_build_hooks/conftest.py
+++ b/tests/integration/image_build_hooks/conftest.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# File: tests/integration/image_build_hooks/conftest.py
+"""Fixtures for the ``deny_raw_apptainer_build.sh`` suite.
+
+The hook is a ``.sh`` asset with no ``tests/<pkg>/`` mirror counterpart, so
+— like the sibling ``heavy_job_hooks`` / ``hpc_login_hooks`` suites — these
+tests live under ``tests/integration/`` to stay OUT of PS-204's mirror
+scope while ``pytest tests/`` still collects and runs them.
+
+The hook is resolved by repo-relative path so a refactor of the asset
+location is caught at collection time, not at agent-boot time.
+
+No mocks: every case drives the real script in a subprocess with the real
+PreToolUse JSON envelope Claude Code sends, and asserts on the real exit
+code / stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+HOOK_DIR = (
+    REPO_ROOT
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+    / "image_build_hooks"
+)
+
+HOOK = HOOK_DIR / "deny_raw_apptainer_build.sh"
+
+#: The real shipped recipes, used to prove the guard works on the actual
+#: artifact rather than only on a synthetic stand-in.
+RECIPES_DIR = REPO_ROOT / "src" / "scitex_agent_container" / "containers"
+
+#: Exit code Claude Code reads as "deny this tool call".
+DENY = 2
+ALLOW = 0
+
+
+def _payload(command: str) -> str:
+    return json.dumps(
+        {"tool_name": "Bash", "tool_input": {"command": command}}
+    )
+
+
+@pytest.fixture
+def run_hook():
+    """Drive the hook with ``command``; return the CompletedProcess."""
+
+    def _run(command: str, env: dict[str, str] | None = None):
+        return subprocess.run(
+            ["bash", str(HOOK)],
+            input=_payload(command),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+
+    return _run
+
+
+@pytest.fixture
+def sac_like_recipe(tmp_path: Path) -> Path:
+    """A recipe carrying ONLY the sac label key, under a neutral filename.
+
+    The layer value is deliberately one that does not exist yet: the guard
+    must key on the label KEY, so that a stage added by the in-flight .def
+    restructuring is caught the day it lands rather than silently skipped.
+    """
+    recipe = tmp_path / "some-renamed-stage.def"
+    recipe.write_text(
+        "Bootstrap: docker\n"
+        "From: ubuntu@sha256:dead\n"
+        "%labels\n"
+        "    org.scitex.layer a-stage-that-does-not-exist-yet\n",
+        encoding="utf-8",
+    )
+    return recipe
+
+
+@pytest.fixture
+def unrelated_recipe(tmp_path: Path) -> Path:
+    """Somebody else's recipe — must keep building."""
+    recipe = tmp_path / "unrelated.def"
+    recipe.write_text(
+        "Bootstrap: docker\n"
+        "From: alpine:3.20\n"
+        "%labels\n"
+        "    org.example.layer whatever\n",
+        encoding="utf-8",
+    )
+    return recipe
+
+# EOF

--- a/tests/integration/image_build_hooks/test_deny_raw_apptainer_build.py
+++ b/tests/integration/image_build_hooks/test_deny_raw_apptainer_build.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+# File: tests/integration/image_build_hooks/test_deny_raw_apptainer_build.py
+"""The guard must be able to FAIL, and must refuse only what is ours.
+
+Two halves, and both matter equally. A guard nobody has seen refuse
+anything is indistinguishable from one that cannot refuse; a guard that
+blocks unrelated builds gets disabled, and then the real rule is gone with
+it. So every refusal case has an allowance case beside it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from .conftest import ALLOW, DENY, HOOK, RECIPES_DIR
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_raw_build_of_sac_recipe(run_hook, sac_like_recipe):
+    # Arrange
+    command = f"apptainer build out.sif {sac_like_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_refuses_the_real_shipped_base_recipe(run_hook):
+    # Arrange
+    command = f"apptainer build sac-base.sif {RECIPES_DIR / 'apptainer-base.def'}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_refuses_every_real_shipped_recipe(run_hook):
+    # Arrange
+    recipes = sorted(RECIPES_DIR.glob("apptainer-*.def"))
+    # Act
+    codes = {
+        r.name: run_hook(f"apptainer build out.sif {r}").returncode
+        for r in recipes
+    }
+    # Assert
+    assert codes == {r.name: DENY for r in recipes}
+
+
+def test_refuses_singularity_spelling_too(run_hook, sac_like_recipe):
+    # Arrange
+    command = f"singularity build out.sif {sac_like_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_refuses_build_behind_a_global_flag(run_hook, sac_like_recipe):
+    # Arrange
+    command = f"apptainer --debug build out.sif {sac_like_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_refuses_the_sandbox_form_the_def_advertises(run_hook, sac_like_recipe):
+    # Arrange — apptainer-base.def's own header comment teaches this spelling
+    command = f"apptainer build --sandbox base/ {sac_like_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_refuses_a_fully_demoted_raw_build(run_hook, sac_like_recipe):
+    # Arrange — this exact command passes enforce_heavy_job_demotion.sh,
+    # which judges only nice'ing; this hook exists to close that gap.
+    command = (
+        "nice -n 19 ionice -c 2 -n 7 apptainer build "
+        f"out.sif {sac_like_recipe}"
+    )
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_sees_through_quoted_bash_c_wrapper(run_hook, sac_like_recipe):
+    # Arrange — spartan-sif-bake.sh:275's shape: absolute argv[0], and the
+    # build visible only INSIDE a quoted argument. An argv[0]-only matcher
+    # misses this, and so would miss a hand-typed workaround spelled the
+    # same way.
+    command = (
+        f"bash -c 'exec /usr/bin/apptainer build --force p.sif {sac_like_recipe}'"
+    )
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_refuses_when_only_the_recipe_directory_is_named(run_hook):
+    # Arrange — file unreadable from here; the path is the only signal
+    command = (
+        "apptainer build out.sif "
+        "/opt/x/scitex_agent_container/containers/apptainer-scitex.def"
+    )
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_refuses_a_remote_build_naming_the_sif_directory(run_hook):
+    # Arrange
+    command = (
+        "ssh spartan 'apptainer build "
+        "~/.scitex/agent-container/containers/sac-base.sif recipe.def'"
+    )
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == DENY
+
+
+# ---------------------------------------------------------------------------
+# The discriminator keys on the label KEY, never the known value set
+# ---------------------------------------------------------------------------
+
+
+def test_matches_label_key_not_known_layer_values(run_hook, tmp_path):
+    # Arrange — a stage name that exists in no current mapping. A matcher
+    # spelled `org\.scitex\.layer (base|scitex|proxy)` would pass its own
+    # tests and silently stop guarding once the .def restructuring lands.
+    recipe = tmp_path / "07-some-future-stage.def"
+    recipe.write_text(
+        "Bootstrap: localimage\n%labels\n    org.scitex.layer python-pkgs\n",
+        encoding="utf-8",
+    )
+    # Act
+    result = run_hook(f"apptainer build out.sif {recipe}")
+    # Assert
+    assert result.returncode == DENY
+
+
+def test_ignores_the_recipe_filename_entirely(run_hook, tmp_path):
+    # Arrange — sac's filename, but somebody else's content
+    impostor = tmp_path / "apptainer-base.def"
+    impostor.write_text(
+        "Bootstrap: docker\nFrom: alpine:3.20\n", encoding="utf-8"
+    )
+    # Act
+    result = run_hook(f"apptainer build out.sif {impostor}")
+    # Assert
+    assert result.returncode == ALLOW
+
+
+# ---------------------------------------------------------------------------
+# Allowances — unrelated work must keep running
+# ---------------------------------------------------------------------------
+
+
+def test_allows_build_of_an_unrelated_recipe(run_hook, unrelated_recipe):
+    # Arrange
+    command = f"apptainer build out.sif {unrelated_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+def test_allows_build_from_a_docker_uri(run_hook):
+    # Arrange
+    command = "apptainer build myimage.sif docker://ubuntu:24.04"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+def test_allows_the_sanctioned_cli_invocation(run_hook):
+    # Arrange
+    command = "sac image build base -y"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+def test_allows_the_sanctioned_bake_wrapper(run_hook):
+    # Arrange — spartan-sif-bake.sh does its own $CTX staging, so it is
+    # exempt on merit rather than by accident.
+    command = (
+        "bash src/scitex_agent_container/containers/spartan-sif-bake.sh "
+        "--layer base"
+    )
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+def test_allows_read_only_label_inspection(run_hook):
+    # Arrange
+    command = (
+        "apptainer inspect --labels "
+        "~/.scitex/agent-container/containers/sac-base.sif"
+    )
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+def test_allows_read_only_deffile_inspection(run_hook):
+    # Arrange
+    command = (
+        "apptainer inspect --deffile "
+        "~/.scitex/agent-container/containers/sac-base.sif"
+    )
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+def test_allows_exec_whose_argv_contains_the_word_build(run_hook):
+    # Arrange — `build` here is make's target, not apptainer's verb
+    command = "apptainer exec img.sif make build"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+def test_allows_a_non_bash_tool_call(run_hook):
+    # Arrange
+    command = ""
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+# ---------------------------------------------------------------------------
+# The refusal must be actionable
+# ---------------------------------------------------------------------------
+
+
+def test_refusal_names_the_replacement_command(run_hook, sac_like_recipe):
+    # Arrange
+    command = f"apptainer build out.sif {sac_like_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert "sac image build base" in result.stderr
+
+
+def test_refusal_names_the_triggering_file(run_hook, sac_like_recipe):
+    # Arrange
+    command = f"apptainer build out.sif {sac_like_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert str(sac_like_recipe) in result.stderr
+
+
+def test_refusal_names_the_override_env_var(run_hook, sac_like_recipe):
+    # Arrange
+    command = f"apptainer build out.sif {sac_like_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert "SAC_ALLOW_RAW_IMAGE_BUILD=1" in result.stderr
+
+
+def test_refusal_explains_the_staging_reason(run_hook, sac_like_recipe):
+    # Arrange
+    command = f"apptainer build out.sif {sac_like_recipe}"
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert "scitex-agent-container-src" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Overrides
+# ---------------------------------------------------------------------------
+
+
+def test_honours_the_inline_bypass_marker(run_hook, sac_like_recipe):
+    # Arrange
+    command = (
+        f"apptainer build out.sif {sac_like_recipe} "
+        "# hook-bypass: raw-apptainer-build"
+    )
+    # Act
+    result = run_hook(command)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+def test_honours_the_bypass_environment_variable(run_hook, sac_like_recipe):
+    # Arrange
+    env = dict(os.environ, SAC_ALLOW_RAW_IMAGE_BUILD="1")
+    # Act
+    result = run_hook(f"apptainer build out.sif {sac_like_recipe}", env=env)
+    # Assert
+    assert result.returncode == ALLOW
+
+
+# ---------------------------------------------------------------------------
+# The asset's own self-test stays green
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_self_test_suite_passes():
+    # Arrange
+    argv = ["bash", str(HOOK), "--self-test"]
+    # Act
+    result = subprocess.run(argv, capture_output=True, text=True, timeout=180)
+    # Assert
+    assert result.returncode == 0, result.stdout
+
+# EOF

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -28,6 +28,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev",
     "scitex_dev._cli._completion",
     "scitex_dev._cli.ecosystem",
+    "scitex_dev.hooks",
     "scitex_dev.hosts",
     "scitex_dev.jobs",
     "scitex_dev.linter._rules._base",

--- a/tests/scitex_agent_container/test__claude_hooks_plugin.py
+++ b/tests/scitex_agent_container/test__claude_hooks_plugin.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# File: tests/scitex_agent_container/test__claude_hooks_plugin.py
+"""sac's ``scitex_dev.hooks`` DECLARATION.
+
+The rows themselves cannot be constructed until scitex-dev ships the
+``scitex_dev.hooks`` contract, so those cases skip cleanly. What is asserted
+unconditionally is the part that can rot silently on our side: the
+entry point stays declared, the declared script path still resolves to a
+real file, and the provider stays importable without scitex-dev present
+(the lazy-import contract that lets this entry point ship inert).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container import _claude_hooks_plugin as plugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+ENTRY_POINT_GROUP = "scitex_dev.hooks"
+
+_HAS_CONTRACT = importlib.util.find_spec("scitex_dev.hooks") is not None
+_needs_contract = pytest.mark.skipif(
+    not _HAS_CONTRACT,
+    reason="scitex_dev.hooks contract not installed yet; provider ships inert",
+)
+
+
+def test_declared_script_resolves_to_a_real_file():
+    # Arrange
+    package_root = Path(plugin.__file__).resolve().parent
+    # Act
+    script = package_root / plugin.DENY_RAW_APPTAINER_BUILD
+    # Assert
+    assert script.is_file()
+
+
+def test_declared_script_is_executable():
+    # Arrange
+    package_root = Path(plugin.__file__).resolve().parent
+    # Act
+    script = package_root / plugin.DENY_RAW_APPTAINER_BUILD
+    # Assert
+    assert script.stat().st_mode & 0o111
+
+
+def test_bundle_dir_matches_declared_relative_path():
+    # Arrange
+    package_root = Path(plugin.__file__).resolve().parent
+    # Act
+    from_relative = (package_root / plugin.DENY_RAW_APPTAINER_BUILD).parent
+    # Assert
+    assert from_relative == plugin.BUNDLE_DIR
+
+
+def test_entry_point_group_is_declared_in_pyproject():
+    # Arrange
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    # Act
+    groups = data["project"]["entry-points"]
+    # Assert
+    assert ENTRY_POINT_GROUP in groups
+
+
+def test_entry_point_targets_this_provider():
+    # Arrange
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    # Act
+    target = data["project"]["entry-points"][ENTRY_POINT_GROUP][
+        "scitex-agent-container"
+    ]
+    # Assert
+    assert target == (
+        "scitex_agent_container._claude_hooks_plugin:provide_hooks"
+    )
+
+
+def test_provider_imports_without_scitex_dev_contract():
+    # Arrange — the lazy-import contract: declaring the entry point must not
+    # require the contract to exist, or a scitex-dev lagging on PyPI breaks
+    # import-time metadata for the whole distribution.
+    module = plugin
+    # Act
+    provider = getattr(module, "provide_hooks", None)
+    # Assert
+    assert callable(provider)
+
+
+@_needs_contract
+def test_provider_yields_the_raw_build_rule():
+    # Arrange
+    expected = "sac.no-raw-apptainer-build"
+    # Act
+    ids = [rule.id for rule in plugin.provide_hooks()]
+    # Assert
+    assert expected in ids
+
+
+@_needs_contract
+def test_raw_build_rule_denies_on_bash_pre_tool_use():
+    # Arrange
+    (rule,) = [
+        r for r in plugin.provide_hooks() if r.id == "sac.no-raw-apptainer-build"
+    ]
+    # Act
+    shape = (rule.event, rule.severity, rule.matches)
+    # Assert
+    assert shape == ("pre-tool-use", "deny", ("Bash",))
+
+
+@_needs_contract
+def test_every_rule_states_a_substantive_reason():
+    # Arrange — the reason field is the auditable part; boilerplate defeats it
+    rules = plugin.provide_hooks()
+    # Act
+    thin = [r.id for r in rules if len(r.reason) < 120]
+    # Assert
+    assert thin == []
+
+# EOF


### PR DESCRIPTION
A hand-run `apptainer build` of a sac image now gets refused, with the CLI named as the replacement. The rule is **declared here and applied by scitex-dev** — the leaf owns the rule about its own images; the keystone federates.

## Why the guard exists

sac's image build is not `apptainer build` plus arguments. `sac image build` stages a build-context directory holding the `.def` alongside a `scitex-agent-container-src/` copy of the installed package, and the `.def` resolves its `%files` sources against that staging dir. `apptainer-base.def` documents this in its own `%files` comment:

> Bundle the package's OWN source tree so the in-SIF sac is the source tree that shipped this .def — never a `git+...@main` snapshot […] apptainer resolves the relative source path below against the build CWD, which the CLI sets to that staging dir.

A hand-run build skips the staging and **does not fail loudly**. It produces a SIF whose in-image sac is whatever happened to be lying around, and the mismatch surfaces weeks later as a version that makes no sense. With the build becoming staged, a hand-run build additionally bypasses parent-chain resolution and staleness checking.

**This is not a duplicate of `heavy_job_hooks`.** That hook judges only whether a heavy command was `nice`'d, so a fully demoted `nice -n 19 ionice -c 2 -n 7 apptainer build … apptainer-base.def` passes it today. `test_refuses_a_fully_demoted_raw_build` pins the gap this closes.

## Where it lives, and how scitex-dev applies it

```
pyproject.toml
  [project.entry-points."scitex_dev.hooks"]
  scitex-agent-container = "scitex_agent_container._claude_hooks_plugin:provide_hooks"
                                            |
_claude_hooks_plugin.py  -> HookRule(id="sac.no-raw-apptainer-build", …)
                                            |
scitex-dev  discover_hooks()  -> installs into $HOME/.claude/hooks/pre-tool-use/
```

Same leaf-declares / keystone-applies split as `scitex_dev.jobs`, `scitex_dev.system_deps` and `scitex_dev.gate.checks`. scitex-dev hardcodes nothing about apptainer; sac installs nothing itself.

The `scitex_dev.hooks` contract does not exist in any released scitex-dev yet, so **the provider imports it lazily and the entry point ships inert** until it lands — the same idiom and the same reason as `_jobs/_jobs_plugin.py`. The three contract tests skip cleanly meanwhile; the rest assert the parts that can rot on our side (entry point declared, script path resolves, script executable).

The bundle also ships `settings.local.json.fragment.json` so it stays installable by hand, matching the four existing `_baseline_assets/*_hooks/` bundles.

## The discriminator, and why

**The recipe's CONTENT — the label key `org.scitex.layer`** — not its filename, not the output SIF's name.

Every sac recipe declares it under `%labels`. Content-keying means the guard survives the `.def` renames currently in flight, survives the recipe directory moving, and still catches a `.def` copied to `/tmp`. It is also the *same* notion of "ours" the built artifact carries: `apptainer inspect --labels x.sif` reports `org.scitex.layer: base`, so the guard and the SIF agree on identity.

The matcher is `^[ \t]*org\.scitex\.layer\b` and stops there — **the key, never the value set**. Spelled `org\.scitex\.layer (base|scitex|proxy)` it would silently stop guarding once `system-deps` / `python-pkgs` stages appear, while still passing its own tests. `test_matches_label_key_not_known_layer_values` uses a stage name that does not exist yet to pin this, and `test_ignores_the_recipe_filename_entirely` proves the converse (sac's filename + foreign content is allowed).

Fallback, only when content is unreadable (a build driven over ssh, a path not yet created): the command text naming `scitex_agent_container/containers` or `.scitex/agent-container/containers`. Honest limit — a build whose recipe is unreadable *and* which names none of sac's directories passes through. That is the safe direction to be wrong.

### Refusing the wrong thing is the failure mode that matters

A guard that blocks unrelated builds gets disabled, and then the real rule is gone with it. Deliberately allowed, each with a test: unrelated recipes, `docker://` URIs, read-only `inspect --labels|--deffile`, `apptainer exec img.sif make build`, `sac image build`, and `spartan-sif-bake.sh` (it does its own `$CTX` staging, so it is exempt **on merit**).

### Seeing through the wrappers

`spartan-sif-bake.sh` produces two shapes that defeat a naive check — an absolute `argv[0]` from `command -v`, and the build appearing only *inside* a quoted `bash -c` argument under `srun`. The detector `basename()`s argv[0] and re-splits builder-bearing tokens, so both are caught. Someone reaching for a workaround produces exactly these shapes.

## Measured, both directions

Raw build of the **real shipped** `apptainer-base.def` → refused, exit 2:

```
BLOCKED by deny_raw_apptainer_build.sh: hand-run `apptainer build` of a sac image.

Triggered by this file:
  .../src/scitex_agent_container/containers/apptainer-base.def
It declares the label key `org.scitex.layer` under %labels, which is how a
sac recipe identifies itself — the same label `apptainer inspect --labels`
reports on the built SIF.

Build it through the CLI instead — same recipe, correct build context:

  sac image build base            # or: scitex | proxy
...
Rare override (know why you're doing it):
  SAC_ALLOW_RAW_IMAGE_BUILD=1   or append   # hook-bypass: raw-apptainer-build
EXITCODE=2
```

The sanctioned path → allowed, and it actually proceeds:

```
$ hook <<< '{"tool_name":"Bash","tool_input":{"command":"sac image build base -y"}}'
HOOK_EXITCODE=0

$ sac image build base --dry-run
[dry-run] would build apptainer layer=base sandbox=False
SAC_EXITCODE=0
```

- bundled `--self-test`: **20/20** (9 refusals, 9 allowances, 2 bypasses)
- pytest: **33 passed, 3 skipped** (`tests/integration/image_build_hooks/` + `tests/scitex_agent_container/test__claude_hooks_plugin.py`)

## Overrides and failure posture

`SAC_ALLOW_RAW_IMAGE_BUILD=1`, or an inline `# hook-bypass: raw-apptainer-build`. The hook **fails open**: if `python3` is unavailable or the decision engine errors, the command is allowed — a broken guard must not wedge the agent's Bash tool.

## Coordination

- Keyed on the label so the in-flight `.def` restructuring into staged layers can rename files freely without touching this hook.
- `apptainer-proxy.def` is covered — it is outside the base→scitex chain, and a chain-shaped matcher would have skipped it.
- Built to the `HookRule` shape the `scitex_dev.hooks` owner specified; the field names may need a one-line follow-up once that PR merges.

## Follow-up filed separately

The `.def` headers still advertise the very command this hook now refuses (`# Build (raw apptainer): apptainer build … containers/apptainer-base.def`). Those files are mid-restructure by another agent, so the correction belongs in their change rather than colliding here.
