### PR TITLE
refactor(runners): extract the residency daemon out of claude_session (v4 step 3)

### DIFF
--- a/src/scitex_agent_container/_runners/claude_session.py
+++ b/src/scitex_agent_container/_runners/claude_session.py
@@ -1,14 +1,18 @@
 """Long-lived runner for the ``runtime: claude-session`` agent path.
 
-This module owns the **lifecycle**: PID file write, SIGTERM/SIGINT
-handling, the heartbeat side-task, the SDK conversation, and clean
-shutdown. The IO surface (state-dir paths, atomic file writes,
-heartbeat / quota helpers) lives in :mod:`._session_state`. The hook
-bridge to ``event_log`` lives in :mod:`._session_hooks`. This file
-re-exports the public names from those siblings so existing
-consumers (``runtimes/claude_session.py``, ``agent_meta.py``, the
-test suite) keep their ``runner.write_pid(...)`` / ``runner.read_quota(...)``
-call shapes.
+Per the v4 design ("sac owns the process; a harness owns only the
+turn") this module owns only the **Claude harness seam**: it supplies
+the Claude-specific turn driver (``_session_conversation.
+run_conversation``) to the shared residency daemon in
+:mod:`.session_daemon`, which owns the lifecycle — PID file write,
+SIGTERM/SIGINT handling, the heartbeat side-task, the turn inbox, the
+optional A2A sidecar, and clean shutdown. The IO surface (state-dir
+paths, atomic file writes, heartbeat / quota helpers) lives in
+:mod:`._session_state`. The hook bridge to ``event_log`` lives in
+:mod:`._session_hooks`. This file re-exports the public names from
+those siblings so existing consumers (``runtimes/claude_session.py``,
+``agent_meta.py``, the test suite) keep their
+``runner.write_pid(...)`` / ``runner.read_quota(...)`` call shapes.
 
 State layout (per agent ``<name>``) — see ``_session_state`` for details:
 
@@ -35,10 +39,6 @@ caller; humans should use ``sac agent start [--foreground]`` instead.
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import os
-import signal
 import sys
 from pathlib import Path
 from typing import Any
@@ -69,9 +69,8 @@ from ._session_state import (
     heartbeat_loop as _heartbeat_loop,
 )
 
-logger = logging.getLogger(__name__)
-
 __all__ = [
+    "_heartbeat_loop",
     "DEFAULT_STATE_ROOT",
     "DEFAULT_TICK_SECONDS",
     "STATE_IDLE",
@@ -127,49 +126,15 @@ def _build_event_log_hooks(
 
 
 # ---------------------------------------------------------------------------
-# Daemon lifecycle (signal handling, heartbeat side-task, mission turn)
+# Daemon lifecycle — extracted to :mod:`.session_daemon` (v4 step 3).
+# ``_autonomous_loop`` is re-imported so ``runner._autonomous_loop`` keeps
+# its call shape for existing consumers.
 # ---------------------------------------------------------------------------
 
 
-async def _autonomous_loop(
-    inbox: "asyncio.Queue",
-    *,
-    mission: str,
-    drive_until: str,
-    max_turns: int,
-    kick_text: str,
-    stop: asyncio.Event,
-    loop: asyncio.AbstractEventLoop,
-) -> int:
-    """Drive turns until ``drive_until`` matches an assistant reply or
-    ``max_turns`` is reached.
+from .session_daemon import _autonomous_loop, run_session_daemon
 
-    Returns 0 on a clean ``drive_until`` match, 1 if the cap is hit
-    without a match. Always sets ``stop`` before returning so the
-    surrounding daemon shuts down cleanly.
-
-    F-CS3 phase 2 — pairs with the schema landed in phase 1
-    (``spec.autonomous`` in agent yaml).
-    """
-    from ._session_inbox import TurnEnvelope
-
-    text = mission
-    rc = 1
-    for _ in range(max(1, max_turns)):
-        if stop.is_set():
-            break
-        env = TurnEnvelope(text=text, response=loop.create_future(), exit_after=False)
-        await inbox.put(env)
-        try:
-            reply = await env.response
-        except Exception:  # stx-allow: fallback (reason: convo task may fail mid-loop; treat as terminal — set stop and exit non-zero)
-            break
-        if drive_until and drive_until in (reply or ""):
-            rc = 0
-            break
-        text = kick_text
-    stop.set()
-    return rc
+__all__ += ["_autonomous_loop", "run_session_daemon"]
 
 
 async def run(
@@ -204,207 +169,36 @@ async def run(
     against it; afterward it idles awaiting SIGTERM. With no mission,
     the runner just heartbeats — useful for lifecycle correctness
     checks and for hand-driven manual sessions.
+
+    Thin wrapper over :func:`.session_daemon.run_session_daemon`: the
+    only Claude-specific contribution is the default turn driver
+    (``_session_conversation.run_conversation``); ``run_conversation_fn``
+    remains the test seam that overrides it.
     """
-    state_dir = state_dir_for(name, state_root)
-    state_dir.mkdir(parents=True, exist_ok=True)
-
-    pid = os.getpid()
-    # Resolve canonical host once so every diary write (heartbeat /
-    # turn / error) tags the same hostname. _resolve_host falls back
-    # to hostname -s when config.yaml is malformed, so this never
-    # raises.
-    from .._state.state_db import _resolve_host
-
-    host = _resolve_host(None)
-
-    stop = asyncio.Event()
-    loop = asyncio.get_running_loop()
-
-    def _on_signal(signum: int) -> None:
-        logger.info("runner %s received signal %d, stopping", name, signum)
-        write_heartbeat(state_dir, pid=pid, state=STATE_STOPPING, name=name, host=host)
-        stop.set()
-
-    # Register signal handlers BEFORE the first heartbeat write. The
-    # initial write_heartbeat now also runs init_schema on state.db
-    # (diary tables); on a fresh DB this can take long enough that a
-    # racing SIGTERM from a fast test fixture would kill the process
-    # before handlers were installed, producing exit -15 instead of 0.
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        try:
-            loop.add_signal_handler(sig, _on_signal, sig)
-        except (
-            NotImplementedError
-        ):  # stx-allow: fallback (reason: Windows / no asyncio signal support)
-            signal.signal(sig, lambda s, _f: _on_signal(s))
-
-    write_pid(state_dir, pid)
-    # Record the session start time so every heartbeat can report
-    # ``elapsed_s``. Preserve an existing value across a respawn that
-    # resumes the same SDK session (resume_session_id present) — the
-    # elapsed clock should track the conversation, not the process.
-    if resume_session_id and read_started_at(state_dir) is not None:
-        pass
-    else:
-        write_started_at(state_dir)
-    write_heartbeat(state_dir, pid=pid, state=STATE_STARTING, name=name, host=host)
-
-    hb_task = asyncio.create_task(
-        _heartbeat_loop(
-            state_dir,
-            pid=pid,
-            tick_seconds=tick_seconds,
-            stop=stop,
-            name=name,
-            host=host,
-        ),
+    turn_driver = (
+        run_conversation_fn if run_conversation_fn is not None else _run_conversation
     )
-
-    from ._session_inbox import ShutdownEnvelope, TurnEnvelope, make_inbox
-
-    inbox: asyncio.Queue = make_inbox()
-    convo_task: asyncio.Task | None = None
-    http_task: asyncio.Task | None = None
-
-    if a2a_port is not None:
-        if serve_inbound_fn is None:
-            from ._session_http import (
-                serve_inbound as serve_inbound_fn,  # type: ignore[no-redef]
-            )
-
-        http_task = asyncio.create_task(
-            serve_inbound_fn(
-                inbox,
-                host=a2a_host,
-                port=a2a_port,
-                stop=stop,
-                agent_name=name,
-                spec_yaml_path=a2a_card_yaml,
-                state_dir=state_dir,
-            ),
-        )
-
-    # Spawn the SDK conversation task whenever the inbox has a producer:
-    # mission seeds it with the boot prompt, or a2a_port lets HTTP feed
-    # turns. Without a producer, no SDK client is needed.
-    autonomous_task: asyncio.Task | None = None
-    if mission or a2a_port is not None:
-        if mission and not autonomous_enabled:
-            # Seed the inbox with the mission turn. exit_after=True only
-            # for foreground (--print-stream) mode so the runner exits
-            # when done.
-            mission_env = TurnEnvelope(
-                text=mission,
-                response=loop.create_future(),
-                exit_after=print_stream,
-            )
-            await inbox.put(mission_env)
-        _convo_fn = (
-            run_conversation_fn
-            if run_conversation_fn is not None
-            else _run_conversation
-        )
-        convo_task = asyncio.create_task(
-            _convo_fn(
-                name,
-                state_dir,
-                pid=pid,
-                inbox=inbox,
-                resume_session_id=resume_session_id,
-                stop=stop,
-                print_stream=print_stream,
-                max_restarts=max_restarts,
-                restart_backoff_s=restart_backoff_s,
-                host=host,
-                channels=channels,
-                a2a_port=a2a_port,
-            )
-        )
-        if mission and autonomous_enabled:
-            # F-CS3 phase 2: drive turns until drive_until matches or
-            # max_turns is reached. The loop sets ``stop`` itself, so
-            # the surrounding shutdown path handles cleanup uniformly.
-            autonomous_task = asyncio.create_task(
-                _autonomous_loop(
-                    inbox,
-                    mission=mission,
-                    drive_until=autonomous_drive_until,
-                    max_turns=autonomous_max_turns,
-                    kick_text=autonomous_kick_text,
-                    stop=stop,
-                    loop=loop,
-                )
-            )
-        if mission and print_stream and not autonomous_enabled:
-            # Foreground mode: wait for mission turn to complete, then exit.
-            try:
-                await convo_task
-            finally:
-                hb_task.cancel()
-                try:
-                    await hb_task
-                except asyncio.CancelledError:
-                    pass
-                write_heartbeat(
-                    state_dir,
-                    pid=pid,
-                    state=STATE_STOPPING,
-                    name=name,
-                    host=host,
-                )
-            return 0
-
-    try:
-        await stop.wait()
-    finally:
-        if autonomous_task is not None and not autonomous_task.done():
-            autonomous_task.cancel()
-            try:
-                await autonomous_task
-            except (
-                asyncio.CancelledError,
-                Exception,
-            ):  # stx-allow: fallback (reason: autonomous loop is best-effort; cancellation must not block shutdown)
-                pass
-        if convo_task is not None and not convo_task.done():
-            await inbox.put(ShutdownEnvelope())
-            try:
-                await asyncio.wait_for(convo_task, timeout=shutdown_timeout_s)
-            except (
-                asyncio.TimeoutError,
-                asyncio.CancelledError,
-            ):  # stx-allow: fallback (reason: runner must always reach STOPPING phase even if SDK hangs)
-                convo_task.cancel()
-                try:
-                    await convo_task
-                except (
-                    asyncio.CancelledError,
-                    Exception,
-                ):  # stx-allow: fallback (reason: SDK surface is broad)
-                    pass
-        if http_task is not None and not http_task.done():
-            try:
-                await asyncio.wait_for(http_task, timeout=shutdown_timeout_s)
-            except (
-                asyncio.TimeoutError,
-                asyncio.CancelledError,
-            ):  # stx-allow: fallback (reason: must stop cleanly even if uvicorn hangs)
-                http_task.cancel()
-                try:
-                    await http_task
-                except (
-                    asyncio.CancelledError,
-                    Exception,
-                ):  # stx-allow: fallback (reason: defensive cleanup)
-                    pass
-        hb_task.cancel()
-        try:
-            await hb_task
-        except asyncio.CancelledError:
-            pass
-        # Final heartbeat so consumers see the clean stop.
-        write_heartbeat(state_dir, pid=pid, state=STATE_STOPPING, name=name, host=host)
-    return 0
+    return await run_session_daemon(
+        name,
+        turn_driver=turn_driver,
+        state_root=state_root,
+        tick_seconds=tick_seconds,
+        mission=mission,
+        resume_session_id=resume_session_id,
+        print_stream=print_stream,
+        a2a_host=a2a_host,
+        a2a_port=a2a_port,
+        a2a_card_yaml=a2a_card_yaml,
+        channels=channels,
+        autonomous_enabled=autonomous_enabled,
+        autonomous_drive_until=autonomous_drive_until,
+        autonomous_max_turns=autonomous_max_turns,
+        autonomous_kick_text=autonomous_kick_text,
+        max_restarts=max_restarts,
+        restart_backoff_s=restart_backoff_s,
+        serve_inbound_fn=serve_inbound_fn,
+        shutdown_timeout_s=shutdown_timeout_s,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/scitex_agent_container/_runners/session_daemon.py
+++ b/src/scitex_agent_container/_runners/session_daemon.py
@@ -1,0 +1,328 @@
+"""Shared residency daemon for long-lived agent runners.
+
+Extracted verbatim from :mod:`.claude_session` (v4 migration step 3 —
+"sac owns the process; a harness owns only the turn"). This module owns
+the RESIDENCY machinery: PID file write, SIGTERM/SIGINT handling, the
+heartbeat side-task, the inbox that feeds turns to the harness, the
+optional A2A inbound sidecar, the autonomous drive-until-done loop, and
+clean shutdown. It knows nothing about any vendor SDK — the actual
+conversation is delegated to the ``turn_driver`` callable that the
+harness-specific runner supplies (:mod:`.claude_session` passes its
+``_session_conversation.run_conversation``).
+
+Turn-driver contract (the seam a future harness runner implements)::
+
+    await turn_driver(
+        name, state_dir,
+        pid=..., inbox=..., resume_session_id=..., stop=...,
+        print_stream=..., max_restarts=..., restart_backoff_s=...,
+        host=..., channels=..., a2a_port=...,
+    )
+
+The driver drains :class:`._session_inbox.TurnEnvelope` items from
+``inbox`` until it sees a :class:`._session_inbox.ShutdownEnvelope`,
+resolving each envelope's ``response`` future with the assistant reply.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+from pathlib import Path
+from typing import Any
+
+from ._session_state import (
+    DEFAULT_TICK_SECONDS,
+    STATE_STARTING,
+    STATE_STOPPING,
+    read_started_at,
+    state_dir_for,
+    write_heartbeat,
+    write_pid,
+    write_started_at,
+)
+from ._session_state import (
+    heartbeat_loop as _heartbeat_loop,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["run_session_daemon"]
+
+
+async def _autonomous_loop(
+    inbox: "asyncio.Queue",
+    *,
+    mission: str,
+    drive_until: str,
+    max_turns: int,
+    kick_text: str,
+    stop: asyncio.Event,
+    loop: asyncio.AbstractEventLoop,
+) -> int:
+    """Drive turns until ``drive_until`` matches an assistant reply or
+    ``max_turns`` is reached.
+
+    Returns 0 on a clean ``drive_until`` match, 1 if the cap is hit
+    without a match. Always sets ``stop`` before returning so the
+    surrounding daemon shuts down cleanly.
+
+    F-CS3 phase 2 — pairs with the schema landed in phase 1
+    (``spec.autonomous`` in agent yaml).
+    """
+    from ._session_inbox import TurnEnvelope
+
+    text = mission
+    rc = 1
+    for _ in range(max(1, max_turns)):
+        if stop.is_set():
+            break
+        env = TurnEnvelope(text=text, response=loop.create_future(), exit_after=False)
+        await inbox.put(env)
+        try:
+            reply = await env.response
+        except Exception:  # stx-allow: fallback (reason: convo task may fail mid-loop; treat as terminal — set stop and exit non-zero)
+            break
+        if drive_until and drive_until in (reply or ""):
+            rc = 0
+            break
+        text = kick_text
+    stop.set()
+    return rc
+
+
+async def run_session_daemon(
+    name: str,
+    *,
+    turn_driver: Any,
+    state_root: Path | None = None,
+    tick_seconds: float = DEFAULT_TICK_SECONDS,
+    mission: str | None = None,
+    resume_session_id: str | None = None,
+    print_stream: bool = False,
+    a2a_host: str = "127.0.0.1",
+    a2a_port: int | None = None,
+    a2a_card_yaml: str = "",
+    channels: list[str] | None = None,
+    autonomous_enabled: bool = False,
+    autonomous_drive_until: str = "DONE",
+    autonomous_max_turns: int = 50,
+    autonomous_kick_text: str = "Continue. Print DONE when finished.",
+    max_restarts: int = 0,
+    restart_backoff_s: float = 1.0,
+    serve_inbound_fn: Any | None = None,
+    shutdown_timeout_s: float = 5.0,
+) -> int:
+    """Run the daemon loop until SIGTERM / SIGINT.
+
+    Returns the exit code (0 on clean shutdown). Idempotent re-entry is
+    *not* attempted — the adapter is responsible for ensuring at most
+    one runner per name.
+
+    ``turn_driver`` is the harness seam: the async callable that owns
+    the conversation (see the module docstring for its call shape). The
+    daemon spawns it as the conversation task whenever the inbox has a
+    producer, and never touches the vendor SDK itself.
+
+    If ``mission`` is given, the daemon drives one conversation turn
+    against it; afterward it idles awaiting SIGTERM. With no mission,
+    the daemon just heartbeats — useful for lifecycle correctness
+    checks and for hand-driven manual sessions.
+    """
+    state_dir = state_dir_for(name, state_root)
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    pid = os.getpid()
+    # Resolve canonical host once so every diary write (heartbeat /
+    # turn / error) tags the same hostname. _resolve_host falls back
+    # to hostname -s when config.yaml is malformed, so this never
+    # raises.
+    from .._state.state_db import _resolve_host
+
+    host = _resolve_host(None)
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _on_signal(signum: int) -> None:
+        logger.info("runner %s received signal %d, stopping", name, signum)
+        write_heartbeat(state_dir, pid=pid, state=STATE_STOPPING, name=name, host=host)
+        stop.set()
+
+    # Register signal handlers BEFORE the first heartbeat write. The
+    # initial write_heartbeat now also runs init_schema on state.db
+    # (diary tables); on a fresh DB this can take long enough that a
+    # racing SIGTERM from a fast test fixture would kill the process
+    # before handlers were installed, producing exit -15 instead of 0.
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _on_signal, sig)
+        except (
+            NotImplementedError
+        ):  # stx-allow: fallback (reason: Windows / no asyncio signal support)
+            signal.signal(sig, lambda s, _f: _on_signal(s))
+
+    write_pid(state_dir, pid)
+    # Record the session start time so every heartbeat can report
+    # ``elapsed_s``. Preserve an existing value across a respawn that
+    # resumes the same SDK session (resume_session_id present) — the
+    # elapsed clock should track the conversation, not the process.
+    if resume_session_id and read_started_at(state_dir) is not None:
+        pass
+    else:
+        write_started_at(state_dir)
+    write_heartbeat(state_dir, pid=pid, state=STATE_STARTING, name=name, host=host)
+
+    hb_task = asyncio.create_task(
+        _heartbeat_loop(
+            state_dir,
+            pid=pid,
+            tick_seconds=tick_seconds,
+            stop=stop,
+            name=name,
+            host=host,
+        ),
+    )
+
+    from ._session_inbox import ShutdownEnvelope, TurnEnvelope, make_inbox
+
+    inbox: asyncio.Queue = make_inbox()
+    convo_task: asyncio.Task | None = None
+    http_task: asyncio.Task | None = None
+
+    if a2a_port is not None:
+        if serve_inbound_fn is None:
+            from ._session_http import (
+                serve_inbound as serve_inbound_fn,  # type: ignore[no-redef]
+            )
+
+        http_task = asyncio.create_task(
+            serve_inbound_fn(
+                inbox,
+                host=a2a_host,
+                port=a2a_port,
+                stop=stop,
+                agent_name=name,
+                spec_yaml_path=a2a_card_yaml,
+                state_dir=state_dir,
+            ),
+        )
+
+    # Spawn the conversation (turn-driver) task whenever the inbox has a
+    # producer: mission seeds it with the boot prompt, or a2a_port lets
+    # HTTP feed turns. Without a producer, no harness client is needed.
+    autonomous_task: asyncio.Task | None = None
+    if mission or a2a_port is not None:
+        if mission and not autonomous_enabled:
+            # Seed the inbox with the mission turn. exit_after=True only
+            # for foreground (--print-stream) mode so the runner exits
+            # when done.
+            mission_env = TurnEnvelope(
+                text=mission,
+                response=loop.create_future(),
+                exit_after=print_stream,
+            )
+            await inbox.put(mission_env)
+        convo_task = asyncio.create_task(
+            turn_driver(
+                name,
+                state_dir,
+                pid=pid,
+                inbox=inbox,
+                resume_session_id=resume_session_id,
+                stop=stop,
+                print_stream=print_stream,
+                max_restarts=max_restarts,
+                restart_backoff_s=restart_backoff_s,
+                host=host,
+                channels=channels,
+                a2a_port=a2a_port,
+            )
+        )
+        if mission and autonomous_enabled:
+            # F-CS3 phase 2: drive turns until drive_until matches or
+            # max_turns is reached. The loop sets ``stop`` itself, so
+            # the surrounding shutdown path handles cleanup uniformly.
+            autonomous_task = asyncio.create_task(
+                _autonomous_loop(
+                    inbox,
+                    mission=mission,
+                    drive_until=autonomous_drive_until,
+                    max_turns=autonomous_max_turns,
+                    kick_text=autonomous_kick_text,
+                    stop=stop,
+                    loop=loop,
+                )
+            )
+        if mission and print_stream and not autonomous_enabled:
+            # Foreground mode: wait for mission turn to complete, then exit.
+            try:
+                await convo_task
+            finally:
+                hb_task.cancel()
+                try:
+                    await hb_task
+                except asyncio.CancelledError:
+                    pass
+                write_heartbeat(
+                    state_dir,
+                    pid=pid,
+                    state=STATE_STOPPING,
+                    name=name,
+                    host=host,
+                )
+            return 0
+
+    try:
+        await stop.wait()
+    finally:
+        if autonomous_task is not None and not autonomous_task.done():
+            autonomous_task.cancel()
+            try:
+                await autonomous_task
+            except (
+                asyncio.CancelledError,
+                Exception,
+            ):  # stx-allow: fallback (reason: autonomous loop is best-effort; cancellation must not block shutdown)
+                pass
+        if convo_task is not None and not convo_task.done():
+            await inbox.put(ShutdownEnvelope())
+            try:
+                await asyncio.wait_for(convo_task, timeout=shutdown_timeout_s)
+            except (
+                asyncio.TimeoutError,
+                asyncio.CancelledError,
+            ):  # stx-allow: fallback (reason: runner must always reach STOPPING phase even if SDK hangs)
+                convo_task.cancel()
+                try:
+                    await convo_task
+                except (
+                    asyncio.CancelledError,
+                    Exception,
+                ):  # stx-allow: fallback (reason: SDK surface is broad)
+                    pass
+        if http_task is not None and not http_task.done():
+            try:
+                await asyncio.wait_for(http_task, timeout=shutdown_timeout_s)
+            except (
+                asyncio.TimeoutError,
+                asyncio.CancelledError,
+            ):  # stx-allow: fallback (reason: must stop cleanly even if uvicorn hangs)
+                http_task.cancel()
+                try:
+                    await http_task
+                except (
+                    asyncio.CancelledError,
+                    Exception,
+                ):  # stx-allow: fallback (reason: defensive cleanup)
+                    pass
+        hb_task.cancel()
+        try:
+            await hb_task
+        except asyncio.CancelledError:
+            pass
+        # Final heartbeat so consumers see the clean stop.
+        write_heartbeat(state_dir, pid=pid, state=STATE_STOPPING, name=name, host=host)
+    return 0

--- a/tests/scitex_agent_container/_runners/test_session_daemon.py
+++ b/tests/scitex_agent_container/_runners/test_session_daemon.py
@@ -1,0 +1,240 @@
+"""Contract tests for :mod:`scitex_agent_container._runners.session_daemon`.
+
+The residency daemon was extracted verbatim from ``claude_session`` (v4
+migration step 3 — "sac owns the process; a harness owns only the
+turn"). Its behavior is already covered end-to-end by
+``test_claude_session.py`` through the ``run()`` wrapper; the tests
+here pin the DAEMON'S OWN surface — the parts a future harness runner
+(v4 step 7) will program against directly:
+
+- ``turn_driver`` is a required keyword (the daemon has no vendor
+  default; the harness module supplies it),
+- the daemon calls the driver with the documented kwarg shape,
+- the lifecycle artifacts (pid file, STOPPING heartbeat) come from the
+  daemon itself, with no harness code involved.
+
+No mocks — hand-rolled coroutines only, same as the sibling suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._runners import session_daemon
+from scitex_agent_container._runners._session_inbox import (
+    ShutdownEnvelope,
+    TurnEnvelope,
+)
+
+
+async def _drain_driver(
+    name: str,
+    state_dir: Path,
+    **kwargs: Any,
+) -> None:
+    """Minimal well-behaved turn driver: ack every turn until shutdown."""
+    inbox = kwargs["inbox"]
+    while True:
+        env = await inbox.get()
+        if isinstance(env, ShutdownEnvelope):
+            return
+        if isinstance(env, TurnEnvelope) and not env.response.done():
+            env.response.set_result("ack")
+
+
+def _sigterm_soon(delay_s: float = 0.05) -> None:
+    async def _kick() -> None:
+        await asyncio.sleep(delay_s)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    asyncio.create_task(_kick())
+
+
+# ---------------------------------------------------------------------------
+# turn_driver is the required harness seam
+# ---------------------------------------------------------------------------
+
+
+def test_run_session_daemon_requires_turn_driver_keyword(tmp_path: Path) -> None:
+    # Arrange: no driver supplied — there is no vendor default here.
+    kwargs = {"state_root": tmp_path}
+    # Act
+    call = lambda: session_daemon.run_session_daemon("ag-seam", **kwargs)  # noqa: E731
+    # Assert
+    with pytest.raises(TypeError):
+        call()
+
+
+def test_run_session_daemon_calls_driver_with_documented_kwargs(
+    tmp_path: Path,
+) -> None:
+    # Arrange: capture the exact call shape the daemon hands the driver.
+    seen: dict[str, Any] = {}
+
+    async def _capturing_driver(name: str, state_dir: Path, **kwargs: Any) -> None:
+        seen["name"] = name
+        seen["state_dir"] = state_dir
+        seen["kwargs"] = set(kwargs)
+        await _drain_driver(name, state_dir, **kwargs)
+
+    async def _scenario() -> int:
+        _sigterm_soon()
+        return await session_daemon.run_session_daemon(
+            "ag-shape",
+            turn_driver=_capturing_driver,
+            state_root=tmp_path,
+            tick_seconds=0.01,
+            mission="boot",
+        )
+
+    # Act
+    asyncio.run(_scenario())
+    # Assert: this is the v4 turn-driver contract; step 7's harness
+    # driver must accept exactly these keywords.
+    assert seen["kwargs"] == {
+        "pid",
+        "inbox",
+        "resume_session_id",
+        "stop",
+        "print_stream",
+        "max_restarts",
+        "restart_backoff_s",
+        "host",
+        "channels",
+        "a2a_port",
+    }
+
+
+def test_run_session_daemon_driver_gets_name_and_state_dir(tmp_path: Path) -> None:
+    # Arrange
+    seen: dict[str, Any] = {}
+
+    async def _capturing_driver(name: str, state_dir: Path, **kwargs: Any) -> None:
+        seen["name"] = name
+        seen["state_dir"] = state_dir
+        await _drain_driver(name, state_dir, **kwargs)
+
+    async def _scenario() -> int:
+        _sigterm_soon()
+        return await session_daemon.run_session_daemon(
+            "ag-dir",
+            turn_driver=_capturing_driver,
+            state_root=tmp_path,
+            tick_seconds=0.01,
+            mission="boot",
+        )
+
+    # Act
+    asyncio.run(_scenario())
+    # Assert
+    assert seen["name"] == "ag-dir" and seen["state_dir"] == tmp_path / "ag-dir"
+
+
+def test_run_session_daemon_without_producer_never_calls_driver(
+    tmp_path: Path,
+) -> None:
+    # Arrange: no mission and no a2a_port — the inbox has no producer,
+    # so the daemon must not spawn a conversation task at all.
+    called: list[str] = []
+
+    async def _driver(name: str, state_dir: Path, **kwargs: Any) -> None:
+        called.append(name)
+
+    async def _scenario() -> int:
+        _sigterm_soon()
+        return await session_daemon.run_session_daemon(
+            "ag-idle",
+            turn_driver=_driver,
+            state_root=tmp_path,
+            tick_seconds=0.01,
+        )
+
+    # Act
+    rc = asyncio.run(_scenario())
+    # Assert
+    assert rc == 0 and called == []
+
+
+# ---------------------------------------------------------------------------
+# lifecycle artifacts are the daemon's own
+# ---------------------------------------------------------------------------
+
+
+def test_run_session_daemon_writes_pid_file(tmp_path: Path) -> None:
+    # Arrange
+    from scitex_agent_container._runners._session_state import read_pid
+
+    async def _scenario() -> int:
+        _sigterm_soon()
+        return await session_daemon.run_session_daemon(
+            "ag-pid",
+            turn_driver=_drain_driver,
+            state_root=tmp_path,
+            tick_seconds=0.01,
+        )
+
+    # Act
+    rc = asyncio.run(_scenario())
+    # Assert
+    assert rc == 0 and read_pid(tmp_path / "ag-pid") == os.getpid()
+
+
+def test_run_session_daemon_final_heartbeat_is_stopping(tmp_path: Path) -> None:
+    # Arrange
+    from scitex_agent_container._runners._session_state import (
+        STATE_STOPPING,
+        read_heartbeat,
+    )
+
+    async def _scenario() -> int:
+        _sigterm_soon()
+        return await session_daemon.run_session_daemon(
+            "ag-stop",
+            turn_driver=_drain_driver,
+            state_root=tmp_path,
+            tick_seconds=0.01,
+        )
+
+    # Act
+    asyncio.run(_scenario())
+    hb = read_heartbeat(tmp_path / "ag-stop")
+    # Assert
+    assert hb is not None and hb["state"] == STATE_STOPPING
+
+
+# ---------------------------------------------------------------------------
+# a2a sidecar stays a daemon concern (the harness never sees it)
+# ---------------------------------------------------------------------------
+
+
+def test_run_session_daemon_spawns_sidecar_with_supplied_port(tmp_path: Path) -> None:
+    # Arrange
+    served: dict[str, Any] = {}
+
+    async def _fake_serve(inbox: Any, *, host: str, port: int, stop: Any, **kw: Any) -> None:
+        served["host"] = host
+        served["port"] = port
+        await stop.wait()
+
+    async def _scenario() -> int:
+        _sigterm_soon()
+        return await session_daemon.run_session_daemon(
+            "ag-side",
+            turn_driver=_drain_driver,
+            state_root=tmp_path,
+            tick_seconds=0.01,
+            a2a_port=12_347,
+            a2a_host="127.0.0.1",
+            serve_inbound_fn=_fake_serve,
+        )
+
+    # Act
+    rc = asyncio.run(_scenario())
+    # Assert
+    assert rc == 0 and served == {"host": "127.0.0.1", "port": 12_347}


### PR DESCRIPTION
## v4 migration, step 3 — extract the residency daemon (pure refactor)

Per the v4 design ("sac owns the process; a harness owns only the turn"), the
residency machinery moves out of `_runners/claude_session.py` into a new
vendor-blind `_runners/session_daemon.py`, verbatim:

- pid file write + started_at preservation
- SIGTERM/SIGINT handlers (including the register-before-first-heartbeat race note)
- heartbeat side-task
- turn inbox + mission seeding
- a2a inbound sidecar spawn
- autonomous drive-until-done loop (`_autonomous_loop`)
- the terminal `await stop.wait()` + the full shutdown sequence

The daemon's entry is:

```python
async def run_session_daemon(name, *, turn_driver, ...) -> int
```

`turn_driver` is the harness seam — a required keyword with **no vendor
default**. `claude_session.run` keeps its exact public signature and becomes a
thin wrapper that resolves the Claude driver (`run_conversation_fn` test seam,
default `_session_conversation.run_conversation`) and delegates. Step 7 wires
the OpenAI runner by passing its own driver; nothing else should need to change.

### Zero behavior change

- Every existing test passes unmodified: the diff touches no existing test file
  (`git diff origin/develop...HEAD -- tests/` = one NEW file only).
- Measured locally on both sides of the change (`_runners/` + `runtimes/`
  suites, same venv, baseline run in a detached worktree at origin/develop
  ea111052):
  - before: **2552 passed**, 3 failed, 35 skipped, 19 errors
  - after: **2559 passed**, 3 failed, 35 skipped, 19 errors
  - the +7 is exactly the new `test_session_daemon.py` contract tests; the
    failed/errored id lists are **byte-identical** before/after (verified by
    diffing the sorted FAILED/ERROR lines). All 22 pre-existing reds live in
    `runtimes/test__sdk_common.py` + `runtimes/test__mcp_spec_env.py` — none
    in `_runners/`, which is fully green on both sides. Cause verified, not
    guessed: they raise `SpecEnvUnresolvedError` because the measuring agent's
    container exports `SAC_SPEC_ENV_KEYS` promising `SCITEX_AGENT_CONTAINER_AGENT`,
    which is absent in the pytest process env — a vantage-point artifact of
    running the suite inside a sac container, not a code bug (CI runs with no
    sac spec-env and is green). Untouched by this PR to keep the refactor pure.
- All `runner.<name>` call shapes survive: `run`, `_autonomous_loop`,
  `_heartbeat_loop`, `_run_conversation`, `_parse_argv`, `main`, and the
  `_session_state` re-exports are all still importable from `claude_session`.
- One inherent side effect of moving code, called out for honesty: the daemon's
  log lines (e.g. "runner %s received signal %d, stopping") now emit under the
  logger name `scitex_agent_container._runners.session_daemon` instead of
  `..._runners.claude_session`. Line content unchanged; nothing filters by that
  logger name.

### Deliberately NOT moved

- `_session_cli.py` (`_parse_argv` / `main`): the argv surface is
  claude-session's own (`--resume-session-id`, `--channels`, the venv boot
  assertion) — it stays the Claude runner's CLI and still calls
  `claude_session.run`.
- `_session_conversation` / `_session_turn` / `_session_hooks`: that IS the
  harness ("owns only the turn") — exactly what stays vendor-side.
- `_build_event_log_hooks` shim: Claude-SDK-specific back-compat, stays put.

### Note for step 5 (do not fix here)

The extraction makes the resident-zombie hazard carded as
`sac-sdk-runner-stop-never-set-zombie-resident-20260814` easy to see: if the
turn driver returns without anything setting `stop` (nothing installs an
`add_done_callback` on `convo_task`), the daemon sits at `await stop.wait()`
forever with a live heartbeat. The right place for the deliberate fix is now
obvious and vendor-neutral: in `run_session_daemon`, right where `convo_task`
is created — step 5's beat/ExitRecord work should attach the done-callback
there (daemon-side, once, for every harness). Not fixed in this PR because it
is behavior change.

### Line budget

`claude_session.py` 423 → 217 lines; `session_daemon.py` 328 — both well under
the 512 ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
