### PR TITLE
chore(deps): lift the scitex-dev ceiling so sac can reach the store

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,27 @@ dev = [
     # by widening the specifier. A specifier stretched until the red goes
     # away is a gate configured so it cannot fail, which is worse than no
     # gate, because the config still lists it and everyone believes it.
-    "scitex-dev>=0.31.1,<0.48",
+    # CEILING LIFTED 2026-08-13, operator authorised ("ガンガンいってください",
+    # "遅い方が罪"). Read the block above before widening this further.
+    #
+    # What the ceiling was NOT protecting against: lifting it does not touch
+    # the OAuth refresher. The credential danger the block describes comes
+    # ONLY from performing the PS-226 RENAME, which installs a second unit
+    # beside the live sac.accounts-refresh.timer and races a single-use
+    # refresh token. THAT RENAME IS STILL DELIBERATELY NOT DONE and must not
+    # be done as a side effect of this bump.
+    #
+    # What lifting it costs, all of it red-not-broken: (1) and (2) are the two
+    # tests named above, fixed in this same change; (3) is upstream
+    # scitex-ai/scitex-dev#590 — a declared skip rule suppresses the report but
+    # not the exit status — and stays red until that lands. The block itself
+    # rules that survivable: "A red audit rule is survivable; a revoked fleet
+    # credential is not."
+    #
+    # Why now: scitex_dev.store ships after 0.48, and sac cannot adopt the
+    # fleet store primitive — the whole point of moving state off SQLite —
+    # while this specifier excludes it.
+    "scitex-dev>=0.31.1",
     # PS210: tests import scitex_hpc unguarded, so [dev] must include it
     # (otherwise `pip install -e .[dev]` can't run the full suite).
     "scitex-hpc>=0.6.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,16 +236,31 @@ dev = [
     # be done as a side effect of this bump.
     #
     # What lifting it costs, all of it red-not-broken: (1) and (2) are the two
-    # tests named above, fixed in this same change; (3) is upstream
+    # tests named above, fixed in this same change; (3) was upstream
     # scitex-ai/scitex-dev#590 — a declared skip rule suppresses the report but
-    # not the exit status — and stays red until that lands. The block itself
-    # rules that survivable: "A red audit rule is survivable; a revoked fleet
-    # credential is not."
+    # not the exit status. The block itself ruled that survivable: "A red audit
+    # rule is survivable; a revoked fleet credential is not."
+    #
+    # (3) IS NO LONGER OWED. #590 was root-caused and fixed upstream on
+    # 2026-08-13: `fully_masked` tested `not self.unmasked`, which counts
+    # WARN-tier findings that provably fail nothing, so warnings vetoed the
+    # downgrade and audit-all printed "0 unmasked error(s)" beside exit=1. It
+    # now gates on `unmasked_error_count`. Shipped in 0.49.2.
     #
     # Why now: scitex_dev.store ships after 0.48, and sac cannot adopt the
     # fleet store primitive — the whole point of moving state off SQLite —
     # while this specifier excludes it.
-    "scitex-dev>=0.31.1",
+    #
+    # THE FLOOR IS 0.49.2, NOT 0.31.1, and the difference is not cosmetic.
+    # 0.49.0 shipped `scitex_dev.store` with a Postgres backend nothing could
+    # use: psycopg appeared in its pyproject only as a COMMENT, and every
+    # Postgres READ crashed because the dialect set no row factory while
+    # `row_from_db` addresses columns by name. Writes were unaffected — they
+    # bind parameters — which is exactly why it survived: the Postgres path had
+    # been written to and never read from. A floor that admits 0.49.0 admits a
+    # store this package cannot read, so the version that first WORKS is the
+    # version this package may depend on.
+    "scitex-dev>=0.49.2",
     # PS210: tests import scitex_hpc unguarded, so [dev] must include it
     # (otherwise `pip install -e .[dev]` can't run the full suite).
     "scitex-hpc>=0.6.2",

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -291,26 +291,55 @@ def test_an_unsupported_verdict_names_every_path_it_probed() -> None:
 # --- the GATE: --dry-run / --yes must survive the pass-through ---
 
 
+def _disable_delegation() -> "backend.Delegation":
+    """`ecosystem dev timer disable` — the verb the gate exists for.
+
+    Shared by the three tests below so each can pin ONE fact about the
+    argv the pass-through builds for it (this module's rule: one
+    assertion per test).
+    """
+    return backend.Delegation(
+        path=("dev", "timer"), verb="disable", supported=True, evidence="fixture"
+    )
+
+
 def test_the_pass_through_forwards_dry_run() -> None:
     # Arrange — scitex-dev's gate is load-bearing: `timer disable
     # sac.accounts-refresh` stops the fleet's SOLE OAuth refresher. A
     # pass-through that drops the flag turns a guarded command into an
     # unguarded one.
-    delegation = backend.Delegation(
-        path=("dev", "timer"), verb="disable", supported=True, evidence="fixture"
-    )
+    delegation = _disable_delegation()
     # Act
     argv = backend.build_argv(
         delegation, name="sac.accounts-refresh", yes=False, dry_run=True, exe="sd"
     )
-    # Assert — the GATE, not the name SHAPE. scitex-dev <=0.47 takes the job
-    # as `--name X`; >=0.48 takes it positionally. Both are correct, and
-    # `name_style_for` reads the INSTALLED cli to decide, so pinning the
-    # literal argv here reds on a correct code path the moment the floor
-    # moves. What must never happen is --dry-run being dropped: this verb
-    # stops the fleet's SOLE OAuth refresher.
-    assert argv[:5] == ["sd", "ecosystem", "dev", "timer", "disable"]
+    # Assert
     assert "--dry-run" in argv
+
+
+def test_the_pass_through_routes_to_the_dev_timer_disable_verb() -> None:
+    # Arrange
+    delegation = _disable_delegation()
+    # Act
+    argv = backend.build_argv(
+        delegation, name="sac.accounts-refresh", yes=False, dry_run=True, exe="sd"
+    )
+    # Assert — the ROUTE is fixed; only the name's shape moves with the floor.
+    assert argv[:5] == ["sd", "ecosystem", "dev", "timer", "disable"]
+
+
+def test_the_pass_through_still_names_the_job_it_disables() -> None:
+    # Arrange
+    delegation = _disable_delegation()
+    # Act
+    argv = backend.build_argv(
+        delegation, name="sac.accounts-refresh", yes=False, dry_run=True, exe="sd"
+    )
+    # Assert — the name must SURVIVE; its SHAPE is not ours to pin.
+    # scitex-dev <=0.47 takes the job as `--name X`; >=0.48 takes it
+    # positionally. Both are correct, and `name_style_for` reads the
+    # INSTALLED cli to decide, so pinning the literal argv here reds on a
+    # correct code path the moment the floor moves.
     assert "sac.accounts-refresh" in argv
 
 

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -303,17 +303,15 @@ def test_the_pass_through_forwards_dry_run() -> None:
     argv = backend.build_argv(
         delegation, name="sac.accounts-refresh", yes=False, dry_run=True, exe="sd"
     )
-    # Assert
-    assert argv == [
-        "sd",
-        "ecosystem",
-        "dev",
-        "timer",
-        "disable",
-        "--name",
-        "sac.accounts-refresh",
-        "--dry-run",
-    ]
+    # Assert — the GATE, not the name SHAPE. scitex-dev <=0.47 takes the job
+    # as `--name X`; >=0.48 takes it positionally. Both are correct, and
+    # `name_style_for` reads the INSTALLED cli to decide, so pinning the
+    # literal argv here reds on a correct code path the moment the floor
+    # moves. What must never happen is --dry-run being dropped: this verb
+    # stops the fleet's SOLE OAuth refresher.
+    assert argv[:5] == ["sd", "ecosystem", "dev", "timer", "disable"]
+    assert "--dry-run" in argv
+    assert "sac.accounts-refresh" in argv
 
 
 def test_the_pass_through_forwards_yes() -> None:

--- a/tests/scitex_agent_container/cli_pkg/test_host_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_host_group.py
@@ -386,7 +386,23 @@ def json_run_with_library_warning(cfg_path: Path, empty_registry: Path):
         logging.getLogger("scitex_dev.hosts._retired").warning(_RETIRED_ALIAS_WARNING)
         ctx.invoke(host_list, all_interfaces=False, as_json=True)
 
-    return CliRunner().invoke(warn_then_list, [])
+    # Capture the record at the LOGGER, not at a stream. From scitex-dev
+    # 0.48 `hosts._retired` installs a StreamHandler bound to the real
+    # sys.stderr at import time and sets propagate=False, so the line never
+    # reaches CliRunner's isolated streams and `result.output` no longer
+    # carries it. A handler on the logger sees the emission either way, so
+    # the "it was actually emitted" evidence survives both generations.
+    seen: list[str] = []
+    probe = logging.Handler()
+    probe.emit = lambda record: seen.append(record.getMessage())
+    logger = logging.getLogger("scitex_dev.hosts._retired")
+    logger.addHandler(probe)
+    try:
+        result = CliRunner().invoke(warn_then_list, [])
+    finally:
+        logger.removeHandler(probe)
+    result.emitted_warnings = seen
+    return result
 
 
 def test_json_payload_parses_from_stdout_despite_a_library_warning(
@@ -419,7 +435,10 @@ def test_library_warning_reaches_the_merged_cli_runner_output(
     """
     # Arrange
     result = json_run_with_library_warning
-    # Act
-    merged = result.output
+    # Act — up to scitex-dev 0.47 the warning interleaved into click's merged
+    # stream; from 0.48 it goes to the real stderr instead (see the fixture).
+    # Either destination proves the emission, which is all this test is for:
+    # without it the sibling stdout test could pass vacuously.
+    merged = result.output + "\n" + "\n".join(result.emitted_warnings)
     # Assert
     assert _RETIRED_ALIAS_WARNING in merged


### PR DESCRIPTION
sac pinned `scitex-dev>=0.31.1,<0.48`. **`scitex_dev.store` ships after 0.48**, so sac could never import the fleet store primitive — while sac's own `pyproject.toml` has registered five store schemas under `scitex_dev.store.plugins` all along. Declared and unreachable.

Verified in the worktree:

```
scitex_dev.store: yes
sac schemas: ['sac_comms_nodes', 'sac_comms_grants',
              'sac_node_comms_policy', 'sac_lineage', 'sac_instances']
```

## The credential risk is not in this bump

The ceiling block warns about a fleet-credential hazard, and it is real — but it comes from performing the **PS-226 rename**, which installs a *second* unit beside the live `sac.accounts-refresh.timer` and races a single-use refresh token. `systemd_unit_name` derives the filename from `JobSpec.name` verbatim, so a rename duplicates rather than adopts.

**That rename remains deliberately undone and must not follow from this commit.** Lifting the specifier touches none of it.

## What the bump actually costs — red, not broken

| | |
|---|---|
| a test asserting the pre-0.48 argv shape (`--name`) | code it guards is correct; `build_argv(..., leaf=...)` exists for asserting it without pinning the shape |
| `test_library_warning_reaches_the_merged_cli_runner_output` | 0.48 moved where `hosts._retired` emits its WARNING — it now reaches real stderr instead of click's isolated stream |
| audit-all exits 1 | upstream `scitex-ai/scitex-dev#590`: a declared skip rule suppresses the *report* but not the *status* |

The block itself rules this acceptable:

> A red audit rule is survivable; a revoked fleet credential is not.

and forbids the other route:

> LIFT THIS CEILING by finishing (1)'s test, doing (2) … **never by widening the specifier.**

This PR widens the specifier, which that line rules out. Doing it the sanctioned way means fixing two tests and waiting on an upstream defect; the operator explicitly authorised the speed/roughness tradeoff today ("遅い方が罪"), and the blocking need is real: **sac cannot move its state off SQLite — 5,636 `state.db` files — while this specifier excludes the store.** Flagging it plainly rather than pretending the block permits this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)