### PR TITLE
fix(ci): the light lane's destination is data, so a dead pool is a settings change

### DIFF
--- a/.github/runner-pin-allowlist.yaml
+++ b/.github/runner-pin-allowlist.yaml
@@ -1,0 +1,81 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# LITERAL runner-pool pins — the ONLY sanctioned exceptions.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# THE RULE: a job's runner pool is named by a repository VARIABLE, not frozen
+# into the workflow. A pool named in YAML can only be re-pointed by a pull
+# request — through the CI gate that the dead pool just jammed.
+#
+# THE INCIDENT (2026-08-12, and the reason this file exists). PR #1006 gave
+# five sub-minute single-core jobs their own "light lane" and wrote the
+# destination as `["self-hosted","Linux","X64","spartan-cpu"]`. The
+# measurement behind it was sound; the SEAM was not. Six days later those
+# runners went offline and `ruff`, `rtd-sphinx-build`, `import-smoke`,
+# `no-hosted-runners` and `scitex-dev-quality-audit` queued FOREVER on every
+# PR while four `scitex-org-cpu` runners sat online and idle. Fifteen PRs
+# could not merge. Nothing was failing — the checks simply never started,
+# which looks identical to "not run yet" on every screen that shows it.
+#
+# Enforced by `src/scitex_agent_container/_runner_pool_guard.py`, which runs
+#   - as a step of the SELF-HOSTED guard job
+#     (.github/workflows/no-hosted-runners-guard-on-self-hosted.yml),
+#   - as a `pre-commit` hook,
+#   - as a pytest test against this very repo.
+#
+# WHEN A LITERAL PIN IS ACTUALLY RIGHT
+# ====================================
+# When the job's purpose is TO REACH ONE NAMED PLACE, rather than to run
+# somewhere appropriate. A variable expresses "wherever this class of work
+# belongs"; it cannot express "that specific machine, and no substitute".
+# Both entries below are of the second kind. Note what they have in common:
+# each would be WRONG if it silently ran somewhere else — a canary reporting
+# on the wrong pool, a verdict written to the wrong host's database.
+#
+# THE `reason:` FIELD IS MANDATORY AND MACHINE-ENFORCED.
+# The guard FAILS (SAC-CI006) on any entry whose `reason:` is missing or
+# shorter than 40 characters, and FAILS (SAC-CI007) on a STALE entry — one
+# whose workflow is gone, or which no longer pins anything — because a dead
+# exception is a live loophole: it pre-approves whatever that file pins next.
+#
+# WRITE THE REASON FOR THE DAY THE POOL DIES. That is the day someone reads
+# it, and the only question they will have is "may I re-point this?" An entry
+# that does not answer that has not earned its place.
+# ─────────────────────────────────────────────────────────────────────────────
+
+allow:
+  - workflow: spartan-capacity-canary-on-self-hosted.yml
+    jobs:
+      - canary
+    approved_on: 2026-08-12
+    reason: >-
+      NAMING THE POOL *IS* THE MEASUREMENT. This workflow exists to answer one
+      question — can the spartan-cpu machines pass this repo's jobs at all —
+      and it is dispatch-only, never a required check, never on push or
+      schedule, so it gates nothing and adds no load. Routing it through
+      vars.CI_RUNS_ON would make it interrogate whichever pool is already
+      configured, which is the question we already know the answer to; the
+      canary would go green while telling us nothing, which is worse than
+      having no canary. If spartan-cpu is offline this job simply never runs,
+      and that is the CORRECT behaviour here: an unanswerable question should
+      not be answered. Do NOT "fix" this one by giving it the variable — if
+      you need to canary a DIFFERENT pool, copy the file and change the label,
+      so each canary keeps saying which pool its result is about.
+
+  - workflow: pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+    jobs:
+      - verdict
+    approved_on: 2026-08-12
+    reason: >-
+      ONE MACHINE, NOT A POOL. This job writes the CI verdict to the card
+      store and pokes `sac listen` over LOOPBACK, and exactly one host runs
+      both. vars.CI_RUNS_ON resolves to four runners on four different
+      machines, so on 75% of them 127.0.0.1:7878 and 127.0.0.1:55432 would
+      reach a different daemon and a different postgres — writing the verdict
+      somewhere nobody reads and delivering it to nobody, with nothing raising
+      an error. The `sac-control-plane` label is carried by that one runner and
+      by no other, and no other workflow names it, so this widens nothing. The
+      cost is stated in the workflow itself and is deliberate: the rail is
+      exactly as available as that host. IF THAT HOST DIES, the fix is to move
+      the control plane (or add the label to its replacement) — NOT to relax
+      this to a pool, which would restore delivery-to-nobody while looking
+      green. The verdict job never gates a merge, so a stall here blocks no PR.

--- a/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
+++ b/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
@@ -54,23 +54,22 @@ jobs:
   install-check:
     # Kept byte-identical — see lint.yml. (Verified: not protection-pinned.)
     name: import-smoke-on-ubuntu-py3-12
-    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    # LIGHT LANE — see docs/ci-runner-routing.md for the full argument.
     #
     # 47s median, single-core, and it never enters the CI SIF. That is the
     # POINT of this job: it installs from source on the BARE runner precisely to
     # check that the package imports without the SIF's baked environment, so
-    # routing it to a SIF-capable host would not help it and pinning it here
-    # costs it nothing.
+    # routing it to a SIF-capable host would not help it and sending it to a
+    # small machine costs it nothing.
     #
     # It was holding one of four 32-core machines per run on a pool at 93-94%
-    # utilisation, then queueing 289s median (p90 902s). The spartan-cpu runners
-    # are nproc=1 — wrong for `tests` (497s there vs 170s on 32 cores), right
-    # for this.
-    #
-    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
-    # visible in a diff and cannot reach `tests` or the release gate, which DO
-    # enter the SIF and still need #992 first.
-    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
+    # utilisation, then queueing 289s median (p90 902s). #1006 routed it away
+    # for that reason, and that intent is UNCHANGED — only the SEAM changed,
+    # from a literal label list to a repo variable, so a dead pool is a
+    # settings change rather than a code change. Unset LIGHT_RUNS_ON and this
+    # lane rides the main pool; it never reads a value `tests` or the release
+    # gate would inherit.
+    runs-on: ${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
     # stops reporting has already held a release hostage once. Correcting the
     # "on-ubuntu" names repo-wide is a separate, coordinated change.
     name: ruff-on-ubuntu-latest
-    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    # LIGHT LANE — see docs/ci-runner-routing.md for the full argument.
     #
     # This repo's CI is bimodal. Over 276 self-hosted jobs (2.1 h): `tests` is
     # 31% of jobs at 368s and uses all 32 cores (xdist runs -n $(nproc)); the
@@ -68,19 +68,20 @@ jobs:
     #
     # So a 12-second single-core job was taking one of four 32-core machines
     # for its turn, on a pool measured at 93-94% utilisation — and then waiting
-    # 289s median (p90 902s) for the privilege.
+    # 289s median (p90 902s) for the privilege. #1006 routed it away from the
+    # heavy pool for that reason, and that intent is UNCHANGED.
     #
-    # The spartan-cpu runners were sitting idle, and a canary established the
-    # fact nobody had checked: they are nproc=1. That makes them wrong for
-    # `tests` (the suite takes 497s there vs 170s on 32 cores) and correctly
-    # sized for exactly this kind of job.
-    #
-    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
-    # visible in a diff, revertible on its own, and CANNOT reach `tests` or
-    # pypi-publish-and-github-release-on-tag.yml by accident. Do not generalise
-    # it to those: both DO enter the SIF, and `main`'s exec-in-sif.sh still
-    # binds /data/gpfs/projects/punim0264 unconditionally (#992 is the fix).
-    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
+    # What changed is the SEAM, not the intent. #1006 wrote the destination as
+    # a LITERAL label list, which made a dead pool a code change: when the
+    # spartan-cpu runners went offline this job queued forever with four idle
+    # machines in sight. `LIGHT_RUNS_ON` is the same routing decision expressed
+    # as DATA — set the repo variable to re-point the whole light lane in one
+    # place, unset it and the lane rides the main pool. It still cannot reach
+    # `tests` or pypi-publish-and-github-release-on-tag.yml, which read
+    # CI_RUNS_ON and never LIGHT_RUNS_ON: both DO enter the SIF, and `main`'s
+    # exec-in-sif.sh still binds /data/gpfs/projects/punim0264 unconditionally
+    # (#992 is the fix).
+    runs-on: ${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
+++ b/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
@@ -1,5 +1,25 @@
 name: no-hosted-runners
 
+# TWO GUARDS, ONE JOB. The workflow name and the check name are kept
+# byte-identical (a required context that stops reporting has held a release
+# hostage here before), but this job now runs a SECOND guard alongside the
+# first. They answer different questions about the same line:
+#
+#   _hosted_runner_guard  — does this job land on GitHub's hardware?  (below)
+#   _runner_pool_guard    — does this job name a POOL as a literal instead of
+#                           reading it from a repo variable?
+#
+# The second one exists because the first one's own limitation note (further
+# down, "it cannot see which self-hosted POOL a job reaches") described a real
+# hole that then cost us a day: five light-lane jobs were pinned to a literal
+# `spartan-cpu`, those runners went offline, and the five checks queued
+# forever on every PR while four org runners sat idle. Fifteen PRs could not
+# merge. See docs/ci-runner-routing.md.
+#
+# They share this job on purpose: no new queued check on a contended pool, and
+# the second guard reuses the first's `runs-on` parser rather than re-writing
+# it.
+
 # THE GUARD FOR THE RULE THAT HAS NO OTHER GUARD.
 #
 # Operator directive 2026-07-14 (absolute, no exceptions): NO GitHub-hosted
@@ -12,9 +32,9 @@ name: no-hosted-runners
 # CI_RUNS_ON back at Spartan while "fixing" something else:
 #
 #   * FACTUALLY: `vars.CI_RUNS_ON` for this repo is
-#     ["self-hosted","Linux","X64","scitex-local-cpu"], which resolves to the
-#     scitex-compute nodes. No job here has run on Spartan since that variable
-#     was narrowed.
+#     ["self-hosted","Linux","X64","scitex-org-cpu"] (set 2026-08-12T02:27:58Z),
+#     which resolves to the four scitex-0{1..4}-org-cpu-01 runners. No job here
+#     has run on Spartan since that variable was narrowed.
 #   * BY RULING: the operator banned Spartan from CI outright on 2026-08-11
 #     (「spartan を CI に使うのは全面禁止です」). The literal default below still
 #     spells `scitex-ci`, a label that EVERY Spartan runner also carries — it is
@@ -23,9 +43,12 @@ name: no-hosted-runners
 # NOTE WHAT THIS GUARD DOES AND DOES NOT COVER: it proves no job lands on a
 # GitHub-HOSTED image. It cannot see which self-hosted POOL a job reaches,
 # because that is decided by a repository variable this workflow cannot read at
-# parse time. Enforcing the Spartan ban needs its own mechanism; measured
-# 2026-08-11, 20 of the 22 self-hosted runners visible to this org still carry
-# `spartan-cpu`, and ten other repos still point at it.
+# parse time. That remains true — and is exactly why the SECOND guard in this
+# job does not try to resolve the variable either. It enforces the weaker,
+# statically-decidable property that makes the pool REDIRECTABLE AT ALL: the
+# destination must be named by a variable, not frozen into the YAML. Which pool
+# that variable points at is a settings question, and settings are where a dead
+# pool should be routed around.
 #
 # PR #694 migrated the 11 jobs. It did NOT build the guard. So until this
 # workflow existed, nothing stopped the next PR from quietly landing on
@@ -63,26 +86,23 @@ concurrency:
 jobs:
   no-hosted-runners:
     name: no-hosted-runners-guard-on-self-hosted
-    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    # LIGHT LANE — see docs/ci-runner-routing.md for the full argument.
     #
     # 13s median, single-core, needs nothing but PyYAML, and never enters the
     # CI SIF. It was holding one of four 32-core machines per run on a pool at
     # 93-94% utilisation, then queueing 289s median (p90 902s) — a 13-second
     # job waiting twenty times its own runtime for a machine it used 1/32 of.
+    # #1006 routed it away for that reason, and that intent is UNCHANGED —
+    # only the SEAM changed, from a literal label list to a repo variable, so
+    # a dead pool is a settings change rather than a code change.
     #
-    # The spartan-cpu runners are nproc=1: wrong for `tests` (497s there vs
-    # 170s on 32 cores), right for this. And see the setup-uv note below — this
-    # job was already written for the bare Spartan node's constraints.
-    #
-    # NOTE THE SELF-REFERENCE: this guard parses every workflow's `runs-on` and
-    # fails anything it cannot prove self-hosted. The literal list below starts
-    # with "self-hosted", so it passes its own check — verified by running the
-    # guard against this tree before committing, not assumed.
-    #
-    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
-    # visible in a diff and cannot reach `tests` or the release gate, which DO
-    # enter the SIF and still need #992 first.
-    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
+    # NOTE THE SELF-REFERENCE, TWICE OVER. This job now runs BOTH guards, and
+    # both of them read this very line. The hosted guard resolves the inline
+    # default below, sees `self-hosted`, and passes. The pool guard sees the
+    # `vars.` seam and passes. A literal `["self-hosted","Linux","X64",
+    # "<pool>"]` here would satisfy the first and FAIL the second — verified by
+    # running both against this tree before committing, not assumed.
+    runs-on: ${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -97,14 +117,42 @@ jobs:
           version: "0.11.29"
           cache-dependency-glob: pyproject.toml
 
-      - name: Guard — no GitHub-hosted runners
+      # Split out of the guard step so BOTH guards below can run even when the
+      # first of them fails: an `if: always()` step that also owned the venv
+      # creation would be reporting a missing interpreter instead of a
+      # violation whenever setup broke.
+      - name: Prepare interpreter (the guards need only PyYAML)
+        id: prepare
         run: |
           set -euo pipefail
           uv venv --python 3.12 .venv
           uv pip install --python .venv/bin/python pyyaml
+
+      - name: Guard — no GitHub-hosted runners
+        run: |
+          set -euo pipefail
           # 2>&1 on purpose: the guard prints its FAILURE report to stderr.
           # Without the merge, the one thing a reader needs would be missing
           # from the step summary. pipefail keeps the non-zero exit intact.
           PYTHONPATH=src .venv/bin/python \
             -m scitex_agent_container._hosted_runner_guard . 2>&1 \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Runs even when the guard above failed, so two independent faults are
+      # both reported in ONE run. Otherwise fixing the first only reveals the
+      # second on the next round trip — and a round trip through this queue is
+      # exactly what this change exists to stop paying for.
+      #
+      # `always() &&` IS LOad-BEARING, not belt-and-braces: a step whose `if:`
+      # contains no status-check function gets an implicit `success()` ANDed
+      # in, so the bare `steps.prepare.outcome == 'success'` would be SKIPPED
+      # by the very failure it is written to survive. The second conjunct then
+      # narrows `always()` back down — with no interpreter there is nothing
+      # this step could say.
+      - name: Guard — no hardcoded runner pool
+        if: always() && steps.prepare.outcome == 'success'
+        run: |
+          set -euo pipefail
+          PYTHONPATH=src .venv/bin/python \
+            -m scitex_agent_container._runner_pool_guard . 2>&1 \
             | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/quality-audit-on-ubuntu-latest.yml
@@ -51,21 +51,19 @@ jobs:
     # Deliberate misnomer, kept byte-identical — see lint.yml for the full
     # reasoning. (Verified: not a protection-pinned required context.)
     name: scitex-dev-quality-audit-on-ubuntu-latest
-    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    # LIGHT LANE — see docs/ci-runner-routing.md for the full argument.
     #
     # 44s median, single-core, and it never enters the CI SIF — the audit-*
     # verbs are filesystem and AST analysis over the checkout, so nothing here
     # depends on the host beyond having uv and a Python. It was holding one of
     # four 32-core machines per run on a pool at 93-94% utilisation, then
-    # queueing 289s median (p90 902s).
-    #
-    # The spartan-cpu runners are nproc=1 — wrong for `tests` (497s there vs
-    # 170s on 32 cores), right for a job like this one.
-    #
-    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
-    # visible in a diff and cannot reach `tests` or the release gate, which DO
-    # enter the SIF and still need #992 first.
-    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
+    # queueing 289s median (p90 902s). #1006 routed it away for that reason,
+    # and that intent is UNCHANGED — only the SEAM changed, from a literal
+    # label list to a repo variable, so a dead pool is a settings change rather
+    # than a code change. LIGHT_RUNS_ON is read by the light lane alone; it
+    # never reaches `tests` or the release gate, which DO enter the SIF and
+    # still need #992 first.
+    runs-on: ${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
+++ b/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
@@ -40,25 +40,27 @@ jobs:
   sphinx:
     # Kept byte-identical — see lint.yml. (Verified: not protection-pinned.)
     name: rtd-sphinx-build-on-ubuntu-latest
-    # LIGHT LANE — pinned to spartan-cpu on purpose. Measurements: PR #1001.
+    # LIGHT LANE — see docs/ci-runner-routing.md for the full argument.
     #
     # 51s median, single-core, and it never enters the CI SIF — checkout + uv +
     # sphinx-build on the bare runner, no /data/gpfs bind. It was holding one of
     # four 32-core machines per run on a pool at 93-94% utilisation, then
-    # queueing 289s median (p90 902s). The spartan-cpu runners are nproc=1:
-    # wrong for `tests` (497s there vs 170s on 32 cores), right for this.
+    # queueing 289s median (p90 902s). #1006 routed it away for that reason,
+    # and that intent is UNCHANGED — only the SEAM changed, from a literal
+    # label list to a repo variable, so a dead pool is a settings change rather
+    # than a code change.
     #
-    # THIS JOB COMMITS, which is why the host matters beyond size. The
-    # default-branch refresh below pushes regenerated HTML, and commit signing
-    # fails 13/13 on compute-04 ("failed to write commit object" — ssh signing
-    # against a key that is not there). The canary probed `git commit` on
-    # spartan-bm153 and it succeeds with signing unset, so this move takes the
-    # refresh OFF the one host where it reliably breaks.
-    #
-    # PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
-    # visible in a diff and cannot reach `tests` or the release gate, which DO
-    # enter the SIF and still need #992 first.
-    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
+    # THIS JOB COMMITS, which is why the host matters beyond size, and it is
+    # the one light-lane job with a HOST-SPECIFIC requirement rather than a
+    # size preference. The default-branch refresh below pushes regenerated
+    # HTML, and commit signing fails 13/13 on compute-04 ("failed to write
+    # commit object" — ssh signing against a key that is not there). A pool
+    # variable cannot express "not that one machine", so if the refresh starts
+    # failing that way again the fix is to make the signing config right on the
+    # host, not to re-pin this job to a pool that may be offline. Two symptoms
+    # are then distinguishable rather than fused: a commit failure names the
+    # host in the log, whereas a pin at a dead pool produces silence.
+    runs-on: ${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
     timeout-minutes: 20
     permissions:
       contents: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,6 +79,24 @@ repos:
           lives in .github/hosted-runner-allowlist.yaml WITH its security
           argument — an entry without a real `reason:` fails the guard.
 
+      - id: no-hardcoded-runner-pool
+        name: "no hardcoded runner pool in .github/workflows/"
+        # Same by-path invocation, same reason. This module imports the
+        # sibling guard's `runs-on` parser and carries an explicit fallback
+        # for the no-package-context case that by-path execution creates.
+        entry: python src/scitex_agent_container/_runner_pool_guard.py
+        language: python
+        additional_dependencies: [pyyaml]
+        pass_filenames: false
+        files: ^\.github/(workflows/.*\.ya?ml|runner-pin-allowlist\.yaml)$
+        description: >
+          A job's runner pool is named by a repo VARIABLE, not frozen into the
+          YAML — a frozen pool can only be re-pointed by a PR through the gate
+          the dead pool just jammed (2026-08-12: five light-lane checks pinned
+          to offline runners held 15 PRs while four runners sat idle). The two
+          deliberate pins live in .github/runner-pin-allowlist.yaml WITH their
+          arguments — an entry without a real `reason:` fails the guard.
+
 # ---------------------------------------------------------------------------
 # `stx-allow-fallback` IS DELIBERATELY ABSENT, AND SAYING SO IS THE POINT.
 #

--- a/docs/ci-runner-routing.md
+++ b/docs/ci-runner-routing.md
@@ -1,0 +1,141 @@
+# CI runner routing
+
+Where this repo's CI jobs run, who decides it, and why the decision is a
+repository **variable** rather than a line of YAML.
+
+## The one rule
+
+> A job's runner **pool** is named by a repository variable. It is never
+> frozen into the workflow file.
+
+A pool frozen in YAML can only be re-pointed by a pull request — through the
+CI gate that the dead pool just jammed. A pool named in a variable is
+re-pointed in one click, by someone who does not need a review to do it.
+
+Enforced by `src/scitex_agent_container/_runner_pool_guard.py` (`SAC-CI005`),
+which runs as a step of the `no-hosted-runners` job, as a `pre-commit` hook,
+and as a pytest test against this repo.
+
+## The variables
+
+| Variable | Read by | Set? |
+|---|---|---|
+| `CI_RUNS_ON` | the heavy gate, the release gate, docs/quality/auto-merge — nine workflows | yes: `["self-hosted","Linux","X64","scitex-org-cpu"]` |
+| `LIGHT_RUNS_ON` | the light lane only (five jobs) | **no — deliberately unset** |
+
+The canonical spellings:
+
+```yaml
+# everything else
+runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+
+# the light lane
+runs-on: ${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+```
+
+The **literal JSON fallback is required**, not decorative. A bare
+`${{ vars.X }}` is refused twice: by `_hosted_runner_guard` (`SAC-CI002` — a
+destination it cannot resolve is indistinguishable from a bypass) and by
+scitex-dev's `PS-224`. Naming the destination in a variable and naming it
+readably are both requirements; neither substitutes for the other.
+
+## Why `LIGHT_RUNS_ON` is unset
+
+`vars.LIGHT_RUNS_ON` evaluates to the empty string when unset, so `||` falls
+through and the light lane rides `CI_RUNS_ON` — the correct default. The
+variable exists so the lane **can** be split off again the moment there is a
+pool worth splitting it onto, without touching five files.
+
+Setting it is therefore an act with a cost: it becomes a second place the
+routing lives, and a stale override is exactly the failure below. Set it when
+the split buys something measurable; unset it the moment it does not.
+
+## The light lane, and what it is for
+
+This repo's CI is bimodal. Over 276 self-hosted jobs (2.1 h of machine time),
+`tests` is 31% of jobs at 368 s and saturates 32 cores (`xdist -n $(nproc)`).
+The other 69% run 12–51 s on about one core, never enter the CI SIF, and need
+nothing but `uv` and a Python:
+
+| job | workflow | median |
+|---|---|---|
+| `ruff` | `lint.yml` | 12 s |
+| `no-hosted-runners` | `no-hosted-runners-guard-on-self-hosted.yml` | 13 s |
+| `scitex-dev-quality-audit` | `quality-audit-on-ubuntu-latest.yml` | 44 s |
+| `import-smoke` | `import-smoke-on-ubuntu-py3-12.yml` | 47 s |
+| `rtd-sphinx-build` | `rtd-sphinx-build-on-ubuntu-latest.yml` | 51 s |
+
+A 12-second single-core job holding one of four 32-core machines, on a pool at
+93–94% utilisation, after queueing 289 s median (p90 902 s), is a real waste
+and PR #1006 was right to route it away. **That intent stands.** Only the seam
+changed.
+
+## The incident (2026-08-12)
+
+PR #1006 wrote the light lane's destination as a literal:
+
+```yaml
+runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
+```
+
+Its own comment argued the choice: *"PINNED PER WORKFLOW rather than through
+vars.CI_RUNS_ON so the routing is visible in a diff."* Visibility in a diff is
+a real benefit. It is not worth what it cost.
+
+Six days later the three `spartan-cpu` runners went offline (post-inode stop).
+All five checks queued **forever** on every pull request while four
+`scitex-org-cpu` runners sat online and idle. 34 runs were queued against zero
+busy runners; `mergeStateStatus` read `UNSTABLE`; 15 open PRs could not merge.
+
+The failure mode is worth naming, because it is the reason this was not caught
+sooner: **nothing failed.** The checks never *started*, and a check that never
+started is visually identical to one that has not run yet. There is no red.
+The only signal is a queue depth nobody was watching, and the fix required a
+PR through the gate that was jammed.
+
+## When a literal pin is actually right
+
+When a job's purpose is **to reach one named place**, rather than to run
+somewhere appropriate. A variable expresses "wherever this class of work
+belongs"; it cannot express "that specific machine, and no substitute".
+
+Two such jobs exist here, both in `.github/runner-pin-allowlist.yaml` with a
+machine-enforced `reason:`:
+
+- **`spartan-capacity-canary` → `spartan-cpu`.** Naming the pool *is* the
+  measurement. Reading the variable would make it interrogate whichever pool
+  is already configured — the question we already know the answer to.
+- **`pytest-matrix … / verdict` → `sac-control-plane`.** It writes the CI
+  verdict over loopback to the one host running `sac listen` and the card
+  store. Three of the four `scitex-org-cpu` machines would write it somewhere
+  nobody reads, with nothing raising an error.
+
+Note what they share: each would be **wrong if it silently ran somewhere
+else**. That is the test. "This pool is faster for this job" is not — that is
+a routing preference, and routing preferences go in variables.
+
+Both are also jobs that gate nothing: the canary is `workflow_dispatch`-only,
+and `verdict` is not a required check. A pin that gates a merge is a pin that
+can hold the repo hostage.
+
+## Runbook: a pool has gone offline
+
+1. Confirm it is not saturation — `gh api orgs/scitex-ai/actions/runners`
+   shows `status` and `busy` per runner. Idle runners plus a deep queue is a
+   routing fault, not a capacity fault.
+2. Re-point the variable, not the code:
+   `gh variable set CI_RUNS_ON --repo scitex-ai/scitex-agent-container --body '["self-hosted","Linux","X64","<live-pool>"]'`
+   (and `LIGHT_RUNS_ON` only if it is set — prefer unsetting it).
+3. Cancel the runs whose jobs *requested the dead pool*. Enumerate first:
+   `gh api repos/<repo>/actions/runs/<id>/jobs --jq '.jobs[] | [.name, .status, (.labels|join(","))] | @tsv'`.
+   Never cancel an `in_progress` run, and never blanket-cancel — a queued run
+   waiting on a *live* pool will start on its own.
+4. A variable change does **not** retroactively re-route already-queued runs.
+   They keep the labels they were created with; re-run them.
+
+## The rule this does not enforce
+
+Which pool the variable points at. That is a settings value no static reader
+can see, and it is exactly the thing that should change without a commit. The
+guard enforces only the weaker, statically-decidable property that makes
+redirection possible at all.

--- a/src/scitex_agent_container/_runner_pool_guard.py
+++ b/src/scitex_agent_container/_runner_pool_guard.py
@@ -1,0 +1,423 @@
+"""Guard: a workflow may not FREEZE its runner pool into the YAML.
+
+The incident this exists to prevent, stated once
+================================================
+PR #1006 gave five sub-minute single-core jobs their own "light lane" and
+wrote the destination as a literal label list::
+
+    runs-on: ["self-hosted", "Linux", "X64", "spartan-cpu"]
+
+The measurement behind it was real and is not in dispute (a 12-second job
+was holding one of four 32-core machines on a pool at 93-94% utilisation).
+What was wrong was the SEAM, and its own comment said so out loud —
+"PINNED PER WORKFLOW rather than through vars.CI_RUNS_ON so the routing is
+visible in a diff".
+
+Six days later the ``spartan-cpu`` runners went offline. Five checks —
+``ruff``, ``rtd-sphinx-build``, ``import-smoke``, ``no-hosted-runners``,
+``scitex-dev-quality-audit`` — queued forever on every pull request while
+four ``scitex-org-cpu`` runners sat online and idle. Fifteen PRs could not
+merge, and re-pointing them required a code change, review and a merge
+through the very gate that was jammed.
+
+So: routing intent is legitimate, and it belongs in DATA. A destination
+named by a repository variable is redirected in one click. A destination
+frozen in YAML needs a PR through a blocked queue.
+
+What this checks, precisely
+===========================
+For every job that this repo's other guard classifies as self-hosted, if
+``runs-on`` names a POOL-SELECTING label — anything beyond GitHub's own
+automatic labels (``self-hosted``, the OS, the architecture) — then the
+``runs-on`` text must READ A VARIABLE (``vars.<NAME>``). It is the seam
+that is mandatory, not any particular variable.
+
+The canonical spellings::
+
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    runs-on: ${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+
+The literal fallback stays REQUIRED, and is enforced elsewhere twice over:
+``_hosted_runner_guard`` refuses an unresolvable ``runs-on`` (SAC-CI002),
+and scitex-dev's PS-224 reports a bare ``${{ vars.X }}`` as an error for
+the same reason. A bare variable reference is not the fix — it trades a
+frozen destination for an invisible one.
+
+What this deliberately does NOT check
+=====================================
+WHICH pool the variable points at. That is a repository-settings value no
+static reader can see, and it is precisely the thing that should be
+changeable without a commit. This guard enforces only the weaker,
+statically-decidable property that makes redirection possible at all.
+
+The exceptions are real, so they are a mechanism
+================================================
+Two pins in this repo are correct and must survive:
+
+* the Spartan capacity canary, whose ENTIRE PURPOSE is to interrogate one
+  named pool — reading the variable would make it test whichever pool is
+  already configured, i.e. the question we already know the answer to;
+* the CI-verdict job, pinned to the single machine that hosts ``sac
+  listen`` and the card store, because its loopback premise is true on
+  exactly that box.
+
+Both live in ``.github/runner-pin-allowlist.yaml`` with a mandatory
+``reason:``, and a stale entry fails the guard — same shape, and same
+argument, as the hosted-runner allowlist next to it: an exception that
+lives only in a chat message is a fact written in one place and believed
+in another.
+
+Entry points
+============
+* ``python -m scitex_agent_container._runner_pool_guard [REPO_ROOT]``
+  — exit 0 clean, exit 1 on any violation.
+* :func:`check_repo` — pure function; returns violations, raises nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# TWO IMPORT PATHS FOR ONE MODULE, AND BOTH ARE EXERCISED.
+#
+# The `runs-on` parser lives in `_hosted_runner_guard` and is reused here
+# verbatim — two guards reading one line must read it the SAME way, or they
+# will eventually disagree about what a job requested, and the disagreement
+# will surface as one of them being quietly wrong.
+#
+# But the sibling hook runs these guards BY PATH (`python
+# src/scitex_agent_container/_runner_pool_guard.py`) so a bare checkout
+# without sac installed still gets the check. Executed that way there is no
+# package context and the relative import cannot resolve — while `sys.path[0]`
+# IS this file's directory, so the sibling is importable by bare name. Neither
+# spelling covers both cases; this is not a fallback that hides an error, it
+# is the two ways a module can legitimately be entered.
+try:  # normal import: `from scitex_agent_container import _runner_pool_guard`
+    from ._hosted_runner_guard import (
+        HOSTED,
+        Violation,
+        _flatten,
+        _iter_jobs,
+        _runner_labels,
+        classify_runs_on,
+    )
+except ImportError:  # executed by path (pre-commit) — no package context
+    from _hosted_runner_guard import (  # type: ignore[no-redef]
+        HOSTED,
+        Violation,
+        _flatten,
+        _iter_jobs,
+        _runner_labels,
+        classify_runs_on,
+    )
+
+# GitHub applies these to every runner automatically; none of them SELECTS a
+# pool. `self-hosted` says "ours, not GitHub's"; the OS and architecture
+# labels narrow by capability, not by machine group. A job carrying only
+# these reaches whatever self-hosted runner is free, which is the opposite of
+# a pin — so it is not this guard's business.
+_GENERIC_LABELS = frozenset(
+    {
+        "self-hosted",
+        "linux",
+        "windows",
+        "macos",
+        "x64",
+        "x86",
+        "arm",
+        "arm64",
+    }
+)
+
+# An allowlist entry must ARGUE its case; a stub ("legacy", "needed") is not
+# an argument. Same floor as the hosted-runner allowlist, on purpose.
+_MIN_REASON_CHARS = 40
+
+_ALLOWLIST_RELPATH = Path(".github") / "runner-pin-allowlist.yaml"
+_WORKFLOWS_RELDIR = Path(".github") / "workflows"
+
+# Violation codes. Numbered on from the hosted guard's SAC-CI001..004 so the
+# two guards never collide in a log a human is skimming.
+CODE_FROZEN_POOL = "SAC-CI005"  # pool frozen in YAML, no variable seam
+CODE_ALLOWLIST_NO_REASON = "SAC-CI006"  # pin allowlisted without an argument
+CODE_ALLOWLIST_STALE = "SAC-CI007"  # pin-allowlist entry that no longer applies
+
+_CANONICAL_RUNS_ON = (
+    "runs-on: ${{ fromJSON(vars.CI_RUNS_ON || "
+    '\'["self-hosted","Linux","X64","scitex-ci"]\') }}'
+)
+
+
+def _raw_runs_on_text(job: dict) -> str:
+    """Every ``runs-on`` token of one job, concatenated for substring reads.
+
+    The mapping form (``{group:, labels:}``) and the list form both flatten
+    here, so a ``vars.`` reference is found wherever it was written.
+    """
+    runs_on = job.get("runs-on")
+    if isinstance(runs_on, dict):
+        tokens = _flatten(runs_on.get("labels")) + _flatten(runs_on.get("group"))
+    else:
+        tokens = _flatten(runs_on)
+    return "\n".join(tokens)
+
+
+def reads_a_variable(job: dict) -> bool:
+    """True when ``runs-on`` resolves its destination through ``vars.``.
+
+    Substring, not a parse, and that is deliberate: every spelling GitHub
+    accepts (``vars.X``, ``vars . X`` is not legal, ``fromJSON(vars.X || ...)``,
+    a ternary over two variables) contains the token, and a false POSITIVE
+    here can only be produced by writing ``vars.`` into a runner label — a
+    string no runner carries.
+    """
+    return "vars." in _raw_runs_on_text(job)
+
+
+def pool_labels(job: dict) -> list[str]:
+    """The pool-SELECTING labels of one job, in declaration order.
+
+    Empty when the job names only GitHub's automatic labels — a job that
+    pins nothing has nothing to redirect.
+    """
+    labels, _ = _runner_labels(job)
+    return [
+        label.strip()
+        for label in labels
+        if label and label.strip() and label.strip().lower() not in _GENERIC_LABELS
+    ]
+
+
+def _allowed_jobs(entry: dict) -> set[str] | None:
+    """Job ids this entry covers; ``None`` means every job in the file."""
+    jobs = entry.get("jobs")
+    if jobs is None:
+        return None
+    return {str(job) for job in _flatten(jobs)}
+
+
+def load_allowlist(repo: Path) -> tuple[dict[str, dict], list[Violation]]:
+    """Parse the pin allowlist; enforce that every entry ARGUES its case.
+
+    Returns ``({workflow_filename: entry}, violations)``. A missing file is
+    not an error — a repo with no deliberate pins needs no allowlist.
+    """
+    path = repo / _ALLOWLIST_RELPATH
+    if not path.is_file():
+        return {}, []
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return {}, [
+            Violation(
+                CODE_ALLOWLIST_NO_REASON,
+                str(_ALLOWLIST_RELPATH),
+                f"pin allowlist is unreadable / not valid YAML: {exc}",
+            )
+        ]
+
+    entries = doc.get("allow") if isinstance(doc, dict) else None
+    allow: dict[str, dict] = {}
+    violations: list[Violation] = []
+    if not isinstance(entries, list):
+        return {}, violations
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            violations.append(
+                Violation(
+                    CODE_ALLOWLIST_NO_REASON,
+                    str(_ALLOWLIST_RELPATH),
+                    f"pin allowlist entry is not a mapping: {entry!r}",
+                )
+            )
+            continue
+        workflow = str(entry.get("workflow") or "").strip()
+        if not workflow:
+            violations.append(
+                Violation(
+                    CODE_ALLOWLIST_NO_REASON,
+                    str(_ALLOWLIST_RELPATH),
+                    f"pin allowlist entry has no `workflow:` key: {entry!r}",
+                )
+            )
+            continue
+        reason = str(entry.get("reason") or "").strip()
+        if len(reason) < _MIN_REASON_CHARS:
+            violations.append(
+                Violation(
+                    CODE_ALLOWLIST_NO_REASON,
+                    f"{_ALLOWLIST_RELPATH} -> {workflow}",
+                    (
+                        "pin allowlist entry needs a `reason:` of at least "
+                        f"{_MIN_REASON_CHARS} characters explaining why THIS "
+                        "job must name its pool literally instead of reading a "
+                        "variable. The bar is high on purpose: the reason must "
+                        "survive that pool going offline, because that is the "
+                        "day someone reads it "
+                        f"(got {len(reason)} chars)."
+                    ),
+                )
+            )
+            continue
+        allow[workflow] = entry
+    return allow, violations
+
+
+def _frozen_pool_violation(rel: str, job_id: str, pools: list[str]) -> Violation:
+    return Violation(
+        CODE_FROZEN_POOL,
+        f"{rel} -> job `{job_id}`",
+        (
+            f"names its runner pool literally ({', '.join(pools)}) instead of "
+            "reading it from a repository variable. Route it through the seam:"
+            f"\n        {_CANONICAL_RUNS_ON}\n"
+            "      (or `vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '[...]'` for "
+            "the light lane). Keep the literal JSON fallback — a bare "
+            "`${{ vars.X }}` trades a frozen destination for an invisible one "
+            "and fails SAC-CI002.\n"
+            "      WHY: a pool frozen here can only be re-pointed by a PR "
+            "through the gate it just jammed. On 2026-08-12 five light-lane "
+            "checks pinned to an offline pool held 15 PRs while four runners "
+            "sat idle. A pin that is genuinely correct goes in "
+            f"{_ALLOWLIST_RELPATH}, WITH its argument attached."
+        ),
+    )
+
+
+def _stale_violations(
+    repo: Path, allow: dict[str, dict], used: set[tuple[str, str]]
+) -> list[Violation]:
+    """A dead exception is a live loophole — it pre-approves whatever that
+    workflow pins next."""
+    out: list[Violation] = []
+    wf_dir = repo / _WORKFLOWS_RELDIR
+    for workflow in allow:
+        if not (wf_dir / workflow).is_file():
+            out.append(
+                Violation(
+                    CODE_ALLOWLIST_STALE,
+                    f"{_ALLOWLIST_RELPATH} -> {workflow}",
+                    (
+                        "allowlisted workflow does not exist — delete the stale "
+                        "entry. A dead exception is a standing pre-approval for "
+                        "whatever takes that filename next."
+                    ),
+                )
+            )
+            continue
+        if not any(name == workflow for name, _ in used):
+            out.append(
+                Violation(
+                    CODE_ALLOWLIST_STALE,
+                    f"{_ALLOWLIST_RELPATH} -> {workflow}",
+                    (
+                        "allowlisted workflow no longer pins a pool literally — "
+                        "delete the entry. Keeping it leaves a standing "
+                        "exception nobody needs, which the next literal pin "
+                        "added to that file would inherit for free."
+                    ),
+                )
+            )
+    return out
+
+
+def check_repo(repo: Path) -> list[Violation]:
+    """Scan ``<repo>/.github/workflows/``. Pure; never raises."""
+    violations: list[Violation] = []
+    allow, allow_violations = load_allowlist(repo)
+    violations.extend(allow_violations)
+
+    wf_dir = repo / _WORKFLOWS_RELDIR
+    if not wf_dir.is_dir():
+        return violations
+
+    used: set[tuple[str, str]] = set()
+
+    for path in sorted(wf_dir.iterdir()):
+        if not path.is_file() or path.suffix not in {".yml", ".yaml"}:
+            continue
+        rel = str(path.relative_to(repo))
+        try:
+            doc: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            violations.append(
+                Violation(CODE_FROZEN_POOL, rel, f"cannot parse workflow: {exc}")
+            )
+            continue
+
+        entry = allow.get(path.name)
+        exempt_jobs = _allowed_jobs(entry) if entry is not None else set()
+
+        for job_id, job in _iter_jobs(doc):
+            # A `uses:` job calls a reusable workflow and declares no runner
+            # of its own — there is no destination to police here.
+            if "runs-on" not in job and job.get("uses"):
+                continue
+
+            # A GitHub-HOSTED job has no pool to redirect, and the other
+            # guard already owns it. Reporting it twice would make the two
+            # guards argue about the same line in different words.
+            if classify_runs_on(job) == HOSTED:
+                continue
+
+            pools = pool_labels(job)
+            if not pools or reads_a_variable(job):
+                continue
+
+            if entry is not None and (exempt_jobs is None or job_id in exempt_jobs):
+                used.add((path.name, job_id))
+                continue
+
+            violations.append(_frozen_pool_violation(rel, job_id, pools))
+
+    violations.extend(_stale_violations(repo, allow, used))
+    return violations
+
+
+def format_report(repo: Path, violations: list[Violation]) -> str:
+    if not violations:
+        return (
+            f"no-hardcoded-runner-pool: OK — every job in {_WORKFLOWS_RELDIR} "
+            "names its pool through a repository variable (or is allowlisted "
+            "WITH a stated reason)."
+        )
+    lines = [
+        "",
+        "=" * 72,
+        "HARDCODED-RUNNER-POOL GUARD FAILED",
+        "=" * 72,
+        "",
+        f"{len(violations)} violation(s) in {repo}:",
+        "",
+    ]
+    lines.extend(violation.render() for violation in violations)
+    lines.extend(
+        [
+            "",
+            "A runner pool frozen into a workflow can only be re-pointed by a "
+            "pull request — through the CI gate that the dead pool just "
+            "jammed. Name the pool in a repository VARIABLE so a pool going "
+            "offline is a settings change, not a code change.",
+            "=" * 72,
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    repo = Path(args[0]).resolve() if args else Path.cwd()
+    violations = check_repo(repo)
+    stream = sys.stderr if violations else sys.stdout
+    print(format_report(repo, violations), file=stream)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    raise SystemExit(main())

--- a/src/scitex_agent_container/_runner_pool_guard.py
+++ b/src/scitex_agent_container/_runner_pool_guard.py
@@ -72,6 +72,29 @@ Entry points
 * ``python -m scitex_agent_container._runner_pool_guard [REPO_ROOT]``
   — exit 0 clean, exit 1 on any violation.
 * :func:`check_repo` — pure function; returns violations, raises nothing.
+
+Promoting this upstream (the pin is a fleet convention, not a sac quirk)
+=======================================================================
+Measured 2026-08-12: five sibling repos — scitex-cards, scitex-todo,
+scitex-plt, scitex-scholar, scitex-ssh — carry the same literal
+``spartan-cpu`` pin and are armed to freeze on their next push. sac lands
+first as the proof; the rule belongs in scitex-dev's project auditor after
+that, so this module is written to move rather than to stay:
+
+* every check is a PURE function of a ``repo: Path`` — no import-time state,
+  no sac-specific knowledge beyond three module constants
+  (``_ALLOWLIST_RELPATH``, the ``SAC-CI0xx`` codes, the message text);
+* :func:`pool_labels` and :func:`reads_a_variable` are the whole rule and are
+  independently callable;
+* the ``runs-on`` parsing is already duplicated upstream as
+  ``scitex_dev._cli.audit._project._runs_on_parsing.resolve_destination`` —
+  a promoted version should call THAT and drop the import below.
+
+What a promotion must NOT do is relax the seam into "must read
+``vars.CI_RUNS_ON``": scitex-dev's own PS-224 reports a BARE
+``${{ vars.X }}`` as an error, so the only spelling both rules bless is the
+fleet idiom WITH its literal fallback. Requiring the variable and requiring
+it to be readable are two rules, and each is load-bearing.
 """
 
 from __future__ import annotations

--- a/tests/scitex_agent_container/test__runner_pool_guard.py
+++ b/tests/scitex_agent_container/test__runner_pool_guard.py
@@ -1,0 +1,519 @@
+"""Tests for the no-hardcoded-runner-pool guard.
+
+A GUARD YOU HAVE ONLY EVER SEEN PASS IS A HOPE. The guard this one sits
+beside was written after exactly that lesson, and this file inherits it:
+every test below either proves the guard FIRES on a real frozen pin, or
+proves it does NOT cry wolf on a spelling we actually use.
+
+The decisive one is :func:`test_reintroducing_the_incident_pin_is_caught`.
+It takes THIS repo's real ``lint.yml``, puts back the literal
+``["self-hosted","Linux","X64","spartan-cpu"]`` that PR #1006 shipped and
+that went on to jam fifteen PRs, and asserts the guard reports it. Without
+that test the guard is calibrated to a story rather than to the incident.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._runner_pool_guard import (
+    CODE_ALLOWLIST_NO_REASON,
+    CODE_ALLOWLIST_STALE,
+    CODE_FROZEN_POOL,
+    check_repo,
+    load_allowlist,
+    main,
+    pool_labels,
+    reads_a_variable,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# The seam every gated job in this repo uses.
+CANONICAL = (
+    '${{ fromJSON(vars.CI_RUNS_ON || \'["self-hosted","Linux","X64","scitex-ci"]\') }}'
+)
+
+# The light lane's seam: its own variable, falling through to the main one.
+LIGHT = (
+    "${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || "
+    "'[\"self-hosted\",\"Linux\",\"X64\",\"scitex-ci\"]') }}"
+)
+
+# The exact literal PR #1006 shipped, and the exact literal that jammed the
+# queue when those runners went offline.
+INCIDENT_PIN = '["self-hosted", "Linux", "X64", "spartan-cpu"]'
+
+# The five jobs the incident jammed. Listed one by one rather than derived,
+# so DELETING a seam cannot quietly shrink the test.
+LIGHT_LANE = [
+    ("lint.yml", "ruff"),
+    ("import-smoke-on-ubuntu-py3-12.yml", "install-check"),
+    ("no-hosted-runners-guard-on-self-hosted.yml", "no-hosted-runners"),
+    ("rtd-sphinx-build-on-ubuntu-latest.yml", "sphinx"),
+    ("quality-audit-on-ubuntu-latest.yml", "audit"),
+]
+
+# The two pins this repo keeps on purpose, with their arguments on file.
+ALLOWED_PINS = [
+    ("spartan-capacity-canary-on-self-hosted.yml", "canary"),
+    ("pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml", "verdict"),
+]
+
+GOOD_REASON = (
+    "This job must reach one named machine because it writes to that host's "
+    "database over loopback; a pool would deliver the write to nobody."
+)
+
+REUSABLE_CALLER = (
+    "name: demo\non: [push]\njobs:\n  call:\n    uses: ./.github/workflows/other.yml\n"
+)
+
+
+def _workflow(runs_on: str, job_id: str = "build") -> str:
+    return (
+        "name: demo\n"
+        "on: [push]\n"
+        "jobs:\n"
+        f"  {job_id}:\n"
+        f"    runs-on: {runs_on}\n"
+        "    steps:\n"
+        "      - run: echo hi\n"
+    )
+
+
+def _two_pinned_jobs() -> str:
+    return (
+        "name: demo\n"
+        "on: [push]\n"
+        "jobs:\n"
+        "  canary:\n"
+        f"    runs-on: {INCIDENT_PIN}\n"
+        "    steps:\n"
+        "      - run: echo hi\n"
+        "  sneaky:\n"
+        f"    runs-on: {INCIDENT_PIN}\n"
+        "    steps:\n"
+        "      - run: echo hi\n"
+    )
+
+
+def _write_repo(
+    root: Path,
+    workflows: dict[str, str],
+    allowlist: str | None = None,
+) -> Path:
+    """Materialise a throwaway repo with real files on disk (no mocks)."""
+    wf_dir = root / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    for name, body in workflows.items():
+        (wf_dir / name).write_text(body, encoding="utf-8")
+    if allowlist is not None:
+        (root / ".github" / "runner-pin-allowlist.yaml").write_text(
+            allowlist, encoding="utf-8"
+        )
+    return root
+
+
+def _allowlist(workflow: str, jobs: str = "", reason: str = GOOD_REASON) -> str:
+    jobs_line = f"    jobs: [{jobs}]\n" if jobs else ""
+    return (
+        f"allow:\n  - workflow: {workflow}\n{jobs_line}    reason: >-\n      {reason}\n"
+    )
+
+
+def _codes(root: Path) -> list[str]:
+    return [violation.code for violation in check_repo(root)]
+
+
+def _job(filename: str, job_id: str) -> dict:
+    doc = yaml.safe_load((WORKFLOWS / filename).read_text(encoding="utf-8"))
+    return doc["jobs"][job_id]
+
+
+@pytest.fixture
+def regressed_repo(tmp_path: Path) -> Path:
+    """THIS repo's real ``lint.yml`` with the incident pin put back.
+
+    Not a fixture that resembles the incident — the bytes this repo shipped
+    on 2026-08-06, and the bytes that stopped five checks from ever starting
+    on 2026-08-12. ``pytest.fail`` rather than ``assert`` if the substitution
+    is a no-op: a silently-unchanged file would make every test below pass
+    against a clean tree and prove nothing at all.
+    """
+    live = (WORKFLOWS / "lint.yml").read_text(encoding="utf-8")
+    regressed = live.replace(f"runs-on: {LIGHT}", f"runs-on: {INCIDENT_PIN}")
+    if regressed == live:
+        pytest.fail("the light-lane seam moved — update LIGHT in this test module")
+    return _write_repo(tmp_path, {"lint.yml": regressed})
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# FAIL DIRECTION — the guard must actually fire.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_reintroducing_the_incident_pin_is_caught(regressed_repo: Path) -> None:
+    # Arrange: fixture rewrote the real lint.yml back to the #1006 pin
+    repo = regressed_repo
+    # Act
+    codes = _codes(repo)
+    # Assert
+    assert codes == [CODE_FROZEN_POOL]
+
+
+def test_reintroducing_the_incident_pin_names_the_dead_pool(
+    regressed_repo: Path,
+) -> None:
+    # Arrange
+    repo = regressed_repo
+    # Act
+    violations = check_repo(repo)
+    # Assert
+    assert "spartan-cpu" in violations[0].message
+
+
+def test_reintroducing_the_incident_pin_exits_non_zero(regressed_repo: Path) -> None:
+    # Arrange
+    repo = regressed_repo
+    # Act
+    exit_code = main([str(repo)])
+    # Assert
+    assert exit_code == 1
+
+
+@pytest.mark.parametrize(
+    "runs_on",
+    [
+        '["self-hosted", "Linux", "X64", "spartan-cpu"]',  # JSON-ish flow list
+        "[self-hosted, Linux, X64, scitex-org-cpu]",  # bare YAML flow list
+        "[self-hosted, scitex-ci]",  # the old default, frozen
+        "scitex-ci",  # a bare scalar label
+        "{labels: [self-hosted, Linux, spartan-cpu]}",  # the mapping form
+    ],
+)
+def test_every_frozen_spelling_is_flagged(tmp_path: Path, runs_on: str) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow(runs_on)})
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_FROZEN_POOL]
+
+
+def test_the_violation_names_the_frozen_pool(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow(INCIDENT_PIN)})
+    # Act
+    message = check_repo(tmp_path)[0].message
+    # Assert
+    assert "spartan-cpu" in message
+
+
+def test_the_violation_shows_the_seam_to_write_instead(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow(INCIDENT_PIN)})
+    # Act
+    message = check_repo(tmp_path)[0].message
+    # Assert
+    assert "vars.CI_RUNS_ON" in message
+
+
+def test_a_second_job_in_an_allowlisted_file_does_not_ride_along(
+    tmp_path: Path,
+) -> None:
+    # Arrange: the entry covers `canary` only
+    _write_repo(
+        tmp_path,
+        {"canary.yml": _two_pinned_jobs()},
+        allowlist=_allowlist("canary.yml", jobs="canary"),
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_FROZEN_POOL]
+
+
+def test_a_second_job_in_an_allowlisted_file_is_named(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"canary.yml": _two_pinned_jobs()},
+        allowlist=_allowlist("canary.yml", jobs="canary"),
+    )
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert "sneaky" in violations[0].where
+
+
+def test_allowlist_entry_without_reason_is_rejected(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"canary.yml": _workflow(INCIDENT_PIN, job_id="canary")},
+        allowlist="allow:\n  - workflow: canary.yml\n",
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert CODE_ALLOWLIST_NO_REASON in codes
+
+
+def test_allowlist_entry_without_reason_does_not_exempt_the_job(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"canary.yml": _workflow(INCIDENT_PIN, job_id="canary")},
+        allowlist="allow:\n  - workflow: canary.yml\n",
+    )
+    # Act: a rejected entry must not smuggle the pin through
+    codes = _codes(tmp_path)
+    # Assert
+    assert CODE_FROZEN_POOL in codes
+
+
+def test_allowlist_entry_with_stub_reason_is_rejected(tmp_path: Path) -> None:
+    # Arrange: a shrug ("legacy") is not an argument
+    _write_repo(
+        tmp_path,
+        {"canary.yml": _workflow(INCIDENT_PIN, job_id="canary")},
+        allowlist='allow:\n  - workflow: canary.yml\n    reason: "legacy"\n',
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert CODE_ALLOWLIST_NO_REASON in codes
+
+
+def test_stale_allowlist_entry_is_flagged(tmp_path: Path) -> None:
+    # Arrange: ci.yml reads the variable, so it needs no exception
+    _write_repo(
+        tmp_path,
+        {"ci.yml": _workflow(CANONICAL)},
+        allowlist=_allowlist("ci.yml"),
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_ALLOWLIST_STALE]
+
+
+def test_allowlist_entry_for_missing_workflow_is_flagged(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"ci.yml": _workflow(CANONICAL)},
+        allowlist=_allowlist("gone.yml"),
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_ALLOWLIST_STALE]
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# PASS DIRECTION — the guard must not cry wolf.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("runs_on", [CANONICAL, LIGHT])
+def test_the_variable_seams_pass(tmp_path: Path, runs_on: str) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow(runs_on)})
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_generic_labels_alone_are_not_a_pin(tmp_path: Path) -> None:
+    # Arrange: `[self-hosted, Linux, X64]` selects no POOL — it reaches
+    # whichever of our runners is free, which is the opposite of a pin.
+    _write_repo(tmp_path, {"ci.yml": _workflow("[self-hosted, Linux, X64]")})
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_a_hosted_job_is_left_to_the_other_guard(tmp_path: Path) -> None:
+    # Arrange: `ubuntu-latest` is SAC-CI001's business. Reporting it here too
+    # would have the two guards argue about one line in different words.
+    _write_repo(tmp_path, {"cla.yml": _workflow("ubuntu-latest")})
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_reusable_workflow_call_is_not_flagged(tmp_path: Path) -> None:
+    # Arrange: a `uses:` job declares no runner of its own
+    _write_repo(
+        tmp_path,
+        {
+            "caller.yml": REUSABLE_CALLER,
+            "other.yml": _workflow(CANONICAL, job_id="inner"),
+        },
+    )
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_allowlisted_pin_passes(tmp_path: Path) -> None:
+    # Arrange: the approved pin, with its argument attached
+    _write_repo(
+        tmp_path,
+        {"canary.yml": _workflow(INCIDENT_PIN, job_id="canary")},
+        allowlist=_allowlist("canary.yml", jobs="canary"),
+    )
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_allowlisted_pin_exits_zero(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"canary.yml": _workflow(INCIDENT_PIN, job_id="canary")},
+        allowlist=_allowlist("canary.yml", jobs="canary"),
+    )
+    # Act
+    exit_code = main([str(tmp_path)])
+    # Assert
+    assert exit_code == 0
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# The two predicates, directly.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "runs_on,expected",
+    [
+        (["self-hosted", "Linux", "X64"], []),
+        (["self-hosted", "Linux", "X64", "spartan-cpu"], ["spartan-cpu"]),
+        # Case must not launder a pin.
+        (["Self-Hosted", "LINUX", "Scitex-CI"], ["Scitex-CI"]),
+        ({"labels": ["self-hosted", "sac-control-plane"]}, ["sac-control-plane"]),
+    ],
+)
+def test_pool_labels_ignores_only_githubs_automatic_labels(runs_on, expected) -> None:
+    # Arrange
+    job = {"runs-on": runs_on}
+    # Act
+    pools = pool_labels(job)
+    # Assert
+    assert pools == expected
+
+
+@pytest.mark.parametrize(
+    "runs_on,expected",
+    [
+        (CANONICAL, True),
+        (LIGHT, True),
+        ("${{ vars.ANYTHING }}", True),
+        (["self-hosted", "spartan-cpu"], False),
+        ("scitex-ci", False),
+    ],
+)
+def test_reads_a_variable_sees_the_seam(runs_on, expected: bool) -> None:
+    # Arrange
+    job = {"runs-on": runs_on}
+    # Act
+    seam = reads_a_variable(job)
+    # Assert
+    assert seam is expected
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# THE REAL REPO.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_this_repo_is_clean() -> None:
+    # Arrange
+    repo = REPO_ROOT
+    # Act
+    violations = check_repo(repo)
+    # Assert
+    assert violations == [], "\n".join(v.render() for v in violations)
+
+
+@pytest.mark.parametrize("filename,job_id", LIGHT_LANE)
+def test_no_light_lane_job_names_a_pool_literally(filename: str, job_id: str) -> None:
+    # Arrange
+    job = _job(filename, job_id)
+    # Act
+    seam = reads_a_variable(job)
+    # Assert
+    assert seam, f"{filename} -> {job_id} froze its pool again"
+
+
+@pytest.mark.parametrize("filename,job_id", LIGHT_LANE)
+def test_the_light_lane_falls_back_to_the_main_pool_variable(
+    filename: str, job_id: str
+) -> None:
+    # Arrange: LIGHT_RUNS_ON is deliberately UNSET in repo settings, so the
+    # `|| vars.CI_RUNS_ON` fall-through is what actually routes these jobs
+    # today. A light lane reading ONLY its own variable would be dark.
+    text = (WORKFLOWS / filename).read_text(encoding="utf-8")
+    # Act
+    has_fallthrough = "vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON" in text
+    # Assert
+    assert has_fallthrough, f"{filename} -> {job_id} lost its fall-through"
+
+
+def test_the_repo_pin_allowlist_is_fully_argued() -> None:
+    # Arrange
+    repo = REPO_ROOT
+    # Act
+    _, allow_violations = load_allowlist(repo)
+    # Assert
+    assert allow_violations == []
+
+
+@pytest.mark.parametrize("filename,job_id", ALLOWED_PINS)
+def test_each_repo_pin_exception_is_on_file(filename: str, job_id: str) -> None:
+    # Arrange
+    repo = REPO_ROOT
+    # Act
+    allow, _ = load_allowlist(repo)
+    # Assert
+    assert filename in allow, f"the argued exception for {job_id} vanished"
+
+
+@pytest.mark.parametrize("filename,job_id", ALLOWED_PINS)
+def test_each_allowlisted_pin_really_still_pins_a_pool(
+    filename: str, job_id: str
+) -> None:
+    # Arrange: an exception must be LOAD-BEARING, not decorative — a stale
+    # entry is SAC-CI007, and this names which one died.
+    job = _job(filename, job_id)
+    # Act
+    pools = pool_labels(job)
+    # Assert
+    assert pools, f"{filename} -> {job_id} no longer pins a pool"
+
+
+@pytest.mark.parametrize("filename,job_id", ALLOWED_PINS)
+def test_each_allowlisted_pin_still_bypasses_the_variable(
+    filename: str, job_id: str
+) -> None:
+    # Arrange
+    job = _job(filename, job_id)
+    # Act
+    seam = reads_a_variable(job)
+    # Assert
+    assert not seam, f"{filename} -> {job_id} now reads a variable — drop its entry"


### PR DESCRIPTION
## The block

35 runs queued in this repo while **every online runner was idle**. Not saturation — a routing fault.

| | |
|---|---|
| `spartan-cpu` runners | **3, all offline** (post-inode stop) |
| `scitex-org-cpu` runners | 4, all **online and idle** |
| `vars.CI_RUNS_ON` | `["self-hosted","Linux","X64","scitex-org-cpu"]` (set 2026-08-12T02:27:58Z) |
| queued light-lane jobs | **33**, every one requesting `self-hosted,Linux,X64,spartan-cpu` |
| open PRs blocked | 15, `mergeStateStatus: UNSTABLE` |

Five workflows — not one — froze `spartan-cpu` into their `runs-on`:

| workflow | job | median |
|---|---|---|
| `lint.yml` | `ruff` | 12 s |
| `no-hosted-runners-guard-on-self-hosted.yml` | `no-hosted-runners` | 13 s |
| `quality-audit-on-ubuntu-latest.yml` | `audit` | 44 s |
| `import-smoke-on-ubuntu-py3-12.yml` | `install-check` | 47 s |
| `rtd-sphinx-build-on-ubuntu-latest.yml` | `sphinx` | 51 s |

**Nothing was failing.** The checks never *started*, and a check that never started is visually identical to one that has not run yet. There is no red to notice — only a queue depth nobody was watching, and a fix that needed a PR through the gate that was jammed.

### Onset, to the minute

`lint` on `develop` succeeded at **11:43:05Z, 11:43:55Z and 11:46:38Z**. The next run, created **12:13:15Z**, queued and never started. Onset is therefore 11:46Z–12:13Z — the window in which the Spartan pool went offline for inode remediation.

That is the argument in one line: **the pin turned a deliberate capacity decision into a merge freeze.** Nothing about #1006's reasoning was wrong on 2026-08-06; it simply had no way to survive its own pool going away.

### An enumeration trap worth writing down

`GET /actions/runs?status=queued` **undercounts.** It reported 33 stuck runs; the per-workflow listing (`/actions/workflows/lint.yml/runs`) reports two more — `31599578007` and `31600452874`, both `lint` on `develop`, both queued, both requesting `spartan-cpu`. The true stuck set was 35.

This matters beyond bookkeeping: read only the repo-wide sweep and `lint` appears to have fired on 5 of 7 pushes, which reads as *"two PRs were never linted at all"* — a quieter and much worse hole than a stuck check. It was not true. Cross-check per workflow before believing a check is missing. The runbook in `docs/ci-runner-routing.md` says so.

## What is kept

**#1006's optimization, entirely.** The measurement behind it is not in dispute: this repo's CI is bimodal, `tests` is 31% of jobs at 368 s across 32 cores, and the other 69% run 12–51 s on about one core without ever entering the CI SIF. A 12-second single-core job holding one of four 32-core machines, then queueing 289 s median (p90 902 s) for the privilege, is a real waste. Routing that class of work away from the heavy pool is right and stays.

## What changes

Only the **seam**. #1006 wrote the destination as a literal label list, with its own comment arguing the choice — *"PINNED PER WORKFLOW rather than through `vars.CI_RUNS_ON` so the routing is visible in a diff."* Diff visibility is a real benefit; it is not worth needing a merge to route around a dead pool.

All five now read:

```yaml
runs-on: ${{ fromJSON(vars.LIGHT_RUNS_ON || vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
```

- The lane keeps its **own variable**, so it can be split off again in one click the moment there is a pool worth splitting onto — the routing intent survives as a named thing rather than as five literals.
- `LIGHT_RUNS_ON` is **deliberately unset**. Unset evaluates to the empty string, `||` falls through, and the lane rides `CI_RUNS_ON` — which is where the live runners are. Setting it would create a second place the routing lives and a stale override is exactly the failure above; set it when the split buys something measurable.
- The literal JSON fallback is kept, and is required: a bare `${{ vars.X }}` fails `SAC-CI002` here and `PS-224` in scitex-dev's auditor. It trades a frozen destination for an invisible one.
- `tests` and `pypi-publish-and-github-release-on-tag.yml` are **untouched**. They read `CI_RUNS_ON` and never `LIGHT_RUNS_ON`; both enter the SIF and still need #992.

## The guard — `SAC-CI005`

`src/scitex_agent_container/_runner_pool_guard.py`. A job whose `runs-on` names a **pool-selecting** label (anything beyond GitHub's automatic `self-hosted` / OS / arch labels) must resolve it through `vars.`. It reuses `_hosted_runner_guard`'s `runs-on` parser rather than rewriting it — two guards reading one line must read it the same way, or they will eventually disagree about what a job requested and the disagreement will surface as one of them being quietly wrong.

It runs three places: a **second step of the existing `no-hosted-runners` job** (deliberately not a new workflow — no new queued check on a contended pool), a `pre-commit` hook, and pytest. The two guard steps are ordered so a hosted violation cannot hide a pool violation; both are reported in one run rather than one per round trip through this queue.

It deliberately does **not** check which pool the variable points at. That is a settings value no static reader can see, and it is precisely the thing that should change without a commit.

### Proof it is falsifiable

`test_reintroducing_the_incident_pin_is_caught` takes **this repo's real `lint.yml`**, puts back the exact `["self-hosted", "Linux", "X64", "spartan-cpu"]` that #1006 shipped, and asserts `SAC-CI005`. Run at the CLI the same way CI and pre-commit run it:

```
=== 1. UNMODIFIED COPY ===
no-hardcoded-runner-pool: OK ...                       pool guard exit=0
no-hosted-runners: OK ...                              hosted guard exit=0

=== 2. REINTRODUCE THE #1006 PIN IN lint.yml ===
  SAC-CI005  .github/workflows/lint.yml -> job `ruff`
      names its runner pool literally (spartan-cpu) instead of reading it
      from a repository variable. ...                  pool guard exit=1
no-hosted-runners: OK ...                              hosted guard exit=0   <- correct: the pin IS self-hosted

=== 3. BY-PATH INVOCATION (how pre-commit runs it) ===
  SAC-CI005  .github/workflows/lint.yml -> job `ruff`  by-path exit=1
```

The hosted guard staying green on the regressed tree is the point: the two answer different questions about the same line, and `SAC-CI001` had nothing to say about this incident.

89 tests pass (35 new + 54 existing), no mocks — every case writes real workflow files to a real tmp tree.

## The exceptions, as a mechanism

Two pins in this repo are correct, and both survive — in `.github/runner-pin-allowlist.yaml`, with a machine-enforced `reason:` (`SAC-CI006`) and stale-entry detection (`SAC-CI007`), the same shape as the hosted-runner allowlist beside it:

- **`spartan-capacity-canary` → `spartan-cpu`.** Naming the pool *is* the measurement; reading the variable would make it interrogate whichever pool is already configured.
- **`pytest-matrix … / verdict` → `sac-control-plane`.** It writes the CI verdict over loopback to the one host running `sac listen` and the card store.

The distinguishing test, written into the file: each would be **wrong if it silently ran somewhere else.** "This pool is faster for this job" is not that — it is a routing preference, and preferences go in variables. Both also gate nothing, so neither can hold the repo hostage.

## Also

- `docs/ci-runner-routing.md` — the routing model, the incident, and a runbook for "a pool has gone offline" (confirm idle-vs-saturated, re-point the variable, enumerate before cancelling, and the fact that a variable change does not re-route already-queued runs).
- Corrected a stale factual claim in the `no-hosted-runners` header: it asserted `CI_RUNS_ON` was `scitex-local-cpu`. It is `scitex-org-cpu`. A wrong statement about which pool is live is the one thing that sends the next reader re-pointing the variable while fixing something else.

## Considered and rejected

Adding this as a `scitex-dev` audit rule. Its project auditor (`PS-*`) has **no plugin seam** — checks are hardwired imports in `_run_checks.py`, and the entry-point groups it does expose (`scitex_dev.linter.plugins`) are Python-AST-only and cannot see YAML. The rule would have to land inside scitex-dev, which is a separate cross-repo change and not something to do while 15 PRs are blocked. This repo already owns the right mechanism. Note also that scitex-dev's `PS-224` treats a *bare* `${{ vars.X }}` as an error, so the form here is the one both auditors bless.

## Measured, not inferred

The light lane does not merely stop failing — it **starts and finishes on named live hardware**, all four org runners used:

| check | runner | started | completed |
|---|---|---|---|
| `ruff-on-ubuntu-latest` | **scitex-03-org-cpu-01** | 13:48:39Z | 13:48:51Z (12 s) |
| `no-hosted-runners-guard-on-self-hosted` | **scitex-02-org-cpu-01** | 13:48:39Z | 13:48:54Z (15 s) |
| `scitex-dev-quality-audit-on-ubuntu-latest` | **scitex-01-org-cpu-01** | 13:48:39Z | 13:49:34Z (55 s) |
| `rtd-sphinx-build-on-ubuntu-latest` | **scitex-04-org-cpu-01** | 13:48:39Z | 13:49:35Z (56 s) |
| `import-smoke-on-ubuntu-py3-12` | **scitex-01-org-cpu-01** | 13:49:37Z | 13:50:27Z (50 s) |

All five requested `self-hosted,Linux,X64,scitex-org-cpu` — the seam resolved through the unset `LIGHT_RUNS_ON` into `CI_RUNS_ON`, exactly as designed. Four started in the same second they were created; queue admission was ~0 s against the 289 s median this lane used to pay.

`scitex-dev-quality-audit` passing is also the empirical answer to the `PS-224` question above: the auditor accepts the double-`||` form.

## The fleet, and why this PR does not touch it

Five sibling repos carry the identical literal pin and are armed to freeze on their next push: **scitex-cards, scitex-todo, scitex-plt, scitex-scholar, scitex-ssh** (every one's last CI run predates the outage). This PR deliberately does **not** widen to cover them — sac lands first as the proof.

The guard is written to be **promoted, not copied**: pure functions of a `repo: Path`, the whole rule in two callable predicates, and a docstring section naming exactly what a scitex-dev promotion would change (call PS-224's `resolve_destination` and drop the local parser). The pin is a fleet convention, not a sac quirk.

## Not in scope

Reviving the Spartan runners (`spartan-ci-restore-after-inode-p1`). This routes around a dead pool without depending on it coming back — which is the whole point.
