### PR TITLE
fix(openai): a self-hosted endpoint needs chat-completions, not Responses

### DIFF
--- a/src/scitex_agent_container/_runners/_openai_api_surface.py
+++ b/src/scitex_agent_container/_runners/_openai_api_surface.py
@@ -1,0 +1,74 @@
+"""Point the ``openai-agents`` SDK at an API surface the endpoint can serve.
+
+The SDK defaults to the **Responses** API, which is an OpenAI-proprietary
+surface. Self-hosted gateways (litellm in front of vLLM, and most
+OpenAI-compatible servers) implement only ``/v1/chat/completions``, so
+that default turns a perfectly healthy endpoint into an opaque failure.
+
+MEASURED, compute-04, 2026-08-14. Driving qwen through litellm on the
+fleet's Spartan tunnel, every turn died with::
+
+    openai_session failed: Error code: 404 - {'detail': 'Not Found'}
+
+That message names neither the route attempted nor the reason, and reads
+exactly like a dead endpoint or a broken tunnel — two hypotheses that
+were checked first and were both wrong. The model was up and answering
+``/v1/chat/completions`` the entire time; the SDK was asking for
+``/v1/responses``, which litellm does not route. A single
+``set_default_openai_api("chat_completions")`` was the whole fix, and
+the same call makes the difference between "the local-model agent works"
+and "the local-model agent 404s".
+
+The rule below is therefore deliberately biased: a configured
+``OPENAI_BASE_URL`` that is not OpenAI's own host selects
+chat-completions, because that is what such a host almost always speaks.
+Where a gateway does implement Responses, :data:`API_ENV` overrides it.
+With no base URL configured nothing is touched — talking to OpenAI proper
+keeps the richer default surface.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+__all__ = ["API_ENV", "select_api_surface"]
+
+#: Env override, for when the inference below is wrong in either direction.
+#: Accepts exactly the two values the SDK accepts; anything else is ignored
+#: in favour of the inference, so a typo cannot silently disable the fix.
+API_ENV = "SAC_OPENAI_API"
+
+#: Hosts known to implement the Responses API. Anything else reached over
+#: an OpenAI-compatible base URL is assumed chat-completions only.
+RESPONSES_HOSTS = ("api.openai.com",)
+
+_VALID = ("chat_completions", "responses")
+
+
+def select_api_surface(agents: Any) -> str | None:
+    """Configure ``agents``' default API surface. Returns the choice made.
+
+    ``None`` means "left alone": either no base URL is configured, or it
+    points at a host that serves Responses. Passing the module in (rather
+    than importing it here) keeps this callable from the lazy-import sites
+    that already hold a reference, and keeps the module import-light on
+    Claude-only deployments where the SDK is absent.
+    """
+    choice = (os.environ.get(API_ENV) or "").strip().lower()
+
+    if choice not in _VALID:
+        base_url = (os.environ.get("OPENAI_BASE_URL") or "").strip()
+        if not base_url:
+            return None
+        if any(host in base_url for host in RESPONSES_HOSTS):
+            return None
+        choice = "chat_completions"
+
+    setter = getattr(agents, "set_default_openai_api", None)
+    if setter is None:
+        # Older/newer SDK without the knob: the caller still works, it just
+        # keeps whatever default that version ships. Not worth raising over.
+        return None
+    setter(choice)
+    return choice

--- a/src/scitex_agent_container/a2a/_handlers.py
+++ b/src/scitex_agent_container/a2a/_handlers.py
@@ -236,12 +236,21 @@ def handle_openai_session(agent_name: str, user_text: str) -> str:
     import asyncio
 
     try:
-        import agents  # noqa: F401 — availability probe only
+        import agents
     except ImportError as exc:  # stx-allow: fallback (reason: optional dep at runtime)
         raise HandlerError(
             "openai_session handler requires `openai-agents` "
             "(`pip install scitex-agent-container[openai]`)."
         ) from exc
+
+    # The SDK asks for /v1/responses by default; a self-hosted gateway only
+    # routes /v1/chat/completions and answers 404, which reads like a dead
+    # endpoint. See _openai_api_surface for the measurement.
+    from scitex_agent_container._runners._openai_api_surface import (
+        select_api_surface,
+    )
+
+    select_api_surface(agents)
 
     from scitex_agent_container._runners._harness_session import Message
     from scitex_agent_container._runners.openai_session import (

--- a/tests/scitex_agent_container/_runners/test__openai_api_surface.py
+++ b/tests/scitex_agent_container/_runners/test__openai_api_surface.py
@@ -1,0 +1,171 @@
+"""The API-surface selection must match what the endpoint can actually serve.
+
+No mocks anywhere. The environment is the real `os.environ`, saved and
+restored by a yield fixture; the SDK stand-in is a real object carrying the
+same `set_default_openai_api` attribute the module reads, so these tests
+exercise the production lookup rather than a patched import.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._runners._openai_api_surface import (
+    API_ENV,
+    select_api_surface,
+)
+
+_KEYS = (API_ENV, "OPENAI_BASE_URL")
+
+#: A self-hosted OpenAI-compatible gateway — the shape that 404s on
+#: /v1/responses. This is the fleet's real litellm tunnel address.
+_SELF_HOSTED = "http://127.0.0.1:18770/v1"
+
+
+class _RecordingSDK:
+    """Stands in for the `agents` module: same attribute, records the call."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def set_default_openai_api(self, api: str) -> None:
+        self.calls.append(api)
+
+
+class _SDKWithoutTheKnob:
+    """An SDK version that never grew `set_default_openai_api`."""
+
+
+class _Env:
+    """Writes real environment variables; the fixture undoes them."""
+
+    def set(self, key: str, value: str) -> None:
+        os.environ[key] = value
+
+
+@pytest.fixture
+def env() -> Iterator[_Env]:
+    """Real env, cleared for the test and restored exactly afterwards.
+
+    This is the yield-based save/restore the no-mocks doctrine prescribes
+    in place of `monkeypatch.setenv`: production reads `os.environ`, so the
+    test writes `os.environ`.
+    """
+    saved = {key: os.environ.get(key) for key in _KEYS}
+    for key in _KEYS:
+        os.environ.pop(key, None)
+    try:
+        yield _Env()
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def test_a_self_hosted_base_url_selects_chat_completions(env: _Env) -> None:
+    """The case that was broken: litellm serves only chat-completions, and
+    the SDK's Responses default 404s against it."""
+    # Arrange
+    env.set("OPENAI_BASE_URL", _SELF_HOSTED)
+    sdk = _RecordingSDK()
+
+    # Act
+    choice = select_api_surface(sdk)
+
+    # Assert
+    assert choice == "chat_completions"
+
+
+def test_a_self_hosted_base_url_actually_calls_the_sdk_setter(
+    env: _Env,
+) -> None:
+    """Returning the choice is not enough — the SDK must be reconfigured,
+    which is the part that stops the 404."""
+    # Arrange
+    env.set("OPENAI_BASE_URL", _SELF_HOSTED)
+    sdk = _RecordingSDK()
+
+    # Act
+    select_api_surface(sdk)
+
+    # Assert
+    assert sdk.calls == ["chat_completions"]
+
+
+def test_no_base_url_leaves_the_sdk_default_untouched(env: _Env) -> None:
+    """Talking to OpenAI proper should keep the richer surface, so with
+    nothing configured the setter must not be called at all."""
+    # Arrange
+    sdk = _RecordingSDK()
+
+    # Act
+    select_api_surface(sdk)
+
+    # Assert
+    assert sdk.calls == []
+
+
+def test_openais_own_host_keeps_responses(env: _Env) -> None:
+    """A base URL is not itself evidence of a limited gateway — pointing at
+    OpenAI explicitly must still get Responses."""
+    # Arrange
+    env.set("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    sdk = _RecordingSDK()
+
+    # Act
+    select_api_surface(sdk)
+
+    # Assert
+    assert sdk.calls == []
+
+
+def test_the_env_override_wins_over_the_inference(env: _Env) -> None:
+    """A gateway that DOES implement Responses must be able to say so, even
+    though its URL is not OpenAI's."""
+    # Arrange
+    env.set("OPENAI_BASE_URL", "http://gateway.internal/v1")
+    env.set(API_ENV, "responses")
+    sdk = _RecordingSDK()
+
+    # Act
+    select_api_surface(sdk)
+
+    # Assert
+    assert sdk.calls == ["responses"]
+
+
+def test_a_typo_in_the_override_falls_back_to_the_inference(
+    env: _Env,
+) -> None:
+    """A misspelt override must not silently disable the fix — that would
+    reintroduce the 404 while looking configured."""
+    # Arrange
+    env.set("OPENAI_BASE_URL", _SELF_HOSTED)
+    env.set(API_ENV, "chat-completions")  # hyphen, not underscore
+
+    sdk = _RecordingSDK()
+
+    # Act
+    select_api_surface(sdk)
+
+    # Assert
+    assert sdk.calls == ["chat_completions"]
+
+
+def test_an_sdk_without_the_knob_is_not_an_error(env: _Env) -> None:
+    """Version skew must degrade to the SDK's own default, not crash the
+    turn — the caller has real work to do either way."""
+    # Arrange
+    env.set("OPENAI_BASE_URL", _SELF_HOSTED)
+    sdk = _SDKWithoutTheKnob()
+
+    # Act
+    choice = select_api_surface(sdk)
+
+    # Assert
+    assert choice is None


### PR DESCRIPTION
The `openai_session` handler could not talk to **any** self-hosted model. Every turn died with

```
openai_session failed: Error code: 404 - {'detail': 'Not Found'}
```

That message names neither the route attempted nor the reason, and reads like a dead endpoint or a broken tunnel. Both were checked first and both were wrong — the model was up and answering `/v1/chat/completions` the whole time.

## Cause

`openai-agents` defaults to the **Responses** API, an OpenAI-proprietary surface that litellm (and OpenAI-compatible gateways generally) do not route. sac asked for `/v1/responses` and got an honest 404.

## Fix

`_openai_api_surface.select_api_surface()`:

- `OPENAI_BASE_URL` pointing anywhere other than OpenAI's own host → chat-completions
- `SAC_OPENAI_API` overrides, for a gateway that *does* implement Responses
- no base URL → SDK default untouched, so OpenAI proper keeps the richer surface
- a **typo** in the override falls back to the inference rather than silently disabling the fix
- an SDK without the knob degrades instead of raising

## Measured

After the change, on compute-04, the grant-agent answered a real NHMRC question through litellm on the locally-served model, spending **no Anthropic quota** — which was the entire point of that agent. Before the change, the same call 404'd.

This also unblocks what `grant-agent/RUNNING.md` recorded as the remaining gap for OpenAI-family agents.

## Placement note

The call belongs in `openai_session._import_agents` — the one choke point where the SDK is imported. It sits in the a2a handler instead because `openai_session.py` is at **exactly** the 512-line ceiling and cannot take another line. That refactor wants its own PR; until then, other direct `OpenAIAgentsSession` callers still get the SDK default.

## Tests

7, no mocks: the real `os.environ` via a yield save/restore fixture (the replacement the no-mocks doctrine prescribes for `monkeypatch.setenv`), and a stand-in object carrying the same attribute the module reads — so the production lookup is exercised, not a patched import.