### PR TITLE
fix(harness): refuse the silent wrong-vendor launch of harness: openai specs (v4 step 2)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_runtime_select.py
+++ b/src/scitex_agent_container/_lifecycle/_runtime_select.py
@@ -4,10 +4,14 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 512-line module limit). ``lifecycle`` re-exports both names so existing
 ``lc._get_runtime`` / ``lc._fallback_workdir`` call sites are unchanged.
 
-``spec.provider`` semantics — the SDK-family selector (top-level,
-``AgentProvider = Literal["anthropic", "openai"]`` — see
-:mod:`config._provider_types`). When ``provider: openai``, the config
-selects the ``openai-agents`` SDK path regardless of ``spec.runtime``.
+``spec.harness`` semantics — the harness axis (top-level,
+``AgentHarness = Literal["anthropic", "openai"]`` — see
+:mod:`config._harness_types`; ``spec.provider`` is the DEPRECATED
+alias). A non-Anthropic harness is REFUSED here (v4 step-2 loudness,
+card ``sac-v4-layering-refactor-harness-runtime-inference-20260813``):
+the lifecycle launch path can only start the Claude harness until the
+step-4 descriptor registry lands, and silently launching Claude under
+an ``harness: openai`` spec is the wrong-vendor bug this guard retires.
 
 ``spec.runtime`` semantics — operator directive 12870, lead a2a
 ``b58dd5d3b4d640d2a7f31f16c710e839``: the field was repurposed from
@@ -30,6 +34,7 @@ import logging
 from pathlib import Path
 
 from ..config import AgentConfig
+from ..config._harness_types import ensure_harness_matches_claude_launch
 
 log = logging.getLogger(__name__)
 
@@ -39,12 +44,17 @@ def _get_runtime(config: AgentConfig):
 
     Branches on TWO axes:
 
-    1. ``config.provider`` — the SDK-family selector (top-level,
-       ``AgentProvider = Literal["anthropic", "openai"]``).
-       When ``provider: openai``, the ``openai-agents`` SDK path is
-       selected. This check runs FIRST so the provider always wins
-       over ``runtime`` — an OpenAI provider must use the OpenAI
-       runner, never Claude.
+    1. ``config.harness`` — the harness axis (``AgentHarness =
+       Literal["anthropic", "openai"]``). This check runs FIRST so the
+       harness always wins over ``runtime`` — and because every runtime
+       this function can return launches the CLAUDE harness, a
+       non-Anthropic harness is REFUSED loudly here instead of being
+       dispatched (v4 step-2 loudness; harness-aware dispatch is the
+       step-4 descriptor registry). The refusal replaces a DEAD read of
+       ``getattr(config, "provider", None)`` — a field the harness
+       rename removed from ``AgentConfig`` — which silently fell
+       through and launched the Claude runner for ``harness: openai``
+       specs.
     2. ``config.runtime`` — the launch-mode selector (operator
        directive 12870). Default: an empty / unset ``runtime``
        selects the interactive in-apptainer ``tui`` runtime
@@ -63,17 +73,26 @@ def _get_runtime(config: AgentConfig):
        when the runtime is actually USED to start something, not
        on every read.
     """
-    provider = getattr(config, "provider", None)
-    # If the config declares an OpenAI provider, always dispatch the
-    # OpenAI runtime — regardless of what runtime says. The provider
-    # field is the definitive SDK-family selector; runtime is just
-    # the launch-mode (tui / claude-agent-sdk) within the Claude family.
-    if provider == "openai":
-        from ..runtimes.openai_session import OpenAISessionRuntime
-
-        return OpenAISessionRuntime()
-
     runtime = getattr(config, "runtime", "") or ""
+    # v4 STEP-2 LOUDNESS (card sac-v4-layering-refactor-harness-runtime-
+    # inference-20260813): every runtime below launches the CLAUDE
+    # harness, so a non-Anthropic ``config.harness`` refuses here rather
+    # than silently falling through (the fate of the old dead
+    # ``getattr(config, "provider", None)`` read this replaces).
+    # ``log=False``: _get_runtime also serves every status / list /
+    # health walk — each degrades this raise into an UNKNOWN verdict
+    # that keeps the message — and a per-read stderr line would
+    # contaminate CliRunner-captured ``--json`` output (the same ruling
+    # that placed the deprecation warnings below on the start path).
+    ensure_harness_matches_claude_launch(
+        config,
+        launching=(
+            "TuiSessionRuntime (the interactive Claude TUI)"
+            if runtime in ("", "tui")
+            else "ClaudeSessionRuntime (the headless claude-agent-sdk runner)"
+        ),
+        log=False,
+    )
     # TUI is the default launch mode (operator directive 2026-06-15,
     # post the SDK-pool cutoff): empty / unset → interactive in-apptainer
     # TUI. Explicit legacy values still map to the headless SDK runner so
@@ -91,8 +110,10 @@ def _get_runtime(config: AgentConfig):
         "spec.runtime must be 'tui' (default, interactive in-apptainer "
         "TUI), 'claude-agent-sdk' (headless SDK runner), or the "
         "back-compat 'apptainer' (mapped to 'claude-agent-sdk'). "
-        "For OpenAI agents, set spec.provider: openai instead of "
-        "spec.runtime."
+        "There is no 'openai' runtime: OpenAI-harness agents cannot yet "
+        "start through the lifecycle launch path (v4 gap, card "
+        "sac-v4-layering-refactor-harness-runtime-inference-20260813) — "
+        "drive them through a2a.handler: openai_session instead."
     )
 
 

--- a/src/scitex_agent_container/config/_harness_types.py
+++ b/src/scitex_agent_container/config/_harness_types.py
@@ -44,6 +44,7 @@ STATED values can disagree.
 
 from __future__ import annotations
 
+import sys
 from typing import Literal, Mapping
 
 __all__ = [
@@ -53,7 +54,10 @@ __all__ = [
     "HARNESS_KEY",
     "LEGACY_HARNESS_KEY",
     "HarnessKeyConflictError",
+    "HarnessRuntimeMismatchError",
+    "V4_HARNESS_DISPATCH_CARD",
     "declared_harness",
+    "ensure_harness_matches_claude_launch",
     "harness_key_conflict_error",
     "is_known_harness",
     "list_harnesses",
@@ -79,6 +83,27 @@ AGENT_HARNESSES: tuple[str, ...] = ("anthropic", "openai")
 
 class HarnessKeyConflictError(ValueError):
     """``spec.harness`` and ``spec.provider`` both stated, and they differ."""
+
+
+class HarnessRuntimeMismatchError(RuntimeError):
+    """A non-Anthropic harness was about to get the Claude launch path.
+
+    Raised by :func:`ensure_harness_matches_claude_launch` — the v4
+    step-2 loudness guard. See that function's docstring for the full
+    story; the short version is that until the descriptor registry
+    (migration step 4) lands, the lifecycle launch path can only start
+    the Claude harness, and starting it under a spec that declared a
+    different harness is a wrong-vendor launch that must refuse loudly
+    instead of proceeding silently.
+    """
+
+
+#: The v4 card tracking harness-aware runtime dispatch (migration step 4,
+#: the descriptor registry). Until it lands, sac VALIDATES ``harness:
+#: openai`` but cannot LAUNCH it through the lifecycle runtime path.
+V4_HARNESS_DISPATCH_CARD = (
+    "sac-v4-layering-refactor-harness-runtime-inference-20260813"
+)
 
 
 def is_known_harness(name: str) -> bool:
@@ -166,3 +191,88 @@ def harness_key_conflict_error(spec: Mapping) -> list[str]:
     except HarnessKeyConflictError as exc:
         return [str(exc)]
     return []
+
+
+def _harness_logger():
+    """scitex-logging logger, imported lazily.
+
+    Same pattern as ``config.__init__._config_logger``: the
+    fleet-consistent coloured ``ERRO:`` stderr line (operator directive
+    2026-07-10), imported inside the function so the package's ~300 ms
+    first-import auto-configuration never taxes ``import
+    scitex_agent_container.config`` itself.
+    """
+    import scitex_logging
+
+    return scitex_logging.getLogger(__name__)
+
+
+def ensure_harness_matches_claude_launch(
+    config, *, launching: str, log: bool = True
+) -> None:
+    """Refuse LOUDLY when ``config.harness`` is non-Anthropic but the
+    calling code path is about to launch ``launching`` — a Claude-family
+    runner — anyway.
+
+    THE v4 STEP-2 LOUDNESS GUARD (additive; card
+    ``sac-v4-layering-refactor-harness-runtime-inference-20260813``).
+    Before it, the three launch-path dispatch sites read
+    ``getattr(config, "provider", None)`` — a field the harness rename
+    REMOVED from ``AgentConfig`` — so every one of those branches was
+    dead: a ``harness: openai`` spec got OPENAI_* auth env (the auth
+    path reads ``config.harness`` correctly) and then SILENTLY launched
+    the Claude runner. A wrong-vendor launch with no error anywhere is
+    exactly what the operator's 「エラーが握りつぶされない」 directive
+    forbids. Selection stays byte-identical for every Anthropic-harness
+    spec; harness-aware DISPATCH is migration step 4 (the descriptor
+    registry), deliberately NOT this guard.
+
+    ``kind: AgentProxy`` is exempt: the a2a proxy runner is
+    vendor-neutral, so a harness value on a proxy spec mismatches
+    nothing this guard protects.
+
+    ``log=False`` skips the scitex-logging ERROR line for callers on
+    shared read paths (``_get_runtime`` also serves every status / list
+    / health walk — each of which degrades a raise into an UNKNOWN
+    verdict that KEEPS this message — and a per-read stderr line would
+    contaminate CliRunner-captured ``--json`` output; the same ruling
+    that placed ``warn_if_legacy_harness_key`` on the start path). The
+    raise itself is never skipped.
+
+    Raises :class:`HarnessRuntimeMismatchError` naming (a) what the spec
+    asked for and through which key, (b) what was actually about to
+    launch, (c) the caller's ``file:line`` (the decision site), and
+    (d) the v4 gap card id.
+    """
+    harness = (
+        str(getattr(config, "harness", "") or DEFAULT_AGENT_HARNESS)
+        .strip()
+        .lower()
+    )
+    if harness == DEFAULT_AGENT_HARNESS:
+        return
+    if getattr(config, "kind", "Agent") == "AgentProxy":
+        return
+    caller = sys._getframe(1)
+    site = f"{caller.f_code.co_filename}:{caller.f_lineno}"
+    key = (
+        LEGACY_HARNESS_KEY
+        if getattr(config, "harness_key_is_legacy", False)
+        else HARNESS_KEY
+    )
+    message = (
+        f"REFUSING to launch agent {getattr(config, 'name', '<unknown>')!r}: "
+        f"spec.{key} declares harness={harness!r}, but this code path was "
+        f"about to launch {launching} (decided at {site}). Harness-aware "
+        f"runtime dispatch is a KNOWN v4 gap — card "
+        f"{V4_HARNESS_DISPATCH_CARD} — so until the descriptor registry "
+        f"(migration step 4) lands, a {harness!r} spec cannot start through "
+        "the lifecycle launch path at all; proceeding would silently run "
+        f"the Claude harness under a spec that asked for {harness!r}. "
+        "Working alternatives today: drive the OpenAI SDK through "
+        "``a2a.handler: openai_session`` (the grant-agent pattern), or set "
+        f"``{HARNESS_KEY}: {DEFAULT_AGENT_HARNESS}``."
+    )
+    if log:
+        _harness_logger().error(message)
+    raise HarnessRuntimeMismatchError(message)

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -37,10 +37,12 @@ from ._apptainer_quota_cache import (
 # ----------------------------------------------------------------------
 RUNNER_MODULE = "scitex_agent_container._runners.claude_session"
 
-# Runner module for the ``provider: openai`` path (scitex-todo
-# card ``openai-compat-2``; ``spec.provider: openai``). Dispatched
-# when the config's provider is ``"openai"``; otherwise the default
-# ``RUNNER_MODULE`` above (claude_session) is used.
+# OpenAI harness runner module (scitex-todo card ``openai-compat-2``).
+# NOT DISPATCHED YET: the old ``getattr(config, "provider", None)``
+# selector was dead (the harness rename removed the field), and v4
+# step 2 replaces it with a loud refusal rather than a repoint —
+# harness-aware dispatch arrives with the step-4 descriptor registry
+# (card ``sac-v4-layering-refactor-harness-runtime-inference-20260813``).
 RUNNER_MODULE_OPENAI = "scitex_agent_container._runners.openai_session"
 
 # Quota-cache constants + resolver now live in _apptainer_quota_cache (this
@@ -71,6 +73,28 @@ def build_run_argv(
     process differs). The caller (``TuiSessionRuntime``) launches the
     returned argv inside a tmux PTY rather than backgrounding it.
     """
+    # v4 STEP-2 LOUDNESS (card sac-v4-layering-refactor-harness-runtime-
+    # inference-20260813): every shape of this argv launches the CLAUDE
+    # harness (TUI, SDK runner, pre-built runner_argv), so a
+    # non-Anthropic ``config.harness`` refuses HERE — before any side
+    # effect (home mkdir, overlay provisioning, auth provisioning).
+    # The old check sat in the pre-built runner_argv branch below and
+    # read ``getattr(config, "provider", None)`` — a field the harness
+    # rename removed — so it was DEAD, while the auth step later in this
+    # function reads ``config.harness`` CORRECTLY. That split-brain is
+    # exactly the bug this guard retires: OPENAI_* auth env provisioned,
+    # Claude runner launched, no error anywhere.
+    from ..config._harness_types import ensure_harness_matches_claude_launch
+
+    ensure_harness_matches_claude_launch(
+        config,
+        launching=(
+            "the interactive claude TUI"
+            if tui
+            else f"runner module {RUNNER_MODULE!r}"
+        ),
+    )
+
     # Hardened isolation by default — see _apptainer_iso_flags for the
     # per-flag skip logic (relaxed opt-out, operator-declared raw_args,
     # overlay/writable-tmpfs incompatibility) and docs/isolation.md.
@@ -428,14 +452,12 @@ def build_run_argv(
         if kind == "AgentProxy":
             module = RUNNER_MODULE_PROXY
         else:
-            # Provider dispatch for pre-built runner_argv: same logic
-            # as build_inner_argv — openai → OpenAI runner, else Claude.
-            provider = getattr(config, "provider", None)
-            module = (
-                RUNNER_MODULE_OPENAI
-                if provider == "openai"
-                else RUNNER_MODULE
-            )
+            # Claude runner unconditionally: the top-of-function harness
+            # guard already refused any non-Anthropic spec (v4 step 2 —
+            # the old ``getattr(config, "provider", None)`` read here
+            # was DEAD, so ``RUNNER_MODULE_OPENAI`` was never actually
+            # dispatched; harness-aware dispatch is step 4).
+            module = RUNNER_MODULE
         inner_argv = [
             "/usr/bin/tini",
             "-s",

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import shlex
 from typing import TYPE_CHECKING
 
+from ..config._harness_types import ensure_harness_matches_claude_launch
 from ._apptainer_inner_argv_tui import (  # noqa: F401 (re-export)
     _home_has_resumable_conversation,
     _tui_runner_argv,
@@ -30,14 +31,16 @@ from ._apptainer_inner_argv_tui import (  # noqa: F401 (re-export)
 if TYPE_CHECKING:
     from ..config import AgentConfig
 
-# Runner-module dispatch by ``config.kind`` and ``config.provider``.
-# Kept here so the parent orchestrator doesn't need to know either
-# runner's module path.
+# Runner-module dispatch by ``config.kind``. Kept here so the parent
+# orchestrator doesn't need to know either runner's module path.
 RUNNER_MODULE_AGENT = "scitex_agent_container._runners.claude_session"
 
-# OpenAI provider runner module (scitex-todo card ``openai-compat-2``;
-# ``spec.provider: openai``). When the config's provider is ``"openai"``,
-# dispatches this module instead of ``RUNNER_MODULE_AGENT``.
+# OpenAI harness runner module (scitex-todo card ``openai-compat-2``).
+# NOT DISPATCHED YET: the old ``getattr(config, "provider", None)``
+# selector was dead (the harness rename removed the field), and v4
+# step 2 replaces it with a loud refusal rather than a repoint —
+# harness-aware dispatch arrives with the step-4 descriptor registry
+# (card ``sac-v4-layering-refactor-harness-runtime-inference-20260813``).
 RUNNER_MODULE_OPENAI = "scitex_agent_container._runners.openai_session"
 
 RUNNER_MODULE_PROXY = "scitex_agent_container._runners.a2a_proxy"
@@ -116,8 +119,7 @@ def build_inner_argv(
     tui_dev_channels: str | None = None,
     tui_settings: str | None = None,
 ) -> list[str]:
-    """Return the apptainer-inner argv. Dispatches on ``config.kind``
-    and ``config.provider``.
+    """Return the apptainer-inner argv. Dispatches on ``config.kind``.
 
     The argv is now ALWAYS wrapped in
     ``[/bin/bash, -lc, "<git-env-alias>; [set -e; <cmd1>; sleep N; <cmd2>;]
@@ -144,14 +146,24 @@ def build_inner_argv(
     is why the file MUST be ``settings.json``, not ``settings.local.json``:
     there is no ``.local.json`` at user scope).
 
-    Provider dispatch: when ``config.provider == "openai"``, the inner
-    runner is ``RUNNER_MODULE_OPENAI`` instead of ``RUNNER_MODULE_AGENT``.
-    The argv tail (mission, a2a flags, etc.) is identical — the OpenAI
-    runner accepts the same CLI flags as the Claude runner (with legacy
-    flags silently ignored).
+    Harness guard (v4 step 2, card ``sac-v4-layering-refactor-harness-
+    runtime-inference-20260813``): both the TUI and SDK branches launch
+    the CLAUDE harness, so a non-Anthropic ``config.harness`` REFUSES
+    loudly instead of dispatching. The old ``getattr(config, "provider",
+    None)`` selector here was DEAD (the harness rename removed the
+    field), so ``harness: openai`` specs silently got the Claude runner;
+    dispatching ``RUNNER_MODULE_OPENAI`` for real is step 4 (the
+    descriptor registry). ``kind: AgentProxy`` is exempt — the a2a proxy
+    runner is vendor-neutral.
     """
     kind = getattr(config, "kind", "Agent")
     if tui:
+        # Same v4 step-2 guard as the SDK branch below: the interactive
+        # claude TUI is just as wrong a vendor for a non-Anthropic
+        # harness (and this branch never had even the dead check).
+        ensure_harness_matches_claude_launch(
+            config, launching="the interactive claude TUI"
+        )
         runner_tail = _tui_runner_argv(
             config,
             mcp_config=tui_mcp_config,
@@ -162,17 +174,15 @@ def build_inner_argv(
     elif kind == "AgentProxy":
         runner_tail = _TINI_PREFIX + [RUNNER_MODULE_PROXY] + _proxy_runner_argv(config)
     else:
-        # Provider dispatch: ``provider: openai`` → the OpenAI runner;
-        # everything else (default "anthropic") → the Claude runner.
-        provider = getattr(config, "provider", None)
-        runner_module = (
-            RUNNER_MODULE_OPENAI
-            if provider == "openai"
-            else RUNNER_MODULE_AGENT
+        # v4 step-2 loudness: refuse a wrong-vendor launch on the REAL
+        # field (the dead ``config.provider`` read used to sit here and
+        # silently fell through to the Claude runner).
+        ensure_harness_matches_claude_launch(
+            config, launching=f"runner module {RUNNER_MODULE_AGENT!r}"
         )
         runner_tail = (
             _TINI_PREFIX
-            + [runner_module]
+            + [RUNNER_MODULE_AGENT]
             + _agent_runner_argv(config, one_shot=one_shot)
         )
 

--- a/tests/integration/test_provider_column_specs.py
+++ b/tests/integration/test_provider_column_specs.py
@@ -8,10 +8,18 @@ seams that make the columns interchangeable, each on REAL objects:
 
 1. **Spec → config**: two real YAML specs differing ONLY in
    ``spec.harness`` load through the one ``load_config`` path.
-2. **Config → entrypoint env** (``build_run_argv`` — the full apptainer
-   argv): the OpenAI column carries the OPENAI_* injection and ZERO
-   Anthropic wiring; the Claude column carries its unchanged Anthropic
-   wiring and ZERO OPENAI_*.
+2. **Config → entrypoint env**: the OpenAI column's env parity is
+   pinned at the AUTH seam (``auth_argv`` — the harness-aware step):
+   OPENAI_* injection, the SAC_PROVIDER marker, and ZERO Anthropic
+   wiring. The FULL ``build_run_argv`` for the OpenAI column now
+   REFUSES with ``HarnessRuntimeMismatchError`` (v4 step-2 loudness,
+   card ``sac-v4-layering-refactor-harness-runtime-inference-20260813``):
+   pre-guard it assembled OPENAI_* auth env around the CLAUDE runner
+   module — the silent wrong-vendor launch these tests unknowingly
+   pinned. Step 4 (the descriptor registry) flips that refusal back
+   into a real OpenAI-runner argv, and THEN the full-argv parity
+   assertions can return here. The Claude column's full argv is
+   unchanged: Anthropic wiring, ZERO OPENAI_*.
 3. **Session-type routing + NormalizedEvent shape**: both columns'
    ``spec.a2a.handler`` keys route to registered executors sharing
    ``BaseSyncExecutor`` (one task-event surface), and the OpenAI
@@ -36,6 +44,10 @@ from scitex_agent_container._runners._harness_session import HarnessSession
 from scitex_agent_container._runners.openai_session import OpenAIAgentsSession
 from scitex_agent_container.a2a.executors import EXECUTORS, BaseSyncExecutor
 from scitex_agent_container.config import load_config
+from scitex_agent_container.config._harness_types import (
+    HarnessRuntimeMismatchError,
+)
+from scitex_agent_container.runtimes._apptainer_auth import auth_argv
 from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
 
 _SPEC_TEMPLATE = """\
@@ -144,6 +156,14 @@ def _column_argv(config, tmp_path: Path) -> list[str]:
     )
 
 
+def _auth_env(config, tmp_path: Path) -> dict[str, str]:
+    """The env the AUTH seam injects — ``auth_argv`` is the harness-aware
+    step ``build_run_argv`` composes, and (until the step-4 descriptor
+    registry re-enables a full OpenAI-column launch argv) the seam where
+    the OpenAI column's env parity is honestly pinned."""
+    return _argv_env(auth_argv(config, tmp_path / "state" / config.name))
+
+
 # ---------------------------------------------------------------------------
 # 1. Spec → config: one loader, two columns
 # ---------------------------------------------------------------------------
@@ -174,31 +194,51 @@ def test_openai_column_spec_loads_as_openai_family(_sandbox_env: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_openai_column_argv_injects_openai_key(_sandbox_env: Path) -> None:
+def test_openai_column_full_argv_refuses_the_wrong_vendor_launch(
+    _sandbox_env: Path,
+) -> None:
+    # Arrange — v4 step-2 loudness: pre-guard, this argv carried the
+    # OPENAI_* env AND the claude_session runner module — a silent
+    # wrong-vendor launch. build_run_argv must refuse until the step-4
+    # descriptor registry can dispatch the OpenAI runner for real.
+    cfg = _openai_column(_sandbox_env)
+    raised: BaseException | None = None
+    # Act
+    try:
+        _column_argv(cfg, _sandbox_env)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert.)
+        raised = exc
+    # Assert
+    assert isinstance(raised, HarnessRuntimeMismatchError)
+
+
+def test_openai_column_auth_seam_injects_openai_key(_sandbox_env: Path) -> None:
     # Arrange
     cfg = _openai_column(_sandbox_env)
     # Act
-    env = _argv_env(_column_argv(cfg, _sandbox_env))
+    env = _auth_env(cfg, _sandbox_env)
     # Assert
     assert env["OPENAI_API_KEY"] == "sk-column-test"
 
 
-def test_openai_column_argv_marks_family_in_container(_sandbox_env: Path) -> None:
-    # Arrange
-    cfg = _openai_column(_sandbox_env)
-    # Act
-    env = _argv_env(_column_argv(cfg, _sandbox_env))
-    # Assert
-    assert env["SAC_PROVIDER"] == "openai"
-
-
-def test_openai_column_argv_carries_no_anthropic_wiring(
+def test_openai_column_auth_seam_marks_family_in_container(
     _sandbox_env: Path,
 ) -> None:
     # Arrange
     cfg = _openai_column(_sandbox_env)
     # Act
-    env = _argv_env(_column_argv(cfg, _sandbox_env))
+    env = _auth_env(cfg, _sandbox_env)
+    # Assert
+    assert env["SAC_PROVIDER"] == "openai"
+
+
+def test_openai_column_auth_seam_carries_no_anthropic_wiring(
+    _sandbox_env: Path,
+) -> None:
+    # Arrange
+    cfg = _openai_column(_sandbox_env)
+    # Act
+    env = _auth_env(cfg, _sandbox_env)
     # Assert
     assert not any(k.startswith(("ANTHROPIC", "CLAUDE_CONFIG")) for k in env)
 

--- a/tests/scitex_agent_container/_lifecycle/test__runtime_select.py
+++ b/tests/scitex_agent_container/_lifecycle/test__runtime_select.py
@@ -7,13 +7,21 @@ unset maps here) → the in-apptainer TUI runner; ``claude-agent-sdk`` →
 the headless SDK runner. Legacy ``apptainer`` maps to ``claude-agent-sdk``
 with a one-line deprecation log.
 
-scitex-todo card ``openai-compat-2``: when ``spec.provider: openai``,
-``_get_runtime`` returns ``OpenAISessionRuntime`` regardless of
-``spec.runtime``.
+v4 step-2 loudness (card
+``sac-v4-layering-refactor-harness-runtime-inference-20260813``): every
+runtime ``_get_runtime`` can return launches the CLAUDE harness, so a
+non-Anthropic ``config.harness`` raises ``HarnessRuntimeMismatchError``
+instead of silently falling through to the Claude/TUI runner. (The old
+``spec.provider: openai -> OpenAISessionRuntime`` tests pinned a DEAD
+branch: they stubbed a ``provider`` attribute that the harness rename
+removed from the real ``AgentConfig``, so production configs never took
+it — verified 2026-08-14, ``hasattr(AgentConfig("x"), "provider")`` is
+False.)
 
-STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — uses a tiny stub
-``SimpleNamespace`` config (the existing test pattern for
-``_get_runtime`` callers; the runtime selector reads ONE attribute).
+STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — a tiny stub
+``SimpleNamespace`` config for the single-attribute selector paths, and
+the REAL ``AgentConfig`` for the harness-refusal contract (the stub is
+exactly what masked the dead branch).
 """
 
 from __future__ import annotations
@@ -28,8 +36,12 @@ from scitex_agent_container._lifecycle._runtime_select import (
     warn_if_legacy_apptainer_runtime,
     warn_if_legacy_harness_key,
 )
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._harness_types import (
+    V4_HARNESS_DISPATCH_CARD,
+    HarnessRuntimeMismatchError,
+)
 from scitex_agent_container.runtimes.claude_session import ClaudeSessionRuntime
-from scitex_agent_container.runtimes.openai_session import OpenAISessionRuntime
 from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
 
 # ---------------------------------------------------------------------------
@@ -279,56 +291,112 @@ def test_get_runtime_rejects_unknown_value_names_accepted_set():
 
 
 # ---------------------------------------------------------------------------
-# OpenAI provider — dispatches OpenAISessionRuntime (openai-compat-2)
+# Non-Anthropic harness — LOUD refusal, never a silent Claude launch
+# (v4 step 2; real AgentConfig on purpose: the old tests stubbed a
+# ``provider`` attribute the harness rename removed, pinning a dead branch)
 # ---------------------------------------------------------------------------
 
 
-def test_get_runtime_returns_openai_session_for_openai_provider():
-    # Arrange — spec.provider: openai selects the OpenAI SDK path
-    # regardless of spec.runtime.
-    config = SimpleNamespace(name="beta", runtime="", provider="openai")
+def test_get_runtime_never_hands_an_openai_harness_the_claude_runner():
+    # Arrange — the pre-fix bug verbatim: harness: openai silently got
+    # TuiSessionRuntime because the dead ``config.provider`` read fell
+    # through. Whatever else happens (today: a refusal raise; step 4: a
+    # real OpenAI dispatch), the Claude-family runner must never come back.
+    config = AgentConfig(name="beta", runtime="tui", harness="openai")
+    rt: object | None = None
     # Act
-    rt = _get_runtime(config)
+    try:
+        rt = _get_runtime(config)
+    except Exception:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; a raise is a PASS for this pin — only a returned Claude runner fails it.)
+        pass
     # Assert
-    assert isinstance(rt, OpenAISessionRuntime)
+    assert not isinstance(rt, (TuiSessionRuntime, ClaudeSessionRuntime))
 
 
-def test_get_runtime_returns_openai_session_even_with_claude_runtime():
-    # Arrange — provider: openai WINS over runtime: claude-agent-sdk.
-    config = SimpleNamespace(name="gamma", runtime="claude-agent-sdk", provider="openai")
+def test_get_runtime_raises_harness_mismatch_for_openai_harness():
+    # Arrange
+    config = AgentConfig(name="beta", runtime="tui", harness="openai")
+    raised: BaseException | None = None
     # Act
-    rt = _get_runtime(config)
+    try:
+        _get_runtime(config)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
     # Assert
-    assert isinstance(rt, OpenAISessionRuntime)
+    assert isinstance(raised, HarnessRuntimeMismatchError)
 
 
-def test_get_runtime_returns_openai_session_even_with_apptainer_runtime():
-    # Arrange — provider: openai WINS over runtime: apptainer (back-compat).
-    config = SimpleNamespace(name="delta", runtime="apptainer", provider="openai")
+def test_get_runtime_openai_harness_refusal_names_what_the_spec_asked():
+    # Arrange
+    config = AgentConfig(name="beta", runtime="tui", harness="openai")
+    raised: BaseException | None = None
     # Act
-    rt = _get_runtime(config)
+    try:
+        _get_runtime(config)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
     # Assert
-    assert isinstance(rt, OpenAISessionRuntime)
+    assert raised is not None and "harness='openai'" in str(raised)
+
+
+def test_get_runtime_openai_harness_refusal_names_what_would_launch():
+    # Arrange — runtime: tui, so the wrong-vendor launch it refuses is
+    # the interactive Claude TUI.
+    config = AgentConfig(name="beta", runtime="tui", harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        _get_runtime(config)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert
+    assert raised is not None and "TuiSessionRuntime" in str(raised)
+
+
+def test_get_runtime_openai_harness_refusal_names_the_decision_site():
+    # Arrange
+    config = AgentConfig(name="beta", runtime="claude-agent-sdk", harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        _get_runtime(config)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert — file:line of the decision, so the reader lands on the guard.
+    assert raised is not None and "_runtime_select.py:" in str(raised)
+
+
+def test_get_runtime_openai_harness_refusal_names_the_v4_card():
+    # Arrange
+    config = AgentConfig(name="beta", runtime="tui", harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        _get_runtime(config)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert
+    assert raised is not None and V4_HARNESS_DISPATCH_CARD in str(raised)
 
 
 # ---------------------------------------------------------------------------
-# Default (anthropic provider) — unchanged behaviour
+# Default (anthropic harness) — unchanged behaviour, byte-identical selection
 # ---------------------------------------------------------------------------
 
 
-def test_get_runtime_returns_tui_session_for_default_provider():
-    # Arrange — default provider is "anthropic" (DEFAULT_AGENT_PROVIDER);
-    # with no provider set and runtime="", we still get TUI.
-    config = SimpleNamespace(name="epsilon")  # runtime defaults to "", provider defaults to None
+def test_get_runtime_returns_tui_session_for_default_harness():
+    # Arrange — default harness is "anthropic" (DEFAULT_AGENT_HARNESS);
+    # with no harness stated and runtime="", we still get TUI.
+    config = SimpleNamespace(name="epsilon")  # runtime defaults to "", harness defaults to anthropic
     # Act
     rt = _get_runtime(config)
     # Assert
     assert isinstance(rt, TuiSessionRuntime)
 
 
-def test_get_runtime_returns_claude_session_for_anthropic_provider():
-    # Arrange — explicit provider: anthropic with runtime: claude-agent-sdk.
-    config = SimpleNamespace(name="zeta", runtime="claude-agent-sdk", provider="anthropic")
+def test_get_runtime_returns_claude_session_for_anthropic_harness():
+    # Arrange — a REAL config with the explicit canonical value.
+    config = AgentConfig(name="zeta", runtime="claude-agent-sdk", harness="anthropic")
     # Act
     rt = _get_runtime(config)
     # Assert

--- a/tests/scitex_agent_container/config/test__harness_types.py
+++ b/tests/scitex_agent_container/config/test__harness_types.py
@@ -25,8 +25,11 @@ from scitex_agent_container.config._explicit_validation import (
 )
 from scitex_agent_container.config._harness_types import (
     DEFAULT_AGENT_HARNESS,
+    V4_HARNESS_DISPATCH_CARD,
     HarnessKeyConflictError,
+    HarnessRuntimeMismatchError,
     declared_harness,
+    ensure_harness_matches_claude_launch,
     is_known_harness,
     list_harnesses,
     resolve_spec_harness,
@@ -386,3 +389,87 @@ def test_the_paste_ready_defaults_write_the_canonical_key():
     written = set(defaults) & {"harness", "provider"}
     # Assert
     assert written == {"harness"}
+
+
+# ---------------------------------------------------------------------------
+# The v4 step-2 loudness guard — ensure_harness_matches_claude_launch
+# (card sac-v4-layering-refactor-harness-runtime-inference-20260813).
+# End to end through the REAL load_config, both key spellings: the guard
+# must attribute the ask to the key the spec actually used.
+# ---------------------------------------------------------------------------
+
+
+def _refusal(config):
+    """The mismatch error the guard raises for ``config``, or ``None``."""
+    try:
+        ensure_harness_matches_claude_launch(
+            config, launching="the Claude runner (test)"
+        )
+    except HarnessRuntimeMismatchError as exc:
+        return exc
+    return None
+
+
+def test_the_guard_refuses_a_canonical_openai_spec(tmp_path):
+    # Arrange
+    config = load_config(_write_spec(tmp_path, "canon", {"harness": "openai"}))
+    # Act
+    exc = _refusal(config)
+    # Assert
+    assert exc is not None
+
+
+def test_the_guard_names_the_canonical_key_when_the_spec_used_it(tmp_path):
+    # Arrange
+    config = load_config(_write_spec(tmp_path, "canon", {"harness": "openai"}))
+    # Act
+    exc = _refusal(config)
+    # Assert
+    assert exc is not None and "spec.harness" in str(exc)
+
+
+def test_the_guard_refuses_a_legacy_provider_openai_spec(tmp_path):
+    # Arrange — the alias the loader still accepts must reach the guard.
+    config = load_config(_legacy_spec(tmp_path, "legacy", "openai"))
+    # Act
+    exc = _refusal(config)
+    # Assert
+    assert exc is not None
+
+
+def test_the_guard_names_the_legacy_key_when_the_spec_used_it(tmp_path):
+    # Arrange — the operator should be pointed at the line THEIR spec has.
+    config = load_config(_legacy_spec(tmp_path, "legacy", "openai"))
+    # Act
+    exc = _refusal(config)
+    # Assert
+    assert exc is not None and "spec.provider" in str(exc)
+
+
+def test_the_guard_names_what_was_about_to_launch(tmp_path):
+    # Arrange
+    config = load_config(_write_spec(tmp_path, "canon", {"harness": "openai"}))
+    # Act
+    exc = _refusal(config)
+    # Assert
+    assert exc is not None and "the Claude runner (test)" in str(exc)
+
+
+def test_the_guard_names_the_v4_card(tmp_path):
+    # Arrange
+    config = load_config(_write_spec(tmp_path, "canon", {"harness": "openai"}))
+    # Act
+    exc = _refusal(config)
+    # Assert
+    assert exc is not None and V4_HARNESS_DISPATCH_CARD in str(exc)
+
+
+def test_the_guard_passes_an_anthropic_spec_untouched(tmp_path):
+    # Arrange — the fleet's entire live spec corpus (117 agent dirs on
+    # this host, surveyed 2026-08-14) resolves to anthropic; the guard
+    # must be a no-op for every one of them.
+    config = load_config(_write_spec(tmp_path, "canon", {"harness": "anthropic"}))
+    # Act
+    exc = _refusal(config)
+    # Assert
+    assert exc is None

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -37,7 +37,11 @@ from typing import Iterator
 
 import pytest
 
-from scitex_agent_container.config import load_config
+from scitex_agent_container.config import AgentConfig, load_config
+from scitex_agent_container.config._harness_types import (
+    V4_HARNESS_DISPATCH_CARD,
+    HarnessRuntimeMismatchError,
+)
 from scitex_agent_container.runtimes._apptainer_auth import (
     CredentialExpiredError,
     credentials_file_bind,
@@ -1286,3 +1290,78 @@ def test_spec_env_key_not_in_fleet_defaults_still_reaches_argv(tmp_path) -> None
     argv = _argv_for_env(tmp_path, env_block)
     # Assert
     assert _env_values(argv, "AGENT_ONLY_FLAG") == ["agent-value"]
+
+
+# ---------------------------------------------------------------------------
+# v4 step-2 harness guard — build_run_argv refuses a wrong-vendor launch
+# BEFORE any side effect (card
+# sac-v4-layering-refactor-harness-runtime-inference-20260813). Pre-fix,
+# the ``getattr(config, "provider", None)`` read in the pre-built
+# runner_argv branch was DEAD (the harness rename removed the field), so a
+# ``harness: openai`` spec got OPENAI_* auth provisioning (the auth step
+# reads config.harness correctly — pre-fix it raised ProviderEnvError over
+# a missing key) and then the CLAUDE runner module: a silent wrong-vendor
+# launch whenever the key resolved.
+# ---------------------------------------------------------------------------
+
+
+def test_build_run_argv_raises_harness_mismatch_for_openai_harness(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the pre-built runner_argv path, whose dispatch held the
+    # dead provider read.
+    cfg = AgentConfig(name="t", runtime="apptainer", harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        build_run_argv(
+            cfg,
+            state_dir=tmp_path / "state",
+            sif_path=tmp_path / "img.sif",
+            runner_argv=["--flag"],
+        )
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert
+    assert isinstance(raised, HarnessRuntimeMismatchError)
+
+
+def test_build_run_argv_openai_harness_refuses_before_any_side_effect(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the guard sits at the top of the function, before the
+    # workspace-home mkdir / overlay provisioning / auth provisioning.
+    cfg = AgentConfig(name="t", runtime="apptainer", harness="openai")
+    state_dir = tmp_path / "state"
+    # Act
+    try:
+        build_run_argv(
+            cfg,
+            state_dir=state_dir,
+            sif_path=tmp_path / "img.sif",
+            runner_argv=["--flag"],
+        )
+    except HarnessRuntimeMismatchError:  # stx-allow: test-capture (reason: STX-TQ002; the raise itself is pinned by the sibling test.)
+        pass
+    # Assert
+    assert not state_dir.exists()
+
+
+def test_build_run_argv_openai_harness_refusal_names_the_v4_card(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="apptainer", harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        build_run_argv(
+            cfg,
+            state_dir=tmp_path / "state",
+            sif_path=tmp_path / "img.sif",
+            runner_argv=["--flag"],
+        )
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert
+    assert raised is not None and V4_HARNESS_DISPATCH_CARD in str(raised)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
@@ -17,6 +17,10 @@ from pathlib import Path
 
 from scitex_agent_container.config import AgentConfig, ProxySpec
 from scitex_agent_container.config._a2a_defaults import DEFAULT_A2A_HOST
+from scitex_agent_container.config._harness_types import (
+    V4_HARNESS_DISPATCH_CARD,
+    HarnessRuntimeMismatchError,
+)
 from scitex_agent_container.config._types import (
     A2ASpec,
     ClaudeSpec,
@@ -728,3 +732,103 @@ def test_build_inner_argv_carries_the_declared_a2a_host_into_the_exec_line():
     tokens = _exec_tail_tokens(build_inner_argv(cfg))
     # Assert
     assert _flag_value(tokens, "--a2a-host") == _WILDCARD_HOST
+
+
+# ---------------------------------------------------------------------------
+# v4 step-2 harness guard — a non-Anthropic harness must never silently get
+# the Claude runner module (card
+# sac-v4-layering-refactor-harness-runtime-inference-20260813). The old
+# dispatch read ``getattr(config, "provider", None)`` — a field the harness
+# rename removed from AgentConfig — so ``harness: openai`` specs silently
+# got RUNNER_MODULE_AGENT (verified pre-fix 2026-08-14).
+# ---------------------------------------------------------------------------
+
+
+def test_build_inner_argv_never_emits_the_claude_runner_for_openai_harness():
+    # Arrange — the pre-fix bug verbatim: the argv carried
+    # scitex_agent_container._runners.claude_session for an openai harness.
+    cfg = _mk_cfg(harness="openai")
+    argv: list[str] = []
+    # Act
+    try:
+        argv = build_inner_argv(cfg)
+    except Exception:  # stx-allow: test-capture (reason: STX-TQ002; a raise is a PASS for this pin — only a silently built Claude argv fails it.)
+        pass
+    # Assert
+    assert "claude_session" not in " ".join(argv)
+
+
+def test_build_inner_argv_raises_harness_mismatch_for_openai_harness():
+    # Arrange
+    cfg = _mk_cfg(harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        build_inner_argv(cfg)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert
+    assert isinstance(raised, HarnessRuntimeMismatchError)
+
+
+def test_build_inner_argv_openai_harness_refusal_names_the_runner_module():
+    # Arrange
+    cfg = _mk_cfg(harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        build_inner_argv(cfg)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert — names what was actually about to launch.
+    assert raised is not None and "claude_session" in str(raised)
+
+
+def test_build_inner_argv_openai_harness_refusal_covers_the_tui_branch():
+    # Arrange — the TUI branch never had even the dead provider check;
+    # the interactive claude TUI is just as wrong a vendor.
+    cfg = _mk_cfg(harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        build_inner_argv(cfg, tui=True)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert
+    assert isinstance(raised, HarnessRuntimeMismatchError)
+
+
+def test_build_inner_argv_openai_harness_refusal_names_the_v4_card():
+    # Arrange
+    cfg = _mk_cfg(harness="openai")
+    raised: BaseException | None = None
+    # Act
+    try:
+        build_inner_argv(cfg)
+    except HarnessRuntimeMismatchError as exc:  # stx-allow: test-capture (reason: STX-TQ002.)
+        raised = exc
+    # Assert
+    assert raised is not None and V4_HARNESS_DISPATCH_CARD in str(raised)
+
+
+def test_build_inner_argv_proxy_kind_is_exempt_from_the_harness_guard():
+    # Arrange — the a2a proxy runner is vendor-neutral: a harness value on
+    # a proxy spec mismatches nothing the guard protects.
+    cfg = _mk_cfg(
+        kind="AgentProxy",
+        proxy=ProxySpec(upstream="http://u"),
+        harness="openai",
+    )
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert "a2a_proxy" in " ".join(argv)
+
+
+def test_build_inner_argv_anthropic_harness_still_gets_the_claude_runner():
+    # Arrange — byte-identical selection for the fleet's real specs.
+    cfg = _mk_cfg(harness="anthropic")
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert "claude_session" in " ".join(argv)


### PR DESCRIPTION
v4 migration step 2 — ADDITIVE LOUDNESS, not a repoint (card `sac-v4-layering-refactor-harness-runtime-inference-20260813`). Follows #1037 / #1038 on `develop`.

## The bug made loud

Three launch-path dispatch sites still read `getattr(config, "provider", None)`, but the field was renamed to `harness` — `hasattr(AgentConfig("x"), "provider")` is **False** (verified) — so every one of those branches was dead and silently fell through to the Claude/TUI path:

1. `src/scitex_agent_container/_lifecycle/_runtime_select.py:66` — the only harness branch on the launch path
2. `src/scitex_agent_container/runtimes/_apptainer_inner_argv.py:167` — inner runner-module dispatch
3. `src/scitex_agent_container/runtimes/_apptainer_build_argv.py:433` — pre-built `runner_argv` dispatch

Meanwhile the auth path reads `config.harness` **correctly**, so a `harness: openai` spec got `OPENAI_*` auth env and then launched the Claude runner — a silent wrong-vendor launch (「エラーが握りつぶされない」 in miniature).

## What this PR does — and does not

- The three dead reads now go through one shared guard, `ensure_harness_matches_claude_launch` (`config/_harness_types.py`), reading the **real** field. When a non-Anthropic harness is about to get the Claude/TUI runner, it **hard-refuses** with a message naming (a) what the spec asked for and through which key (`spec.harness` or the legacy `spec.provider` alias), (b) what was actually about to launch, (c) the `file:line` of the decision, and (d) the v4 gap card id. Emission follows the existing scitex-logging idiom (lazy `scitex_logging.getLogger`, the `_config_logger` pattern).
- Selection is **byte-identical** for every Anthropic-harness spec (the fleet's entire corpus — see survey below). No descriptor registry, no `RUNNER_MODULE_OPENAI` dispatch: that is step 4.
- `kind: AgentProxy` is exempt (the a2a proxy runner is vendor-neutral); pinned by test.

## Hard refusal, not a warning — the spec-survey evidence

Surveyed `~/.scitex/agent-container/agents/*/spec.yaml` on this host: **117 agent dirs, zero declare a non-Anthropic harness.** Every top-level `provider:` is `anthropic`; no spec writes `harness:` with any other value. The only OpenAI-flavoured specs (`grant-agent`, `_template_handyman`) reach OpenAI through `a2a.handler: openai_session` with `provider: anthropic` + `runtime: claude-agent-sdk` — untouched by this guard (verified: their selection is byte-identical). So the hard refusal breaks nothing that works today, and a wrong-vendor launch is never what the operator wants — start has an honest failure path from #1038 to carry it.

## Per-site notes

- **`_runtime_select._get_runtime`** raises without the log line (`log=False`): it also serves every status / list / health walk, all of which degrade the raise into an UNKNOWN verdict that keeps the message (`_agent_list_probe`, `_health_liveness`, `_agent_exec_liveness` each guard it), and a per-read stderr line would contaminate CliRunner-captured `--json` output — the same ruling that placed `warn_if_legacy_*` on the start path. The start path (`start_agent` → `runtime_factory(config)`) propagates it loudly.
- **`build_inner_argv`** guards the TUI branch too — it never had even the dead check, and the interactive `claude` TUI is just as wrong a vendor.
- **`build_run_argv`**'s guard is hoisted to the top of the function so the refusal fires **before any side effect** (workspace-home mkdir, overlay provisioning, auth provisioning). Pre-fix, an openai-harness spec with no key died on a **misleading** `ProviderEnvError` (implying that setting `SAC_OPENAI_API_KEY` would make it work — it would have made it silently launch Claude); post-fix the truth comes first. The `runner_argv` branch's dead read is gone; the branch now emits `RUNNER_MODULE` with a comment pointing at the top guard.
- The stale advice in `_get_runtime`'s unknown-runtime `ValueError` ("set spec.provider: openai instead") is corrected to point at `a2a.handler: openai_session`.

## Tests — real configs, no mocks, proven red pre-fix

The old `spec.provider: openai → OpenAISessionRuntime` tests pinned the dead branch via `SimpleNamespace` stubs that faked the removed attribute (a field that validates is not a field that runs); they are replaced with real-`AgentConfig` refusal tests, plus end-to-end `load_config` coverage of **both key spellings** in `test__harness_types.py` (the guard names `spec.provider` when the spec used the legacy alias).

Pre-fix proof: with the three site files reverted to `5af45160` (guard module kept so imports resolve), **14 of the new tests fail**, each showing the bug verbatim:

```
test_get_runtime_never_hands_an_openai_harness_the_claude_runner
E   AssertionError: assert not True
E    +  where True = isinstance(<...tui_session.TuiSessionRuntime object at 0x74235d6b29c0>,
                                (<class '...TuiSessionRuntime'>, <class '...ClaudeSessionRuntime'>))

test_build_inner_argv_never_emits_the_claude_runner_for_openai_harness
E   AssertionError: assert 'claude_session' not in '/bin/bash -...ackoff-s 1.0'
E     'claude_session' is contained here:
E       ._runners.claude_session --name t --state-root /state --max-restarts 3 --restart-backoff-s 1.0

test_build_run_argv_raises_harness_mismatch_for_openai_harness
E   scitex_agent_container.runtimes._apptainer_provider.ProviderEnvError: spec.harness: openai but
    neither SAC_OPENAI_API_KEY (preferred; sac-tracked) nor OPENAI_API_KEY resolves through
    scitex-config (...)   ← the auth split-brain: harness-aware auth, harness-blind dispatch
```

(full run: `14 failed, 124 passed, 2 skipped` pre-fix → all green post-fix; the anthropic-control and proxy-exemption tests pass in BOTH states, pinning unchanged selection)

Post-fix refusal, observed:

```
ERRO: REFUSING to launch agent 'probe': spec.harness declares harness='openai', but this code path
was about to launch runner module 'scitex_agent_container._runners.claude_session' (decided at
.../_lifecycle/_runtime_select.py:87). Harness-aware runtime dispatch is a KNOWN v4 gap — card
sac-v4-layering-refactor-harness-runtime-inference-20260813 — ...
```

## CI follow-up (second commit)

The first CI run (py3.11) failed exactly three tests — `tests/integration/test_provider_column_specs.py::test_openai_column_argv_{injects_openai_key,marks_family_in_container,carries_no_anthropic_wiring}` — which drove `build_run_argv` on a `harness: openai` spec and asserted the OPENAI_* env in the resulting argv. That argv's runner module was `claude_session`: the tests were unknowingly pinning the split-brain this PR retires. The env-parity assertions now live at the seam that still legitimately produces them (`auth_argv`, the harness-aware step), and a new test pins the full-argv contract for the openai column: `HarnessRuntimeMismatchError` until step 4 dispatches the OpenAI runner for real. Verified locally: 11 passed, 1 skipped.

## Files

- `src/scitex_agent_container/config/_harness_types.py` — `HarnessRuntimeMismatchError`, `V4_HARNESS_DISPATCH_CARD`, `ensure_harness_matches_claude_launch`
- `src/scitex_agent_container/_lifecycle/_runtime_select.py` — site 1
- `src/scitex_agent_container/runtimes/_apptainer_inner_argv.py` — site 2 (+ TUI branch)
- `src/scitex_agent_container/runtimes/_apptainer_build_argv.py` — site 3 (guard hoisted before side effects)
- `tests/…/test__runtime_select.py`, `tests/…/test__apptainer_inner_argv.py`, `tests/…/test__apptainer_build_argv.py`, `tests/…/test__harness_types.py`, `tests/integration/test_provider_column_specs.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
