### PR TITLE
feat(start): verify the launch before reporting it — never SUCC over a dead agent

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_launch_verify.py
+++ b/src/scitex_agent_container/_lifecycle/_launch_verify.py
@@ -1,0 +1,403 @@
+"""Post-launch verification for ``sac agents start`` — did it actually COME UP?
+
+WHAT THIS FIXES (v4 migration step 1 — ships alone, before any refactor)
+------------------------------------------------------------------------
+``sac agents start`` printed its green SUCC the moment the launch command
+returned, and for the detached runtimes that moment proves almost nothing:
+``ApptainerContainerRuntime.start`` returns as soon as ``apptainer exec``
+is backgrounded and its pid file is written. An agent that died seconds
+later — an a2a port bind collision (``OSError: [Errno 98]``), a
+``VenvDistributionError`` boot refusal, the SDK's 1MiB stdio frame kill;
+all three real, all three server-side deaths behind a SUCC on 2026-08-14 —
+was reported as started, exit 0. Operator directive, verbatim:
+「そういう場合には必ずエラーを caller 側に出さないとだめです」 and
+「エラーが握りつぶされないこと…エラーがどこで起こったかを示せるととても
+よいです」.
+
+THE EVIDENCE, PER PATH (only signals that are actually WRITTEN today)
+---------------------------------------------------------------------
+* SDK / ``claude-agent-sdk`` (and every other non-TUI runtime): the
+  in-container runner writes ``<state>/heartbeat.json`` synchronously at
+  boot — ``STATE_STARTING`` first, wall-clock ``ts``, through the
+  ``/state`` bind (``_runners/claude_session.py::run``; the same
+  ``write_heartbeat`` call also lands the ``state.db.heartbeats`` diary
+  row — the JSON file is the documented local fast path for exactly this
+  kind of read). A beat whose ``ts`` is at/after the moment we launched is
+  POSITIVE evidence a NEW incarnation booted. A beat with
+  ``state == "stopping"`` is excluded: on a ``--force`` cycle the OLD
+  incarnation's farewell beat can also land after our launch timestamp
+  and must not vouch for the new one.
+* TUI: ``TuiSessionRuntime.start`` already blocks through its boot drain
+  and only returns True once the session survived boot (session alive +
+  input-ready observed, or the liveness probe when the drain is off).
+  No runner-written heartbeat exists on this path — TUI beats come from
+  the listen daemon's centralized loop, which may not be running — so the
+  genuine post-start signal is the runtime's own liveness probe (tmux
+  pane process alive). We re-probe once instead of waiting 90s for a
+  beat nobody writes.
+
+THREE-VALUED, NEVER BINARY (fleet constitution)
+-----------------------------------------------
+The verdict distinguishes:
+
+* ``verified-up``     — positive evidence observed; the ONLY status that
+  may be reported as a green "started".
+* ``verified-failed`` — the launched process is GONE; the boot log tail
+  (the real error text, e.g. the Errno 98 line) rides on the verdict so
+  it reaches the caller's terminal, and the file it was read from is
+  named so the operator can go deeper.
+* ``unverified``      — the window expired with the process still
+  standing but nothing vouching for it. NOT collapsed into either pole:
+  it exits non-zero like a failure, but its wording says "could not
+  verify" and names where to look, never "failed".
+* ``skipped``         — verification did not apply (window disabled,
+  foreground/one-shot, or the start was brokered to another host where
+  the evidence lives). Reported honestly, never as SUCC-with-evidence.
+
+The window is configurable: ``--verify-window`` on ``sac agents start``
+(transported via ``SAC_START_VERIFY_WINDOW_S`` so the parallel re-exec
+path inherits it), default 90s, ``0`` disables.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable
+
+__all__ = [
+    "DEFAULT_POLL_INTERVAL_S",
+    "DEFAULT_VERIFY_WINDOW_S",
+    "SKIPPED",
+    "UNVERIFIED",
+    "VERIFIED_FAILED",
+    "VERIFIED_UP",
+    "VERIFY_WINDOW_ENV",
+    "LaunchVerdict",
+    "resolve_verify_window",
+    "verify_launch",
+]
+
+# Verdict statuses — the closed vocabulary callers branch on.
+VERIFIED_UP = "verified-up"
+VERIFIED_FAILED = "verified-failed"
+UNVERIFIED = "unverified"
+SKIPPED = "skipped"
+
+#: Default bounded wait for launch evidence. Generous enough for a cold
+#: apptainer boot + venv checks + the runner's first heartbeat on a
+#: loaded host; short enough that a stillborn launch is reported while
+#: the operator is still looking at the terminal.
+DEFAULT_VERIFY_WINDOW_S = 90.0
+
+#: Env transport for the window (the ``--verify-window`` click callback
+#: sets it; the parallel per-agent re-exec inherits it). ``0`` disables.
+VERIFY_WINDOW_ENV = "SAC_START_VERIFY_WINDOW_S"
+
+DEFAULT_POLL_INTERVAL_S = 1.0
+
+#: Bound on the boot-log tail carried on a verdict — mirrors the 4000
+#: chars ``_start_failure_diag._format_boot_stderr_section`` uses, so
+#: the two failure reports show the same amount of context.
+_TAIL_CHARS = 4_000
+
+#: The old incarnation's farewell state — never evidence of a NEW boot.
+_STATE_STOPPING = "stopping"
+
+
+@dataclass(frozen=True)
+class LaunchVerdict:
+    """The post-launch verdict plus the evidence it was drawn from.
+
+    ``status`` is one of the four module constants; ``evidence`` is the
+    operator-facing sentence naming WHAT was observed (or not);
+    ``log_path``/``log_tail`` carry the boot log that explains a failure
+    (the file is NAMED so the operator can go deeper than the tail);
+    ``heartbeat_path`` names the evidence file the wait was watching
+    (``None`` on the TUI path, which has no runner-written heartbeat);
+    ``waited_s`` is how long the verdict took to reach.
+    """
+
+    status: str
+    evidence: str
+    log_path: str | None
+    log_tail: str
+    waited_s: float
+    heartbeat_path: str | None
+
+    @property
+    def ok(self) -> bool:
+        """True iff this verdict must NOT flip the caller's exit code."""
+        return self.status in (VERIFIED_UP, SKIPPED)
+
+    def as_dict(self) -> dict:
+        """``--json`` envelope fields (flat, self-describing)."""
+        return {
+            "status": self.status,
+            "evidence": self.evidence,
+            "boot_log": self.log_path,
+            "boot_log_tail": self.log_tail,
+            "heartbeat_file": self.heartbeat_path,
+            "waited_s": round(self.waited_s, 1),
+        }
+
+
+def resolve_verify_window(explicit: float | None = None) -> float:
+    """Resolve the verification window: explicit arg > env var > default.
+
+    A malformed env value FAILS LOUD (``ValueError`` naming the variable
+    and the bad text) rather than silently falling back — a typo'd
+    window must not quietly become 90s of unexpected blocking, nor
+    quietly disable verification.
+    """
+    if explicit is not None:
+        return float(explicit)
+    raw = os.environ.get(VERIFY_WINDOW_ENV, "").strip()
+    if not raw:
+        return DEFAULT_VERIFY_WINDOW_S
+    try:
+        return float(raw)
+    except ValueError:
+        raise ValueError(
+            f"{VERIFY_WINDOW_ENV}={raw!r} is not a number of seconds. "
+            f"Use e.g. {VERIFY_WINDOW_ENV}=90 (or 0 to disable launch "
+            "verification)."
+        )
+
+
+def _resolve_state_dir(config: Any) -> Path:
+    """The agent's host-side state dir — SAME resolution the runtimes use.
+
+    ``_runners._session_state.state_dir_for`` rooted at the project-scope
+    ``runtime/`` when the spec lives in one (mirrors
+    ``ApptainerContainerRuntime._state_dir`` / ``tui_session.
+    state_dir_for_config``), else the home-scope default.
+    """
+    from ..runtimes._provider_common import project_runtime_root
+    from .._runners._session_state import state_dir_for
+
+    return state_dir_for(config.name, root=project_runtime_root(config))
+
+
+def _is_tui_runtime(runtime: Any) -> bool:
+    """True iff ``runtime`` is the interactive TUI runtime.
+
+    Decided on the runtime OBJECT (the same dispatch ``_get_runtime``
+    performed), not on ``config.runtime`` — ``provider: openai`` selects
+    the OpenAI runtime regardless of the runtime string, and an empty
+    runtime string means TUI only in the Claude family.
+    """
+    try:
+        from ..runtimes.tui_session import TuiSessionRuntime
+    except Exception:  # stx-allow: fallback (reason: a partial install without the tmux stack cannot be running TUI agents — the generic heartbeat path is the honest probe)
+        return False
+    return isinstance(runtime, TuiSessionRuntime)
+
+
+def _first_existing(state_dir: Path, names: tuple[str, ...]) -> Path | None:
+    """First boot-log candidate that exists on disk, else ``None``."""
+    for name in names:
+        candidate = state_dir / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _tail(path: Path | None) -> str:
+    """Bounded tail of ``path`` — empty (never raising) when unreadable."""
+    if path is None or not path.is_file():
+        return ""
+    try:
+        return path.read_text(errors="replace")[-_TAIL_CHARS:].rstrip()
+    except OSError:  # stx-allow: fallback (reason: an unreadable log must degrade to "no tail", not mask the launch verdict itself)
+        return ""
+
+
+def _iso(ts: float) -> str:
+    """Wall-clock heartbeat ``ts`` as a local-timezone ISO stamp."""
+    return datetime.fromtimestamp(ts).astimezone().isoformat(timespec="seconds")
+
+
+def _runtime_reports_running(runtime: Any, config: Any) -> bool:
+    """The runtime's own liveness probe — a RAISING probe is UNKNOWN.
+
+    A probe that could not run must not convict (the false-RED lesson of
+    :mod:`._start_verdict`): treat it as "still possibly alive" so the
+    wait continues and the window expiry reports UNVERIFIED, never a
+    fabricated death.
+    """
+    try:
+        return bool(runtime.is_running(config))
+    except Exception:  # stx-allow: fallback (reason: a probe that cannot run is UNKNOWN liveness, not evidence of death — see _start_verdict's false-RED rationale)
+        return True
+
+
+def verify_launch(
+    config: Any,
+    runtime: Any | None = None,
+    *,
+    launched_at: float,
+    window_s: float | None = None,
+    poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    state_dir: Path | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    now_fn: Callable[[], float] = time.time,
+) -> LaunchVerdict:
+    """Wait (bounded) for evidence the just-launched agent actually came up.
+
+    ``launched_at`` is the caller's wall-clock stamp taken BEFORE the
+    launch — freshness of a heartbeat is judged against it. ``runtime``
+    and ``state_dir`` are injection seams defaulting to the real
+    ``_get_runtime(config)`` dispatch and the runtimes' shared state-dir
+    resolution; ``sleep_fn``/``now_fn`` let the suite drive the wait
+    deterministically with real time values.
+
+    Never raises on the evidence paths — every outcome is a verdict.
+    """
+    window = resolve_verify_window(window_s)
+    if window <= 0:
+        return LaunchVerdict(
+            SKIPPED,
+            f"launch verification disabled ({VERIFY_WINDOW_ENV}={window:g})",
+            None,
+            "",
+            0.0,
+            None,
+        )
+    if runtime is None:
+        from ._runtime_select import _get_runtime
+
+        runtime = _get_runtime(config)
+    if state_dir is None:
+        state_dir = _resolve_state_dir(config)
+
+    if _is_tui_runtime(runtime):
+        return _verify_tui(config, runtime, state_dir, launched_at, now_fn)
+    return _verify_by_heartbeat(
+        config,
+        runtime,
+        state_dir,
+        launched_at=launched_at,
+        window=window,
+        poll_interval_s=poll_interval_s,
+        sleep_fn=sleep_fn,
+        now_fn=now_fn,
+    )
+
+
+def _verify_tui(
+    config: Any,
+    runtime: Any,
+    state_dir: Path,
+    launched_at: float,
+    now_fn: Callable[[], float],
+) -> LaunchVerdict:
+    """TUI verdict — one liveness re-probe after the runtime's boot drain.
+
+    ``TuiSessionRuntime.start`` already refused to return True unless the
+    session survived boot; this probe is the second witness at report
+    time, and its failure reading points at ``boot.stderr.log`` (where
+    the runtime redirects the inner ``apptainer exec … claude`` stderr).
+    """
+    waited = max(0.0, now_fn() - launched_at)
+    log_path = _first_existing(state_dir, ("boot.stderr.log", "stdout.log"))
+    if _runtime_reports_running(runtime, config):
+        return LaunchVerdict(
+            VERIFIED_UP,
+            "ready: boot drain passed and the tmux pane process is alive "
+            f"(probed {waited:.1f}s after launch)",
+            str(log_path) if log_path else None,
+            "",
+            waited,
+            None,
+        )
+    return LaunchVerdict(
+        VERIFIED_FAILED,
+        f"tmux session/pane is GONE {waited:.1f}s after launch "
+        "(runtime.is_running -> False) — the inner claude did not survive "
+        "boot",
+        str(log_path) if log_path else None,
+        _tail(log_path),
+        waited,
+        None,
+    )
+
+
+def _verify_by_heartbeat(
+    config: Any,
+    runtime: Any,
+    state_dir: Path,
+    *,
+    launched_at: float,
+    window: float,
+    poll_interval_s: float,
+    sleep_fn: Callable[[float], None],
+    now_fn: Callable[[], float],
+) -> LaunchVerdict:
+    """SDK-path verdict — poll for a FRESH heartbeat from a NEW incarnation.
+
+    Per tick, in evidence order: (1) a beat stamped at/after
+    ``launched_at`` (and not the old run's ``stopping`` farewell) proves
+    the new runner booted → VERIFIED_UP; (2) the runtime's own pid probe
+    reporting the container DEAD is definitive → VERIFIED_FAILED with the
+    boot-log tail (``stdout.log`` — apptainer merges the runner's stderr
+    into it, so the Errno 98 / VenvDistributionError text lives there);
+    (3) window expiry with the process still standing → UNVERIFIED, which
+    is exit-nonzero but worded as "could not verify", never "failed".
+    """
+    from .._runners._session_state import read_heartbeat
+
+    heartbeat_path = state_dir / "heartbeat.json"
+    log_candidates = ("stdout.log", "boot.stderr.log")
+    deadline = launched_at + window
+    while True:
+        beat = read_heartbeat(state_dir)
+        if beat is not None:
+            ts = beat.get("ts")
+            state = beat.get("state")
+            if (
+                isinstance(ts, (int, float))
+                and float(ts) >= launched_at
+                and state != _STATE_STOPPING
+            ):
+                waited = max(0.0, now_fn() - launched_at)
+                return LaunchVerdict(
+                    VERIFIED_UP,
+                    f"ready: first fresh heartbeat at {_iso(float(ts))} "
+                    f"(state={state}, pid {beat.get('pid')}), "
+                    f"{waited:.1f}s after launch",
+                    None,
+                    "",
+                    waited,
+                    str(heartbeat_path),
+                )
+        if not _runtime_reports_running(runtime, config):
+            waited = max(0.0, now_fn() - launched_at)
+            log_path = _first_existing(state_dir, log_candidates)
+            return LaunchVerdict(
+                VERIFIED_FAILED,
+                f"container process is DEAD {waited:.1f}s after launch "
+                "(runtime.is_running -> False) and no fresh heartbeat was "
+                "ever written",
+                str(log_path) if log_path else None,
+                _tail(log_path),
+                waited,
+                str(heartbeat_path),
+            )
+        if now_fn() >= deadline:
+            waited = max(0.0, now_fn() - launched_at)
+            log_path = _first_existing(state_dir, log_candidates)
+            return LaunchVerdict(
+                UNVERIFIED,
+                f"no fresh heartbeat within {window:g}s — the container "
+                "process still reports running, but nothing proves the "
+                "agent came up",
+                str(log_path) if log_path else None,
+                _tail(log_path),
+                waited,
+                str(heartbeat_path),
+            )
+        sleep_fn(poll_interval_s)

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -16,7 +16,7 @@ import click
 
 from .._helpers import agent_name_complete, console
 from ._common import _iter_agent_yamls
-from ._start_gate_options import spec_gate_options
+from ._start_gate_options import spec_gate_options, verify_window_option
 from ._start_group_filter import apply_group_targets, group_option
 from ._start_preflight_gate import make_preflight_runner
 
@@ -186,6 +186,7 @@ from ._start_preflight_gate import make_preflight_runner
     help="Replace existing materialised yamls under --params-out.",
 )
 @spec_gate_options
+@verify_window_option
 @click.option(
     "--no-redispatch",
     "no_redispatch",

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_gate_options.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_gate_options.py
@@ -42,6 +42,7 @@ import os
 import click
 
 from ..._drift._local import ALLOW_STALE_ENV
+from ..._lifecycle._launch_verify import DEFAULT_VERIFY_WINDOW_S, VERIFY_WINDOW_ENV
 from ..._lifecycle._layers_preflight import ALLOW_ENV as ALLOW_LAYERS_ENV
 
 
@@ -75,6 +76,39 @@ def _set_env_when_given(env_var: str):
         return value
 
     return _callback
+
+
+def _set_verify_window_env(ctx, param, value):  # noqa: ARG001 - click callback signature
+    """``--verify-window N`` -> ``SAC_START_VERIFY_WINDOW_S=N``.
+
+    Same env transport as the gate overrides above, for the same reason:
+    a multi-target start re-execs one subprocess per agent
+    (``_start_parallel``) and only the environment survives that hop.
+    Only SET when the flag is passed — an absent flag must leave an
+    operator-exported value alone.
+    """
+    if value is not None:
+        os.environ[VERIFY_WINDOW_ENV] = str(value)
+    return value
+
+
+#: ``--verify-window`` for ``sac agents start`` — the bounded wait for
+#: launch evidence (v4 step 1). Lives in this module (rather than a line
+#: in ``_start.py``) because it reuses the env-transport pattern above
+#: and the click entry file sits at its per-file line budget.
+verify_window_option = click.option(
+    "--verify-window",
+    type=float,
+    default=None,
+    expose_value=False,
+    callback=_set_verify_window_env,
+    help=(
+        "Seconds to wait after launching for evidence the agent actually "
+        "came up (fresh runner heartbeat, or the live TUI session) before "
+        f"the start verdict. Default {DEFAULT_VERIFY_WINDOW_S:g}s; 0 "
+        f"disables verification. Env: {VERIFY_WINDOW_ENV}."
+    ),
+)
 
 
 def spec_gate_options(func):
@@ -114,4 +148,4 @@ def spec_gate_options(func):
     return func
 
 
-__all__ = ["spec_gate_options"]
+__all__ = ["spec_gate_options", "verify_window_option"]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json as _json
 import os
 import sys
+import time
 import traceback
 from contextlib import nullcontext
 from pathlib import Path
@@ -303,6 +304,9 @@ def run_single_targets(
                         is_remote=is_remote,
                         tail_lines=tail_lines,
                     )
+                # Wall-clock stamp taken BEFORE the launch — heartbeat
+                # freshness in the launch verdict is judged against it.
+                _launched_at = time.time()
                 _outcome = agent_start(
                     config_path,
                     no_preflight=no_preflight,
@@ -316,64 +320,29 @@ def run_single_targets(
                     strict_drift=strict_drift,
                 )
                 _noop = outcome_kind(_outcome) == KIND_ALREADY_RUNNING
-                if as_json:
-                    from ..._state.port_allocator import get_port as _get_port
-                    from ..._state.state_db import now_iso as _now_iso
+                # v4 step 1 — the launch VERDICT: the launch only counts
+                # as STARTED once evidence shows the agent actually came
+                # up; never SUCC on an unverified launch. Reporting
+                # (human + --json) and the three-valued verdict live in
+                # ``_start_verify_report``; a failed / unverifiable
+                # launch flips the exit code below.
+                from ._start_verify_report import report_start_result
 
-                    _raw_port = getattr(getattr(config, "a2a", None), "port", None)
-                    _resolved_port: int | None = (
-                        None
-                        if (dry_run or _raw_port is None)
-                        else _get_port(config.name)
-                    )
-                    _emit(
-                        {
-                            "name": config.name,
-                            "status": (
-                                "dry_run_ok"
-                                if dry_run
-                                else ("already_running" if _noop else "started")
-                            ),
-                            "host": host,
-                            "host_workdir": host_workdir,
-                            "container_workdir": container_workdir,
-                            "dry_run": dry_run,
-                            "a2a_port": _resolved_port,
-                            "started_at": None if dry_run else _now_iso(),
-                        }
-                    )
-                else:
-                    if foreground and not dry_run:
-                        # Agent stdout often lacks a trailing newline.
-                        click.echo("")
-                    # The no-op branch already reported the state and the
-                    # options; a SUCC "started" after it would assert an
-                    # action that did not happen.
-                    if not _noop:
-                        verb = (
-                            "dry-run prepared the workspace for"
-                            if dry_run
-                            else "started"
-                        )
-                        tail = "" if dry_run else f" [dim]({location})[/dim]"
-                        system_msg(
-                            f"[bold]{config.name}[/bold] {verb}{tail}", style="green"
-                        )
-                    if (
-                        not dry_run
-                        and not config.claude.auto_accept
-                        and any(
-                            df in f
-                            for f in config.claude.flags
-                            for df in (
-                                "--dangerously-skip-permissions",
-                                "--dangerously-load-development-channels",
-                            )
-                        )
-                    ):
-                        console.print(
-                            f"[yellow]auto_accept: false — manual TUI acceptance required on {host}[/yellow]"
-                        )
+                if not report_start_result(
+                    config,
+                    noop=_noop,
+                    dry_run=dry_run,
+                    foreground=foreground,
+                    one_shot=one_shot,
+                    as_json=as_json,
+                    emit=_emit,
+                    launched_at=_launched_at,
+                    host=host,
+                    host_workdir=host_workdir,
+                    container_workdir=container_workdir,
+                    location=location,
+                ):
+                    any_error = True
             except ResumePreflightError as exc:
                 # Informative, operator-facing --resume miss (#192, Part B #3).
                 # The message body IS the candidate listing + next-step hint;

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_verify_report.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_verify_report.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Post-``agent_start`` reporting for ``sac agents start`` — the launch verdict.
+
+Extracted from ``_start_single.py`` (512-line per-file cap) together with
+the NEW post-launch verification it now performs (v4 migration step 1):
+the green "started" line only prints once :mod:`_lifecycle._launch_verify`
+observed evidence the agent actually came up — never SUCC on an
+unverified launch. On a verified failure the boot-log tail (the real
+error text — e.g. the ``[Errno 98]`` line) is printed to the caller's
+terminal along with the FILE it was read from; on an in-window
+non-answer the wording says "could not verify" and names where to look.
+Both of those return ``False`` so the caller exits non-zero.
+
+The pre-existing report shapes (``--json`` statuses ``dry_run_ok`` /
+``already_running`` / ``started``, the human dry-run and started lines,
+the manual-TUI-acceptance warning) are preserved; ``--json`` gains a
+``verify`` sub-object on real launches and the honest statuses
+``start-failed`` / ``start-unverified`` when the launch did not verify.
+Error paths go through ``system_msg`` — sac's scitex-logging surface —
+so ``ERRO`` marks the verified failure and ``FAIL`` the failed check.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import click
+
+from ..._lifecycle._launch_verify import (
+    SKIPPED,
+    UNVERIFIED,
+    VERIFIED_FAILED,
+    VERIFIED_UP,
+    LaunchVerdict,
+    verify_launch,
+)
+from .._helpers import console, system_msg
+
+#: verdict status -> the ``--json`` ``status`` field. ``skipped`` maps to
+#: the historical ``started`` (nothing contradicts it and scripts keyed
+#: on ``started`` must not break when verification does not apply); the
+#: two negative verdicts get their own honest statuses.
+_JSON_STATUS = {
+    VERIFIED_UP: "started",
+    SKIPPED: "started",
+    VERIFIED_FAILED: "start-failed",
+    UNVERIFIED: "start-unverified",
+}
+
+
+def _indent(text: str, prefix: str = "      ") -> str:
+    """Indent a multi-line body so it reads as one sub-section (mirrors
+    ``_start_failure_diag._indent_block``)."""
+    return "\n".join(f"{prefix}{line}" for line in (text.splitlines() or [""]))
+
+
+def _echo_boot_log_tail(verdict: LaunchVerdict, *, style: str) -> None:
+    """Headline via ``system_msg`` (leveled), tail body VERBATIM.
+
+    The body deliberately bypasses ``system_msg``: the console helper
+    strips ``[tag]``-shaped rich markup before logging, and the exact
+    text this report exists to surface is bracket-shaped —
+    ``[Errno 98]`` matches the tag regex and would be silently eaten
+    (measured: the pre-fix render showed ``OSError:  error while
+    attempting to bind``). ``click.echo(..., err=True)`` keeps it
+    byte-exact and on stderr, where the listen's detached-launch
+    adoption also captures it into the STARTUP_FAILED marker.
+    """
+    system_msg(f"boot log tail ({verdict.log_path}):", style=style)
+    click.echo(_indent(verdict.log_tail), err=True)
+
+
+def _emit_report_json(
+    emit: Callable[[dict], None],
+    config: Any,
+    *,
+    status: str,
+    dry_run: bool,
+    host: str,
+    host_workdir: str,
+    container_workdir: str,
+    verify: dict | None,
+) -> None:
+    """The structured ``--json`` report — same fields as before, plus
+    ``verify`` when a launch verdict exists."""
+    from ..._state.port_allocator import get_port as _get_port
+    from ..._state.state_db import now_iso as _now_iso
+
+    _raw_port = getattr(getattr(config, "a2a", None), "port", None)
+    _resolved_port: int | None = (
+        None if (dry_run or _raw_port is None) else _get_port(config.name)
+    )
+    payload = {
+        "name": config.name,
+        "status": status,
+        "host": host,
+        "host_workdir": host_workdir,
+        "container_workdir": container_workdir,
+        "dry_run": dry_run,
+        "a2a_port": _resolved_port,
+        "started_at": None if dry_run else _now_iso(),
+    }
+    if verify is not None:
+        payload["verify"] = verify
+    emit(payload)
+
+
+def _warn_manual_accept(config: Any, host: str, *, dry_run: bool) -> None:
+    """The pre-existing manual-TUI-acceptance warning, verbatim."""
+    if (
+        not dry_run
+        and not config.claude.auto_accept
+        and any(
+            df in f
+            for f in config.claude.flags
+            for df in (
+                "--dangerously-skip-permissions",
+                "--dangerously-load-development-channels",
+            )
+        )
+    ):
+        console.print(
+            f"[yellow]auto_accept: false — manual TUI acceptance required on {host}[/yellow]"
+        )
+
+
+def _skip_reason(*, foreground: bool, one_shot: bool) -> str | None:
+    """Why verification does not apply to this launch, or ``None``.
+
+    In-SIF: ``agent_start`` brokered the spawn to the host listen, whose
+    own ``sac agents start`` subprocess runs this same verification where
+    the evidence lives (a container-side probe of host state dirs could
+    only ever read an empty directory — the ``_restart_verify`` lesson).
+    """
+    if foreground:
+        return (
+            "foreground run attached this terminal to the agent directly "
+            "(nothing detached to verify)"
+        )
+    if one_shot:
+        return "--one-shot runs its turn to completion and exits by design"
+    from ..._lifecycle._in_sif_broker import is_in_sif
+
+    if is_in_sif():
+        return (
+            "start was brokered to the host `sac listen` — the evidence "
+            "lives on the host, whose own start subprocess verifies there"
+        )
+    return None
+
+
+def report_start_result(
+    config: Any,
+    *,
+    noop: bool,
+    dry_run: bool,
+    foreground: bool,
+    one_shot: bool,
+    as_json: bool,
+    emit: Callable[[dict], None],
+    launched_at: float,
+    host: str,
+    host_workdir: str,
+    container_workdir: str,
+    location: str,
+    verify_fn: Callable[..., LaunchVerdict] | None = None,
+) -> bool:
+    """Verify the launch (bounded) and report the outcome. False = exit 1.
+
+    ``verify_fn`` is the injection seam for the verdict producer (a real
+    callable with :func:`verify_launch`'s keyword shape; production is
+    ``verify_launch`` itself).
+    """
+    # No-op / dry-run: nothing was launched, so there is nothing to
+    # verify — report exactly as before.
+    if dry_run or noop:
+        if as_json:
+            _emit_report_json(
+                emit,
+                config,
+                status="dry_run_ok" if dry_run else "already_running",
+                dry_run=dry_run,
+                host=host,
+                host_workdir=host_workdir,
+                container_workdir=container_workdir,
+                verify=None,
+            )
+        else:
+            if not noop:
+                system_msg(
+                    f"[bold]{config.name}[/bold] dry-run prepared the workspace for",
+                    style="green",
+                )
+            _warn_manual_accept(config, host, dry_run=dry_run)
+        return True
+
+    reason = _skip_reason(foreground=foreground, one_shot=one_shot)
+    if reason is not None:
+        verdict = LaunchVerdict(SKIPPED, reason, None, "", 0.0, None)
+    else:
+        verdict = (verify_fn or verify_launch)(config, launched_at=launched_at)
+
+    if as_json:
+        _emit_report_json(
+            emit,
+            config,
+            status=_JSON_STATUS[verdict.status],
+            dry_run=False,
+            host=host,
+            host_workdir=host_workdir,
+            container_workdir=container_workdir,
+            verify=verdict.as_dict(),
+        )
+        return verdict.ok
+
+    if foreground:
+        # Agent stdout often lacks a trailing newline.
+        click.echo("")
+    if verdict.status == VERIFIED_UP:
+        system_msg(
+            f"[bold]{config.name}[/bold] started [dim]({location})[/dim] — "
+            f"{verdict.evidence}",
+            style="green",
+        )
+    elif verdict.status == SKIPPED:
+        # Launched, but unverifiable BY DESIGN here — say so instead of
+        # asserting an accomplishment nothing observed.
+        system_msg(
+            f"[bold]{config.name}[/bold] launched [dim]({location})[/dim] — "
+            f"launch verification skipped: {verdict.evidence}",
+            style="info",
+        )
+    elif verdict.status == VERIFIED_FAILED:
+        system_msg(
+            f"{config.name}: launch did NOT verify — {verdict.evidence}",
+            style="error",
+        )
+        if verdict.log_tail:
+            _echo_boot_log_tail(verdict, style="error")
+        elif verdict.log_path:
+            system_msg(
+                f"boot log ({verdict.log_path}) exists but is empty — the "
+                "runtime died before writing anything",
+                style="error",
+            )
+        else:
+            system_msg(
+                "no boot log was written — the runtime never launched far "
+                "enough to leave one",
+                style="error",
+            )
+    else:  # UNVERIFIED — worded as "could not verify", never "failed".
+        system_msg(
+            f"{config.name}: launch NOT verified — {verdict.evidence}",
+            style="fail",
+        )
+        looked_at = " and ".join(
+            p for p in (verdict.heartbeat_path, verdict.log_path) if p
+        )
+        if looked_at:
+            system_msg(
+                f"cannot tell whether the agent is up; go deeper via: {looked_at}",
+                style="fail",
+            )
+        if verdict.log_tail:
+            _echo_boot_log_tail(verdict, style="fail")
+    _warn_manual_accept(config, host, dry_run=False)
+    return verdict.ok
+
+
+__all__ = ["report_start_result"]

--- a/tests/scitex_agent_container/_lifecycle/test__launch_verify.py
+++ b/tests/scitex_agent_container/_lifecycle/test__launch_verify.py
@@ -1,0 +1,318 @@
+"""``_lifecycle._launch_verify`` — the post-launch verdict (v4 step 1).
+
+Pins the three-valued contract that ``sac agents start`` must never
+report SUCC on an unverified launch (2026-08-14 outage: Errno 98 a2a
+bind collision, VenvDistributionError boot refusal, SDK 1MiB stdio
+frame kill — all died server-side while start printed SUCC):
+
+* a FRESH heartbeat from the NEW incarnation → ``verified-up``;
+* a dead container process → ``verified-failed`` carrying the boot-log
+  tail (the real error text) AND the file it was read from;
+* window expiry with the process still standing → ``unverified`` —
+  distinct from failure, never collapsed.
+
+NO MOCKS — real state dirs (tmp_path), the real ``write_heartbeat``
+writer (JSON-only shape: no name/host, so no state.db rows), and tiny
+real runtime doubles implementing ``is_running`` (the same seam style
+``TuiSessionRuntime`` tests use). Each test: AAA markers, one
+assertion, 3+-word name.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._launch_verify import (
+    SKIPPED,
+    UNVERIFIED,
+    VERIFIED_FAILED,
+    VERIFIED_UP,
+    VERIFY_WINDOW_ENV,
+    resolve_verify_window,
+    verify_launch,
+)
+from scitex_agent_container._runners._session_state import write_heartbeat
+
+# ---------------------------------------------------------------------------
+# Real collaborators — no mocks.
+# ---------------------------------------------------------------------------
+
+
+class _AliveRuntime:
+    """Real runtime double whose liveness probe says the process is up."""
+
+    def is_running(self, config) -> bool:  # noqa: ARG002 - runtime seam shape
+        return True
+
+
+class _DeadRuntime:
+    """Real runtime double whose liveness probe says the process is gone."""
+
+    def is_running(self, config) -> bool:  # noqa: ARG002 - runtime seam shape
+        return False
+
+
+def _config(name: str = "verify-x") -> SimpleNamespace:
+    return SimpleNamespace(name=name)
+
+
+_ERRNO98 = (
+    "ERROR: [Errno 98] Address already in use: ('127.0.0.1', 8631)\n"
+    "OSError: [Errno 98] error while attempting to bind on address\n"
+)
+
+
+@pytest.fixture
+def clean_window_env() -> Iterator[None]:
+    """Save/restore ``SAC_START_VERIFY_WINDOW_S`` around each test."""
+    saved = os.environ.get(VERIFY_WINDOW_ENV)
+    os.environ.pop(VERIFY_WINDOW_ENV, None)
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(VERIFY_WINDOW_ENV, None)
+        else:
+            os.environ[VERIFY_WINDOW_ENV] = saved
+
+
+# ---------------------------------------------------------------------------
+# verified-up — a fresh heartbeat from the new incarnation.
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_heartbeat_verifies_up(clean_window_env, tmp_path: Path) -> None:
+    """A beat stamped at/after launch is POSITIVE evidence of boot."""
+    # Arrange — launch stamp taken FIRST, then the runner's boot beat.
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="starting")
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == VERIFIED_UP
+
+
+def test_verified_up_names_the_heartbeat_file(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """The evidence FILE is named so the operator can go deeper."""
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="starting")
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.heartbeat_path == str(tmp_path / "heartbeat.json")
+
+
+def test_stale_heartbeat_is_not_evidence_of_up(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """A beat from BEFORE the launch belongs to the previous incarnation."""
+    # Arrange — beat stamped 100s before this launch.
+    write_heartbeat(tmp_path, pid=4242, state="idle", ts=time.time() - 100.0)
+    launched_at = time.time()
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=0.2,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == UNVERIFIED
+
+
+def test_old_run_stopping_farewell_is_not_evidence(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """On a --force cycle the OLD run's ``stopping`` beat can land after
+    the launch stamp — it must not vouch for the new incarnation."""
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="stopping")
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=0.2,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# verified-failed — the launched process died; the error must surface.
+# ---------------------------------------------------------------------------
+
+
+def test_dead_process_reports_verified_failed(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """No fresh beat + dead pid = a definitive failure, not a timeout."""
+    # Arrange
+    launched_at = time.time()
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _DeadRuntime(),
+        launched_at=launched_at,
+        window_s=5.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == VERIFIED_FAILED
+
+
+def test_dead_process_surfaces_boot_log_tail(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """The real error text (the Errno 98 line) rides on the verdict."""
+    # Arrange — the apptainer runtime merges the runner's stderr into
+    # <state>/stdout.log; that is where the bind collision text lands.
+    (tmp_path / "stdout.log").write_text(_ERRNO98)
+    launched_at = time.time()
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _DeadRuntime(),
+        launched_at=launched_at,
+        window_s=5.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert "[Errno 98]" in verdict.log_tail
+
+
+def test_dead_process_names_the_boot_log_file(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """The verdict names the FILE it read so the operator can go deeper."""
+    # Arrange
+    (tmp_path / "stdout.log").write_text(_ERRNO98)
+    launched_at = time.time()
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _DeadRuntime(),
+        launched_at=launched_at,
+        window_s=5.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.log_path == str(tmp_path / "stdout.log")
+
+
+# ---------------------------------------------------------------------------
+# unverified — the third value; never collapsed into either pole.
+# ---------------------------------------------------------------------------
+
+
+def test_window_expiry_reports_unverified_not_failed(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """A standing process with no beat is "could not verify" — a distinct
+    verdict from "verified failed" (fleet constitution: no binary
+    collapse)."""
+    # Arrange
+    launched_at = time.time()
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=0.2,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == UNVERIFIED
+
+
+def test_unverified_verdict_flips_the_exit_code(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """``ok`` is False for UNVERIFIED — exit-nonzero like a failure."""
+    # Arrange
+    launched_at = time.time()
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=0.2,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.ok is False
+
+
+# ---------------------------------------------------------------------------
+# window configuration — explicit arg > env var > default; 0 disables.
+# ---------------------------------------------------------------------------
+
+
+def test_window_zero_skips_verification(clean_window_env, tmp_path: Path) -> None:
+    """``--verify-window 0`` is the documented opt-out."""
+    # Arrange
+    launched_at = time.time()
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=0.0,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == SKIPPED
+
+
+def test_env_var_overrides_default_window(clean_window_env) -> None:
+    """``SAC_START_VERIFY_WINDOW_S`` is the env transport for the window."""
+    # Arrange
+    os.environ[VERIFY_WINDOW_ENV] = "12.5"
+    # Act
+    window = resolve_verify_window()
+    # Assert
+    assert window == 12.5
+
+
+def test_malformed_env_window_fails_loud(clean_window_env) -> None:
+    """A typo'd window must not silently become the default."""
+    # Arrange
+    os.environ[VERIFY_WINDOW_ENV] = "ninety"
+    # Act
+    raiser = pytest.raises(ValueError)
+    # Assert
+    with raiser:
+        resolve_verify_window()

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_verify_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_verify_wiring.py
@@ -1,0 +1,213 @@
+"""``run_single_targets`` — the launch verdict is WIRED into the start path.
+
+The unit suites pin the verdict (``test__launch_verify``) and its
+rendering (``test__start_verify_report``); this module pins that
+``run_single_targets`` actually routes its report through them — i.e.
+that ``sac agents start --json`` now carries a ``verify`` sub-object.
+
+Exercised through the in-SIF broker path (the same real loopback listen
+server ``test__start_single_assume_yes`` uses) because it reaches the
+real reporting code with zero container infrastructure: a brokered start
+returns success locally while the EVIDENCE lives on the host, so the
+verdict must be an honest ``skipped`` — pre-fix, the payload had no
+``verify`` key at all and the start was reported as a bare ``started``.
+
+NO MOCKS — real spec.yaml on disk, real isolated state.db, a real
+loopback HTTP listen. AAA markers, one assertion per test, 3+-word names.
+"""
+
+from __future__ import annotations
+
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container.cli_pkg.lifecycle._start_single import (
+    run_single_targets,
+)
+
+_SIF_KEYS = ("APPTAINER_CONTAINER", "SINGULARITY_CONTAINER")
+_LISTEN_KEYS = (
+    "SAC_LISTEN_BASE_URL",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BASE_URL",
+    "SAC_LISTEN_BEARER",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BEARER",
+    "SAC_NAME",
+    "SCITEX_AGENT_CONTAINER_NAME",
+    "SAC_ASSUME_YES",
+)
+
+
+@pytest.fixture
+def broker_env() -> Iterator[Any]:
+    """Yield a setter for the in-SIF + listen env vars (save/restore)."""
+    keys = _SIF_KEYS + _LISTEN_KEYS
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+
+    def _set(key: str, value: str | None) -> None:
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+    try:
+        yield _set
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    """Real isolated state.db + runtime dir + HOME (mirrors the sibling
+    ``test__start_single_assume_yes`` fixture)."""
+    db = tmp_path / "state.db"
+    runtime_dir = tmp_path / "runtime"
+    home = tmp_path / "home"
+    home.mkdir()
+    keys = {
+        "SCITEX_AGENT_CONTAINER_STATE_DB": str(db),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": str(runtime_dir),
+        "HOME": str(home),
+        "SCITEX_DIR": str(home / ".scitex"),
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ.update(keys)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def _write_spec(yaml_root: Path, name: str) -> Path:
+    agent_dir = yaml_root / name
+    agent_dir.mkdir(parents=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "spec:\n"
+            "  runtime: apptainer\n"
+            "  host: ${HOSTNAME}\n"
+            f"  workdir: {yaml_root / (name + '-work')}\n"
+            "  apptainer:\n    image: /x.sif\n    binds: []\n"
+            "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+            "  claude:\n"
+            "    model: sonnet\n"
+            "  health:\n"
+            "    enabled: false\n"
+            "    interval: 60\n"
+        )
+    )
+    return spec
+
+
+def _start_loopback_listen():
+    """Real loopback HTTP server answering the brokered /agents POST."""
+    import http.server
+    import threading
+
+    captured: dict = {}
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            captured["body"] = self.rfile.read(length)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"name": "capsule-child", "returncode": 0}).encode()
+            )
+
+        def log_message(self, *_args):  # silence test noise
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://{host}:{port}", captured, server, thread
+
+
+def _run_brokered_start(broker_env, tmp_path: Path, capsys) -> dict:
+    """Drive one brokered ``--json`` start; return the report payload."""
+    broker_env("APPTAINER_CONTAINER", "/path/to/agent.sif")
+    base_url, _captured, server, thread = _start_loopback_listen()
+    broker_env("SAC_LISTEN_BASE_URL", base_url)
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    try:
+        run_single_targets(
+            [str(spec)],
+            no_preflight=True,
+            force=False,
+            resume_id=None,
+            session_mode=None,
+            dry_run=False,
+            as_json=True,
+            foreground=False,
+            one_shot=False,
+            strict_drift=False,
+            no_redispatch=True,
+            multi_foreground=False,
+            preflight_runner=lambda: None,
+            yes=True,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    for line in capsys.readouterr().out.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            payload = json.loads(line)
+            if payload.get("name") == "capsule-child":
+                return payload
+    raise AssertionError("no JSON report line for 'capsule-child' on stdout")
+
+
+def test_brokered_start_json_carries_verify_object(
+    isolated_state, broker_env, tmp_path: Path, capsys
+) -> None:
+    """The ``--json`` report now carries the launch verdict (pre-fix the
+    payload had no ``verify`` key and success was asserted blind)."""
+    # Arrange / Act — one brokered start through the real loopback listen.
+    # Arrange
+    del isolated_state
+    # Act
+    payload = _run_brokered_start(broker_env, tmp_path, capsys)
+    # Assert
+    assert "verify" in payload
+
+
+def test_brokered_start_verdict_is_honest_skipped(
+    isolated_state, broker_env, tmp_path: Path, capsys
+) -> None:
+    """A brokered start cannot see host evidence — the verdict must say
+    ``skipped`` (verification happens host-side), never a fabricated
+    verified-up."""
+    # Arrange
+    del isolated_state
+    # Act
+    payload = _run_brokered_start(broker_env, tmp_path, capsys)
+    # Assert
+    assert payload["verify"]["status"] == "skipped"

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_verify_report.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_verify_report.py
@@ -1,0 +1,331 @@
+"""``_start_verify_report.report_start_result`` — the caller-visible verdict.
+
+Pins the operator contract from the 2026-08-14 outage (Errno 98 / venv
+refusal / stdio frame kill all died server-side behind a SUCC):
+
+* a verified failure exits non-zero, carries the boot-log tail (the real
+  error text) to the terminal, and names the file it was read from;
+* an in-window non-answer is its own status (``start-unverified``), also
+  non-zero, never collapsed into "failed" or "started";
+* only a verified (or by-design unverifiable) launch keeps exit 0, and
+  the legacy ``--json`` statuses (``dry_run_ok`` / ``already_running`` /
+  ``started``) are preserved for scripts.
+
+NO MOCKS — real emit closures, real ``LaunchVerdict`` values produced by
+real ``verify_fn`` callables (the documented injection seam), a real
+minimal config object. Each test: AAA markers, one assertion, 3+-word
+name.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._launch_verify import (
+    UNVERIFIED,
+    VERIFIED_FAILED,
+    VERIFIED_UP,
+    LaunchVerdict,
+)
+from scitex_agent_container.cli_pkg.lifecycle._start_verify_report import (
+    report_start_result,
+)
+
+# ---------------------------------------------------------------------------
+# Real collaborators.
+# ---------------------------------------------------------------------------
+
+
+def _config(name: str = "verify-x") -> SimpleNamespace:
+    """Minimal real config carrying exactly the fields the report reads."""
+    return SimpleNamespace(
+        name=name,
+        a2a=SimpleNamespace(port=None),
+        claude=SimpleNamespace(auto_accept=True, flags=[]),
+    )
+
+
+_ERRNO98_TAIL = "OSError: [Errno 98] error while attempting to bind on address"
+
+
+def _failed_verdict(**overrides) -> LaunchVerdict:
+    fields = dict(
+        status=VERIFIED_FAILED,
+        evidence="container process is DEAD 3.2s after launch "
+        "(runtime.is_running -> False) and no fresh heartbeat was ever written",
+        log_path="/state/verify-x/stdout.log",
+        log_tail=_ERRNO98_TAIL,
+        waited_s=3.2,
+        heartbeat_path="/state/verify-x/heartbeat.json",
+    )
+    fields.update(overrides)
+    return LaunchVerdict(**fields)
+
+
+def _up_verdict() -> LaunchVerdict:
+    return LaunchVerdict(
+        VERIFIED_UP,
+        "ready: first fresh heartbeat at 2026-08-14T21:00:00+09:00 "
+        "(state=starting, pid 4242), 4.0s after launch",
+        None,
+        "",
+        4.0,
+        "/state/verify-x/heartbeat.json",
+    )
+
+
+def _unverified_verdict() -> LaunchVerdict:
+    return LaunchVerdict(
+        UNVERIFIED,
+        "no fresh heartbeat within 90s — the container process still "
+        "reports running, but nothing proves the agent came up",
+        "/state/verify-x/stdout.log",
+        "",
+        90.0,
+        "/state/verify-x/heartbeat.json",
+    )
+
+
+def _verify_fn_returning(verdict: LaunchVerdict):
+    """A REAL verify_fn (the documented seam) that yields ``verdict``."""
+
+    def _verify(config, **kwargs):  # noqa: ARG001 - verify_launch keyword shape
+        return verdict
+
+    return _verify
+
+
+def _report(verdict: LaunchVerdict, *, as_json: bool, emitted: list) -> bool:
+    return report_start_result(
+        _config(),
+        noop=False,
+        dry_run=False,
+        foreground=False,
+        one_shot=False,
+        as_json=as_json,
+        emit=emitted.append,
+        launched_at=time.time(),
+        host="test-host",
+        host_workdir="/work",
+        container_workdir="/work",
+        location="test-host@/work:/work",
+        verify_fn=_verify_fn_returning(verdict),
+    )
+
+
+@pytest.fixture
+def not_in_sif() -> Iterator[None]:
+    """Ensure the in-SIF skip cannot mask the verdict under test."""
+    keys = ("APPTAINER_CONTAINER", "SINGULARITY_CONTAINER")
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    try:
+        yield
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+# ---------------------------------------------------------------------------
+# verified failure — exit non-zero, error text on the terminal.
+# ---------------------------------------------------------------------------
+
+
+def test_verified_failure_returns_false(not_in_sif) -> None:
+    """A launch whose process died must flip the caller's exit code."""
+    # Arrange
+    emitted: list = []
+    # Act
+    ok = _report(_failed_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert ok is False
+
+
+def test_verified_failure_json_status_is_start_failed(not_in_sif) -> None:
+    """``--json`` says ``start-failed`` — never a false ``started``."""
+    # Arrange
+    emitted: list = []
+    # Act
+    _report(_failed_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert emitted[0]["status"] == "start-failed"
+
+
+def test_verified_failure_json_carries_boot_log_tail(not_in_sif) -> None:
+    """The real error text (the Errno 98 line) reaches the JSON caller."""
+    # Arrange
+    emitted: list = []
+    # Act
+    _report(_failed_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert "[Errno 98]" in emitted[0]["verify"]["boot_log_tail"]
+
+
+def test_verified_failure_json_names_the_boot_log(not_in_sif) -> None:
+    """The file the tail came from is named so the operator can go deeper."""
+    # Arrange
+    emitted: list = []
+    # Act
+    _report(_failed_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert emitted[0]["verify"]["boot_log"] == "/state/verify-x/stdout.log"
+
+
+def test_verified_failure_prints_error_text_to_terminal(
+    not_in_sif, capsys
+) -> None:
+    """Human mode: the Errno 98 line must reach the caller's terminal —
+    the operator's verbatim requirement (エラーが握りつぶされないこと)."""
+    # Arrange
+    emitted: list = []
+    # Act
+    _report(_failed_verdict(), as_json=False, emitted=emitted)
+    # Assert
+    captured = capsys.readouterr()
+    assert "[Errno 98]" in (captured.out + captured.err)
+
+
+# ---------------------------------------------------------------------------
+# unverified — the third value, distinct wording, still non-zero.
+# ---------------------------------------------------------------------------
+
+
+def test_unverified_launch_returns_false(not_in_sif) -> None:
+    """"Could not verify" is exit-nonzero like a failure."""
+    # Arrange
+    emitted: list = []
+    # Act
+    ok = _report(_unverified_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert ok is False
+
+
+def test_unverified_json_status_is_start_unverified(not_in_sif) -> None:
+    """The third value keeps its own status — no binary collapse."""
+    # Arrange
+    emitted: list = []
+    # Act
+    _report(_unverified_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert emitted[0]["status"] == "start-unverified"
+
+
+# ---------------------------------------------------------------------------
+# verified up — the only path that keeps the legacy success shape.
+# ---------------------------------------------------------------------------
+
+
+def test_verified_up_returns_true(not_in_sif) -> None:
+    """A verified launch keeps exit 0."""
+    # Arrange
+    emitted: list = []
+    # Act
+    ok = _report(_up_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert ok is True
+
+
+def test_verified_up_json_status_stays_started(not_in_sif) -> None:
+    """Scripts keyed on ``status == "started"`` keep working."""
+    # Arrange
+    emitted: list = []
+    # Act
+    _report(_up_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert emitted[0]["status"] == "started"
+
+
+def test_verified_up_json_carries_the_evidence(not_in_sif) -> None:
+    """The success is falsifiable: it says WHAT was observed."""
+    # Arrange
+    emitted: list = []
+    # Act
+    _report(_up_verdict(), as_json=True, emitted=emitted)
+    # Assert
+    assert "first fresh heartbeat" in emitted[0]["verify"]["evidence"]
+
+
+# ---------------------------------------------------------------------------
+# legacy shapes — no-op and dry-run are reported exactly as before.
+# ---------------------------------------------------------------------------
+
+
+def test_noop_keeps_already_running_status(not_in_sif) -> None:
+    """The idempotent no-op emits the legacy status untouched."""
+    # Arrange
+    emitted: list = []
+    # Act
+    report_start_result(
+        _config(),
+        noop=True,
+        dry_run=False,
+        foreground=False,
+        one_shot=False,
+        as_json=True,
+        emit=emitted.append,
+        launched_at=time.time(),
+        host="test-host",
+        host_workdir="/work",
+        container_workdir="/work",
+        location="test-host@/work:/work",
+        verify_fn=_verify_fn_returning(_failed_verdict()),
+    )
+    # Assert
+    assert emitted[0]["status"] == "already_running"
+
+
+def test_noop_payload_has_no_verify_key(not_in_sif) -> None:
+    """Nothing was launched, so no verdict is asserted (back-compat)."""
+    # Arrange
+    emitted: list = []
+    # Act
+    report_start_result(
+        _config(),
+        noop=True,
+        dry_run=False,
+        foreground=False,
+        one_shot=False,
+        as_json=True,
+        emit=emitted.append,
+        launched_at=time.time(),
+        host="test-host",
+        host_workdir="/work",
+        container_workdir="/work",
+        location="test-host@/work:/work",
+        verify_fn=_verify_fn_returning(_failed_verdict()),
+    )
+    # Assert
+    assert "verify" not in emitted[0]
+
+
+def test_dry_run_keeps_dry_run_ok_status(not_in_sif) -> None:
+    """Dry-run emits the legacy status untouched."""
+    # Arrange
+    emitted: list = []
+    # Act
+    report_start_result(
+        _config(),
+        noop=False,
+        dry_run=True,
+        foreground=False,
+        one_shot=False,
+        as_json=True,
+        emit=emitted.append,
+        launched_at=time.time(),
+        host="test-host",
+        host_workdir="/work",
+        container_workdir="/work",
+        location="test-host@/work:/work",
+        verify_fn=_verify_fn_returning(_failed_verdict()),
+    )
+    # Assert
+    assert emitted[0]["status"] == "dry_run_ok"


### PR DESCRIPTION
## v4 migration step 1 — ships alone, before any refactor

`sac agents start` printed SUCC the moment the launch command returned. Three real 2026-08-14 outage errors (a2a `[Errno 98]` bind collision, `VenvDistributionError` boot refusal, SDK 1MiB stdio frame kill) all died server-side while start reported success, exit 0. Operator directive, verbatim: 「そういう場合には必ずエラーを caller 側に出さないとだめです」「エラーが握りつぶされないこと…エラーがどこで起こったかを示せるととてもよいです」.

## What changes

After launching, the start waits a bounded window (`--verify-window`, env `SAC_START_VERIFY_WINDOW_S`, default 90s, 0 disables; env transport so the parallel per-agent re-exec inherits it) for evidence the agent actually came up — using only signals that are genuinely written today:

- **SDK / claude-agent-sdk**: the in-container runner's own first heartbeat (`<state>/heartbeat.json`, written synchronously at boot with `STATE_STARTING` through the /state bind — the same write that lands the `state.db.heartbeats` diary row). A beat stamped at/after the launch is evidence of the NEW incarnation; the old run's `stopping` farewell is excluded.
- **TUI**: no runner heartbeat exists on this path (TUI beats come from the listen daemon's loop, which may not run), so the genuine signal is the runtime's own pane-process liveness after its boot drain — a probe, not a 90s wait for a beat nobody writes.

Three-valued verdict per the fleet constitution — no binary collapse:

| verdict | exit | caller sees |
|---|---|---|
| verified-up | 0 | `SUCC: <name> started (…) — ready: first fresh heartbeat at <ts> (state=starting, pid <pid>), N.Ns after launch` |
| verified-failed | 1 | `ERRO: <name>: launch did NOT verify — container process is DEAD N.Ns after launch …` + `boot log tail (<file>):` with the VERBATIM error text (the Errno 98 line) and the file named |
| unverified | 1 | `FAIL: <name>: launch NOT verified — no fresh heartbeat within 90s …` + `cannot tell whether the agent is up; go deeper via: <heartbeat.json> and <stdout.log>` |

`--json` keeps its legacy statuses (`dry_run_ok` / `already_running` / `started`) and gains an honest `verify` sub-object plus `start-failed` / `start-unverified`.

Found while testing: `system_msg`'s rich-markup stripper eats bracket-shaped text — `[Errno 98]` matches its tag regex, so the exact error text this PR exists to surface was being silently mangled. The verbatim tail therefore prints via `click.echo(err=True)`; headlines stay on scitex-logging (`system_msg`), per the existing idiom.

Brokered (in-SIF) starts skip local verification honestly (`verify.status: skipped`) — evidence lives on the host, whose own start subprocess verifies there; the listen's 202-adoption path already turns a nonzero child rc into a STARTUP_FAILED marker, which now carries this verdict's stderr.

## Deliberately NOT in this PR

No descriptor registry, no session_daemon extraction, no renames, no repo-wide logging refactor. Restart-side verification is #1037 (merged; this is the complementary start side — no shared files touched).

## Tests

27 new tests, no mocks (real state dirs, the real `write_heartbeat` writer, real runtime doubles, a real loopback listen for the wiring tests). Full `_lifecycle` + `cli_pkg/lifecycle` suites: **2813 passed, 7 skipped**.

Pre-fix failure evidence (src reverted to origin/develop, new tests run, restored):
- wiring: `AssertionError: assert 'verify' in {'name': 'capsule-child', 'status': 'started', …}` and `KeyError: 'verify'` — the blind `started` with no verdict, verbatim
- unit suites: `ModuleNotFoundError: No module named 'scitex_agent_container._lifecycle._launch_verify'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)