### PR TITLE
fix(test-ports): a dead port must be HELD, not released a moment earlier

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,8 +219,11 @@ def _ensure_subprocess_coverage_shim() -> None:
 _ensure_subprocess_coverage_shim()
 
 # Expose shared no-mocks helpers (subprocess_shim, env_save_restore,
-# ssh_exec_shim, ssh_http_shim) as session-wide fixtures so any test under
-# tests/ can use them by name.
+# ssh_exec_shim, ssh_http_shim, dead_port) as session-wide fixtures so any test
+# under tests/ can use them by name.
+from tests.scitex_agent_container._helpers.ports import (  # noqa: E402,F401
+    dead_port,
+)
 from tests.scitex_agent_container._helpers.ssh_exec_shim import (  # noqa: E402,F401
     ssh_exec_shim,
 )

--- a/tests/develop/test_dead_port_helper.py
+++ b/tests/develop/test_dead_port_helper.py
@@ -1,5 +1,33 @@
 """The dead-port helper must be FALSIFIABLE, so every claim it makes is a test.
 
+WHY THIS FILE LIVES IN ``tests/develop/`` AND NOT BESIDE THE HELPER
+==================================================================
+It tests ``tests/scitex_agent_container/_helpers/ports.py``, so the obvious
+home is next to it. That home is wrong, and the auditor is right to say so.
+
+``tests/<pkg>/`` is the MIRROR TREE: every ``test_X.py`` there must
+correspond to ``src/<pkg>/.../X.py``. **PS-204 §2 (orphan-test-file)** fires
+on any that does not, and this test has no src counterpart *by design* — the
+thing under test is test-support code that must never ship. Putting it in the
+mirror tree reddened both matrix legs (PR #1026, run 31607851531): audit-all
+exit 1, 1 unmasked error, green on the base commit.
+
+The helper itself stays exactly where it is. It is not a ``test_*.py``, so
+PS-204 never looks at it, and **PS-207 is documented as "src-aware so it
+never flags fixture trees that legitimately have no source counterpart"** —
+i.e. a `_helpers/` directory of support modules with no `src/` mirror is a
+BLESSED shape, which is why `loopback_server.py` and `ssh_exec_shim.py` have
+sat there unflagged. Only the *test* had to move, and relocating is the
+remedy PS-204 itself is built to suggest (its detail is "enriched" precisely
+to name a relocate target), not a dodge around the rule.
+
+``tests/develop/`` is where this repo keeps gates about its own tooling and
+conventions — ``test_audit.py``, ``test_git_hooks.py``,
+``test_pytest_plugin_gate.py``, ``test_skills_quality.py``. A gate pinning
+the contract of shared test infrastructure is exactly that genre, and the
+directory is outside PS-204's scope. Do not move this back.
+
+
 A test-support module that nothing tests is an assertion, not a guarantee —
 and the bug this one fixes (CI 2026-08-12, develop ``d21cb5f6``, py3.11 leg
 only) is precisely a helper that *claimed* "nothing is listening on this port"

--- a/tests/develop/test_tests_mirror_src.py
+++ b/tests/develop/test_tests_mirror_src.py
@@ -1,0 +1,124 @@
+"""A `test_*.py` in the mirror tree must mirror a `src/` module — fast, locally.
+
+WHY THIS EXISTS (PR #1026, run 31607851531, both matrix legs red)
+=================================================================
+A shared test-helper landed at ``tests/scitex_agent_container/_helpers/ports.py``
+— correct, and the same shape as its siblings ``loopback_server.py`` and
+``ssh_exec_shim.py``. Its test landed beside it as ``_helpers/test_ports.py``,
+which is the obvious place and the wrong one::
+
+    [E] [PS-204 §2 orphan-test-file]
+        tests/scitex_agent_container/_helpers/test_ports.py:
+        no matching src file (orphan test);
+        mirror dir `src/scitex_agent_container/_helpers` does not exist
+
+``tests/<pkg>/`` is the MIRROR TREE: a ``test_X.py`` there asserts that
+``src/<pkg>/.../X.py`` exists. A `_helpers/` package is test-only by design and
+has no `src/` counterpart — PS-207 is even documented as "src-aware so it never
+flags fixture trees that legitimately have no source counterpart", which is
+exactly why dropping a `test_*.py` into one is such a quiet trap: the directory
+is blessed, so nothing warns you until CI. Tests with no src counterpart belong
+OUTSIDE the mirror tree (``tests/develop/``, ``tests/integration/``,
+``tests/e2e/``, ``tests/smoke/``), which is where this file and the relocated
+``test_dead_port_helper.py`` now live.
+
+WHY NOT JUST LEAN ON ``test_audit.py``
+--------------------------------------
+It does catch this — it is what went red — but only after a full
+``scitex-dev ecosystem audit-all``, and it is skippable
+(``SCITEX_DEV_SKIP_AUDIT=1``) and silent when the audit corpus is not
+installed. So the trap can reach a push without a word. This is a
+millisecond, dependency-free echo of one narrow half of PS-204 §2 — the
+missing-mirror-DIRECTORY case, which is the half that bites — so the mistake
+surfaces in a normal local run.
+
+**scitex-dev remains the source of truth.** This deliberately does NOT
+re-implement the rest of PS-204 (per-file basename matching, the enriched
+relocate hint, the public/private prefix rules of PS-205). A directory-level
+invariant cannot drift away from the auditor the way a re-implemented
+file-level one would.
+
+NO MOCKS — real directories on disk, including the negative control.
+
+AAA markers (TQ002); 3+-word test names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_PKG = _REPO_ROOT / "tests" / "scitex_agent_container"
+_SRC_PKG = _REPO_ROOT / "src" / "scitex_agent_container"
+
+# Directories outside the mirror tree, where a test with no src counterpart
+# belongs. Named here so the failure message can point at them.
+_NON_MIRROR_HOMES = ("tests/develop/", "tests/integration/", "tests/e2e/", "tests/smoke/")
+
+
+def _unmirrored_test_dirs(tests_pkg: Path, src_pkg: Path) -> List[Tuple[Path, Path]]:
+    """Every dir holding a ``test_*.py`` whose ``src/`` mirror dir is missing.
+
+    Returns ``(test_dir, expected_src_dir)`` pairs so the caller can print both
+    halves — "what you wrote" and "what would have had to exist".
+    """
+    test_dirs = {p.parent for p in tests_pkg.rglob("test_*.py")}
+    missing = []
+    for test_dir in sorted(test_dirs):
+        mirror = src_pkg / test_dir.relative_to(tests_pkg)
+        if not mirror.is_dir():
+            missing.append((test_dir, mirror))
+    return missing
+
+
+def _render(offenders: List[Tuple[Path, Path]]) -> str:
+    lines = ["test files live in the mirror tree but have no src/ mirror dir:"]
+    for test_dir, mirror in offenders:
+        rel = test_dir.relative_to(_REPO_ROOT)
+        names = sorted(p.name for p in test_dir.glob("test_*.py"))
+        lines.append(f"  {rel}/  ({', '.join(names)})")
+        lines.append(f"      needs {mirror.relative_to(_REPO_ROOT)}/ to exist")
+    lines.append("")
+    lines.append("This is PS-204 §2 (orphan-test-file). If the code under test is")
+    lines.append("test-only support with no src/ counterpart, the TEST moves out of")
+    lines.append("the mirror tree — the helper itself stays put. Homes: " )
+    lines.append("  " + "  ".join(_NON_MIRROR_HOMES))
+    return "\n".join(lines)
+
+
+def test_every_test_dir_mirrors_a_src_dir():
+    # Arrange — the real tree, as shipped.
+    # Act
+    offenders = _unmirrored_test_dirs(_TESTS_PKG, _SRC_PKG)
+    # Assert
+    assert offenders == [], _render(offenders)
+
+
+def test_the_guard_detects_an_unmirrored_test_dir(tmp_path):
+    # Arrange — the negative control, built from REAL directories: a test-only
+    # `_helpers` package holding a test, exactly the 2026-08-12 mistake. A
+    # guard that cannot fail is not a guard.
+    tests_pkg = tmp_path / "tests" / "pkg"
+    (tests_pkg / "_helpers").mkdir(parents=True)
+    (tests_pkg / "_helpers" / "test_ports.py").write_text("def test_x(): pass\n")
+    src_pkg = tmp_path / "src" / "pkg"
+    src_pkg.mkdir(parents=True)
+    # Act
+    offenders = _unmirrored_test_dirs(tests_pkg, src_pkg)
+    # Assert
+    assert [d.name for d, _ in offenders] == ["_helpers"]
+
+
+def test_the_guard_passes_a_mirrored_test_dir(tmp_path):
+    # Arrange — the same shape, but with the src/ mirror present: this one is
+    # legitimate and must NOT be flagged, or the guard would block real tests.
+    tests_pkg = tmp_path / "tests" / "pkg"
+    (tests_pkg / "cli").mkdir(parents=True)
+    (tests_pkg / "cli" / "test_run.py").write_text("def test_x(): pass\n")
+    src_pkg = tmp_path / "src" / "pkg"
+    (src_pkg / "cli").mkdir(parents=True)
+    # Act
+    offenders = _unmirrored_test_dirs(tests_pkg, src_pkg)
+    # Assert
+    assert offenders == []

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -32,7 +32,6 @@ operator's real agents.
 from __future__ import annotations
 
 import shutil
-import socket
 import subprocess
 import time
 import uuid
@@ -42,15 +41,8 @@ from typing import Iterator
 import pytest
 
 # ---------------------------------------------------------------------------
-# Shared helpers — port allocation, sac binary discovery, registry probe.
+# Shared helpers — sac binary discovery, registry probe.
 # ---------------------------------------------------------------------------
-
-
-def _free_port() -> int:
-    """Return a free TCP port on localhost."""
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return int(s.getsockname()[1])
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_sac_listen_health_probe.py
+++ b/tests/integration/test_sac_listen_health_probe.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import http.server
 import os
 import shutil
-import socket
 import subprocess
 import threading
 from pathlib import Path
@@ -79,13 +78,11 @@ def live_health_server():
         server.server_close()
 
 
-def _free_port() -> int:
-    """Grab then release a port so nothing is listening on it."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+# The dead port comes from the shared ``dead_port`` fixture
+# (tests/scitex_agent_container/_helpers/ports.py, wired in tests/conftest.py):
+# bound WITHOUT listening, so it refuses, and HELD, so nothing can take it
+# mid-test. The helper that used to live here grabbed a port and released it
+# again before the probe ran — see that module for the flake it caused.
 
 
 @pytest.fixture(autouse=True)
@@ -135,10 +132,10 @@ def _run_probe(*args: str, env_extra: dict[str, str] | None = None):
     )
 
 
-def _down_env() -> dict[str, str]:
-    """Env pointing the probe at a real closed port (connection refused)."""
+def _down_env(dead_port) -> dict[str, str]:
+    """Env pointing the probe at a held, never-listened port (refuses)."""
     return {
-        "SAC_LISTEN_HEALTH_URL": f"http://127.0.0.1:{_free_port()}/v1/health",
+        "SAC_LISTEN_HEALTH_URL": dead_port.url("/v1/health"),
         "SAC_LISTEN_PROBE_TIMEOUT": "2",
     }
 
@@ -155,18 +152,18 @@ def test_check_only_passes_against_live_server(live_health_server):
     assert result.returncode == 0
 
 
-def test_check_only_fails_against_dead_port():
+def test_check_only_fails_against_dead_port(dead_port):
     # Arrange
-    env = _down_env()
+    env = _down_env(dead_port)
     # Act
     result = _run_probe("--check-only", env_extra=env)
     # Assert
     assert result.returncode == 1
 
 
-def test_check_only_down_names_the_verdict():
+def test_check_only_down_names_the_verdict(dead_port):
     # Arrange
-    env = _down_env()
+    env = _down_env(dead_port)
     # Act
     result = _run_probe("--check-only", env_extra=env)
     # Assert — the probe now reports a THREE-STATE verdict. "UNHEALTHY" was a
@@ -189,7 +186,7 @@ def test_check_only_healthy_is_quiet(live_health_server):
 # --- probe: heal-mode loudness (no real systemctl needed) -----------------
 
 
-def _corroborated_down_env() -> dict[str, str]:
+def _corroborated_down_env(dead_port) -> dict[str, str]:
     """A dead port, probed ONCE already — the next probe corroborates.
 
     A SINGLE failed probe is no longer grounds to restart: that was the
@@ -199,15 +196,15 @@ def _corroborated_down_env() -> dict[str, str]:
     the bug. They now earn the verdict first (a refusal is weight 2, the
     threshold is 3, so a second one crosses it).
     """
-    env = _down_env()
+    env = _down_env(dead_port)
     env["SAC_LISTEN_UNIT"] = "sac-listen-nonexistent-test.service"
     _run_probe(env_extra=env)
     return env
 
 
-def test_uncorroborated_down_does_not_restart():
+def test_uncorroborated_down_does_not_restart(dead_port):
     # Arrange — the regression that made this whole rewrite necessary.
-    env = _down_env()
+    env = _down_env(dead_port)
     env["SAC_LISTEN_UNIT"] = "sac-listen-nonexistent-test.service"
     # Act
     result = _run_probe(env_extra=env)
@@ -215,18 +212,18 @@ def test_uncorroborated_down_does_not_restart():
     assert "RESTARTING" not in result.stderr
 
 
-def test_heal_mode_corroborated_down_emits_loud_error():
+def test_heal_mode_corroborated_down_emits_loud_error(dead_port):
     # Arrange
-    env = _corroborated_down_env()
+    env = _corroborated_down_env(dead_port)
     # Act
     result = _run_probe(env_extra=env)
     # Assert
     assert "ERROR: sac-listen DOWN" in result.stderr
 
 
-def test_heal_mode_logs_restart_intent():
+def test_heal_mode_logs_restart_intent(dead_port):
     # Arrange
-    env = _corroborated_down_env()
+    env = _corroborated_down_env(dead_port)
     # Act
     result = _run_probe(env_extra=env)
     # Assert — a genuinely dead listen still comes back (incident 2026-06-26).

--- a/tests/integration/test_sac_listen_health_watchdog_decision.py
+++ b/tests/integration/test_sac_listen_health_watchdog_decision.py
@@ -20,7 +20,8 @@ Both directions are bugs. These tests pin BOTH:
 
 No mocks (STX-NM002). Every case drives the REAL probe script against a REAL
 HTTP server on a REAL ephemeral loopback socket — slow, refusing, 5xx-ing,
-401-ing, dying. The "refused" case points at a genuinely closed port. Nothing
+401-ing, dying. The "refused" case points at a port that is bound but never
+listened on, so it refuses for the whole test AND cannot be stolen. Nothing
 here ever touches port 7878: that is the live control plane the whole fleet
 depends on, and a test that restarts it would repeat the incident.
 
@@ -32,7 +33,6 @@ from __future__ import annotations
 import http.server
 import os
 import shutil
-import socket
 import subprocess
 import threading
 from pathlib import Path
@@ -99,13 +99,16 @@ class _Server:
         self._srv.server_close()
 
 
-def _closed_port() -> int:
-    """Bind then release a port, so nothing is listening on it."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+# A port that refuses connections comes from the shared ``dead_port`` fixture
+# (tests/scitex_agent_container/_helpers/ports.py), wired suite-wide in
+# tests/conftest.py. It binds WITHOUT listening and HOLDS the socket, so the
+# port both refuses and cannot be taken by anything else mid-test.
+#
+# What used to be here bound a port, closed it, and returned the number. That
+# released the port back into the ephemeral pool before the probe ever ran, so
+# any other test or xdist worker could bind it — and then the URL this file
+# calls "dead" ANSWERED. That is how ``test_one_success_does_not_wipe_failure_
+# streak`` inverted and reddened the py3.11 leg alone on develop d21cb5f6.
 
 
 # --- driving the real probe -----------------------------------------------
@@ -218,9 +221,9 @@ def test_timeout_reports_tcp_did_connect(tmp_path):
     assert "the port IS bound" in result.stderr
 
 
-def test_refused_is_reported_as_down(tmp_path):
+def test_refused_is_reported_as_down(tmp_path, dead_port):
     # Arrange — a genuinely closed port: the kernel sends RST.
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     # Act
     result = probe.run("--check-only")
     # Assert
@@ -307,19 +310,19 @@ def test_single_server_error_does_not_restart(tmp_path):
 # ==========================================================================
 
 
-def test_first_refusal_does_not_restart(tmp_path):
+def test_first_refusal_does_not_restart(tmp_path, dead_port):
     # Arrange
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     # Act
     decided = probe.restarted()
     # Assert — even a HARD down (weight 2) is below the threshold (3) alone.
     assert decided is False
 
 
-def test_second_refusal_restarts_dead_listen(tmp_path):
+def test_second_refusal_restarts_dead_listen(tmp_path, dead_port):
     # Arrange — a genuinely dead listen MUST still come back
     # (incident 2026-06-26). Crash coverage is not weakened.
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     # Act
     first = probe.restarted()
     second = probe.restarted()
@@ -355,9 +358,9 @@ def test_two_timeouts_do_not_yet_restart(tmp_path):
     assert decisions == [False, False]
 
 
-def test_uncorroborated_failure_says_not_restarting(tmp_path):
+def test_uncorroborated_failure_says_not_restarting(tmp_path, dead_port):
     # Arrange
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     # Act
     result = probe.run()
     # Assert — it must SAY it saw a failure and chose not to act.
@@ -370,11 +373,11 @@ def test_uncorroborated_failure_says_not_restarting(tmp_path):
 # ==========================================================================
 
 
-def test_one_success_does_not_wipe_failure_streak(tmp_path):
+def test_one_success_does_not_wipe_failure_streak(tmp_path, dead_port):
     # Arrange — the bug PR #673 fixed in sac listen's own holder check: a
     # single reply reset `consecutive_unhealthy = 0`, so a FLAPPING daemon
     # oscillated 1/2 -> "healthy" -> 1/2 forever and was NEVER acted on.
-    dead = f"http://127.0.0.1:{_closed_port()}/v1/health"
+    dead = dead_port.url("/v1/health")
     srv = _Server(status=200)
     live = srv.url
     probe = _Probe(tmp_path, dead)
@@ -391,9 +394,9 @@ def test_one_success_does_not_wipe_failure_streak(tmp_path):
     assert (first, third) == (False, True)
 
 
-def test_single_success_keeps_ledger_standing(tmp_path):
+def test_single_success_keeps_ledger_standing(tmp_path, dead_port):
     # Arrange
-    dead = f"http://127.0.0.1:{_closed_port()}/v1/health"
+    dead = dead_port.url("/v1/health")
     srv = _Server(status=200)
     probe = _Probe(tmp_path, dead)
     try:
@@ -407,10 +410,10 @@ def test_single_success_keeps_ledger_standing(tmp_path):
     assert "still stands" in result.stderr
 
 
-def test_sustained_recovery_clears_the_ledger(tmp_path):
+def test_sustained_recovery_clears_the_ledger(tmp_path, dead_port):
     # Arrange — a daemon that blips once and then genuinely recovers must NOT
     # be destroyed. Two consecutive answers clear it.
-    dead = f"http://127.0.0.1:{_closed_port()}/v1/health"
+    dead = dead_port.url("/v1/health")
     srv = _Server(status=200)
     probe = _Probe(tmp_path, dead)
     try:
@@ -426,10 +429,10 @@ def test_sustained_recovery_clears_the_ledger(tmp_path):
     assert "RECOVERED" in result.stderr
 
 
-def test_recovered_daemon_survives_a_later_blip(tmp_path):
+def test_recovered_daemon_survives_a_later_blip(tmp_path, dead_port):
     # Arrange — after a genuine recovery the ledger is clean, so a single
     # later failure is once again just a blip, not a death sentence.
-    dead = f"http://127.0.0.1:{_closed_port()}/v1/health"
+    dead = dead_port.url("/v1/health")
     srv = _Server(status=200)
     probe = _Probe(tmp_path, dead)
     try:
@@ -462,12 +465,12 @@ def _drive_to_restart(probe: _Probe) -> None:
     probe.run()
 
 
-def test_backoff_blocks_the_second_restart(tmp_path):
+def test_backoff_blocks_the_second_restart(tmp_path, dead_port):
     # Arrange — THE incident. The old probe restarted, then re-probed 26s
     # later DURING its own restart, saw a genuinely-down daemon, and
     # restarted AGAIN. Drive it to a real restart, then keep probing a
     # still-dead port.
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     _drive_to_restart(probe)
     # Act — the timer keeps firing while the daemon is coming back up.
     followups = [probe.restarted() for _ in range(3)]
@@ -475,9 +478,9 @@ def test_backoff_blocks_the_second_restart(tmp_path):
     assert followups == [False, False, False]
 
 
-def test_backoff_refuses_to_even_probe(tmp_path):
+def test_backoff_refuses_to_even_probe(tmp_path, dead_port):
     # Arrange
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     probe.run()
     probe.run()  # restart issued
     # Act
@@ -486,10 +489,10 @@ def test_backoff_refuses_to_even_probe(tmp_path):
     assert "post-restart backoff" in result.stderr and "NOT probing" in result.stderr
 
 
-def test_backoff_expiry_allows_healing_again(tmp_path):
+def test_backoff_expiry_allows_healing_again(tmp_path, dead_port):
     # Arrange — the backoff must not be a permanent gag: once it lapses, a
     # still-dead listen is healed again.
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     probe.run()
     probe.run()  # restart #1
     # Act — a 0s backoff is the expiry, exactly as the timer would see it.
@@ -505,12 +508,12 @@ def test_backoff_expiry_allows_healing_again(tmp_path):
 # ==========================================================================
 
 
-def test_restarts_are_capped_per_window(tmp_path):
+def test_restarts_are_capped_per_window(tmp_path, dead_port):
     # Arrange — a listen that never comes back. Backoff off so we can reach
     # the cap; the cap is the thing under test.
     probe = _Probe(
         tmp_path,
-        f"http://127.0.0.1:{_closed_port()}/v1/health",
+        dead_port.url("/v1/health"),
         SAC_LISTEN_RESTART_BACKOFF=0,
     )
     # Act — six probes; each pair corroborates into one restart attempt.
@@ -520,11 +523,11 @@ def test_restarts_are_capped_per_window(tmp_path):
 
 
 @pytest.fixture()
-def exhausted_probe(tmp_path):
+def exhausted_probe(tmp_path, dead_port):
     """A watchdog that has spent its restart budget on a listen still dead."""
     probe = _Probe(
         tmp_path,
-        f"http://127.0.0.1:{_closed_port()}/v1/health",
+        dead_port.url("/v1/health"),
         SAC_LISTEN_RESTART_BACKOFF=0,
     )
     for _ in range(5):  # 2 restarts issued; the cap (2) is now reached
@@ -574,9 +577,9 @@ def test_giving_up_still_exits_nonzero(exhausted_probe):
 # ==========================================================================
 
 
-def test_check_only_writes_no_state(tmp_path):
+def test_check_only_writes_no_state(tmp_path, dead_port):
     # Arrange — a probe that mutates is not a probe.
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     # Act
     for _ in range(5):
         probe.run("--check-only")
@@ -584,9 +587,9 @@ def test_check_only_writes_no_state(tmp_path):
     assert not probe.state.exists()
 
 
-def test_check_only_never_restarts(tmp_path):
+def test_check_only_never_restarts(tmp_path, dead_port):
     # Arrange
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     # Act
     outs = [probe.run("--check-only").stderr for _ in range(5)]
     # Assert
@@ -598,9 +601,9 @@ def test_check_only_never_restarts(tmp_path):
 # ==========================================================================
 
 
-def test_corrupt_ledger_does_not_restart(tmp_path):
+def test_corrupt_ledger_does_not_restart(tmp_path, dead_port):
     # Arrange — garbage (and a shell injection attempt) in the state file.
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     probe.state.write_text(
         "failures=$(touch /tmp/sac-pwned)\n"
         "serving_streak=../../etc\n"
@@ -613,10 +616,10 @@ def test_corrupt_ledger_does_not_restart(tmp_path):
     assert decided is False
 
 
-def test_corrupt_ledger_is_not_executed(tmp_path):
+def test_corrupt_ledger_is_not_executed(tmp_path, dead_port):
     # Arrange — the state file must never be `source`d.
     canary = tmp_path / "pwned"
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     probe.state.write_text(f"failures=9\nrestarts=$(touch {canary})\n")
     # Act
     probe.run()
@@ -624,9 +627,9 @@ def test_corrupt_ledger_is_not_executed(tmp_path):
     assert not canary.exists()
 
 
-def test_status_reports_the_ledger(tmp_path):
+def test_status_reports_the_ledger(tmp_path, dead_port):
     # Arrange
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     probe.run()  # accrue a real failure
     # Act
     result = probe.run("--status")
@@ -634,9 +637,9 @@ def test_status_reports_the_ledger(tmp_path):
     assert "failure_weight:  2 / 3" in result.stdout
 
 
-def test_reset_clears_the_ledger(tmp_path):
+def test_reset_clears_the_ledger(tmp_path, dead_port):
     # Arrange
-    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe = _Probe(tmp_path, dead_port.url("/v1/health"))
     probe.run()
     # Act
     probe.run("--reset")

--- a/tests/scitex_agent_container/_helpers/ports.py
+++ b/tests/scitex_agent_container/_helpers/ports.py
@@ -1,0 +1,234 @@
+"""Test ports: one that REFUSES connections, and one you are about to bind.
+
+Why this exists (CI failure 2026-08-12, develop ``d21cb5f6``, **py3.11 leg
+only** — py3.12 and py3.13 green on the identical tree)::
+
+    FAILED tests/integration/test_sac_listen_health_watchdog_decision.py
+        ::test_one_success_does_not_wipe_failure_streak
+    assert (False, False) == (False, True)
+
+The test was right; its port helper was wrong. Ten-plus test modules had each
+hand-rolled the same idiom to mean "a port nothing is listening on" —
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()          # <-- the port is RELEASED here
+    return port
+
+— and that ``close()`` is a **race by construction**. The instant it returns,
+the port is free again and back in the kernel's ephemeral pool. Between that
+line and the moment the test actually probes the URL, *anything* can take it:
+another test in the same session, another xdist worker (CI runs ``-n``), any
+process on the box. When something does, the URL the test believes is DEAD
+**answers**, no failure accrues, and a streak assertion inverts. It is
+per-leg nondeterministic rather than a clean pass/fail, which is exactly the
+signature we saw: one leg red, two green, same commit.
+
+The property the failing test guards is a real shipped bug (#673): one lucky
+reply reset ``consecutive_unhealthy``, so a flapping daemon oscillated
+``1/2 -> "healthy" -> 1/2`` forever and was never acted on. Relaxing that
+assertion — or papering over the race with a retry or a sleep — would delete
+the regression guard and keep the flake. So the helper is what changes.
+
+**The fix: bind, and never close.** A socket that is ``bind()``ed but never
+``listen()``ed gives both properties at once, and neither is an accident of
+timing:
+
+* **It refuses.** With no accept queue the kernel answers the SYN with RST,
+  so ``connect()`` fails ``ECONNREFUSED`` and curl exits 7 with "Failed to
+  connect". That is precisely the "nothing is listening here" semantics the
+  callers want — the same thing they were trying to synthesise by closing.
+* **It holds the port.** While the socket lives nothing else can bind that
+  port, and the kernel will not hand it out to another ``bind(port 0)``.
+
+Measured on this platform (see ``test_ports_helper.py``, which asserts every
+one of these rather than trusting the paragraph above): connect ->
+``ECONNREFUSED`` (errno 111); curl -> exit 7; a second ``bind()`` -> errno 98
+``EADDRINUSE``, and still ``EADDRINUSE`` when the newcomer sets
+``SO_REUSEADDR`` **or** ``SO_REUSEPORT``, and still ``EADDRINUSE`` when the
+newcomer asks for the wildcard ``0.0.0.0``. By contrast the old
+bind-then-close port re-binds on the first try — that *is* the bug, and it is
+pinned as a test too, so this module's value is falsifiable rather than
+asserted.
+
+Deliberately, the holder socket sets **no** socket options. ``SO_REUSEADDR``
+and ``SO_REUSEPORT`` are the two things that would let a later binder share
+the port; setting either on the holder would re-open the hole this module
+closes.
+
+**Why this defect is durable, and what that demands of this file.** The bug
+survives review because ``s.close()`` *looks* deliberate — in scitex-dev's
+copy it is even commented ``# Socket is closed by here, which is the point:
+the port is free.`` A reader sees an obviously-intentional close and moves
+on. The un-close must therefore be at least as obviously intentional, or the
+next reader will "tidy up the leaked socket" and restore the flake. That is
+why the not-closing is stated at every level here: in this docstring, in a
+comment at the ``bind()`` itself, and — the part that actually bites — in
+``test_ports.py::test_helper_socket_is_still_open_after_handing_out_port``,
+which fails if someone adds the close back.
+
+**Promoting this to scitex-dev.** The same defect exists at
+``scitex-dev tests/scitex_dev/_cli/gui/test__lifecycle.py::free_port``, whose
+docstring promises "a port number nothing is listening on" while the code
+only guarantees "was free a moment ago" — so this module is written to move
+there (scitex-dev hosts the primitive, leaves declare specifics) rather than
+be welded to sac. It imports only ``contextlib``, ``socket``, ``typing`` and
+``pytest``; nothing from ``scitex_agent_container``, nothing from the sac
+fleet, no repo-relative paths, no env vars. A promotion would change three
+things and nothing else: the module's home, the ``from tests...._helpers.ports
+import`` lines at each call site, and the re-export in ``tests/conftest.py``
+that makes ``dead_port`` a suite-wide fixture. Prove it in the leaf first —
+this PR — then promote.
+
+**The other need, which is NOT this one.** Some call sites reach for the same
+idiom to mean "a free port I am about to bind MYSELF" — pick one, then hand it
+to uvicorn, ``http.server``, or a subprocess. That need genuinely requires
+releasing the port, so it cannot use ``dead_port``, and it is racy for a
+different reason (someone else may take the port before the real server binds
+it). ``reserved_port`` serves it honestly: it holds the port right up until
+the caller is ready, shrinking the window to the smallest one a
+non-fd-passing API allows, and it says so out loud rather than pretending the
+race is gone.
+
+NO MOCKS — real sockets, real kernel behaviour, real refusals.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+from typing import Iterator, List
+
+import pytest
+
+__all__ = [
+    "DeadPortAllocator",
+    "bind_without_listen",
+    "dead_port",
+    "hold_dead_port",
+    "reserved_port",
+]
+
+_LOOPBACK = "127.0.0.1"
+
+
+def bind_without_listen(host: str = _LOOPBACK) -> socket.socket:
+    """A socket BOUND to an ephemeral port and never ``listen()``ed.
+
+    Connecting to it is REFUSED (no accept queue -> RST), and the port is
+    HELD for as long as the returned socket is open. See the module docstring
+    for why both halves matter and how they are measured.
+
+    The caller owns the socket and must close it. Prefer ``hold_dead_port``
+    (a context manager) or the ``dead_port`` fixture, which do that for you.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # No SO_REUSEADDR / SO_REUSEPORT on purpose: those are exactly what would
+    # let another binder move in behind the test's back.
+    sock.bind((host, 0))
+    # !! DO NOT close() OR listen() THIS SOCKET HERE. !!
+    # Returning it OPEN is the entire point, not a leaked fd:
+    #   * open + never listen()ed  ->  connections are REFUSED (what callers want)
+    #   * open                     ->  the port cannot be stolen (what fixes the flake)
+    # Closing here restores the 2026-08-12 py3.11 flake exactly. Ownership
+    # passes to the caller; hold_dead_port / the dead_port fixture close it at
+    # teardown. Pinned by test_ports.py::
+    #   test_helper_socket_is_still_open_after_handing_out_port
+    return sock
+
+
+class DeadPortAllocator:
+    """Hands out refusing ports and HOLDS every one of them until ``close()``.
+
+    Callable, so a call site that had ``_closed_port()`` inline in an f-string
+    keeps its shape::
+
+        def test_refused_is_reported_as_down(tmp_path, dead_port):
+            probe = _Probe(tmp_path, dead_port.url("/v1/health"))
+    """
+
+    def __init__(self, host: str = _LOOPBACK) -> None:
+        self._host = host
+        self._held: List[socket.socket] = []
+
+    def __call__(self) -> int:
+        """A fresh port that refuses connections, held until teardown."""
+        sock = bind_without_listen(self._host)
+        self._held.append(sock)
+        return int(sock.getsockname()[1])
+
+    def url(self, path: str = "/", scheme: str = "http") -> str:
+        """A URL on a fresh dead port — the shape most call sites want."""
+        return f"{scheme}://{self._host}:{self()}{path}"
+
+    def close(self) -> None:
+        """Release every port handed out. Idempotent."""
+        for sock in self._held:
+            with contextlib.suppress(OSError):
+                sock.close()
+        self._held.clear()
+
+
+@contextlib.contextmanager
+def hold_dead_port(host: str = _LOOPBACK) -> Iterator[int]:
+    """One port that refuses connections, held for the duration of the block.
+
+    For code that is not a pytest test (module-level smoke helpers, say) and
+    therefore cannot take the ``dead_port`` fixture.
+    """
+    sock = bind_without_listen(host)
+    try:
+        yield int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+
+@contextlib.contextmanager
+def reserved_port(host: str = _LOOPBACK) -> Iterator[socket.socket]:
+    """A free port HELD until you are ready to bind it yourself.
+
+    The other need (see the module docstring): the caller is about to start a
+    REAL server — uvicorn, ``http.server``, a subprocess — on this port, so
+    the port must actually be free when that server binds. This cannot be
+    ``dead_port``; releasing is the point.
+
+    It is still an improvement on bind-then-close-then-return-an-int, because
+    the port stays held for the whole setup in between (writing a spec file,
+    building a config, spawning a process) instead of being released at the
+    top. Yield gives you the SOCKET; call ``.close()`` on it at the last
+    moment, immediately before the real bind::
+
+        with reserved_port() as sock:
+            port = sock.getsockname()[1]
+            config = build_config(port=port)   # port still held here
+            sock.close()                       # release
+            serve(config)                      # ... and immediately re-bind
+
+    Be honest about what remains: between that ``close()`` and the server's
+    ``bind()`` the port IS free, and no helper can shrink that to zero without
+    passing the file descriptor to the server (which most of these APIs do not
+    accept). If a server DOES accept an fd, pass it this socket instead and
+    the race disappears entirely.
+    """
+    sock = bind_without_listen(host)
+    try:
+        yield sock
+    finally:
+        with contextlib.suppress(OSError):
+            sock.close()
+
+
+@pytest.fixture()
+def dead_port() -> Iterator[DeadPortAllocator]:
+    """Call it for a port that REFUSES connections and cannot be stolen.
+
+    ``dead_port()`` -> int, ``dead_port.url("/v1/health")`` -> str. Every port
+    handed out stays bound (and therefore refusing, and therefore un-stealable)
+    until this test finishes.
+    """
+    allocator = DeadPortAllocator()
+    try:
+        yield allocator
+    finally:
+        allocator.close()

--- a/tests/scitex_agent_container/_helpers/ports.py
+++ b/tests/scitex_agent_container/_helpers/ports.py
@@ -42,7 +42,10 @@ timing:
 * **It holds the port.** While the socket lives nothing else can bind that
   port, and the kernel will not hand it out to another ``bind(port 0)``.
 
-Measured on this platform (see ``test_ports_helper.py``, which asserts every
+Measured on this platform (see ``tests/develop/test_dead_port_helper.py``,
+which lives outside the mirror tree because PS-204 reserves ``tests/<pkg>/``
+for tests that mirror a ``src/`` module and this one has no src counterpart
+by design, and which asserts every
 one of these rather than trusting the paragraph above): connect ->
 ``ECONNREFUSED`` (errno 111); curl -> exit 7; a second ``bind()`` -> errno 98
 ``EADDRINUSE``, and still ``EADDRINUSE`` when the newcomer sets
@@ -65,8 +68,9 @@ on. The un-close must therefore be at least as obviously intentional, or the
 next reader will "tidy up the leaked socket" and restore the flake. That is
 why the not-closing is stated at every level here: in this docstring, in a
 comment at the ``bind()`` itself, and — the part that actually bites — in
-``test_ports.py::test_helper_socket_is_still_open_after_handing_out_port``,
-which fails if someone adds the close back.
+``tests/develop/test_dead_port_helper.py::
+test_helper_socket_is_still_open_after_handing_out_port``, which fails if
+someone adds the close back.
 
 **Promoting this to scitex-dev.** The same defect exists at
 ``scitex-dev tests/scitex_dev/_cli/gui/test__lifecycle.py::free_port``, whose
@@ -133,7 +137,7 @@ def bind_without_listen(host: str = _LOOPBACK) -> socket.socket:
     #   * open                     ->  the port cannot be stolen (what fixes the flake)
     # Closing here restores the 2026-08-12 py3.11 flake exactly. Ownership
     # passes to the caller; hold_dead_port / the dead_port fixture close it at
-    # teardown. Pinned by test_ports.py::
+    # teardown. Pinned by tests/develop/test_dead_port_helper.py::
     #   test_helper_socket_is_still_open_after_handing_out_port
     return sock
 

--- a/tests/scitex_agent_container/_helpers/test_ports.py
+++ b/tests/scitex_agent_container/_helpers/test_ports.py
@@ -1,0 +1,385 @@
+"""The dead-port helper must be FALSIFIABLE, so every claim it makes is a test.
+
+A test-support module that nothing tests is an assertion, not a guarantee —
+and the bug this one fixes (CI 2026-08-12, develop ``d21cb5f6``, py3.11 leg
+only) is precisely a helper that *claimed* "nothing is listening on this port"
+and delivered "nothing was listening on this port a moment ago". A test which
+would ALSO pass against the broken bind-then-close helper proves nothing, so
+each property below is paired with the old idiom failing it.
+
+Two claims, both measured here rather than asserted in prose:
+
+* a port from ``dead_port`` REFUSES connections (``ECONNREFUSED``, and curl
+  exits 7 — the real client the shipped watchdog probe uses);
+* that port is HELD — nothing can bind it, not with ``SO_REUSEADDR``, not
+  with ``SO_REUSEPORT``, not via the wildcard address, and not by asking the
+  kernel for an ephemeral port.
+
+Plus the anti-regression one that matters most in practice: the helper's
+socket is still OPEN after it hands out the port. The defect is durable
+because ``close()`` looks intentional; this is what fails when a future
+reader "tidies up the leaked socket" and restores the flake.
+
+NO MOCKS — real sockets, real binds, a real curl.
+
+AAA markers (TQ002); 3+-word test names.
+"""
+
+from __future__ import annotations
+
+import errno
+import shutil
+import socket
+import subprocess
+
+import pytest
+
+from tests.scitex_agent_container._helpers.ports import (
+    DeadPortAllocator,
+    bind_without_listen,
+    hold_dead_port,
+    reserved_port,
+)
+
+
+def _old_broken_closed_port() -> int:
+    """The idiom being replaced, verbatim, so the new tests are falsifiable.
+
+    Kept HERE (never exported) purely as the negative control: several tests
+    below assert that this shape fails the property the new helper passes. If
+    a test cannot tell the two apart, it is not testing anything.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+def _connect_error(port: int, timeout: float = 2.0) -> OSError | None:
+    """Really connect. Return the OSError, or None if the connection SUCCEEDED."""
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.settimeout(timeout)
+    try:
+        client.connect(("127.0.0.1", port))
+        return None
+    except OSError as exc:
+        return exc
+    finally:
+        client.close()
+
+
+def _bind_error(port: int, *, opts: tuple = (), host: str = "127.0.0.1") -> OSError | None:
+    """Really try to bind `port`. Return the OSError, or None if the bind WON."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        for opt in opts:
+            sock.setsockopt(socket.SOL_SOCKET, opt, 1)
+        sock.bind((host, port))
+        return None
+    except OSError as exc:
+        return exc
+    finally:
+        sock.close()
+
+
+# ==========================================================================
+# CLAIM 1 — a dead port REFUSES connections
+# ==========================================================================
+
+
+def test_dead_port_refuses_connections():
+    # Arrange
+    with hold_dead_port() as port:
+        # Act
+        err = _connect_error(port)
+    # Assert — a bound-but-never-listen()ed socket has no accept queue, so the
+    # kernel answers the SYN with RST. That IS "nothing is listening here".
+    assert err is not None and err.errno == errno.ECONNREFUSED
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="needs a real curl")
+def test_dead_port_refuses_real_curl():
+    # Arrange — curl is the client the SHIPPED watchdog probe actually uses,
+    # so its verdict is the one that decides the test this fix unbreaks.
+    with hold_dead_port() as port:
+        cmd = ["curl", "-sS", "-m", "5", f"http://127.0.0.1:{port}/v1/health"]
+        # Act
+        result = subprocess.run(cmd, capture_output=True, text=True)
+    # Assert — curl(7) is "Failed to connect", i.e. connection refused.
+    assert result.returncode == 7, result.stderr
+
+
+# ==========================================================================
+# CLAIM 2 — a dead port is HELD, and the old idiom's is not
+# ==========================================================================
+
+
+def test_dead_port_cannot_be_rebound():
+    # Arrange
+    with hold_dead_port() as port:
+        # Act
+        err = _bind_error(port)
+    # Assert
+    assert err is not None and err.errno == errno.EADDRINUSE
+
+
+def test_released_port_can_be_rebound():
+    # Arrange — the negative control: THE BUG. If this ever starts failing,
+    # the tests above have stopped discriminating and must be re-examined.
+    port = _old_broken_closed_port()
+    # Act
+    err = _bind_error(port)
+    # Assert — the "dead" port is free for anyone to take, which is exactly
+    # how a URL the test believed was dead ends up ANSWERING.
+    assert err is None
+
+
+def test_reuseaddr_cannot_steal_dead_port():
+    # Arrange — http.server and uvicorn both set SO_REUSEADDR, so a competing
+    # server in the same suite is the realistic thief.
+    with hold_dead_port() as port:
+        # Act
+        err = _bind_error(port, opts=(socket.SO_REUSEADDR,))
+    # Assert — SO_REUSEADDR only helps against TIME_WAIT, not a live bind.
+    assert err is not None and err.errno == errno.EADDRINUSE
+
+
+def test_reuseport_cannot_steal_dead_port():
+    # Arrange — SO_REUSEPORT shares a port only when EVERY binder sets it.
+    # The holder deliberately sets no options, so it can never be shared.
+    with hold_dead_port() as port:
+        # Act
+        err = _bind_error(port, opts=(socket.SO_REUSEPORT,))
+    # Assert
+    assert err is not None and err.errno == errno.EADDRINUSE
+
+
+def test_wildcard_bind_cannot_steal_dead_port():
+    # Arrange — a server told to listen on 0.0.0.0 must not be able to take a
+    # port held on 127.0.0.1 out from under the test.
+    with hold_dead_port() as port:
+        # Act
+        err = _bind_error(port, opts=(socket.SO_REUSEADDR,), host="0.0.0.0")
+    # Assert
+    assert err is not None and err.errno == errno.EADDRINUSE
+
+
+def test_ephemeral_allocation_skips_held_port():
+    # Arrange — the xdist-worker case: another test asks the kernel for "any
+    # free port". It must never be handed one we are holding.
+    with hold_dead_port() as held:
+        others = []
+        try:
+            # Act — enough draws that a colliding allocator would show up.
+            for _ in range(50):
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.bind(("127.0.0.1", 0))
+                others.append(sock)
+            drawn = [s.getsockname()[1] for s in others]
+        finally:
+            for sock in others:
+                sock.close()
+    # Assert
+    assert held not in drawn
+
+
+# ==========================================================================
+# THE ANTI-REGRESSION — the close must stay gone
+# ==========================================================================
+
+
+@pytest.fixture()
+def raw_holder():
+    """The socket ``bind_without_listen`` returns, closed after the test."""
+    sock = bind_without_listen()
+    try:
+        yield sock
+    finally:
+        sock.close()
+
+
+def test_helper_socket_is_still_open_after_handing_out_port(raw_holder):
+    # Arrange — THIS is the test that fires when someone "fixes the leaked
+    # socket". Returning it OPEN is the fix, not an oversight.
+    # Act — fileno() is -1 on a closed socket; a live one answers its port.
+    still_open = raw_holder.fileno() != -1
+    # Assert
+    assert still_open
+
+
+def test_open_helper_socket_still_owns_its_port(raw_holder):
+    # Arrange
+    port = raw_holder.getsockname()[1]
+    # Act
+    err = _bind_error(port)
+    # Assert — being open is only useful because it keeps the port.
+    assert err is not None and err.errno == errno.EADDRINUSE
+
+
+def test_bound_helper_socket_is_not_listening(raw_holder):
+    # Arrange — if anyone adds listen(), the port stops refusing and every
+    # "dead endpoint" test silently starts probing a live socket.
+    # Act
+    err = _connect_error(raw_holder.getsockname()[1])
+    # Assert
+    assert err is not None and err.errno == errno.ECONNREFUSED
+
+
+# ==========================================================================
+# THE ALLOCATOR / FIXTURE — many ports, all held, all released at teardown
+# ==========================================================================
+
+
+@pytest.fixture()
+def allocator():
+    """A ``DeadPortAllocator``, released after the test."""
+    alloc = DeadPortAllocator()
+    try:
+        yield alloc
+    finally:
+        alloc.close()
+
+
+def test_allocator_hands_out_distinct_ports(allocator):
+    # Arrange — one test can need several dead ports at once.
+    # Act
+    ports = [allocator() for _ in range(5)]
+    # Assert
+    assert len(set(ports)) == 5
+
+
+def test_allocator_holds_every_port_it_hands_out(allocator):
+    # Arrange — holding only the LAST one would leave the earlier ports
+    # stealable, which is the original bug with extra steps.
+    ports = [allocator() for _ in range(5)]
+    # Act
+    errs = [_bind_error(p) for p in ports]
+    # Assert
+    assert all(e is not None and e.errno == errno.EADDRINUSE for e in errs)
+
+
+def test_allocator_releases_ports_on_close():
+    # Arrange — held for the test, not for the session: a helper that never
+    # released would leak an fd per call across a 10k-test suite.
+    allocator = DeadPortAllocator()
+    ports = [allocator() for _ in range(3)]
+    # Act
+    allocator.close()
+    # Assert
+    assert all(_bind_error(p) is None for p in ports)
+
+
+def test_allocator_close_is_idempotent():
+    # Arrange
+    allocator = DeadPortAllocator()
+    allocator()
+    # Act
+    allocator.close()
+    allocator.close()
+    # Assert — a fixture teardown after an explicit close must not explode.
+    assert allocator._held == []
+
+
+def _port_of(url: str) -> int:
+    return int(url.rsplit(":", 1)[1].split("/")[0])
+
+
+def test_allocator_url_has_loopback_host_and_path(allocator):
+    # Arrange
+    # Act
+    url = allocator.url("/v1/health")
+    # Assert
+    assert url.startswith("http://127.0.0.1:") and url.endswith("/v1/health")
+
+
+def test_allocator_url_port_refuses_connections(allocator):
+    # Arrange — the convenience form must be as dead as the raw one.
+    url = allocator.url("/v1/health")
+    # Act
+    err = _connect_error(_port_of(url))
+    # Assert
+    assert err is not None and err.errno == errno.ECONNREFUSED
+
+
+def test_allocator_url_port_is_held(allocator):
+    # Arrange
+    url = allocator.url("/v1/health")
+    # Act
+    err = _bind_error(_port_of(url))
+    # Assert
+    assert err is not None and err.errno == errno.EADDRINUSE
+
+
+def test_dead_port_fixture_refuses_connections(dead_port):
+    # Arrange — the suite-wide fixture, wired in tests/conftest.py.
+    port = dead_port()
+    # Act
+    err = _connect_error(port)
+    # Assert
+    assert err is not None and err.errno == errno.ECONNREFUSED
+
+
+def test_dead_port_fixture_holds_the_port(dead_port):
+    # Arrange
+    port = dead_port()
+    # Act
+    err = _bind_error(port)
+    # Assert
+    assert err is not None and err.errno == errno.EADDRINUSE
+
+
+def test_dead_port_fixture_hands_out_distinct_ports(dead_port):
+    # Arrange
+    # Act
+    ports = [dead_port() for _ in range(4)]
+    # Assert
+    assert len(set(ports)) == 4
+
+
+def test_dead_port_fixture_holds_every_port(dead_port):
+    # Arrange — not just the newest one.
+    ports = [dead_port() for _ in range(4)]
+    # Act
+    errs = [_bind_error(p) for p in ports]
+    # Assert
+    assert all(e is not None and e.errno == errno.EADDRINUSE for e in errs)
+
+
+# ==========================================================================
+# THE OTHER NEED — a port you are about to bind YOURSELF
+# ==========================================================================
+
+
+def test_reserved_port_is_held_inside_the_block():
+    # Arrange — the whole value of reserved_port over bind-then-close is that
+    # the port survives the setup work in between.
+    with reserved_port() as sock:
+        port = sock.getsockname()[1]
+        # Act
+        err = _bind_error(port)
+        # Assert
+        assert err is not None and err.errno == errno.EADDRINUSE
+
+
+def test_reserved_port_is_bindable_after_release():
+    # Arrange — and it must genuinely hand the port over, or the real server
+    # it was reserved for could never start.
+    with reserved_port() as sock:
+        port = sock.getsockname()[1]
+        # Act
+        sock.close()
+        err = _bind_error(port)
+    # Assert
+    assert err is None
+
+
+def test_reserved_port_close_inside_block_is_safe():
+    # Arrange — the documented usage closes early; teardown must tolerate it.
+    with reserved_port() as sock:
+        port = sock.getsockname()[1]
+        sock.close()
+    # Act
+    err = _bind_error(port)
+    # Assert — no double-close explosion on the way out of the block.
+    assert err is None

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
@@ -683,17 +683,13 @@ def test_real_loopback_401_carries_status_401(listen_env) -> None:
     assert status == 401
 
 
-def test_real_connection_failure_surfaces_unreachable(listen_env) -> None:
-    # Arrange — bind a loopback socket, grab its port, then close it so
-    # the port is (almost certainly) refused: a GENUINE transport failure,
-    # which MUST read as 'cannot reach' (unlike the 401 above).
-    import socket
-
-    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    probe.bind(("127.0.0.1", 0))
-    _h, dead_port = probe.getsockname()
-    probe.close()
-    listen_env("LISTEN_BASE_URL", f"http://127.0.0.1:{dead_port}")
+def test_real_connection_failure_surfaces_unreachable(listen_env, dead_port) -> None:
+    # Arrange — a loopback port bound but never listened on, and HELD for the
+    # test: the connect is refused, which is a GENUINE transport failure and
+    # MUST read as 'cannot reach' (unlike the 401 above). "Almost certainly
+    # refused" was the old shape — the port was released before this ran, so
+    # anything binding it turned this into a live endpoint.
+    listen_env("LISTEN_BASE_URL", dead_port.url(""))
     message = ""
     # Act — default opener; the connection is refused.
     try:

--- a/tests/scitex_agent_container/_lifecycle/test_health.py
+++ b/tests/scitex_agent_container/_lifecycle/test_health.py
@@ -355,9 +355,12 @@ def test_check_a2a_card_http_error_includes_status_code(
     assert "HTTP 503" in msg
 
 
-def test_check_a2a_card_url_error_when_port_closed(tmp_path: Path) -> None:
-    # Arrange: YAML points at a guaranteed-closed port.
-    closed_port = _free_port()
+def test_check_a2a_card_url_error_when_port_closed(tmp_path: Path, dead_port) -> None:
+    # Arrange: YAML points at a port bound but never listened on, and HELD —
+    # so it is guaranteed closed for the whole test, not merely closed at the
+    # moment we looked. (`_free_port` above is the OTHER need: a port a real
+    # server is about to bind. It must not be used for a must-stay-dead port.)
+    closed_port = dead_port()
     cfg = _make_cfg(name="ag1", method="a2a-card")
     cfg.config_path = str(_write_a2a_yaml(tmp_path, port=closed_port))
     # Act
@@ -648,19 +651,20 @@ def _no_delay(_seconds: float) -> None:
     return None
 
 
-def test_sdk_alive_fails_a_live_tui_agent_whose_turn_bridge_is_dead() -> None:
+def test_sdk_alive_fails_a_live_tui_agent_whose_turn_bridge_is_dead(dead_port) -> None:
     # Arrange — the measured fault: tmux session alive, nothing bound to the
-    # a2a port. This is the case that used to report healthy.
-    cfg = _bridge_cfg(port=_free_port())
+    # a2a port. This is the case that used to report healthy. The port is HELD
+    # unbound, so no other test can bind it and make the bridge look alive.
+    cfg = _bridge_cfg(port=dead_port())
     # Act
     healthy, _message = health_mod.health_check(cfg, runtime=FakeRuntime(running=True))
     # Assert
     assert healthy is False
 
 
-def test_dead_turn_bridge_message_names_the_unserved_url() -> None:
+def test_dead_turn_bridge_message_names_the_unserved_url(dead_port) -> None:
     # Arrange
-    port = _free_port()
+    port = dead_port()
     cfg = _bridge_cfg(port=port)
     # Act
     _healthy, message = health_mod.health_check(cfg, runtime=FakeRuntime(running=True))
@@ -694,10 +698,10 @@ def test_healthy_message_reports_the_turn_bridge_alongside_the_runtime() -> None
     assert "turn bridge healthy" in message
 
 
-def test_a_dead_runtime_dominates_the_bridge_verdict() -> None:
+def test_a_dead_runtime_dominates_the_bridge_verdict(dead_port) -> None:
     # Arrange — a stopped agent must be reported as a stopped RUNTIME, not as
     # a missing bridge (naming the symptom would send the reader hunting).
-    cfg = _bridge_cfg(port=_free_port())
+    cfg = _bridge_cfg(port=dead_port())
     # Act
     _healthy, message = health_mod.health_check(cfg, runtime=FakeRuntime(running=False))
     # Assert
@@ -733,9 +737,9 @@ def test_turn_bridge_method_probes_the_bridge_directly() -> None:
     assert healthy is True
 
 
-def test_turn_bridge_method_fails_when_nothing_is_bound() -> None:
+def test_turn_bridge_method_fails_when_nothing_is_bound(dead_port) -> None:
     # Arrange
-    cfg = _bridge_cfg(port=_free_port(), method="turn-bridge")
+    cfg = _bridge_cfg(port=dead_port(), method="turn-bridge")
     # Act
     healthy, _message = health_mod.health_check(cfg)
     # Assert
@@ -780,18 +784,19 @@ def test_a_bridge_that_binds_during_the_backoff_is_reported_healthy() -> None:
     assert healthy is True
 
 
-def test_a_persistently_dead_bridge_is_failed_after_every_attempt() -> None:
-    # Arrange
-    cfg = _bridge_cfg(port=_free_port())
+def test_a_persistently_dead_bridge_is_failed_after_every_attempt(dead_port) -> None:
+    # Arrange — PERSISTENTLY dead: the port is held unbound across all three
+    # probes, so "still dead on attempt 3" is a property, not a coincidence.
+    cfg = _bridge_cfg(port=dead_port())
     # Act
     healthy, _message = health_mod._check_turn_bridge(cfg, sleep_fn=_no_delay)
     # Assert
     assert healthy is False
 
 
-def test_a_failed_verdict_states_how_many_probes_confirmed_it() -> None:
+def test_a_failed_verdict_states_how_many_probes_confirmed_it(dead_port) -> None:
     # Arrange
-    cfg = _bridge_cfg(port=_free_port())
+    cfg = _bridge_cfg(port=dead_port())
     # Act
     _healthy, message = health_mod._check_turn_bridge(
         cfg, attempts=3, sleep_fn=_no_delay

--- a/tests/scitex_agent_container/_mcp/test__channel_send_errors.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_send_errors.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import socket
 from typing import Any
 
 import pytest
@@ -145,12 +144,10 @@ def _body(result) -> dict[str, Any]:
     return json.loads(result.content[0].text)
 
 
-def _refused_port() -> int:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    port = int(s.getsockname()[1])
-    s.close()
-    return port
+# A refusing port comes from the shared ``dead_port`` fixture
+# (tests/scitex_agent_container/_helpers/ports.py, wired in tests/conftest.py):
+# bound WITHOUT listening so a connect is refused, and HELD so nothing else can
+# bind it mid-test. The helper that used to live here released the port first.
 
 
 # ---------------------------------------------------------------------------
@@ -202,11 +199,12 @@ async def test_absent_subscriber_count_is_not_an_mcp_error(listen):
 
 
 @pytest.mark.asyncio
-async def test_unreachable_listen_is_an_mcp_error():
+async def test_unreachable_listen_is_an_mcp_error(dead_port):
     """Connection refused is a demonstrable non-delivery — also a caller-
     visible failure, not a quietly-swallowed one."""
-    # Arrange — nothing is listening on this port.
-    url = f"http://127.0.0.1:{_refused_port()}"
+    # Arrange — nothing is listening on this port, and it is HELD so nothing
+    # can start.
+    url = dead_port.url("")
     # Act
     result = await _call(url, "a2a_send", {"target": "bob", "content": "hi"})
     # Assert
@@ -312,9 +310,9 @@ async def test_no_subscriber_error_does_not_prescribe_a_restart(listen):
 
 
 @pytest.mark.asyncio
-async def test_unreachable_error_carries_machine_readable_code():
+async def test_unreachable_error_carries_machine_readable_code(dead_port):
     # Arrange
-    url = f"http://127.0.0.1:{_refused_port()}"
+    url = dead_port.url("")
     # Act
     result = await _call(url, "a2a_send", {"target": "bob", "content": "hi"})
     # Assert

--- a/tests/scitex_agent_container/_mcp/test__channel_tools.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_tools.py
@@ -794,21 +794,17 @@ async def test_a2a_send_delivery_error_status_returns_loud_error(
 
 
 @pytest.mark.asyncio
-async def test_a2a_send_agent_stopped_connection_refused_returns_loud_error():
+async def test_a2a_send_agent_stopped_connection_refused_returns_loud_error(dead_port):
     """Target agent down / listen unreachable (refused connection) → loud
     'agent unreachable' error rather than a hang or silent success."""
-    # Arrange — register tools pointing at a closed loopback port.
-    import socket
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    refused_port = s.getsockname()[1]
-    s.close()
+    # Arrange — register tools pointing at a HELD, never-listened loopback
+    # port. Held, so nothing can bind it and turn "unreachable" into a
+    # success while the test is running.
     rec = _ToolRecorder()
     register_tools(
         rec,
         agent_name="alice",
-        listen_url=f"http://127.0.0.1:{refused_port}",
+        listen_url=dead_port.url(""),
         bearer=None,
     )
     # Act

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -740,17 +740,12 @@ async def test_consume_sse_skips_malformed_json_frames(
 
 
 @pytest.mark.asyncio
-async def test_consume_sse_retries_after_connection_error():
-    """Bind a loopback socket then immediately close to force refused
-    connection. The consumer must log + retry rather than crash."""
-    # Arrange — find a closed port by binding and closing.
-    import socket
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    refused_port = s.getsockname()[1]
-    s.close()
-    url = f"http://127.0.0.1:{refused_port}/agents/x/inbox/stream"
+async def test_consume_sse_retries_after_connection_error(dead_port):
+    """A port bound but never listened on forces a refused connection. The
+    consumer must log + retry rather than crash."""
+    # Arrange — the port is HELD for the whole test, so nothing can move in
+    # behind us and turn this "refused" endpoint into a live one.
+    url = dead_port.url("/agents/x/inbox/stream")
     received: list[dict[str, Any]] = []
 
     async def on_event(ev: dict[str, Any]) -> None:
@@ -1221,19 +1216,13 @@ async def test_push_channel_event_skips_auto_ack_without_send_config(fake_listen
 
 
 @pytest.mark.asyncio
-async def test_auto_ack_failure_is_best_effort_does_not_raise():
+async def test_auto_ack_failure_is_best_effort_does_not_raise(dead_port):
     """A failed auto-ack POST must be swallowed-with-a-loud-log, never
     re-raised: it can neither block injection nor kill the SSE consumer.
     Point the adapter at a refused port to force the failure."""
-    # Arrange — a closed loopback port (bind then close) refuses connect.
-    import socket
-
+    # Arrange — a HELD, never-listened loopback port refuses connect.
     from scitex_agent_container._mcp.channel import _push_channel_event
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    refused_port = s.getsockname()[1]
-    s.close()
     session = _CapturingSession()
     event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
     # Act — must complete without raising despite the ack POST failing.
@@ -1241,7 +1230,7 @@ async def test_auto_ack_failure_is_best_effort_does_not_raise():
         session,
         event,
         agent_name="alice",
-        listen_url=f"http://127.0.0.1:{refused_port}",
+        listen_url=dead_port.url(""),
         bearer=None,
     )
     # Assert — injection still succeeded (the failure was contained).
@@ -1527,19 +1516,16 @@ async def test_push_without_turn_url_falls_back_to_notification(fake_listen):
 
 
 @pytest.mark.asyncio
-async def test_wake_failure_propagates_to_caller():
+async def test_wake_failure_propagates_to_caller(dead_port):
     """WI-2 fail-loud: when the wake POST cannot reach the runner (refused
     connection), ``_push_channel_event`` must RAISE rather than silently
     pretend the message was delivered."""
-    # Arrange — a closed loopback port refuses connect.
-    import socket
-
+    # Arrange — a HELD, never-listened loopback port refuses connect. Holding
+    # it matters here: if anything bound the port the wake would SUCCEED and
+    # this fail-loud test would assert the opposite of what it means to.
     from scitex_agent_container._mcp.channel import _push_channel_event
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    refused_port = s.getsockname()[1]
-    s.close()
+    refused_port = dead_port()
     session = _CapturingSession()
     event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
 

--- a/tests/scitex_agent_container/cli_pkg/test__send.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send.py
@@ -618,17 +618,12 @@ def test_agent_send_diagnosis_dead_pid_reports_pid_not_alive(
 
 
 def test_agent_send_diagnosis_port_unreachable_when_nothing_listening(
-    state_db_env, fresh_lead_creds_path
+    state_db_env, fresh_lead_creds_path, dead_port
 ):
-    # Arrange — a2a_port that no process is listening on. We grab a free
-    # port from the OS and immediately release it so the connect refuses.
-    import socket as _socket
-
-    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    free_port = s.getsockname()[1]
-    s.close()
-    _seed_local("alpha", a2a_port=free_port)
+    # Arrange — an a2a_port no process is listening on. The port is bound
+    # WITHOUT listening (so the connect refuses) and HELD for the test (so
+    # nothing else can bind it and make the port reachable after all).
+    _seed_local("alpha", a2a_port=dead_port())
     from scitex_agent_container._network.peer import PeerError
 
     def fake_post(url, text, *, timeout_s):
@@ -777,16 +772,11 @@ def test_agent_send_nonblocking_reports_delivered_subscriber_count(
 
 
 def test_agent_send_nonblocking_fails_loud_when_port_unreachable(
-    state_db_env, fresh_lead_creds_path
+    state_db_env, fresh_lead_creds_path, dead_port
 ):
-    # Arrange — grab then release a port so nothing is listening on it.
-    import socket as _socket
-
-    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    dead_port = s.getsockname()[1]
-    s.close()
-    _seed_local("alpha", a2a_port=dead_port)
+    # Arrange — a port bound but never listened on, and HELD, so nothing is
+    # listening on it and nothing can start.
+    _seed_local("alpha", a2a_port=dead_port())
     # Act
     with _exploding_post_turn():
         result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
@@ -795,16 +785,10 @@ def test_agent_send_nonblocking_fails_loud_when_port_unreachable(
 
 
 def test_agent_send_nonblocking_port_unreachable_error_carries_diagnosis(
-    state_db_env, fresh_lead_creds_path
+    state_db_env, fresh_lead_creds_path, dead_port
 ):
     # Arrange
-    import socket as _socket
-
-    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    dead_port = s.getsockname()[1]
-    s.close()
-    _seed_local("alpha", a2a_port=dead_port)
+    _seed_local("alpha", a2a_port=dead_port())
     # Act
     with _exploding_post_turn():
         result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
@@ -899,14 +883,9 @@ def test_agent_send_allocator_claim_diagnosis_reports_running(
     # listening on, so the dispatch fails its reachability gate and we
     # can inspect the attached diagnosis. The agent is RUNNING (the claim
     # proves it), so the diagnosis must NOT repeat the split-brain lie of
-    # "stopped".
-    import socket as _socket
-
-    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    dead_port = s.getsockname()[1]
-    s.close()
-    _seed_port_claim("beta", dead_port)
+    # "stopped". The port is bound-but-never-listened and HELD, so the
+    # reachability gate cannot be flipped by anything else binding it.
+    _seed_port_claim("beta", dead_port())
     # Act
     with _exploding_post_turn():
         result = send_to_agent("beta", "hi", lead_creds_path=fresh_lead_creds_path)

--- a/tests/scitex_agent_container/cli_pkg/test__send.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send.py
@@ -877,7 +877,7 @@ def test_agent_send_allocator_claim_url_uses_claimed_port_blocking(
 
 
 def test_agent_send_allocator_claim_diagnosis_reports_running(
-    state_db_env, fresh_lead_creds_path
+    state_db_env, fresh_lead_creds_path, dead_port
 ):
     # Arrange — only an allocator claim (no row) on a port nothing is
     # listening on, so the dispatch fails its reachability gate and we

--- a/tests/scitex_agent_container/cli_pkg/test__send_broker.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send_broker.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 
 import http.server
 import json
-import socket
 import socketserver
 import threading
 import time

--- a/tests/scitex_agent_container/cli_pkg/test__send_broker.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send_broker.py
@@ -60,13 +60,11 @@ from scitex_agent_container.cli_pkg._send_broker import (
 _LOCAL_HOST = "test-host"
 
 
-def _closed_port() -> int:
-    """Return a port number that nothing is listening on."""
-    sock = socket.socket()
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-    sock.close()
-    return port
+# "A port nothing is listening on" comes from the shared ``dead_port`` fixture
+# (tests/scitex_agent_container/_helpers/ports.py, wired in tests/conftest.py):
+# bound WITHOUT listening, so a connect is refused, and HELD, so no other test
+# or xdist worker can bind it mid-test. The helper that used to live here
+# released the port before the probe ran — see that module for the flake.
 
 
 def _status_body(**over) -> bytes:
@@ -261,12 +259,12 @@ def test_startup_failed_is_carried_as_a_hint_only(fake_host_listen):
 
 
 def test_unreachable_broker_raises_rather_than_reporting_stopped(
-    env_save_restore, tmp_path
+    env_save_restore, tmp_path, dead_port
 ):
     # Arrange — in a SIF, but the host listen is down.
     env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
     env_save_restore.set(
-        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+        "SAC_LISTEN_BASE_URL", dead_port.url("")
     )
     env_save_restore.set(
         "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
@@ -384,13 +382,13 @@ def test_dispatch_targets_the_port_the_host_reported(
 
 
 def test_unreachable_broker_never_reports_the_peer_stopped(
-    env_save_restore, tmp_path, fresh_lead_creds_path
+    env_save_restore, tmp_path, fresh_lead_creds_path, dead_port
 ):
     # Arrange — in a SIF; the host listen is down, so we cannot check.
     env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
     env_save_restore.set("SAC_HOST", _LOCAL_HOST)
     env_save_restore.set(
-        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+        "SAC_LISTEN_BASE_URL", dead_port.url("")
     )
     env_save_restore.set(
         "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
@@ -405,13 +403,13 @@ def test_unreachable_broker_never_reports_the_peer_stopped(
 
 
 def test_unreachable_broker_names_the_broker_as_the_failure(
-    env_save_restore, tmp_path, fresh_lead_creds_path
+    env_save_restore, tmp_path, fresh_lead_creds_path, dead_port
 ):
     # Arrange
     env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
     env_save_restore.set("SAC_HOST", _LOCAL_HOST)
     env_save_restore.set(
-        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+        "SAC_LISTEN_BASE_URL", dead_port.url("")
     )
     env_save_restore.set(
         "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
@@ -425,7 +423,7 @@ def test_unreachable_broker_names_the_broker_as_the_failure(
 
 
 def test_unbound_turn_port_still_reports_the_agent_running(
-    fake_host_listen, fresh_lead_creds_path
+    fake_host_listen, fresh_lead_creds_path, dead_port
 ):
     # Arrange — the live-fleet norm: the host holds a port claim but nothing
     # listens on it (41 of 47 agents, measured 2026-07-14). Those agents are
@@ -433,7 +431,7 @@ def test_unbound_turn_port_still_reports_the_agent_running(
     fake_host_listen.enqueue(
         200,
         _status_body(
-            a2a_port=_closed_port(),
+            a2a_port=dead_port(),
             turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
         ),
     )
@@ -446,13 +444,13 @@ def test_unbound_turn_port_still_reports_the_agent_running(
 
 
 def test_unbound_turn_port_does_not_fabricate_a_dead_pid(
-    fake_host_listen, fresh_lead_creds_path
+    fake_host_listen, fresh_lead_creds_path, dead_port
 ):
     # Arrange
     fake_host_listen.enqueue(
         200,
         _status_body(
-            a2a_port=_closed_port(),
+            a2a_port=dead_port(),
             turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
         ),
     )
@@ -466,13 +464,13 @@ def test_unbound_turn_port_does_not_fabricate_a_dead_pid(
 
 
 def test_unbound_turn_port_does_not_fabricate_a_failed_boot(
-    fake_host_listen, fresh_lead_creds_path
+    fake_host_listen, fresh_lead_creds_path, dead_port
 ):
     # Arrange
     fake_host_listen.enqueue(
         200,
         _status_body(
-            a2a_port=_closed_port(),
+            a2a_port=dead_port(),
             turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
         ),
     )
@@ -485,13 +483,13 @@ def test_unbound_turn_port_does_not_fabricate_a_failed_boot(
 
 
 def test_unbound_turn_port_error_does_not_claim_the_agent_crashed(
-    fake_host_listen, fresh_lead_creds_path
+    fake_host_listen, fresh_lead_creds_path, dead_port
 ):
     # Arrange
     fake_host_listen.enqueue(
         200,
         _status_body(
-            a2a_port=_closed_port(),
+            a2a_port=dead_port(),
             turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
         ),
     )

--- a/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
@@ -263,9 +263,12 @@ def test_doctor_malformed_json_exits_one(tmp_path: Path, card_server: Any) -> No
     assert res.exit_code == 1
 
 
-def test_doctor_connection_refused_exits_one(tmp_path: Path) -> None:
-    # Arrange: a free port that nothing is listening on
-    closed_port = _free_port()
+def test_doctor_connection_refused_exits_one(tmp_path: Path, dead_port) -> None:
+    # Arrange: a port bound but never listened on, and HELD for the test, so
+    # the connect is refused and stays refused. (`_free_port` above is the
+    # OTHER need — a port a real card server is about to bind — and must not
+    # be used here: it releases the port before the CLI ever probes it.)
+    closed_port = dead_port()
     name = "ag-down"
     spec = _write_spec(tmp_path, name, port=closed_port)
     # Act: short timeout so the test stays fast

--- a/tests/scitex_agent_container/cli_pkg/test_ports_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_ports_cmds.py
@@ -61,21 +61,23 @@ def listening_port():
 
 
 @pytest.fixture
-def free_port():
-    """A port that was bound then released — almost certainly nothing
-    listens on it, so a probe reports it dead (orphan).
+def dead_claim_port(dead_port):
+    """A port with nothing listening on it, so a probe reports it dead (orphan).
 
-    The socket is acquired inside a ``with`` block, so the fd is closed
-    even if ``bind()`` raises, and the fixture ``yield``s (rather than
-    ``return``s) per STX-TQ005: a fixture that acquires an external
-    resource owns its teardown.
+    ``collect_ports_data``'s default probe is ``port_is_bound`` — a real
+    outbound TCP CONNECT — so a socket bound WITHOUT ``listen()`` answers the
+    SYN with RST and is correctly classified dead, exactly like the released
+    port this used to hand out.
+
+    Unlike that one, this port is HELD (see the shared ``dead_port`` fixture in
+    tests/scitex_agent_container/_helpers/ports.py). Releasing it put the
+    number back in the ephemeral pool before the probe ran, so any other test
+    or xdist worker could bind it and the "orphan" would report LIVE.
+
+    Renamed from ``free_port``: nothing here wants a port it can bind, and that
+    conflation is what the shared helper exists to keep apart.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        port = sock.getsockname()[1]
-    # Closed on block exit — the point of the fixture is a port number
-    # with nothing listening behind it.
-    yield port
+    return dead_port()
 
 
 @pytest.fixture
@@ -145,9 +147,9 @@ def test_collect_listen_row_carries_pidfile_path(db: Path, tmp_path: Path) -> No
 # ---------------------------------------------------------------------------
 
 
-def test_collect_lists_a2a_claim_owner(db: Path, free_port: int) -> None:
+def test_collect_lists_a2a_claim_owner(db: Path, dead_claim_port: int) -> None:
     # Arrange
-    pa.claim_port("alpha", explicit=free_port, db_path=db)
+    pa.claim_port("alpha", explicit=dead_claim_port, db_path=db)
     data = collect_ports_data(db_path=db, listen_port=7878)
     # Act
     owners = {row["owner"] for row in data["a2a_claims"]}
@@ -167,9 +169,9 @@ def test_collect_marks_live_listening_port_as_live(
     assert row["live"] is True
 
 
-def test_collect_marks_dead_claim_as_orphan(db: Path, free_port: int) -> None:
-    # Arrange — claim a released port; nothing listens on it.
-    pa.claim_port("gamma", explicit=free_port, db_path=db)
+def test_collect_marks_dead_claim_as_orphan(db: Path, dead_claim_port: int) -> None:
+    # Arrange — claim a HELD, never-listened port; nothing listens on it.
+    pa.claim_port("gamma", explicit=dead_claim_port, db_path=db)
     data = collect_ports_data(db_path=db, listen_port=7878, probe_timeout=0.2)
     # Act
     row = next(r for r in data["a2a_claims"] if r["owner"] == "gamma")
@@ -177,9 +179,11 @@ def test_collect_marks_dead_claim_as_orphan(db: Path, free_port: int) -> None:
     assert row["orphan"] is True
 
 
-def test_collect_lists_dead_claim_in_orphans_section(db: Path, free_port: int) -> None:
+def test_collect_lists_dead_claim_in_orphans_section(
+    db: Path, dead_claim_port: int
+) -> None:
     # Arrange
-    pa.claim_port("gamma", explicit=free_port, db_path=db)
+    pa.claim_port("gamma", explicit=dead_claim_port, db_path=db)
     data = collect_ports_data(db_path=db, listen_port=7878, probe_timeout=0.2)
     # Act
     orphan_agents = {o["agent"] for o in data["orphans"]}
@@ -193,20 +197,22 @@ def test_collect_lists_dead_claim_in_orphans_section(db: Path, free_port: int) -
 
 
 def test_collect_flags_conflict_when_agent_claims_listen_port(
-    db: Path, free_port: int
+    db: Path, dead_claim_port: int
 ) -> None:
     # Arrange — an agent claims the same port sac listen is told to use.
-    pa.claim_port("clash", explicit=free_port, db_path=db)
-    data = collect_ports_data(db_path=db, listen_port=free_port, probe_timeout=0.2)
+    pa.claim_port("clash", explicit=dead_claim_port, db_path=db)
+    data = collect_ports_data(
+        db_path=db, listen_port=dead_claim_port, probe_timeout=0.2
+    )
     # Act
     conflict_ports = {c["port"] for c in data["conflicts"]}
     # Assert
-    assert free_port in conflict_ports
+    assert dead_claim_port in conflict_ports
 
 
-def test_collect_no_conflict_for_disjoint_ports(db: Path, free_port: int) -> None:
+def test_collect_no_conflict_for_disjoint_ports(db: Path, dead_claim_port: int) -> None:
     # Arrange — claim differs from the listen port.
-    pa.claim_port("solo", explicit=free_port, db_path=db)
+    pa.claim_port("solo", explicit=dead_claim_port, db_path=db)
     data = collect_ports_data(db_path=db, listen_port=7878, probe_timeout=0.2)
     # Act
     conflicts = data["conflicts"]


### PR DESCRIPTION
## What reddened develop

All three matrix legs failed `tests/develop/test_audit.py::test_audit_all_clean`. The wrapper assertion names no rule; the rule is four screens into the captured stdout:

```
[E] [PS-108b §1 src-flat-py-files-over-threshold]
    src/scitex_agent_container: 16 flat .py files at `scitex_agent_container/` root (threshold: 15)
```

It counts every `.py` directly under the package root except `__init__` / `__main__`, and fails above 15.

## Why nobody broke it

`#1018` added `_claude_hooks_plugin.py`. `#1020` added `_store_plugin.py`. `#1021` added two modules under existing subpackages. **Each was clean on its own branch** — the sixteenth file crossed a cumulative threshold none of them crossed alone. Because PR jobs test the merge result, every open PR inherited the red the moment develop had it.

## The fix

Grouping, not a bigger number. Raising the threshold or declaring a skip would preserve exactly the shape the rule exists to catch — and we have been adding to that root all night.

`_workdir_audit.py` and `_walk_exclusions.py` are the one genuinely coupled pair in the root: `_walk_exclusions` exists to say what the audit's walk (and `_host_merge`'s, and the `to_home` deref-copy's) must not descend into. They become:

```
src/scitex_agent_container/_workdir/
  __init__.py            # thin — re-exports audit_workdir_claude, to_dict
  _audit.py              # was _workdir_audit.py
  _walk_exclusions.py    # was _walk_exclusions.py
```

Root goes **16 -> 14**. Tests move alongside to keep the PS-205 mirror: `tests/scitex_agent_container/_workdir/test__audit.py` and `test__walk_exclusions.py`.

**Nothing else moves, deliberately.** Every entry-point target (`_linter_plugin`, `_store_plugin`, `_claude_hooks_plugin`, `_system_deps`, `cli`, `statusline`) and the `python -m scitex_agent_container._hosted_runner_guard` workflow path stays put, so no installed dist-info and no workflow string can go stale against new code. This is the smallest grouping that clears the threshold; further tidying belongs in its own PR.

## A brittle anchor the move exposed

`test__audit.py` built its child process's `PYTHONPATH` as `Path(__file__).resolve().parents[2] / "src"` — correct only while the file sat directly in `tests/scitex_agent_container/`. One level deeper it pointed at `tests/`, the child imported nothing and printed nothing, and five tests died on `JSONDecodeError: Expecting value: line 1 column 1` naming neither the path nor the cause.

It now derives the path from `scitex_agent_container.__file__`. That states the actual requirement — the child must import the **same** package the parent did, which is what the comment there always claimed — and it cannot drift when a test file moves.

## Measured

| check | before | after |
| :--- | :--- | :--- |
| `scitex-dev ecosystem audit-all --path .` | 1 unmasked error, exit 1 | **0 unmasked errors, exit 0** |
| audit-project warnings / info | 97 / 1 | 97 / 1 (unchanged — the move added none) |
| moved tests + every importer's suite | — | **103 passed** |

Test scope for that 103: `tests/scitex_agent_container/_workdir/`, `cli_pkg/test_status_cmds_workdir_audit.py`, `runtimes/test__symlink_resolve.py`, `runtimes/test__host_merge.py`.

Import smoke against the moved tree confirms `_workdir`, `_workdir._audit`, `_workdir._walk_exclusions` and all five importing modules load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
