### PR TITLE
feat(base-image): ship psql, and gate it like the driver it pairs with

### DIFF
--- a/src/scitex_agent_container/_system_deps.py
+++ b/src/scitex_agent_container/_system_deps.py
@@ -81,6 +81,16 @@ def provide() -> list[SystemDepSpec]:
             "and the fallback probe for the listen daemon's health endpoint",
             _PROVIDER,
         ),
+        SystemDepSpec(
+            "postgresql-client",
+            "the cards/fleet store IS PostgreSQL and the image already gates "
+            "its PYTHON driver (psycopg); psql is the other half — the one a "
+            "person or an agent uses to look at the store. Measured 2026-08-13: "
+            "asked how the fleet DB is organised, this container had no psql "
+            "and could only answer from general knowledge instead of from the "
+            "database in front of it",
+            _PROVIDER,
+        ),
     ]
 
 

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -61,10 +61,20 @@ From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c5
     # symlinks in section 1b. ``tree`` is still source-built in section
     # 5 (apt ships an older 2.0.x; we want 2.1.3 features).
     #
-    # postgresql-client: the cards/fleet store IS PostgreSQL, and the image
-    # already gates the PYTHON driver (psycopg, section 7). The CLI was the
-    # missing half — an agent asked to inspect the store had no `psql` and
-    # could not answer, which is how this gap surfaced (2026-08-13).
+    # postgresql-client: the cards/fleet store IS PostgreSQL, and this image
+    # already gates the PYTHON driver (psycopg, section 7). The CLI is the
+    # other half — what a person, or an agent answering a question about the
+    # store, uses to look at it. Surfaced 2026-08-13: asked how the fleet DB
+    # is organised, an agent on this image had no psql and could answer only
+    # from general knowledge rather than from the database in front of it.
+    #
+    # Baked at :base — NOT left to scitex_dev.system_deps — for the SAME
+    # reason as the Chromium libs below: the system-deps SSoT only runs at
+    # the :scitex layer, where scitex-dev is installed, and EVERY agent runs
+    # on :base regardless of which scitex packages its overlay carries. It is
+    # ALSO declared in ``_system_deps.py`` so the :scitex layer gets it
+    # through the federation; the duplication is the layer boundary, not an
+    # oversight.
     #
     # Agent-useful, non-interactive CLI tool set:
     #   fd-find ripgrep bat eza tree jq git-delta postgresql-client (apt)

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -61,8 +61,13 @@ From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c5
     # symlinks in section 1b. ``tree`` is still source-built in section
     # 5 (apt ships an older 2.0.x; we want 2.1.3 features).
     #
+    # postgresql-client: the cards/fleet store IS PostgreSQL, and the image
+    # already gates the PYTHON driver (psycopg, section 7). The CLI was the
+    # missing half — an agent asked to inspect the store had no `psql` and
+    # could not answer, which is how this gap surfaced (2026-08-13).
+    #
     # Agent-useful, non-interactive CLI tool set:
-    #   fd-find ripgrep bat eza tree jq git-delta (apt)
+    #   fd-find ripgrep bat eza tree jq git-delta postgresql-client (apt)
     #   yq sd dust (sections 4a / 4b — not in apt)
     #   gdu — NOT from apt: Ubuntu's `gdu` package is the ambiguous
     #         "gnu-disk-usage" build with no machine-readable output;
@@ -124,6 +129,7 @@ From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c5
         procps lsof strace less \
         iputils-ping dnsutils netcat-openbsd \
         nano jq \
+        postgresql-client \
         fd-find ripgrep bat eza \
         git-delta \
         direnv \
@@ -731,6 +737,21 @@ try:
         )
 except Exception as _exc:
     failures.append("psycopg is not importable: %r" % (_exc,))
+
+# psql GATE — the CLI half of the same store. The driver above lets CODE reach
+# PostgreSQL; this lets a PERSON (or an agent answering a question about the
+# store) look at it. Gated rather than merely listed in apt because an apt line
+# is a request and this is the assertion that it arrived: 2026-08-13 an agent
+# asked to describe the fleet DB had no psql, no driver reachable either, and
+# could only answer from general knowledge.
+import shutil as _shutil
+
+if _shutil.which("psql") is None:
+    failures.append(
+        "psql not on PATH — the cards/fleet store is PostgreSQL and this image "
+        "gates its Python driver, so the CLI must be present too. Check that "
+        "postgresql-client survived the apt line in section 1."
+    )
 
 # The version string lies (uv's wheel cache is version-keyed and sac's
 # version does not advance per-commit). File content cannot lie — but the

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -61,23 +61,8 @@ From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c5
     # symlinks in section 1b. ``tree`` is still source-built in section
     # 5 (apt ships an older 2.0.x; we want 2.1.3 features).
     #
-    # postgresql-client: the cards/fleet store IS PostgreSQL, and this image
-    # already gates the PYTHON driver (psycopg, section 7). The CLI is the
-    # other half — what a person, or an agent answering a question about the
-    # store, uses to look at it. Surfaced 2026-08-13: asked how the fleet DB
-    # is organised, an agent on this image had no psql and could answer only
-    # from general knowledge rather than from the database in front of it.
-    #
-    # Baked at :base — NOT left to scitex_dev.system_deps — for the SAME
-    # reason as the Chromium libs below: the system-deps SSoT only runs at
-    # the :scitex layer, where scitex-dev is installed, and EVERY agent runs
-    # on :base regardless of which scitex packages its overlay carries. It is
-    # ALSO declared in ``_system_deps.py`` so the :scitex layer gets it
-    # through the federation; the duplication is the layer boundary, not an
-    # oversight.
-    #
     # Agent-useful, non-interactive CLI tool set:
-    #   fd-find ripgrep bat eza tree jq git-delta postgresql-client (apt)
+    #   fd-find ripgrep bat eza tree jq git-delta (apt)
     #   yq sd dust (sections 4a / 4b — not in apt)
     #   gdu — NOT from apt: Ubuntu's `gdu` package is the ambiguous
     #         "gnu-disk-usage" build with no machine-readable output;
@@ -139,7 +124,6 @@ From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c5
         procps lsof strace less \
         iputils-ping dnsutils netcat-openbsd \
         nano jq \
-        postgresql-client \
         fd-find ripgrep bat eza \
         git-delta \
         direnv \
@@ -748,20 +732,6 @@ try:
 except Exception as _exc:
     failures.append("psycopg is not importable: %r" % (_exc,))
 
-# psql GATE — the CLI half of the same store. The driver above lets CODE reach
-# PostgreSQL; this lets a PERSON (or an agent answering a question about the
-# store) look at it. Gated rather than merely listed in apt because an apt line
-# is a request and this is the assertion that it arrived: 2026-08-13 an agent
-# asked to describe the fleet DB had no psql, no driver reachable either, and
-# could only answer from general knowledge.
-import shutil as _shutil
-
-if _shutil.which("psql") is None:
-    failures.append(
-        "psql not on PATH — the cards/fleet store is PostgreSQL and this image "
-        "gates its Python driver, so the CLI must be present too. Check that "
-        "postgresql-client survived the apt line in section 1."
-    )
 
 # The version string lies (uv's wheel cache is version-keyed and sac's
 # version does not advance per-commit). File content cannot lie — but the


### PR DESCRIPTION
## What

Adds `postgresql-client` to the base image's apt set, and asserts `psql` in
`%post` next to the existing psycopg gate.

## Why

The image already gates **psycopg**, on the stated reasoning that the
cards/fleet store *is* PostgreSQL and a container without a usable driver
cannot touch the board. The same argument covers the CLI, and it was missing.

Surfaced 2026-08-13: the operator asked how the fleet database should be
organised (schema per leaf? ACL per table or per row?). The answer needed a
look at the live store — and this container had **no `psql`**, so the question
could only be answered from general PostgreSQL knowledge rather than from the
database in front of us.

## Why gate it, rather than just add the apt line

An apt line is a *request*; the gate is what makes its arrival a *fact*. That
distinction is exactly why the psycopg check exists — it was written after a
phantom namespace-package `psycopg/` directory made `import psycopg` succeed
while nothing was installed, and every agent then blamed the database for a
missing driver.

## Note

Driver and CLI are two halves of one capability: code reaches the store through
psycopg, a person (or an agent answering a question about it) reaches it through
psql. Shipping one without the other leaves the store legible only to programs.

Takes effect on the next base-image rebuild; nothing changes for running
containers until then.
