### PR TITLE
refactor(harness): this Protocol names a harness, not a provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,8 +125,8 @@ slurm = [
 ]
 openai = [
     # openai-compat-2: the `openai` agent-SDK family (spec.provider:
-    # openai). Backs `_runners/openai_session.py` (OpenAISession — the
-    # concrete ProviderSession over Runner.run_streamed + SQLiteSession)
+    # openai). Backs `_runners/openai_session.py` (OpenAIAgentsSession — the
+    # concrete HarnessSession over Runner.run_streamed + SQLiteSession)
     # and the `openai_session` A2A handler/executor. OPTIONAL on purpose:
     # Claude-only deployments must not pull it — every import is lazy and
     # the handler raises a clear HandlerError when absent. 0.17.4 floor

--- a/src/scitex_agent_container/_runners/_harness_session.py
+++ b/src/scitex_agent_container/_runners/_harness_session.py
@@ -1,7 +1,9 @@
-"""Provider-agnostic session Protocol + normalized event/message shapes.
+"""Harness-agnostic session Protocol + normalized event/message shapes.
 
 Foundation for the ``openai`` agent SDK family (scitex-todo card
-``openai-compat-1``, "Land ProviderConfig + ProviderSession Protocol").
+``openai-compat-1``, "Land ProviderConfig + ProviderSession Protocol" —
+that card title is quoted verbatim; the Protocol it landed is the one
+renamed to :class:`HarnessSession` here).
 This module defines the SHAPES a future ``openai-agents``-backed session
 (openai-compat-2) will produce and consume, so that both the existing
 ``claude-agent-sdk`` path and the future OpenAI path can eventually be
@@ -11,8 +13,8 @@ Landed foundation-only: nothing in the live runner (``_runners/
 claude_session.py`` → ``_session_conversation.py`` → ``_session_turn.py``)
 imports or calls anything in this module yet. It is pure, additive,
 unused-by-default code — behaviourally a no-op for existing Claude
-agents. openai-compat-2 will add a concrete ``OpenAISession`` class that
-satisfies :class:`ProviderSession`, wrapping ``openai-agents``'
+agents. openai-compat-2 will add a concrete ``OpenAIAgentsSession`` class that
+satisfies :class:`HarnessSession`, wrapping ``openai-agents``'
 ``Runner.run_streamed()``. A concrete Claude-side implementation MAY be
 added later as a retrofit of ``_drive_turn`` (see "Composition with
 RuntimeBase" below) — that retrofit is explicitly NOT part of this phase,
@@ -38,7 +40,7 @@ this mirrors that, needing no second method on the Protocol).
 
 Composition with RuntimeBase
 -----------------------------
-:class:`ProviderSession` is deliberately NOT a subtype of, or a
+:class:`HarnessSession` is deliberately NOT a subtype of, or a
 replacement for, :class:`runtimes.base.RuntimeBase`. They operate at
 different layers of the stack:
 
@@ -46,17 +48,25 @@ different layers of the stack:
   PROCESS lifecycle — ``start`` / ``stop`` / ``is_running`` / ``logs`` for
   one whole agent's container, driven from the HOST/CLI side
   (``sac agents start <name>``).
-* ``ProviderSession`` is CONVERSATION lifecycle — one provider SDK
+* ``HarnessSession`` is CONVERSATION lifecycle — one agent SDK
   connection's turn-taking, driven INSIDE the running container by the
   runner (today: ``_session_conversation.py`` opening one
   ``ClaudeSDKClient`` and calling ``_drive_turn`` per inbound message).
 
+The name is HARNESS, not PROVIDER, because the axis this Protocol
+selects on is WHICH AGENT PROGRAM RUNS THE LOOP — its implementations
+are ``ClaudeCodeSession`` / ``CodexSession`` / :class:`OpenAIAgentsSession`
+/ ``PiSession`` / ``OpenHandsSession``, which are agent programs, not
+inference providers. "Which model thinks" is a separate axis
+(``inference``); conflating the two is what the old ``ProviderSession``
+name did.
+
 They compose VERTICALLY, not by inheritance: a future runner selects a
-``ProviderSession`` implementation based on ``AgentConfig.provider``
+``HarnessSession`` implementation based on ``AgentConfig.provider``
 (``config._provider_types.AgentProvider`` — see the naming-collision
 note there against the unrelated ``ClaudeSpec.provider``) and drives it
 from inside the process that ``RuntimeBase.start()`` launched. Reusing
-``ProviderSession`` for both providers (rather than only using it as an
+``HarnessSession`` for both harnesses (rather than only using it as an
 OpenAI-side implementation detail) is what keeps ``openai-compat-2``
 from having to reinvent the turn-loop contract.
 """
@@ -71,7 +81,7 @@ __all__ = [
     "Message",
     "NormalizedEvent",
     "RunResult",
-    "ProviderSession",
+    "HarnessSession",
 ]
 
 # Chat-message role vocabulary — the intersection both SDKs accept
@@ -95,7 +105,7 @@ EventKind = Literal[
 
 @dataclass(frozen=True)
 class ToolSpec:
-    """A tool definition, provider-agnostic.
+    """A tool definition, harness-agnostic.
 
     Maps onto ``claude-agent-sdk``'s MCP tool registration
     (``create_sdk_mcp_server`` / ``SdkMcpTool``: name, description, a JSON
@@ -120,7 +130,7 @@ class ToolSpec:
 
 @dataclass(frozen=True)
 class Message:
-    """One chat-history entry, provider-agnostic.
+    """One chat-history entry, harness-agnostic.
 
     ``tool_call_id`` is set only on ``role="tool"`` messages (the result
     being fed back for a specific prior tool call); ``name`` is set only
@@ -153,11 +163,11 @@ class RunResult:
 
 @dataclass(frozen=True)
 class NormalizedEvent:
-    """One provider-agnostic event in a session's turn stream.
+    """One harness-agnostic event in a session's turn stream.
 
     ``kind`` discriminates which fields are meaningful (see
     :data:`EventKind`); unused fields keep their default. ``raw`` is an
-    escape hatch — the provider-native object, kept for debugging /
+    escape hatch — the harness-native object, kept for debugging /
     forward-compat — and is NEVER required for correct handling of a
     known ``kind``.
     """
@@ -173,17 +183,17 @@ class NormalizedEvent:
 
 
 @runtime_checkable
-class ProviderSession(Protocol):
-    """Provider-agnostic conversational session.
+class HarnessSession(Protocol):
+    """Harness-agnostic conversational session.
 
-    Wraps a single provider SDK's client/session object with a uniform
+    Wraps a single agent SDK's client/session object with a uniform
     surface: one :meth:`start`, N :meth:`send` turns (each an async
     stream of :class:`NormalizedEvent`, terminating in a ``kind="result"``
     event carrying a :class:`RunResult`), then :meth:`close`. Mirrors the
     ``ClaudeSDKClient`` open → ``query``/``receive_response`` (repeated
     per turn) → close lifecycle already in production use (see
     ``_runners/_session_conversation.py`` / ``_session_turn.py``), so a
-    future runner can drive EITHER provider through the same loop shape.
+    future runner can drive EITHER harness through the same loop shape.
 
     Concrete implementations are NOT required in this phase (foundation
     only — see the module docstring). openai-compat-2 lands the first
@@ -192,7 +202,7 @@ class ProviderSession(Protocol):
     """
 
     async def start(self) -> None:
-        """Open the underlying provider connection (auth + client init)."""
+        """Open the underlying harness connection (auth + client init)."""
         ...
 
     def send(self, message: Message) -> AsyncIterator[NormalizedEvent]:
@@ -207,5 +217,5 @@ class ProviderSession(Protocol):
         ...
 
     async def close(self) -> None:
-        """Tear down the underlying provider connection."""
+        """Tear down the underlying harness connection."""
         ...

--- a/src/scitex_agent_container/_runners/_harness_session.py
+++ b/src/scitex_agent_container/_runners/_harness_session.py
@@ -53,14 +53,6 @@ different layers of the stack:
   runner (today: ``_session_conversation.py`` opening one
   ``ClaudeSDKClient`` and calling ``_drive_turn`` per inbound message).
 
-The name is HARNESS, not PROVIDER, because the axis this Protocol
-selects on is WHICH AGENT PROGRAM RUNS THE LOOP — its implementations
-are ``ClaudeCodeSession`` / ``CodexSession`` / :class:`OpenAIAgentsSession`
-/ ``PiSession`` / ``OpenHandsSession``, which are agent programs, not
-inference providers. "Which model thinks" is a separate axis
-(``inference``); conflating the two is what the old ``ProviderSession``
-name did.
-
 They compose VERTICALLY, not by inheritance: a future runner selects a
 ``HarnessSession`` implementation based on ``AgentConfig.provider``
 (``config._provider_types.AgentProvider`` — see the naming-collision
@@ -69,6 +61,18 @@ from inside the process that ``RuntimeBase.start()`` launched. Reusing
 ``HarnessSession`` for both harnesses (rather than only using it as an
 OpenAI-side implementation detail) is what keeps ``openai-compat-2``
 from having to reinvent the turn-loop contract.
+
+Why HARNESS and not PROVIDER
+-----------------------------
+The axis this Protocol selects on is WHICH AGENT PROGRAM RUNS THE LOOP:
+its implementations are ``ClaudeCodeSession`` / ``CodexSession`` /
+``OpenAIAgentsSession`` / ``PiSession`` / ``OpenHandsSession``, which are
+agent PROGRAMS, not inference providers. "Which model thinks" is a
+separate axis (``inference``) — e.g. ``ClaudeSpec.provider`` above, which
+points the SAME harness at an Anthropic-compatible backend. The former
+name ``ProviderSession`` named the wrong axis, and ``OpenAISession`` was
+the sharper case: it wraps the ``openai-agents`` SDK, not an OpenAI model
+provider.
 """
 
 from __future__ import annotations

--- a/src/scitex_agent_container/_runners/openai_session.py
+++ b/src/scitex_agent_container/_runners/openai_session.py
@@ -1,17 +1,17 @@
-"""Concrete :class:`ProviderSession` backed by the ``openai-agents`` SDK.
+"""Concrete :class:`HarnessSession` backed by the ``openai-agents`` SDK.
 
 scitex-todo card ``openai-compat-2`` — the first concrete implementation
-of the openai-compat-1 Protocol (see :mod:`_runners._provider_session`
+of the openai-compat-1 Protocol (see :mod:`_runners._harness_session`
 for the shape rationale). Wires:
 
-* :class:`~._provider_session.ToolSpec` → ``agents.FunctionTool``
+* :class:`~._harness_session.ToolSpec` → ``agents.FunctionTool``
   (:func:`tool_spec_to_function_tool` — a near-direct field mapping, as
   the ToolSpec docstring predicted).
 * ``Runner.run_streamed()`` → an async generator of
-  :class:`~._provider_session.NormalizedEvent`
-  (:func:`normalize_stream_event` + :meth:`OpenAISession.send`).
+  :class:`~._harness_session.NormalizedEvent`
+  (:func:`normalize_stream_event` + :meth:`OpenAIAgentsSession.send`).
 * ``SQLiteSession`` for conversation state (multi-turn memory across
-  :meth:`OpenAISession.send` calls; placement via
+  :meth:`OpenAIAgentsSession.send` calls; placement via
   :func:`runtimes._openai_sdk_common.resolve_state_db_path`).
 * Per-turn spend recording into the ledger of
   :mod:`_account.openai_usage` (spend-based tracking — best-effort,
@@ -19,8 +19,8 @@ for the shape rationale). Wires:
 
 The ``openai-agents`` dependency is OPTIONAL (``pip install
 scitex-agent-container[openai]``). This module imports it LAZILY inside
-:meth:`OpenAISession.start` / :func:`tool_spec_to_function_tool` —
-importing the module (and constructing :class:`OpenAISession`) works on
+:meth:`OpenAIAgentsSession.start` / :func:`tool_spec_to_function_tool` —
+importing the module (and constructing :class:`OpenAIAgentsSession`) works on
 Claude-only deployments; only actually OPENING a session requires the
 SDK. :func:`normalize_stream_event` is deliberately duck-typed on the
 SDK's own ``type`` / ``name`` string discriminators (stable public
@@ -50,11 +50,11 @@ import json
 from pathlib import Path
 from typing import Any, AsyncIterator, Sequence
 
-from ._provider_session import Message, NormalizedEvent, RunResult, ToolSpec
+from ._harness_session import Message, NormalizedEvent, RunResult, ToolSpec
 
 __all__ = [
     "OpenAISessionError",
-    "OpenAISession",
+    "OpenAIAgentsSession",
     "tool_spec_to_function_tool",
     "normalize_stream_event",
     "usage_as_dict",
@@ -100,7 +100,7 @@ def _import_agents() -> Any:
 
 
 def tool_spec_to_function_tool(spec: ToolSpec) -> Any:
-    """Convert a provider-agnostic :class:`ToolSpec` into ``agents.FunctionTool``.
+    """Convert a harness-agnostic :class:`ToolSpec` into ``agents.FunctionTool``.
 
     Field mapping: ``name`` → ``name``, ``description`` → ``description``,
     ``parameters`` → ``params_json_schema`` (defaulted to an empty object
@@ -178,7 +178,7 @@ def _reasoning_text(item: Any) -> str:
 def normalize_stream_event(event: Any) -> NormalizedEvent | None:
     """Map one ``openai-agents`` stream event to a :class:`NormalizedEvent`.
 
-    Returns ``None`` for events with no provider-agnostic meaning (raw
+    Returns ``None`` for events with no harness-agnostic meaning (raw
     protocol deltas other than text, assembled-message duplicates,
     unknown future kinds) — callers drop those. Pure and duck-typed on
     the SDK's own ``type`` / ``name`` Literal discriminators, so it
@@ -277,8 +277,8 @@ def _run_result_from_streamed(
 # ---------------------------------------------------------------------------
 
 
-class OpenAISession:
-    """:class:`ProviderSession` implementation over ``openai-agents``.
+class OpenAIAgentsSession:
+    """:class:`HarnessSession` implementation over ``openai-agents``.
 
     Lifecycle mirrors the Protocol (and the production ``ClaudeSDKClient``
     loop it was modelled on): one :meth:`start` (auth + ``Agent`` +
@@ -336,7 +336,7 @@ class OpenAISession:
         self._session: Any = None
         self._started = False
 
-    # -- ProviderSession surface ----------------------------------------
+    # -- HarnessSession surface ----------------------------------------
 
     async def start(self) -> None:
         """Open the session: auth, tool conversion, ``Agent`` + ``SQLiteSession``.
@@ -382,7 +382,7 @@ class OpenAISession:
         instead (per the Protocol docstring both are turn-ending).
         """
         if not self._started:
-            raise OpenAISessionError("OpenAISession.send() called before start().")
+            raise OpenAISessionError("OpenAIAgentsSession.send() called before start().")
         agents = _import_agents()
 
         joined: list[str] = []

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_provider_types.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_provider_types.html
@@ -465,7 +465,7 @@
 <span class="c1"># but nothing branches on ``AgentConfig.provider`` yet — selecting</span>
 <span class="c1"># ``&quot;openai&quot;`` today only affects `sac agents explain` / config introspection.</span>
 <span class="c1"># openai-compat-2 lands the concrete ``openai`` runner (see</span>
-<span class="c1"># ``_runners/_provider_session.py`` for the ``ProviderSession`` Protocol it</span>
+<span class="c1"># ``_runners/_harness_session.py`` for the ``HarnessSession`` Protocol it</span>
 <span class="c1"># will implement); openai-compat-3 wires the selection into the apptainer</span>
 <span class="c1"># entrypoint + container image.</span>
 <span class="n">AgentProvider</span> <span class="o">=</span> <span class="n">Literal</span><span class="p">[</span><span class="s2">&quot;anthropic&quot;</span><span class="p">,</span> <span class="s2">&quot;openai&quot;</span><span class="p">]</span>

--- a/src/scitex_agent_container/a2a/_handlers.py
+++ b/src/scitex_agent_container/a2a/_handlers.py
@@ -215,8 +215,8 @@ def handle_openai_session(agent_name: str, user_text: str) -> str:
 
     Same sync wire contract as :func:`handle_claude_session`
     (``(name, text) -> str``), backed by
-    :class:`scitex_agent_container._runners.openai_session.OpenAISession`
-    (the concrete ``ProviderSession`` — see openai-compat-2). Unlike the
+    :class:`scitex_agent_container._runners.openai_session.OpenAIAgentsSession`
+    (the concrete ``HarnessSession`` — see openai-compat-2). Unlike the
     Claude handler this one is STATEFUL: the session persists turns in
     the agent's ``SQLiteSession`` db (see
     ``runtimes._openai_sdk_common.resolve_state_db_path``), so repeated
@@ -243,9 +243,9 @@ def handle_openai_session(agent_name: str, user_text: str) -> str:
             "(`pip install scitex-agent-container[openai]`)."
         ) from exc
 
-    from scitex_agent_container._runners._provider_session import Message
+    from scitex_agent_container._runners._harness_session import Message
     from scitex_agent_container._runners.openai_session import (
-        OpenAISession,
+        OpenAIAgentsSession,
         OpenAISessionError,
     )
     from scitex_agent_container.runtimes._openai_sdk_common import (
@@ -256,7 +256,7 @@ def handle_openai_session(agent_name: str, user_text: str) -> str:
     model = _sac_env("A2A_OPENAI_MODEL") or None
 
     async def _drive() -> str:
-        session = OpenAISession(agent_name, model=model, instructions=system)
+        session = OpenAIAgentsSession(agent_name, model=model, instructions=system)
         await session.start()
         try:
             reply = ""

--- a/src/scitex_agent_container/a2a/executors/_openai_session.py
+++ b/src/scitex_agent_container/a2a/executors/_openai_session.py
@@ -4,7 +4,7 @@ Sibling of :class:`ClaudeSessionExecutor` for the OpenAI agent-SDK
 family (scitex-todo card ``openai-compat-2``). Same wire surface (sync
 ``(name, text) -> str``); the underlying transport is
 ``agents.Runner.run_streamed`` normalized through
-:class:`scitex_agent_container._runners.openai_session.OpenAISession`,
+:class:`scitex_agent_container._runners.openai_session.OpenAIAgentsSession`,
 with conversation state persisted in the agent's ``SQLiteSession`` db.
 
 Requires the optional ``[openai]`` extra

--- a/src/scitex_agent_container/config/_provider_types.py
+++ b/src/scitex_agent_container/config/_provider_types.py
@@ -42,7 +42,7 @@ from typing import Literal
 # but nothing branches on ``AgentConfig.provider`` yet — selecting
 # ``"openai"`` today only affects `sac agents explain` / config introspection.
 # openai-compat-2 lands the concrete ``openai`` runner (see
-# ``_runners/_provider_session.py`` for the ``ProviderSession`` Protocol it
+# ``_runners/_harness_session.py`` for the ``HarnessSession`` Protocol it
 # will implement); openai-compat-3 wires the selection into the apptainer
 # entrypoint + container image.
 AgentProvider = Literal["anthropic", "openai"]

--- a/tests/integration/test_provider_column_specs.py
+++ b/tests/integration/test_provider_column_specs.py
@@ -15,10 +15,10 @@ seams that make the columns interchangeable, each on REAL objects:
 3. **Session-type routing + NormalizedEvent shape**: both columns'
    ``spec.a2a.handler`` keys route to registered executors sharing
    ``BaseSyncExecutor`` (one task-event surface), and the OpenAI
-   column's concrete session satisfies the ``ProviderSession`` Protocol
+   column's concrete session satisfies the ``HarnessSession`` Protocol
    — the contract whose ``send`` streams :class:`NormalizedEvent`s for
-   BOTH SDK families (the Claude column's ProviderSession retrofit is
-   explicitly future work per ``_provider_session``'s module docstring,
+   BOTH SDK families (the Claude column's HarnessSession retrofit is
+   explicitly future work per ``_harness_session``'s module docstring,
    so the Protocol itself is the shared shape both columns meet today).
 
 Real seams only (no mocks). STX-TQ002 AAA + STX-TQ007 one-assert.
@@ -32,8 +32,8 @@ from typing import Iterator
 
 import pytest
 
-from scitex_agent_container._runners._provider_session import ProviderSession
-from scitex_agent_container._runners.openai_session import OpenAISession
+from scitex_agent_container._runners._harness_session import HarnessSession
+from scitex_agent_container._runners.openai_session import OpenAIAgentsSession
 from scitex_agent_container.a2a.executors import EXECUTORS, BaseSyncExecutor
 from scitex_agent_container.config import load_config
 from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
@@ -253,14 +253,14 @@ def test_both_column_executors_share_the_task_event_surface(
     assert shared is True
 
 
-def test_openai_column_session_satisfies_provider_session_protocol(
+def test_openai_column_session_satisfies_harness_session_protocol(
     _sandbox_env: Path,
 ) -> None:
-    # Arrange — ProviderSession is the shape whose ``send`` streams
+    # Arrange — HarnessSession is the shape whose ``send`` streams
     # NormalizedEvents; construction needs no openai-agents install.
-    session = OpenAISession("openai-col")
+    session = OpenAIAgentsSession("openai-col")
     # Act
-    conforms = isinstance(session, ProviderSession)
+    conforms = isinstance(session, HarnessSession)
     # Assert
     assert conforms is True
 
@@ -268,14 +268,14 @@ def test_openai_column_session_satisfies_provider_session_protocol(
 def test_openai_column_session_streams_normalized_events_shape() -> None:
     # Arrange — real-SDK tier: with openai-agents installed, a real
     # stream event normalizes into the shared NormalizedEvent vocabulary
-    # (the same dataclass the future Claude-side ProviderSession must
+    # (the same dataclass the future Claude-side HarnessSession must
     # yield). Uses the SDK's own event classes — no network. Construction
     # mirrors test_openai_session.py's real-SDK tier exactly.
     pytest.importorskip("agents")
     from agents.stream_events import RawResponsesStreamEvent
     from openai.types.responses import ResponseTextDeltaEvent
 
-    from scitex_agent_container._runners._provider_session import NormalizedEvent
+    from scitex_agent_container._runners._harness_session import NormalizedEvent
     from scitex_agent_container._runners.openai_session import (
         normalize_stream_event,
     )

--- a/tests/scitex_agent_container/_runners/test__harness_session.py
+++ b/tests/scitex_agent_container/_runners/test__harness_session.py
@@ -1,7 +1,7 @@
-"""Tests for ``_runners/_provider_session.py`` (openai-compat-1 foundation).
+"""Tests for ``_runners/_harness_session.py`` (openai-compat-1 foundation).
 
 Covers the four dataclasses (``ToolSpec``, ``Message``, ``NormalizedEvent``,
-``RunResult``) and the ``ProviderSession`` Protocol. No mocks — the
+``RunResult``) and the ``HarnessSession`` Protocol. No mocks — the
 Protocol is exercised against a REAL, hand-written implementation
 (``_FakeSession``, mirroring the ``_ScriptedClient`` pattern in
 ``tests/.../test__session_turn.py``), proving the shape is actually
@@ -22,10 +22,10 @@ from __future__ import annotations
 import asyncio
 from typing import AsyncIterator
 
-from scitex_agent_container._runners._provider_session import (
+from scitex_agent_container._runners._harness_session import (
     Message,
     NormalizedEvent,
-    ProviderSession,
+    HarnessSession,
     RunResult,
     ToolSpec,
 )
@@ -235,12 +235,12 @@ def test_normalized_event_terminal_result_kind_carries_run_result():
 
 
 # ---------------------------------------------------------------------------
-# ProviderSession Protocol — exercised against a REAL implementation
+# HarnessSession Protocol — exercised against a REAL implementation
 # ---------------------------------------------------------------------------
 
 
 class _FakeSession:
-    """A real, minimal ``ProviderSession`` implementation for shape-testing.
+    """A real, minimal ``HarnessSession`` implementation for shape-testing.
 
     Mirrors the ``_ScriptedClient`` pattern in
     ``tests/.../_runners/test__session_turn.py`` — a hand-written stand-in,
@@ -268,27 +268,27 @@ class _FakeSession:
         self.closed = True
 
 
-def test_fake_session_satisfies_provider_session_isinstance_check():
+def test_fake_session_satisfies_harness_session_isinstance_check():
     # Arrange
     session = _FakeSession()
     # Act
-    conforms = isinstance(session, ProviderSession)
+    conforms = isinstance(session, HarnessSession)
     # Assert
     assert conforms is True
 
 
-def test_plain_object_does_not_satisfy_provider_session_isinstance_check():
+def test_plain_object_does_not_satisfy_harness_session_isinstance_check():
     # Arrange
     class _NotASession:
         pass
 
     # Act
-    conforms = isinstance(_NotASession(), ProviderSession)
+    conforms = isinstance(_NotASession(), HarnessSession)
     # Assert
     assert conforms is False
 
 
-def test_provider_session_start_sets_started_flag():
+def test_harness_session_start_sets_started_flag():
     # Arrange
     async def _go() -> bool:
         session = _FakeSession()
@@ -301,7 +301,7 @@ def test_provider_session_start_sets_started_flag():
     assert started is True
 
 
-def test_provider_session_close_sets_closed_flag():
+def test_harness_session_close_sets_closed_flag():
     # Arrange
     async def _go() -> bool:
         session = _FakeSession()
@@ -325,7 +325,7 @@ def _drive_one_turn() -> list[NormalizedEvent]:
     return asyncio.run(_go())
 
 
-def test_provider_session_send_yields_text_delta_events_in_order():
+def test_harness_session_send_yields_text_delta_events_in_order():
     # Arrange
     # Act
     events = _drive_one_turn()
@@ -333,7 +333,7 @@ def test_provider_session_send_yields_text_delta_events_in_order():
     assert [e.text for e in events if e.kind == "text_delta"] == ["hel", "lo"]
 
 
-def test_provider_session_send_terminates_with_result_kind():
+def test_harness_session_send_terminates_with_result_kind():
     # Arrange
     # Act
     events = _drive_one_turn()
@@ -341,7 +341,7 @@ def test_provider_session_send_terminates_with_result_kind():
     assert events[-1].kind == "result"
 
 
-def test_provider_session_terminal_event_carries_run_result_text():
+def test_harness_session_terminal_event_carries_run_result_text():
     # Arrange
     # Act
     events = _drive_one_turn()
@@ -349,7 +349,7 @@ def test_provider_session_terminal_event_carries_run_result_text():
     assert events[-1].result.text == "hello"
 
 
-def test_provider_session_terminal_event_carries_session_id():
+def test_harness_session_terminal_event_carries_session_id():
     # Arrange
     # Act
     events = _drive_one_turn()

--- a/tests/scitex_agent_container/_runners/test_openai_session.py
+++ b/tests/scitex_agent_container/_runners/test_openai_session.py
@@ -19,7 +19,7 @@ network-shape-independent: any failure must surface as a turn-ending
 ``kind="error"`` event, never an exception mid-iteration).
 
 STX-TQ002 AAA + STX-TQ007 one-assert-per-test; async via
-``asyncio.run(_go())`` (the ``test__provider_session.py`` convention).
+``asyncio.run(_go())`` (the ``test__harness_session.py`` convention).
 """
 
 from __future__ import annotations
@@ -35,14 +35,14 @@ from typing import Any
 
 import pytest
 
-from scitex_agent_container._runners._provider_session import (
+from scitex_agent_container._runners._harness_session import (
     Message,
     NormalizedEvent,
-    ProviderSession,
+    HarnessSession,
     ToolSpec,
 )
 from scitex_agent_container._runners.openai_session import (
-    OpenAISession,
+    OpenAIAgentsSession,
     OpenAISessionError,
     _run_result_from_streamed,
     normalize_stream_event,
@@ -407,15 +407,15 @@ def test_run_result_stop_reason_complete_when_stream_finished():
 
 
 # ---------------------------------------------------------------------------
-# OpenAISession — Protocol conformance + lazy-import contract (SDK-free)
+# OpenAIAgentsSession — Protocol conformance + lazy-import contract (SDK-free)
 # ---------------------------------------------------------------------------
 
 
-def test_openai_session_satisfies_provider_session_protocol():
+def test_openai_session_satisfies_harness_session_protocol():
     # Arrange
-    session = OpenAISession("alpha")
+    session = OpenAIAgentsSession("alpha")
     # Act
-    conforms = isinstance(session, ProviderSession)
+    conforms = isinstance(session, HarnessSession)
     # Assert
     assert conforms is True
 
@@ -423,7 +423,7 @@ def test_openai_session_satisfies_provider_session_protocol():
 def test_openai_session_tracing_defaults_off():
     # Arrange: sac must not POST trace payloads to OpenAI by default.
     # Act
-    session = OpenAISession("alpha")
+    session = OpenAIAgentsSession("alpha")
     # Assert
     assert session.tracing is False
 
@@ -445,7 +445,7 @@ def test_start_with_agents_blocked_raises_with_install_hint(
     block_agents_import, openai_env
 ):
     # Arrange
-    session = OpenAISession("alpha")
+    session = OpenAIAgentsSession("alpha")
 
     async def _go() -> str:
         try:
@@ -477,7 +477,7 @@ def test_tool_conversion_with_agents_blocked_raises_openai_session_error(
 
 def test_send_before_start_raises():
     # Arrange
-    session = OpenAISession("alpha")
+    session = OpenAIAgentsSession("alpha")
 
     async def _go() -> Exception | None:
         try:
@@ -649,7 +649,7 @@ def test_start_builds_sqlite_session_state(openai_env: Path):
     # Arrange
     agents = pytest.importorskip("agents")
     db_path = openai_env / "state.sqlite3"
-    session = OpenAISession("alpha", model="gpt-4o-mini", db_path=db_path)
+    session = OpenAIAgentsSession("alpha", model="gpt-4o-mini", db_path=db_path)
 
     async def _go() -> Any:
         await session.start()
@@ -667,7 +667,7 @@ def test_start_creates_the_state_db_file(openai_env: Path):
     # Arrange
     pytest.importorskip("agents")
     db_path = openai_env / "state.sqlite3"
-    session = OpenAISession("alpha", model="gpt-4o-mini", db_path=db_path)
+    session = OpenAIAgentsSession("alpha", model="gpt-4o-mini", db_path=db_path)
 
     async def _go() -> None:
         await session.start()
@@ -682,7 +682,7 @@ def test_start_creates_the_state_db_file(openai_env: Path):
 def test_close_resets_started_flag(openai_env: Path):
     # Arrange
     pytest.importorskip("agents")
-    session = OpenAISession(
+    session = OpenAIAgentsSession(
         "alpha", model="gpt-4o-mini", db_path=openai_env / "s.sqlite3"
     )
 
@@ -702,7 +702,7 @@ def test_send_failure_surfaces_as_turn_ending_error_event(openai_env: Path):
     yield a terminal ``kind="error"`` event, never leak an exception."""
     # Arrange
     pytest.importorskip("agents")
-    session = OpenAISession(
+    session = OpenAIAgentsSession(
         "alpha",
         model="gpt-4o-mini",
         db_path=openai_env / "s.sqlite3",


### PR DESCRIPTION
Step ① of the v4 layering refactor. **No behaviour change** — this is a
rename plus the docstring wording that carried the old meaning.

## Why: the protocol is a *harness* abstraction, not a *provider* one

`ProviderSession` defines `start()` / `send() -> AsyncIterator[NormalizedEvent]`
/ `close()`. That is **conversation lifecycle**, and its future implementations
are `ClaudeCodeSession`, `CodexSession`, `OpenAIAgentsSession`, `PiSession`,
`OpenHandsSession` — agent **programs**, not inference providers.

Under the new layering the two axes are:

* **`inference`** — which model thinks.
* **`harness`** — which program runs the loop.

The old name named the wrong one.

`OpenAISession` was the worse offender. It wraps the **openai-agents SDK** —
it converts `Runner.run_streamed()` into `NormalizedEvent` — not an OpenAI
model provider. A reader scanning for "the OpenAI provider integration" found
the harness adapter instead.

The existing *design* is sound and stays exactly as it was: `RuntimeBase` is
process lifecycle, this Protocol is conversation lifecycle, and they compose
vertically rather than by inheritance. That split is already documented in the
module. This change only carries that intent into the name, and adds a short
paragraph stating the harness/inference distinction so the next reader does not
have to re-derive it.

## Rename, not migration

Checked **every** `__init__.py` in the package, not just the top-level one:

* `ProviderSession` — appears in **no** `__init__.py`, and lives in a private
  module (`_provider_session.py`) inside a private package (`_runners`).
* `OpenAISession` — likewise absent from every `__init__.py`.

Neither is a published contract, so no deprecation alias is warranted; an alias
here would be dead code with a removal chore attached. A hard rename is correct.

The only `__all__` export in this neighbourhood is `OpenAISessionExecutor`, and
that one is **deliberately untouched** — see below.

## What was deliberately NOT renamed

`scitex-dev rename-symbols` matches on **substring**, not word boundary. The
unguarded plan for `OpenAISession -> OpenAIAgentsSession` reported **54**
matches where the symbol itself occurs only 25 times. The extra 29 were two
different symbols that merely share the prefix:

| symbol | occurrences | why it must not change |
| --- | ---: | --- |
| `OpenAISessionError` | 15 | not in scope; renaming it was not requested |
| `OpenAISessionExecutor` | 14 | **exported in `a2a/executors/__init__.py`'s `__all__`** and bound to the spec-facing registry key `"openai_session"` — renaming it is a contract break, i.e. a behaviour change |

The rename was therefore run as a guarded regex,
`OpenAISession(?!Error|Executor)`, which lands exactly the 25 real
occurrences. Both preserved symbols were re-counted after the fact and are
unchanged at 15 and 14, and the `"openai_session"` executor key is untouched.

Also left alone, deliberately: **`spec.claude.provider` / `ProviderSpec`** —
the Anthropic-compatible *inference* backend override (DeepSeek, Mimo, a
self-hosted gateway). That is a different axis and is legitimately named.
Conflating it with the harness axis is the exact bug this refactor exists to
fix.

## File moves

Following the repo convention (`test_<module>.py`, doubled for
underscore-prefixed modules):

```
src/scitex_agent_container/_runners/_provider_session.py
  -> src/scitex_agent_container/_runners/_harness_session.py

tests/scitex_agent_container/_runners/test__provider_session.py
  -> tests/scitex_agent_container/_runners/test__harness_session.py
```

Both are recorded by git as renames (`R`), so the history follows the file. The
test moved with its source, which keeps `tests/develop/test_tests_mirror_src.py`
and the per-file PS-204 §2 audit green.

## Scope, measured

`ProviderSession` came to **exactly 30 occurrences**, matching the agreed
measurement — but across **10** files, not 8. The two not on the original list:

* `pyproject.toml` — a comment in the `[openai]` extra.
* `src/scitex_agent_container/_sphinx_html/.../_provider_types.html` — committed
  generated doc output holding a rendered copy of a source comment that this PR
  changes. Updated so the committed artifact stays consistent with its source;
  it is regenerated by the docs build regardless.

Zero matches in `.old/`, `.scitex/`, `examples/`, `docs/` and `scripts/`, so no
data file or live identity string is in the diff. The dry-run plans reported
**0 collisions** and **0 protected-file** hits on all three passes.

One thing the sweep got wrong and that is corrected by hand: it rewrote a
**verbatim quoted scitex-todo card title** (`"Land ProviderConfig +
ProviderSession Protocol"`) in two files. That string is a historical citation —
note `ProviderConfig` in the same quote was never renamed — so corrupting it
would make the card unfindable by its own title. Both are restored, which
dropped `runtimes/_provider_common.py` out of this diff entirely.

## Tests

Run against **this worktree's** source (`PYTHONPATH` pinned to it, verified via
`scitex_agent_container.__file__`, because the editable install otherwise
resolves to the main checkout).

`174 passed, 1 failed` across the affected suites.

The one failure, `test__handlers.py::test_claude_session_reads_model_env_for_options`,
is **pre-existing and environmental, not caused by this change**. Proven rather
than assumed: the same test fails identically on an unmodified `origin/develop`
worktree at the same HEAD, with `ProviderSession` still present — same error,
same `1 failed, 30 passed`. It raises `SpecEnvUnresolvedError` because the
development container has `SAC_SPEC_ENV_KEYS` set, which a CI runner does not.
None of the files in its traceback (`_sdk_common.py`, `_mcp_spec_env.py`,
`test__handlers.py`) appear in this diff. Reported separately rather than fixed
here, so this stays a reviewable pure rename.

## Follow-ups found, deliberately not done here

1. **`spec.provider` / `AgentProvider` is on the harness axis and is misnamed.**
   `config/_provider_types.py` documents it as selecting "WHICH AGENT SDK /
   tool-calling framework backs the session at all" — `anthropic`
   (`claude-agent-sdk`) vs `openai` (`openai-agents` SDK). By this PR's own
   argument that field is `harness`, not `provider`. But it is **spec-facing
   YAML**, so it needs a real migration (accept both keys, then deprecate) —
   not a rename. This is the natural step ②.
2. `_runners/openai_session.py` (the module filename) and `OpenAISessionError`
   still carry the old wording. Renaming them was not requested and would pull
   in the executor module and the `[openai]` extra; worth a follow-up.
