### PR TITLE
feat(sync): say which sac rows are the fleet's and which are one host's

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,6 +331,27 @@ library_dirs = ["src", "tests", "apps", "config", "docs", ".github"]
 [project.entry-points."scitex_dev.system_deps"]
 scitex-agent-container = "scitex_agent_container._system_deps:provide"
 
+# sac's LEAF declaration of multi-host sync semantics, aggregated by
+# scitex_dev.store.discover_store_plugins. scitex-dev owns the replication
+# PRIMITIVE (oplog, HLC, per-origin cursors, field-level merge); each leaf
+# declares what ITS rows mean when two hosts merge them. sac is a leaf here,
+# not privileged.
+#
+# The declaration is the deliverable because sac's existing cross-host path
+# is unsafe in a way that is invisible: state_db_export.import_state does
+# INSERT OR IGNORE, so a row that CONTRADICTS the local one and a
+# byte-identical duplicate both return rowcount 0. The success value is also
+# the didn't-happen value, and two hosts can disagree forever with every call
+# reporting success.
+#
+# The classification each schema encodes: an agent's pid/heartbeat is
+# PER-HOST truth (two hosts describe two different processes and each is
+# right about itself — merging them is the bug), the comms directory and the
+# ACL tables are FLEET truth (disagreement is a real conflict), and lineage
+# is append-only HISTORY (a merge must never lose a branch).
+[project.entry-points."scitex_dev.store.plugins"]
+scitex-agent-container = "scitex_agent_container._store_plugin:provide"
+
 # C10 — sac's consumer on scitex-todo's shared card-event bus. When
 # scitex-todo's board emits a card-event (commented / created /
 # reassigned / status_changed / completed / committed / pushed /

--- a/src/scitex_agent_container/_never_stop_when_task_remains/_awaiting_operator.py
+++ b/src/scitex_agent_container/_never_stop_when_task_remains/_awaiting_operator.py
@@ -185,10 +185,26 @@ def redact(target: str) -> str:
 def _store_identity() -> str:
     """What the package says it resolved to, redacted. ``""`` if it will not say.
 
-    The ``store_uuid`` is carried because it is THE thing that separates two
-    clones of the same database: a URL alone cannot tell
-    ``127.0.0.1:55432/scitex_cards`` on this host from the identical string on
-    another, and "two Postgres clones" is the fleet's current state.
+    A URL alone cannot tell ``127.0.0.1:55432/scitex_cards`` on this host from
+    the identical string on another, and "two clones" is the fleet's current
+    state — so the store's own identity is carried alongside it.
+
+    But ``store_uuid`` ALONE does not separate two clones, and this function
+    used to claim it did. **A uuid stored inside a database is copied by a fork
+    of that database**, so it names the LINEAGE ("which store am I a copy
+    of?"), never the instance. Measured 2026-08-11: two endpoints — ``:55432``
+    and a tunnel at ``127.0.0.1:5442`` — both answered ``store_uuid``
+    ``1d55dd6e-3d2a-4c24-a429-a78835ab988f`` while holding 404 and 146 cards
+    the other lacked. Every operation on both succeeded.
+
+    The half a fork cannot forge comes from the ENGINE, not the rows —
+    ``pg_control_system().system_identifier`` on Postgres, its sqlite analogue
+    on a file store. So identity is the PAIR. When the store reports only the
+    uuid, this says so in the rendered line rather than presenting a
+    lineage id as though it identified this instance: a reader who is told
+    ``uuid 1d55dd6e`` and nothing else will reasonably assume two agents
+    printing it are on the same store, which is exactly the inference that was
+    false on 2026-08-11.
     """
     try:
         proc = subprocess.run(
@@ -219,8 +235,15 @@ def _store_identity() -> str:
     if not resolved:
         return ""
     uuid = str(data.get("store_uuid") or "").strip()
+    system = str(data.get("system_identifier") or "").strip()
     identity = redact(resolved)
-    return f"{identity} (uuid {uuid[:8]})" if uuid else identity
+    if not uuid:
+        return identity
+    if system:
+        return f"{identity} (uuid {uuid[:8]} sys {system[:8]})"
+    # Lineage id with no engine half: it cannot rule out a fork, and saying
+    # so costs three words. Silence here reads as certainty.
+    return f"{identity} (uuid {uuid[:8]}, lineage only — fork undetectable)"
 
 
 def cache_path(agent: str) -> Path:

--- a/src/scitex_agent_container/_store_plugin.py
+++ b/src/scitex_agent_container/_store_plugin.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_agent_container/_store_plugin.py
+"""sac's LEAF declaration of what its state means when two hosts merge it.
+
+scitex-dev owns the replication primitive (``scitex_dev.store``: oplog,
+hybrid logical clock, per-origin cursors, the gapless
+``first_seq == cursor + 1`` assertion, field-level merge). scitex-cards
+declares the card semantics. This module is the third leaf: **sac says
+what sac's rows MEAN**, and nothing else. It builds no sync mechanism,
+opens no connection, and writes no SQL.
+
+The whole design is one classification
+======================================
+Every row in sac's state DB is exactly one of three things, and the merge
+rules are a consequence rather than a choice:
+
+``PER_HOST``
+    A host's own observation of its own processes. An agent's pid, its
+    tmux/screen name, its heartbeat: compute-04 and spartan describing
+    "the same agent" are describing **two different processes**, and each
+    is right about itself. Two hosts disagreeing here is NOT a conflict to
+    resolve — resolving it is the bug, because last-writer-wins would let
+    one host's clock erase another host's true observation.
+
+    Expressed by putting ``host`` in the record IDENTITY, so the two
+    observations are different RECORDS that never meet in a merge at all,
+    and by ``SINGLE_WRITER`` so only the observing host may write them.
+    The primitive documents that exact case: *"Right for stores whose
+    records have a genuine, stable owner — a host writing its own
+    telemetry."*
+
+``FLEET``
+    One fact the whole fleet shares. "Agent X is reachable at host:port"
+    is the same claim everywhere, so two hosts disagreeing IS a conflict
+    and needs a stated rule.
+
+``HISTORY``
+    Append-only. Merging must never lose a branch. Each edge is its own
+    record keyed by the child, so distinct edges never collide and none
+    can be dropped; a genuine contradiction (two parents claimed for one
+    child) is surfaced as a ``MergeConflict``, never silently resolved.
+
+A fourth category is not synced at all, and saying so out loud is the
+point — see :data:`NEVER_SYNCED`.
+
+Why classification is the deliverable
+-------------------------------------
+sac already ships a cross-host path, and it is unsafe in a way that is
+invisible: ``state_db_export.import_state`` does
+``INSERT OR IGNORE INTO <t>``. A byte-identical duplicate and a row that
+CONTRADICTS the local one both yield ``rowcount == 0``. The importer's
+success value is also its didn't-happen value, so two hosts can disagree
+permanently while every call returns 0 and reports success. That path is
+what the primitive replaces; this module is the declaration that makes
+the replacement safe rather than merely different.
+
+Measured, not inferred (scitex-compute-04, 2026-08-12)::
+
+    in-container  /state/scitex-agent-container/state.db
+                  instances 0    events 0    channel_events 0     lineage 0
+    bare host     ~/.scitex/agent-container/runtime/state.db
+                  instances 192  events 366  channel_events 1872  lineage 4
+
+Same host, same package, same schema, both readable, every call exit 0.
+An empty read cannot distinguish "no rows anywhere" from "I only looked
+in one place" — which is how, on 2026-08-09, three agents read the empty
+shard and escalated it as P1 fleet-registry data loss.
+
+Does sac's state know where it came from?
+------------------------------------------
+Asked because scitex-cards found its own ``origin_node`` declared at
+SCHEMA_VERSION 11 and written by nothing — a column that answers "which
+host is this row from?" and is empty on every row. A schema tells you a
+field is PRESENT, never that it is FILLED, so the honest check is to grep
+for WRITERS. sac's answer is mixed and worth stating plainly:
+
+* ``instances`` — YES. ``host`` is written by ``record_instance_start``
+  from the resolved canonical host, and it is populated by DEFAULT rather
+  than only when a caller remembers to pass it. A test in this module's
+  suite exercises the real writer and asserts the column lands non-empty,
+  because the per-host identity below is worthless if it does not.
+* ``turns`` / ``errors`` / ``heartbeats`` — YES, each carries a written
+  ``host``. All three are refused for other reasons (see NEVER_SYNCED).
+* ``lineage``, ``comms_grants``, ``node_comms_policy``, ``node_tokens``,
+  ``channel_events`` — NO origin column of any kind exists.
+* ``comms_nodes.source_host`` — present, but NULL for every locally
+  registered row and set only on the PULL path. It records who a row was
+  pulled FROM, not who created it, so a locally-created row is anonymous
+  by design.
+
+That gap is closed by adopting the primitive rather than by adding
+columns here: ``_origin`` is a RESERVED column the store stamps on every
+op from ``Store.node``, so provenance stops being something each leaf
+has to remember to write.
+
+But ``_origin`` is NOT a substitute for ``host``, and conflating them
+would rebuild the bug in a new place. ``_origin`` is PROVENANCE — which
+node told me this. ``host`` is SUBJECT — which machine the row is ABOUT.
+They coincide for ``sac_instances`` only because SINGLE_WRITER makes the
+observing host the only writer; the moment a row is relayed, replayed
+from an oplog, or handed over on relocation, the two diverge. So ``host``
+stays an explicitly declared IDENTITY field.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from scitex_dev.store import (
+    FieldKind,
+    FieldPolicy,
+    FieldRole,
+    MergeRule,
+    Schema,
+    WriterPolicy,
+)
+
+_PROVIDER = "scitex-agent-container"
+_PKG = "scitex-agent-container"
+
+
+class Truth(str, Enum):
+    """Whose fact a row is — the classification the merge rules follow from."""
+
+    PER_HOST = "per_host"
+    FLEET = "fleet"
+    HISTORY = "history"
+
+
+def _identity(kind: FieldKind) -> FieldPolicy:
+    """An IDENTITY field. The primitive requires these be IMMUTABLE+required."""
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.IDENTITY,
+        required=True,
+        merge=MergeRule.IMMUTABLE,
+        indexed=True,
+    )
+
+
+def _data(
+    kind: FieldKind,
+    merge: MergeRule,
+    *,
+    required: bool = False,
+    indexed: bool = False,
+) -> FieldPolicy:
+    """A DATA field carrying an explicit merge rule."""
+    return FieldPolicy(
+        kind=kind, role=FieldRole.DATA, required=required, merge=merge, indexed=indexed
+    )
+
+
+# ---------------------------------------------------------------------------
+# FLEET — one fact the fleet shares; disagreement is a real conflict.
+# ---------------------------------------------------------------------------
+# The cross-host directory (ADR-0014): "agent <name> is reachable at
+# host:a2a_port". This is the one table sac already syncs, and the one
+# whose existing sync is provably lossy — state_db_comms_nodes.py:241
+# admits deletion propagation "will need an UPDATE-shaped sync (future
+# work)" because INSERT OR IGNORE can carry neither an update nor a
+# tombstone.
+#
+# Two hand-rolled columns are DELETED here rather than declared, because
+# the primitive owns both concepts natively and a second copy would drift:
+#   * ``ended_at``   — the soft tombstone. The primitive's hide()/unhide()
+#                      is "the ONLY removal" and replicates as an op, so a
+#                      tombstone now propagates by construction.
+#   * ``source_host`` — hand-rolled provenance. The oplog's ``_origin`` is
+#                      exactly this, maintained by the primitive.
+#
+# ``registered_at`` is IMMUTABLE deliberately: two hosts claiming the same
+# agent NAME with different registration times is precisely the collision
+# sac already raises CommsNodeConflictError for, and IMMUTABLE reports it
+# as a MergeConflict (kept/rejected/reason) instead of quietly picking one.
+COMMS_NODES = Schema.build(
+    "sac_comms_nodes",
+    {
+        "name": _identity(FieldKind.TEXT),
+        "host": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True, indexed=True),
+        "a2a_port": _data(FieldKind.INTEGER, MergeRule.LAST_WRITER_WINS, required=True),
+        "registered_at": _data(FieldKind.REAL, MergeRule.IMMUTABLE, required=True),
+    },
+)
+
+# ---------------------------------------------------------------------------
+# HISTORY — append-only; merging must never lose a branch.
+# ---------------------------------------------------------------------------
+# One record per CHILD (a child has exactly one parent, ever), so distinct
+# edges are distinct records and a union can drop none of them. The
+# load-bearing choice is IMMUTABLE on ``parent_name``: if two hosts claim
+# different parents for one child, that is a real contradiction about the
+# spawn DAG and it surfaces as a MergeConflict carrying both values.
+# LAST_WRITER_WINS here would silently rewrite the family tree, and the
+# ACL derives group membership from it (check_lineage_acl), so a silent
+# rewrite is a silent privilege change.
+#
+# MULTI_WRITER, not SINGLE_WRITER: a cross-host spawn is brokered, so the
+# edge can legitimately be written by either end, and a second writer must
+# get the loud MergeConflict rather than an ownership rejection that says
+# nothing about WHY the two disagree.
+LINEAGE = Schema.build(
+    "sac_lineage",
+    {
+        "child_name": _identity(FieldKind.TEXT),
+        "parent_name": _data(FieldKind.TEXT, MergeRule.IMMUTABLE, required=True, indexed=True),
+        "created_at": _data(FieldKind.REAL, MergeRule.IMMUTABLE, required=True),
+    },
+)
+
+# ---------------------------------------------------------------------------
+# PER_HOST — each host is right about itself.
+# ---------------------------------------------------------------------------
+# ``host`` is an IDENTITY field, and that is the entire per-host-truth
+# mechanism: it makes compute-04's row and spartan's row DIFFERENT
+# RECORDS, so a merge between them is not resolved-in-favour-of-one, it
+# never occurs. ``id`` (uuid7, minted at the origin) is also identity, so
+# even repeated observations of one agent name stay separate lifetimes.
+#
+# The merge rules on the mutable fields are chosen so a STALE replica can
+# never move a live host's truth backwards:
+#   * last_heartbeat_at → MAX. An ISO-8601 UTC string sorts lexicographically,
+#     so MAX is a high-water mark: an old sample arriving late cannot
+#     resurrect a dead agent or rewind a live one. LAST_WRITER_WINS would
+#     let a delayed delivery do exactly that.
+#   * iter_count / input_tokens / output_tokens → MAX. Monotone counters.
+#   * ended_at / exit_reason → IMMUTABLE. A process ends ONCE. A second,
+#     different end time is not a later opinion, it is a contradiction —
+#     and sac has already been burned by believing one: on 2026-08-11
+#     eleven rows shared ended_at=2026-08-11T17:54:26Z and three readers
+#     independently read that as a simultaneous mass kill. It was one
+#     now_iso() evaluated once per GC sweep and stamped on every reaped
+#     row; the agents had died 10h46m earlier. IMMUTABLE makes the second
+#     stamp a reported conflict instead of a believed fact.
+#   * started_at → IMMUTABLE for the same reason, in the other direction.
+#
+# SINGLE_WRITER: only the observing host may write its own telemetry. An
+# agent RELOCATION (sac moves a running agent between hosts) is then not
+# an illegal cross-host write but an explicit ownership handover() — which
+# is the honest shape, because relocation already carries a fencing lease.
+INSTANCES = Schema.build(
+    "sac_instances",
+    {
+        "id": _identity(FieldKind.TEXT),
+        "host": _identity(FieldKind.TEXT),
+        "name": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True, indexed=True),
+        "pid": _data(FieldKind.INTEGER, MergeRule.LAST_WRITER_WINS),
+        "a2a_port": _data(FieldKind.INTEGER, MergeRule.LAST_WRITER_WINS),
+        "spawned_by": _data(FieldKind.TEXT, MergeRule.IMMUTABLE),
+        "started_at": _data(FieldKind.TEXT, MergeRule.IMMUTABLE, required=True),
+        "last_heartbeat_at": _data(FieldKind.TEXT, MergeRule.MAX),
+        "iter_count": _data(FieldKind.INTEGER, MergeRule.MAX),
+        "input_tokens": _data(FieldKind.INTEGER, MergeRule.MAX),
+        "output_tokens": _data(FieldKind.INTEGER, MergeRule.MAX),
+        "ended_at": _data(FieldKind.TEXT, MergeRule.IMMUTABLE),
+        "exit_reason": _data(FieldKind.TEXT, MergeRule.IMMUTABLE),
+    },
+)
+
+
+# The two ACL tables. Both are FLEET truth, and both are declared rather
+# than deferred because getting an ACL wrong is a PRIVILEGE bug: an ACL
+# that silently diverges between hosts means the same agent is authorised
+# on one host and refused on another, which reads as a flaky feature
+# rather than as a security fault.
+#
+# comms_grants is the case that most needs the primitive. It is a SET, and
+# its revocation is a raw DELETE today — a deletion INSERT OR IGNORE can
+# never carry, so a revoked grant is resurrected by the next pull from any
+# peer that still has it. Under the primitive, revoke is hide(), which
+# replicates as an op like any other; that single change is the difference
+# between a revocation that sticks and one that silently comes back.
+COMMS_GRANTS = Schema.build(
+    "sac_comms_grants",
+    {
+        "sender_name": _identity(FieldKind.TEXT),
+        "target_name": _identity(FieldKind.TEXT),
+        "created_at": _data(FieldKind.REAL, MergeRule.IMMUTABLE, required=True),
+        "note": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS),
+    },
+)
+
+# Per-agent capsule-isolation policy, upserted at every agent_start from
+# the loaded spec. Its content is DERIVED from the spec, so the newest
+# write is genuinely the best answer and LAST_WRITER_WINS is honest here —
+# unlike on a heartbeat, where the newest DELIVERY is not the newest FACT.
+# ``updated_at`` is MAX rather than LWW so the row's own clock cannot be
+# walked backwards by a late-arriving stale replica.
+NODE_COMMS_POLICY = Schema.build(
+    "sac_node_comms_policy",
+    {
+        "name": _identity(FieldKind.TEXT),
+        "outbound_siblings": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
+        "outbound_parent": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
+        "inbound_siblings": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
+        "inbound_parent": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
+        "lineage_group": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
+        "may_spawn": _data(FieldKind.BOOL, MergeRule.LAST_WRITER_WINS, required=True),
+        "group_names": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
+        "updated_at": _data(FieldKind.REAL, MergeRule.MAX, required=True),
+    },
+)
+
+
+#: Every schema sac declares, with the classification it follows from.
+CLASSIFIED: dict[str, tuple[Schema, Truth, WriterPolicy]] = {
+    "sac_comms_nodes": (COMMS_NODES, Truth.FLEET, WriterPolicy.SINGLE_WRITER),
+    "sac_comms_grants": (COMMS_GRANTS, Truth.FLEET, WriterPolicy.MULTI_WRITER),
+    "sac_node_comms_policy": (
+        NODE_COMMS_POLICY,
+        Truth.FLEET,
+        WriterPolicy.SINGLE_WRITER,
+    ),
+    "sac_lineage": (LINEAGE, Truth.HISTORY, WriterPolicy.MULTI_WRITER),
+    "sac_instances": (INSTANCES, Truth.PER_HOST, WriterPolicy.SINGLE_WRITER),
+}
+
+
+#: Which sac state table each declared schema replicates, so the
+#: classification can be checked for COMPLETENESS against the real DB
+#: rather than against this module's own opinion of it.
+SOURCE_TABLE: dict[str, str] = {
+    "sac_comms_nodes": "comms_nodes",
+    "sac_comms_grants": "comms_grants",
+    "sac_node_comms_policy": "node_comms_policy",
+    "sac_lineage": "lineage",
+    "sac_instances": "instances",
+}
+
+
+#: Tables in sac's state DB that MUST NOT replicate, and why.
+#:
+#: A refusal is a design decision and belongs in the declaration, not in a
+#: reviewer's memory. Two of these would be actively harmful to sync and
+#: one is merely worthless; the reason field is what lets a future reader
+#: tell those apart, exactly as it does for ``_system_deps``.
+NEVER_SYNCED: dict[str, str] = {
+    "node_tokens": (
+        "bearer SECRETS. A token is the authenticated identity the listen "
+        "server resolves Authorization: Bearer against; replicating it "
+        "hands every host the credentials to impersonate every agent on "
+        "every other host, turning one host's compromise into the fleet's"
+    ),
+    "channel_events": (
+        "the autoincrement id IS the SSE cursor a client passes back as "
+        "Last-Event-ID. Interleaving another host's numbering silently "
+        "changes what 'resume from N' means, so a reconnecting client "
+        "skips or replays frames with no error anywhere"
+    ),
+    "acl_deny_notify_log": (
+        "a per-host rate-limit ledger (last_notified_at). Merging it "
+        "suppresses a deny-notification on a host that never sent one — "
+        "the failure is a notification that does NOT arrive, which is "
+        "invisible by construction"
+    ),
+    "instance_heartbeats": (
+        "the per-sample heartbeat STREAM, thousands of rows per agent per "
+        "day, whose fleet-relevant content is one number: the latest. That "
+        "number is carried as sac_instances.last_heartbeat_at under "
+        "MergeRule.MAX, so syncing the stream would move the same fact at "
+        "thousands of times the cost"
+    ),
+    "attempts": (
+        "declared in KNOWN_TABLES and exported by sac today, but it has "
+        "ZERO writers anywhere in src/ — replicating a table nothing "
+        "writes moves no information"
+    ),
+    "definitions": (
+        "same: in KNOWN_TABLES, FK'd from instances.definition_id, and "
+        "never INSERTed by any code path. Sync it only once something "
+        "writes it; a spec is a promise and its truth is the YAML on disk"
+    ),
+    "events": (
+        "per-host lifecycle log carrying only kind='start'/'stop', both of "
+        "which are already the started_at/ended_at columns of the "
+        "sac_instances row it points at. Its autoincrement id would also "
+        "collide across hosts, so it costs a key rewrite to move a fact "
+        "that is already replicated"
+    ),
+    "turns": (
+        "the agent conversation diary — prompt_text and response_text, i.e. "
+        "the full content of what agents were asked and answered. It has NO "
+        "primary key at all, so today's importer duplicates every row on "
+        "every re-import. High-volume per-host diagnostics whose content is "
+        "the most sensitive thing in the DB: it should not leave its host "
+        "as a side effect of a directory sync"
+    ),
+    "errors": (
+        "per-host error journal keyed by an autoincrement error_id. Useful "
+        "to READ across hosts, but that is a query concern; replicating it "
+        "puts an unbounded diagnostic stream on the sync path and its ids "
+        "collide between hosts"
+    ),
+    "heartbeats": (
+        "the diary-style heartbeat stream (name, host, pid, state, ts), "
+        "append-only with an autoincrement id and no uniqueness. Same "
+        "argument as instance_heartbeats: the fleet-relevant content is the "
+        "latest sample, carried as sac_instances.last_heartbeat_at"
+    ),
+}
+
+
+def provide() -> list:
+    """sac's store plugins, for ``scitex_dev.store.discover_store_plugins``.
+
+    Returns ``list[StorePlugin]``. The import is deliberately local and
+    deliberately NOT guarded: ``StorePlugin`` ships with the store
+    federation, and a leaf that silently degraded to "no plugins" when the
+    federation is absent would be indistinguishable from a leaf that
+    declares nothing — the exact success-shaped failure this whole module
+    exists to avoid. The discoverer already skips a raising provider with
+    a logged warning, so the loud path is also the safe one.
+    """
+    from scitex_dev.store import StorePlugin
+
+    return [
+        StorePlugin(
+            name=name,
+            pkg=_PKG,
+            schema=schema,
+            writer_policy=policy,
+            provider=_PROVIDER,
+            description=f"sac {truth.value} state",
+        )
+        for name, (schema, truth, policy) in CLASSIFIED.items()
+    ]
+
+
+__all__ = [
+    "CLASSIFIED",
+    "COMMS_NODES",
+    "INSTANCES",
+    "LINEAGE",
+    "NEVER_SYNCED",
+    "Truth",
+    "provide",
+]
+
+# EOF

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -33,6 +33,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev.linter._rules._base",
     "scitex_dev.linter._rules._lookup",
     "scitex_dev.linter.checker",
+    "scitex_dev.store",
     "scitex_dev.system_deps",
     "scitex_dev.versioning",
     "scitex_logging",

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
@@ -160,6 +160,22 @@ LIVE_STORE_JSON = json.dumps(
     }
 )
 
+#: The SAME store, once it also reports the engine half of its identity.
+#: ``store_uuid`` lives in the rows and is therefore copied by a fork;
+#: ``system_identifier`` comes from the engine (Postgres
+#: ``pg_control_system()``), which a file copy cannot carry with it. On
+#: 2026-08-11 two endpoints shared the uuid below while their
+#: system_identifiers differed — 7671108644284358700 vs 7672112238472680366 —
+#: and that difference was the only thing that distinguished them.
+PAIRED_STORE_JSON = json.dumps(
+    {
+        "resolved": "postgresql://scitex_cards@127.0.0.1:55432/scitex_cards",
+        "backend": "postgresql",
+        "store_uuid": "1d55dd6e-3d2a-4c24-a429-a78835ab988f",
+        "system_identifier": "7671108644284358700",
+    }
+)
+
 #: The ABANDONED sidecar, measured the same night: 365 rows, 149 unseen, a
 #: zero-byte WAL, and no write since the previous morning while readers kept
 #: attaching. Opened constantly, written never.

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/test__awaiting_operator.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/test__awaiting_operator.py
@@ -32,6 +32,7 @@ from scitex_agent_container._never_stop_when_task_remains._awaiting_operator imp
 from ._fake_detector import (
     DEAD_SIDECAR_JSON,
     LIVE_STORE_JSON,
+    PAIRED_STORE_JSON,
     SCOPE_ENV,
     awaiting_cards,
     isolate_runtime,
@@ -320,6 +321,60 @@ def test_the_line_carries_the_store_uuid(env_save_restore, tmp_path):
     line = notice("agent-x")
     # Assert
     assert "uuid 1d55dd6e" in line
+
+
+def test_a_uuid_without_the_engine_half_is_marked_fork_undetectable(
+    env_save_restore, tmp_path
+):
+    """A uuid stored INSIDE the database is copied by a fork of that database.
+
+    Measured 2026-08-11: two endpoints both answered store_uuid 1d55dd6e while
+    holding 404 and 146 cards the other lacked. Printing that uuid bare invites
+    the false inference that two agents quoting it share a store.
+    """
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, LIVE_STORE_JSON)
+    awaiting_cards(
+        env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=30)]
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "fork undetectable" in line
+
+
+def test_the_engine_identifier_is_carried_when_the_store_reports_it(
+    env_save_restore, tmp_path
+):
+    """The engine half is the part a file copy cannot bring with it."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, PAIRED_STORE_JSON)
+    awaiting_cards(
+        env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=30)]
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "sys 76711086" in line
+
+
+def test_a_paired_identity_is_not_marked_fork_undetectable(
+    env_save_restore, tmp_path
+):
+    """The caveat must disappear once the pair can actually detect a fork —
+    a warning that never clears is one readers learn to ignore."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, PAIRED_STORE_JSON)
+    awaiting_cards(
+        env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=30)]
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "fork undetectable" not in line
 
 
 def test_a_store_password_is_never_printed():

--- a/tests/scitex_agent_container/test__store_plugin.py
+++ b/tests/scitex_agent_container/test__store_plugin.py
@@ -1,0 +1,398 @@
+"""sac's leaf declaration for multi-host sync: what its state MEANS.
+
+These tests deliberately EXERCISE ``scitex_dev.store.merge_field`` with real
+values rather than asserting that a declaration contains a particular enum
+member. Asserting ``policy.merge is MergeRule.MAX`` only proves this module
+says MAX; running the merge proves a stale replica cannot roll a live host's
+heartbeat backwards, which is the property anyone actually depends on.
+
+No mocks (PA-306): the real primitive, the real policies, the real
+entry-point metadata. AAA markers, one assertion per test.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+import pytest
+from scitex_dev.store import HLC, MergeRule, merge_field
+
+from scitex_agent_container._state.state_db import KNOWN_TABLES
+from scitex_agent_container._store_plugin import (
+    CLASSIFIED,
+    INSTANCES,
+    LINEAGE,
+    NEVER_SYNCED,
+    SOURCE_TABLE,
+    Truth,
+    provide,
+)
+
+_GROUP = "scitex_dev.store.plugins"
+
+
+def _stamp(wall_us: int, node: str = "compute-04") -> HLC:
+    return HLC(wall_us=wall_us, logical=0, node=node)
+
+
+# ---------------------------------------------------------------------------
+# Completeness — the anti-omission gate.
+# ---------------------------------------------------------------------------
+
+
+def test_every_known_table_has_an_explicit_sync_decision():
+    # Arrange: the failure this guards is a NEW table added to the state DB
+    # that nobody classified. It would then be silently absent from sync,
+    # which looks identical to a table deliberately excluded. Forcing every
+    # KNOWN_TABLES entry into exactly one of the two sets makes the omission
+    # a red test instead of a quiet gap.
+    decided = set(SOURCE_TABLE.values()) | set(NEVER_SYNCED)
+    # Act
+    undecided = sorted(set(KNOWN_TABLES) - decided)
+    # Assert
+    assert undecided == []
+
+
+def test_no_table_is_both_replicated_and_never_synced():
+    # Arrange: the two sets are a partition, not overlapping opinions.
+    replicated = set(SOURCE_TABLE.values())
+    # Act
+    both = sorted(replicated & set(NEVER_SYNCED))
+    # Assert
+    assert both == []
+
+
+def test_every_refusal_states_why():
+    # Arrange: mirrors the _system_deps doctrine — the REASON is the point.
+    # "channel_events: excluded" would satisfy a non-empty check and carry
+    # nothing a future reader could act on.
+    # Act
+    thin = sorted(t for t, why in NEVER_SYNCED.items() if len(why.split()) < 12)
+    # Assert
+    assert thin == []
+
+
+# ---------------------------------------------------------------------------
+# PER-HOST TRUTH — two hosts disagreeing must not be a conflict at all.
+# ---------------------------------------------------------------------------
+
+
+def test_host_is_part_of_the_instance_identity():
+    # Arrange: this single fact IS the per-host-truth mechanism. With host in
+    # the key, compute-04's observation and spartan's observation are
+    # different RECORDS, so no merge rule ever has to choose between two true
+    # observations of two different processes.
+    schema = INSTANCES
+    # Act
+    identity = schema.identity_fields
+    # Assert
+    assert "host" in identity
+
+
+def test_the_field_the_per_host_identity_depends_on_is_actually_written(tmp_path):
+    """A column declared in a schema and never populated is inert.
+
+    This fleet found four such things in one night — scitex_dev.store with
+    zero callers, spec.provider:openai with no runner, a freshness value
+    hardcoded so it cannot fail, and scitex-cards' own ``origin_node``,
+    declared at SCHEMA_VERSION 11 and written by nothing. Reading a schema
+    tells you a field is PRESENT, never that it is FILLED.
+
+    ``sac_instances`` puts ``host`` in the record identity, so if sac did not
+    actually write that column the whole per-host classification would rest on
+    an empty string and every host's rows would collide into one anonymous
+    record. This exercises the real writer against a real (temporary) DB with
+    no host argument, so it also proves the DEFAULT populates it — a value
+    that only appears when a caller remembers to pass it is not an origin.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+    from scitex_agent_container._state.state_db_export import export_state
+
+    db = tmp_path / "state.db"
+    record_instance_start("agent-under-test", db_path=db)
+    # Act
+    rows = export_state(db_path=db)["tables"]["instances"]
+    # Assert
+    assert (rows[0]["host"] or "").strip() != ""
+
+
+def test_a_stale_replica_cannot_roll_a_heartbeat_backwards():
+    # Arrange: the live host observed 12:00:05. An older sample (12:00:01)
+    # arrives LATE, so it carries the HIGHER hlc — under LAST_WRITER_WINS it
+    # would win and rewind a live agent. MAX makes the field a high-water
+    # mark, so delivery order cannot rewrite observation order.
+    policy = INSTANCES.fields["last_heartbeat_at"]
+    # Act
+    outcome = merge_field(
+        "last_heartbeat_at",
+        policy,
+        current="2026-08-12T12:00:05Z",
+        current_stamp=_stamp(1_000),
+        incoming="2026-08-12T12:00:01Z",
+        incoming_stamp=_stamp(9_999),
+    )
+    # Assert
+    assert outcome.value == "2026-08-12T12:00:05Z"
+
+
+def test_monotone_counters_never_decrease():
+    # Arrange: iter_count is monotone; a late-delivered lower sample must not
+    # subtract work the agent demonstrably did.
+    policy = INSTANCES.fields["iter_count"]
+    # Act
+    outcome = merge_field(
+        "iter_count",
+        policy,
+        current=412,
+        current_stamp=_stamp(1_000),
+        incoming=7,
+        incoming_stamp=_stamp(9_999),
+    )
+    # Assert
+    assert outcome.value == 412
+
+
+def test_a_second_different_end_time_is_reported_not_believed():
+    # Arrange: the 2026-08-11 incident — eleven rows stamped with one
+    # now_iso() evaluated once per GC sweep, read by three separate readers
+    # as a simultaneous mass kill when the agents had died 10h46m earlier. A
+    # process ends ONCE, so a second differing end time is a contradiction,
+    # and IMMUTABLE surfaces it as a conflict instead of overwriting.
+    policy = INSTANCES.fields["ended_at"]
+    # Act
+    outcome = merge_field(
+        "ended_at",
+        policy,
+        current="2026-08-11T07:08:00Z",
+        current_stamp=_stamp(1_000),
+        incoming="2026-08-11T17:54:26Z",
+        incoming_stamp=_stamp(9_999),
+    )
+    # Assert
+    assert outcome.conflict is not None
+
+
+def test_the_original_end_time_survives_that_conflict():
+    # Arrange: reporting a conflict is only half the guarantee — the first
+    # observation must also still be the one presented.
+    policy = INSTANCES.fields["ended_at"]
+    # Act
+    outcome = merge_field(
+        "ended_at",
+        policy,
+        current="2026-08-11T07:08:00Z",
+        current_stamp=_stamp(1_000),
+        incoming="2026-08-11T17:54:26Z",
+        incoming_stamp=_stamp(9_999),
+    )
+    # Assert
+    assert outcome.value == "2026-08-11T07:08:00Z"
+
+
+# ---------------------------------------------------------------------------
+# HISTORY — merging must never lose a branch.
+# ---------------------------------------------------------------------------
+
+
+def test_two_hosts_claiming_different_parents_is_a_reported_conflict():
+    # Arrange: the ACL derives group membership from lineage
+    # (check_lineage_acl), so a silent rewrite of the family tree is a silent
+    # privilege change. LAST_WRITER_WINS would take whichever host spoke
+    # last; IMMUTABLE reports the contradiction carrying BOTH values.
+    policy = LINEAGE.fields["parent_name"]
+    # Act
+    outcome = merge_field(
+        "parent_name",
+        policy,
+        current="scitex-dev",
+        current_stamp=_stamp(1_000),
+        incoming="scitex-cards",
+        incoming_stamp=_stamp(9_999),
+    )
+    # Assert
+    assert outcome.conflict is not None
+
+
+def test_the_rejected_parent_is_named_in_the_conflict():
+    # Arrange: a conflict that says only "there was a conflict" cannot be
+    # acted on. The report must carry what was dropped.
+    policy = LINEAGE.fields["parent_name"]
+    # Act
+    outcome = merge_field(
+        "parent_name",
+        policy,
+        current="scitex-dev",
+        current_stamp=_stamp(1_000),
+        incoming="scitex-cards",
+        incoming_stamp=_stamp(9_999),
+    )
+    # Assert
+    assert outcome.conflict.rejected == "scitex-cards"
+
+
+def test_each_child_is_its_own_record_so_no_branch_can_collide():
+    # Arrange: "merging must never lose a branch" reduces to keying the edge
+    # by the child. Distinct children are then distinct records and a union
+    # can drop none of them.
+    schema = LINEAGE
+    # Act
+    identity = schema.identity_fields
+    # Assert
+    assert identity == ("child_name",)
+
+
+# ---------------------------------------------------------------------------
+# Refusals that are security-relevant.
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_tokens_are_never_replicated():
+    # Arrange: node_tokens is the authenticated-identity primitive. Copying
+    # it to every host turns one host's compromise into the fleet's.
+    # Act
+    refused = "node_tokens" in NEVER_SYNCED
+    # Assert
+    assert refused
+
+
+def test_the_sse_cursor_table_is_never_replicated():
+    # Arrange: channel_events.id IS the Last-Event-ID a client resumes from.
+    # Interleaving another host's numbering makes "resume from N" mean
+    # something different, so a reconnecting client skips or replays frames
+    # with no error raised anywhere.
+    # Act
+    refused = "channel_events" in NEVER_SYNCED
+    # Assert
+    assert refused
+
+
+# ---------------------------------------------------------------------------
+# The classification itself.
+# ---------------------------------------------------------------------------
+
+
+def test_instances_is_the_per_host_classification():
+    # Arrange
+    _schema, truth, _policy = CLASSIFIED["sac_instances"]
+    # Act
+    got = truth
+    # Assert
+    assert got is Truth.PER_HOST
+
+
+def test_the_directory_is_fleet_truth():
+    # Arrange: "agent X is reachable at host:port" is the same claim on every
+    # host, so disagreement here IS a conflict and needs a stated rule.
+    _schema, truth, _policy = CLASSIFIED["sac_comms_nodes"]
+    # Act
+    got = truth
+    # Assert
+    assert got is Truth.FLEET
+
+
+def test_a_declared_identity_field_is_never_last_writer_wins():
+    # Arrange: an identity field that could be overwritten would silently
+    # re-key a record, which is indistinguishable from losing it.
+    offenders = [
+        f"{name}.{field}"
+        for name, (schema, _t, _w) in CLASSIFIED.items()
+        for field in schema.identity_fields
+        if schema.fields[field].merge is MergeRule.LAST_WRITER_WINS
+    ]
+    # Act
+    got = sorted(offenders)
+    # Assert
+    assert got == []
+
+
+def test_the_tombstone_column_is_not_redeclared():
+    # Arrange: comms_nodes.ended_at was a hand-rolled soft tombstone that
+    # INSERT OR IGNORE could never propagate. The primitive's hide() is "the
+    # ONLY removal" and replicates as an op, so keeping a second copy of the
+    # concept would let the two drift.
+    schema, _t, _w = CLASSIFIED["sac_comms_nodes"]
+    # Act
+    declared = sorted(schema.fields)
+    # Assert
+    assert "ended_at" not in declared
+
+
+# ---------------------------------------------------------------------------
+# Federation wiring.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sac_entry_point():
+    """The installed entry point, or skip when the package is not installed."""
+    eps = [ep for ep in entry_points(group=_GROUP) if ep.name == "scitex-agent-container"]
+    if not eps:
+        pytest.skip("scitex-agent-container entry point not installed in this env")
+    return eps[0]
+
+
+@pytest.fixture
+def federation_available():
+    """Skip unless scitex-dev has landed the StorePlugin federation."""
+    try:
+        from scitex_dev.store import StorePlugin  # noqa: F401
+    except ImportError:
+        pytest.skip("scitex_dev.store.StorePlugin not shipped yet")
+    return True
+
+
+def test_the_entry_point_is_registered(sac_entry_point):
+    # Arrange: the module existing is not enough — discover_store_plugins
+    # finds leaves through the entry-point group, so an unregistered provider
+    # is invisible no matter how well it is written.
+    ep = sac_entry_point
+    # Act
+    name = ep.name
+    # Assert
+    assert name == "scitex-agent-container"
+
+
+def test_the_entry_point_resolves_to_this_provider(sac_entry_point):
+    # Arrange: a registered name that loads something else is worse than an
+    # absent one, because it looks correct in the metadata.
+    ep = sac_entry_point
+    # Act
+    loaded = ep.load()
+    # Assert
+    assert loaded is provide
+
+
+@pytest.fixture
+def federation_absent():
+    """Skip unless the StorePlugin federation is still unshipped."""
+    try:
+        from scitex_dev.store import StorePlugin  # noqa: F401
+    except ImportError:
+        return True
+    pytest.skip("federation present; the absent-path contract is not exercisable")
+
+
+def test_provide_raises_rather_than_returning_an_empty_list(federation_absent):
+    # Arrange: scitex_dev.store 0.47.0 ships the primitive but NOT the
+    # StorePlugin federation. A leaf that degraded to "no plugins" would be
+    # indistinguishable from a leaf that declares nothing — the exact
+    # success-shaped failure this work exists to remove. When the federation
+    # is absent the answer must be an exception, never a quiet [].
+    provider = provide
+    # Act
+    caught = pytest.raises(ImportError)
+    # Assert
+    with caught:
+        provider()
+
+
+def test_provide_declares_every_classified_schema(federation_available):
+    # Arrange: the federation dedups on plugin name, so a leaf that silently
+    # dropped one of its schemas would simply be absent from the merge with
+    # nothing reporting it.
+    plugins = provide()
+    # Act
+    names = sorted(p.name for p in plugins)
+    # Assert
+    assert names == sorted(CLASSIFIED)


### PR DESCRIPTION
The sac leaf of the three-party multi-host DB sync (scitex-dev owns the primitive and federates, scitex-cards declares card semantics, sac declares its own). **No sync mechanism is built here** — `scitex_dev.store` already has the oplog, HLC, per-origin cursors, the gapless `first_seq == cursor + 1` assertion and field-level merge. This says what sac's rows MEAN. No SQL, no connection, sac is a leaf and not privileged.

## The classification is the design

| kind | tables | why |
|---|---|---|
| **PER-HOST** | `instances` | compute-04 and spartan describing "the same agent" describe **two different processes**, and each is right about itself. Merging them is the bug. |
| **FLEET** | `comms_nodes`, `comms_grants`, `node_comms_policy` | one fact the fleet shares, so disagreement IS a conflict and needs a rule |
| **HISTORY** | `lineage` | append-only; a merge must never lose a branch |
| **REFUSED** | 10 more, each with a stated reason | a refusal is a design decision, not a reviewer's memory |

Per-host truth needed no new merge rule. Putting `host` in the record **IDENTITY** makes the two observations different *records* that never meet in a merge at all — so two hosts disagreeing is not resolved-in-favour-of-one, it never occurs. `SINGLE_WRITER` then matches the primitive's own documented case, "a host writing its own telemetry", and agent **relocation** becomes an explicit ownership `handover()` rather than an illegal cross-host write.

The merge rules follow rather than being chosen:
- `last_heartbeat_at` → **MAX**, not LWW. Newest *delivery* is not newest *fact*; a late older sample must not rewind a live agent.
- `ended_at` → **IMMUTABLE**. A process ends once. sac has already been burned believing otherwise: eleven rows sharing one `now_iso()` from a single GC sweep were read by three separate readers as a simultaneous mass kill, when the agents had died 10h46m earlier.
- `lineage.parent_name` → **IMMUTABLE**. The ACL derives group membership from lineage, so a silent rewrite of the family tree is a silent privilege change.

Two hand-rolled columns are **dropped** rather than declared, because the primitive owns both natively: `comms_nodes.ended_at` (the soft tombstone `state_db_comms_nodes` admits `INSERT OR IGNORE` cannot carry — `hide()` replicates as an op) and `source_host` (the oplog's `_origin`).

## How divergence becomes loud

Measured live on scitex-compute-04, both endpoints readable, every call exit 0:

```
in-container  /state/scitex-agent-container/state.db      instances 0    events 0    lineage 0
bare host     ~/.scitex/.../runtime/state.db              instances 192  events 366  lineage 4
```

That is the shape this work targets: an empty read cannot distinguish "no rows anywhere" from "I only looked in one place". Three failures last night all reported success. So:

- conflicts are **reported**, not resolved — `IMMUTABLE` returns a `MergeConflict` carrying kept/rejected/reason instead of picking a winner
- `provide()` **raises** rather than returning `[]` when the federation is absent, because a silent empty list is indistinguishable from a leaf that declares nothing
- a completeness test asserts every `KNOWN_TABLES` entry is in exactly one of replicated-or-refused, so a new table cannot be added without a sync decision

## Identity

sac's `_awaiting_operator` claimed `store_uuid` "is THE thing that separates two clones of the same database". **It is not** — a uuid stored inside a database is copied by a fork of it, so it names the lineage, never the instance. On 2026-08-11 two endpoints both answered `store_uuid 1d55dd6e` while holding 404 and 146 cards the other lacked. The line now carries the engine half when reported and says `fork undetectable` when it cannot, because a bare uuid invites exactly the inference that was false that night.

## Does sac's state know where it came from?

Checked by grepping for **writers**, not by reading the schema (prompted by scitex-cards finding its own `origin_node` declared at schema version 11 and written by nothing):

- `instances.host` — **written**, by default rather than only when a caller passes it. A test exercises the real writer against a real temp DB, because the per-host identity is worthless if that column is merely present.
- `lineage`, `comms_grants`, `node_comms_policy`, `node_tokens`, `channel_events` — **no origin column at all**
- `comms_nodes.source_host` — NULL for every locally-created row; it records who a row was pulled *from*, not who made it

Adopting the primitive closes that gap (`_origin` is stamped on every op). But `_origin` is *provenance* and `host` is *subject*; they coincide only while SINGLE_WRITER holds, so conflating them would rebuild the bug somewhere new.

## Verification

19 + 98 tests green. **Every load-bearing assertion was driven red first**: six sabotaged declarations (MAX→LWW, IMMUTABLE→LWW, `host` out of identity, a dropped refusal) produce **nine** failures, and reverting the identity render reproduces the misleading `(uuid 1d55dd6e)` string. Tests exercise the real `merge_field` with real values rather than asserting a declaration contains an enum member.

## Left out, deliberately

- sac's `INSERT OR IGNORE` importer is **untouched** — it is what the primitive replaces. Its `rowcount 0` means both "identical duplicate" and "contradiction", so its success value is also its didn't-happen value.
- the eleven live tables outside `KNOWN_TABLES` (`dispatches`, `a2a_ports`, `relocation_*`, …) are unclassified
- `provide()` raises until scitex-dev lands `StorePlugin` — currently **uncommitted** in its worktree, so the entry point is inert until then. Group name and shape were confirmed with scitex-dev by a2a rather than assumed.
