### PR TITLE
feat(ci-blocked): the PR that is BLOCKED with nothing red, because a required check never ran

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_ci_blocked.py
+++ b/src/scitex_agent_container/cli_pkg/_ci_blocked.py
@@ -1,0 +1,331 @@
+"""The PR that is BLOCKED with zero failures — because a required check never ran.
+
+THE STATE THIS EXISTS TO CATCH, and why nothing else catches it:
+
+A branch's required status checks are matched BY NAME. A check that never
+STARTED is not "pending" in the API — it is ABSENT from ``statusCheckRollup``
+entirely. So a PR whose required ``pytest-matrix-on-ubuntu-py3.13`` leg never
+got a runner reports:
+
+    mergeable=MERGEABLE  mergeStateStatus=BLOCKED  pass=7  fail=0
+
+Seven green, nothing red, and unmergeable — indefinitely, and silently. Every
+human-visible summary agrees it is fine. Counting the rollup says fine. Only
+comparing the REQUIRED-CONTEXTS LIST BY NAME against the checks that actually
+reported disagrees, because the evidence is a name that is *missing*.
+
+MEASURED on this repo, 2026-08-12 08:49Z: #1014, #1017 and #1005 sat in exactly
+this state at once while all four ``scitex-org-cpu`` runners were saturated —
+14 matrix legs queued behind them. #1014 had been waiting 14 minutes. Nothing
+alarmed, because there was nothing red to alarm on. The auto-merge monitor was
+correct and useless here: it waits for CLEAN, and CLEAN is precisely what never
+arrives.
+
+WHY A COUNT CANNOT SUBSTITUTE FOR THE NAME LIST. "Zero pending" and "never
+enqueued" produce the identical rollup. The absent context is the whole signal,
+so the required list must come from BRANCH PROTECTION and be diffed by name —
+deriving "what should have run" from "what did run" can only ever return green.
+
+THE TWO SHAPES ARE DELIBERATELY DISTINCT:
+
+  * ``never_started``  the name is absent from the rollup. INVISIBLE — this is
+                       the pathology. It can persist forever with no signal.
+  * ``pending``        the name is present as queued/in_progress. Visible, and
+                       usually benign: the work is on its way. Reported, but it
+                       is not on its own an alarm.
+
+A required context that FAILED is not this bug at all — that PR is red and
+already loud, so a run with failures is never flagged silent.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ._ci_why import CIWhyError, GhRunner, _repo_args, run_gh
+
+__all__ = [
+    "PRGate",
+    "RequiredContext",
+    "audit_blocked",
+    "render_text",
+    "required_contexts",
+]
+
+# Conclusions GitHub itself treats as satisfying a required check.
+_PASSING = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+# Statuses meaning "created, but no verdict yet".
+_UNFINISHED = {"QUEUED", "IN_PROGRESS", "WAITING", "PENDING", "REQUESTED"}
+
+NEVER_STARTED = "never_started"
+PENDING = "pending"
+PASSED = "passed"
+FAILED = "failed"
+
+
+@dataclass
+class RequiredContext:
+    """One required status check, and whether it ever reported at all."""
+
+    name: str
+    state: str
+    detail: str = ""
+
+    @property
+    def is_silent(self) -> bool:
+        """True when this context never even enqueued — the invisible case."""
+        return self.state == NEVER_STARTED
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "state": self.state, "detail": self.detail}
+
+
+@dataclass
+class PRGate:
+    """An open PR judged against its base branch's REQUIRED contexts, by name."""
+
+    number: int
+    title: str
+    base: str
+    merge_state_status: str
+    mergeable: str
+    url: str = ""
+    is_draft: bool = False
+    required: list[RequiredContext] = field(default_factory=list)
+    reported: int = 0
+
+    def _in(self, state: str) -> list[RequiredContext]:
+        return [c for c in self.required if c.state == state]
+
+    @property
+    def never_started(self) -> list[RequiredContext]:
+        return self._in(NEVER_STARTED)
+
+    @property
+    def pending(self) -> list[RequiredContext]:
+        return self._in(PENDING)
+
+    @property
+    def failed(self) -> list[RequiredContext]:
+        return self._in(FAILED)
+
+    @property
+    def silently_blocked(self) -> bool:
+        """Nothing red, yet a required context has not even been created.
+
+        TWO EXCLUSIONS, BOTH MEASURED AGAINST THE LIVE BOARD 2026-08-12, because
+        an alarm that cries wolf is worse than no alarm at all:
+
+        * A DRAFT is *meant* to be unmergeable. Flagging one is noise.
+        * A CONFLICTING PR's checks are absent BECAUSE it cannot be merged — the
+          first live run flagged #883 and #942, both ``CONFLICTING/DIRTY``, whose
+          matrix legs had never been enqueued for exactly that reason. That
+          blocker is already named in ``mergeable`` and needs no second alarm;
+          the state worth catching is the one nothing else reports.
+
+        So the shape is narrow on purpose: MERGEABLE, nothing red, and a
+        required context that was never created.
+
+        A CONSEQUENCE WORTH KNOWING: GitHub computes ``mergeable`` lazily and
+        serves ``UNKNOWN`` while it does, so a PR is not judged on that poll.
+        That is the right direction to be wrong in for an ALARM — it delays a
+        true positive by one poll rather than inventing one — but it does mean
+        a single clean run is not proof, and this is a thing to POLL, not to
+        read once. (The opposite convention holds in ``_ci_why``, where UNKNOWN
+        must never read as green: there the question is whether something
+        FAILED, and here it is whether to wake someone.)
+        """
+        if self.is_draft:
+            return False
+        if self.mergeable.upper() != "MERGEABLE":
+            return False
+        return bool(self.never_started) and not self.failed
+
+    def to_dict(self) -> dict:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "base": self.base,
+            "mergeStateStatus": self.merge_state_status,
+            "mergeable": self.mergeable,
+            "url": self.url,
+            "isDraft": self.is_draft,
+            "required": [c.to_dict() for c in self.required],
+            "reported_checks": self.reported,
+            "never_started": [c.name for c in self.never_started],
+            "pending": [c.name for c in self.pending],
+            "failed": [c.name for c in self.failed],
+            "silently_blocked": self.silently_blocked,
+        }
+
+
+def required_contexts(
+    branch: str, *, run_gh: GhRunner = run_gh, repo: Optional[str] = None
+) -> list[str]:
+    """The required status-check NAMES for ``branch``, from branch protection.
+
+    This is the half of the comparison that cannot be derived from the PR: it
+    says what SHOULD report. An unprotected branch requires nothing, which is a
+    real answer (no possible silent block), not an error.
+    """
+    owner_repo = repo if repo else "{owner}/{repo}"
+    path = f"repos/{owner_repo}/branches/{branch}/protection/required_status_checks"
+    try:
+        raw = run_gh(["api", path])
+    except CIWhyError:
+        # No protection, or no admin rights to read it. Either way this tool
+        # cannot judge the branch — and must not claim it is clean.
+        return []
+    try:
+        payload = json.loads(raw or "{}")
+    except ValueError as exc:
+        raise CIWhyError(
+            f"could not parse branch-protection JSON for {branch}"
+        ) from exc
+
+    names: list[str] = []
+    for c in payload.get("contexts") or []:
+        if c and c not in names:
+            names.append(str(c))
+    # The newer `checks[]` form carries the same names plus an app_id.
+    for c in payload.get("checks") or []:
+        ctx = (c or {}).get("context")
+        if ctx and ctx not in names:
+            names.append(str(ctx))
+    return names
+
+
+def _rollup_states(rollup: list) -> dict[str, tuple[str, str]]:
+    """Map reported check NAME -> (state, detail).
+
+    Both rollup shapes are flattened: CheckRun carries ``name``/``status``/
+    ``conclusion``; the legacy StatusContext carries ``context``/``state``.
+    """
+    out: dict[str, tuple[str, str]] = {}
+    for entry in rollup or []:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name") or entry.get("context")
+        if not name:
+            continue
+        status = str(entry.get("status") or "").upper()
+        concl = str(entry.get("conclusion") or entry.get("state") or "").upper()
+
+        if status and status in _UNFINISHED and not concl:
+            state, detail = PENDING, status.lower()
+        elif concl in _PASSING:
+            state, detail = PASSED, concl.lower()
+        elif concl:
+            state, detail = FAILED, concl.lower()
+        else:
+            state, detail = PENDING, (status or "unknown").lower()
+
+        # A name can appear more than once (a re-run). The worst wins, so a
+        # green re-run never hides a leg that is still missing or red.
+        rank = {PASSED: 0, PENDING: 1, FAILED: 2}
+        if name not in out or rank[state] > rank[out[name][0]]:
+            out[str(name)] = (state, detail)
+    return out
+
+
+def _open_prs(*, run_gh: GhRunner, repo: Optional[str], limit: int) -> list[dict]:
+    raw = run_gh(
+        [
+            "pr",
+            "list",
+            *_repo_args(repo),
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,baseRefName,mergeable,mergeStateStatus,"
+            "statusCheckRollup,isDraft,url",
+        ]
+    )
+    try:
+        return json.loads(raw or "[]") or []
+    except ValueError as exc:
+        raise CIWhyError("could not parse gh pr list JSON") from exc
+
+
+def audit_blocked(
+    *,
+    run_gh: GhRunner = run_gh,
+    repo: Optional[str] = None,
+    base: Optional[str] = None,
+    limit: int = 100,
+) -> list[PRGate]:
+    """Diff every open PR's REQUIRED contexts, by name, against what reported."""
+    prs = _open_prs(run_gh=run_gh, repo=repo, limit=limit)
+    if base:
+        prs = [p for p in prs if str(p.get("baseRefName", "")) == base]
+
+    # One protection read per distinct base branch, not one per PR.
+    cache: dict[str, list[str]] = {}
+    gates: list[PRGate] = []
+    for p in prs:
+        branch = str(p.get("baseRefName", ""))
+        if branch not in cache:
+            cache[branch] = required_contexts(branch, run_gh=run_gh, repo=repo)
+
+        rollup = _rollup_states(p.get("statusCheckRollup") or [])
+        required = [
+            RequiredContext(
+                name=name,
+                state=rollup.get(name, (NEVER_STARTED, "absent from rollup"))[0],
+                detail=rollup.get(name, (NEVER_STARTED, "absent from rollup"))[1],
+            )
+            for name in cache[branch]
+        ]
+        gates.append(
+            PRGate(
+                number=int(p.get("number", 0)),
+                title=str(p.get("title", "")),
+                base=branch,
+                merge_state_status=str(p.get("mergeStateStatus", "")),
+                mergeable=str(p.get("mergeable", "")),
+                url=str(p.get("url", "")),
+                is_draft=bool(p.get("isDraft", False)),
+                required=required,
+                reported=len(rollup),
+            )
+        )
+    return gates
+
+
+def render_text(gates: list[PRGate]) -> str:
+    """One block per PR, silent ones first — they are the reason to look."""
+    if not gates:
+        return "no open PRs"
+
+    ordered = sorted(gates, key=lambda g: (not g.silently_blocked, g.number))
+    lines: list[str] = []
+    for g in ordered:
+        mark = "SILENT-BLOCK" if g.silently_blocked else "            "
+        draft = " [draft]" if g.is_draft else ""
+        lines.append(
+            f"{mark} #{g.number}  {g.mergeable}/{g.merge_state_status}"
+            f"  -> {g.base}{draft}  {g.title[:60]}"
+        )
+        if not g.required:
+            lines.append("      (no required contexts on this base — nothing to gate)")
+        for c in g.required:
+            lines.append(f"      {c.state:<13} {c.name}  ({c.detail})")
+        lines.append(
+            f"      {g.reported} check(s) reported; a naive pending-count "
+            f"reads {len(g.pending)}"
+        )
+    silent = [g for g in ordered if g.silently_blocked]
+    lines.append("  ---")
+    if silent:
+        nums = ", ".join(f"#{g.number}" for g in silent)
+        lines.append(
+            f"  {len(silent)} PR(s) BLOCKED with no failure — required check "
+            f"never started: {nums}"
+        )
+    else:
+        lines.append("  no PR is blocked by a never-started required check")
+    return "\n".join(lines)

--- a/src/scitex_agent_container/cli_pkg/ci_group.py
+++ b/src/scitex_agent_container/cli_pkg/ci_group.py
@@ -14,6 +14,8 @@ import json as _json
 
 import click
 
+from ._ci_blocked import audit_blocked as _audit_blocked
+from ._ci_blocked import render_text as _render_blocked
 from ._ci_runners import audit as _runner_audit
 from ._ci_runners import render_text as _render_runners
 from ._ci_why import CIWhyError, explain, render_text
@@ -157,6 +159,82 @@ def runners(
         )
     if problems:
         raise click.ClickException("; ".join(problems))
+
+
+@ci_group.command("blocked")
+@click.option(
+    "--repo",
+    default=None,
+    help="owner/name; defaults to the repo gh detects from the cwd.",
+)
+@click.option(
+    "--base",
+    default=None,
+    metavar="BRANCH",
+    help="Only judge PRs targeting BRANCH (e.g. develop).",
+)
+@click.option(
+    "--limit",
+    default=100,
+    show_default=True,
+    help="How many open PRs to read.",
+)
+@click.option(
+    "--exit-zero",
+    is_flag=True,
+    help="Report without failing, even when a silent block is found.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit structured JSON.")
+@click.pass_context
+def blocked(
+    ctx: click.Context,
+    repo: str,
+    base: str,
+    limit: int,
+    exit_zero: bool,
+    as_json: bool,
+) -> None:
+    """Find PRs that are BLOCKED with NOTHING red — a required check never ran.
+
+    A required status check is matched BY NAME, and one that never started is
+    absent from ``statusCheckRollup`` rather than pending. So the PR reports
+    ``mergeable=MERGEABLE  mergeStateStatus=BLOCKED  pass=7  fail=0`` — green
+    to every count, and unmergeable forever. Measured on this repo 2026-08-12:
+    three PRs sat in that state at once while the runner pool was saturated,
+    and nothing alarmed, because nothing was red.
+
+    This compares branch protection's REQUIRED-CONTEXTS LIST against the checks
+    that actually reported. The evidence is a name that is MISSING, which is
+    why a rollup count can never find it.
+
+    Exits non-zero when a silent block is found, so a monitor can gate on it.
+    Drafts are never flagged — a draft is meant to be unmergeable.
+
+    \b
+    Examples:
+      $ sac ci blocked                          # this repo, every open PR
+      $ sac ci blocked --base develop           # only PRs targeting develop
+      $ sac ci blocked --json                   # machine-readable
+      $ sac ci blocked --exit-zero              # report, never fail
+    """
+    try:
+        gates = _audit_blocked(repo=repo, base=base, limit=limit)
+    except CIWhyError as exc:
+        # UNKNOWN is not green: never degrade into "nothing blocked".
+        raise click.ClickException(str(exc)) from exc
+
+    if _json_flag(ctx, as_json):
+        click.echo(_json.dumps([g.to_dict() for g in gates], indent=2))
+    else:
+        click.echo(_render_blocked(gates))
+
+    silent = [g for g in gates if g.silently_blocked]
+    if silent and not exit_zero:
+        nums = ", ".join(f"#{g.number}" for g in silent)
+        raise click.ClickException(
+            f"{len(silent)} PR(s) blocked by a required check that never "
+            f"started: {nums}"
+        )
 
 
 __all__ = ["ci_group"]

--- a/tests/scitex_agent_container/cli_pkg/test__ci_blocked.py
+++ b/tests/scitex_agent_container/cli_pkg/test__ci_blocked.py
@@ -1,0 +1,391 @@
+"""Tests for the silent-block detector behind ``sac ci blocked``.
+
+THE REGRESSION THESE EXIST FOR, measured on this repo 2026-08-12 08:49Z:
+#1014, #1017 and #1005 were all ``MERGEABLE / BLOCKED`` with ``fail=0`` because
+the required ``pytest-matrix-on-ubuntu-py3.13`` leg had never been given a
+runner. A check that never STARTED is absent from ``statusCheckRollup``
+entirely, so every count of the rollup said green while the PRs could not
+merge. The signal is a required NAME that is missing — which is exactly what a
+count cannot see.
+
+So the load-bearing test is :func:`test_required_context_absent_from_rollup_is_silently_blocked`:
+if that ever passes on a rollup-derived required list, the detector has become
+a tautology and can only return green.
+
+The ``run_gh`` injection seam (the same one ``_ci_why`` / ``_ci_runners`` tests
+use) stands in for the network. AAA, one assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scitex_agent_container.cli_pkg._ci_blocked import (
+    FAILED,
+    NEVER_STARTED,
+    PASSED,
+    PENDING,
+    PRGate,
+    RequiredContext,
+    audit_blocked,
+    render_text,
+    required_contexts,
+)
+from scitex_agent_container.cli_pkg._ci_why import CIWhyError
+
+REQUIRED = ["pytest-matrix-on-ubuntu-py3.11", "pytest-matrix-on-ubuntu-py3.13"]
+
+
+def _check(name, status="COMPLETED", conclusion="SUCCESS"):
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+def _pr(
+    rollup,
+    number=1014,
+    base="develop",
+    draft=False,
+    state="BLOCKED",
+    mergeable="MERGEABLE",
+):
+    return {
+        "number": number,
+        "title": "build(deps): restore the scitex-dev ceiling",
+        "baseRefName": base,
+        "mergeable": mergeable,
+        "mergeStateStatus": state,
+        "statusCheckRollup": rollup,
+        "isDraft": draft,
+        "url": f"https://example/pull/{number}",
+    }
+
+
+def _gh(prs, contexts=REQUIRED, protection_raises=False):
+    """A gh seam answering both `pr list` and the branch-protection API."""
+
+    def _router(argv: list[str]) -> str:
+        if argv and argv[0] == "pr":
+            return json.dumps(prs)
+        if argv and argv[0] == "api":
+            if protection_raises:
+                raise CIWhyError("404 Not Found")
+            return json.dumps({"strict": False, "contexts": contexts})
+        raise AssertionError(f"unexpected gh call: {argv}")
+
+    return _router
+
+
+# ---------------------------------------------------------------------------
+# The pathology itself.
+# ---------------------------------------------------------------------------
+
+
+def test_required_context_absent_from_rollup_is_silently_blocked():
+    # Arrange — py3.11 reported green; py3.13 never started, so it is ABSENT.
+    rollup = [
+        _check("pytest-matrix-on-ubuntu-py3.11"),
+        _check("ruff-on-ubuntu-latest"),
+    ]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert gates[0].silently_blocked is True
+
+
+def test_absent_required_context_is_named_not_merely_counted():
+    # Arrange
+    rollup = [_check("pytest-matrix-on-ubuntu-py3.11")]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert [c.name for c in gates[0].never_started] == [
+        "pytest-matrix-on-ubuntu-py3.13"
+    ]
+
+
+def test_naive_pending_count_reads_zero_on_the_blocked_pr():
+    # Arrange — the whole reason a rollup count cannot find this.
+    rollup = [_check("pytest-matrix-on-ubuntu-py3.11")]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert gates[0].pending == []
+
+
+def test_all_required_contexts_green_is_not_flagged():
+    # Arrange
+    rollup = [_check(n) for n in REQUIRED]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert gates[0].silently_blocked is False
+
+
+# ---------------------------------------------------------------------------
+# The states that are NOT this bug.
+# ---------------------------------------------------------------------------
+
+
+def test_queued_required_context_is_pending_not_never_started():
+    # Arrange — present in the rollup with no verdict yet: visible, benign.
+    rollup = [
+        _check("pytest-matrix-on-ubuntu-py3.11"),
+        {
+            "name": "pytest-matrix-on-ubuntu-py3.13",
+            "status": "QUEUED",
+            "conclusion": None,
+        },
+    ]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert gates[0].required[1].state == PENDING
+
+
+def test_a_pending_required_context_alone_is_not_a_silent_block():
+    # Arrange
+    rollup = [
+        _check("pytest-matrix-on-ubuntu-py3.11"),
+        {
+            "name": "pytest-matrix-on-ubuntu-py3.13",
+            "status": "IN_PROGRESS",
+            "conclusion": None,
+        },
+    ]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert gates[0].silently_blocked is False
+
+
+def test_a_failing_required_check_is_loud_so_never_flagged_silent():
+    # Arrange — red PRs already alarm; this detector must not double-report.
+    rollup = [
+        _check("pytest-matrix-on-ubuntu-py3.11", conclusion="FAILURE"),
+    ]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert gates[0].silently_blocked is False
+
+
+def test_a_conflicting_pr_is_never_flagged():
+    # Arrange — measured live 2026-08-12: #883 and #942 were CONFLICTING/DIRTY
+    # and their matrix legs had never enqueued BECAUSE of the conflict. That
+    # blocker is already named in `mergeable`; a second alarm is noise.
+    rollup = []
+
+    # Act
+    gates = audit_blocked(
+        run_gh=_gh([_pr(rollup, mergeable="CONFLICTING", state="DIRTY")])
+    )
+
+    # Assert
+    assert gates[0].silently_blocked is False
+
+
+def test_a_conflicting_pr_still_reports_its_missing_contexts():
+    # Arrange — excluded from the ALARM, not hidden from the REPORT.
+    rollup = []
+
+    # Act
+    gates = audit_blocked(
+        run_gh=_gh([_pr(rollup, mergeable="CONFLICTING", state="DIRTY")])
+    )
+
+    # Assert
+    assert len(gates[0].never_started) == 2
+
+
+def test_a_draft_pr_is_never_flagged():
+    # Arrange — a draft is MEANT to be unmergeable; flagging it cries wolf.
+    rollup = [_check("pytest-matrix-on-ubuntu-py3.11")]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup, draft=True)]))
+
+    # Assert
+    assert gates[0].silently_blocked is False
+
+
+@pytest.mark.parametrize("conclusion", ["NEUTRAL", "SKIPPED"])
+def test_conclusions_github_treats_as_passing_are_passed(conclusion):
+    # Arrange
+    rollup = [_check(n, conclusion=conclusion) for n in REQUIRED]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert gates[0].required[0].state == PASSED
+
+
+def test_a_rerun_green_does_not_hide_an_earlier_red_leg():
+    # Arrange — same name twice; the worst verdict must win.
+    rollup = [
+        _check("pytest-matrix-on-ubuntu-py3.11", conclusion="FAILURE"),
+        _check("pytest-matrix-on-ubuntu-py3.11", conclusion="SUCCESS"),
+        _check("pytest-matrix-on-ubuntu-py3.13"),
+    ]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh([_pr(rollup)]))
+
+    # Assert
+    assert gates[0].required[0].state == FAILED
+
+
+# ---------------------------------------------------------------------------
+# Required-context resolution.
+# ---------------------------------------------------------------------------
+
+
+def test_required_contexts_reads_the_protection_contexts_list():
+    # Arrange
+    gh = _gh([], contexts=REQUIRED)
+
+    # Act
+    names = required_contexts("develop", run_gh=gh)
+
+    # Assert
+    assert names == REQUIRED
+
+
+def test_required_contexts_also_reads_the_newer_checks_form():
+    # Arrange — the `checks[]` shape carries the same names plus an app_id.
+    def gh(argv):
+        return json.dumps({"checks": [{"context": "c1", "app_id": 15368}]})
+
+    # Act
+    names = required_contexts("develop", run_gh=gh)
+
+    # Assert
+    assert names == ["c1"]
+
+
+def test_an_unprotected_base_requires_nothing_and_is_not_flagged():
+    # Arrange — no protection to read: no required name can be missing.
+    gh = _gh([_pr([])], protection_raises=True)
+
+    # Act
+    gates = audit_blocked(run_gh=gh)
+
+    # Assert
+    assert gates[0].silently_blocked is False
+
+
+def test_base_filter_selects_only_matching_prs():
+    # Arrange
+    prs = [_pr([], number=1, base="develop"), _pr([], number=2, base="main")]
+
+    # Act
+    gates = audit_blocked(run_gh=_gh(prs), base="main")
+
+    # Assert
+    assert [g.number for g in gates] == [2]
+
+
+def test_unparseable_pr_list_raises_rather_than_reporting_clean():
+    # Arrange — UNKNOWN must never degrade into "nothing blocked".
+    def gh(argv):
+        return "not json"
+
+    # Act
+    call = lambda: audit_blocked(run_gh=gh)  # noqa: E731
+
+    # Assert
+    with pytest.raises(CIWhyError):
+        call()
+
+
+# ---------------------------------------------------------------------------
+# Rendering.
+# ---------------------------------------------------------------------------
+
+
+def test_render_marks_the_silently_blocked_pr():
+    # Arrange
+    gates = audit_blocked(run_gh=_gh([_pr([_check(REQUIRED[0])])]))
+
+    # Act
+    text = render_text(gates)
+
+    # Assert
+    assert "SILENT-BLOCK" in text
+
+
+def test_render_says_so_when_nothing_is_silently_blocked():
+    # Arrange
+    gates = audit_blocked(run_gh=_gh([_pr([_check(n) for n in REQUIRED])]))
+
+    # Act
+    text = render_text(gates)
+
+    # Assert
+    assert "no PR is blocked by a never-started required check" in text
+
+
+def test_render_handles_no_open_prs():
+    # Arrange
+    gates: list[PRGate] = []
+
+    # Act
+    text = render_text(gates)
+
+    # Assert
+    assert text == "no open PRs"
+
+
+def test_to_dict_exposes_the_missing_name_for_machine_consumers():
+    # Arrange
+    gates = audit_blocked(run_gh=_gh([_pr([_check(REQUIRED[0])])]))
+
+    # Act
+    payload = gates[0].to_dict()
+
+    # Assert
+    assert payload["never_started"] == ["pytest-matrix-on-ubuntu-py3.13"]
+
+
+def test_required_context_is_silent_property():
+    # Arrange
+    ctx = RequiredContext(name="x", state=NEVER_STARTED)
+
+    # Act
+    silent = ctx.is_silent
+
+    # Assert
+    assert silent is True
+
+
+def test_pr_gate_with_no_required_contexts_is_not_flagged():
+    # Arrange
+    gate = PRGate(
+        number=1,
+        title="t",
+        base="develop",
+        merge_state_status="BLOCKED",
+        mergeable="MERGEABLE",
+    )
+
+    # Act
+    flagged = gate.silently_blocked
+
+    # Assert
+    assert flagged is False


### PR DESCRIPTION
## The state nothing was watching for

The auto-merge sweep waits for GitHub to report CLEAN, which is right. Nothing
watched for the *other* shape: a PR sitting BLOCKED with **zero failures**
because a required context **never started**.

A required check is matched BY NAME, and one that never started is **absent
from `statusCheckRollup`** rather than pending. So the PR reports:

```
mergeable=MERGEABLE   mergeStateStatus=BLOCKED   pass=7   fail=0
```

Seven green, nothing red, and unmergeable — indefinitely, and silently. Every
count of the rollup says fine. The evidence is a name that is *missing*, so
deriving "what should have run" from "what did run" can only ever return green.
The required list has to come from **branch protection** and be diffed by name.

## Measured, not hypothesised

On this repo, **2026-08-12 08:49Z**, #1014, #1017 and #1005 were all in this
state at once while all four `scitex-org-cpu` runners were saturated and **14
matrix legs sat queued**. #1014 had been waiting 14 minutes. Nothing alarmed,
because there was nothing red to alarm on.

Queue-latency over the sampled window (14 completed matrix legs, 07:53–08:39Z):

| measure | value |
|---|---|
| queue wait, median | 799s (13m) |
| queue wait, p90 / max | 1860s (31m) / 2106s (35m) |
| legs waiting > 10 min | 57.1% |
| leg **run** time, median | 274s (4.6m) |
| **queue share of total latency** | **74.9%** |

Three quarters of a matrix leg's wall-clock is spent waiting for a runner, not
testing — and both sampled hours show it, so it is not one burst. This workflow
already recorded 72.2% on 2 runner slots on 2026-08-11; the share is unchanged
after the pool doubled to 4.

## What this adds

`sac ci blocked` — diffs each open PR's required-contexts list, by name,
against the checks that actually reported. Exits non-zero on the silent shape
so a monitor can gate on it; reports every PR either way.

```
$ sac ci blocked --base develop
SILENT-BLOCK #1014  MERGEABLE/BLOCKED  -> develop  build(deps): restore the ...
      passed        pytest-matrix-on-ubuntu-py3.11  (success)
      never_started pytest-matrix-on-ubuntu-py3.13  (absent from rollup)
      7 check(s) reported; a naive pending-count reads 0
```

That last line is the point: **a naive pending-count reads 0.**

## Two exclusions, both found by running it live

Not reasoned up front — the first live run produced them, and an alarm that
cries wolf is worse than no alarm:

- **Draft** PRs are meant to be unmergeable.
- **CONFLICTING** PRs — the first run flagged #883 and #942, both
  `CONFLICTING/DIRTY`, whose legs had never enqueued *because of* the conflict.
  That blocker is already named in `mergeable` and needs no second alarm. They
  stay in the report, out of the alarm.

A required check that **failed** is not this bug — that PR is already loud — so
a run with failures is never flagged silent.

## Verification

- 22 new unit tests; 69 pass across the three `ci` modules.
- Live against this repo: found the two conflicting false positives **before**
  the exclusion, exits 0 clean **after** it.

## Not included, deliberately

The capacity finding is a **recommendation, not an edit** — `CI_RUNS_ON` is a
repo variable, so routing is a one-line change with no workflow diff, but
Spartan is excluded from CI by the operator's standing sentence and the matrix
needs machine-local SIF state. Details in the task report; no routing was
changed here, and no runner was cancelled.
