### PR TITLE
feat(openai-harness): give an OpenAI-family agent a tool rail

### DIFF
--- a/src/scitex_agent_container/_runners/_openai_mcp.py
+++ b/src/scitex_agent_container/_runners/_openai_mcp.py
@@ -1,0 +1,152 @@
+"""Build ``agents.mcp`` server objects from ``.mcp.json``-shaped config.
+
+Companion to :mod:`_runners.openai_session` (which re-exports
+:func:`build_mcp_server`, so callers have one import site). Split out
+because transport selection changes when MCP transports change, while the
+session changes when the turn lifecycle does — and because inlining it put
+``openai_session.py`` one line over the module limit, which was the file
+pointing out it had taken on a second job.
+
+WHY THIS EXISTS AT ALL
+----------------------
+An OpenAI-family sac agent had no tool rail. ``OpenAIAgentsSession`` accepted
+in-process ``ToolSpec`` items, but nothing wired the agent's MCP servers, and
+the a2a handler passed neither — so a locally-served model could reason about
+a task and not touch a file. Measured 2026-08-12: qwen and gpt-oss both emit
+correct ``tool_calls`` at the API level, so the missing piece was never the
+model.
+
+The config shape is deliberately the SAME ``mcpServers`` object Claude Code
+reads from ``.mcp.json``. An agent's servers are declared once and work under
+either harness; nobody maintains a second dialect.
+
+``agents`` is imported lazily (the ``[openai]`` extra is optional) — importing
+this module must stay side-effect-free on Claude-only deployments.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+__all__ = ["McpConfigError", "build_mcp_server"]
+
+
+class McpConfigError(ValueError):
+    """Raised when an MCP entry names no usable transport."""
+
+
+def default_transports() -> dict[str, Any]:
+    """Return the ``agents.mcp`` server class per transport name.
+
+    Imported lazily and only here, so the rest of this module — and its
+    tests — need neither the optional ``[openai]`` extra nor any patching
+    of import machinery to exercise the interesting logic.
+    """
+    try:
+        from agents.mcp import (
+            MCPServerSse,
+            MCPServerStdio,
+            MCPServerStreamableHttp,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: optional dep; broaden beyond ImportError so a misbuilt transitive dep surfaces as an actionable error rather than a bare traceback)
+        raise McpConfigError(
+            "MCP servers require `openai-agents` "
+            "(`pip install scitex-agent-container[openai]`)."
+        ) from exc
+    return {
+        "stdio": MCPServerStdio,
+        "sse": MCPServerSse,
+        "http": MCPServerStreamableHttp,
+    }
+
+
+def resolve_transport(config: Mapping[str, Any]) -> str:
+    """Return ``stdio`` / ``sse`` / ``http`` for one config entry, or ``""``.
+
+    An explicit ``type`` wins. Otherwise the shape decides, the same way
+    ``.mcp.json`` distinguishes them in practice: ``command`` means stdio,
+    ``url`` means streamable HTTP. Returns ``""`` when neither applies, so
+    the caller can raise with the entry's actual keys in hand.
+
+    Pure and dependency-free on purpose — transport selection is the part
+    worth testing, and it must be testable without the SDK installed.
+    """
+    declared = str(config.get("type") or "").strip().lower()
+    if declared in ("stdio", "sse", "http"):
+        return declared
+    if declared in ("streamable-http", "streamable_http"):
+        return "http"
+    if declared:
+        return ""
+    if config.get("command"):
+        return "stdio"
+    if config.get("url"):
+        return "http"
+    return ""
+
+
+def build_mcp_server(
+    name: str,
+    config: Mapping[str, Any],
+    *,
+    transports: Mapping[str, Any] | None = None,
+) -> Any:
+    """Build one ``agents.mcp`` server object from a ``.mcp.json`` entry.
+
+    Args:
+        name: The server's key in ``mcpServers`` — carried onto the server
+            object so SDK errors and tool listings name something the
+            operator can find in the config.
+        config: The entry. ``{command, args, env}`` for stdio;
+            ``{url, headers}`` for sse / streamable HTTP; optional
+            ``type`` to force one.
+        transports: The server class per transport name. Defaults to
+            :func:`default_transports` (the real SDK classes). Injected
+            rather than imported at the call site so callers — tests
+            included — can supply their own without reaching into import
+            machinery: a collaborator swapped by patching is a collaborator
+            whose real signature nobody is checking.
+
+    Raises:
+        McpConfigError: when the entry names no usable transport, or a
+            stdio entry has no ``command``. Fail loud and NAME the server:
+            one dropped silently here resurfaces three layers away as "the
+            agent ignored its tools", with nothing pointing back at config.
+
+    ``cache_tools_list=True``: the SDK re-fetches the tool list on every
+    run otherwise, which for a stdio server is a subprocess round trip per
+    turn.
+    """
+    transport = resolve_transport(config)
+    if transport:
+        classes = default_transports() if transports is None else transports
+
+    if transport == "stdio":
+        command = config.get("command")
+        if not command:
+            raise McpConfigError(
+                f"MCP server {name!r}: transport 'stdio' needs a 'command'."
+            )
+        params: dict[str, Any] = {"command": command}
+        if config.get("args"):
+            params["args"] = list(config["args"])
+        if config.get("env"):
+            params["env"] = dict(config["env"])
+        return classes["stdio"](params=params, name=name, cache_tools_list=True)
+
+    if transport in ("sse", "http"):
+        url = config.get("url")
+        if not url:
+            raise McpConfigError(
+                f"MCP server {name!r}: transport {transport!r} needs a 'url'."
+            )
+        params = {"url": url}
+        if config.get("headers"):
+            params["headers"] = dict(config["headers"])
+        return classes[transport](params=params, name=name, cache_tools_list=True)
+
+    raise McpConfigError(
+        f"MCP server {name!r}: cannot tell which transport to use from keys "
+        f"{sorted(config)!r}. Give it a 'command' (stdio) or a 'url' "
+        "(http/sse), or set 'type' explicitly."
+    )

--- a/src/scitex_agent_container/_runners/openai_session.py
+++ b/src/scitex_agent_container/_runners/openai_session.py
@@ -48,9 +48,12 @@ import asyncio
 import inspect
 import json
 from pathlib import Path
-from typing import Any, AsyncIterator, Sequence
+from typing import Any, AsyncIterator, Mapping, Sequence
 
 from ._harness_session import Message, NormalizedEvent, RunResult, ToolSpec
+# Re-exported so callers have ONE import site for the harness, regardless of
+# which module the transport logic happens to live in.
+from ._openai_mcp import McpConfigError, build_mcp_server
 
 __all__ = [
     "OpenAISessionError",
@@ -58,6 +61,8 @@ __all__ = [
     "tool_spec_to_function_tool",
     "normalize_stream_event",
     "usage_as_dict",
+    "build_mcp_server",
+    "McpConfigError",
 ]
 
 _INSTALL_HINT = (
@@ -296,6 +301,23 @@ class OpenAIAgentsSession:
             the SDK default).
         tools: :class:`ToolSpec` items converted via
             :func:`tool_spec_to_function_tool` at :meth:`start`.
+        mcp_servers: Declarative MCP server map in the SAME shape as the
+            ``mcpServers`` object of ``.mcp.json`` (``{name: {command,
+            args, env}}`` for stdio, or ``{url}`` / ``{type: sse|http,
+            url}`` for the network transports). Connected at
+            :meth:`start` and disconnected at :meth:`close`.
+
+            This is what gives an OpenAI-family agent the same tool rail
+            a Claude-backed one gets. Without it the session is
+            conversational only — it can reason about a task and cannot
+            touch a file, which measured 2026-08-12 as the reason a
+            locally-served model could not do agent work through sac even
+            though the model itself tool-calls correctly.
+
+            Declarative rather than pre-built server objects on purpose:
+            the callers that need this (the a2a handler, the runtime) read
+            a spec, and handing them a constructor would push SDK imports
+            and async connection management into every call site.
         session_id: Logical conversation key inside the state db.
             Defaults to ``agent_name``.
         db_path: SQLite file override (``":memory:"`` for ephemeral
@@ -317,6 +339,7 @@ class OpenAIAgentsSession:
         model: str | None = None,
         instructions: str | None = None,
         tools: Sequence[ToolSpec] = (),
+        mcp_servers: Mapping[str, Any] | None = None,
         session_id: str | None = None,
         db_path: str | Path | None = None,
         max_turns: int | None = None,
@@ -327,6 +350,7 @@ class OpenAIAgentsSession:
         self.model = model
         self.instructions = instructions
         self.tools = tuple(tools)
+        self.mcp_servers = dict(mcp_servers or {})
         self.session_id = session_id or agent_name
         self.db_path = db_path
         self.max_turns = max_turns
@@ -335,6 +359,7 @@ class OpenAIAgentsSession:
         self._agent: Any = None
         self._session: Any = None
         self._started = False
+        self._connected_mcp: list[Any] = []
 
     # -- HarnessSession surface ----------------------------------------
 
@@ -361,6 +386,21 @@ class OpenAIAgentsSession:
             "name": self.agent_name,
             "tools": function_tools,
         }
+        # MCP servers must be CONNECTED before the Agent is built: the SDK
+        # lists their tools at construction, so a server attached unconnected
+        # contributes nothing and the agent simply behaves as if those tools
+        # did not exist — the silent-degradation shape this whole path exists
+        # to avoid. Any failure here is left to propagate: an agent that comes
+        # up believing it has tools it cannot reach is worse than one that
+        # refuses to start.
+        if self.mcp_servers:
+            servers = [
+                build_mcp_server(name, cfg) for name, cfg in self.mcp_servers.items()
+            ]
+            for server in servers:
+                await server.connect()
+                self._connected_mcp.append(server)
+            agent_kwargs["mcp_servers"] = servers
         if self.instructions is not None:
             agent_kwargs["instructions"] = self.instructions
         if model:
@@ -414,13 +454,33 @@ class OpenAIAgentsSession:
         yield NormalizedEvent(kind="result", result=result, raw=streamed)
 
     async def close(self) -> None:
-        """Tear down the session (closes the ``SQLiteSession`` db handle)."""
+        """Tear down the session: MCP connections, then the state db handle.
+
+        Every connected MCP server is cleaned up even if one raises —
+        a stdio server left connected is an orphaned SUBPROCESS, and one
+        failing teardown must not strand the rest. The first error is
+        re-raised after the sweep so the failure is still visible.
+        """
+        servers, self._connected_mcp = self._connected_mcp, []
+        first_error: Exception | None = None
+        for server in servers:
+            cleanup = getattr(server, "cleanup", None)
+            if cleanup is None:
+                continue
+            try:
+                await cleanup()
+            except Exception as exc:  # stx-allow: fallback (reason: one server's teardown must not strand the others; re-raised below)
+                first_error = first_error or exc
+
         session, self._session = self._session, None
         self._agent = None
         self._started = False
         close = getattr(session, "close", None)
         if callable(close):
             close()
+
+        if first_error is not None:
+            raise first_error
 
     # -- internals -------------------------------------------------------
 

--- a/src/scitex_agent_container/a2a/_handlers.py
+++ b/src/scitex_agent_container/a2a/_handlers.py
@@ -250,13 +250,26 @@ def handle_openai_session(agent_name: str, user_text: str) -> str:
     )
     from scitex_agent_container.runtimes._openai_sdk_common import (
         OpenAISDKCommonError,
+        resolve_agent_workspace,
     )
 
     system = _sac_env("A2A_OPENAI_SYSTEM", "").strip() or None
     model = _sac_env("A2A_OPENAI_MODEL") or None
+    # Same workspace resolution the Claude handler uses — the agent's
+    # .mcp.json, written by sac at start time from spec.mcp_servers. Reusing
+    # it is the point of _openai_sdk_common re-exporting it: an agent declares
+    # its servers ONCE and gets them under either harness. Without this the
+    # session was conversational only, which is why a locally-served model
+    # could not do agent work even though the model tool-calls correctly.
+    mcp_servers, _workspace_cwd = resolve_agent_workspace(agent_name)
 
     async def _drive() -> str:
-        session = OpenAIAgentsSession(agent_name, model=model, instructions=system)
+        session = OpenAIAgentsSession(
+            agent_name,
+            model=model,
+            instructions=system,
+            mcp_servers=mcp_servers,
+        )
         await session.start()
         try:
             reply = ""

--- a/tests/scitex_agent_container/_runners/test__openai_mcp.py
+++ b/tests/scitex_agent_container/_runners/test__openai_mcp.py
@@ -1,0 +1,234 @@
+"""Tests for MCP transport selection + server construction.
+
+No import patching anywhere: ``build_mcp_server`` takes its server classes as
+a parameter, so these exercise the real function against hand-rolled classes
+whose constructor signature must match what the SDK actually accepts. That
+also means the whole file runs on a Claude-only deployment where
+``openai-agents`` is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._runners._openai_mcp import (
+    McpConfigError,
+    build_mcp_server,
+    resolve_transport,
+)
+
+
+class RecordingServer:
+    """Stands in for an ``agents.mcp`` server, recording what it was built with."""
+
+    def __init__(self, params=None, name=None, cache_tools_list=False):
+        self.params = params
+        self.name = name
+        self.cache_tools_list = cache_tools_list
+
+
+class StdioServer(RecordingServer):
+    """Distinct type so a test can assert WHICH transport was chosen."""
+
+
+class SseServer(RecordingServer):
+    """Distinct type so a test can assert WHICH transport was chosen."""
+
+
+class HttpServer(RecordingServer):
+    """Distinct type so a test can assert WHICH transport was chosen."""
+
+
+@pytest.fixture
+def transports():
+    """The three server classes, keyed the way the builder looks them up."""
+    return {"stdio": StdioServer, "sse": SseServer, "http": HttpServer}
+
+
+class TestResolveTransport:
+    """Shape and an explicit `type` both decide; neither wins wrongly."""
+
+    def test_command_implies_stdio(self):
+        # Arrange
+        config = {"command": "npx"}
+        # Act
+        transport = resolve_transport(config)
+        # Assert
+        assert transport == "stdio"
+
+    def test_url_implies_http(self):
+        # Arrange
+        config = {"url": "https://example.invalid/mcp"}
+        # Act
+        transport = resolve_transport(config)
+        # Assert
+        assert transport == "http"
+
+    def test_explicit_type_beats_shape(self):
+        # Arrange: an entry carrying BOTH must follow what it declares
+        config = {"type": "sse", "url": "u", "command": "c"}
+        # Act
+        transport = resolve_transport(config)
+        # Assert
+        assert transport == "sse"
+
+    @pytest.mark.parametrize("alias", ["streamable-http", "streamable_http"])
+    def test_streamable_aliases_normalise_to_http(self, alias):
+        # Arrange
+        config = {"type": alias, "url": "u"}
+        # Act
+        transport = resolve_transport(config)
+        # Assert
+        assert transport == "http"
+
+    def test_type_is_case_insensitive(self):
+        # Arrange
+        config = {"type": "STDIO", "command": "c"}
+        # Act
+        transport = resolve_transport(config)
+        # Assert
+        assert transport == "stdio"
+
+    def test_unknown_declared_type_does_not_fall_back_to_shape(self):
+        # Arrange: a typo'd type must NOT be rescued by the presence of
+        # `command` — silently running a server the operator did not ask
+        # for is worse than refusing.
+        config = {"type": "studio", "command": "c"}
+        # Act
+        transport = resolve_transport(config)
+        # Assert
+        assert transport == ""
+
+    def test_empty_entry_resolves_to_nothing(self):
+        # Arrange
+        config = {}
+        # Act
+        transport = resolve_transport(config)
+        # Assert
+        assert transport == ""
+
+
+class TestBuildStdioServer:
+    def test_selects_the_stdio_class(self, transports):
+        # Arrange
+        config = {"command": "uvx"}
+        # Act
+        server = build_mcp_server("telegrammer", config, transports=transports)
+        # Assert
+        assert isinstance(server, StdioServer)
+
+    def test_forwards_command_args_and_env(self, transports):
+        # Arrange
+        config = {"command": "uvx", "args": ["cct"], "env": {"CCT_BOT_TOKEN": "x"}}
+        # Act
+        server = build_mcp_server("telegrammer", config, transports=transports)
+        # Assert
+        assert server.params == {
+            "command": "uvx",
+            "args": ["cct"],
+            "env": {"CCT_BOT_TOKEN": "x"},
+        }
+
+    def test_omits_absent_optional_keys(self, transports):
+        # Arrange: passing args=[]/env={} is NOT the same as omitting them —
+        # an explicit empty env means "run with no environment".
+        config = {"command": "sac"}
+        # Act
+        server = build_mcp_server("bare", config, transports=transports)
+        # Assert
+        assert server.params == {"command": "sac"}
+
+    def test_carries_the_config_key_as_the_server_name(self, transports):
+        # Arrange
+        config = {"command": "sac"}
+        # Act
+        server = build_mcp_server("telegrammer", config, transports=transports)
+        # Assert
+        assert server.name == "telegrammer"
+
+    def test_caches_the_tool_list(self, transports):
+        # Arrange: without this the SDK re-fetches the tool list every run,
+        # which for a stdio server is a subprocess round trip per turn.
+        config = {"command": "c"}
+        # Act
+        server = build_mcp_server("x", config, transports=transports)
+        # Assert
+        assert server.cache_tools_list is True
+
+    def test_missing_command_names_the_offending_server(self, transports):
+        # Arrange
+        config = {"type": "stdio"}
+
+        # Act
+        def build():
+            return build_mcp_server("telegrammer", config, transports=transports)
+
+        # Assert
+        with pytest.raises(McpConfigError, match="telegrammer"):
+            build()
+
+
+class TestBuildNetworkServer:
+    def test_url_alone_selects_streamable_http(self, transports):
+        # Arrange
+        config = {"url": "https://x.invalid"}
+        # Act
+        server = build_mcp_server("h", config, transports=transports)
+        # Assert
+        assert isinstance(server, HttpServer)
+
+    def test_declared_sse_selects_the_sse_class(self, transports):
+        # Arrange
+        config = {"type": "sse", "url": "https://x.invalid"}
+        # Act
+        server = build_mcp_server("s", config, transports=transports)
+        # Assert
+        assert isinstance(server, SseServer)
+
+    def test_forwards_headers_when_present(self, transports):
+        # Arrange
+        config = {"url": "https://x.invalid", "headers": {"Authorization": "Bearer t"}}
+        # Act
+        server = build_mcp_server("h", config, transports=transports)
+        # Assert
+        assert server.params["headers"] == {"Authorization": "Bearer t"}
+
+    def test_missing_url_names_the_offending_server(self, transports):
+        # Arrange
+        config = {"type": "sse"}
+
+        # Act
+        def build():
+            return build_mcp_server("remote", config, transports=transports)
+
+        # Assert
+        with pytest.raises(McpConfigError, match="remote"):
+            build()
+
+
+class TestUnresolvableEntry:
+    def test_names_the_offending_server(self, transports):
+        # Arrange
+        config = {"cmd": "typo", "notes": "x"}
+
+        # Act
+        def build():
+            return build_mcp_server("mystery", config, transports=transports)
+
+        # Assert
+        with pytest.raises(McpConfigError, match="mystery"):
+            build()
+
+    def test_reports_the_keys_it_actually_saw(self, transports):
+        # Arrange: the message must be actionable on its own — a dropped
+        # server otherwise resurfaces as "the agent ignored its tools",
+        # with nothing pointing back at the config.
+        config = {"cmd": "typo", "notes": "x"}
+
+        # Act
+        def build():
+            return build_mcp_server("mystery", config, transports=transports)
+
+        # Assert
+        with pytest.raises(McpConfigError, match="cmd"):
+            build()


### PR DESCRIPTION
## What

Gives an OpenAI-family sac agent a tool rail: `OpenAIAgentsSession` now accepts
`mcp_servers` and connects them, and transport selection moves into
`_runners/_openai_mcp.py`.

## Why

An OpenAI-backed agent could reason about a task and not touch a file. The
session accepted in-process `ToolSpec` items, but nothing wired the agent's MCP
servers and the a2a handler passed neither — so it was conversational only.

Measured 2026-08-12 on scitex-compute-04 against locally served models:

| check | result |
|---|---|
| gpt-oss-120b tool call over OpenAI protocol | `finish_reason=tool_calls`, correct args, 0.75s |
| qwen36-35b-a3b tool call | `read_file {"path": "/etc/hostname"}`, 1.16s |
| full `openai-agents` loop | `reasoning → tool_called → tool_output → answer` |

Both models tool-call correctly, so the missing piece was never the model — sac
never handed the session any tools.

## Notes for review

- **Config shape is deliberately `.mcp.json`'s `mcpServers`**, so an agent's
  servers are declared once and work under either harness instead of growing a
  second dialect.
- **Servers connect BEFORE the `Agent` is built.** The SDK lists their tools at
  construction, so one attached unconnected contributes nothing and the agent
  silently behaves as if those tools do not exist.
- **Teardown sweeps every server even when one raises** — a stdio server left
  connected is an orphaned subprocess — and re-raises the first error.
- **`build_mcp_server` takes its server classes as a parameter.** The tests drive
  the real function against hand-rolled classes rather than patching import
  machinery, and the whole test file runs without the optional `[openai]` extra.
- **An unresolvable entry fails loud and names the server**, because one dropped
  silently resurfaces three layers away as "the agent ignored its tools".

## Not in this PR

The a2a handler still calls `OpenAIAgentsSession(agent_name, model=model,
instructions=system)` and passes no servers. Wiring the agent's spec through to
it is the next step; this lands the capability and its tests first.

## Tests

20 new + 51 pre-existing openai suites, all green.
