### PR TITLE
feat(openai-runtime): give an OpenAI-family agent a launch mode

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_runtime_select.py
+++ b/src/scitex_agent_container/_lifecycle/_runtime_select.py
@@ -4,6 +4,11 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 512-line module limit). ``lifecycle`` re-exports both names so existing
 ``lc._get_runtime`` / ``lc._fallback_workdir`` call sites are unchanged.
 
+``spec.provider`` semantics — the SDK-family selector (top-level,
+``AgentProvider = Literal["anthropic", "openai"]`` — see
+:mod:`config._provider_types`). When ``provider: openai``, the config
+selects the ``openai-agents`` SDK path regardless of ``spec.runtime``.
+
 ``spec.runtime`` semantics — operator directive 12870, lead a2a
 ``b58dd5d3b4d640d2a7f31f16c710e839``: the field was repurposed from
 container-engine selector to LAUNCH-MODE selector. Accepted values
@@ -32,24 +37,43 @@ log = logging.getLogger(__name__)
 def _get_runtime(config: AgentConfig):
     """Return the runtime adapter for the config's launch mode.
 
-    Branches on ``config.runtime`` (the launch-mode selector).
-    Default: an empty / unset ``runtime`` selects the interactive
-    in-apptainer ``tui`` runtime (operator directive 2026-06-15).
-    Back-compat: the legacy ``"apptainer"`` value (the old
-    container-engine selector) maps to ``"claude-agent-sdk"``
-    SILENTLY. The deprecation log for ``runtime='apptainer'`` fires
-    at the actual start path
-    (:func:`_lifecycle._start.start_agent`) — not here, because
-    every status / list / discovery walk also goes through
-    :func:`_get_runtime` and a per-call warning would (a) spam the
-    operator's logs and (b) contaminate CLI output streams
-    (CliRunner-captured commands like ``sac agents status --json``
-    end up with the warning text in ``result.output``).
-    Lead a2a ``f468a6d2e11443598103ed1672e2e40b``: emit the
-    deprecation when the runtime is actually USED to start
-    something, not on every read.
+    Branches on TWO axes:
+
+    1. ``config.provider`` — the SDK-family selector (top-level,
+       ``AgentProvider = Literal["anthropic", "openai"]``).
+       When ``provider: openai``, the ``openai-agents`` SDK path is
+       selected. This check runs FIRST so the provider always wins
+       over ``runtime`` — an OpenAI provider must use the OpenAI
+       runner, never Claude.
+    2. ``config.runtime`` — the launch-mode selector (operator
+       directive 12870). Default: an empty / unset ``runtime``
+       selects the interactive in-apptainer ``tui`` runtime
+       (operator directive 2026-06-15). Back-compat: the legacy
+       ``"apptainer"`` value (the old container-engine selector)
+       maps to ``"claude-agent-sdk"`` SILENTLY. The deprecation
+       log for ``runtime='apptainer'`` fires at the actual start
+       path (:func:`_lifecycle._start.start_agent`) — not here,
+       because every status / list / discovery walk also goes
+       through :func:`_get_runtime` and a per-call warning would
+       (a) spam the operator's logs and (b) contaminate CLI output
+       streams (CliRunner-captured commands like
+       ``sac agents status --json`` end up with the warning text
+       in ``result.output``). Lead a2a
+       ``f468a6d2e11443598103ed1672e2e40b``: emit the deprecation
+       when the runtime is actually USED to start something, not
+       on every read.
     """
-    runtime = config.runtime or ""
+    provider = getattr(config, "provider", None)
+    # If the config declares an OpenAI provider, always dispatch the
+    # OpenAI runtime — regardless of what runtime says. The provider
+    # field is the definitive SDK-family selector; runtime is just
+    # the launch-mode (tui / claude-agent-sdk) within the Claude family.
+    if provider == "openai":
+        from ..runtimes.openai_session import OpenAISessionRuntime
+
+        return OpenAISessionRuntime()
+
+    runtime = getattr(config, "runtime", "") or ""
     # TUI is the default launch mode (operator directive 2026-06-15,
     # post the SDK-pool cutoff): empty / unset → interactive in-apptainer
     # TUI. Explicit legacy values still map to the headless SDK runner so
@@ -66,7 +90,9 @@ def _get_runtime(config: AgentConfig):
         f"Unsupported runtime: {runtime!r}. "
         "spec.runtime must be 'tui' (default, interactive in-apptainer "
         "TUI), 'claude-agent-sdk' (headless SDK runner), or the "
-        "back-compat 'apptainer' (mapped to 'claude-agent-sdk')."
+        "back-compat 'apptainer' (mapped to 'claude-agent-sdk'). "
+        "For OpenAI agents, set spec.provider: openai instead of "
+        "spec.runtime."
     )
 
 

--- a/src/scitex_agent_container/_runners/openai_session.py
+++ b/src/scitex_agent_container/_runners/openai_session.py
@@ -58,6 +58,8 @@ __all__ = [
     "tool_spec_to_function_tool",
     "normalize_stream_event",
     "usage_as_dict",
+    "_parse_argv",
+    "main",
 ]
 
 _INSTALL_HINT = (
@@ -437,3 +439,162 @@ class OpenAISession:
             )
         except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
             pass
+
+
+# ---------------------------------------------------------------------------
+# CLI entry — mirrors the claude-session argument parser so the runtime
+# adapter's fixed argv lands here without ``ArgumentError`` on extra flags.
+# ---------------------------------------------------------------------------
+
+
+def _parse_argv(argv: list[str] | None = None) -> argparse.Namespace:
+    """Argparse mirror of the claude-session parser."""
+    import argparse as _argparse
+    from pathlib import Path as _Path
+
+    from ._session_state import DEFAULT_TICK_SECONDS
+
+    p = _argparse.ArgumentParser(
+        prog="python -m scitex_agent_container._runners.openai_session",
+        description="openai-session runner.",
+    )
+    p.add_argument("--name", required=True, help="Agent name (state-dir leaf).")
+    p.add_argument(
+        "--state-root",
+        type=_Path,
+        default=None,
+        help="Accepted for parity; OpenAI runner has no state directory.",  # no heartbeat/PID
+    )
+    p.add_argument(
+        "--tick-seconds",
+        type=float,
+        default=DEFAULT_TICK_SECONDS,
+        help="Accepted for parity; no heartbeat loop.",  # no daemon loop
+    )
+    p.add_argument(
+        "--mission",
+        type=str,
+        default=None,
+        help="Initial user prompt (first user message).",
+    )
+    p.add_argument(
+        "--resume-session-id",
+        type=str,
+        default=None,
+        help="Accepted for parity; maps to session_id on the state db.",  # maps to session_id
+    )
+    p.add_argument(
+        "--a2a-port",
+        type=int,
+        default=None,
+        help="Accepted for parity; no HTTP sidecar.",  # no HTTP server
+    )
+    p.add_argument(
+        "--a2a-host",
+        type=str,
+        default="127.0.0.1",
+        help="Accepted for parity; no a2a-port sidecar.",  # no HTTP server
+    )
+    p.add_argument(
+        "--a2a-card-yaml",
+        type=str,
+        default="",
+        help="Accepted for parity; no card publishing.",  # no HTTP server
+    )
+    p.add_argument(
+        "--channels",
+        action="append",
+        default=None,
+        metavar="CHANNEL",
+        help="Accepted for parity; channel wiring is claude-SDK-specific.",  # no SDK channel system
+    )
+    p.add_argument(
+        "--print-stream",
+        action="store_true",
+        help="Mirror assistant text to stdout.",
+    )
+    p.add_argument(
+        "--autonomous-enabled",
+        action="store_true",
+        help="Accepted for parity; no autonomous loop.",  # single-turn mission only
+    )
+    p.add_argument(
+        "--autonomous-drive-until",
+        type=str,
+        default="DONE",
+        help="Accepted for parity; no autonomous loop.",  # single-turn mission only
+    )
+    p.add_argument(
+        "--autonomous-max-turns",
+        type=int,
+        default=50,
+        help="Turn cap; forwarded to OpenAISession.max_turns.",
+    )
+    p.add_argument(
+        "--autonomous-kick-text",
+        type=str,
+        default="Continue. Print DONE when finished.",
+        help="Accepted for parity; no autonomous loop.",  # single-turn mission only
+    )
+    p.add_argument(
+        "--max-restarts",
+        type=int,
+        default=0,
+        help="Accepted for parity; no restart logic.",  # no supervisor loop
+    )
+    p.add_argument(
+        "--restart-backoff-s",
+        type=float,
+        default=1.0,
+        help="Accepted for parity; no restart logic.",  # no supervisor loop
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point — construct an :class:`OpenAISession`, run one
+    mission turn (if any), then tear down."""
+    import sys
+
+    args = _parse_argv(argv)
+
+    # BOOT ASSERTION — same contract as claude_session's main().
+    from .._maintenance._venv_dist_assertion import assert_venv_distributions_unique
+
+    assert_venv_distributions_unique(args.name)
+
+    session = OpenAISession(
+        args.name,
+        session_id=args.resume_session_id or args.name,
+        max_turns=args.autonomous_max_turns
+        if args.autonomous_enabled
+        else None,
+    )
+
+    async def _run() -> int:
+        print_stream = args.print_stream
+        await session.start()
+        try:
+            if args.mission:
+                async for event in session.send(
+                    Message(role="user", content=args.mission)
+                ):
+                    if print_stream and event.kind == "text_delta":
+                        sys.stdout.write(event.text)
+                        sys.stdout.flush()
+                    if event.kind == "result":
+                        return 0
+                    if event.kind == "error":
+                        print(f"error: {event.error}", file=sys.stderr)
+                        return 1
+                return 0
+            else:
+                return 0
+        finally:
+            await session.close()
+
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised by adapter
+    sys.exit(main())

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -37,6 +37,12 @@ from ._apptainer_quota_cache import (
 # ----------------------------------------------------------------------
 RUNNER_MODULE = "scitex_agent_container._runners.claude_session"
 
+# Runner module for the ``provider: openai`` path (scitex-todo
+# card ``openai-compat-2``; ``spec.provider: openai``). Dispatched
+# when the config's provider is ``"openai"``; otherwise the default
+# ``RUNNER_MODULE`` above (claude_session) is used.
+RUNNER_MODULE_OPENAI = "scitex_agent_container._runners.openai_session"
+
 # Quota-cache constants + resolver now live in _apptainer_quota_cache (this
 # file sat at the 512-line cap); imported below and re-exported via __all__ so
 # both historical import paths keep resolving.
@@ -419,7 +425,17 @@ def build_run_argv(
         )
     else:
         kind = getattr(config, "kind", "Agent")
-        module = RUNNER_MODULE_PROXY if kind == "AgentProxy" else RUNNER_MODULE
+        if kind == "AgentProxy":
+            module = RUNNER_MODULE_PROXY
+        else:
+            # Provider dispatch for pre-built runner_argv: same logic
+            # as build_inner_argv — openai → OpenAI runner, else Claude.
+            provider = getattr(config, "provider", None)
+            module = (
+                RUNNER_MODULE_OPENAI
+                if provider == "openai"
+                else RUNNER_MODULE
+            )
         inner_argv = [
             "/usr/bin/tini",
             "-s",

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -30,9 +30,16 @@ from ._apptainer_inner_argv_tui import (  # noqa: F401 (re-export)
 if TYPE_CHECKING:
     from ..config import AgentConfig
 
-# Runner-module dispatch by ``config.kind``. Kept here so the parent
-# orchestrator doesn't need to know either runner's module path.
+# Runner-module dispatch by ``config.kind`` and ``config.provider``.
+# Kept here so the parent orchestrator doesn't need to know either
+# runner's module path.
 RUNNER_MODULE_AGENT = "scitex_agent_container._runners.claude_session"
+
+# OpenAI provider runner module (scitex-todo card ``openai-compat-2``;
+# ``spec.provider: openai``). When the config's provider is ``"openai"``,
+# dispatches this module instead of ``RUNNER_MODULE_AGENT``.
+RUNNER_MODULE_OPENAI = "scitex_agent_container._runners.openai_session"
+
 RUNNER_MODULE_PROXY = "scitex_agent_container._runners.a2a_proxy"
 
 _TINI_PREFIX = ["/usr/bin/tini", "-s", "--", "python3", "-m"]
@@ -109,14 +116,15 @@ def build_inner_argv(
     tui_dev_channels: str | None = None,
     tui_settings: str | None = None,
 ) -> list[str]:
-    """Return the apptainer-inner argv. Dispatches on ``config.kind``.
+    """Return the apptainer-inner argv. Dispatches on ``config.kind``
+    and ``config.provider``.
 
     The argv is now ALWAYS wrapped in
     ``[/bin/bash, -lc, "<git-env-alias>; [set -e; <cmd1>; sleep N; <cmd2>;]
     exec <tini ...>"]`` — never returned bare. The first steps are the
     fixed, unconditional :data:`_GIT_ENV_ALIAS_STEPS` (see there); when
     ``spec.startup_commands`` is also non-empty those follow next, run as
-    container-internal shell BEFORE the claude SDK process starts. ``exec``
+    container-internal shell BEFORE the SDK process starts. ``exec``
     replaces bash with tini, keeping PID 1 clean. NOT a claude prompt — see
     ``spec.startup_prompts``.
 
@@ -135,6 +143,12 @@ def build_inner_argv(
     belt-and-suspenders (the flag is a no-op for the interactive TUI, which
     is why the file MUST be ``settings.json``, not ``settings.local.json``:
     there is no ``.local.json`` at user scope).
+
+    Provider dispatch: when ``config.provider == "openai"``, the inner
+    runner is ``RUNNER_MODULE_OPENAI`` instead of ``RUNNER_MODULE_AGENT``.
+    The argv tail (mission, a2a flags, etc.) is identical — the OpenAI
+    runner accepts the same CLI flags as the Claude runner (with legacy
+    flags silently ignored).
     """
     kind = getattr(config, "kind", "Agent")
     if tui:
@@ -148,9 +162,17 @@ def build_inner_argv(
     elif kind == "AgentProxy":
         runner_tail = _TINI_PREFIX + [RUNNER_MODULE_PROXY] + _proxy_runner_argv(config)
     else:
+        # Provider dispatch: ``provider: openai`` → the OpenAI runner;
+        # everything else (default "anthropic") → the Claude runner.
+        provider = getattr(config, "provider", None)
+        runner_module = (
+            RUNNER_MODULE_OPENAI
+            if provider == "openai"
+            else RUNNER_MODULE_AGENT
+        )
         runner_tail = (
             _TINI_PREFIX
-            + [RUNNER_MODULE_AGENT]
+            + [runner_module]
             + _agent_runner_argv(config, one_shot=one_shot)
         )
 
@@ -332,6 +354,7 @@ def _proxy_runner_argv(config: "AgentConfig") -> list[str]:
 
 __all__ = [
     "RUNNER_MODULE_AGENT",
+    "RUNNER_MODULE_OPENAI",
     "RUNNER_MODULE_PROXY",
     "build_inner_argv",
 ]

--- a/src/scitex_agent_container/runtimes/openai_session.py
+++ b/src/scitex_agent_container/runtimes/openai_session.py
@@ -1,0 +1,330 @@
+"""``openai-session`` runtime adapter — thin container wrapper.
+
+Mirrors :mod:`runtimes.claude_session` but targets the ``openai-agents``
+SDK path (scitex-todo card ``openai-compat-2``; ``spec.provider: openai``).
+
+Key differences from ClaudeSessionRuntime:
+  * No CLAUDE.md materialisation — there is no Claude SDK to discover
+    skills/hooks/settings from ``$HOME/.claude/``.
+  * No F-CS8 heavy-workdir warning — the workdir ``.claude/`` bloat
+    heuristic is Claude-SDK-specific.
+  * No ``_skills_boot_log`` — skills boot logging is Claude-specific.
+  * Still does: ``to_home`` deployment (``.env``, ``.mcp.json``,
+    ``settings.json``, etc.), same container isolation/binds/overlay,
+    same state-dir semantics.
+
+Everything else — the apptainer dispatch, the runtime contract
+(``RuntimeBase``), the container-runtime injection seam, the pid
+recording — is identical to the Claude path.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ..config import AgentConfig
+from ._to_home import deploy_to_home
+from .base import RuntimeBase
+
+__all__ = ["OpenAISessionRuntime"]
+
+
+def _spec_dir_for(config: AgentConfig) -> Path | None:
+    """Return the directory containing the agent's spec.yaml, or ``None``."""
+    cp = getattr(config, "config_path", "")
+    if not cp:
+        return None
+    return Path(cp).parent
+
+
+def _materialize_home_layouts(config: AgentConfig, home_dir: str) -> None:
+    """Materialize the agent's ``to_home/`` layout into ``home_dir``.
+
+    Mirrors :func:`_to_home_deployers._materialize_home_layouts` from
+    the Claude path verbatim — the ``to_home/`` tree (``.env``,
+    ``.mcp.json``, ``settings.json``, hooks, etc.) is provider-agnostic
+    and needed by every agent regardless of SDK family.
+
+    The legacy ``dot_claude/`` layout was removed (ADR-0006); a spec
+    that still ships a ``dot_claude/`` dir is a hard error pointing
+    at ``to_home/``.
+    """
+    spec_dir = _spec_dir_for(config)
+    if spec_dir is not None and (spec_dir / "dot_claude").is_dir():
+        raise RuntimeError(
+            f"Spec {getattr(config, 'config_path', '<unknown>')!r} ships a "
+            "legacy 'dot_claude/' dir next to spec.yaml. The dot_claude/ "
+            "layout was removed (see ADR-0006) — rename it to 'to_home/' "
+            "and move its contents to the $HOME-relative layout "
+            "(to_home/{CLAUDE.md,.mcp.json,.env,.claude/{hooks,skills}}). "
+            "Refusing to start with stale config."
+        )
+    deploy_to_home(config, home_dir)
+
+
+# 2026-05-13 docker/podman ripout: apptainer is the only accepted
+# runtime. Empty / unset ``spec.runtime`` is treated as ``apptainer``.
+_CONTAINER_ENGINES: tuple[str, ...] = ("apptainer",)
+
+
+def _container_runtime_for(config: AgentConfig):
+    """Return the apptainer container runtime, or None for an
+    unrecognised ``spec.runtime``.
+
+    The OpenAI path uses the same container dispatch as the Claude path:
+    ``apptainer exec`` into the SIF, with the inner command swapped to
+    ``python -m scitex_agent_container._runners.openai_session`` by
+    the apptainer argv builder (which branches on ``spec.provider``).
+    """
+    runtime = getattr(config, "runtime", "") or "apptainer"
+    # Both the legacy ``apptainer`` value and the current
+    # ``claude-agent-sdk`` selector dispatch the headless SDK runner via
+    # ``apptainer exec``. The OpenAI path uses the same container
+    # runtime — only the inner module differs.
+    if runtime in ("apptainer", "claude-agent-sdk"):
+        from ._apptainer_runtime import ApptainerContainerRuntime
+
+        return ApptainerContainerRuntime()
+    return None
+
+
+class OpenAISessionRuntime(RuntimeBase):
+    """Daemon-mode runtime backed by ``openai-agents``, dispatched
+    via apptainer. The host side never spawns a Python subprocess —
+    every ``start`` goes through ``apptainer exec`` (or equivalent).
+
+    Mirrors :class:`ClaudeSessionRuntime` — same isolation, binds,
+    overlay, to_home, state-dir behaviour — but the inner module
+    is ``scitex_agent_container._runners.openai_session`` instead
+    of ``claude_session``.
+
+    Key differences from the Claude path:
+      * No CLAUDE.md materialisation (no Claude SDK).
+      * No F-CS8 workdir-bloat warning (Claude-SDK-specific).
+      * No skills-boot logging (Claude-SDK-specific).
+      * Still does: ``to_home`` deployment, container dispatch,
+        state-dir management, pid recording.
+
+    ``container_runtime_for`` is an injection seam — defaults to the
+    module-level ``_container_runtime_for`` lookup. Tests pass a
+    callable that returns a fake container runtime so the dispatch
+    glue can be exercised without booting a real container.
+    """
+
+    def __init__(self, container_runtime_for=None):
+        self._container_runtime_for = container_runtime_for or _container_runtime_for
+
+    def _setup_workspace(self, config: AgentConfig) -> None:
+        """Materialise the agent's ``to_home/`` layout into the container
+        ``$HOME``.
+
+        ADR-0003 (D6/D7): the agent's container ``$HOME`` is bind-mounted
+        from ``runtime/<name>/home/``. We materialise ``to_home/`` there
+        so the container sees ``.env``, ``.mcp.json``, ``settings.json``,
+        hooks, etc.
+
+        Best-effort: skipped for stub configs that don't carry the full
+        AgentConfig surface (unit-test SimpleNamespace fixtures).
+        """
+        required_attrs = ("expanded_workdir", "skills", "claude", "env", "labels")
+        if not all(hasattr(config, a) for a in required_attrs):
+            return
+        home_dir = str(self._state_dir(config) / "home")
+        Path(home_dir).mkdir(parents=True, exist_ok=True)
+        _materialize_home_layouts(config, home_dir)
+        # Mirror the same tree into the overlay's upper home so it lands
+        # as part of the container filesystem (no-op for non-overlay specs).
+        from ._to_home_overlay import deploy_to_home_overlay
+
+        deploy_to_home_overlay(config)
+
+    def _cleanup_workspace(self, config: AgentConfig) -> None:
+        """No-op — the OpenAI path has no CLAUDE.md to scrub on stop."""
+        # No managed CLAUDE.md section to remove; the to_home tree
+        # is persistent and belongs to the agent's workspace, not
+        # sac's lifecycle.
+        pass
+
+    def start(
+        self,
+        config: AgentConfig,
+        no_preflight: bool = False,
+        force: bool = False,
+        dry_run: bool = False,
+        foreground: bool = False,
+        one_shot: bool = False,
+    ) -> bool:
+        """Spawn the container backing the agent.
+
+        Mirrors :meth:`ClaudeSessionRuntime.start` — same ``apptainer exec``
+        dispatch, same parameter contract. Only differs in:
+          * No CLAUDE.md setup.
+          * No F-CS8 warning.
+        """
+        # Operator directive 12870 (lead a2a b58dd5d3): emit the legacy
+        # ``runtime: apptainer`` deprecation HERE (real start path), not
+        # in ``_get_runtime`` (status / list / discovery walks).
+        from .._lifecycle._runtime_select import warn_if_legacy_apptainer_runtime
+
+        warn_if_legacy_apptainer_runtime(config)
+
+        container_rt = self._container_runtime_for(config)
+        if container_rt is None:
+            print(
+                f"error: OpenAISessionRuntime requires a container engine "
+                f"(spec.runtime: docker | podman). Got: "
+                f"{getattr(config, 'runtime', '<unset>')!r}.",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+
+        # to_home materialisation — .env, .mcp.json, settings.json, etc.
+        self._setup_workspace(config)
+
+        # No F-CS8 workdir-bloat check: the OpenAI SDK does not walk
+        # ``<workdir>/.claude/`` at session start, so heavy trees
+        # cannot cause silent discovery failures.
+
+        return container_rt.start(
+            config,
+            no_preflight=no_preflight,
+            force=force,
+            dry_run=dry_run,
+            foreground=foreground,
+            one_shot=one_shot,
+        )
+
+    def stop(self, config: AgentConfig) -> bool:
+        """Stop the container."""
+        container_rt = self._container_runtime_for(config)
+        if container_rt is None:
+            return False
+        return container_rt.stop(config)
+
+    def is_running(self, config: AgentConfig) -> bool:
+        container_rt = self._container_runtime_for(config)
+        if container_rt is None:
+            return False
+        return container_rt.is_running(config)
+
+    def agent_pid(self, config: AgentConfig) -> int | None:
+        """The container process pid (``RuntimeBase`` seam).
+
+        Delegates to the container runtime exactly as :meth:`is_running`
+        above does, so the pid recorded in ``instances.pid`` is the same
+        one this runtime's liveness verdict is keyed on — for apptainer,
+        the long-lived ``apptainer`` process.
+
+        ``None`` when the spec's runtime resolves to no container runtime
+        (unrecognised ``spec.runtime``) or the container runtime cannot
+        name a pid — honestly "unknown", never a fabricated value.
+        """
+        container_rt = self._container_runtime_for(config)
+        if container_rt is None:
+            return None
+        getter = getattr(container_rt, "agent_pid", None)
+        if not callable(getter):
+            return None
+        return getter(config)
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        """Prefer the rendered ``session.jsonl`` tail (host-side via
+        /state bind-mount). Fall through to ``docker logs --tail N``
+        when the transcript hasn't been written yet."""
+        container_rt = self._container_runtime_for(config)
+        if container_rt is None:
+            return ""
+        state_dir = self._state_dir(config)
+        rendered = _format_session_tail(state_dir, lines)
+        if rendered:
+            return rendered
+        return container_rt.logs(config, lines=lines)
+
+    def _state_dir(self, config: AgentConfig) -> Path:
+        """Per-agent state dir on the host: project-local if available,
+        else ``~/.scitex/agent-container/runtime/<name>/``.
+
+        Reuses the claude runner's state-dir resolver so both SDK
+        families land state in the same place (shared ``state.db``,
+        ``heartbeat.json``, etc.).
+        """
+        from .._runners import claude_session as _runner
+
+        return _runner.state_dir_for(config.name, root=_project_runtime_root(config))
+
+
+def _format_session_tail(state_dir, max_lines: int) -> str:
+    """Render the tail of ``session.jsonl`` as a compact human view.
+
+    Returns the empty string if the file is absent (caller falls back
+    to ``container_rt.logs``). Each record renders as a single line
+    keyed by type:
+
+      [user]      mission text
+      [assistant] streamed chunk
+      [result]    session=<sid>  in/out/cache totals
+      [error]     kind  detail
+      [user_echo] (verbatim repr trimmed in the runner)
+    """
+    import json as _json
+
+    transcript = state_dir / "session.jsonl"
+    if not transcript.is_file():
+        return ""
+    try:
+        with transcript.open(encoding="utf-8") as fh:
+            raw = fh.readlines()[-max_lines:]
+    except OSError:
+        return ""
+    out: list[str] = []
+    for line in raw:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = _json.loads(line)
+        except _json.JSONDecodeError:
+            continue
+        kind = rec.get("type", "?")
+        if kind == "user":
+            out.append(f"[user]      {rec.get('text', '')}")
+        elif kind == "assistant":
+            out.append(f"[assistant] {rec.get('text', '')}")
+        elif kind == "result":
+            usage = rec.get("usage") or {}
+            out.append(
+                f"[result]    session={rec.get('session_id', '?')}  "
+                f"in={usage.get('input_tokens', 0)} "
+                f"out={usage.get('output_tokens', 0)} "
+                f"cache_w={usage.get('cache_creation_input_tokens', 0)} "
+                f"cache_r={usage.get('cache_read_input_tokens', 0)}"
+            )
+        elif kind == "error":
+            out.append(f"[error]     {rec.get('kind', '?')}: {rec.get('detail', '')}")
+        elif kind == "user_echo":
+            out.append(f"[user_echo] {rec.get('raw', '')}")
+        else:
+            out.append(f"[{kind}]      {_json.dumps(rec, ensure_ascii=False)[:200]}")
+    return "\n".join(out)
+
+
+def _project_runtime_root(config: AgentConfig) -> "Path | None":
+    """If the agent's YAML lives under a project-scope
+    ``.scitex/agent-container/`` tree (a git repo with that subdir),
+    return the sibling ``runtime/`` so per-agent state lands inside
+    the same repo. Otherwise None.
+
+    In-repo test agents get in-repo state, keeping ``~/.scitex``
+    clean and letting CI snapshot transcripts as build artifacts.
+    """
+    src = getattr(config, "config_path", "") or ""
+    if not src:
+        return None
+    try:
+        from scitex_config._ecosystem import local_state
+    except Exception:  # stx-allow: fallback (reason: scitex-config optional; degrade to home-scope state)
+        return None
+    scope = local_state.find_project_scope("agent-container", start=Path(src).parent)
+    return (scope / "runtime") if scope is not None else None

--- a/tests/scitex_agent_container/_lifecycle/test__runtime_select.py
+++ b/tests/scitex_agent_container/_lifecycle/test__runtime_select.py
@@ -7,6 +7,10 @@ unset maps here) → the in-apptainer TUI runner; ``claude-agent-sdk`` →
 the headless SDK runner. Legacy ``apptainer`` maps to ``claude-agent-sdk``
 with a one-line deprecation log.
 
+scitex-todo card ``openai-compat-2``: when ``spec.provider: openai``,
+``_get_runtime`` returns ``OpenAISessionRuntime`` regardless of
+``spec.runtime``.
+
 STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — uses a tiny stub
 ``SimpleNamespace`` config (the existing test pattern for
 ``_get_runtime`` callers; the runtime selector reads ONE attribute).
@@ -24,6 +28,7 @@ from scitex_agent_container._lifecycle._runtime_select import (
     warn_if_legacy_apptainer_runtime,
 )
 from scitex_agent_container.runtimes.claude_session import ClaudeSessionRuntime
+from scitex_agent_container.runtimes.openai_session import OpenAISessionRuntime
 from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
 
 # ---------------------------------------------------------------------------
@@ -191,3 +196,60 @@ def test_get_runtime_rejects_unknown_value_names_accepted_set():
         raised = exc
     # Assert
     assert raised is not None and "claude-agent-sdk" in str(raised)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI provider — dispatches OpenAISessionRuntime (openai-compat-2)
+# ---------------------------------------------------------------------------
+
+
+def test_get_runtime_returns_openai_session_for_openai_provider():
+    # Arrange — spec.provider: openai selects the OpenAI SDK path
+    # regardless of spec.runtime.
+    config = SimpleNamespace(name="beta", runtime="", provider="openai")
+    # Act
+    rt = _get_runtime(config)
+    # Assert
+    assert isinstance(rt, OpenAISessionRuntime)
+
+
+def test_get_runtime_returns_openai_session_even_with_claude_runtime():
+    # Arrange — provider: openai WINS over runtime: claude-agent-sdk.
+    config = SimpleNamespace(name="gamma", runtime="claude-agent-sdk", provider="openai")
+    # Act
+    rt = _get_runtime(config)
+    # Assert
+    assert isinstance(rt, OpenAISessionRuntime)
+
+
+def test_get_runtime_returns_openai_session_even_with_apptainer_runtime():
+    # Arrange — provider: openai WINS over runtime: apptainer (back-compat).
+    config = SimpleNamespace(name="delta", runtime="apptainer", provider="openai")
+    # Act
+    rt = _get_runtime(config)
+    # Assert
+    assert isinstance(rt, OpenAISessionRuntime)
+
+
+# ---------------------------------------------------------------------------
+# Default (anthropic provider) — unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_get_runtime_returns_tui_session_for_default_provider():
+    # Arrange — default provider is "anthropic" (DEFAULT_AGENT_PROVIDER);
+    # with no provider set and runtime="", we still get TUI.
+    config = SimpleNamespace(name="epsilon")  # runtime defaults to "", provider defaults to None
+    # Act
+    rt = _get_runtime(config)
+    # Assert
+    assert isinstance(rt, TuiSessionRuntime)
+
+
+def test_get_runtime_returns_claude_session_for_anthropic_provider():
+    # Arrange — explicit provider: anthropic with runtime: claude-agent-sdk.
+    config = SimpleNamespace(name="zeta", runtime="claude-agent-sdk", provider="anthropic")
+    # Act
+    rt = _get_runtime(config)
+    # Assert
+    assert isinstance(rt, ClaudeSessionRuntime)


### PR DESCRIPTION
A spec could already say `provider: openai`, `a2a.handler: openai_session`, `OPENAI_BASE_URL` and `SAC_OPENAI_MODEL`. **None of it reached the launcher.**

Measured on grant-agent, whose spec says exactly that:

```
ps   -> python3 -m scitex_agent_container._runners.claude_session --name grant-agent
turn -> API Error 400 from POST /v1/messages    <- the ANTHROPIC endpoint
        "Input should be 'user' or 'assistant'", input: 'system'
```

That is Claude's SDK speaking Anthropic protocol at a vLLM server, which rejects a `system` role in `messages`. Not a model, auth or quota problem — the fields validated and did not run.

## Three sites made it so

1. `_lifecycle/_runtime_select.py::_get_runtime` branched only on `config.runtime`; both live values return a Claude runtime.
2. The runner module was a constant — `_apptainer_build_argv.RUNNER_MODULE`, repeated as `_apptainer_inner_argv.RUNNER_MODULE_AGENT`.
3. `_runners/openai_session.py` had no `main()`, so it could not be launched as `python -m` at all.

## What this adds

- an entrypoint on the runner (append-only; `OpenAISession` and `OpenAISessionError` untouched)
- `OpenAISessionRuntime` — same isolation, binds, overlay and to_home as the Claude path; only the inner module differs
- a provider branch in the selector and in both argv builders; the Claude constants keep their values and the OpenAI module name sits alongside

## Measured

`_runtime_select` tests: 16 passed.

Same subset on this branch and on origin/main in a **separate worktree** (not a stash — a stash would have changed the build):

| | failed | passed |
|---|---|---|
| origin/main | 15 | 4574 |
| this branch | 15 | 4574 |

Delta zero.

**Correction to an earlier revision of this description.** I first wrote that those 15 are tests which write real home config or leave shared state. That was a guess and it was wrong on both counts — the tests isolate correctly, redirecting `HOME` to `tmp_path` and reading config through `SCITEX_AGENT_CONTAINER_CONFIG`. The actual failing line is `FileNotFoundError: .../.bashrc`, because `cli_pkg/_main.py` shells out to the sibling binaries to generate completions and only *warns* when that fails; the reviewer's container had a broken `scitex-cards`, so the write was skipped. They are green in CI on this PR. Nothing to fix — the local red measured the environment, not the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)