### PR TITLE
fix(accounts): one account was showing up as two, and both bars were believed

### DIFF
--- a/src/scitex_agent_container/_account/account_identity.py
+++ b/src/scitex_agent_container/_account/account_identity.py
@@ -37,12 +37,19 @@ from .claude_usage import (
 _PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
 
 
-def _fetch_email_from_api(access_token: str, *, opener=None) -> str | None:
-    """GET the OAuth profile and return ``account.email``, or None on failure.
+def _fetch_identity_from_api(
+    access_token: str, *, opener=None
+) -> tuple[str | None, str | None]:
+    """GET the OAuth profile; return ``(account.email, account.uuid)``.
+
+    The UUID is the STRONGEST identity the endpoint exposes and the only one
+    that survives a display-name or email change, so duplicate detection keys
+    off it in preference to the email. Either element is ``None`` when the
+    response omits it; ``(None, None)`` on any failure.
 
     Best-effort: every failure mode (network error, non-2xx, non-JSON body,
-    unexpected shape) collapses to ``None``. The token is used only to build
-    the ``Authorization`` header here and never leaves the function.
+    unexpected shape) collapses to ``(None, None)``. The token is used only
+    to build the ``Authorization`` header here and never leaves the function.
     """
     req = urllib.request.Request(
         _PROFILE_URL,
@@ -62,17 +69,24 @@ def _fetch_email_from_api(access_token: str, *, opener=None) -> str | None:
             raw = resp.read()
         payload = json.loads(raw)
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        return None
+        return None, None
 
     if not isinstance(payload, dict):
-        return None
+        return None, None
     account = payload.get("account")
     if not isinstance(account, dict):
-        return None
+        return None, None
     email = account.get("email")
-    if isinstance(email, str) and email.strip():
-        return email.strip()
-    return None
+    uuid = account.get("uuid")
+    return (
+        email.strip() if isinstance(email, str) and email.strip() else None,
+        uuid.strip() if isinstance(uuid, str) and uuid.strip() else None,
+    )
+
+
+def _fetch_email_from_api(access_token: str, *, opener=None) -> str | None:
+    """``_fetch_identity_from_api`` narrowed to the email (back-compat)."""
+    return _fetch_identity_from_api(access_token, opener=opener)[0]
 
 
 def fetch_account_email(credentials_path: Path, *, opener=None) -> str | None:
@@ -95,10 +109,29 @@ def fetch_account_email(credentials_path: Path, *, opener=None) -> str | None:
     Returns:
         The account email string, or ``None`` on any failure/offline path.
     """
+    return fetch_account_identity(credentials_path, opener=opener)[0]
+
+
+def fetch_account_identity(
+    credentials_path: Path, *, opener=None
+) -> tuple[str | None, str | None]:
+    """Return ``(email, account_uuid)`` for the token in ``credentials_path``.
+
+    The full-identity form of :func:`fetch_account_email`. Callers that need
+    to answer "are these two stored accounts the SAME Anthropic account?"
+    must compare the UUID: two DIFFERENT tokens can authenticate as one
+    account (measured 2026-08-12 — two store directories held distinct
+    tokens whose profiles returned the same ``account.uuid``), so a token
+    fingerprint is NOT an account identity and comparing fingerprints
+    reports "distinct" for a genuine duplicate.
+
+    Same contract as :func:`fetch_account_email`: reads the token internally,
+    never returns it, never raises, ``(None, None)`` on any failure.
+    """
     access_token, _, _, _ = _read_tokens_at(Path(credentials_path))
     if not access_token:
-        return None
-    return _fetch_email_from_api(access_token, opener=opener)
+        return None, None
+    return _fetch_identity_from_api(access_token, opener=opener)
 
 
-__all__ = ["fetch_account_email"]
+__all__ = ["fetch_account_email", "fetch_account_identity"]

--- a/src/scitex_agent_container/_account/account_verify.py
+++ b/src/scitex_agent_container/_account/account_verify.py
@@ -1,0 +1,339 @@
+"""Verify that a stored account's credential really belongs to that account.
+
+INCIDENT 2026-08-12 — `sac accounts list` reported ``ywatanabe-scitex-ai``
+at 2 % weekly while the Anthropic console showed 92 % for that account. The
+number was not stale and not miscomputed: it was **truthful about a
+different account**. ``accounts/anthropic/ywatanabe-scitex-ai/`` held a
+credential that authenticates as ``ywata1989@gmail.com``, so one account was
+rendered as two rows with two labels, and a capacity plan was built on the
+resulting phantom headroom.
+
+The defect is that account identity was resolved **by directory name**. A
+stored credential carries no identity claim whatsoever — the OAuth snapshot
+holds only ``accessToken`` / ``refreshToken`` / ``expiresAt`` / ``scopes`` /
+``subscriptionType`` / ``rateLimitTier``, and the tokens are opaque
+``sk-ant-oat01-…`` strings, not decodable JWTs. So the ONLY things naming an
+account were the directory name and the ``account.json`` sidecar written
+beside it, neither of which is re-checked after it is written. Any operation
+that puts a credential in the wrong directory — a manual ``/login``, a store
+consolidation onto a new canonical host, a rotation, a push to a peer —
+relabels one account as another permanently and invisibly. Nothing looks
+broken; every number stays internally consistent.
+
+This module supplies the missing check. ``GET /api/oauth/profile`` returns
+the account a bearer token actually authenticates as, and sac already calls
+its sibling ``/api/oauth/usage`` with the same headers on the same host, so
+the authoritative answer costs one extra GET.
+
+Binding the cache to the token
+------------------------------
+A cached verification has exactly the staleness problem it exists to solve:
+verify at 09:00, re-login at 09:30, and a 6-hour TTL keeps asserting the old
+identity. So the cache is keyed to the FINGERPRINT of the token it verified
+(``sha256`` prefix — a digest, never the token). When the credential file
+changes for any reason, the fingerprint changes, the cached verdict no
+longer applies, and the account is re-verified or reported UNVERIFIED. A
+``/login`` therefore invalidates the verdict the instant it lands, rather
+than after a timeout. The TTL remains as a second bound for the case where
+the same token is held across a server-side account change.
+
+States
+------
+``verified``    the profile endpoint answered and the account it named
+                matches what this directory claims.
+``mismatch``    the profile endpoint answered and named a DIFFERENT account.
+                The directory label is wrong; every figure attributed to
+                this row belongs to someone else.
+``unverified``  no answer (offline, no token, non-2xx, stale fingerprint).
+                sac does not know whose numbers these are.
+
+``unverified`` is deliberately NOT merged into ``verified``: "could not
+check" and "checked and fine" are different facts, and rendering them alike
+is the defect this module exists to remove.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from .account_identity import fetch_account_identity
+from .token_refresh import _read_tokens_at
+
+# Identity is stable, so a long TTL is fine; the token-fingerprint binding
+# (see the module docstring) is what actually catches a re-login, and it is
+# immediate. The TTL only bounds the case where the SAME token outlives a
+# server-side account change.
+_VERIFY_TTL_SECONDS = 6 * 3600
+
+VERIFIED = "verified"
+MISMATCH = "mismatch"
+UNVERIFIED = "unverified"
+
+
+@dataclass(frozen=True)
+class AccountIdentity:
+    """The verdict on one stored account's identity.
+
+    ``claimed_email`` is what the store SAYS (``account.json``);
+    ``verified_email`` / ``verified_uuid`` are what the token PROVED.
+    ``duplicate_of`` is filled in by :func:`mark_duplicates` once the whole
+    set is known — a single account cannot know it is a duplicate.
+    """
+
+    name: str
+    state: str
+    claimed_email: str | None = None
+    verified_email: str | None = None
+    verified_uuid: str | None = None
+    verified_at: str | None = None
+    duplicate_of: str | None = None
+
+    @property
+    def trustworthy(self) -> bool:
+        """True only when the label was CHECKED and found correct.
+
+        Any figure rendered under this account's name is attributable to
+        that name only when this is true. ``unverified`` returns False —
+        an unchecked label is not a correct one.
+        """
+        return self.state == VERIFIED and self.duplicate_of is None
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def token_fingerprint(access_token: str | None) -> str | None:
+    """Stable non-reversible digest of a token, for cache invalidation.
+
+    A truncated ``sha256`` — enough to detect that the credential changed,
+    useless for authenticating. Never store or log the token itself.
+    """
+    if not access_token:
+        return None
+    return hashlib.sha256(access_token.encode("utf-8")).hexdigest()[:16]
+
+
+def _cache_path(credentials_path: Path) -> Path:
+    """Identity verdict lives beside the credential, like ``usage.json``."""
+    return Path(credentials_path).parent / "identity.json"
+
+
+def _read_cache(path: Path, *, fingerprint: str | None, now: datetime) -> dict | None:
+    """Return the cached verdict iff it still applies to THIS token.
+
+    Two independent gates, both of which must pass:
+
+    1. the fingerprint matches — the verdict was reached about the token
+       currently on disk, not a predecessor;
+    2. the verdict is younger than the TTL.
+
+    Either failing returns ``None``, i.e. "re-verify".
+    """
+    # stx-allow: fallback (reason: a missing/corrupt identity cache must mean
+    # "re-verify", never a crash and never a silent pass.)
+    try:
+        with Path(path).open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("token_fingerprint") != fingerprint:
+        return None
+    stamp = data.get("verified_at")
+    if not isinstance(stamp, str):
+        return None
+    # stx-allow: fallback (reason: malformed timestamp forces re-verification)
+    try:
+        verified_at = datetime.fromisoformat(stamp)
+    except ValueError:  # stx-allow: fallback (reason: format mismatch)
+        return None
+    if verified_at.tzinfo is None:
+        verified_at = verified_at.replace(tzinfo=timezone.utc)
+    if (now - verified_at).total_seconds() >= _VERIFY_TTL_SECONDS:
+        return None
+    return data
+
+
+def _write_cache(path: Path, payload: dict[str, Any]) -> None:
+    """Persist a verdict atomically; best-effort, never raises."""
+    # stx-allow: fallback (reason: the cache is an optimisation — a read-only
+    # or full filesystem must not break `sac accounts list`.)
+    try:
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = Path(str(p) + ".tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+        tmp.rename(p)
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net)
+        pass
+
+
+def _emails_match(claimed: str | None, verified: str | None) -> bool:
+    """Case-insensitive email comparison; unknown on either side is no match."""
+    if not claimed or not verified:
+        return False
+    return claimed.strip().lower() == verified.strip().lower()
+
+
+def verify_account(
+    name: str,
+    credentials_path: Path,
+    *,
+    claimed_email: str | None = None,
+    opener=None,
+    now: datetime | None = None,
+    use_cache: bool = True,
+) -> AccountIdentity:
+    """Resolve who the credential at ``credentials_path`` really belongs to.
+
+    Returns an :class:`AccountIdentity` whose ``state`` is one of
+    ``verified`` / ``mismatch`` / ``unverified`` (see the module docstring).
+    Never raises and never returns the token.
+
+    ``claimed_email`` is the store's own assertion (``account.json``'s
+    ``email_address``). When the store makes no claim there is nothing to
+    contradict, so a successful lookup is recorded as ``verified`` against
+    the fetched email — the row then at least displays a REAL identity.
+    """
+    _now = now or _now_utc()
+    creds = Path(credentials_path)
+    access_token, _, _, _ = _read_tokens_at(creds)
+    fingerprint = token_fingerprint(access_token)
+    if fingerprint is None:
+        return AccountIdentity(
+            name=name, state=UNVERIFIED, claimed_email=claimed_email
+        )
+
+    cache_file = _cache_path(creds)
+    cached = (
+        _read_cache(cache_file, fingerprint=fingerprint, now=_now)
+        if use_cache
+        else None
+    )
+    if cached is not None:
+        email = cached.get("verified_email")
+        uuid = cached.get("verified_uuid")
+        stamp = cached.get("verified_at")
+    else:
+        email, uuid = fetch_account_identity(creds, opener=opener)
+        if email is None and uuid is None:
+            # The endpoint did not answer. Report NOT-KNOWN rather than
+            # falling back to the label, which is the very thing in doubt.
+            return AccountIdentity(
+                name=name, state=UNVERIFIED, claimed_email=claimed_email
+            )
+        stamp = _now.isoformat()
+        _write_cache(
+            cache_file,
+            {
+                "verified_email": email,
+                "verified_uuid": uuid,
+                "verified_at": stamp,
+                "token_fingerprint": fingerprint,
+            },
+        )
+
+    if claimed_email and not _emails_match(claimed_email, email):
+        state = MISMATCH
+    else:
+        state = VERIFIED
+    return AccountIdentity(
+        name=name,
+        state=state,
+        claimed_email=claimed_email,
+        verified_email=email,
+        verified_uuid=uuid,
+        verified_at=stamp if isinstance(stamp, str) else None,
+    )
+
+
+def _is_verified(identities: list[AccountIdentity], name: str) -> bool:
+    """True iff the account called ``name`` in this set verified cleanly."""
+    return any(i.name == name and i.state == VERIFIED for i in identities)
+
+
+def mark_duplicates(identities: Iterable[AccountIdentity]) -> list[AccountIdentity]:
+    """Flag stored accounts that resolve to the SAME Anthropic account.
+
+    Two store directories holding two DIFFERENT tokens for one account is
+    the exact shape of the 2026-08-12 incident, and it is invisible to any
+    check that compares credential files. Grouping is by ``verified_uuid``
+    when present (the strongest key), else by ``verified_email``.
+
+    Every member of a duplicate group except the OWNER gets ``duplicate_of``
+    set to the owner's name — so the aggregate can count the account ONCE.
+    Double-counting one account as two is what turns a saturated fleet into
+    apparent headroom.
+
+    The owner is the group's ``verified`` member where there is one, and only
+    otherwise the first seen. Order alone would be the wrong rule: in the
+    2026-08-12 store the two directories were ``ywata1989-gmail-com``
+    (correctly labelled) and ``ywatanabe-scitex-ai`` (holding the same
+    account under the wrong name), and had they sorted the other way the
+    MISLABELLED row would have become the owner — suppressing the usage of
+    the account that was named correctly and keeping the one that was not.
+    Preferring the verified member makes the outcome independent of
+    directory naming.
+
+    Accounts with no verified identity are never grouped: "both unknown" is
+    not evidence of sameness.
+    """
+    idents = list(identities)
+
+    def _key(ident: AccountIdentity) -> str | None:
+        return ident.verified_uuid or (
+            ident.verified_email.strip().lower() if ident.verified_email else None
+        )
+
+    # Pass 1: provisional owner is the first member of each group.
+    owners: dict[str, str] = {}
+    for ident in idents:
+        key = _key(ident)
+        if key and key not in owners:
+            owners[key] = ident.name
+
+    # Pass 2: a VERIFIED member displaces that provisional owner.
+    for ident in idents:
+        key = _key(ident)
+        if key and ident.state == VERIFIED:
+            owners.setdefault(key, ident.name)
+            if not _is_verified(idents, owners[key]):
+                owners[key] = ident.name
+
+    out: list[AccountIdentity] = []
+    for ident in idents:
+        key = _key(ident)
+        if not key or owners.get(key) == ident.name:
+            out.append(ident)
+            continue
+        out.append(
+            AccountIdentity(
+                name=ident.name,
+                state=ident.state,
+                claimed_email=ident.claimed_email,
+                verified_email=ident.verified_email,
+                verified_uuid=ident.verified_uuid,
+                verified_at=ident.verified_at,
+                duplicate_of=owners[key],
+            )
+        )
+    return out
+
+
+__all__ = [
+    "AccountIdentity",
+    "MISMATCH",
+    "UNVERIFIED",
+    "VERIFIED",
+    "mark_duplicates",
+    "token_fingerprint",
+    "verify_account",
+]

--- a/src/scitex_agent_container/cli_pkg/_account_list_build.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_build.py
@@ -1,0 +1,324 @@
+"""Data acquisition + orchestration behind ``sac accounts list``.
+
+Split out of :mod:`._account_list_render`, which had grown to hold three
+responsibilities its own docstring already enumerated. The dividing line is
+side effects: everything here touches the network, the credential store or
+the clock, while what remains in ``_account_list_render`` is the row model
+and the ``rich`` table built from it. That separation is what lets the
+renderer be tested by hand-rolling an ``AccountRow`` with no monkeypatching
+at all.
+
+Every public name is re-exported from ``_account_list_render`` so existing
+importers keep working unchanged.
+
+Identity, and why it is fetched here
+------------------------------------
+INCIDENT 2026-08-12: ``sac accounts list`` showed ``ywatanabe-scitex-ai`` at
+2 % weekly while the Anthropic console showed 92 % for that account. Neither
+number was wrong — they described DIFFERENT accounts. The directory
+``accounts/anthropic/ywatanabe-scitex-ai/`` held a credential belonging to
+``ywata1989@gmail.com``, so one Anthropic account was rendered as two rows
+and the fleet looked to have headroom it did not have.
+
+A stored credential contains no identity claim of any kind, so nothing in
+the store could have caught this. :func:`verify_stored_identities` asks the
+authoritative source — the OAuth profile endpoint — and its answer gates the
+percentages: a figure fetched with a credential that turns out to belong to
+somebody else is not this row's usage, no matter how fresh it is.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ._account_list_render import AccountRow
+
+# ``AccountRow`` is imported INSIDE the functions that construct it, not at
+# module scope. ``_account_list_render`` re-exports this module's names for
+# back-compat, so a module-scope import here would make the pair mutually
+# importable — and a cycle resolves or explodes depending on which half the
+# caller happens to import first, which is the worst kind of bug to own.
+# ``from __future__ import annotations`` keeps the signatures readable
+# without needing the runtime symbol.
+
+# ---------------------------------------------------------------------------
+# Per-account usage fetch
+# ---------------------------------------------------------------------------
+
+
+def _per_account_usage_cache_path(name: str):
+    """Return the absolute path of the per-account ``usage.json`` cache."""
+    from .._state.account_store import _store_path
+
+    return _store_path(None, Path.home()) / name / "usage.json"
+
+
+def usage_for_account(acct_meta: dict, *, refresh: bool = False) -> dict | None:
+    """Live PER-ACCOUNT usage fetch (5-min cache); ``--refresh`` busts it.
+
+    The snapshot lives at
+    ``~/.scitex/agent-container/accounts/<name>/.credentials.json``
+    (cascade-resolved via ``_store_path``); the fetch result is cached
+    next to that file as ``usage.json`` so the same
+    ``read_account_usage_cache`` reader sees the live value across
+    invocations. Any failure (missing snapshot, expired token, network
+    error) returns ``None`` → caller renders ``"-"`` for that row only;
+    the rest of the list keeps rendering.
+
+    When ``refresh`` is true the on-disk ``usage.json`` is removed
+    before the fetch so the API is hit even when the cache is fresh —
+    wiring for ``sac accounts list --refresh``.
+
+    NOTE the fallback to ``read_account_usage_cache`` is UNBOUNDED in age
+    by design — a figure from yesterday is still worth showing when the
+    API is unreachable. What must never happen is showing it AS IF it were
+    current, which is why every consumer runs the result through
+    :func:`._account_usage_state.classify_usage` rather than reading
+    ``used_pct_*`` directly.
+    """
+    from .._account.claude_usage import fetch_usage_for_credentials
+    from .._state.account_store import _store_path, read_account_usage_cache
+
+    name = acct_meta.get("name")
+    if not name:
+        return None
+    store = _store_path(None, Path.home())
+    creds_path = store / name / ".credentials.json"
+    if not creds_path.is_file():
+        return read_account_usage_cache(name)
+    if refresh:
+        cache_path = _per_account_usage_cache_path(name)
+        # stx-allow: fallback (reason: best-effort cache bust; if the
+        # file is already gone or locked, the next call still re-fetches
+        # because the cache reader gracefully returns None.)
+        try:
+            cache_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    # stx-allow: fallback (reason: fetch_usage_for_credentials is documented never-raise, but defence-in-depth so one bad row never crashes `account list`)
+    try:
+        result = fetch_usage_for_credentials(creds_path)
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        return read_account_usage_cache(name)
+    if result.get("error") or result.get("used_pct_5h") is None:
+        cached = read_account_usage_cache(name)
+        return cached if cached else None
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Identity verification
+# ---------------------------------------------------------------------------
+
+
+def verify_stored_identities(accounts: list[dict], *, opener=None) -> dict:
+    """Resolve, for every stored account, WHOSE credential it actually holds.
+
+    Returns ``{name: AccountIdentity}``. The store keeps no identity claim
+    inside a credential, so until this runs the directory name is the only
+    thing naming the account — and a directory name is not evidence. See
+    :mod:`.._account.account_verify` for the incident this guards.
+
+    Duplicate marking happens across the whole set at once, because a
+    single account cannot know that another directory holds the same
+    Anthropic account.
+    """
+    from .._account.account_verify import mark_duplicates, verify_account
+    from .._state.account_store import _store_path
+
+    store = _store_path(None, Path.home())
+    identities = [
+        verify_account(
+            acct["name"],
+            store / acct["name"] / ".credentials.json",
+            claimed_email=acct.get("email_address"),
+            opener=opener,
+        )
+        for acct in accounts
+    ]
+    return {ident.name: ident for ident in mark_duplicates(identities)}
+
+
+# ---------------------------------------------------------------------------
+# Row / JSON orchestrators
+# ---------------------------------------------------------------------------
+
+
+def build_stored_rows(
+    accounts: list[dict], *, refresh: bool = False, opener=None
+) -> list[AccountRow]:
+    """Convert stored-account dicts into :class:`AccountRow` for rendering.
+
+    Pulls credential freshness (live recompute from ``expiresAt`` on every
+    call), the account's VERIFIED identity, and usage% (cached or re-fetched
+    depending on ``refresh``). Also carries through the per-window
+    ``reset_at_5h`` / ``reset_at_7d`` so the usage-bars block can render the
+    inline reset hint (gripe #2 of 2026-06-09; moved from the table cells
+    onto the bars by the 2026-07-11 dedupe directive). Plan/tier are no
+    longer resolved here — no human surface renders them (the JSON path
+    keeps them via :func:`build_stored_json`).
+
+    The identity check GATES the percentages: a usage figure read with a
+    credential that turns out to belong to a different account is not this
+    account's usage, however freshly it was fetched, so
+    :func:`._account_usage_state.classify_usage` collapses it to ``unknown``
+    and ``used_pct_*`` is dropped rather than displayed under the wrong name.
+    """
+    from .._account.creds_sync import account_freshness
+    from ._account_list_render import AccountRow
+    from ._account_usage_state import classify_usage
+
+    identities = verify_stored_identities(accounts, opener=opener)
+    rows: list[AccountRow] = []
+    for acct in accounts:
+        name = acct["name"]
+        fresh = account_freshness(name)
+        usage = usage_for_account(acct, refresh=refresh) or {}
+        ident = identities.get(name)
+        reading = classify_usage(usage, ident)
+        rows.append(
+            AccountRow(
+                name=name,
+                freshness_state=fresh.state,
+                freshness_hours=fresh.hours,
+                used_pct_5h=reading.pct_5h,
+                used_pct_7d=reading.pct_7d,
+                snapshot_as_of=reading.as_of,
+                reset_at_5h=reading.reset_at_5h,
+                reset_at_7d=reading.reset_at_7d,
+                provider="claude-code",
+                usage_state=reading.state,
+                usage_age_seconds=reading.age_seconds,
+                usage_reason=reading.reason,
+                identity_state=ident.state if ident else "unverified",
+                verified_email=ident.verified_email if ident else None,
+                duplicate_of=ident.duplicate_of if ident else None,
+            )
+        )
+    return rows
+
+
+def build_stored_json(
+    accounts: list[dict], *, refresh: bool = False, opener=None
+) -> list[dict]:
+    """Enrich stored-account dicts for ``sac accounts list --json``.
+
+    Each entry carries OFFLINE plan/tier, credential FRESHNESS
+    (``state`` + signed hours), the per-account usage payload, and — new
+    since the 2026-08-12 incident — the account's verified ``identity``.
+    Timestamps remain ISO-8601 for JSON consumers; only the human renderer
+    reformats.
+
+    ``usage_state`` is emitted ALONGSIDE the raw ``usage`` payload rather
+    than in place of it. Machine consumers keep the numbers they already
+    parse, but can no longer read them without also being told whether sac
+    stands behind them — a scripted capacity check that ignores the state
+    field is now doing so visibly.
+    """
+    from .._account.creds_sync import account_freshness
+    from .._state.account_store import read_account_plan
+    from ._account_usage_state import classify_usage
+
+    identities = verify_stored_identities(accounts, opener=opener)
+    stored: list[dict] = []
+    for acct in accounts:
+        entry = dict(acct)
+        name = acct["name"]
+        entry["provider"] = "claude-code"
+        entry["qualified_id"] = f"claude-code:{name}"
+        entry.update(read_account_plan(name))
+        fresh = account_freshness(name)
+        entry["freshness"] = fresh.state
+        entry["freshness_hours"] = fresh.hours
+        usage = usage_for_account(acct, refresh=refresh)
+        entry["usage"] = usage
+        ident = identities.get(name)
+        reading = classify_usage(usage or {}, ident)
+        entry["usage_state"] = reading.state
+        entry["usage_age_seconds"] = reading.age_seconds
+        entry["usage_unknown_reason"] = reading.reason
+        entry["identity"] = {
+            "state": ident.state if ident else "unverified",
+            "claimed_email": ident.claimed_email if ident else None,
+            "verified_email": ident.verified_email if ident else None,
+            "verified_uuid": ident.verified_uuid if ident else None,
+            "duplicate_of": ident.duplicate_of if ident else None,
+        }
+        stored.append(entry)
+    return stored
+
+
+# ---------------------------------------------------------------------------
+# OpenAI / cross-provider projections
+# ---------------------------------------------------------------------------
+
+
+def openai_account_name(meta: dict) -> str:
+    """Derive the stable, human account slug used in provider-qualified IDs."""
+    source = (
+        meta.get("gateway_alias")
+        or meta.get("email_address")
+        or meta.get("account_id")
+        or "active"
+    )
+    slug = re.sub(r"[^a-z0-9]+", "-", str(source).lower()).strip("-")
+    return slug or "active"
+
+
+def build_openai_row(meta: dict) -> "AccountRow | None":
+    """Project the active Codex login into the provider-aware account table."""
+    from ._account_list_render import AccountRow
+
+    if not meta:
+        return None
+    return AccountRow(
+        name=openai_account_name(meta),
+        provider="openai",
+        freshness_state="CONFIGURED",
+        freshness_hours=None,
+        used_pct_5h=None,
+        used_pct_7d=None,
+        snapshot_as_of=meta.get("last_refresh"),
+    )
+
+
+def build_openai_rows(accounts: list[dict]) -> list[AccountRow]:
+    """Project all gateway-configured Codex logins into account rows."""
+    return [row for meta in accounts if (row := build_openai_row(meta)) is not None]
+
+
+def build_provider_accounts_json(
+    stored: list[dict], openai_meta: dict | list[dict]
+) -> list[dict]:
+    """Build the collision-free cross-provider identity list for JSON users."""
+    accounts = [dict(item) for item in stored]
+    openai_accounts = openai_meta if isinstance(openai_meta, list) else [openai_meta]
+    for meta in openai_accounts:
+        if not meta:
+            continue
+        name = openai_account_name(meta)
+        accounts.append(
+            {
+                "provider": "openai",
+                "name": name,
+                "qualified_id": f"openai:{name}",
+                "active": True,
+                "metadata": dict(meta),
+            }
+        )
+    return accounts
+
+
+__all__ = [
+    "build_openai_row",
+    "build_openai_rows",
+    "build_provider_accounts_json",
+    "build_stored_json",
+    "build_stored_rows",
+    "openai_account_name",
+    "usage_for_account",
+    "verify_stored_identities",
+]

--- a/src/scitex_agent_container/cli_pkg/_account_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_render.py
@@ -94,6 +94,25 @@ class AccountRow:
         ``None`` when the API did not return them (older caches /
         outages); the bars block then omits the reset hint for that
         window rather than fabricating a value.
+    usage_state
+        ``"known"`` / ``"stale"`` / ``"unknown"`` — sac's STANDING to
+        assert the percentages, decided by
+        :func:`._account_usage_state.classify_usage`. ``used_pct_*`` is
+        ``None`` whenever this is ``"unknown"``, so an unattributable
+        figure is not merely undrawn but unrepresentable.
+    usage_age_seconds, usage_reason
+        The snapshot's age, and — when the reading is not ``known`` — a
+        one-line prose statement of why, shown under the bars.
+    identity_state, verified_email
+        Whether the credential in this account's directory was CHECKED to
+        belong to this account (``verified`` / ``mismatch`` /
+        ``unverified``) and the email it actually authenticates as. The
+        store carries no identity claim inside the credential, so without
+        this check the directory name is the only thing naming the
+        account — see :mod:`.._account.account_verify`.
+    duplicate_of
+        Name of the earlier account this one resolves to the same
+        Anthropic account as, or ``None``.
     """
 
     name: str
@@ -105,6 +124,17 @@ class AccountRow:
     reset_at_5h: str | None = None
     reset_at_7d: str | None = None
     provider: str = "claude-code"
+    # Defaults to UNKNOWN, not "known", on purpose. A field that defaults to
+    # the confident value makes every forgetful caller assert something it
+    # never checked — the defect class this whole change exists to remove.
+    # Unknown-until-proven fails safe: the worst a caller who forgets can do
+    # is under-claim.
+    usage_state: str = "unknown"
+    usage_age_seconds: int | None = None
+    usage_reason: str | None = None
+    identity_state: str = "unverified"
+    verified_email: str | None = None
+    duplicate_of: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -123,10 +153,43 @@ def _fmt_status(state: str, hours: float | None) -> str:
 def _fmt_last_update_cell(
     snapshot_as_of: str | None, *, now: datetime | None = None
 ) -> str:
-    """Combine short day+hour with age suffix: ``Sun 21h (3m)`` / ``- (?)``."""
+    """Combine short day+hour with age suffix: ``Sun 21h (3m)`` / ``- (?)``.
+
+    This is the age of the USAGE SNAPSHOT and of nothing else. The column
+    was headed ``Last Update``, which named no particular fact and sat one
+    cell away from the credential's ``VALID +7h06m``; a reader had no way
+    to tell which of the two it timestamped. The header now says so —
+    see :func:`render_stored_table`.
+    """
     if not snapshot_as_of:
         return "-"
     return f"{format_as_of_short(snapshot_as_of)} ({format_snapshot_age(snapshot_as_of, now=now)})"
+
+
+def _fmt_identity_cell(row: AccountRow) -> str:
+    """State WHO this row's credential proved to be, or that nobody asked.
+
+    Three outcomes, never collapsed into two:
+
+    * ``verified`` — the email is shown plainly (or ``ok`` when the store
+      made no claim to compare against).
+    * ``mismatch`` — the directory label is wrong; the cell NAMES the
+      account the credential really belongs to, because that is the fact
+      an operator needs in order to act on it.
+    * ``unverified`` — sac could not ask. Shown as ``unverified``, never
+      as blank and never as the label, since displaying an unchecked
+      label here is exactly how a wrong name passes for a right one.
+
+    Deliberately contains no square brackets: these cells go through
+    ``rich``, which would parse ``[...]`` as markup.
+    """
+    if row.duplicate_of:
+        return f"DUPLICATE of {row.duplicate_of}"
+    if row.identity_state == "mismatch":
+        return f"MISMATCH -> {row.verified_email or 'another account'}"
+    if row.identity_state == "verified":
+        return row.verified_email or "ok"
+    return "unverified"
 
 
 def render_stored_table(
@@ -137,7 +200,18 @@ def render_stored_table(
     """Build a ``rich.table.Table`` for the Stored-accounts block.
 
     Columns (left-to-right):
-      Provider | Account | Status | Last Update
+      Provider | Account | Status | Identity | Usage as of
+
+    ``Identity`` says whether the credential in this account's directory
+    was CHECKED to belong to this account, and names the real owner when
+    it does not (INCIDENT 2026-08-12 — one Anthropic account occupied two
+    directories and was reported as two accounts' worth of headroom).
+
+    ``Usage as of`` was headed ``Last Update``. That name asserted nothing
+    in particular while sitting beside the credential TTL, so a fresh-
+    looking age there was read as vouching for the percentage beside it.
+    The header now names the one fact the cell carries: when the USAGE
+    snapshot was taken.
 
     Operator directive 2026-07-11: the table holds ONLY what the
     usage-bars block below it cannot express — the account slug, the
@@ -155,12 +229,14 @@ def render_stored_table(
     table.add_column("Provider")
     table.add_column("Account", style="bold")
     table.add_column("Status")
-    table.add_column("Last Update")
+    table.add_column("Identity")
+    table.add_column("Usage as of")
     for r in rows:
         table.add_row(
             r.provider,
             r.name,
             _fmt_status(r.freshness_state, r.freshness_hours),
+            _fmt_identity_cell(r),
             _fmt_last_update_cell(r.snapshot_as_of, now=now),
         )
     return table
@@ -213,188 +289,23 @@ def render_stored_table_to_str(
     finally:
         console.file.close()
 
-
 # ---------------------------------------------------------------------------
-# Per-account usage fetch + JSON/human orchestrators
+# Re-exports — data acquisition now lives in ``_account_list_build``
 # ---------------------------------------------------------------------------
-
-
-def _per_account_usage_cache_path(name: str):
-    """Return the absolute path of the per-account ``usage.json`` cache."""
-    from pathlib import Path
-
-    from .._state.account_store import _store_path
-
-    return _store_path(None, Path.home()) / name / "usage.json"
-
-
-def usage_for_account(acct_meta: dict, *, refresh: bool = False) -> dict | None:
-    """Live PER-ACCOUNT usage fetch (5-min cache); ``--refresh`` busts it.
-
-    The snapshot lives at
-    ``~/.scitex/agent-container/accounts/<name>/.credentials.json``
-    (cascade-resolved via ``_store_path``); the fetch result is cached
-    next to that file as ``usage.json`` so the same
-    ``read_account_usage_cache`` reader sees the live value across
-    invocations. Any failure (missing snapshot, expired token, network
-    error) returns ``None`` → caller renders ``"-"`` for that row only;
-    the rest of the list keeps rendering.
-
-    When ``refresh`` is true the on-disk ``usage.json`` is removed
-    before the fetch so the API is hit even when the cache is fresh —
-    wiring for ``sac accounts list --refresh``.
-    """
-    from pathlib import Path
-
-    from .._account.claude_usage import fetch_usage_for_credentials
-    from .._state.account_store import _store_path, read_account_usage_cache
-
-    name = acct_meta.get("name")
-    if not name:
-        return None
-    store = _store_path(None, Path.home())
-    creds_path = store / name / ".credentials.json"
-    if not creds_path.is_file():
-        return read_account_usage_cache(name)
-    if refresh:
-        cache_path = _per_account_usage_cache_path(name)
-        # stx-allow: fallback (reason: best-effort cache bust; if the
-        # file is already gone or locked, the next call still re-fetches
-        # because the cache reader gracefully returns None.)
-        try:
-            cache_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-    # stx-allow: fallback (reason: fetch_usage_for_credentials is documented never-raise, but defence-in-depth so one bad row never crashes `account list`)
-    try:
-        result = fetch_usage_for_credentials(creds_path)
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        return read_account_usage_cache(name)
-    if result.get("error") or result.get("used_pct_5h") is None:
-        cached = read_account_usage_cache(name)
-        return cached if cached else None
-    return result
-
-
-def build_stored_rows(
-    accounts: list[dict], *, refresh: bool = False
-) -> list[AccountRow]:
-    """Convert stored-account dicts into :class:`AccountRow` for rendering.
-
-    Pure orchestration: pulls credential freshness (live recompute from
-    ``expiresAt`` on every call) and usage% (cached or re-fetched
-    depending on ``refresh``). Also carries through the per-window
-    ``reset_at_5h`` / ``reset_at_7d`` so the usage-bars block can render
-    the inline reset hint (gripe #2 of 2026-06-09; moved from the table
-    cells onto the bars by the 2026-07-11 dedupe directive). Plan/tier
-    are no longer resolved here — no human surface renders them (the
-    JSON path keeps them via :func:`build_stored_json`).
-    """
-    from .._account.creds_sync import account_freshness
-
-    rows: list[AccountRow] = []
-    for acct in accounts:
-        name = acct["name"]
-        fresh = account_freshness(name)
-        usage = usage_for_account(acct, refresh=refresh) or {}
-        rows.append(
-            AccountRow(
-                name=name,
-                freshness_state=fresh.state,
-                freshness_hours=fresh.hours,
-                used_pct_5h=usage.get("used_pct_5h"),
-                used_pct_7d=usage.get("used_pct_7d"),
-                snapshot_as_of=usage.get("as_of") or usage.get("fetched_at"),
-                reset_at_5h=usage.get("reset_at_5h"),
-                reset_at_7d=usage.get("reset_at_7d"),
-                provider="claude-code",
-            )
-        )
-    return rows
-
-
-def build_stored_json(accounts: list[dict], *, refresh: bool = False) -> list[dict]:
-    """Enrich stored-account dicts for ``sac accounts list --json``.
-
-    Each entry carries OFFLINE plan/tier, credential FRESHNESS
-    (``state`` + signed hours), and the per-account usage payload.
-    Timestamps remain ISO-8601 for JSON consumers — only the human
-    renderer reformats. The usage dict already carries
-    ``reset_at_5h`` / ``reset_at_7d`` from the upstream API, so JSON
-    consumers can compute their own reset hints if they want one.
-    """
-    from .._account.creds_sync import account_freshness
-    from .._state.account_store import read_account_plan
-
-    stored: list[dict] = []
-    for acct in accounts:
-        entry = dict(acct)
-        entry["provider"] = "claude-code"
-        entry["qualified_id"] = f"claude-code:{acct['name']}"
-        entry.update(read_account_plan(acct["name"]))
-        fresh = account_freshness(acct["name"])
-        entry["freshness"] = fresh.state
-        entry["freshness_hours"] = fresh.hours
-        entry["usage"] = usage_for_account(acct, refresh=refresh)
-        stored.append(entry)
-    return stored
-
-
-def openai_account_name(meta: dict) -> str:
-    """Derive the stable, human account slug used in provider-qualified IDs."""
-    import re
-
-    source = (
-        meta.get("gateway_alias")
-        or meta.get("email_address")
-        or meta.get("account_id")
-        or "active"
-    )
-    slug = re.sub(r"[^a-z0-9]+", "-", str(source).lower()).strip("-")
-    return slug or "active"
-
-
-def build_openai_row(meta: dict) -> AccountRow | None:
-    """Project the active Codex login into the provider-aware account table."""
-    if not meta:
-        return None
-    return AccountRow(
-        name=openai_account_name(meta),
-        provider="openai",
-        freshness_state="CONFIGURED",
-        freshness_hours=None,
-        used_pct_5h=None,
-        used_pct_7d=None,
-        snapshot_as_of=meta.get("last_refresh"),
-    )
-
-
-def build_openai_rows(accounts: list[dict]) -> list[AccountRow]:
-    """Project all gateway-configured Codex logins into account rows."""
-    return [row for meta in accounts if (row := build_openai_row(meta)) is not None]
-
-
-def build_provider_accounts_json(
-    stored: list[dict], openai_meta: dict | list[dict]
-) -> list[dict]:
-    """Build the collision-free cross-provider identity list for JSON users."""
-    accounts = [dict(item) for item in stored]
-    openai_accounts = openai_meta if isinstance(openai_meta, list) else [openai_meta]
-    for meta in openai_accounts:
-        if not meta:
-            continue
-        name = openai_account_name(meta)
-        accounts.append(
-            {
-                "provider": "openai",
-                "name": name,
-                "qualified_id": f"openai:{name}",
-                "active": True,
-                "metadata": dict(meta),
-            }
-        )
-    return accounts
-
+# Imported at the BOTTOM, after ``AccountRow`` exists, because
+# ``_account_list_build`` constructs it. Keeping the import here (rather than
+# at the top) means this module is fully defined before the other one runs,
+# so the pair is safe to import in either order.
+from ._account_list_build import (  # noqa: E402
+    build_openai_row,
+    build_openai_rows,
+    build_provider_accounts_json,
+    build_stored_json,
+    build_stored_rows,
+    openai_account_name,
+    usage_for_account,
+    verify_stored_identities,
+)
 
 __all__ = [
     "AccountRow",
@@ -414,4 +325,5 @@ __all__ = [
     "render_stored_table_to_str",
     "rolling_legend_line",
     "usage_for_account",
+    "verify_stored_identities",
 ]

--- a/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
+++ b/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
@@ -74,6 +74,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterable
 
+from ._account_usage_state import KNOWN, STALE, UNKNOWN, format_age_short
 from ._timefmt import _coerce_dt, format_relative_until
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -92,26 +93,37 @@ _DEFAULT_BAR_WIDTH = 20
 # ---------------------------------------------------------------------------
 
 
-def render_usage_bar(pct: float | None, *, width: int = _DEFAULT_BAR_WIDTH) -> str:
+def render_usage_bar(
+    pct: float | None,
+    *,
+    width: int = _DEFAULT_BAR_WIDTH,
+    placeholder: str = "no data",
+) -> str:
     """Render ``pct`` (0-100) as a fixed-width bracketed ASCII bar.
 
-    ``[████████░░░░░░░░░░░░]`` for a number; a same-width
-    ``[      no data       ]`` placeholder for ``None`` so columns of
-    bars stay vertically aligned whether or not a row has data.
+    ``[████████░░░░░░░░░░░░]`` for a number; a same-width word placeholder
+    (``[      no data       ]`` / ``[      unknown       ]``) for ``None``
+    so columns of bars stay vertically aligned whether or not a row has
+    data.
 
-    Guards against two visual lies:
+    Guards against three visual lies:
 
     * a value ``< 100`` never renders a completely full bar (so 99 %
       is visibly distinct from 100 %);
     * a value ``> 0`` never renders a completely empty bar (so 1 % is
-      visibly distinct from 0 %).
+      visibly distinct from 0 %);
+    * a figure sac cannot vouch for is never drawn AT ALL. Callers pass
+      ``pct=None`` for an unknown reading rather than a number, because a
+      bar is an assertion and there is no fill level that honestly means
+      "we did not measure this" — the 2026-08-12 incident was a confident
+      2 % bar drawn over a figure belonging to another account.
 
     Values outside ``[0, 100]`` are clamped. Never raises.
     """
     if width < 1:
         width = 1
     if pct is None:
-        return "[" + "no data".center(width) + "]"
+        return "[" + placeholder.center(width)[:width] + "]"
     p = max(0.0, min(100.0, float(pct)))
     filled = int(round(p / 100.0 * width))
     if filled >= width and p < 100.0:
@@ -121,11 +133,26 @@ def render_usage_bar(pct: float | None, *, width: int = _DEFAULT_BAR_WIDTH) -> s
     return "[" + _BAR_FILL * filled + _BAR_EMPTY * (width - filled) + "]"
 
 
-def _pct_paren(pct: float | None) -> str:
-    """Trailing percentage label: ``(29%)`` for a number, ``(?)`` for unknown."""
-    if pct is None:
-        return "(?)"
-    return f"({int(round(max(0.0, min(100.0, float(pct)))))}%)"
+def _pct_paren(
+    pct: float | None,
+    *,
+    state: str = KNOWN,
+    age_seconds: int | None = None,
+) -> str:
+    """Trailing label, carrying the reading's STANDING as well as its value.
+
+    ``(29%)`` for a measured figure, ``(29% stale 1d)`` for one older than
+    the refresh window, ``(unknown)`` when sac cannot vouch for a number at
+    all. The staleness never appears as a bare percentage: an operator
+    reading ``(2%)`` has no way to know it is a day old, which is precisely
+    how the 2026-08-12 capacity misread happened.
+    """
+    if state == UNKNOWN or pct is None:
+        return "(unknown)"
+    value = int(round(max(0.0, min(100.0, float(pct)))))
+    if state == STALE:
+        return f"({value}% stale {format_age_short(age_seconds)})"
+    return f"({value}%)"
 
 
 def _wrap_hint(hint: str) -> str:
@@ -140,6 +167,8 @@ def render_window_line(
     hint: str,
     hint_width: int,
     width: int = _DEFAULT_BAR_WIDTH,
+    state: str = KNOWN,
+    age_seconds: int | None = None,
 ) -> str:
     """One per-window line of an account block, operator-mockup shape:
 
@@ -153,12 +182,24 @@ def render_window_line(
     every line pads its hint to it, so the bars of BOTH windows of
     EVERY account start at the same column. ``hint_width == 0`` (no row
     in the block has any cached reset) omits the hint column entirely.
+
+    ``state`` is the reading's standing (``known`` / ``stale`` /
+    ``unknown``). An ``unknown`` reading draws NO bar — the percentage is
+    suppressed even if one was passed, so a caller cannot accidentally
+    render an unattributable figure as a fact.
     """
+    drawable = None if state == UNKNOWN else pct
     parts = [f"  {window}"]
     if hint_width > 0:
         parts.append(hint.ljust(max(hint_width, len(hint))))
-    parts.append(render_usage_bar(pct, width=width))
-    parts.append(_pct_paren(pct))
+    parts.append(
+        render_usage_bar(
+            drawable,
+            width=width,
+            placeholder="unknown" if state == UNKNOWN else "no data",
+        )
+    )
+    parts.append(_pct_paren(drawable, state=state, age_seconds=age_seconds))
     return " ".join(parts)
 
 
@@ -170,21 +211,44 @@ def render_account_block(
     hint_width: int,
     width: int = _DEFAULT_BAR_WIDTH,
 ) -> list[str]:
-    """The 3-line block for one account (operator mockup 2026-07-17):
+    """The block for one account (operator mockup 2026-07-17):
 
     ``- <name>`` then one :func:`render_window_line` per window
     (5h first, then 7d). The caller inserts the blank line BETWEEN
     accounts and supplies the block-level ``hint_width``.
+
+    When the reading is not ``known`` a fourth line states WHY in prose.
+    An operator who sees ``(unknown)`` needs to know whether the network
+    was down or the credential belongs to somebody else — those call for
+    opposite responses, and a bare ``unknown`` cannot distinguish them.
     """
-    return [
+    state = getattr(row, "usage_state", UNKNOWN)
+    age = getattr(row, "usage_age_seconds", None)
+    lines = [
         f"- {row.provider}:{row.name}",
         render_window_line(
-            "5h", row.used_pct_5h, hint=hint_5h, hint_width=hint_width, width=width
+            "5h",
+            row.used_pct_5h,
+            hint=hint_5h,
+            hint_width=hint_width,
+            width=width,
+            state=state,
+            age_seconds=age,
         ),
         render_window_line(
-            "7d", row.used_pct_7d, hint=hint_7d, hint_width=hint_width, width=width
+            "7d",
+            row.used_pct_7d,
+            hint=hint_7d,
+            hint_width=hint_width,
+            width=width,
+            state=state,
+            age_seconds=age,
         ),
     ]
+    reason = getattr(row, "usage_reason", None)
+    if state != KNOWN and reason:
+        lines.append(f"     ! {reason}")
+    return lines
 
 
 def _mean_reset_at(rows: Iterable["AccountRow"]) -> datetime | None:
@@ -230,19 +294,36 @@ def render_average_block(
     used to be the ``Fleet 7d capacity used:`` line, rendered in the same
     visual language as every other bar instead of as prose.
 
-    ``n`` counts only accounts WITH cached 7d usage — the same denominator
-    :func:`fleet_7d_capacity_used` averages over, so the percentage and the
-    count can never describe different populations. Returns ``[]`` when no
-    account has data, so the caller emits nothing rather than an empty bar
-    that would read as 0%.
+    ``n`` counts only accounts whose 7d reading is ``known`` — the same
+    denominator :func:`fleet_7d_capacity_used` averages over, so the
+    percentage and the count can never describe different populations.
+    Returns ``[]`` when no account has a known reading, so the caller emits
+    nothing rather than an empty bar that would read as 0 %.
+
+    Readings that are ``stale`` or ``unknown`` are EXCLUDED, and the count
+    of exclusions is stated beside the average. Averaging them in would
+    launder their uncertainty: the fleet figure would look exactly as
+    confident as an all-fresh one, which is how the 2026-08-12 plan came to
+    treat a saturated fleet as having 98 % headroom. A capacity number
+    computed from two rows out of three must say so.
     """
     row_list = list(rows)
-    pct, n = fleet_7d_capacity_used(r.used_pct_7d for r in row_list)
+    # The getattr fallback is UNKNOWN, not KNOWN: a row that cannot say it was
+    # measured must not be counted into a capacity figure on the strength of
+    # having omitted the field.
+    counted = [r for r in row_list if getattr(r, "usage_state", UNKNOWN) == KNOWN]
+    excluded = len(row_list) - len(counted)
+    pct, n = fleet_7d_capacity_used(r.used_pct_7d for r in counted)
     if pct is None:
+        if excluded:
+            return [f"- Average (unknown — {excluded} of {len(row_list)} not counted)"]
         return []
-    hint = _wrap_hint(format_relative_until(_mean_reset_at(row_list), now=now))
+    label = f"- Average (n={n})"
+    if excluded:
+        label += f" — {excluded} of {len(row_list)} not counted"
+    hint = _wrap_hint(format_relative_until(_mean_reset_at(counted), now=now))
     return [
-        f"- Average (n={n})",
+        label,
         render_window_line("7d", pct, hint=hint, hint_width=hint_width, width=width),
     ]
 

--- a/src/scitex_agent_container/cli_pkg/_account_usage_state.py
+++ b/src/scitex_agent_container/cli_pkg/_account_usage_state.py
@@ -1,0 +1,197 @@
+"""Decide whether a usage figure may be shown as a fact, and say why not.
+
+INCIDENT 2026-08-12 — `sac accounts list` drew a confident 2 % bar for an
+account the Anthropic console had at 92 %. A bar is an ASSERTION: a reader
+cannot tell a measured 2 % from a 2 % that is a day old, or from a 2 % that
+belongs to a different account. Drawing all three identically is what let a
+capacity plan be built on a number nobody had checked.
+
+So a usage figure is three-valued here, never two:
+
+``known``   fetched within the fetcher's own refresh window, from an account
+            whose identity was verified. Safe to render as a fact.
+``stale``   real, attributable, but older than the window in which the
+            fetcher itself would have re-fetched it. Renderable WITH its
+            age attached — never silently.
+``unknown`` sac cannot vouch for it: absent, or belonging to an account
+            whose label was not verified or was found wrong. Nothing
+            numeric may be drawn.
+
+The staleness threshold is deliberately the FETCHER's TTL rather than a
+second, looser display constant. The fetcher treats a cache older than
+``_CACHE_TTL_SECONDS`` as needing a re-fetch; if it needed one and did not
+get one, the display has no standing to call the value current. Two
+thresholds for one fact is how a renderer comes to disagree with the
+component it renders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from .._account.account_verify import MISMATCH, UNVERIFIED, AccountIdentity
+
+# SSOT with the fetcher: a value the fetcher would have re-fetched is, by
+# definition, not current. Imported rather than re-declared so the display
+# threshold and the fetch threshold can never drift apart.
+from .._account.claude_usage import _CACHE_TTL_SECONDS as _FRESH_SECONDS
+from ._account_list_format import _coerce_dt
+
+KNOWN = "known"
+STALE = "stale"
+UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class UsageReading:
+    """A usage figure together with sac's standing to assert it.
+
+    ``pct_5h`` / ``pct_7d`` are ``None`` whenever ``state`` is ``unknown``.
+    That is not a convenience — it makes "we don't know" unrepresentable as
+    a number, so no downstream renderer or aggregate can accidentally treat
+    an unverified figure as data.
+    """
+
+    state: str
+    pct_5h: float | None = None
+    pct_7d: float | None = None
+    reset_at_5h: str | None = None
+    reset_at_7d: str | None = None
+    as_of: str | None = None
+    age_seconds: int | None = None
+    reason: str | None = None
+
+    @property
+    def countable(self) -> bool:
+        """May this row contribute to a fleet aggregate?
+
+        Only ``known`` readings count. A ``stale`` figure is shown to the
+        operator with its age so they can judge it, but averaging it into a
+        fleet capacity number would launder the staleness away — the
+        aggregate would look exactly as confident as an all-fresh one.
+        """
+        return self.state == KNOWN
+
+
+def _age_seconds(as_of: str | None, now: datetime | None) -> int | None:
+    dt = _coerce_dt(as_of)
+    if dt is None:
+        return None
+    _now = now or datetime.now(timezone.utc)
+    if _now.tzinfo is None:
+        _now = _now.replace(tzinfo=timezone.utc)
+    return max(0, int((_now - dt).total_seconds()))
+
+
+def classify_usage(
+    usage: dict | None,
+    identity: AccountIdentity | None,
+    *,
+    now: datetime | None = None,
+) -> UsageReading:
+    """Grade a raw usage payload into a :class:`UsageReading`.
+
+    Identity is checked BEFORE the numbers, because a figure attributed to
+    the wrong account is wrong no matter how fresh it is — that was the
+    2026-08-12 failure, where the freshest possible number was also the
+    most misleading one.
+    """
+    if identity is not None:
+        # DISOWNED: sac knows these figures are not this row's. Nothing from
+        # the snapshot is carried over — not the percentages, not the reset
+        # instants, not even the "as of" stamp, because every one of them
+        # would describe a different account under this account's name.
+        if identity.state == MISMATCH:
+            return UsageReading(
+                state=UNKNOWN,
+                reason=(
+                    f"credential belongs to "
+                    f"{identity.verified_email or 'another account'}"
+                    f", not {identity.claimed_email or identity.name}"
+                ),
+            )
+        if identity.duplicate_of:
+            return UsageReading(
+                state=UNKNOWN,
+                reason=f"same Anthropic account as {identity.duplicate_of}",
+            )
+
+    if not usage:
+        return UsageReading(state=UNKNOWN, reason="no usage snapshot")
+    pct_5h = usage.get("used_pct_5h")
+    pct_7d = usage.get("used_pct_7d")
+    if pct_5h is None and pct_7d is None:
+        return UsageReading(
+            state=UNKNOWN, reason=usage.get("error") or "no usage figures returned"
+        )
+
+    as_of = usage.get("as_of") or usage.get("fetched_at")
+    age = _age_seconds(as_of, now)
+    if age is None:
+        # A figure with no timestamp cannot be aged, and an un-ageable
+        # number is exactly the "fresh-looking but arbitrarily old" shape
+        # this module exists to refuse.
+        return UsageReading(
+            state=UNKNOWN, reason="usage snapshot carries no timestamp"
+        )
+
+    state = KNOWN if age < _FRESH_SECONDS else STALE
+    reason = None if state == KNOWN else "snapshot older than the refresh window"
+
+    # UNCHECKED: the identity lookup could not run (offline, no token, a
+    # credential that changed since it was last verified). That is NOT the
+    # same as knowing the figures are somebody else's, so the snapshot's
+    # metadata — when the window resets, when the reading was taken — is
+    # still carried. Only the PERCENTAGE is withheld, because the percentage
+    # is the thing that gets believed.
+    #
+    # Collapsing this case to a bare `unknown` would blind the whole table on
+    # any transient failure of the profile endpoint, which would make the
+    # tool useless precisely when an operator reaches for it during an
+    # incident. Note a previously-verified account survives an outage anyway:
+    # the verifier's cache is bound to the token, so it keeps answering
+    # `verified` offline until the credential itself changes.
+    if identity is not None and identity.state == UNVERIFIED:
+        return UsageReading(
+            state=UNKNOWN,
+            reset_at_5h=usage.get("reset_at_5h"),
+            reset_at_7d=usage.get("reset_at_7d"),
+            as_of=as_of,
+            age_seconds=age,
+            reason="account identity could not be verified",
+        )
+
+    return UsageReading(
+        state=state,
+        pct_5h=pct_5h,
+        pct_7d=pct_7d,
+        reset_at_5h=usage.get("reset_at_5h"),
+        reset_at_7d=usage.get("reset_at_7d"),
+        as_of=as_of,
+        age_seconds=age,
+        reason=reason,
+    )
+
+
+def format_age_short(age_seconds: int | None) -> str:
+    """Compact age for the stale marker: ``45s`` / ``12m`` / ``3h`` / ``2d``."""
+    if age_seconds is None:
+        return "?"
+    if age_seconds < 60:
+        return f"{age_seconds}s"
+    if age_seconds < 3600:
+        return f"{age_seconds // 60}m"
+    if age_seconds < 86400:
+        return f"{age_seconds // 3600}h"
+    return f"{age_seconds // 86400}d"
+
+
+__all__ = [
+    "KNOWN",
+    "STALE",
+    "UNKNOWN",
+    "UsageReading",
+    "classify_usage",
+    "format_age_short",
+]

--- a/tests/scitex_agent_container/_account/test_account_verify.py
+++ b/tests/scitex_agent_container/_account/test_account_verify.py
@@ -1,0 +1,364 @@
+"""Gates for the account-identity verifier (INCIDENT 2026-08-12).
+
+The incident: ``accounts/anthropic/ywatanabe-scitex-ai/`` held a credential
+belonging to ``ywata1989@gmail.com``. One Anthropic account was rendered as
+two rows, and the fleet appeared to have headroom it did not have. Nothing
+in the store could catch it — a stored credential carries no identity claim
+at all — so the directory name was the only thing naming the account, and it
+was wrong.
+
+Each test below drives a state sac must not mistake for a healthy one.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime, timedelta, timezone
+
+from scitex_agent_container._account.account_verify import (
+    MISMATCH,
+    UNVERIFIED,
+    VERIFIED,
+    AccountIdentity,
+    mark_duplicates,
+    verify_account,
+)
+
+NOW = datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)
+
+
+class _Resp(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _profile_opener(email, uuid="uuid-1"):
+    def _opener(req, *a, **kw):
+        return _Resp(json.dumps({"account": {"email": email, "uuid": uuid}}).encode())
+
+    return _opener
+
+
+def _dead_opener(req, *a, **kw):
+    raise OSError("network down")
+
+
+def _write_creds(path, token="tok-a"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": token,
+                    "refreshToken": "r-" + token,
+                    "expiresAt": 9_999_999_999_000,
+                }
+            }
+        )
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# A credential that matches its directory
+# ---------------------------------------------------------------------------
+
+
+def test_matching_email_verifies(tmp_path):
+    # Arrange
+    creds = _write_creds(tmp_path / "acct" / ".credentials.json")
+    # Act
+    ident = verify_account(
+        "acct",
+        creds,
+        claimed_email="a@example.com",
+        opener=_profile_opener("a@example.com"),
+        now=NOW,
+    )
+    # Assert
+    assert ident.state == VERIFIED
+
+
+def test_matching_email_records_the_verified_address(tmp_path):
+    # Arrange
+    creds = _write_creds(tmp_path / "acct" / ".credentials.json")
+    # Act
+    ident = verify_account(
+        "acct",
+        creds,
+        claimed_email="a@example.com",
+        opener=_profile_opener("a@example.com"),
+        now=NOW,
+    )
+    # Assert
+    assert ident.verified_email == "a@example.com"
+
+
+def test_matching_email_is_trustworthy(tmp_path):
+    # Arrange
+    creds = _write_creds(tmp_path / "acct" / ".credentials.json")
+    # Act
+    ident = verify_account(
+        "acct",
+        creds,
+        claimed_email="a@example.com",
+        opener=_profile_opener("a@example.com"),
+        now=NOW,
+    )
+    # Assert
+    assert ident.trustworthy
+
+
+# ---------------------------------------------------------------------------
+# The incident: directory says one account, token proves another
+# ---------------------------------------------------------------------------
+
+
+def test_credential_belonging_to_another_account_is_a_mismatch(tmp_path):
+    # Arrange
+    creds = _write_creds(tmp_path / "ywatanabe-scitex-ai" / ".credentials.json")
+    # Act
+    ident = verify_account(
+        "ywatanabe-scitex-ai",
+        creds,
+        claimed_email="ywatanabe@scitex.ai",
+        opener=_profile_opener("ywata1989@gmail.com"),
+        now=NOW,
+    )
+    # Assert
+    assert ident.state == MISMATCH
+
+
+def test_mismatch_names_the_real_owner(tmp_path):
+    # Arrange — the operator needs the NAME to act; "wrong" alone is unusable.
+    creds = _write_creds(tmp_path / "ywatanabe-scitex-ai" / ".credentials.json")
+    # Act
+    ident = verify_account(
+        "ywatanabe-scitex-ai",
+        creds,
+        claimed_email="ywatanabe@scitex.ai",
+        opener=_profile_opener("ywata1989@gmail.com"),
+        now=NOW,
+    )
+    # Assert
+    assert ident.verified_email == "ywata1989@gmail.com"
+
+
+def test_mismatch_is_not_trustworthy(tmp_path):
+    # Arrange — every figure gathered with this credential is someone else's.
+    creds = _write_creds(tmp_path / "ywatanabe-scitex-ai" / ".credentials.json")
+    # Act
+    ident = verify_account(
+        "ywatanabe-scitex-ai",
+        creds,
+        claimed_email="ywatanabe@scitex.ai",
+        opener=_profile_opener("ywata1989@gmail.com"),
+        now=NOW,
+    )
+    # Assert
+    assert not ident.trustworthy
+
+
+# ---------------------------------------------------------------------------
+# "Could not check" is its own state, never folded into "checked and fine"
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_endpoint_reports_unverified_not_verified(tmp_path):
+    # Arrange
+    creds = _write_creds(tmp_path / "acct" / ".credentials.json")
+    # Act
+    ident = verify_account(
+        "acct", creds, claimed_email="a@example.com", opener=_dead_opener, now=NOW
+    )
+    # Assert
+    assert ident.state == UNVERIFIED
+
+
+def test_unverified_is_not_trustworthy(tmp_path):
+    # Arrange
+    creds = _write_creds(tmp_path / "acct" / ".credentials.json")
+    # Act
+    ident = verify_account(
+        "acct", creds, claimed_email="a@example.com", opener=_dead_opener, now=NOW
+    )
+    # Assert
+    assert not ident.trustworthy
+
+
+def test_missing_token_is_unverified(tmp_path):
+    # Arrange
+    creds = tmp_path / "acct" / ".credentials.json"
+    creds.parent.mkdir(parents=True)
+    creds.write_text(json.dumps({"claudeAiOauth": {}}))
+    # Act
+    ident = verify_account("acct", creds, claimed_email="a@example.com", now=NOW)
+    # Assert
+    assert ident.state == UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# Cache validity is bound to the token, not only to a clock
+# ---------------------------------------------------------------------------
+
+
+def test_cached_verdict_is_reused_for_the_same_token(tmp_path):
+    # Arrange
+    creds = _write_creds(tmp_path / "acct" / ".credentials.json")
+    verify_account(
+        "acct",
+        creds,
+        claimed_email="a@example.com",
+        opener=_profile_opener("a@example.com"),
+        now=NOW,
+    )
+    # Act — endpoint now dead; the verdict still applies to THIS token.
+    ident = verify_account(
+        "acct", creds, claimed_email="a@example.com", opener=_dead_opener, now=NOW
+    )
+    # Assert
+    assert ident.state == VERIFIED
+
+
+def test_relogin_invalidates_the_cached_verdict(tmp_path):
+    """A `/login` swaps the token; the old verdict must stop applying AT ONCE.
+
+    This is the operator's actual scenario. A plain TTL would keep asserting
+    the previous identity for hours after the credential changed underneath
+    it — the cache would then be the very thing hiding the swap it exists to
+    detect.
+    """
+    # Arrange — verify, then replace the credential as a re-login would.
+    creds = _write_creds(tmp_path / "acct" / ".credentials.json", token="tok-old")
+    verify_account(
+        "acct",
+        creds,
+        claimed_email="a@example.com",
+        opener=_profile_opener("a@example.com"),
+        now=NOW,
+    )
+    _write_creds(creds, token="tok-new-after-login")
+    # Act — endpoint unreachable, so nothing can re-verify the new token.
+    ident = verify_account(
+        "acct", creds, claimed_email="a@example.com", opener=_dead_opener, now=NOW
+    )
+    # Assert — NOT the stale VERIFIED verdict.
+    assert ident.state == UNVERIFIED
+
+
+def test_expired_verdict_is_not_reused(tmp_path):
+    # Arrange
+    creds = _write_creds(tmp_path / "acct" / ".credentials.json")
+    verify_account(
+        "acct",
+        creds,
+        claimed_email="a@example.com",
+        opener=_profile_opener("a@example.com"),
+        now=NOW,
+    )
+    # Act — well past the TTL, with no way to re-check.
+    ident = verify_account(
+        "acct",
+        creds,
+        claimed_email="a@example.com",
+        opener=_dead_opener,
+        now=NOW + timedelta(hours=7),
+    )
+    # Assert
+    assert ident.state == UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# Two directories, one Anthropic account
+# ---------------------------------------------------------------------------
+
+
+def _one_account_two_directories():
+    """Two DIFFERENT tokens that are one account — the shape that fooled us.
+
+    Comparing credential files (or token fingerprints) reports "distinct"
+    here, which is how the duplication survived inspection. Only the account
+    UUID answers the question.
+    """
+    return [
+        AccountIdentity(
+            name="ywata1989-gmail-com",
+            state=VERIFIED,
+            verified_email="ywata1989@gmail.com",
+            verified_uuid="a84bd9dd",
+        ),
+        AccountIdentity(
+            name="ywatanabe-scitex-ai",
+            state=MISMATCH,
+            claimed_email="ywatanabe@scitex.ai",
+            verified_email="ywata1989@gmail.com",
+            verified_uuid="a84bd9dd",
+        ),
+    ]
+
+
+def test_first_of_a_duplicate_pair_keeps_its_identity():
+    # Arrange
+    idents = _one_account_two_directories()
+    # Act
+    marked = mark_duplicates(idents)
+    # Assert
+    assert marked[0].duplicate_of is None
+
+
+def test_second_directory_is_marked_a_duplicate_of_the_first():
+    # Arrange
+    idents = _one_account_two_directories()
+    # Act
+    marked = mark_duplicates(idents)
+    # Assert
+    assert marked[1].duplicate_of == "ywata1989-gmail-com"
+
+
+def test_duplicate_is_not_trustworthy():
+    # Arrange — counting it again would double the fleet's apparent capacity.
+    idents = _one_account_two_directories()
+    # Act
+    marked = mark_duplicates(idents)
+    # Assert
+    assert not marked[1].trustworthy
+
+
+def test_the_verified_member_owns_the_group_regardless_of_order():
+    """Directory order must not decide which row keeps its usage figure.
+
+    Reversed, the MISLABELLED directory comes first. If ownership went by
+    order it would claim the group, and the correctly-named account would be
+    the one whose numbers got suppressed — the incident inverted.
+    """
+    # Arrange
+    idents = list(reversed(_one_account_two_directories()))
+    # Act
+    marked = mark_duplicates(idents)
+    # Assert — the mismatched row (now first) is still the duplicate.
+    assert marked[0].duplicate_of == "ywata1989-gmail-com"
+
+
+def test_the_correctly_labelled_account_keeps_its_figures():
+    # Arrange
+    idents = list(reversed(_one_account_two_directories()))
+    # Act
+    marked = mark_duplicates(idents)
+    # Assert
+    assert marked[1].duplicate_of is None
+
+
+def test_unverified_accounts_are_never_grouped_as_duplicates():
+    # Arrange — two unknowns are not evidence of sameness.
+    idents = [
+        AccountIdentity(name="a", state=UNVERIFIED),
+        AccountIdentity(name="b", state=UNVERIFIED),
+    ]
+    # Act
+    marked = mark_duplicates(idents)
+    # Assert
+    assert [m.duplicate_of for m in marked] == [None, None]

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
@@ -361,14 +361,21 @@ def _table_row(**overrides) -> AccountRow:
 
 
 def test_render_stored_table_has_column_headers():
-    """The 2026-07-11 contract: exactly Account | Status | Last Update."""
+    """Account | Status | Identity | Usage as of.
+
+    ``Identity`` joined the table after INCIDENT 2026-08-12, when a
+    credential sitting in the wrong account's directory made sac report one
+    Anthropic account as two. ``Last Update`` became ``Usage as of``: the old
+    header named no particular fact while sitting beside the credential TTL,
+    so a fresh-looking age there was read as vouching for the percentage.
+    """
     # Arrange — one row.
     rows = [_table_row()]
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
     # Act
     out = render_stored_table_to_str(rows, now=now)
     # Assert — every column header is present.
-    for col in ("Account", "Status", "Last Update"):
+    for col in ("Account", "Status", "Identity", "Usage as of"):
         assert col in out, f"missing column header: {col!r}\n---\n{out}"
 
 
@@ -585,14 +592,19 @@ def _build_last_update_header_inputs() -> tuple[list[AccountRow], datetime]:
     return rows, now
 
 
-def test_render_stored_table_header_includes_last_update():
-    """The renamed ``Last Update`` header is present in the table."""
+def test_render_stored_table_header_names_the_usage_snapshot():
+    """The header must name WHICH fact it timestamps, not just "Last Update".
+
+    INCIDENT 2026-08-12: an ambiguous header one cell away from the
+    credential's ``VALID +7h06m`` let a fresh-looking age be read as
+    vouching for the usage percentage beside it.
+    """
     # Arrange
     rows, now = _build_last_update_header_inputs()
     # Act
     out = render_stored_table_to_str(rows, now=now)
     # Assert
-    assert "Last Update" in out
+    assert "Usage as of" in out
 
 
 def test_render_stored_table_header_omits_legacy_as_of():
@@ -882,8 +894,8 @@ def test_cli_list_human_renders_table_columns(sandbox_home):
     runner = CliRunner()
     # Act
     result = runner.invoke(account, ["list"])
-    # Assert — the 2026-07-11 three-column contract from the rich table.
-    for col in ("Account", "Status", "Last Update"):
+    # Assert — the rich table's column contract, end to end through the CLI.
+    for col in ("Account", "Status", "Identity", "Usage as of"):
         assert col in result.output, f"missing column {col!r}:\n{result.output}"
 
 

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
@@ -154,13 +154,15 @@ def test_render_window_line_omits_hint_column_when_block_hintless():
     assert line.startswith("  5h [")
 
 
-def test_render_window_line_unknown_pct_renders_question_mark():
-    # Arrange
+def test_render_window_line_unknown_pct_renders_unknown_label():
+    # Arrange — the label was `(?)`, which reads as a typo or a rounding
+    # artefact rather than as a statement. INCIDENT 2026-08-12: the operator
+    # needs an absent measurement to announce itself in words.
     pct = None
     # Act
     line = render_window_line("7d", pct, hint="", hint_width=0, width=20)
     # Assert
-    assert line.endswith("] (?)")
+    assert line.endswith("] (unknown)")
 
 
 def test_render_account_block_first_line_is_dashed_name():
@@ -205,7 +207,14 @@ def test_render_usage_bars_block_empty_rows_is_empty_string():
 
 
 def _two_bar_rows() -> list[AccountRow]:
-    """Two accounts with different-length names for alignment tests."""
+    """Two accounts with different-length names for alignment tests.
+
+    ``usage_state="known"`` is explicit because ``AccountRow`` defaults it to
+    ``"unknown"`` — unknown-until-proven, so a row that never says it was
+    measured does not get drawn as if it had been (INCIDENT 2026-08-12).
+    These fixtures are asserting how a MEASURED reading renders, so they must
+    declare that they are one.
+    """
     return [
         AccountRow(
             name="alpha-example-com",
@@ -214,6 +223,7 @@ def _two_bar_rows() -> list[AccountRow]:
             used_pct_5h=0.0,
             used_pct_7d=99.0,
             snapshot_as_of=None,
+            usage_state="known",
         ),
         AccountRow(
             name="beta-example-com",
@@ -222,6 +232,7 @@ def _two_bar_rows() -> list[AccountRow]:
             used_pct_5h=14.0,
             used_pct_7d=15.0,
             snapshot_as_of=None,
+            usage_state="known",
         ),
     ]
 
@@ -263,7 +274,10 @@ def test_render_usage_bars_block_hintless_rows_share_bar_column():
 
 
 def test_render_usage_bars_block_no_data_row_renders_placeholder():
-    # Arrange — an account with no cached usage must not crash the block.
+    # Arrange — an account with no cached usage must not crash the block. It
+    # now reads `unknown` rather than `no data`: an absent measurement and a
+    # measurement sac cannot vouch for are the same thing to a reader
+    # deciding whether to trust the row, and one word for it is enough.
     rows = [
         AccountRow(
             name="cold",
@@ -277,7 +291,7 @@ def test_render_usage_bars_block_no_data_row_renders_placeholder():
     # Act
     block = render_usage_bars_block(rows)
     # Assert
-    assert "no data" in block
+    assert "unknown" in block
 
 
 # Fixed clock so the relative reset hints are deterministic (operator
@@ -298,6 +312,7 @@ def _hinted_bar_rows() -> list[AccountRow]:
             # From _HINT_NOW: +4h05m → "in 4h05m"; +2d3h → "in 2d03h".
             reset_at_5h="2026-07-12T04:05:00+00:00",
             reset_at_7d="2026-07-14T03:00:00+00:00",
+            usage_state="known",
         ),
         AccountRow(
             name="beta-example-com",
@@ -306,6 +321,7 @@ def _hinted_bar_rows() -> list[AccountRow]:
             used_pct_5h=14.0,
             used_pct_7d=15.0,
             snapshot_as_of=None,
+            usage_state="known",
         ),
     ]
 

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_bars_average.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_bars_average.py
@@ -26,7 +26,15 @@ from scitex_agent_container.cli_pkg._account_usage_bars import (
 _NOW = datetime(2026, 7, 30, 2, 52, tzinfo=timezone.utc)
 
 
-def _row(name, pct_5h, pct_7d, *, in_5h=1.0, in_7d=100.0):
+def _row(name, pct_5h, pct_7d, *, in_5h=1.0, in_7d=100.0, usage_state="known"):
+    """An AccountRow-shaped reading the fleet average is entitled to count.
+
+    ``usage_state`` is explicit because the Average counts ONLY ``known``
+    readings (INCIDENT 2026-08-12: a stale figure and a figure belonging to
+    another account were both averaged in, and the fleet looked to have
+    headroom it did not have). These rows model measured readings, so they
+    have to say so — a row that omits the field is not counted.
+    """
     return SimpleNamespace(
         provider="claude-code",
         name=name,
@@ -34,6 +42,9 @@ def _row(name, pct_5h, pct_7d, *, in_5h=1.0, in_7d=100.0):
         used_pct_7d=pct_7d,
         reset_at_5h=_NOW + timedelta(hours=in_5h),
         reset_at_7d=_NOW + timedelta(hours=in_7d),
+        usage_state=usage_state,
+        usage_age_seconds=0,
+        usage_reason=None,
     )
 
 

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_bars_unknown.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_bars_unknown.py
@@ -1,0 +1,161 @@
+"""The bars must not draw what sac cannot vouch for (INCIDENT 2026-08-12).
+
+A bar is an assertion. Before this change every reading got one, so a 2 %
+belonging to another account looked exactly like a measured 2 %, and the
+fleet Average counted it. These tests pin the visual contract: an unknown
+reading produces NO fill glyphs at all, a stale one always carries its age,
+and the Average states how many rows it declined to count.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.cli_pkg._account_list_render import AccountRow
+from scitex_agent_container.cli_pkg._account_usage_bars import (
+    render_account_block,
+    render_average_block,
+    render_window_line,
+)
+from scitex_agent_container.cli_pkg._account_usage_state import KNOWN, STALE, UNKNOWN
+
+_FILL = "█"
+
+
+def _row(name, pct, state, **kw):
+    return AccountRow(
+        name=name,
+        freshness_state="VALID",
+        freshness_hours=7.0,
+        used_pct_5h=pct,
+        used_pct_7d=pct,
+        snapshot_as_of=None,
+        usage_state=state,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# unknown draws nothing
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_window_draws_no_filled_blocks():
+    # Arrange — a percentage IS supplied; the state must override it.
+    pct = 3.0
+    # Act
+    line = render_window_line("7d", pct, hint="", hint_width=0, state=UNKNOWN)
+    # Assert
+    assert _FILL not in line
+
+
+def test_unknown_window_is_labelled_unknown():
+    # Arrange
+    pct = 3.0
+    # Act
+    line = render_window_line("7d", pct, hint="", hint_width=0, state=UNKNOWN)
+    # Assert
+    assert "(unknown)" in line
+
+
+def test_unknown_window_says_unknown_inside_the_bar():
+    # Arrange — "no data" would read as an absent account rather than an
+    # unattributable one.
+    pct = None
+    # Act
+    line = render_window_line("5h", pct, hint="", hint_width=0, state=UNKNOWN)
+    # Assert
+    assert "unknown" in line.split("]")[0]
+
+
+# ---------------------------------------------------------------------------
+# stale always shows its age
+# ---------------------------------------------------------------------------
+
+
+def test_stale_window_shows_the_percentage_with_its_age():
+    # Arrange
+    pct = 3.0
+    # Act
+    line = render_window_line(
+        "7d", pct, hint="", hint_width=0, state=STALE, age_seconds=86_400
+    )
+    # Assert
+    assert "(3% stale 1d)" in line
+
+
+def test_known_window_shows_a_bare_percentage():
+    # Arrange
+    pct = 3.0
+    # Act
+    line = render_window_line("7d", pct, hint="", hint_width=0, state=KNOWN)
+    # Assert
+    assert "(3%)" in line
+
+
+# ---------------------------------------------------------------------------
+# the block explains itself
+# ---------------------------------------------------------------------------
+
+
+def test_block_states_why_a_reading_is_not_known():
+    # Arrange — "network down" and "wrong account" need opposite responses,
+    # and a bare `unknown` cannot tell them apart.
+    row = _row(
+        "ywatanabe-scitex-ai",
+        None,
+        UNKNOWN,
+        usage_reason="credential belongs to ywata1989@gmail.com",
+    )
+    # Act
+    block = render_account_block(row, hint_5h="", hint_7d="", hint_width=0)
+    # Assert
+    assert block[-1].strip() == "! credential belongs to ywata1989@gmail.com"
+
+
+def test_known_block_has_no_explanation_line():
+    # Arrange
+    row = _row("acct", 3.0, KNOWN)
+    # Act
+    block = render_account_block(row, hint_5h="", hint_7d="", hint_width=0)
+    # Assert
+    assert len(block) == 3
+
+
+# ---------------------------------------------------------------------------
+# the fleet average refuses to count what it cannot vouch for
+# ---------------------------------------------------------------------------
+
+
+def test_average_counts_only_known_rows():
+    # Arrange — the incident: one real account, one duplicate of it.
+    rows = [_row("real", 3.0, KNOWN), _row("twin", None, UNKNOWN)]
+    # Act
+    block = render_average_block(rows, hint_width=0)
+    # Assert
+    assert block[0].startswith("- Average (n=1)")
+
+
+def test_average_states_how_many_rows_it_declined_to_count():
+    # Arrange
+    rows = [_row("real", 3.0, KNOWN), _row("twin", None, UNKNOWN)]
+    # Act
+    block = render_average_block(rows, hint_width=0)
+    # Assert
+    assert "1 of 2 not counted" in block[0]
+
+
+def test_average_excludes_stale_rows_from_the_mean():
+    # Arrange — 3 % known and 99 % stale must not average to 51 %.
+    rows = [_row("fresh", 3.0, KNOWN), _row("old", 99.0, STALE)]
+    # Act
+    block = render_average_block(rows, hint_width=0)
+    # Assert
+    assert "(3%)" in block[1]
+
+
+def test_average_is_unknown_when_no_row_can_be_counted():
+    # Arrange — must NOT render an empty bar, which reads as 0 %.
+    rows = [_row("a", None, UNKNOWN), _row("b", None, UNKNOWN)]
+    # Act
+    block = render_average_block(rows, hint_width=0)
+    # Assert
+    assert block == ["- Average (unknown — 2 of 2 not counted)"]

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_state.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_state.py
@@ -1,0 +1,239 @@
+"""Gates for the three-valued usage reading (INCIDENT 2026-08-12).
+
+`sac accounts list` drew a confident 2 % bar over a figure the Anthropic
+console had at 92 %. The number was neither stale nor miscomputed — it
+belonged to a DIFFERENT account. A bar is an assertion, and the renderer had
+no way to say "I did not measure this", so it asserted anyway.
+
+These tests pin the three states apart. The ones that matter most assert
+that ``pct_*`` is ``None`` for an unknown reading: making "we don't know"
+unrepresentable as a number is what stops a downstream renderer or aggregate
+from quietly treating it as data.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from scitex_agent_container._account.account_verify import (
+    MISMATCH,
+    UNVERIFIED,
+    VERIFIED,
+    AccountIdentity,
+)
+from scitex_agent_container.cli_pkg._account_usage_state import (
+    KNOWN,
+    STALE,
+    UNKNOWN,
+    classify_usage,
+    format_age_short,
+)
+
+NOW = datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)
+
+GOOD = AccountIdentity(
+    name="acct", state=VERIFIED, verified_email="a@example.com", verified_uuid="u1"
+)
+WRONG_OWNER = AccountIdentity(
+    name="ywatanabe-scitex-ai",
+    state=MISMATCH,
+    claimed_email="ywatanabe@scitex.ai",
+    verified_email="ywata1989@gmail.com",
+)
+NOT_CHECKED = AccountIdentity(name="acct", state=UNVERIFIED)
+
+
+def _usage(age_seconds=10):
+    as_of = (NOW - timedelta(seconds=age_seconds)).isoformat()
+    return {
+        "used_pct_5h": 9.0,
+        "used_pct_7d": 3.0,
+        "reset_at_5h": "2026-08-12T14:49:59+00:00",
+        "reset_at_7d": "2026-08-18T08:00:00+00:00",
+        "as_of": as_of,
+        "fetched_at": as_of,
+    }
+
+
+# ---------------------------------------------------------------------------
+# known
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_usage_from_a_verified_account_is_known():
+    # Arrange
+    usage = _usage(age_seconds=10)
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.state == KNOWN
+
+
+def test_known_reading_carries_the_percentage():
+    # Arrange
+    usage = _usage(age_seconds=10)
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.pct_7d == 3.0
+
+
+def test_known_reading_is_countable_in_the_fleet_average():
+    # Arrange
+    usage = _usage(age_seconds=10)
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.countable
+
+
+# ---------------------------------------------------------------------------
+# stale
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_older_than_the_refresh_window_is_stale():
+    # Arrange — a day old, which is what the store actually held.
+    usage = _usage(age_seconds=86_400)
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.state == STALE
+
+
+def test_stale_reading_keeps_its_number_for_display():
+    # Arrange — the operator can still judge a day-old figure, if TOLD it is.
+    usage = _usage(age_seconds=86_400)
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.pct_7d == 3.0
+
+
+def test_stale_reading_reports_its_age():
+    # Arrange
+    usage = _usage(age_seconds=86_400)
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.age_seconds == 86_400
+
+
+def test_stale_reading_is_not_countable_in_the_fleet_average():
+    # Arrange — averaging it in would launder the staleness away.
+    usage = _usage(age_seconds=86_400)
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert not reading.countable
+
+
+# ---------------------------------------------------------------------------
+# unknown — identity
+# ---------------------------------------------------------------------------
+
+
+def test_usage_from_a_mismatched_credential_is_unknown():
+    # Arrange — the exact incident: freshest possible number, wrong account.
+    usage = _usage(age_seconds=1)
+    # Act
+    reading = classify_usage(usage, WRONG_OWNER, now=NOW)
+    # Assert
+    assert reading.state == UNKNOWN
+
+
+def test_mismatched_credential_drops_the_percentage_entirely():
+    # Arrange
+    usage = _usage(age_seconds=1)
+    # Act
+    reading = classify_usage(usage, WRONG_OWNER, now=NOW)
+    # Assert — not merely undrawn; unrepresentable.
+    assert reading.pct_7d is None
+
+
+def test_mismatch_reason_names_both_accounts():
+    # Arrange
+    usage = _usage(age_seconds=1)
+    # Act
+    reading = classify_usage(usage, WRONG_OWNER, now=NOW)
+    # Assert
+    assert "ywata1989@gmail.com" in reading.reason
+
+
+def test_unverified_identity_makes_usage_unknown():
+    # Arrange — sac could not check whose numbers these are.
+    usage = _usage(age_seconds=1)
+    # Act
+    reading = classify_usage(usage, NOT_CHECKED, now=NOW)
+    # Assert
+    assert reading.state == UNKNOWN
+
+
+def test_duplicate_account_usage_is_unknown():
+    # Arrange — counting it again is what invented the phantom headroom.
+    twin = AccountIdentity(
+        name="ywatanabe-scitex-ai",
+        state=VERIFIED,
+        verified_email="ywata1989@gmail.com",
+        duplicate_of="ywata1989-gmail-com",
+    )
+    # Act
+    reading = classify_usage(_usage(age_seconds=1), twin, now=NOW)
+    # Assert
+    assert reading.reason == "same Anthropic account as ywata1989-gmail-com"
+
+
+# ---------------------------------------------------------------------------
+# unknown — data
+# ---------------------------------------------------------------------------
+
+
+def test_absent_usage_is_unknown():
+    # Arrange
+    usage = None
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.state == UNKNOWN
+
+
+def test_untimestamped_usage_is_unknown_not_fresh():
+    # Arrange — a figure that cannot be aged is the "fresh-looking but
+    # arbitrarily old" shape this module exists to refuse.
+    usage = {"used_pct_5h": 9.0, "used_pct_7d": 3.0}
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.state == UNKNOWN
+
+
+def test_usage_with_no_figures_is_unknown():
+    # Arrange
+    usage = {"used_pct_5h": None, "used_pct_7d": None, "as_of": NOW.isoformat()}
+    # Act
+    reading = classify_usage(usage, GOOD, now=NOW)
+    # Assert
+    assert reading.state == UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# age formatting
+# ---------------------------------------------------------------------------
+
+
+def test_day_old_age_renders_in_days():
+    # Arrange
+    age = 90_000
+    # Act
+    rendered = format_age_short(age)
+    # Assert
+    assert rendered == "1d"
+
+
+def test_unknown_age_renders_as_question_mark():
+    # Arrange
+    age = None
+    # Act
+    rendered = format_age_short(age)
+    # Assert
+    assert rendered == "?"


### PR DESCRIPTION
## What happened

`sac accounts list` reported `claude-code:ywatanabe-scitex-ai` at **2% weekly**. The Anthropic console, same account, same moment: **92% used, session 100%, resets Tue 08:00**. Two accounts were reported as having 98% headroom and capacity was planned on that.

The number was **not stale and not miscomputed**. It was truthful about a **different account**.

## Where the number comes from

The real Anthropic OAuth API — `GET /api/oauth/usage`. Nothing is locally accounted. I probed it read-only (GET only, no refresh, no credential written) and sac's `five_hour`/`seven_day` utilization match the payload's own `limits[]` `session`/`weekly_all` percents exactly. The parsing is correct.

## Root cause

Measured on the host:

| store directory | profile says | account uuid |
| --- | --- | --- |
| `anthropic/ywata1989-gmail-com/` | ywata1989@gmail.com | `a84bd9dd…` |
| `anthropic/ywatanabe-scitex-ai/` | **ywata1989@gmail.com** | **`a84bd9dd…`** |
| `anthropic/wyusuuke-gmail-com/` | wyusuuke@gmail.com | `1f84bada…` |

One Anthropic account occupied **two directories**, so it was rendered as two rows and counted twice in the fleet average. Meanwhile `wyusuuke-gmail-com` was at `seven_day` utilization **100.0**, `limits[weekly_all]` severity **critical** — the fleet was saturated while the average said otherwise.

The two directories hold **different access tokens**. Comparing credential files, or token fingerprints, reports "distinct" for a genuine duplicate — I made exactly that mistake first. Only the account uuid answers it.

**Account identity was resolved by directory name.** A stored credential carries no identity claim of any kind — the OAuth snapshot holds only `accessToken` / `refreshToken` / `expiresAt` / `scopes` / `subscriptionType` / `rateLimitTier`, and the tokens are opaque `sk-ant-oat01-…` strings, not decodable JWTs. So the directory name and a write-once `account.json` sidecar were the only things naming an account, and neither is re-checked after it is written. Any write into the wrong directory — a manual `/login`, a store consolidation onto a new canonical host, a rotation, a peer push — relabels one account as another permanently and invisibly. Nothing looks broken; every number stays internally consistent.

The whoami primitive already existed (`_account/account_identity.fetch_account_email`, added for `creds_sync` after a 2026-07 clobber). The display path never called it.

## What changed

- **`_account/account_verify.py`** — asks `GET /api/oauth/profile` (same host and headers as the usage call sac already makes) for the account a credential actually authenticates as. Three states, never two: `verified` / `mismatch` / `unverified`. Verdicts cache beside the credential, keyed to a **sha256 prefix of the token** they were reached about, so a `/login` invalidates them the instant it lands rather than after a timeout.
- **`mark_duplicates`** groups by account uuid and prefers the **verified** member as group owner — directory order must not decide which row keeps its figures, or the incident inverts and the correctly-named account is the one silenced.
- **`cli_pkg/_account_usage_state.py`** — grades every reading `known` / `stale` / `unknown`. `pct_*` is `None` whenever the state is unknown, so "we don't know" is **unrepresentable as a number** and no renderer or aggregate can treat it as data. The staleness threshold is the fetcher's own TTL, imported rather than redeclared.
- **The bars no longer draw what sac cannot vouch for.** Unknown gets no fill glyphs, an `(unknown)` label, and a line saying why. Stale always carries its age. The Average counts only `known` rows and states how many it declined to count.
- **`Last Update` → `Usage as of`**, plus a new **`Identity`** column naming the account a credential proved to be, or that nobody could ask.

An unverified identity withholds only the *percentage*, not the reset hints — collapsing on a transient endpoint failure would blind the table exactly when an operator reaches for it, and a previously-verified account survives an outage anyway because its cached verdict is token-bound.

`_account_list_render` was over the 512-line cap, so acquisition moved to `_account_list_build`; every moved name is re-exported.

## Proof

Same fixtures, same measured payloads, driven offline through both code paths (`urlopen` patched; no credential touched).

**Before** — the incident, reproduced:

```
│ claude-code │ ywata1989-gmail-com │ VALID +7h00m │ Wed 11h (10s) │
│ claude-code │ ywatanabe-scitex-ai │ VALID +7h00m │ Wed 11h (10s) │

- claude-code:ywata1989-gmail-com
  7d (in 5d20h) [█░░░░░░░░░░░░░░░░░░░] (3%)
- claude-code:ywatanabe-scitex-ai
  7d (in 5d20h) [█░░░░░░░░░░░░░░░░░░░] (3%)
- Average (n=2)
  7d (in 5d20h) [█░░░░░░░░░░░░░░░░░░░] (3%)
```

**After**:

```
│ claude-code │ ywata1989-gmail-com │ VALID +7h00m │ ywata1989@gmail.com              │ Wed 11h (10s) │
│ claude-code │ ywatanabe-scitex-ai │ VALID +7h00m │ DUPLICATE of ywata1989-gmail-com │ -             │

- claude-code:ywata1989-gmail-com
  7d (in 5d20h) [█░░░░░░░░░░░░░░░░░░░] (3%)
- claude-code:ywatanabe-scitex-ai
  5h            [      unknown       ] (unknown)
  7d            [      unknown       ] (unknown)
     ! credential belongs to ywata1989@gmail.com, not ywatanabe@scitex.ai
- Average (n=1) — 1 of 2 not counted
  7d (in 5d20h) [█░░░░░░░░░░░░░░░░░░░] (3%)
```

**Staleness**, day-old snapshot with the usage API unreachable — before `(3%)`, after `(3% stale 1d)` and excluded from the average.

## Tests

`3530 passed, 1 skipped` across `tests/scitex_agent_container/cli_pkg/` + `tests/scitex_agent_container/_account/`. 44 new gates; 10 pre-existing tests updated where they encoded the old contract (the column name, `(?)` → `(unknown)`, and fixtures that now declare they model a *measured* reading).

## Operational note — not fixed here

The store on this host still has a ywata1989 credential in the `ywatanabe-scitex-ai` directory. This PR makes sac *report* that rather than hide it; repairing the store means re-logging that account into its own directory, which I did not touch per instruction. And `wyusuuke-gmail-com` is genuinely at 100% weekly.
