### PR TITLE
fix(accounts): refresh-quota-cache could never report, so quota went stale

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_refresh_quota_cache.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh_quota_cache.py
@@ -89,7 +89,7 @@ def account_refresh_quota_cache(cache_path: str | None, as_json: bool) -> None:
             err=True,
         )
     else:
-        from .._helpers import system_msg
+        from ._helpers import system_msg
 
         results = result["results"]
         if not results:

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_quota_cache_imports.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_quota_cache_imports.py
@@ -1,0 +1,79 @@
+"""`accounts refresh-quota-cache` must be able to reach its console helper.
+
+The command imported `from .._helpers import system_msg`. From a module that
+already lives in `cli_pkg/`, `..` is the PACKAGE ROOT, where no `_helpers`
+exists — the helper is at `cli_pkg/_helpers/`. So the command raised
+
+    ModuleNotFoundError: No module named 'scitex_agent_container._helpers'
+
+WHY IT SURVIVED, and why this test is shaped the way it is: the bad import
+sits INSIDE a function body, on the branch taken only when accounts ARE
+stored. Importing the module never executes it, so an import-only test passes
+against the broken code — I wrote that test first and it did exactly that.
+The only test that catches this must actually REACH the branch, which means a
+HOME with at least one stored account.
+
+Consequence, measured on compute-04 2026-08-14: the usage cache could never be
+refreshed, so `sac accounts list` kept serving a stale figure —
+`ywatanabe-scitex-ai` showed 35% used while the account was at 92%. The fleet
+believed it had most of a week's capacity that did not exist.
+
+No mocks: a real temporary HOME with real files on disk, and the real Click
+command invoked end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._account_refresh_quota_cache import (
+    account_refresh_quota_cache,
+)
+
+
+@pytest.fixture
+def home_with_one_account(tmp_path: Path) -> Iterator[Path]:
+    """A real HOME holding one stored account, restored afterwards.
+
+    `os.environ` is written and put back by hand — the no-mocks rule bans
+    `monkeypatch`, and production reads the real environment.
+    """
+    saved = os.environ.get("HOME")
+    account = tmp_path / ".scitex" / "agent-container" / "accounts" / "acct-under-test"
+    account.mkdir(parents=True)
+    # Shape-valid but non-live: enough for the walk to find an account, so the
+    # command reaches the reporting branch. The fetch itself is expected to
+    # fail against it, which is fine — this asserts the branch RUNS.
+    (account / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": "not-a-live-token"}}),
+        encoding="utf-8",
+    )
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def test_the_reporting_branch_runs_without_a_missing_module_error(
+    home_with_one_account: Path,
+) -> None:
+    """With an account stored, the command takes the branch that imports the
+    console helper. A wrong relative level raises ModuleNotFoundError here."""
+    # Arrange
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(account_refresh_quota_cache, [])
+
+    # Assert
+    assert not isinstance(result.exception, ModuleNotFoundError), result.output


### PR DESCRIPTION
`sac accounts refresh-quota-cache` imported `from .._helpers import system_msg`. From a module already inside `cli_pkg/`, `..` is the package **root**, which has no `_helpers` — the helper lives at `cli_pkg/_helpers/`:

```
ModuleNotFoundError: No module named 'scitex_agent_container._helpers'
```

## Why it survived

The import sits **inside a function body**, on the branch reached only when accounts ARE stored. A host with none takes the other branch, exits 0, and looks healthy. So the failing path was the one that mattered, and the passing path was the one that got exercised.

## Measured consequence (compute-04, 2026-08-14)

The per-account usage cache could not be refreshed, so `accounts list` kept serving a stale figure:

| account | displayed (stale cache) | actual (fresh credential, cache cleared) |
|---|---|---|
| ywata1989-gmail-com | 7d 35% | 7d 35% |
| **ywatanabe-scitex-ai** | **7d 35%** | **7d 92%** |

The operator reported the account was near its weekly limit and the tool disagreed — he was right. The fleet believed it held most of a week of capacity that did not exist, which is precisely the number a scheduler acts on.

## Scope

The sibling `from .._helpers` imports under `cli_pkg/lifecycle/` are **correct** — they sit one level deeper, so `..` resolves to `cli_pkg`. Only this one was wrong.

## Test

It drives the real Click command against a real temporary HOME holding one stored account, because that is the only way to reach the branch — **an import-only test passes against the broken code** (I wrote that first and it did exactly that, which is why it isn't what shipped). No mocks: real files via `tmp_path`, real `os.environ` saved and restored by hand.

Verified both directions: passes on the fix, and fails with the original `ModuleNotFoundError` when the import is reverted.