### PR TITLE
fix(restart): stop and restart reported success four times over an untouched process

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_instances.py
+++ b/src/scitex_agent_container/_lifecycle/_instances.py
@@ -84,6 +84,47 @@ def _runtime_pid(config: AgentConfig, runtime: Any) -> int | None:
     return pid
 
 
+def _runtime_session_name(config: AgentConfig, runtime: Any) -> str | None:
+    """Resolve the multiplexer session the runtime just launched into.
+
+    Asks the runtime itself (:meth:`runtimes.base.RuntimeBase.session_name`)
+    rather than re-deriving the name from a convention, so the string
+    landing in ``instances.screen`` is THE SAME one the runtime passed to
+    ``tmux new-session -s`` — a re-derivation is free to drift from what
+    was actually created, and a drifted name probes an empty answer that
+    reads exactly like a dead agent.
+
+    Why the column must be filled at all: ``screen`` is the only column in
+    ``instances`` naming something the OS can be asked about independently
+    of sac's own bookkeeping. Nothing wrote it, so every "did this agent
+    cycle?" question could only be answered from the rows sac itself had
+    just written — an echo, not evidence. MEASURED 2026-08-14 on
+    scitex-compute-04: three ``instances`` rows for one agent, all with
+    ``screen`` NULL and pids matching no live process, while the ONE real
+    tmux session (``tui-scitex-agent-container``) had been alive since the
+    previous day. ``sac agents stop`` / ``restart`` reported success over
+    it every time.
+
+    Returns ``None`` (honestly "this runtime has no session to name") for
+    a runtime without the seam, a runtime that has no multiplexer at all
+    (SDK / apptainer / docker), or a probe that failed. ``None`` is SAFE
+    by construction: the restart postcondition reads a NULL ``screen`` as
+    "cannot verify" rather than as "verified", so an absent name costs an
+    abstention — whereas a GUESSED name would buy a false verification,
+    which is the very failure this exists to kill.
+    """
+    getter = getattr(runtime, "session_name", None)
+    if not callable(getter):
+        return None
+    try:
+        session = getter(config)
+    except Exception:  # stx-allow: fallback (reason: a session-name probe hiccup must never block an agent start; NULL is the honest "unknown" and downstream reads it as "cannot verify" — see docstring)
+        return None
+    if not isinstance(session, str) or not session.strip():
+        return None
+    return session
+
+
 def _state_dir_for(config: AgentConfig, runtime: Any):
     """Per-agent runtime state dir, via the runtime's own resolver.
 
@@ -170,10 +211,20 @@ def record_local_instance(
     # ``os.kill``, so a peer's pid could collide with an unrelated local
     # process and vouch for a dead agent as alive). Those correctly stay
     # NULL.
+    #
+    # ``screen`` is the same story one column over: the runtime names the
+    # multiplexer session it just created (see
+    # :func:`_runtime_session_name`), so the row carries a handle the OS
+    # can be asked about WITHOUT re-reading sac's own bookkeeping. The
+    # three remote call sites leave it NULL for the same reason they leave
+    # ``pid`` NULL — a peer's tmux session is not in this host's namespace,
+    # so a name recorded here could only ever be probed against the wrong
+    # server.
     instance_id = record_instance_start(
         name=config.name,
         host=host,
         pid=_runtime_pid(config, runtime),
+        screen=_runtime_session_name(config, runtime),
         a2a_port=a2a_port,
         bound_port=a2a_port,
         remote=False,

--- a/src/scitex_agent_container/_runners/_tmux/_tmux_probe.py
+++ b/src/scitex_agent_container/_runners/_tmux/_tmux_probe.py
@@ -127,10 +127,58 @@ def list_sessions_activity_detailed(
 
     Never raises.
     """
+    return _list_sessions_field(
+        "#{session_activity}", timeout_s=timeout_s, socket_name=socket_name
+    )
+
+
+def list_sessions_created(
+    *, timeout_s: float = BATCH_PROBE_TIMEOUT_S, socket_name: str | None = None
+) -> dict[str, int] | None:
+    """Return ``{session_name: created_epoch}`` for EVERY session, in ONE probe.
+
+    The BIRTHDAY of each session, where :func:`list_sessions_activity`
+    returns its last heartbeat. Same one-subprocess shape, same
+    dict/``{}``/``None`` contract (see that function) — only the tmux
+    format field differs.
+
+    WHY A SECOND FIELD IS NEEDED, rather than reusing ``session_activity``:
+    the question "did this agent's session CYCLE?" needs a stamp that is
+    CONSTANT for the life of one session and DIFFERENT for the next one.
+    ``session_activity`` is neither — tmux advances it on any pane I/O, so
+    an untouched session's stamp moves anyway and would read as a cycle
+    (a false verification), while a freshly-created idle session can share
+    the previous one's stamp to the second. ``session_created`` is set once
+    at ``tmux new-session`` and never moves again, so comparing it across a
+    restart answers exactly the question asked: same birthday means the
+    SAME session survived, and sac never touched the process.
+
+    Never raises.
+    """
+    return _list_sessions_field(
+        "#{session_created}", timeout_s=timeout_s, socket_name=socket_name
+    )[0]
+
+
+def _list_sessions_field(
+    field: str,
+    *,
+    timeout_s: float = BATCH_PROBE_TIMEOUT_S,
+    socket_name: str | None = None,
+) -> tuple[dict[str, int] | None, bool | None]:
+    r"""One ``tmux list-sessions -F`` reading of ``#{session_name}\t<field>``.
+
+    The shared body behind :func:`list_sessions_activity_detailed` and
+    :func:`list_sessions_created`: ONE place that knows how to spawn the
+    probe, how to tell "no server" from "wedged", and how to parse the
+    rows — so the two callers can never drift into disagreeing about what
+    an empty answer means. ``field`` must be an integer-valued tmux format
+    (unparseable rows are dropped, exactly as before).
+    """
     argv = ["tmux"]
     if socket_name:
         argv += ["-L", socket_name]
-    argv += ["list-sessions", "-F", "#{session_name}\t#{session_activity}"]
+    argv += ["list-sessions", "-F", f"#{{session_name}}\t{field}"]
     try:
         result = subprocess.run(
             argv, capture_output=True, text=True, timeout=timeout_s

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
@@ -59,7 +59,11 @@ from ._restart_remote import (  # noqa: F401
     log_restart_decision,
     must_broker_to_host,
 )
-from ._restart_verify import read_run_identity, verify_cycled  # noqa: F401
+from ._restart_verify import (  # noqa: F401
+    read_run_identity,
+    read_session_identity,
+    verify_cycled,
+)
 from ._selection import (
     _enumerate_fleet,
     _enumerate_running,
@@ -190,13 +194,29 @@ def _restart_locally(name: str, *, as_json: bool) -> tuple[dict, bool]:
     # reads the AGENT: a restart that changed nothing must not report
     # success no matter what the call returned (P0 2026-07-20 — an
     # in-container restart printed green over an untouched process).
+    #
+    # BOTH witnesses are captured BEFORE the call, because both are
+    # destroyed by it: ``agent_restart`` rewrites the marker and (when it
+    # really works) replaces the tmux session. The session reading is the
+    # one that makes this a check at all — the marker is written by the
+    # start path we are checking, so on its own it can only ever agree
+    # with itself (P0 2026-08-14, scitex-compute-04: "verified: ... is a
+    # NEW run" printed over a tmux session alive and untouched since the
+    # previous day).
     before = read_run_identity(name)
+    session_before = read_session_identity(name)
     _result = agent_restart(name)
     restarted = _result is not False
     if outcome_kind(_result) == KIND_ALREADY_RUNNING:
         restarted = False
         no_op_reason = KIND_ALREADY_RUNNING
-    verdict = verify_cycled(name, before, read_run_identity(name))
+    verdict = verify_cycled(
+        name,
+        before,
+        read_run_identity(name),
+        session_before=session_before,
+        session_after=read_session_identity(name),
+    )
     if verdict.verified is False:
         # DEFINITIVE: we held the before-evidence and the run did not
         # change (or vanished). Veto the success. ``verified is None``
@@ -227,7 +247,11 @@ def _print_local_outcome(name, restarted, no_op_reason, verdict) -> None:
     """Console rendering for a locally-performed restart (no JSON here)."""
     if restarted:
         console.print(f"[green]Agent '{name}' restarted[/green]")
-        console.print(f"[dim]verified: {verdict.reason}[/dim]")
+        # Only a True verdict may be labelled "verified". A None verdict
+        # is an ABSTENTION, and printing it under that word is how an
+        # unchecked restart came to read as a checked one.
+        label = "verified" if verdict.verified else "NOT verified"
+        console.print(f"[dim]{label}: {verdict.reason}[/dim]")
         return
     if no_op_reason == _NOT_CYCLED:
         console.print(f"[red]Agent '{name}' NOT restarted — {verdict.reason}[/red]")

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart_verify.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart_verify.py
@@ -20,17 +20,51 @@ IDENTITY-OF-RUN
 It therefore names THE RUN, not the agent: a cycled agent has a new one,
 an agent that never cycled has the old one, and a stopped agent has none.
 
+THE LEDGER IS NECESSARY, NEVER SUFFICIENT
+-----------------------------------------
+
+The marker above is written by the same start path whose work we are
+checking, so on its own it is not evidence — it is an ECHO. Reading it
+alone is how this module's own contract got broken: MEASURED 2026-08-14
+on scitex-compute-04, ``sac agents restart`` printed ``verified: agent
+'scitex-agent-container' is a NEW run (c06d2fec-… -> 67068008-…)`` while
+the agent's tmux session (``tui-scitex-agent-container``) had been alive
+and untouched since 11:22 the previous day. Three ``instances`` rows had
+been minted that night; every one carried ``screen`` NULL and a pid
+matching no live process. Nothing in the restart had ever ASKED THE OS
+anything — and because the maintenance path then refuses with
+``agent_not_running``, the corrupt container venv it was trying to repair
+could not be repaired by sac at all. The only sequence that worked was a
+hand-run ``tmux kill-session``, then ``stop``, then ``start``.
+
+So a ``True`` now requires TWO independent witnesses:
+
+  1. the LEDGER says the identity-of-run changed, and
+  2. the OS says the agent's multiplexer session changed with it —
+     ``#{session_created}``, the one tmux stamp that is constant for the
+     life of a session and different for the next one.
+
+Witness 2 is read through ``instances.screen``, which
+:func:`_lifecycle._instances.record_local_instance` fills with the name
+the runtime passed to ``tmux new-session -s``. A row that does not name a
+session cannot be checked against anything, and the honest answer there
+is "cannot verify" — NOT "verified".
+
 TERNARY, NEVER BINARY
 ---------------------
 
 The verdict has THREE states, because "I could not see" is a real answer
 and collapsing it into either pole is a lie:
 
-  * ``True``  — a run exists now and it is NOT the run we saw before.
+  * ``True``  — a run exists now, it is NOT the run we saw before, AND
+    the session the OS reports for it is a different session than before.
   * ``False`` — we saw a run before and it is either still that same run
-    (nothing cycled) or gone entirely (the restart left the agent DOWN).
-    Both are definitive: we HELD the before-evidence.
-  * ``None``  — no marker before AND none after. No evidence either way.
+    (nothing cycled), gone entirely (the restart left the agent DOWN), or
+    the ledger minted a new id over a session the OS says never moved.
+    All three are definitive: we HELD the before-evidence.
+  * ``None``  — no evidence either way: no marker before AND none after,
+    or a ledger that claims a new run while no process observation could
+    be taken (``screen`` NULL, a wedged tmux, a container's namespace).
     The caller must leave its own verdict untouched; inventing a FAILURE
     here is exactly the mirror of the false SUCCESS this module exists to
     kill, and would be equally misleading.
@@ -51,12 +85,41 @@ is produced where the evidence lives.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Callable
 
 __all__ = [
     "RestartVerdict",
+    "SessionObservation",
     "read_run_identity",
+    "read_session_identity",
     "verify_cycled",
 ]
+
+
+@dataclass(frozen=True)
+class SessionObservation:
+    """Did we LOOK at the agent's multiplexer session, and what did we see?
+
+    Three states, and the caller must be able to tell all three apart:
+
+      * ``observed=True``, ``identity="tui-x@1755000000"`` — a probe that
+        could see this host's tmux ran, and the session is THERE, with
+        that birthday.
+      * ``observed=True``, ``identity=None`` — the same probe ran and the
+        session is CONFIRMED ABSENT.
+      * ``observed=False`` — WE COULD NOT LOOK. ``blind_because`` says
+        why. This is the state the whole module turns on: it must never
+        be collapsed into "absent", because "I could not see the session"
+        and "the session is not there" authorise opposite conclusions.
+
+    The default constructs the blind state on purpose, so a caller that
+    forgets to pass an observation gets an abstention rather than a
+    silently-unchecked pass.
+    """
+
+    observed: bool = False
+    identity: str | None = None
+    blind_because: str = "no process observation was taken"
 
 
 @dataclass(frozen=True)
@@ -64,16 +127,19 @@ class RestartVerdict:
     """The postcondition verdict plus the evidence it was drawn from.
 
     ``verified`` is the ternary described in the module docstring;
-    ``reason`` is a short operator-facing sentence naming WHY, and
-    ``before``/``after`` carry the raw identity-of-run values so a
-    ``--json`` consumer can re-check the reasoning without re-running
-    anything.
+    ``reason`` is a short operator-facing sentence naming WHY,
+    ``before``/``after`` carry the raw identity-of-run values, and
+    ``session_before``/``session_after`` carry the OS-side session
+    identities — so a ``--json`` consumer can re-check the reasoning,
+    from BOTH witnesses, without re-running anything.
     """
 
     verified: bool | None
     reason: str
     before: str | None
     after: str | None
+    session_before: str | None = None
+    session_after: str | None = None
 
     def as_dict(self) -> dict:
         """JSON-envelope fields for this verdict (flat, prefixed)."""
@@ -82,6 +148,8 @@ class RestartVerdict:
             "verified_reason": self.reason,
             "run_before": self.before,
             "run_after": self.after,
+            "session_before": self.session_before,
+            "session_after": self.session_after,
         }
 
 
@@ -102,20 +170,124 @@ def read_run_identity(name: str) -> str | None:
     return read_instance_id(_runtime_state_dir(name))
 
 
-def verify_cycled(name: str, before: str | None, after: str | None) -> RestartVerdict:
+def _created_snapshot(*, socket_name: str | None = None) -> dict | None:
+    """``{session: created_epoch}`` for every session, or ``None`` if blind."""
+    from ..._runners._tmux._tmux_probe import list_sessions_created
+
+    return list_sessions_created(socket_name=socket_name)
+
+
+def recorded_session_name(name: str) -> str | None:
+    """The multiplexer session ``name``'s newest ``instances`` row names.
+
+    ``instances.screen``, read through :func:`_state.state_db
+    .last_known_instance` so an ENDED row still answers — a row that says
+    "stopped" while its session is demonstrably alive is precisely the
+    disagreement this module has to be able to see.
+
+    ``None`` when the agent has no row, when the row predates
+    :func:`_lifecycle._instances.record_local_instance` filling the column
+    (``screen`` NULL), or when the row was written on ANOTHER HOST: that
+    session lives in a tmux server we cannot reach, so probing the name
+    here would answer about this machine and mean nothing. Never raises.
+    """
+    try:
+        from ..._state.state_db import last_known_instance
+
+        row = last_known_instance(name)
+    except Exception:  # stx-allow: fallback (an unreadable registry is "we could not look", never a claim about the session)
+        return None
+    if not row:
+        return None
+    session = str(row.get("screen") or "").strip()
+    if not session:
+        return None
+    row_host = str(row.get("host") or "")
+    if row_host:
+        from ..._lifecycle._verdict_tmux import pid_namespace_is_observable
+
+        # Same predicate the liveness probe uses for pids, and for the same
+        # reason: a name minted in another machine's (or the host's, when
+        # we are in a SIF) namespace is not ours to read.
+        observable, _why = pid_namespace_is_observable(row_host=row_host)
+        if not observable:
+            return None
+    return session
+
+
+def read_session_identity(
+    name: str,
+    *,
+    session_name_fn: Callable[[str], str | None] | None = None,
+    snapshot_fn: Callable[..., dict | None] | None = None,
+) -> SessionObservation:
+    """Ask the OS what ``name``'s multiplexer session is RIGHT NOW.
+
+    The second, independent witness (see the module docstring). Returns a
+    :class:`SessionObservation` whose ``identity`` pairs the session name
+    with its ``#{session_created}`` birthday — the one tmux stamp that
+    does not move for a session that was never touched, so comparing it
+    across a restart answers exactly the question the ledger cannot.
+
+    Blindness is reported as blindness. A row with no ``screen``, a
+    cross-host row, a wedged tmux, or a container that cannot see the
+    host's tmux server all come back ``observed=False`` — never as an
+    absent session, which would read as a definitive failure.
+
+    ``session_name_fn`` / ``snapshot_fn`` are the injection seams (real
+    callables, no mocks): tests drive the RULE without a live fleet.
+    """
+    session = (session_name_fn or recorded_session_name)(name)
+    if not session:
+        return SessionObservation(
+            False,
+            None,
+            f"no ``instances`` row names a tmux session for {name!r} "
+            f"(``screen`` is NULL, or the row belongs to another host), so "
+            f"there is no handle to ask the OS about",
+        )
+    from ..._lifecycle._verdict_tmux import observed_session_snapshot
+
+    snapshot = observed_session_snapshot(
+        snapshot_fn=snapshot_fn or _created_snapshot
+    )
+    if snapshot is None:
+        return SessionObservation(
+            False,
+            None,
+            "no tmux probe could see this host's sessions (a wedged server, "
+            "or we are inside a container whose tmux is a different mount "
+            "namespace) — that is a non-observation, not an empty fleet",
+        )
+    created = snapshot.get(session)
+    if created is None:
+        return SessionObservation(True, None, "")
+    return SessionObservation(True, f"{session}@{created}", "")
+
+
+def verify_cycled(
+    name: str,
+    before: str | None,
+    after: str | None,
+    *,
+    session_before: SessionObservation | None = None,
+    session_after: SessionObservation | None = None,
+) -> RestartVerdict:
     """Decide whether ``name`` actually cycled between ``before`` and ``after``.
 
-    See the module docstring for the ternary contract. The four cases are
-    written out one per branch, in evidence order, so the decision reads
-    as a table rather than as a chain of conditions.
+    See the module docstring for the ternary contract and for why the
+    ledger alone can never reach ``True``. The cases are written out one
+    per branch, in evidence order, so the decision reads as a table rather
+    than as a chain of conditions.
+
+    ``session_before`` / ``session_after`` are the OS-side witness
+    (:func:`read_session_identity`). Omitting them is not a shortcut to a
+    pass: the default is the BLIND observation, so a caller that offers no
+    process evidence gets ``None`` ("cannot verify"), never ``True``.
     """
-    if after is not None and after != before:
-        return RestartVerdict(
-            True,
-            f"agent {name!r} is a NEW run ({before or 'no run'} -> {after})",
-            before,
-            after,
-        )
+    seen_before = session_before or SessionObservation()
+    seen_after = session_after or SessionObservation()
+
     if before is not None and after == before:
         return RestartVerdict(
             False,
@@ -124,6 +296,8 @@ def verify_cycled(name: str, before: str | None, after: str | None) -> RestartVe
             f"credentials",
             before,
             after,
+            seen_before.identity,
+            seen_after.identity,
         )
     if before is not None and after is None:
         return RestartVerdict(
@@ -132,12 +306,70 @@ def verify_cycled(name: str, before: str | None, after: str | None) -> RestartVe
             f"the stop leg ran but nothing came back up",
             before,
             after,
+            seen_before.identity,
+            seen_after.identity,
+        )
+    if after is None:
+        return RestartVerdict(
+            None,
+            f"agent {name!r} had no instance_id marker before OR after, so the "
+            f"restart could not be verified either way (no evidence — this is "
+            f"NOT a reported failure)",
+            before,
+            after,
+            seen_before.identity,
+            seen_after.identity,
+        )
+
+    # The ledger says NEW RUN. On its own that is an echo of the write the
+    # start path just made, so the OS has to corroborate it before this
+    # reports a pass.
+    if not (seen_before.observed and seen_after.observed):
+        blind = seen_after.blind_because or seen_before.blind_because
+        return RestartVerdict(
+            None,
+            f"agent {name!r} has a NEW run id ({before or 'no run'} -> "
+            f"{after}), but that id was minted by the very start path we are "
+            f"checking — and NO process observation backs it up: {blind}. "
+            f"CANNOT VERIFY (not a reported failure); confirm by hand with "
+            f"`tmux ls`",
+            before,
+            after,
+            seen_before.identity,
+            seen_after.identity,
+        )
+    if seen_after.identity is None:
+        return RestartVerdict(
+            False,
+            f"agent {name!r} has a NEW run id ({before or 'no run'} -> "
+            f"{after}) but NO session is running for it — the ledger says it "
+            f"came back up and the OS says it did not",
+            before,
+            after,
+            seen_before.identity,
+            seen_after.identity,
+        )
+    if seen_after.identity == seen_before.identity:
+        return RestartVerdict(
+            False,
+            f"agent {name!r} did NOT cycle: the ledger minted a new run id "
+            f"({before or 'no run'} -> {after}) but its session "
+            f"{seen_after.identity} is the SAME one, at the same birthday — "
+            f"the restart wrote rows and never touched the process. Kill it "
+            f"by hand: tmux kill-session -t "
+            f"{seen_after.identity.rsplit('@', 1)[0]}",
+            before,
+            after,
+            seen_before.identity,
+            seen_after.identity,
         )
     return RestartVerdict(
-        None,
-        f"agent {name!r} had no instance_id marker before OR after, so the "
-        f"restart could not be verified either way (no evidence — this is "
-        f"NOT a reported failure)",
+        True,
+        f"agent {name!r} is a NEW run ({before or 'no run'} -> {after}) and "
+        f"the OS agrees: its session cycled "
+        f"({seen_before.identity or 'no session'} -> {seen_after.identity})",
         before,
         after,
+        seen_before.identity,
+        seen_after.identity,
     )

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart_verify.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart_verify.py
@@ -177,7 +177,11 @@ def _created_snapshot(*, socket_name: str | None = None) -> dict | None:
     return list_sessions_created(socket_name=socket_name)
 
 
-def recorded_session_name(name: str) -> str | None:
+def recorded_session_name(
+    name: str,
+    *,
+    in_sif_fn: Callable[[], bool] | None = None,
+) -> str | None:
     """The multiplexer session ``name``'s newest ``instances`` row names.
 
     ``instances.screen``, read through :func:`_state.state_db
@@ -187,9 +191,18 @@ def recorded_session_name(name: str) -> str | None:
 
     ``None`` when the agent has no row, when the row predates
     :func:`_lifecycle._instances.record_local_instance` filling the column
-    (``screen`` NULL), or when the row was written on ANOTHER HOST: that
-    session lives in a tmux server we cannot reach, so probing the name
-    here would answer about this machine and mean nothing. Never raises.
+    (``screen`` NULL), or when that session is not ours to look at — a row
+    written on ANOTHER HOST, or a caller sitting inside a container, whose
+    tmux is a different namespace from the host's. In both of those the
+    name would be probed against the wrong server, and an answer from the
+    wrong server is not a weaker answer, it is not an answer.
+
+    ``in_sif_fn`` is the injection seam (a real callable; see
+    :func:`_lifecycle._verdict_tmux.pid_namespace_is_observable`) so a
+    test can drive BOTH namespace answers deterministically. It has to
+    exist: this suite runs inside a SIF while its conftest clears the
+    in-SIF markers, so the ambient answer is whatever the harness happens
+    to have left behind — a host-dependent test either way. Never raises.
     """
     try:
         from ..._state.state_db import last_known_instance
@@ -202,16 +215,22 @@ def recorded_session_name(name: str) -> str | None:
     session = str(row.get("screen") or "").strip()
     if not session:
         return None
-    row_host = str(row.get("host") or "")
-    if row_host:
-        from ..._lifecycle._verdict_tmux import pid_namespace_is_observable
+    from ..._lifecycle._verdict_tmux import pid_namespace_is_observable
 
-        # Same predicate the liveness probe uses for pids, and for the same
-        # reason: a name minted in another machine's (or the host's, when
-        # we are in a SIF) namespace is not ours to read.
-        observable, _why = pid_namespace_is_observable(row_host=row_host)
-        if not observable:
-            return None
+    # Same predicate the liveness probe uses for pids, and for the same
+    # reason: a name minted in another machine's (or the host's, when we
+    # are in a SIF) namespace is not ours to read. Asked UNCONDITIONALLY,
+    # never only when the row names a host: ``row_host=None`` skips just
+    # the cross-host arm, and the container arm is the one that must fire
+    # for every row — gating the whole predicate on ``row_host`` let an
+    # in-SIF caller probe a hostless row's name against the CONTAINER's
+    # tmux and read the answer as the host's.
+    observable, _why = pid_namespace_is_observable(
+        row_host=str(row.get("host") or "") or None,
+        in_sif_fn=in_sif_fn,
+    )
+    if not observable:
+        return None
     return session
 
 
@@ -248,9 +267,7 @@ def read_session_identity(
         )
     from ..._lifecycle._verdict_tmux import observed_session_snapshot
 
-    snapshot = observed_session_snapshot(
-        snapshot_fn=snapshot_fn or _created_snapshot
-    )
+    snapshot = observed_session_snapshot(snapshot_fn=snapshot_fn or _created_snapshot)
     if snapshot is None:
         return SessionObservation(
             False,

--- a/src/scitex_agent_container/runtimes/base.py
+++ b/src/scitex_agent_container/runtimes/base.py
@@ -83,3 +83,33 @@ class RuntimeBase(ABC):
         """
         del config
         return None
+
+    def session_name(self, config: AgentConfig) -> str | None:
+        """Return the multiplexer session this runtime launches into, or ``None``.
+
+        This is the string ``instances.screen`` records (see
+        :func:`_lifecycle._instances.record_local_instance`), and it must
+        be THE SAME value the runtime passes to ``tmux new-session -s``
+        rather than a name re-derived from a convention, which is free to
+        drift from what was actually launched.
+
+        Why the column has to be filled: ``screen`` is the only column in
+        ``instances`` naming a thing the OS can be asked about
+        independently of sac's own bookkeeping. Without it every "did this
+        agent cycle?" question can only be answered by re-reading the rows
+        sac itself just wrote, which is not evidence but an echo. Measured
+        2026-08-14 on scitex-compute-04: three ``instances`` rows, every
+        one with ``screen`` NULL, while the single real tmux session had
+        been alive and untouched since the previous day — and ``sac agents
+        restart`` compared the ids it had just minted and printed
+        ``verified: ... is a NEW run`` over a process it never touched.
+
+        NOT abstract, and the default is ``None`` ON PURPOSE — the same
+        contract as :meth:`agent_pid`. A runtime with no multiplexer
+        session (the SDK / apptainer runtimes run a bare container
+        process; SSHRemote's session lives on another host) MUST leave
+        this ``None``. ``None`` reads downstream as "cannot verify", which
+        is honest; a guessed name would read as a verified one.
+        """
+        del config
+        return None

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -450,6 +450,13 @@ class TuiSessionRuntime(
             pane_pid_fn=getattr(self._mux, "pane_pid", None),
         )
 
+    def session_name(self, config: AgentConfig) -> str | None:
+        """The ``tui-<name>`` session — the seam ``instances.screen`` reads.
+
+        THE SAME call :meth:`start` passes to ``tmux new-session -s``.
+        """
+        return session_name_for(config)
+
     def is_responsive(
         self, config: AgentConfig, max_idle_s: float = _DEFAULT_MAX_IDLE_S
     ) -> bool:

--- a/tests/scitex_agent_container/_lifecycle/test__instances_screen.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_screen.py
@@ -1,0 +1,259 @@
+"""``instances.screen`` is populated with the tmux session the start created.
+
+ROOT CAUSE (P0, 2026-08-14, scitex-compute-04). ``record_instance_start``
+has always accepted ``screen=`` and NO caller ever passed it, so the column
+was NULL on every locally-started row. ``screen`` is the only column in
+``instances`` naming something the OS can be asked about INDEPENDENTLY of
+sac's own bookkeeping — with it NULL, every "did this agent cycle?"
+question could only be answered by re-reading the rows sac itself had just
+written. That is an echo, not evidence.
+
+What it cost: three ``instances`` rows were minted for one agent that
+night, all with ``screen`` NULL and pids matching no live process, while
+the ONE real tmux session (``tui-scitex-agent-container``) had been alive
+and untouched since the previous day. ``sac agents stop`` and ``sac agents
+restart`` reported success over it FOUR times without touching the
+process — and the maintenance path then refused the overlay-venv repair
+with ``agent_not_running``, so the corruption it was there to fix could
+not be fixed by sac at all.
+
+THE NAIVE FIX IS WRONG: re-deriving ``tui-<name>`` at record time is free
+to drift from what the runtime actually launched, and a drifted name
+probes an empty answer that reads exactly like a dead agent. The value
+must come from the runtime that just started the session
+(:meth:`runtimes.base.RuntimeBase.session_name`), so the recorded string
+is THE SAME one passed to ``tmux new-session -s``.
+
+Real on-disk SQLite state.db (env-overridden per test) and the REAL
+``TuiSessionRuntime``. No mocks.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db location, exported via env (explicit save/restore)."""
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+class _SessionRuntime:
+    """Honest runtime collaborator implementing the ``RuntimeBase`` seam.
+
+    Mirrors the real runtimes' shape: a ``_state_dir`` resolver plus the
+    ``session_name`` accessor. ``start`` re-reads the attribute so a restart
+    can hand back a DIFFERENT session, exactly as a respawned tmux session
+    would.
+    """
+
+    def __init__(self, root: Path, session: object) -> None:
+        self._root = root
+        self.session = session
+
+    def _state_dir(self, config: AgentConfig) -> Path:
+        return self._root / config.name
+
+    def session_name(self, config: AgentConfig):
+        del config
+        return self.session
+
+    def start(self, config: AgentConfig) -> bool:
+        del config
+        return True
+
+
+class _LegacyRuntime:
+    """A runtime predating the ``session_name`` seam (back-compat guard)."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def _state_dir(self, config: AgentConfig) -> Path:
+        return self._root / config.name
+
+
+class _ExplodingRuntime(_SessionRuntime):
+    """A runtime whose session probe raises — a start must never be blocked."""
+
+    def session_name(self, config: AgentConfig):
+        del config
+        raise RuntimeError("tmux probe blew up")
+
+
+def _row_for(name: str) -> dict:
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    return [r for r in list_active_instances() if r["name"] == name][0]
+
+
+# ---------------------------------------------------------------------------
+# record_local_instance now persists the runtime's session name
+# ---------------------------------------------------------------------------
+
+
+def test_record_local_instance_persists_runtime_session_name(db_path, tmp_path) -> None:
+    # Arrange — the runtime reports the session it just launched into.
+    from scitex_agent_container._lifecycle._instances import record_local_instance
+
+    cfg = AgentConfig(name="screen-1", runtime="tui")
+    # Act
+    record_local_instance(cfg, _SessionRuntime(tmp_path, "tui-screen-1"))
+    # Assert — THE regression guard. Pre-fix this column was NULL on every row.
+    assert _row_for("screen-1")["screen"] == "tui-screen-1"
+
+
+def test_record_local_instance_leaves_screen_null_for_legacy_runtime(
+    db_path, tmp_path
+) -> None:
+    # Arrange — a runtime without the seam must not fabricate a session name.
+    from scitex_agent_container._lifecycle._instances import record_local_instance
+
+    cfg = AgentConfig(name="screen-legacy", runtime="apptainer")
+    # Act
+    record_local_instance(cfg, _LegacyRuntime(tmp_path))
+    # Assert — NULL is the honest "this runtime has no session to name".
+    assert _row_for("screen-legacy")["screen"] is None
+
+
+def test_restart_and_record_refreshes_the_session_name(db_path, tmp_path) -> None:
+    # Arrange — the supervisor restarts the agent into a NEW tmux session; a
+    # STALE session name is worse than none, because the verifier would then
+    # compare a live session against a name that no longer refers to it.
+    from scitex_agent_container._lifecycle._instances import (
+        record_local_instance,
+        restart_and_record,
+    )
+
+    cfg = AgentConfig(name="screen-restart", runtime="tui")
+    rt = _SessionRuntime(tmp_path, "tui-screen-restart-old")
+    record_local_instance(cfg, rt)
+    rt.session = "tui-screen-restart-new"
+    # Act
+    restart_and_record(cfg, lambda _c: rt)
+    # Assert
+    assert _row_for("screen-restart")["screen"] == "tui-screen-restart-new"
+
+
+# ---------------------------------------------------------------------------
+# _runtime_session_name: only a real, non-empty string is a session name
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_session_name_rejects_a_blank_name(tmp_path) -> None:
+    # Arrange — a whitespace-only name would be probed against tmux and always
+    # miss, which reads exactly like a dead agent.
+    from scitex_agent_container._lifecycle._instances import _runtime_session_name
+
+    cfg = AgentConfig(name="screen-blank", runtime="tui")
+    # Act
+    resolved = _runtime_session_name(cfg, _SessionRuntime(tmp_path, "   "))
+    # Assert
+    assert resolved is None
+
+
+def test_runtime_session_name_rejects_a_non_string(tmp_path) -> None:
+    # Arrange — the column is TEXT; a non-string would stringify into a name
+    # no tmux server has ever heard of.
+    from scitex_agent_container._lifecycle._instances import _runtime_session_name
+
+    cfg = AgentConfig(name="screen-nonstr", runtime="tui")
+    # Act
+    resolved = _runtime_session_name(cfg, _SessionRuntime(tmp_path, 12345))
+    # Assert
+    assert resolved is None
+
+
+def test_runtime_session_name_survives_a_raising_probe(tmp_path) -> None:
+    # Arrange — a session-name hiccup must degrade to "unknown", never abort
+    # the agent start it is only annotating.
+    from scitex_agent_container._lifecycle._instances import _runtime_session_name
+
+    cfg = AgentConfig(name="screen-boom", runtime="tui")
+    # Act
+    resolved = _runtime_session_name(cfg, _ExplodingRuntime(tmp_path, "tui-x"))
+    # Assert
+    assert resolved is None
+
+
+# ---------------------------------------------------------------------------
+# The REAL runtime implements the seam, and returns the SAME string it hands
+# to ``tmux new-session -s`` — the drift guard the whole fix rests on.
+# ---------------------------------------------------------------------------
+
+
+def test_base_runtime_session_name_defaults_to_none() -> None:
+    # Arrange — a runtime with no multiplexer at all (SDK / apptainer / docker,
+    # or SSHRemote whose session lives on another host) inherits the base
+    # default rather than fabricating a name.
+    from scitex_agent_container.runtimes.base import RuntimeBase
+
+    cfg = AgentConfig(name="base-default", runtime="apptainer")
+    # Act
+    session = RuntimeBase.session_name(object(), cfg)  # type: ignore[arg-type]
+    # Assert
+    assert session is None
+
+
+def test_real_tui_runtime_names_its_own_session() -> None:
+    # Arrange — the production runtime, not a stand-in.
+    from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
+
+    cfg = AgentConfig(name="real-tui", runtime="tui")
+    # Act
+    session = TuiSessionRuntime().session_name(cfg)
+    # Assert
+    assert session == "tui-real-tui"
+
+
+def test_real_tui_runtime_session_name_matches_the_launch_convention() -> None:
+    # Arrange — the recorded name must be THE SAME call ``start`` passes to
+    # ``tmux new-session -s``. Asserting against ``session_name_for`` (rather
+    # than against a literal) is what makes this a DRIFT guard: if the launch
+    # convention ever moves, this fails instead of silently recording a name
+    # that no longer names anything.
+    from scitex_agent_container.runtimes.tui_session import (
+        TuiSessionRuntime,
+        session_name_for,
+    )
+
+    cfg = AgentConfig(name="drift-guard", runtime="tui")
+    # Act
+    session = TuiSessionRuntime().session_name(cfg)
+    # Assert
+    assert session == session_name_for(cfg)
+
+
+def test_real_tui_runtime_session_name_reaches_the_recorder(tmp_path) -> None:
+    # Arrange — the seam is only worth anything if the RECORDER accepts what
+    # the REAL runtime returns; the two stand-in tests above would both pass
+    # over a runtime the recorder rejects.
+    from scitex_agent_container._lifecycle._instances import _runtime_session_name
+    from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
+
+    cfg = AgentConfig(name="real-recorded", runtime="tui")
+    # Act
+    resolved = _runtime_session_name(cfg, TuiSessionRuntime())
+    # Assert
+    assert resolved == "tui-real-recorded"

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
@@ -32,6 +32,7 @@ from click.testing import CliRunner
 
 import scitex_agent_container.cli_pkg.lifecycle._restart as restart_mod
 from scitex_agent_container.cli_pkg.lifecycle._restart import restart
+from scitex_agent_container.cli_pkg.lifecycle._restart_verify import SessionObservation
 
 
 @pytest.fixture(autouse=True)
@@ -68,7 +69,20 @@ def _isolate_runtime_root(tmp_path):
     directions: the legacy happy-path tests get a guaranteed-empty root (no
     marker either side → the verdict abstains → their historical success is
     preserved), and no test can ever touch the operator's real runtime dir.
+
+    RESTORING THE ENV VAR IS NOT ENOUGH, and the teardown reload below is not
+    decoration. ``_runners._session_state.DEFAULT_STATE_ROOT`` is a MODULE
+    CONSTANT evaluated once, at import — and that import happens lazily, from
+    inside the first test that reads a run marker, i.e. while this fixture
+    has the env var pointed at a pytest tmp dir. Dropping the env var
+    afterwards therefore un-pinned nothing: the constant stayed at the first
+    test's ``tmp_path`` for the rest of the worker, and the suite's own state
+    floor flagged it on the teardown of EVERY subsequent test in this file
+    (69 such errors, all of them this one cause). Re-importing AFTER the
+    restore is what actually puts the constant back.
     """
+    import importlib
+
     from scitex_agent_container._runtime_paths import RUNTIME_DIR_ENV
 
     root = tmp_path / "runtime-root"
@@ -82,6 +96,11 @@ def _isolate_runtime_root(tmp_path):
             os.environ.pop(RUNTIME_DIR_ENV, None)
         else:
             os.environ[RUNTIME_DIR_ENV] = saved
+        # Order matters: the env var is restored FIRST, then the module is
+        # re-executed, so the constant is re-derived from the real value.
+        import scitex_agent_container._runners._session_state as _session_state
+
+        importlib.reload(_session_state)
 
 
 @contextmanager
@@ -464,7 +483,7 @@ def test_no_row_agent_restarts_locally_without_ssh(cross_host_state_db, ssh_shim
     runner = CliRunner()
     # Act
     with _swap("agent_restart", lambda name: called.append(name)):
-        result = runner.invoke(restart, ["solo", "-y"])
+        runner.invoke(restart, ["solo", "-y"])
     # Assert — local path taken (agent_restart called), no ssh dispatched.
     assert called == ["solo"] and _ssh_invocations(ssh_shim) == []
 
@@ -1168,6 +1187,18 @@ def test_in_sif_without_a_listen_url_names_the_missing_env_var(
 # the restart collaborator is a REAL function that either rewrites the marker
 # (a genuine restart), leaves it alone (the P0's no-op) or deletes it (a stop
 # whose start leg never came back).
+#
+# THE MARKER IS NECESSARY, NEVER SUFFICIENT (P0 2026-08-14). It is written by
+# the same start path these tests are checking, so a NEW marker on its own is
+# an echo, not evidence — measured on scitex-compute-04, "verified: ... is a
+# NEW run" printed over a tmux session alive and untouched since the previous
+# day. A pass now also needs the OS to agree, read through the session name
+# ``instances.screen`` records; with the registry isolated and EMPTY here,
+# that second witness is absent by construction, so these tests pin the
+# ABSTENTION ("cannot verify") rather than the old unearned pass. The
+# two-witness table itself is ``test_verify_cycled_is_a_ternary`` below, and
+# the end-to-end proof against a real tmux server lives in
+# ``test__restart_verify_session.py``.
 # ---------------------------------------------------------------------------
 
 
@@ -1175,6 +1206,37 @@ def test_in_sif_without_a_listen_url_names_the_missing_env_var(
 def runtime_root(_isolate_runtime_root):
     """The per-test runtime root, named for tests that write markers into it."""
     return _isolate_runtime_root
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path):
+    """Pin the ``instances`` registry at a real, EMPTY, per-test state.db.
+
+    The postcondition now reads a SECOND witness — ``instances.screen``, the
+    tmux session the start path recorded — so the registry is live input to
+    every test below, exactly as the runtime root already was. Left ambient,
+    these tests would ask the OPERATOR'S real fleet database whether
+    ``verify-me`` names a session, and would answer differently on a host
+    that happens to hold such a row. Isolating it makes "no row names a
+    session for this agent" a FACT of the test rather than a property of the
+    machine it runs on.
+    """
+    import importlib
+
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(tmp_path / "state.db")
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield tmp_path / "state.db"
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
 
 
 def _write_run_marker(root, name: str, value: str) -> None:
@@ -1201,7 +1263,7 @@ def _envelope(result):
 
 
 @pytest.fixture
-def armed_run_marker(runtime_root):
+def armed_run_marker(runtime_root, isolated_state_db):
     """Give ``verify-me`` a real run marker and PROVE the CLI can read it.
 
     Arming is checked HERE, not in each test: a fixture that silently
@@ -1220,7 +1282,7 @@ def armed_run_marker(runtime_root):
 
 
 @pytest.fixture
-def no_run_marker(runtime_root):
+def no_run_marker(runtime_root, isolated_state_db):
     """Prove ``ghost-agent`` has NO run marker (the abstention case)."""
     assert _current_run("ghost-agent") is None, (
         "fixture failed to arm the no-evidence case — a stray marker would "
@@ -1292,14 +1354,41 @@ def test_restart_that_cycles_the_run_exits_zero(armed_run_marker):
     assert result.exit_code == 0, result.output
 
 
-def test_restart_that_cycles_the_run_reports_verified_true(armed_run_marker):
-    # Arrange
+def test_restart_that_cycles_only_the_ledger_cannot_be_verified(armed_run_marker):
+    # Arrange — the marker cycles, and NOTHING else does. This used to report
+    # ``verified: true``, which is the P0 of 2026-08-14: the marker is written
+    # by the very start path being checked, so on its own it can only ever
+    # agree with itself. With no ``instances`` row naming a tmux session there
+    # is no second witness, and the honest answer is "I could not check".
+    runner = CliRunner()
+    # Act
+    with _swap("agent_restart", _cycling_restart_for(armed_run_marker)):
+        result = runner.invoke(restart, ["verify-me", "-y", "--json"])
+    # Assert — an abstention, not the old unearned pass.
+    assert _envelope(result).get("verified") is None
+
+
+def test_unverifiable_restart_is_not_reported_as_a_failure(armed_run_marker):
+    # Arrange — the mirror-image lie must not be invented either: "I could not
+    # check" is not "it failed", so the restart's own outcome stands.
     runner = CliRunner()
     # Act
     with _swap("agent_restart", _cycling_restart_for(armed_run_marker)):
         result = runner.invoke(restart, ["verify-me", "-y", "--json"])
     # Assert
-    assert _envelope(result).get("verified") is True
+    assert _envelope(result).get("restarted") is True
+
+
+def test_unverifiable_restart_is_not_printed_under_the_word_verified(armed_run_marker):
+    # Arrange — the console line is what the operator actually reads, and
+    # printing an ABSTENTION under the word "verified" is how an unchecked
+    # restart came to look like a checked one.
+    runner = CliRunner()
+    # Act
+    with _swap("agent_restart", _cycling_restart_for(armed_run_marker)):
+        result = runner.invoke(restart, ["verify-me", "-y"])
+    # Assert
+    assert "NOT verified" in result.output
 
 
 def test_restart_that_leaves_no_run_at_all_exits_one(armed_run_marker):
@@ -1337,22 +1426,48 @@ def test_no_marker_on_either_side_reports_verified_null(no_run_marker):
     assert _envelope(result).get("verified") is None
 
 
+_BLIND = SessionObservation()
+_OLD_SESSION = SessionObservation(True, "tui-some-agent@1000")
+_NEW_SESSION = SessionObservation(True, "tui-some-agent@2000")
+_NO_SESSION = SessionObservation(True, None)
+
+
 @pytest.mark.parametrize(
-    "before,after,expected",
+    "before,after,seen_before,seen_after,expected",
     [
-        ("run-1", "run-2", True),
-        (None, "run-2", True),
-        ("run-1", "run-1", False),
-        ("run-1", None, False),
-        (None, None, None),
+        # BOTH witnesses agree the agent cycled — the only path to a pass.
+        ("run-1", "run-2", _OLD_SESSION, _NEW_SESSION, True),
+        ("run-1", "run-2", _NO_SESSION, _NEW_SESSION, True),
+        (None, "run-2", _NO_SESSION, _NEW_SESSION, True),
+        # The ledger says NEW RUN and nobody asked the OS. This is the P0's
+        # own input, and it used to be the pass above: the marker is written
+        # by the start path under test, so alone it is an echo, not evidence.
+        ("run-1", "run-2", _BLIND, _BLIND, None),
+        (None, "run-2", _BLIND, _BLIND, None),
+        # A new run id minted over a session the OS says never moved.
+        ("run-1", "run-2", _OLD_SESSION, _OLD_SESSION, False),
+        # The ledger says it came back up; the OS says nothing is running.
+        ("run-1", "run-2", _OLD_SESSION, _NO_SESSION, False),
+        # Ledger-definitive NOs, unchanged: still the same run, or no run at
+        # all afterwards. These need no second witness to be conclusive.
+        ("run-1", "run-1", _BLIND, _BLIND, False),
+        ("run-1", None, _BLIND, _BLIND, False),
+        # No evidence from either witness.
+        (None, None, _BLIND, _BLIND, None),
     ],
 )
-def test_verify_cycled_is_a_ternary(before, after, expected):
+def test_verify_cycled_is_a_ternary(before, after, seen_before, seen_after, expected):
     # Arrange
     from scitex_agent_container.cli_pkg.lifecycle._restart_verify import verify_cycled
 
     # Act
-    verdict = verify_cycled("some-agent", before, after)
+    verdict = verify_cycled(
+        "some-agent",
+        before,
+        after,
+        session_before=seen_before,
+        session_after=seen_after,
+    )
     # Assert — True / False / None, never a two-valued collapse.
     assert verdict.verified is expected
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart_verify_session.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart_verify_session.py
@@ -1,0 +1,400 @@
+"""Restart verification must ASK THE OS, and abstain when it cannot.
+
+P0, 2026-08-14, scitex-compute-04. ``sac agents restart`` printed::
+
+    verified: agent 'scitex-agent-container' is a NEW run
+              (c06d2fec-… -> 67068008-…)
+
+while the agent's tmux session (``tui-scitex-agent-container``) had been
+alive and untouched since 11:22 the PREVIOUS DAY. The check compared two
+readings of ``<runtime-dir>/<agent>/instance_id`` — a marker written by the
+very start path it was checking. That is not a witness, it is an ECHO: the
+start path agreed with itself and the word "verified" was printed over a
+process nothing had touched. ``stop`` and ``restart`` reported success four
+times running, and the maintenance path then refused the overlay-venv
+repair with ``agent_not_running``.
+
+So a ``True`` now needs TWO independent witnesses — the ledger's
+identity-of-run AND the OS's ``#{session_created}``, the one tmux stamp
+that is constant for a session's life and different for the next one. And
+where the second witness cannot be taken (``instances.screen`` NULL, a row
+from another host, a wedged tmux, a caller inside a container), the honest
+answer is "CANNOT VERIFY" — ``None``, never ``True`` and never ``False``.
+Inventing a failure there is the exact mirror of the false success.
+
+NO MOCKS. A REAL tmux server on a private socket with REAL sessions, plus
+a REAL on-disk state.db; the production functions' documented injection
+seams (``session_name_fn`` / ``snapshot_fn`` / ``in_sif_fn``) are passed
+REAL callables.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg.lifecycle._restart_verify import (
+    SessionObservation,
+    read_session_identity,
+    recorded_session_name,
+    verify_cycled,
+)
+
+# A tmux socket is keyed by (user, socket-NAME), never by process, so a
+# LITERAL name is a HOST-GLOBAL namespace shared with the operator's real
+# fleet AND with our own concurrent CI legs (runners -01/-02/-03 are three
+# registrations of ONE Spartan node and do overlap). Unique per PROCESS so
+# neither can collide with us. Orphan servers self-reap: every session below
+# runs `sleep`, and tmux exits with its last session.
+SOCKET = f"sac-verify-tests-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("tmux") is None, reason="tmux is not installed on this host"
+)
+
+
+def _tmux(*args: str) -> subprocess.CompletedProcess:
+    # 30s: three CI legs share one node, so a `tmux` spawn competes for a
+    # loaded box's CPU. A deadline tight enough to blow under load is a race,
+    # and blowing it here raises inside a FIXTURE — reported as a broken test
+    # rather than as a busy host.
+    return subprocess.run(
+        ["tmux", "-L", SOCKET, *args], capture_output=True, text=True, timeout=30
+    )
+
+
+@pytest.fixture()
+def tmux_server():
+    """A real tmux server on a socket only this process can name."""
+    # SOCKET is per-process, so tests in one process share a server: this kill
+    # is what isolates each test from the last one's sessions.
+    _tmux("kill-server")
+    yield _tmux
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        _tmux("kill-server")
+
+
+def _snapshot_on_socket(*, socket_name: str | None = None) -> dict | None:
+    """The REAL production probe, aimed at this process's private socket.
+
+    Deliberately NOT a re-implementation: a hand-copied parse in the test
+    drifts from the code it claims to cover. ``socket_name`` is accepted and
+    ignored because ``observed_session_snapshot`` passes it positionally to
+    whatever ``snapshot_fn`` it is given.
+    """
+    del socket_name
+    from scitex_agent_container._runners._tmux._tmux_probe import list_sessions_created
+
+    return list_sessions_created(socket_name=SOCKET)
+
+
+def _identity_of(agent: str, session: str) -> SessionObservation:
+    """Read ``session``'s live identity through the production reader."""
+    return read_session_identity(
+        agent,
+        session_name_fn=lambda _n: session,
+        snapshot_fn=_snapshot_on_socket,
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db location, exported via env (explicit save/restore)."""
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+def _on_this_host() -> str:
+    from scitex_agent_container._state.state_db import _resolve_host
+
+    return _resolve_host(None)
+
+
+def _seed_row(name: str, *, screen: str | None, host: str | None = None) -> None:
+    """Insert a REAL ``instances`` row, exactly as a start would."""
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name=name, host=host or _on_this_host(), screen=screen)
+
+
+# ---------------------------------------------------------------------------
+# recorded_session_name — which rows are ours to probe at all
+# ---------------------------------------------------------------------------
+
+
+def test_a_row_with_screen_null_names_no_session(db_path) -> None:
+    # Arrange — every locally-started row looked like this before the fix.
+    _seed_row("null-screen", screen=None)
+    # Act
+    session = recorded_session_name("null-screen", in_sif_fn=lambda: False)
+    # Assert — no handle to ask the OS about.
+    assert session is None
+
+
+def test_a_row_that_names_a_session_hands_it_over(db_path) -> None:
+    # Arrange — a row written by the fixed start path, on THIS host.
+    _seed_row("named-screen", screen="tui-named-screen")
+    # Act
+    session = recorded_session_name("named-screen", in_sif_fn=lambda: False)
+    # Assert
+    assert session == "tui-named-screen"
+
+
+def test_an_unknown_agent_names_no_session(db_path) -> None:
+    # Arrange — no row at all (an agent this host has never started).
+    # Act
+    session = recorded_session_name("never-seen", in_sif_fn=lambda: False)
+    # Assert
+    assert session is None
+
+
+def test_a_caller_inside_a_container_refuses_to_probe_the_name(db_path) -> None:
+    # Arrange — the row is perfectly good and on this host, but the CALLER is
+    # in a SIF, whose tmux is a different mount namespace. Probing the name
+    # here answers about the CONTAINER's tmux server; an answer from the wrong
+    # server is not a weaker answer, it is not an answer.
+    _seed_row("in-sif", screen="tui-in-sif")
+    # Act
+    session = recorded_session_name("in-sif", in_sif_fn=lambda: True)
+    # Assert
+    assert session is None
+
+
+def test_a_row_written_on_another_host_refuses_to_probe_the_name(db_path) -> None:
+    # Arrange — that session lives in a tmux server on a machine we cannot
+    # reach; the same name here would answer about THIS machine.
+    _seed_row("elsewhere", screen="tui-elsewhere", host="some-other-host")
+    # Act
+    session = recorded_session_name("elsewhere", in_sif_fn=lambda: False)
+    # Assert
+    assert session is None
+
+
+# ---------------------------------------------------------------------------
+# read_session_identity — blindness is reported AS blindness
+# ---------------------------------------------------------------------------
+
+
+def test_screen_null_reports_that_we_could_not_look(db_path) -> None:
+    # Arrange — the P0's registry state, read through the production path.
+    _seed_row("blind-agent", screen=None)
+    # Act
+    seen = read_session_identity(
+        "blind-agent",
+        session_name_fn=lambda n: recorded_session_name(n, in_sif_fn=lambda: False),
+        snapshot_fn=_snapshot_on_socket,
+    )
+    # Assert — "I could not look", never "the session is not there".
+    assert seen.observed is False
+
+
+def test_screen_null_names_the_column_in_its_reason(db_path) -> None:
+    # Arrange
+    _seed_row("blind-why", screen=None)
+    # Act
+    seen = read_session_identity(
+        "blind-why",
+        session_name_fn=lambda n: recorded_session_name(n, in_sif_fn=lambda: False),
+        snapshot_fn=_snapshot_on_socket,
+    )
+    # Assert — the operator is told WHICH fact is missing.
+    assert "screen" in seen.blind_because
+
+
+def test_a_live_session_is_observed_with_its_birthday(tmux_server, db_path) -> None:
+    # Arrange — a REAL row naming a REAL tmux session.
+    tmux_server("new-session", "-d", "-s", "tui-live-1", "sleep", "60")
+    _seed_row("live-1", screen="tui-live-1")
+    # Act — the full chain: state.db row -> name -> real tmux probe.
+    seen = read_session_identity(
+        "live-1",
+        session_name_fn=lambda n: recorded_session_name(n, in_sif_fn=lambda: False),
+        snapshot_fn=_snapshot_on_socket,
+    )
+    # Assert — a plausible unix epoch rides with the name, not a placeholder.
+    assert int(seen.identity.rsplit("@", 1)[1]) > 1_600_000_000
+
+
+def test_a_session_absent_from_a_good_probe_is_confirmed_absent(tmux_server) -> None:
+    # Arrange — a live server holding OTHER sessions. The probe SUCCEEDED, so
+    # this absence is real (unlike an empty/failed probe, which is unknown).
+    tmux_server("new-session", "-d", "-s", "tui-somebody-else", "sleep", "60")
+    # Act
+    seen = _identity_of("gone", "tui-gone")
+    # Assert — we DID look (observed), and there is nothing there (no identity).
+    assert (seen.observed, seen.identity) == (True, None)
+
+
+def test_a_wedged_probe_is_blindness_not_an_absent_session() -> None:
+    # Arrange — a probe that cannot answer. Reading this as "the session is
+    # gone" would turn a loaded host into a reported restart failure.
+    def _wedged(*, socket_name: str | None = None):
+        del socket_name
+        return None
+
+    # Act
+    seen = read_session_identity(
+        "wedged", session_name_fn=lambda _n: "tui-wedged", snapshot_fn=_wedged
+    )
+    # Assert
+    assert seen.observed is False
+
+
+# ---------------------------------------------------------------------------
+# verify_cycled — the ledger alone can never reach True
+# ---------------------------------------------------------------------------
+
+
+def test_a_new_run_id_with_no_process_evidence_cannot_be_verified() -> None:
+    # Arrange — THE regression guard, and the exact P0 input: the ledger says
+    # NEW RUN and nothing looked at the OS. Pre-fix this printed "verified".
+    # Act
+    verdict = verify_cycled("echo-only", "run-1", "run-2")
+    # Assert — abstention, not a pass.
+    assert verdict.verified is None
+
+
+def test_an_unverifiable_new_run_says_cannot_verify(tmux_server) -> None:
+    # Arrange
+    blind = SessionObservation()
+    # Act
+    verdict = verify_cycled(
+        "echo-only", "run-1", "run-2", session_before=blind, session_after=blind
+    )
+    # Assert — the operator is told to confirm by hand, not told it passed.
+    assert "CANNOT VERIFY" in verdict.reason
+
+
+def test_a_new_run_id_over_an_untouched_session_is_a_failure(
+    tmux_server, db_path
+) -> None:
+    # Arrange — THE P0, reproduced against real tmux: the ledger mints a new
+    # run id while the session is never touched. Both readings are taken from
+    # the SAME live session, exactly as a no-op restart would produce.
+    tmux_server("new-session", "-d", "-s", "tui-untouched", "sleep", "60")
+    _seed_row("untouched", screen="tui-untouched")
+    before = _identity_of("untouched", "tui-untouched")
+    after = _identity_of("untouched", "tui-untouched")
+    # Act
+    verdict = verify_cycled(
+        "untouched", "run-1", "run-2", session_before=before, session_after=after
+    )
+    # Assert — the ledger is overruled by the OS.
+    assert verdict.verified is False
+
+
+def test_a_new_run_id_over_an_untouched_session_hands_over_the_kill_command(
+    tmux_server,
+) -> None:
+    # Arrange — the only sequence that actually recovered the P0 was a
+    # hand-run `tmux kill-session`, so the verdict must name it.
+    tmux_server("new-session", "-d", "-s", "tui-untouched-2", "sleep", "60")
+    seen = _identity_of("untouched-2", "tui-untouched-2")
+    # Act
+    verdict = verify_cycled(
+        "untouched-2", "run-1", "run-2", session_before=seen, session_after=seen
+    )
+    # Assert
+    assert "tmux kill-session -t tui-untouched-2" in verdict.reason
+
+
+def test_a_genuinely_cycled_session_verifies_true(tmux_server) -> None:
+    # Arrange — a REAL cycle: the session is killed and a new one created
+    # under the same name, which is what a working restart does.
+    tmux_server("new-session", "-d", "-s", "tui-cycled", "sleep", "60")
+    before = _identity_of("cycled", "tui-cycled")
+    # tmux reports #{session_created} in WHOLE SECONDS, so two sessions born
+    # inside one second share a birthday. Crossing the boundary is what makes
+    # the two readings distinguishable here; in production the gap is the
+    # whole stop+start leg. (A real agent restarted within one second of
+    # being started is the only shape this cannot separate.)
+    time.sleep(1.1)
+    tmux_server("kill-session", "-t", "tui-cycled")
+    tmux_server("new-session", "-d", "-s", "tui-cycled", "sleep", "60")
+    after = _identity_of("cycled", "tui-cycled")
+    # Act
+    verdict = verify_cycled(
+        "cycled", "run-1", "run-2", session_before=before, session_after=after
+    )
+    # Assert — both witnesses agree, so this is the one path to a pass.
+    assert verdict.verified is True
+
+
+def test_a_new_run_id_with_no_session_at_all_is_a_failure(tmux_server) -> None:
+    # Arrange — the ledger says it came back up; the OS says it did not. The
+    # server is live and holds another session, so the absence is CONFIRMED.
+    tmux_server("new-session", "-d", "-s", "tui-someone", "sleep", "60")
+    before = _identity_of("down", "tui-down")
+    after = _identity_of("down", "tui-down")
+    # Act
+    verdict = verify_cycled(
+        "down", "run-1", "run-2", session_before=before, session_after=after
+    )
+    # Assert
+    assert verdict.verified is False
+
+
+def test_an_unchanged_run_id_stays_a_failure_without_any_session_evidence() -> None:
+    # Arrange — the ledger's own definitive NO must not be weakened into an
+    # abstention just because the OS could not be consulted.
+    # Act
+    verdict = verify_cycled("stuck", "run-1", "run-1")
+    # Assert
+    assert verdict.verified is False
+
+
+def test_no_marker_either_side_stays_an_abstention() -> None:
+    # Arrange — no evidence at all, from either witness.
+    # Act
+    verdict = verify_cycled("ghost", None, None)
+    # Assert
+    assert verdict.verified is None
+
+
+# ---------------------------------------------------------------------------
+# The evidence travels with the verdict, so --json can be re-checked
+# ---------------------------------------------------------------------------
+
+
+def test_the_verdict_carries_both_session_readings(tmux_server) -> None:
+    # Arrange — a --json consumer must be able to re-check the OS-side
+    # reasoning without re-running anything.
+    tmux_server("new-session", "-d", "-s", "tui-evidence", "sleep", "60")
+    seen = _identity_of("evidence", "tui-evidence")
+    # Act
+    payload = verify_cycled(
+        "evidence", "run-1", "run-2", session_before=seen, session_after=seen
+    ).as_dict()
+    # Assert
+    assert payload["session_before"] == payload["session_after"] == seen.identity
+
+
+def test_the_default_observation_is_the_blind_one() -> None:
+    # Arrange — a caller that forgets to pass an observation must get an
+    # abstention, never a silently-unchecked pass. That default is the reason
+    # the ledger-only case above cannot reach True.
+    # Act
+    seen = SessionObservation()
+    # Assert
+    assert seen.observed is False


### PR DESCRIPTION
## What was broken

`sac agents stop` and `sac agents restart` reported success **four times**
against `scitex-agent-container` on scitex-compute-04 without ever touching
the running process. The restart even printed:

```
verified: agent 'scitex-agent-container' is a NEW run (c06d2fec-… -> 67068008-…)
```

while the agent's tmux session `tui-scitex-agent-container` had been alive
and untouched **since 11:22 the previous day**.

Two independent defects produced that line, and neither is visible from the
other:

1. **`instances.screen` was NULL on every row.** `record_instance_start` has
   always accepted `screen=`, and no caller ever passed it. `screen` is the
   only column in `instances` naming something the OS can be asked about
   *independently of sac's own bookkeeping* — with it NULL there was nothing
   to ask about. Measured that night: three `instances` rows for one agent,
   every one with `screen` NULL and a pid matching no live process.

2. **The restart postcondition compared registry UUIDs it had just written.**
   `verify_cycled` read `<runtime-dir>/<agent>/instance_id` before and after
   — a marker minted by the very start path being checked. That is not a
   witness, it is an **echo**: the start path agreed with itself, and the
   word "verified" was printed over a process nothing had touched.

The blast radius was not just a misleading message. The maintenance path
refuses with `agent_not_running` while the ledger says "running", so the
corrupt overlay venv this restart was trying to repair **could not be
repaired by sac at all**. The only sequence that worked was a hand-run
`tmux kill-session`, then `stop`, then `start`.

## What this changes

A `True` verdict now requires **two independent witnesses**:

1. the ledger says the identity-of-run changed, **and**
2. the OS says the multiplexer session changed with it — `#{session_created}`,
   the one tmux stamp that is constant for a session's life and different for
   the next one.

Witness 2 is read through `instances.screen`, which the start path now fills
with the name the runtime passed to `tmux new-session -s` (asked of the
runtime via a new `RuntimeBase.session_name` seam, never re-derived from a
convention — a re-derivation is free to drift, and a drifted name probes an
empty answer indistinguishable from a dead agent).

Where the second witness **cannot** be taken — `screen` NULL, a row from
another host, a wedged tmux, a caller inside a container — the answer is
`None`, "CANNOT VERIFY". Not `True`, and not `False`: inventing a failure
there is the exact mirror of the false success being fixed. `None` does not
veto the restart's own outcome, so no working path regresses; the console
just stops printing an abstention under the word "verified".

The last commit finishes an injection seam the branch had left half-written
(`in_sif_fn` was in the signature and the docstring but never read) and, in
doing so, closes a real hole: the namespace check was gated behind
`if row_host:`, so a row naming no host skipped it entirely and an in-SIF
caller would probe that name against the **container's** tmux server.

## Evidence the tests are real

Both new suites were run against **pre-fix source** (the six files reverted
to `develop`) before being run against the fix.

**Behaviour 1 — the start path records the session name.** Pre-fix:

```
tests/scitex_agent_container/_lifecycle/test__instances_screen.py:124:
    assert _row_for("screen-1")["screen"] == "tui-screen-1"
E   AssertionError: assert None == 'tui-screen-1'
...
========================= 9 failed, 1 passed in 0.65s ==========================
```

`assert None == 'tui-screen-1'` is the P0's registry state exactly. Post-fix
all 10 pass. (The one pre-fix pass is the back-compat guard asserting a
runtime *without* the seam still records NULL — correct on both sides by
design, not a regression guard.)

**Behaviour 2 — verification abstains instead of vouching.** The decisive
input, run against develop's own code:

```
PRE-FIX verified = True
PRE-FIX reason   = agent 'scitex-agent-container' is a NEW run (c06d2fec -> 67068008)
```

That is the incident's printed line, reproduced from unfixed code with the
incident's own uuids. Post-fix the same call returns `None` with a reason
naming what could not be observed and telling the operator to confirm with
`tmux ls`. The new test file itself cannot even import against pre-fix
source (`ImportError: cannot import name 'SessionObservation'`), which is an
honest failure but a weaker one — the semantic check above is the real proof.

## Test coverage added

* `tests/.../_lifecycle/test__instances_screen.py` — 10 tests. Real on-disk
  state.db; the REAL `TuiSessionRuntime`, not only a stand-in; a **drift
  guard** asserting the recorded name is the same `session_name_for` call
  `start` passes to tmux.
* `tests/.../cli_pkg/lifecycle/test__restart_verify_session.py` — 20 tests.
  A **real tmux server** on a per-process private socket plus a real
  state.db. Covers the P0 shape (same session read twice → `False`, with the
  `tmux kill-session` recovery in the reason), a genuine kill-and-recreate
  (→ `True`), and blindness in all four forms.

No mocks anywhere; the production functions' documented injection seams take
real callables.

## Existing tests that changed, and why

Three tests in `test__restart.py` asserted the ledger-only pass and had to
move to the new contract:

* `test_verify_cycled_is_a_ternary` — the table now spans **both** witnesses
  (10 rows). Its two old `True` rows are re-stated as the abstention they
  should always have been, and `True` is still reachable, now only with
  session evidence.
* `test_restart_that_cycles_the_run_reports_verified_true` → split into
  `test_restart_that_cycles_only_the_ledger_cannot_be_verified` plus guards
  that the abstention is neither reported as a failure nor printed under the
  word "verified".

The postcondition fixtures gained an isolated state.db, so "no row names a
session for this agent" is a fact of the test rather than a property of the
host it runs on.

## One pre-existing problem fixed in passing

`test__restart.py` was raising the suite's own **state-floor** assertion on
the teardown of nearly every test in the file — **69 errors on develop**,
unrelated to this branch. Cause: `_isolate_runtime_root` restored
`SCITEX_AGENT_CONTAINER_RUNTIME_DIR` but never re-imported
`_runners._session_state`, whose `DEFAULT_STATE_ROOT` is a module constant
evaluated at import — and that import happens lazily inside the first test
that reads a run marker, i.e. while the fixture has the var pointed at a tmp
dir. The fixture now reloads the module *after* restoring the var, which is
the remedy the floor message itself names. The file now runs
**82 passed, 0 errors**.

## Known limitation (not a regression)

`#{session_created}` has one-second resolution, so a restart that completed
within the same wall-clock second as the session it replaced would read as
"did not cycle". This is narrow rather than theoretical-but-likely: the
before-reading is taken *before* the restart, so a collision additionally
requires the OLD session to have been born in that same second. Worth
knowing; not worth widening this diff for.
