### PR TITLE
fix(fleet-sync): a diagnostic on stderr was being counted as JSON payload

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_fleet_sync.py
+++ b/src/scitex_agent_container/cli_pkg/_fleet_sync.py
@@ -37,13 +37,11 @@ from pathlib import Path
 from typing import Any
 
 import click
-
 from rich.console import Console
 
 from .._state.host_config import Config, build_ssh_argv, load
 from .._state.spec_manifest import build_manifest, diff_manifests
 from ._helpers import console
-
 
 _DEFAULT_AGENTS_DIR = "~/.scitex/agent-container/agents"
 
@@ -149,7 +147,8 @@ def _render_text_conflicts(diff: dict[str, Any]) -> None:
     The shared ``_helpers.console`` is a plain ``Console()`` — i.e. stdout —
     so this deliberately uses the module's ``_err_console`` instead. The
     docstring above has promised stderr since the command landed; until
-    #1006 the code wrote to stdout regardless.
+    PR #1024 the code wrote to stdout regardless, which meant
+    ``sac fleet sync > out`` silently swallowed the whole conflict report.
     """
     fleet = diff["fleet"]
     unreachable = diff.get("unreachable", [])
@@ -199,7 +198,9 @@ def _render_text_conflicts(diff: dict[str, Any]) -> None:
         style="bold",
     )
     _err_console.print("Operator action (sac will NEVER do this for you):")
-    _err_console.print("  1. Pick the authoritative copy per agent — sac has no opinion.")
+    _err_console.print(
+        "  1. Pick the authoritative copy per agent — sac has no opinion."
+    )
     _err_console.print("  2. Rsync that tree to the diverged hosts manually.")
     _err_console.print("  3. Re-run `sac fleet sync` until it exits 0.")
     _err_console.print("=" * 72)

--- a/src/scitex_agent_container/cli_pkg/_fleet_sync.py
+++ b/src/scitex_agent_container/cli_pkg/_fleet_sync.py
@@ -38,12 +38,23 @@ from typing import Any
 
 import click
 
+from rich.console import Console
+
 from .._state.host_config import Config, build_ssh_argv, load
 from .._state.spec_manifest import build_manifest, diff_manifests
 from ._helpers import console
 
 
 _DEFAULT_AGENTS_DIR = "~/.scitex/agent-container/agents"
+
+# The conflict report is a DIAGNOSTIC, not this command's payload: `sac fleet
+# sync` exits non-zero when it prints one, and its sibling fail-loud paths
+# (``_fail_loud_unreachable`` / ``_fail_loud_unresolvable``) already use
+# ``err=True``. Routing it through a stderr Console keeps stdout carrying only
+# the payload, so `sac fleet sync --json | jq` and `sac fleet sync > out` both
+# stay honest. ``Console(stderr=True)`` resolves ``sys.stderr`` per write, so it
+# stays in lockstep with click's isolated streams and pytest's capture.
+_err_console = Console(stderr=True)
 
 
 def _resolve_agents_dir(override: Path | None) -> Path:
@@ -133,17 +144,25 @@ def _fail_loud_unresolvable(
 
 def _render_text_conflicts(diff: dict[str, Any]) -> None:
     """Loud, operator-readable conflict report. Written on stderr so
-    JSON consumers can rely on stdout staying clean."""
+    JSON consumers can rely on stdout staying clean.
+
+    The shared ``_helpers.console`` is a plain ``Console()`` — i.e. stdout —
+    so this deliberately uses the module's ``_err_console`` instead. The
+    docstring above has promised stderr since the command landed; until
+    #1006 the code wrote to stdout regardless.
+    """
     fleet = diff["fleet"]
     unreachable = diff.get("unreachable", [])
-    console.print("FLEET SPEC CONFLICT — fail loud, no auto-merge", style="bold red")
-    console.print("=" * 72)
-    console.print(f"fleet hosts: {', '.join(fleet)}")
+    _err_console.print(
+        "FLEET SPEC CONFLICT — fail loud, no auto-merge", style="bold red"
+    )
+    _err_console.print("=" * 72)
+    _err_console.print(f"fleet hosts: {', '.join(fleet)}")
     if unreachable:
-        console.print("[yellow]warnings (unresolvable peers):[/yellow]")
+        _err_console.print("[yellow]warnings (unresolvable peers):[/yellow]")
         for u in unreachable:
-            console.print(f"  - {u['peer']}: {u.get('reason', '?')}")
-    console.print("")
+            _err_console.print(f"  - {u['peer']}: {u.get('reason', '?')}")
+    _err_console.print("")
 
     conflict_count = 0
     for agent in sorted(diff["agents"].keys()):
@@ -151,37 +170,39 @@ def _render_text_conflicts(diff: dict[str, Any]) -> None:
         if entry["ok"]:
             continue
         conflict_count += 1
-        console.print(f"agent: {agent}", style="bold")
+        _err_console.print(f"agent: {agent}", style="bold")
         for c in entry["conflicts"]:
-            console.print(f"  file: {c['file']}")
-            console.print(f"    kind:       {c['kind']}")
+            _err_console.print(f"  file: {c['file']}")
+            _err_console.print(f"    kind:       {c['kind']}")
             for h in fleet:
                 ph = c["per_host"].get(h)
                 if ph is None:
                     continue
                 if not ph.get("present"):
                     marker = "<-- DIFFERS" if h in c["diverged_hosts"] else ""
-                    console.print(f"    {h:<11} <missing>                                     {marker}")
+                    _err_console.print(
+                        f"    {h:<11} <missing>                                     {marker}"
+                    )
                     continue
                 sha = ph.get("sha256", "")
                 size = ph.get("size", "")
                 mode = ph.get("mode", "")
                 marker = "<-- DIFFERS" if h in c["diverged_hosts"] else ""
-                console.print(
+                _err_console.print(
                     f"    {h:<11} sha256={sha[:14] + '...' if sha else '':<18} "
                     f"size={size}  mode={mode}   {marker}".rstrip()
                 )
-        console.print("")
-    console.print("=" * 72)
-    console.print(
+        _err_console.print("")
+    _err_console.print("=" * 72)
+    _err_console.print(
         f"SUMMARY: {conflict_count} agent(s) conflict across {len(fleet)} host(s); refusing to merge.",
         style="bold",
     )
-    console.print("Operator action (sac will NEVER do this for you):")
-    console.print("  1. Pick the authoritative copy per agent — sac has no opinion.")
-    console.print("  2. Rsync that tree to the diverged hosts manually.")
-    console.print("  3. Re-run `sac fleet sync` until it exits 0.")
-    console.print("=" * 72)
+    _err_console.print("Operator action (sac will NEVER do this for you):")
+    _err_console.print("  1. Pick the authoritative copy per agent — sac has no opinion.")
+    _err_console.print("  2. Rsync that tree to the diverged hosts manually.")
+    _err_console.print("  3. Re-run `sac fleet sync` until it exits 0.")
+    _err_console.print("=" * 72)
 
 
 def _fetch_peer_manifest(

--- a/tests/scitex_agent_container/cli_pkg/test_fleet_group_sync.py
+++ b/tests/scitex_agent_container/cli_pkg/test_fleet_group_sync.py
@@ -14,6 +14,31 @@ keeps tests hermetic while exercising the full real argv-build /
 real-subprocess path through production.
 
 One assertion per test (TQ007), AAA layout (TQ002).
+
+``result.stdout`` vs ``result.output`` — read this before "simplifying"
+---------------------------------------------------------------------
+Every JSON assertion below parses ``result.stdout``, never
+``result.output``. Under click >= 8.2 the ``mix_stderr`` knob is gone and
+``result.output`` is the MERGED stdout+stderr transcript; ``result.stdout``
+is the payload stream on its own. Parsing the merged transcript asserts
+"this command emitted no diagnostics at all", which is a stricter and
+different contract from the one ``--json`` actually offers ("stdout carries
+only the JSON"). Any log record that lands on stderr while the command runs
+— scitex-logging's handler resolves ``sys.stderr`` per emit, so it follows
+click's isolated streams — then gets appended after the JSON and
+``json.loads`` raises ``Extra data`` at exactly ``len(payload)``.
+
+That is not hypothetical: develop went red on 2026-08-12 with
+``Extra data: line 45 column 1 (char 1036)`` and ``... (char 546)``, where
+1036 and 546 are the exact byte lengths of the two clean payloads. Only the
+py3.12 xdist leg failed; py3.11 and py3.13 passed the same code, because
+whether a background log record lands inside a given invoke is a race.
+
+Switching to ``result.stdout`` narrows the assertion to the real contract
+WITHOUT weakening it: a genuine stdout leak still fails here, because the
+junk would still be in ``result.stdout``. See
+``test_sync_json_stdout_stays_pure_json_when_a_log_record_is_emitted``,
+which pins that contract directly.
 """
 
 from __future__ import annotations
@@ -23,10 +48,13 @@ import os
 import sys
 from pathlib import Path
 
+import click
+import scitex_logging
 import yaml
 from click.testing import CliRunner
 
 from scitex_agent_container._state.spec_manifest import build_manifest
+from scitex_agent_container.cli_pkg._fleet_sync import fleet_sync_impl
 from scitex_agent_container.cli_pkg.fleet_group import fleet_group
 
 # ---------------------------------------------------------------------------
@@ -159,7 +187,7 @@ def test_sync_collect_emits_manifest_with_local_host_name(
     runner = CliRunner()
     # Act
     result = runner.invoke(fleet_group, ["sync", "--collect", "--json"])
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     # Assert
     assert payload["host"] == "local"
 
@@ -173,7 +201,7 @@ def test_sync_collect_emits_spec_yaml_sha256(tmp_path: Path, env_save_restore) -
     runner = CliRunner()
     # Act
     result = runner.invoke(fleet_group, ["sync", "--collect", "--json"])
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     # Assert
     assert "sha256" in payload["agents"]["alpha"]["files"]["spec.yaml"]
 
@@ -324,7 +352,7 @@ def test_sync_json_output_marks_overall_ok_false_on_divergence(
     runner = CliRunner()
     # Act
     result = runner.invoke(fleet_group, ["sync", "--json"])
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     # Assert
     assert payload["ok"] is False
 
@@ -360,7 +388,7 @@ def test_sync_json_output_lists_diverged_hosts_for_conflict(
     runner = CliRunner()
     # Act
     result = runner.invoke(fleet_group, ["sync", "--json"])
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     spec_conflict = next(
         c for c in payload["agents"]["alpha"]["conflicts"] if c["file"] == "spec.yaml"
     )
@@ -481,7 +509,7 @@ def test_sync_missing_agent_on_peer_flagged_as_agent_missing_on_host(
     runner = CliRunner()
     # Act
     result = runner.invoke(fleet_group, ["sync", "--json"])
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     kinds = {c["kind"] for c in payload["agents"]["alpha"]["conflicts"]}
     # Assert
     assert "agent_missing_on_host" in kinds
@@ -522,7 +550,7 @@ def test_sync_only_flag_narrows_audit_to_named_agents(
     runner = CliRunner()
     # Act
     result = runner.invoke(fleet_group, ["sync", "--json", "--only", "alpha"])
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     # Assert
     assert payload["ok"] is True
 
@@ -624,9 +652,115 @@ def test_sync_allow_unresolvable_downgrades_unresolvable_peer_to_warning(
     runner = CliRunner()
     # Act
     result = runner.invoke(fleet_group, ["sync", "--json", "--allow-unresolvable"])
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     # Assert
     assert payload["unreachable"][0]["peer"] == "hpc"
+
+
+# ---------------------------------------------------------------------------
+# The stdout/stderr split itself — the contract `--json` actually offers.
+# ---------------------------------------------------------------------------
+
+
+def _diverged_fleet_probe(tmp_path: Path, env_save_restore) -> click.Command:
+    """Stage a one-conflict fleet and wrap the REAL impl in a click command
+    that also emits a REAL sac diagnostic while the command is running.
+
+    No mocks (PA-306): real ``fleet_sync_impl``, real ``scitex_logging``
+    logger, real handler. This is the CI failure mode in miniature — sac's
+    log handler re-resolves ``sys.stderr`` on every emit, so a record emitted
+    mid-command lands in click's isolated stderr, and therefore in the merged
+    ``result.output``, right after the JSON.
+    """
+    _write_config(
+        tmp_path,
+        env_save_restore,
+        canonical="local",
+        peers={"spartan": {"ssh": "spartan-host"}},
+    )
+    home = _redirect_home(tmp_path, env_save_restore)
+    _make_agent(home / ".scitex/agent-container/agents", "alpha", spec="v1\n")
+    peer_agents = tmp_path / "spartan_agents"
+    _make_agent(peer_agents, "alpha", spec="v2\n")
+    _install_ssh_shim(
+        tmp_path,
+        mapping={"spartan-host": {"stdout": _manifest_json("spartan", peer_agents)}},
+        env_save_restore=env_save_restore,
+    )
+
+    @click.command("probe")
+    def _probe() -> None:
+        try:
+            fleet_sync_impl(
+                as_json=True,
+                only=(),
+                peer_filter=(),
+                allow_unresolvable=False,
+                collect=False,
+                agents_dir_override=None,
+            )
+        except SystemExit:
+            pass  # exit 1 is the expected divergence verdict; keep emitting.
+        scitex_logging.getLogger("scitex_agent_container").error(
+            "github_ci_poll_loop: `gh` is not installed/authenticated"
+        )
+
+    return _probe
+
+
+def test_sync_json_stdout_stays_pure_json_when_a_log_record_is_emitted(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange
+    probe = _diverged_fleet_probe(tmp_path, env_save_restore)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(probe, [])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["ok"] is False
+
+
+def test_sync_diagnostic_log_record_goes_to_stderr_not_stdout(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — guards the test above against being vacuously true: if the
+    # record never reached the captured stderr, the "stdout is clean"
+    # assertion would prove nothing.
+    probe = _diverged_fleet_probe(tmp_path, env_save_restore)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(probe, [])
+    # Assert
+    assert "github_ci_poll_loop" in result.stderr
+
+
+def test_sync_text_conflict_report_keeps_stdout_empty(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — text mode exits 1; the report is a diagnostic, so stdout must
+    # stay empty rather than carrying the human report (the docstring on
+    # ``_render_text_conflicts`` has always promised stderr).
+    _write_config(
+        tmp_path,
+        env_save_restore,
+        canonical="local",
+        peers={"spartan": {"ssh": "spartan-host"}},
+    )
+    home = _redirect_home(tmp_path, env_save_restore)
+    _make_agent(home / ".scitex/agent-container/agents", "alpha", spec="v1\n")
+    peer_agents = tmp_path / "spartan_agents"
+    _make_agent(peer_agents, "alpha", spec="v2\n")
+    _install_ssh_shim(
+        tmp_path,
+        mapping={"spartan-host": {"stdout": _manifest_json("spartan", peer_agents)}},
+        env_save_restore=env_save_restore,
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(fleet_group, ["sync"])
+    # Assert
+    assert result.stdout == ""
 
 
 # EOF


### PR DESCRIPTION
## What the "extra data" actually was

`develop`'s py3.12 matrix leg went red with:

```
test_sync_json_output_lists_diverged_hosts_for_conflict          Extra data: line 45 column 1 (char 1036)
test_sync_missing_agent_on_peer_flagged_as_agent_missing_on_host Extra data: line 33 column 1 (char 546)
```

I measured the two clean payloads locally: **1036 and 546 bytes exactly.** So the
JSON was complete and correct, and the extra data began at the first byte past it.

It was **stderr**, not a stdout leak.

* Under click >= 8.2 the `mix_stderr` knob is gone. `result.output` is the
  **merged** stdout+stderr transcript; `result.stdout` is the payload stream alone.
* scitex-logging's root handler is a `LazyStderrStreamHandler` that re-resolves
  `sys.stderr` on **every emit** — deliberately, per its own docstring, "so it
  stays in lockstep with ... click's isolated streams". A record logged while the
  command runs therefore lands in click's captured stderr, and so in
  `result.output`, right after the JSON.

Measured directly — a `scitex_logging` record emitted during an invoke:

```
json.loads(result.output): FAILED -> Extra data: line 7 column 1 (char 52)
  extra data at 52: 'ERRO: github_ci_poll_loop: `gh` is not installed/authenticated\n'
json.loads(result.stdout): OK
```

That is the CI signature reproduced exactly: extra data starting at `len(payload)`.

## Did it begin with #1005?

**No — #1005 is not the cause.** The suspicion was reasonable, and that `ERRO:
github_ci_poll_loop` line does appear ~20 times in the failing job's log, but:

* it goes to `logger.error(...)`, i.e. **stderr**, which is correct;
* the same trap predates it — any record on any logger does this;
* **py3.11 and py3.13 passed the identical code in the same run.** Whether a
  record lands inside a given invoke is a race, not a property of #1005.

Nor is it py3.12-specific: py3.12 is simply the leg that lost the race this time.

## The fix

**Tests parse `result.stdout`.** This narrows the assertion to the contract
`--json` actually offers ("stdout carries only the JSON") instead of the stricter
and different one it was accidentally asserting ("this command emitted no
diagnostics at all"). It is **not** tolerating trailing junk: a genuine stdout
leak still fails, because the junk would still be in `result.stdout`.

sac's production contract was already correct — `sac fleet sync --json | jq` gets
clean stdout, verified.

**One real emitter bug did turn up next door,** and is fixed here.
`_render_text_conflicts` has promised, in its own docstring since the command
landed, that it is "written on stderr so JSON consumers can rely on stdout staying
clean" — but it printed through the shared `_helpers.console`, which is a plain
`Console()`, i.e. **stdout**. Its sibling fail-loud paths (`_fail_loud_unreachable`,
`_fail_loud_unresolvable`) all use `err=True`. It now uses a stderr `Console`, so
`sac fleet sync > out` no longer swallows the conflict report into the redirect.

## Tests

Three new tests pin the contract directly rather than relying on the incidental
absence of diagnostics:

* `test_sync_json_stdout_stays_pure_json_when_a_log_record_is_emitted` — real
  `fleet_sync_impl`, real scitex-logging record emitted mid-command, no mocks.
* `test_sync_diagnostic_log_record_goes_to_stderr_not_stdout` — guards the above
  against passing vacuously if the record never reached the captured stderr.
* `test_sync_text_conflict_report_keeps_stdout_empty` — text mode leaves stdout
  empty.

The module docstring now records why `result.stdout` is deliberate, with the
measured offsets, so nobody "simplifies" it back.

**Measured: 21 passed in the file (was 18).** No matrix leg weakened or skipped.

## Pre-existing, not fixed here

The same trap is latent at **122 more `json.loads(result.output)` call sites
across 32 test files** (`test_a2a_group.py` 11, `test_state_db.py` 10,
`test_status_cmds.py` 8, `test_db_group.py` 8, ...). Every one can go red at
random the same way. Left out of this PR because this one is gating develop —
recommend a follow-up sweep.

Separately, run 31572778831 (py3.11, 07:09Z, pre-#1005) failed
`test_priority_cmds.py::test_check_priority_honours_explicit_current_host_flag`
with `Expecting value: line 1 column 1 (char 0)` — an *empty* stream, so a
different fault from this one, not the same mechanism. Flagging it as a
separate open flake rather than folding it in here.
