### PR TITLE
feat(harness): resolve_harness_key + the HarnessDescriptor registry (v4 step 4)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_runtime_select.py
+++ b/src/scitex_agent_container/_lifecycle/_runtime_select.py
@@ -34,6 +34,12 @@ import logging
 from pathlib import Path
 
 from ..config import AgentConfig
+from ..config._harness_registry import (
+    CLAUDE_AGENT_SDK,
+    CLAUDE_CODE_TUI,
+    resolve_harness_key,
+    runtime_spellings_for,
+)
 from ..config._harness_types import ensure_harness_matches_claude_launch
 
 log = logging.getLogger(__name__)
@@ -42,29 +48,29 @@ log = logging.getLogger(__name__)
 def _get_runtime(config: AgentConfig):
     """Return the runtime adapter for the config's launch mode.
 
-    Branches on TWO axes:
+    Resolution (v4 step 4 — the harness registry,
+    ``config._harness_registry``):
 
-    1. ``config.harness`` — the harness axis (``AgentHarness =
-       Literal["anthropic", "openai"]``). This check runs FIRST so the
-       harness always wins over ``runtime`` — and because every runtime
-       this function can return launches the CLAUDE harness, a
-       non-Anthropic harness is REFUSED loudly here instead of being
-       dispatched (v4 step-2 loudness; harness-aware dispatch is the
-       step-4 descriptor registry). The refusal replaces a DEAD read of
-       ``getattr(config, "provider", None)`` — a field the harness
-       rename removed from ``AgentConfig`` — which silently fell
-       through and launched the Claude runner for ``harness: openai``
-       specs.
-    2. ``config.runtime`` — the launch-mode selector (operator
-       directive 12870). Default: an empty / unset ``runtime``
-       selects the interactive in-apptainer ``tui`` runtime
-       (operator directive 2026-06-15). Back-compat: the legacy
-       ``"apptainer"`` value (the old container-engine selector)
-       maps to ``"claude-agent-sdk"`` SILENTLY. The deprecation
-       log for ``runtime='apptainer'`` fires at the actual start
-       path (:func:`_lifecycle._start.start_agent`) — not here,
-       because every status / list / discovery walk also goes
-       through :func:`_get_runtime` and a per-call warning would
+    1. ``config.harness`` — the harness axis — is checked FIRST so the
+       harness always wins over ``runtime``: every adapter this function
+       can return launches the CLAUDE harness, so a non-Anthropic
+       harness is REFUSED loudly here instead of being dispatched
+       (v4 step-2 loudness, preserved verbatim; key-based launch of
+       non-Anthropic harnesses is migration step 7). The refusal
+       replaced a DEAD read of ``getattr(config, "provider", None)`` —
+       a field the harness rename removed from ``AgentConfig`` — which
+       silently fell through and launched the Claude runner for
+       ``harness: openai`` specs.
+    2. The surviving axes collapse to ONE registry key via
+       :func:`resolve_harness_key` and the key picks the adapter.
+       Default: an empty / unset ``runtime`` selects the interactive
+       in-apptainer TUI entry (operator directive 2026-06-15).
+       Back-compat: the legacy ``"apptainer"`` value (the old
+       container-engine selector) maps to the SDK-runner entry
+       SILENTLY. The deprecation log for ``runtime='apptainer'`` fires
+       at the actual start path (:func:`_lifecycle._start.start_agent`)
+       — not here, because every status / list / discovery walk also
+       goes through :func:`_get_runtime` and a per-call warning would
        (a) spam the operator's logs and (b) contaminate CLI output
        streams (CliRunner-captured commands like
        ``sac agents status --json`` end up with the warning text
@@ -72,10 +78,15 @@ def _get_runtime(config: AgentConfig):
        ``f468a6d2e11443598103ed1672e2e40b``: emit the deprecation
        when the runtime is actually USED to start something, not
        on every read.
+
+    ``kind: AgentProxy`` states no harness (the a2a proxy runner is
+    vendor-neutral — the same exemption the step-2 guard applies), so a
+    proxy resolves by the launch-mode axis alone: its harness field, if
+    any, selects nothing here.
     """
     runtime = getattr(config, "runtime", "") or ""
     # v4 STEP-2 LOUDNESS (card sac-v4-layering-refactor-harness-runtime-
-    # inference-20260813): every runtime below launches the CLAUDE
+    # inference-20260813): every adapter below launches the CLAUDE
     # harness, so a non-Anthropic ``config.harness`` refuses here rather
     # than silently falling through (the fate of the old dead
     # ``getattr(config, "provider", None)`` read this replaces).
@@ -88,30 +99,35 @@ def _get_runtime(config: AgentConfig):
         config,
         launching=(
             "TuiSessionRuntime (the interactive Claude TUI)"
-            if runtime in ("", "tui")
+            if runtime in runtime_spellings_for(CLAUDE_CODE_TUI)
             else "ClaudeSessionRuntime (the headless claude-agent-sdk runner)"
         ),
         log=False,
     )
-    # TUI is the default launch mode (operator directive 2026-06-15,
-    # post the SDK-pool cutoff): empty / unset → interactive in-apptainer
-    # TUI. Explicit legacy values still map to the headless SDK runner so
-    # existing SDK specs are untouched.
-    if runtime in ("", "tui"):
+    if getattr(config, "kind", "Agent") == "AgentProxy":
+        # A proxy is not a harness: resolve by launch mode alone (an
+        # empty mapping states no harness, so only ``runtime`` selects).
+        key = resolve_harness_key({"runtime": runtime})
+    else:
+        # Post-guard the harness is Anthropic-family, so the key is one
+        # of the two Claude entries; an unknown ``runtime`` spelling
+        # raises UnmappableHarnessError (a ValueError) naming both spec
+        # values and the v4 card.
+        key = resolve_harness_key(config)
+    if key == CLAUDE_CODE_TUI:
         from ..runtimes.tui_session import TuiSessionRuntime
 
         return TuiSessionRuntime()
-    if runtime in ("apptainer", "claude-agent-sdk"):
+    if key == CLAUDE_AGENT_SDK:
         from ..runtimes.claude_session import ClaudeSessionRuntime
 
         return ClaudeSessionRuntime()
+    # Defensive totality: a registry key with no lifecycle adapter (the
+    # openai-agents entry is guard-refused above until step 7 lands).
     raise ValueError(
-        f"Unsupported runtime: {runtime!r}. "
-        "spec.runtime must be 'tui' (default, interactive in-apptainer "
-        "TUI), 'claude-agent-sdk' (headless SDK runner), or the "
-        "back-compat 'apptainer' (mapped to 'claude-agent-sdk'). "
-        "There is no 'openai' runtime: OpenAI-harness agents cannot yet "
-        "start through the lifecycle launch path (v4 gap, card "
+        f"Unsupported runtime: no lifecycle adapter for harness key "
+        f"{key!r} (spec.runtime={runtime!r}). Key-based launch of "
+        "non-Anthropic harnesses is a KNOWN v4 gap (card "
         "sac-v4-layering-refactor-harness-runtime-inference-20260813) — "
         "drive them through a2a.handler: openai_session instead."
     )

--- a/src/scitex_agent_container/_lifecycle/_sdk_heartbeat_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_sdk_heartbeat_loop.py
@@ -55,6 +55,8 @@ from concurrent.futures import TimeoutError as _FuturesTimeout
 from pathlib import Path
 from typing import Any, Callable
 
+from ..config._harness_registry import host_probed_runtime_spellings
+
 logger = logging.getLogger(__name__)
 
 # Default cadence. The SDK ``health.interval`` default is 300s; beating
@@ -75,8 +77,10 @@ DEFAULT_PROBE_TIMEOUT_S = 2.0
 
 # Runtimes handled by the TUI loop, NOT here (avoid double-beating a TUI
 # agent — the TUI loop stamps the pane-activity epoch, this loop would
-# clobber it with wall clock).
-_TUI_RUNTIMES = frozenset({"", "tui"})
+# clobber it with wall clock). DERIVED from the harness registry (v4
+# step 4): the spellings of every entry whose ``beat_writer`` is
+# ``host-probe`` — exactly the agents whose beats another loop owns.
+_TUI_RUNTIMES = host_probed_runtime_spellings()
 
 # State written for a live SDK agent. ``running`` mirrors the
 # observability vocabulary the TUI/SDK heartbeat use; the read side

--- a/src/scitex_agent_container/_lifecycle/_stop_escalate.py
+++ b/src/scitex_agent_container/_lifecycle/_stop_escalate.py
@@ -237,8 +237,12 @@ def _remedy(name: str, config: AgentConfig, pid: int | None) -> str:
             f"   # STAT 'D' = uninterruptible I/O: SIGKILL cannot land until "
             f"the syscall returns"
         )
-    # "" and "tui" both select TuiSessionRuntime (see _runtime_select).
-    if (getattr(config, "runtime", "") or "").strip().lower() in ("", "tui"):
+    # Every TUI-entry spelling selects TuiSessionRuntime (harness
+    # registry derivation, v4 step 4 — see _runtime_select).
+    from ..config._harness_registry import CLAUDE_CODE_TUI, runtime_spellings_for
+
+    runtime_spelling = (getattr(config, "runtime", "") or "").strip().lower()
+    if runtime_spelling in runtime_spellings_for(CLAUDE_CODE_TUI):
         lines.append(f"  tmux kill-session -t tui-{name}")
     lines.append(f"  sac agents start {name} -y --fresh")
     return "\n".join(lines)

--- a/src/scitex_agent_container/_lifecycle/health.py
+++ b/src/scitex_agent_container/_lifecycle/health.py
@@ -118,11 +118,15 @@ def _check_sdk_alive(
 def _is_tui_runtime(config: AgentConfig) -> bool:
     """True iff this spec runs under the TUI runtime (the default when unset).
 
-    Mirrors ``_runtime_select._get_runtime``'s mapping — ``""`` and ``"tui"``
-    both mean TuiSessionRuntime — so the gate covers exactly the agents that
-    HAVE a host-side turn bridge.
+    Mirrors ``_runtime_select._get_runtime``'s mapping — every spelling
+    the harness registry's TUI entry claims (``""`` and ``"tui"``, v4
+    step-4 derivation) means TuiSessionRuntime — so the gate covers
+    exactly the agents that HAVE a host-side turn bridge.
     """
-    return (getattr(config, "runtime", "") or "tui").strip() in ("", "tui")
+    from ..config._harness_registry import CLAUDE_CODE_TUI, runtime_spellings_for
+
+    spelling = (getattr(config, "runtime", "") or "tui").strip()
+    return spelling in runtime_spellings_for(CLAUDE_CODE_TUI)
 
 
 def _gate_on_turn_bridge(config: AgentConfig, healthy_message: str) -> tuple[bool, str]:

--- a/src/scitex_agent_container/config/_harness_registry.py
+++ b/src/scitex_agent_container/config/_harness_registry.py
@@ -1,0 +1,470 @@
+"""The harness registry — ONE table describing every way sac runs an agent loop.
+
+v4 migration step 4 (card
+``sac-v4-layering-refactor-harness-runtime-inference-20260813``, design
+comment 2026-08-14). Before this module, the answer to "which harness
+does this spec select, and what does that imply?" was smeared across six
+hardcoded sets that had to agree by hand:
+
+  * ``config/_validation._VALID_RUNTIMES`` (the accepted spellings),
+  * ``_lifecycle/_runtime_select._get_runtime`` (spelling → adapter),
+  * the two inner-argv dispatches
+    (``runtimes/_apptainer_inner_argv.build_inner_argv`` and the
+    pre-built-argv module choice in
+    ``runtimes/_apptainer_build_argv.build_run_argv``),
+  * ``_lifecycle/_sdk_heartbeat_loop._TUI_RUNTIMES`` (who beats whom),
+  * the harness-axis enums (``config/_harness_types.AGENT_HARNESSES``,
+    ``runtimes/_apptainer_provider._VALID_AGENT_HARNESSES``).
+
+Every one of those now DERIVES from :data:`HARNESS_DESCRIPTORS`, so a
+fourth harness is one dict entry here, not a six-file scavenger hunt.
+
+TWO HALF-WIRED SPEC AXES, ONE KEY. Today's specs reach the harness
+through two fields that each carry half the answer: ``spec.runtime`` is
+the LAUNCH MODE (``tui`` vs headless SDK runner — an Anthropic-family
+distinction wearing a vendor-neutral name) and ``spec.harness`` is the
+SDK FAMILY (``anthropic`` | ``openai``). :func:`resolve_harness_key`
+collapses the pair into one registry key at config-read time — NO spec
+on disk is edited; the axes stay as they are until the v4 spec schema
+lands. The mapping is TOTAL over the accepted spellings and an
+unmappable combination raises :class:`UnmappableHarnessError` naming
+both spec values and the card (the operator's errors-reach-the-caller
+directive).
+
+WHAT THIS STEP DOES NOT CHANGE (behavior-preserving by contract):
+
+  * The step-2 refusal (PR #1039) still owns wrong-vendor protection:
+    a ``harness: openai`` spec resolves to a real registry key here, but
+    the lifecycle launch path still cannot START it —
+    ``ensure_harness_matches_claude_launch`` refuses before any dispatch
+    site consults a descriptor. Key-based launch of non-Anthropic
+    harnesses is migration step 7.
+  * The ``SAC_PROVIDER`` ops-only env override keeps its own surface
+    (``runtimes/_apptainer_provider.resolve_agent_harness``); this
+    resolver reads the SPEC axes only.
+  * ``kind: AgentProxy`` is not a harness — the proxy runner is
+    vendor-neutral and dispatched by ``kind``, outside this registry.
+
+THE REGISTRY IS CODE, NOT CONFIG: entries live in this module, are
+frozen dataclasses, and are import-time-validated (no YAML surface —
+deliberate for this step). Vendor names appear ONLY inside the entries
+(and the private constants feeding them); the machinery — the
+dataclass, the resolver, the derivation helpers — is vendor-neutral and
+named by intent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, Literal
+
+if TYPE_CHECKING:  # pragma: no cover — typing only, no runtime import cycle
+    from pathlib import Path
+
+    from ._types import AgentConfig
+
+__all__ = [
+    "CLAUDE_AGENT_SDK",
+    "CLAUDE_CODE_TUI",
+    "HARNESS_DESCRIPTORS",
+    "HarnessDescriptor",
+    "OPENAI_AGENTS",
+    "UnmappableHarnessError",
+    "host_probed_runtime_spellings",
+    "known_harnesses",
+    "resolve_harness_key",
+    "runtime_spellings_for",
+    "valid_runtime_spellings",
+]
+
+
+# ---------------------------------------------------------------------------
+# Registry keys — one per harness sac can run TODAY. These are the values
+# :func:`resolve_harness_key` returns and the only strings a consumer
+# should branch on (never the raw spec spellings).
+# ---------------------------------------------------------------------------
+
+#: The interactive Claude Code TUI in a tmux PTY (``spec.runtime: tui`` /
+#: unset — the operator-directive-2026-06-15 default).
+CLAUDE_CODE_TUI = "claude-code-tui"
+
+#: The headless ``claude-agent-sdk`` session runner
+#: (``spec.runtime: claude-agent-sdk``; legacy ``apptainer`` maps here).
+CLAUDE_AGENT_SDK = "claude-agent-sdk"
+
+#: The ``openai-agents`` SDK session runner (``spec.harness: openai``).
+OPENAI_AGENTS = "openai-agents"
+
+
+class UnmappableHarnessError(ValueError):
+    """``spec.harness`` + ``spec.runtime`` select no registered harness.
+
+    A ``ValueError`` subclass so every caller that historically caught
+    ``_get_runtime``'s ``ValueError("Unsupported runtime: ...")`` keeps
+    working unchanged. The message always names BOTH spec values and the
+    v4 card (errors-reach-the-caller directive, operator 2026-08-14).
+    """
+
+
+def _v4_card() -> str:
+    # Lazy: _harness_types imports THIS module at module level (to derive
+    # AGENT_HARNESSES), so the reverse import must stay call-time only.
+    from ._harness_types import V4_HARNESS_DISPATCH_CARD
+
+    return V4_HARNESS_DISPATCH_CARD
+
+
+# ---------------------------------------------------------------------------
+# Per-entry callables. Defined at module level (not lambdas) so tests and
+# tracebacks can name them; every runtimes/ import is call-time only —
+# runtimes imports config, never the reverse at module level.
+# ---------------------------------------------------------------------------
+
+
+def _noop_prepare_home(config: "AgentConfig") -> None:
+    """Default ``prepare_home`` — nothing beyond the shared machinery.
+
+    Home materialisation (``to_home`` deployment, CLAUDE.md management)
+    still lives in the runtime adapters (``ClaudeSessionRuntime`` /
+    ``OpenAISessionRuntime`` / ``TuiSessionRuntime`` ``_setup_workspace``)
+    today; harnesses hook per-harness extras here in a later step.
+    """
+
+
+def _claude_tui_inner_argv(
+    config: "AgentConfig", options: "Mapping[str, object] | None" = None
+) -> list[str]:
+    """Inner argv for the interactive Claude Code TUI (pre-shell-wrap)."""
+    options = options or {}
+    from ..runtimes._apptainer_inner_argv_tui import _tui_runner_argv
+
+    return _tui_runner_argv(
+        config,
+        mcp_config=options.get("tui_mcp_config"),  # type: ignore[arg-type]
+        channel_mcp=options.get("tui_channel_mcp"),  # type: ignore[arg-type]
+        dev_channels=options.get("tui_dev_channels"),  # type: ignore[arg-type]
+        settings=options.get("tui_settings"),  # type: ignore[arg-type]
+    )
+
+
+def _session_runner_inner_argv(
+    config: "AgentConfig", module: str, options: "Mapping[str, object] | None"
+) -> list[str]:
+    """Shared ``tini → python -m <module>`` tail for runner-hosted entries.
+
+    Both runner-hosted SDK families take the SAME argv surface today
+    (``--name`` / ``--state-root`` / supervisor caps / ``--mission`` /
+    ``--a2a-*`` / ``--channels`` / autonomous flags — the openai session
+    CLI accepts every one of them for parity), so the builder is shared
+    and only the module differs.
+    """
+    options = options or {}
+    from ..runtimes._apptainer_inner_argv import _TINI_PREFIX, _agent_runner_argv
+
+    return (
+        list(_TINI_PREFIX)
+        + [module]
+        + _agent_runner_argv(config, one_shot=bool(options.get("one_shot", False)))
+    )
+
+
+def _claude_sdk_inner_argv(
+    config: "AgentConfig", options: "Mapping[str, object] | None" = None
+) -> list[str]:
+    """Inner argv for the headless ``claude-agent-sdk`` session runner."""
+    return _session_runner_inner_argv(config, _CLAUDE_SESSION_RUNNER, options)
+
+
+def _openai_agents_inner_argv(
+    config: "AgentConfig", options: "Mapping[str, object] | None" = None
+) -> list[str]:
+    """Inner argv for the ``openai-agents`` session runner.
+
+    REAL but not yet lifecycle-reachable: the step-2 refusal
+    (``ensure_harness_matches_claude_launch``) still guards every launch
+    path, so nothing dispatches this until migration step 7.
+    """
+    return _session_runner_inner_argv(config, _OPENAI_SESSION_RUNNER, options)
+
+
+def _claude_env_and_binds(config: "AgentConfig", state_dir: "Path") -> list[str]:
+    """Auth env + creds-bind flags for the Claude-family entries.
+
+    Delegates to :func:`runtimes._apptainer_auth.auth_argv` — the real
+    builder both the TUI and SDK launches already flow through (OAuth
+    creds bind, or ``spec.claude.provider`` API-key backend).
+    """
+    from ..runtimes._apptainer_auth import auth_argv
+
+    return auth_argv(config, state_dir)
+
+
+def _openai_env_and_binds(config: "AgentConfig", state_dir: "Path") -> list[str]:
+    """Auth env flags for the ``openai-agents`` entry (no creds bind).
+
+    Delegates to :func:`runtimes._apptainer_provider.openai_env_flags` —
+    OPENAI_* key injection + routing pass-throughs; declines (returns
+    ``[]``) when the launch does not resolve to the openai harness.
+    """
+    del state_dir  # the openai path mounts no credentials file
+    from ..runtimes._apptainer_provider import openai_env_flags
+
+    return openai_env_flags(config)
+
+
+# Runner-module paths (the ``python -m`` targets). Fed into the entries
+# below and derived FROM them by ``runtimes/_apptainer_inner_argv`` /
+# ``_apptainer_build_argv`` (their ``RUNNER_MODULE*`` re-exports).
+_CLAUDE_SESSION_RUNNER = "scitex_agent_container._runners.claude_session"
+_OPENAI_SESSION_RUNNER = "scitex_agent_container._runners.openai_session"
+
+
+@dataclass(frozen=True)
+class HarnessDescriptor:
+    """Everything sac needs to know about ONE harness, in one row.
+
+    The six BEHAVIORAL fields are the v4 design's descriptor contract
+    (card comment 2026-08-14): ``inner_argv`` / ``hosted`` /
+    ``beat_writer`` / ``can_resume`` / ``env_and_binds`` /
+    ``prepare_home``. The remaining fields are the registry's own data:
+    ``key`` (identity) and the two SELECTION fields (``spec_harness``,
+    ``spec_runtimes``) that make the spec→key mapping and the derived
+    validation sets live IN the entry — which is exactly what lets a
+    fourth harness be one dict entry instead of six edits.
+    """
+
+    #: Registry identity — what :func:`resolve_harness_key` returns.
+    key: str
+
+    #: The ``spec.harness`` family this entry serves (selection data).
+    spec_harness: str
+
+    #: The ``spec.runtime`` spellings that select this entry WITHIN its
+    #: family (selection data). Empty when the family has one entry and
+    #: the runtime axis does not discriminate.
+    spec_runtimes: frozenset[str]
+
+    #: The ``python -m`` runner module, or ``None`` for an external
+    #: process (the interactive ``claude`` binary is not a sac runner).
+    runner_module: str | None
+
+    #: ``inner_argv(config, options) -> list[str]`` — the harness's inner
+    #: process argv, BEFORE the uniform container-shell wrap (git-env
+    #: alias + startup_commands + ``exec``) that ``build_inner_argv``
+    #: applies to every entry identically.
+    inner_argv: Callable[..., list[str]]
+
+    #: Who owns the process loop: ``"runner"`` = a sac session runner
+    #: hosts it (daemon residency, pid file, a2a sidecar);
+    #: ``"external"`` = an external binary owns its own loop and sac
+    #: supervises from outside (tmux pane).
+    hosted: Literal["runner", "external"]
+
+    #: Who writes liveness beats: ``"in-process"`` = the runner stamps
+    #: its own heartbeat; ``"host-probe"`` = a host-side loop probes and
+    #: stamps (an external process cannot beat for itself).
+    beat_writer: Literal["in-process", "host-probe"]
+
+    #: Whether the harness can resume a prior conversation/session.
+    can_resume: bool
+
+    #: ``env_and_binds(config, state_dir) -> list[str]`` — the harness's
+    #: auth/backend ``--env`` / ``--bind`` container flags.
+    env_and_binds: Callable[..., list[str]]
+
+    #: ``prepare_home(config) -> None`` — per-harness home extras beyond
+    #: the shared ``to_home`` machinery. Default no-op (per the design).
+    prepare_home: Callable[..., None] = field(default=_noop_prepare_home)
+
+
+#: THE registry. One entry per harness; a fourth harness is one more row.
+HARNESS_DESCRIPTORS: dict[str, HarnessDescriptor] = {
+    descriptor.key: descriptor
+    for descriptor in (
+        HarnessDescriptor(
+            key=CLAUDE_CODE_TUI,
+            spec_harness="anthropic",
+            spec_runtimes=frozenset({"", "tui"}),
+            runner_module=None,  # inner process is the `claude` binary
+            inner_argv=_claude_tui_inner_argv,
+            hosted="external",
+            beat_writer="host-probe",  # pane-activity epoch, host-stamped
+            can_resume=True,  # tmux-resume / --continue conversation walk
+            env_and_binds=_claude_env_and_binds,
+        ),
+        HarnessDescriptor(
+            key=CLAUDE_AGENT_SDK,
+            spec_harness="anthropic",
+            # "apptainer" is the pre-2026-06-13 container-engine spelling,
+            # honoured as a back-compat alias of the SDK runner (see
+            # _runtime_select.warn_if_legacy_apptainer_runtime).
+            spec_runtimes=frozenset({"apptainer", "claude-agent-sdk"}),
+            runner_module=_CLAUDE_SESSION_RUNNER,
+            inner_argv=_claude_sdk_inner_argv,
+            hosted="runner",
+            beat_writer="in-process",  # heartbeat.json, stamped by the runner
+            can_resume=True,  # persisted session_id + history-walk recovery
+            env_and_binds=_claude_env_and_binds,
+        ),
+        HarnessDescriptor(
+            key=OPENAI_AGENTS,
+            spec_harness="openai",
+            # Sole entry of its family — the harness axis alone selects it
+            # (the runtime axis names Anthropic launch modes; #1039's
+            # refusal keeps those paths from ever launching this entry).
+            spec_runtimes=frozenset(),
+            runner_module=_OPENAI_SESSION_RUNNER,
+            inner_argv=_openai_agents_inner_argv,
+            hosted="runner",
+            beat_writer="in-process",
+            can_resume=False,  # single-turn CLI today; resume flags are parity-only
+            env_and_binds=_openai_env_and_binds,
+        ),
+    )
+}
+
+
+# ---------------------------------------------------------------------------
+# Resolution — the ONE mapping from spec axes to a registry key.
+# ---------------------------------------------------------------------------
+
+
+def resolve_harness_key(spec: "Mapping | AgentConfig") -> str:
+    """Collapse ``spec.harness`` + ``spec.runtime`` into ONE registry key.
+
+    Accepts either a RAW spec mapping (the YAML ``spec:`` block — the
+    deprecated ``provider:`` alias and the stated-conflict rule are
+    honoured via :func:`config._harness_types.resolve_spec_harness`) or a
+    loaded :class:`AgentConfig` (whose ``harness`` the loader already
+    resolved). No spec on disk is read or edited — this is a pure
+    function of the values handed to it.
+
+    Total over the accepted spellings: every currently-valid
+    harness × runtime combination maps to a key. Raises
+    :class:`UnmappableHarnessError` (a ``ValueError``) for anything else,
+    naming both spec values and the v4 card. Raises
+    :class:`config._harness_types.HarnessKeyConflictError` when a raw
+    mapping states ``harness`` and ``provider`` disagreeing — same as
+    the loader.
+
+    Deliberately blind to ``kind`` (``AgentProxy`` is not a harness) and
+    to the ``SAC_PROVIDER`` ops env override (a separate launch-time
+    surface — see ``runtimes/_apptainer_provider.resolve_agent_harness``).
+    """
+    if isinstance(spec, Mapping):
+        from ._harness_types import resolve_spec_harness
+
+        harness = resolve_spec_harness(spec)
+        runtime = str(spec.get("runtime") or "")
+    else:
+        from ._harness_types import DEFAULT_AGENT_HARNESS
+
+        harness = (
+            str(getattr(spec, "harness", "") or DEFAULT_AGENT_HARNESS)
+            .strip()
+            .lower()
+        )
+        runtime = str(getattr(spec, "runtime", "") or "")
+
+    family = [
+        descriptor
+        for descriptor in HARNESS_DESCRIPTORS.values()
+        if descriptor.spec_harness == harness
+    ]
+    if not family:
+        raise UnmappableHarnessError(
+            f"Unknown harness: spec.harness={harness!r} (with "
+            f"spec.runtime={runtime!r}) matches no registered harness "
+            f"family. Known harnesses: {', '.join(known_harnesses())}. "
+            f"(v4 harness registry — card {_v4_card()})"
+        )
+    if len(family) == 1:
+        return family[0].key
+    for descriptor in family:
+        if runtime in descriptor.spec_runtimes:
+            return descriptor.key
+    mappings = "; ".join(
+        f"{sorted(d.spec_runtimes)} → {d.key!r}" for d in family
+    )
+    raise UnmappableHarnessError(
+        f"Unsupported runtime: spec.runtime={runtime!r} maps to no "
+        f"registered harness under spec.harness={harness!r}. Accepted "
+        f"spec.runtime spellings for this harness: {mappings}. "
+        f"(v4 harness registry — card {_v4_card()})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Derivation helpers — the ONLY source for the formerly-hardcoded sets.
+# ---------------------------------------------------------------------------
+
+
+def valid_runtime_spellings() -> frozenset[str]:
+    """Every accepted ``spec.runtime`` spelling, derived from the entries.
+
+    The single source for ``config/_validation._VALID_RUNTIMES``.
+    """
+    spellings: set[str] = set()
+    for descriptor in HARNESS_DESCRIPTORS.values():
+        spellings |= descriptor.spec_runtimes
+    return frozenset(spellings)
+
+
+def runtime_spellings_for(key: str) -> frozenset[str]:
+    """The ``spec.runtime`` spellings that select the entry at ``key``."""
+    return HARNESS_DESCRIPTORS[key].spec_runtimes
+
+
+def host_probed_runtime_spellings() -> frozenset[str]:
+    """Spellings of every entry whose beats are HOST-probed, not in-process.
+
+    The single source for ``_lifecycle/_sdk_heartbeat_loop._TUI_RUNTIMES``
+    (the set that loop must SKIP so it never clobbers a host-stamped
+    pane-activity epoch with wall clock).
+    """
+    spellings: set[str] = set()
+    for descriptor in HARNESS_DESCRIPTORS.values():
+        if descriptor.beat_writer == "host-probe":
+            spellings |= descriptor.spec_runtimes
+    return frozenset(spellings)
+
+
+def known_harnesses() -> tuple[str, ...]:
+    """Every ``spec.harness`` family a registered entry serves, sorted.
+
+    The single source for ``config/_harness_types.AGENT_HARNESSES`` and
+    ``runtimes/_apptainer_provider._VALID_AGENT_HARNESSES``.
+    """
+    return tuple(
+        sorted({descriptor.spec_harness for descriptor in HARNESS_DESCRIPTORS.values()})
+    )
+
+
+def _check_registry() -> None:
+    """Import-time invariants — a malformed registry fails LOUD at import.
+
+    Guards the two properties resolution depends on: dict key == entry
+    key (a copy-paste drift would make lookups lie), and no two entries
+    of one family claiming the same ``spec.runtime`` spelling (first-
+    match would silently win).
+    """
+    claimed: dict[tuple[str, str], str] = {}
+    for key, descriptor in HARNESS_DESCRIPTORS.items():
+        if key != descriptor.key:
+            raise RuntimeError(
+                f"harness registry corrupt: dict key {key!r} != entry key "
+                f"{descriptor.key!r}. Fix the HARNESS_DESCRIPTORS literal."
+            )
+        for spelling in descriptor.spec_runtimes:
+            owner = claimed.setdefault((descriptor.spec_harness, spelling), key)
+            if owner != key:
+                raise RuntimeError(
+                    f"harness registry corrupt: spec.runtime={spelling!r} "
+                    f"under spec.harness={descriptor.spec_harness!r} is "
+                    f"claimed by both {owner!r} and {key!r} — resolution "
+                    "would silently pick the first."
+                )
+
+
+_check_registry()

--- a/src/scitex_agent_container/config/_harness_types.py
+++ b/src/scitex_agent_container/config/_harness_types.py
@@ -47,6 +47,8 @@ from __future__ import annotations
 import sys
 from typing import Literal, Mapping
 
+from ._harness_registry import known_harnesses
+
 __all__ = [
     "AGENT_HARNESSES",
     "AgentHarness",
@@ -77,8 +79,13 @@ DEFAULT_AGENT_HARNESS: AgentHarness = "anthropic"
 
 #: The closed set of agent harnesses sac knows how to run a session
 #: through at all. ``"openai"`` validates and resolves; the concrete
-#: runner landed with openai-compat-2/3.
-AGENT_HARNESSES: tuple[str, ...] = ("anthropic", "openai")
+#: runner landed with openai-compat-2/3. DERIVED from the harness
+#: registry (v4 step 4, ``config._harness_registry``): the set is
+#: whatever families the descriptor entries declare, so a new harness
+#: is one registry entry, not an edit here. The registry module imports
+#: NOTHING from this module at import time, so the derivation is not a
+#: cycle (its reverse imports are call-time only).
+AGENT_HARNESSES: tuple[str, ...] = known_harnesses()
 
 
 class HarnessKeyConflictError(ValueError):

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -27,6 +27,7 @@ from ._placement_validation import validate_placement
 # DEPRECATED alias spec.provider — distinct from spec.claude.provider
 # (the inference backend, validated inside validate_claude via
 # _provider_validation). See config._harness_types.
+from ._harness_registry import valid_runtime_spellings
 from ._harness_types import (
     HARNESS_KEY,
     LEGACY_HARNESS_KEY,
@@ -55,7 +56,11 @@ _VALID_KINDS = frozenset({"Agent", "AgentProxy"})
 # (degenerate since sac became apptainer-only on 2026-05-13). ``""``
 # and ``"apptainer"`` are accepted as back-compat and mapped to
 # ``"claude-agent-sdk"`` at dispatch — see ``_lifecycle/_runtime_select``.
-_VALID_RUNTIMES = frozenset({"claude-agent-sdk", "tui", "apptainer", ""})
+# DERIVED from the harness registry (v4 step 4): the accepted spellings
+# are whatever the descriptor entries claim, so a new harness's runtime
+# spelling is one registry entry, not an edit here. The name is kept —
+# it is imported elsewhere (e.g. ``_lifecycle/_relocate_probe_shell``).
+_VALID_RUNTIMES = valid_runtime_spellings()
 
 # spec.container.runtime — every value here must have a working engine
 # behind it. docker/podman were ripped out 2026-05-13.

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -23,6 +23,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from ..config import AgentConfig
+from ..config._harness_registry import (
+    CLAUDE_AGENT_SDK,
+    HARNESS_DESCRIPTORS,
+    OPENAI_AGENTS,
+)
 from ._apptainer_overlay import ensure_overlay_dirs, overlay_flags
 from ._apptainer_quota_cache import (
     QUOTA_CACHE_CONTAINER_PATH,
@@ -33,17 +38,20 @@ from ._apptainer_quota_cache import (
 
 # ----------------------------------------------------------------------
 # Module-level constants (moved from _apptainer_runtime, re-exported
-# there for back-compat).
+# there for back-compat). DERIVED from the harness registry (v4 step 4,
+# ``config._harness_registry``) — the registry entry is the single
+# source for each runner-module path.
 # ----------------------------------------------------------------------
-RUNNER_MODULE = "scitex_agent_container._runners.claude_session"
+RUNNER_MODULE = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].runner_module
 
 # OpenAI harness runner module (scitex-todo card ``openai-compat-2``).
-# NOT DISPATCHED YET: the old ``getattr(config, "provider", None)``
-# selector was dead (the harness rename removed the field), and v4
-# step 2 replaces it with a loud refusal rather than a repoint —
-# harness-aware dispatch arrives with the step-4 descriptor registry
+# NOT DISPATCHED from here YET: the v4 step-2 refusal at the top of
+# ``build_run_argv`` guards every shape of this argv, so a non-Anthropic
+# harness raises instead of dispatching. The registry's ``openai-agents``
+# entry carries the real module + argv builder; key-based launch is
+# migration step 7
 # (card ``sac-v4-layering-refactor-harness-runtime-inference-20260813``).
-RUNNER_MODULE_OPENAI = "scitex_agent_container._runners.openai_session"
+RUNNER_MODULE_OPENAI = HARNESS_DESCRIPTORS[OPENAI_AGENTS].runner_module
 
 # Quota-cache constants + resolver now live in _apptainer_quota_cache (this
 # file sat at the 512-line cap); imported below and re-exported via __all__ so
@@ -456,7 +464,9 @@ def build_run_argv(
             # guard already refused any non-Anthropic spec (v4 step 2 —
             # the old ``getattr(config, "provider", None)`` read here
             # was DEAD, so ``RUNNER_MODULE_OPENAI`` was never actually
-            # dispatched; harness-aware dispatch is step 4).
+            # dispatched). ``RUNNER_MODULE`` is now DERIVED from the
+            # harness registry's SDK entry (v4 step 4); dispatching
+            # OTHER entries' modules here is migration step 7.
             module = RUNNER_MODULE
         inner_argv = [
             "/usr/bin/tini",

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -19,6 +19,12 @@ from __future__ import annotations
 import shlex
 from typing import TYPE_CHECKING
 
+from ..config._harness_registry import (
+    CLAUDE_AGENT_SDK,
+    CLAUDE_CODE_TUI,
+    HARNESS_DESCRIPTORS,
+    OPENAI_AGENTS,
+)
 from ..config._harness_types import ensure_harness_matches_claude_launch
 from ._apptainer_inner_argv_tui import (  # noqa: F401 (re-export)
     _home_has_resumable_conversation,
@@ -31,17 +37,20 @@ from ._apptainer_inner_argv_tui import (  # noqa: F401 (re-export)
 if TYPE_CHECKING:
     from ..config import AgentConfig
 
-# Runner-module dispatch by ``config.kind``. Kept here so the parent
-# orchestrator doesn't need to know either runner's module path.
-RUNNER_MODULE_AGENT = "scitex_agent_container._runners.claude_session"
+# Runner-module names, DERIVED from the harness registry (v4 step 4,
+# ``config._harness_registry``) — the registry entry is the single
+# source for each module path; these constants remain because they are
+# imported by tests and sibling modules.
+RUNNER_MODULE_AGENT = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].runner_module
 
 # OpenAI harness runner module (scitex-todo card ``openai-compat-2``).
-# NOT DISPATCHED YET: the old ``getattr(config, "provider", None)``
-# selector was dead (the harness rename removed the field), and v4
-# step 2 replaces it with a loud refusal rather than a repoint —
-# harness-aware dispatch arrives with the step-4 descriptor registry
+# NOT DISPATCHED from here YET: the v4 step-2 refusal
+# (``ensure_harness_matches_claude_launch``) guards every branch below,
+# so a non-Anthropic harness raises instead of dispatching. The
+# registry's ``openai-agents`` entry carries the REAL argv builder;
+# key-based launch is migration step 7
 # (card ``sac-v4-layering-refactor-harness-runtime-inference-20260813``).
-RUNNER_MODULE_OPENAI = "scitex_agent_container._runners.openai_session"
+RUNNER_MODULE_OPENAI = HARNESS_DESCRIPTORS[OPENAI_AGENTS].runner_module
 
 RUNNER_MODULE_PROXY = "scitex_agent_container._runners.a2a_proxy"
 
@@ -164,26 +173,34 @@ def build_inner_argv(
         ensure_harness_matches_claude_launch(
             config, launching="the interactive claude TUI"
         )
-        runner_tail = _tui_runner_argv(
+        # v4 step 4: the registry entry owns the argv shape. The entry is
+        # keyed by the caller's already-decided launch mode (``tui=True``
+        # came from TuiSessionRuntime), never re-derived from the config —
+        # direct/dry-run callers pass configs whose ``runtime`` field this
+        # builder must not second-guess.
+        runner_tail = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI].inner_argv(
             config,
-            mcp_config=tui_mcp_config,
-            channel_mcp=tui_channel_mcp,
-            dev_channels=tui_dev_channels,
-            settings=tui_settings,
+            {
+                "tui_mcp_config": tui_mcp_config,
+                "tui_channel_mcp": tui_channel_mcp,
+                "tui_dev_channels": tui_dev_channels,
+                "tui_settings": tui_settings,
+            },
         )
     elif kind == "AgentProxy":
         runner_tail = _TINI_PREFIX + [RUNNER_MODULE_PROXY] + _proxy_runner_argv(config)
     else:
         # v4 step-2 loudness: refuse a wrong-vendor launch on the REAL
         # field (the dead ``config.provider`` read used to sit here and
-        # silently fell through to the Claude runner).
+        # silently fell through to the Claude runner). Post-guard the
+        # harness is Anthropic-family, so the SDK entry is the only
+        # runner-hosted candidate; key-based launch of other entries is
+        # migration step 7.
         ensure_harness_matches_claude_launch(
             config, launching=f"runner module {RUNNER_MODULE_AGENT!r}"
         )
-        runner_tail = (
-            _TINI_PREFIX
-            + [RUNNER_MODULE_AGENT]
-            + _agent_runner_argv(config, one_shot=one_shot)
+        runner_tail = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].inner_argv(
+            config, {"one_shot": one_shot}
         )
 
     startup_cmds = list(getattr(config, "startup_commands", []) or [])

--- a/src/scitex_agent_container/runtimes/_apptainer_provider.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_provider.py
@@ -116,6 +116,7 @@ from pathlib import Path
 from scitex_config import PriorityConfig, load_dotenv
 
 from ..config import AgentConfig
+from ..config._harness_registry import known_harnesses
 
 
 class ProviderEnvError(RuntimeError):
@@ -244,7 +245,9 @@ def provider_env_flags(config: AgentConfig) -> list[str]:
 # once. It is listed as a follow-up, not fixed here.
 AGENT_HARNESS_ENV = "SAC_PROVIDER"
 
-_VALID_AGENT_HARNESSES = ("anthropic", "openai")
+# DERIVED from the harness registry (v4 step 4): the families the
+# descriptor entries declare, so a new harness is one registry entry.
+_VALID_AGENT_HARNESSES = known_harnesses()
 
 _SAC_OPENAI_KEY_ENV = "SAC_OPENAI_API_KEY"
 _OPENAI_KEY_ENV = "OPENAI_API_KEY"

--- a/src/scitex_agent_container/runtimes/claude_session.py
+++ b/src/scitex_agent_container/runtimes/claude_session.py
@@ -210,16 +210,19 @@ def _container_runtime_for(config: AgentConfig):
     unrecognised ``spec.runtime``.
     """
     runtime = getattr(config, "runtime", "") or "apptainer"
-    # Both the legacy ``apptainer`` value and the current
-    # ``claude-agent-sdk`` selector dispatch the headless SDK runner via
-    # ``apptainer exec`` — the registry (_runtime_select) maps BOTH to
-    # ClaudeSessionRuntime, so both must resolve to a container runtime
+    # Every spelling the harness registry's SDK entry claims (the legacy
+    # ``apptainer`` value AND the current ``claude-agent-sdk`` selector —
+    # v4 step-4 derivation) dispatches the headless SDK runner via
+    # ``apptainer exec`` — ``_runtime_select`` maps ALL of them to
+    # ClaudeSessionRuntime, so all must resolve to a container runtime
     # here. Previously only ``apptainer`` did, so ``runtime:
     # claude-agent-sdk`` fell through to None and start() failed loud with
     # "requires docker|podman" — despite docker having been ripped out
     # (apptainer is the only engine). This made the recommended value
     # unusable while the deprecated alias worked; both now resolve.
-    if runtime in ("apptainer", "claude-agent-sdk"):
+    from ..config._harness_registry import CLAUDE_AGENT_SDK, runtime_spellings_for
+
+    if runtime in runtime_spellings_for(CLAUDE_AGENT_SDK):
         from ._apptainer_runtime import ApptainerContainerRuntime
 
         return ApptainerContainerRuntime()

--- a/src/scitex_agent_container/runtimes/openai_session.py
+++ b/src/scitex_agent_container/runtimes/openai_session.py
@@ -78,11 +78,14 @@ def _container_runtime_for(config: AgentConfig):
     the apptainer argv builder (which branches on ``spec.provider``).
     """
     runtime = getattr(config, "runtime", "") or "apptainer"
-    # Both the legacy ``apptainer`` value and the current
-    # ``claude-agent-sdk`` selector dispatch the headless SDK runner via
+    # Every spelling the harness registry's SDK entry claims (the legacy
+    # ``apptainer`` value and the current ``claude-agent-sdk`` selector —
+    # v4 step-4 derivation) dispatches the headless SDK runner via
     # ``apptainer exec``. The OpenAI path uses the same container
     # runtime — only the inner module differs.
-    if runtime in ("apptainer", "claude-agent-sdk"):
+    from ..config._harness_registry import CLAUDE_AGENT_SDK, runtime_spellings_for
+
+    if runtime in runtime_spellings_for(CLAUDE_AGENT_SDK):
         from ._apptainer_runtime import ApptainerContainerRuntime
 
         return ApptainerContainerRuntime()

--- a/tests/scitex_agent_container/config/test__harness_registry.py
+++ b/tests/scitex_agent_container/config/test__harness_registry.py
@@ -1,0 +1,695 @@
+"""Tests for ``config/_harness_registry.py`` (v4 migration step 4).
+
+The registry is the single source for the harness axes: the spec→key
+resolution (:func:`resolve_harness_key`) and every formerly-hardcoded
+set the codebase derives from it (``_VALID_RUNTIMES``, ``_get_runtime``'s
+branch sets, both inner-argv dispatches, ``_TUI_RUNTIMES``, the
+harness-axis enums). Card
+``sac-v4-layering-refactor-harness-runtime-inference-20260813``.
+
+No mocks: every assertion runs the real resolver / real descriptors /
+real derived consumers against real ``AgentConfig`` objects.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._harness_registry import (
+    CLAUDE_AGENT_SDK,
+    CLAUDE_CODE_TUI,
+    HARNESS_DESCRIPTORS,
+    OPENAI_AGENTS,
+    UnmappableHarnessError,
+    host_probed_runtime_spellings,
+    known_harnesses,
+    resolve_harness_key,
+    runtime_spellings_for,
+    valid_runtime_spellings,
+)
+from scitex_agent_container.config._harness_types import (
+    AGENT_HARNESSES,
+    V4_HARNESS_DISPATCH_CARD,
+    HarnessKeyConflictError,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_harness_key — the spec→key mapping, raw-Mapping surface
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_empty_spec_maps_to_the_tui_key():
+    # Arrange — a spec stating neither axis: the fleet default.
+    spec: dict = {}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CLAUDE_CODE_TUI
+
+
+def test_resolve_empty_runtime_spelling_maps_to_the_tui_key():
+    # Arrange
+    spec = {"runtime": ""}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CLAUDE_CODE_TUI
+
+
+def test_resolve_runtime_tui_maps_to_the_tui_key():
+    # Arrange
+    spec = {"runtime": "tui"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CLAUDE_CODE_TUI
+
+
+def test_resolve_runtime_claude_agent_sdk_maps_to_the_sdk_key():
+    # Arrange
+    spec = {"runtime": "claude-agent-sdk"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CLAUDE_AGENT_SDK
+
+
+def test_resolve_legacy_apptainer_spelling_maps_to_the_sdk_key():
+    # Arrange — the pre-2026-06-13 container-engine value stays an alias.
+    spec = {"runtime": "apptainer"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CLAUDE_AGENT_SDK
+
+
+def test_resolve_harness_openai_maps_to_the_openai_key():
+    # Arrange
+    spec = {"harness": "openai"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == OPENAI_AGENTS
+
+
+def test_resolve_harness_axis_wins_over_the_runtime_axis():
+    # Arrange — the harness states the SDK family while the runtime
+    # spelling names an Anthropic launch mode; the family must win
+    # (same precedence _get_runtime's guard applies).
+    spec = {"harness": "openai", "runtime": "tui"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == OPENAI_AGENTS
+
+
+def test_resolve_honours_the_legacy_provider_alias():
+    # Arrange — spec.provider is the deprecated spelling of the harness
+    # axis and must resolve identically (the live corpus still uses it).
+    spec = {"provider": "openai"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == OPENAI_AGENTS
+
+
+def test_resolve_raises_the_stated_conflict_like_the_loader():
+    # Arrange — harness and provider stating DIFFERENT values.
+    spec = {"harness": "anthropic", "provider": "openai"}
+    # Act — resolution refuses to pick one silently.
+    # Assert — same exception type the loader raises.
+    with pytest.raises(HarnessKeyConflictError):
+        resolve_harness_key(spec)
+
+
+def test_resolve_unknown_runtime_raises_unmappable():
+    # Arrange
+    spec = {"runtime": "docker"}
+    # Act — the mapping is total; anything outside it is a loud error.
+    # Assert
+    with pytest.raises(UnmappableHarnessError):
+        resolve_harness_key(spec)
+
+
+def test_resolve_unknown_runtime_error_names_the_runtime_value():
+    # Arrange — the errors-reach-the-caller directive: the message must
+    # name what the spec actually said.
+    spec = {"runtime": "docker"}
+    # Act
+    # Assert
+    with pytest.raises(UnmappableHarnessError, match="'docker'"):
+        resolve_harness_key(spec)
+
+
+def test_resolve_unknown_runtime_error_names_the_harness_value():
+    # Arrange — both axes must appear in the message, not just the
+    # offending one.
+    spec = {"runtime": "docker"}
+    # Act
+    # Assert
+    with pytest.raises(UnmappableHarnessError, match="'anthropic'"):
+        resolve_harness_key(spec)
+
+
+def test_resolve_unknown_runtime_error_names_the_v4_card():
+    # Arrange
+    spec = {"runtime": "docker"}
+    # Act
+    # Assert
+    with pytest.raises(UnmappableHarnessError, match=V4_HARNESS_DISPATCH_CARD):
+        resolve_harness_key(spec)
+
+
+def test_resolve_unknown_harness_raises_unmappable():
+    # Arrange
+    spec = {"harness": "qwen"}
+    # Act
+    # Assert
+    with pytest.raises(UnmappableHarnessError):
+        resolve_harness_key(spec)
+
+
+def test_resolve_unknown_harness_error_names_the_value():
+    # Arrange
+    spec = {"harness": "qwen"}
+    # Act
+    # Assert
+    with pytest.raises(UnmappableHarnessError, match="'qwen'"):
+        resolve_harness_key(spec)
+
+
+def test_resolve_unknown_harness_error_names_the_v4_card():
+    # Arrange
+    spec = {"harness": "qwen"}
+    # Act
+    # Assert
+    with pytest.raises(UnmappableHarnessError, match=V4_HARNESS_DISPATCH_CARD):
+        resolve_harness_key(spec)
+
+
+def test_unmappable_error_is_a_value_error():
+    # Arrange — callers that historically caught _get_runtime's
+    # ValueError("Unsupported runtime: ...") must keep working.
+    error_type = UnmappableHarnessError
+    # Act
+    is_value_error = issubclass(error_type, ValueError)
+    # Assert
+    assert is_value_error
+
+
+# ---------------------------------------------------------------------------
+# resolve_harness_key — loaded-AgentConfig surface
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_accepts_a_loaded_config_default_runtime():
+    # Arrange — AgentConfig's runtime field defaults to "tui" (the
+    # loader default).
+    cfg = AgentConfig(name="t")
+    # Act
+    key = resolve_harness_key(cfg)
+    # Assert
+    assert key == CLAUDE_CODE_TUI
+
+
+def test_resolve_accepts_a_loaded_config_sdk_runtime():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="claude-agent-sdk")
+    # Act
+    key = resolve_harness_key(cfg)
+    # Assert
+    assert key == CLAUDE_AGENT_SDK
+
+
+def test_resolve_accepts_a_loaded_config_legacy_apptainer():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="apptainer")
+    # Act
+    key = resolve_harness_key(cfg)
+    # Assert
+    assert key == CLAUDE_AGENT_SDK
+
+
+def test_resolve_accepts_a_loaded_config_openai_harness():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="tui", harness="openai")
+    # Act
+    key = resolve_harness_key(cfg)
+    # Assert
+    assert key == OPENAI_AGENTS
+
+
+def test_resolve_config_and_mapping_surfaces_agree():
+    # Arrange — the same axes must resolve identically whichever
+    # surface hands them over: the loader's AgentConfig or the raw
+    # YAML mapping.
+    spellings = sorted(valid_runtime_spellings())
+    # Act
+    per_config = [
+        resolve_harness_key(AgentConfig(name="t", runtime=s)) for s in spellings
+    ]
+    per_mapping = [resolve_harness_key({"runtime": s}) for s in spellings]
+    # Assert
+    assert per_config == per_mapping
+
+
+# ---------------------------------------------------------------------------
+# The registry entries — shape and stated contracts
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_exactly_the_three_real_entries():
+    # Arrange
+    expected = {CLAUDE_CODE_TUI, CLAUDE_AGENT_SDK, OPENAI_AGENTS}
+    # Act
+    keys = set(HARNESS_DESCRIPTORS)
+    # Assert
+    assert keys == expected
+
+
+def test_every_dict_key_matches_its_entry_key():
+    # Arrange
+    items = HARNESS_DESCRIPTORS.items()
+    # Act
+    all_match = all(key == descriptor.key for key, descriptor in items)
+    # Assert
+    assert all_match
+
+
+def test_the_tui_entry_is_external_hosted():
+    # Arrange — the interactive `claude` binary owns its own loop; sac
+    # supervises from outside (tmux pane).
+    entry = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI]
+    # Act
+    hosted = entry.hosted
+    # Assert
+    assert hosted == "external"
+
+
+def test_the_sdk_entry_is_runner_hosted():
+    # Arrange
+    entry = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK]
+    # Act
+    hosted = entry.hosted
+    # Assert
+    assert hosted == "runner"
+
+
+def test_the_openai_entry_is_runner_hosted():
+    # Arrange
+    entry = HARNESS_DESCRIPTORS[OPENAI_AGENTS]
+    # Act
+    hosted = entry.hosted
+    # Assert
+    assert hosted == "runner"
+
+
+def test_the_tui_entry_beats_are_host_probed():
+    # Arrange — an external process cannot beat for itself; the TUI
+    # heartbeat loop stamps the pane-activity epoch from the host side.
+    entry = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI]
+    # Act
+    beat_writer = entry.beat_writer
+    # Assert
+    assert beat_writer == "host-probe"
+
+
+def test_the_sdk_entry_beats_in_process():
+    # Arrange
+    entry = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK]
+    # Act
+    beat_writer = entry.beat_writer
+    # Assert
+    assert beat_writer == "in-process"
+
+
+def test_the_openai_entry_beats_in_process():
+    # Arrange
+    entry = HARNESS_DESCRIPTORS[OPENAI_AGENTS]
+    # Act
+    beat_writer = entry.beat_writer
+    # Assert
+    assert beat_writer == "in-process"
+
+
+def test_the_tui_entry_can_resume():
+    # Arrange
+    entry = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI]
+    # Act
+    can_resume = entry.can_resume
+    # Assert
+    assert can_resume
+
+
+def test_the_sdk_entry_can_resume():
+    # Arrange
+    entry = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK]
+    # Act
+    can_resume = entry.can_resume
+    # Assert
+    assert can_resume
+
+
+def test_the_openai_entry_cannot_resume():
+    # Arrange — the openai session CLI's resume flags are parity-only
+    # today.
+    entry = HARNESS_DESCRIPTORS[OPENAI_AGENTS]
+    # Act
+    can_resume = entry.can_resume
+    # Assert
+    assert not can_resume
+
+
+def test_the_tui_entry_has_no_runner_module():
+    # Arrange — its inner process is the `claude` binary, not a
+    # `python -m` runner.
+    entry = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI]
+    # Act
+    module = entry.runner_module
+    # Assert
+    assert module is None
+
+
+def test_the_sdk_entry_names_the_claude_session_runner():
+    # Arrange
+    entry = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK]
+    # Act
+    module = entry.runner_module
+    # Assert
+    assert module == "scitex_agent_container._runners.claude_session"
+
+
+def test_the_openai_entry_names_the_openai_session_runner():
+    # Arrange
+    entry = HARNESS_DESCRIPTORS[OPENAI_AGENTS]
+    # Act
+    module = entry.runner_module
+    # Assert
+    assert module == "scitex_agent_container._runners.openai_session"
+
+
+def test_prepare_home_defaults_to_a_no_op_for_every_entry():
+    # Arrange — the design gives prepare_home a default no-op;
+    # per-harness home extras hook in at a later migration step.
+    cfg = AgentConfig(name="t")
+    # Act
+    results = [d.prepare_home(cfg) for d in HARNESS_DESCRIPTORS.values()]
+    # Assert
+    assert results == [None] * len(HARNESS_DESCRIPTORS)
+
+
+def test_the_claude_entries_share_one_env_and_binds_builder():
+    # Arrange — both Claude-family launches flow through the same real
+    # auth builder (runtimes._apptainer_auth.auth_argv); the entries
+    # must not fork it.
+    tui_entry = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI]
+    sdk_entry = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK]
+    # Act
+    same_builder = tui_entry.env_and_binds is sdk_entry.env_and_binds
+    # Assert
+    assert same_builder
+
+
+def test_the_openai_env_builder_declines_a_non_openai_launch():
+    # Arrange — real call, no env manipulation: openai_env_flags
+    # returns [] when the launch does not resolve to the openai harness.
+    entry = HARNESS_DESCRIPTORS[OPENAI_AGENTS]
+    # Act
+    flags = entry.env_and_binds(AgentConfig(name="t"), None)
+    # Assert
+    assert flags == []
+
+
+# ---------------------------------------------------------------------------
+# inner_argv — the entries build the REAL runner tails
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_inner_argv_is_the_tini_wrapped_session_runner():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="apptainer")
+    # Act
+    argv = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].inner_argv(cfg)
+    # Assert
+    assert argv[:5] == ["/usr/bin/tini", "-s", "--", "python3", "-m"]
+
+
+def test_sdk_inner_argv_dispatches_the_claude_session_module():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="apptainer")
+    # Act
+    argv = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].inner_argv(cfg)
+    # Assert
+    assert argv[5] == "scitex_agent_container._runners.claude_session"
+
+
+def test_sdk_inner_argv_carries_the_agent_name():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="apptainer")
+    # Act
+    argv = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].inner_argv(cfg)
+    # Assert
+    assert argv[argv.index("--name") + 1] == "t"
+
+
+def test_openai_inner_argv_dispatches_the_openai_session_module():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="apptainer", harness="openai")
+    # Act
+    argv = HARNESS_DESCRIPTORS[OPENAI_AGENTS].inner_argv(cfg)
+    # Assert
+    assert argv[5] == "scitex_agent_container._runners.openai_session"
+
+
+def test_openai_inner_argv_never_names_the_claude_runner():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="apptainer", harness="openai")
+    # Act
+    argv = HARNESS_DESCRIPTORS[OPENAI_AGENTS].inner_argv(cfg)
+    # Assert
+    assert "claude_session" not in " ".join(argv)
+
+
+def test_tui_inner_argv_launches_the_claude_binary():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="tui")
+    # Act
+    argv = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI].inner_argv(cfg)
+    # Assert
+    assert argv[0] == "claude"
+
+
+def test_tui_inner_argv_threads_the_mcp_config_option():
+    # Arrange
+    cfg = AgentConfig(name="t", runtime="tui")
+    # Act
+    argv = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI].inner_argv(
+        cfg, {"tui_mcp_config": "/home/agent/.mcp.json"}
+    )
+    # Assert
+    assert argv[argv.index("--mcp-config") + 1] == "/home/agent/.mcp.json"
+
+
+def test_build_inner_argv_embeds_the_registry_built_sdk_tail():
+    # Arrange — the dispatch site must emit exactly what the registry
+    # entry builds: the derivation is real, not parallel code.
+    from scitex_agent_container.runtimes._apptainer_inner_argv import (
+        build_inner_argv,
+    )
+
+    cfg = AgentConfig(name="t", runtime="apptainer")
+    tail = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].inner_argv(cfg, {"one_shot": False})
+    # Act
+    wrapped = build_inner_argv(cfg)
+    # Assert
+    assert " ".join(tail) in wrapped[2]
+
+
+# ---------------------------------------------------------------------------
+# Derivations — the formerly-hardcoded sets all read from the registry
+# ---------------------------------------------------------------------------
+
+
+def test_valid_runtime_spellings_is_the_union_of_the_entries():
+    # Arrange
+    expected = frozenset({"", "tui", "apptainer", "claude-agent-sdk"})
+    # Act
+    spellings = valid_runtime_spellings()
+    # Assert
+    assert spellings == expected
+
+
+def test_validation_valid_runtimes_derives_from_the_registry():
+    # Arrange
+    from scitex_agent_container.config._validation import _VALID_RUNTIMES
+
+    # Act
+    derived = valid_runtime_spellings()
+    # Assert
+    assert _VALID_RUNTIMES == derived
+
+
+def test_tui_spellings_cover_default_and_explicit():
+    # Arrange
+    expected = frozenset({"", "tui"})
+    # Act
+    spellings = runtime_spellings_for(CLAUDE_CODE_TUI)
+    # Assert
+    assert spellings == expected
+
+
+def test_sdk_spellings_cover_current_and_legacy():
+    # Arrange
+    expected = frozenset({"apptainer", "claude-agent-sdk"})
+    # Act
+    spellings = runtime_spellings_for(CLAUDE_AGENT_SDK)
+    # Assert
+    assert spellings == expected
+
+
+def test_host_probed_spellings_are_exactly_the_tui_entrys():
+    # Arrange
+    tui_spellings = runtime_spellings_for(CLAUDE_CODE_TUI)
+    # Act
+    probed = host_probed_runtime_spellings()
+    # Assert
+    assert probed == tui_spellings
+
+
+def test_sdk_heartbeat_loop_skip_set_derives_from_the_registry():
+    # Arrange
+    from scitex_agent_container._lifecycle._sdk_heartbeat_loop import _TUI_RUNTIMES
+
+    # Act
+    derived = host_probed_runtime_spellings()
+    # Assert
+    assert _TUI_RUNTIMES == derived
+
+
+def test_known_harnesses_lists_the_two_families_sorted():
+    # Arrange
+    expected = ("anthropic", "openai")
+    # Act
+    harnesses = known_harnesses()
+    # Assert
+    assert harnesses == expected
+
+
+def test_harness_types_enum_derives_from_the_registry():
+    # Arrange
+    derived = known_harnesses()
+    # Act
+    enum_value = AGENT_HARNESSES
+    # Assert
+    assert enum_value == derived
+
+
+def test_provider_env_override_enum_derives_from_the_registry():
+    # Arrange
+    from scitex_agent_container.runtimes._apptainer_provider import (
+        _VALID_AGENT_HARNESSES,
+    )
+
+    # Act
+    derived = known_harnesses()
+    # Assert
+    assert _VALID_AGENT_HARNESSES == derived
+
+
+def test_inner_argv_agent_runner_module_derives_from_the_registry():
+    # Arrange
+    from scitex_agent_container.runtimes._apptainer_inner_argv import (
+        RUNNER_MODULE_AGENT,
+    )
+
+    # Act
+    derived = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].runner_module
+    # Assert
+    assert RUNNER_MODULE_AGENT == derived
+
+
+def test_inner_argv_openai_runner_module_derives_from_the_registry():
+    # Arrange
+    from scitex_agent_container.runtimes._apptainer_inner_argv import (
+        RUNNER_MODULE_OPENAI,
+    )
+
+    # Act
+    derived = HARNESS_DESCRIPTORS[OPENAI_AGENTS].runner_module
+    # Assert
+    assert RUNNER_MODULE_OPENAI == derived
+
+
+def test_build_argv_runner_module_constant_derives_from_the_registry():
+    # Arrange
+    from scitex_agent_container.runtimes._apptainer_build_argv import RUNNER_MODULE
+
+    # Act
+    derived = HARNESS_DESCRIPTORS[CLAUDE_AGENT_SDK].runner_module
+    # Assert
+    assert RUNNER_MODULE == derived
+
+
+# ---------------------------------------------------------------------------
+# _get_runtime — key-based dispatch, preserved behavior
+# ---------------------------------------------------------------------------
+
+
+def test_get_runtime_default_still_selects_the_tui_adapter():
+    # Arrange
+    from scitex_agent_container._lifecycle._runtime_select import _get_runtime
+    from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
+
+    cfg = AgentConfig(name="t")
+    # Act
+    adapter = _get_runtime(cfg)
+    # Assert
+    assert isinstance(adapter, TuiSessionRuntime)
+
+
+def test_get_runtime_sdk_spelling_still_selects_the_sdk_adapter():
+    # Arrange
+    from scitex_agent_container._lifecycle._runtime_select import _get_runtime
+    from scitex_agent_container.runtimes.claude_session import ClaudeSessionRuntime
+
+    cfg = AgentConfig(name="t", runtime="claude-agent-sdk")
+    # Act
+    adapter = _get_runtime(cfg)
+    # Assert
+    assert isinstance(adapter, ClaudeSessionRuntime)
+
+
+def test_get_runtime_unknown_spelling_error_names_the_card():
+    # Arrange — the registry's loud config error replaces the old
+    # hand-written message and must carry the card id (the
+    # "Unsupported runtime" phrasing is preserved — see
+    # test_lifecycle.test_get_runtime_unsupported_runtime_raises).
+    from scitex_agent_container._lifecycle._runtime_select import _get_runtime
+
+    cfg = AgentConfig(name="t", runtime="docker-legacy")
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=V4_HARNESS_DISPATCH_CARD):
+        _get_runtime(cfg)
+
+
+def test_get_runtime_proxy_resolves_by_launch_mode_alone():
+    # Arrange — an AgentProxy is not a harness (vendor-neutral
+    # forwarder): a harness value on a proxy spec must not change its
+    # adapter.
+    from scitex_agent_container._lifecycle._runtime_select import _get_runtime
+    from scitex_agent_container.config import ProxySpec
+    from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
+
+    cfg = AgentConfig(
+        name="t",
+        runtime="tui",
+        harness="openai",
+        kind="AgentProxy",
+        proxy=ProxySpec(upstream="http://u"),
+    )
+    # Act
+    adapter = _get_runtime(cfg)
+    # Assert
+    assert isinstance(adapter, TuiSessionRuntime)


### PR DESCRIPTION
## v4 migration step 4 — `resolve_harness_key` + the HarnessDescriptor registry

Card: `sac-v4-layering-refactor-harness-runtime-inference-20260813` (design comment 2026-08-14). Steps 1–3 are merged (#1038 start verdict, #1039 wrong-vendor refusal, #1040 session_daemon extraction); this branch is cut from `82fe2db5`.

### What lands

**`config/_harness_registry.py`** — one dict, `HARNESS_DESCRIPTORS`, one frozen entry per harness sac can run today (`claude-code-tui`, `claude-agent-sdk`, `openai-agents`). Each entry carries the design's six behavioral fields plus the registry's own selection data:

| field | claude-code-tui | claude-agent-sdk | openai-agents |
|---|---|---|---|
| `inner_argv(config, options)` | interactive `claude` TUI argv (`_tui_runner_argv`) | `tini → python -m …claude_session` + `_agent_runner_argv` | `tini → python -m …openai_session` + `_agent_runner_argv` |
| `hosted` | `external` | `runner` | `runner` |
| `beat_writer` | `host-probe` | `in-process` | `in-process` |
| `can_resume` | `True` | `True` | `False` |
| `env_and_binds(config, state_dir)` | `_apptainer_auth.auth_argv` (shared with SDK entry) | same object | `_apptainer_provider.openai_env_flags` |
| `prepare_home(config)` | default no-op | default no-op | default no-op |
| `spec_harness` (selection) | `anthropic` | `anthropic` | `openai` |
| `spec_runtimes` (selection) | `{"", "tui"}` | `{"apptainer", "claude-agent-sdk"}` | `{}` (family-selected) |
| `runner_module` | `None` (external binary) | `…_runners.claude_session` | `…_runners.openai_session` |

`env_and_binds` takes `(config, state_dir)` rather than the design sketch's bare `(config)` because the real Claude builder (`auth_argv`) needs `state_dir` for the credentials bind — noted here so the deviation is deliberate, not drift.

**`resolve_harness_key(spec) -> str`** collapses the two half-wired axes (`spec.runtime` launch mode, `spec.harness` SDK family + its deprecated `provider` alias) into ONE registry key at config-read time; accepts a raw spec mapping or a loaded `AgentConfig`; **no spec on disk is edited**. Mapping (total over the accepted spellings):

- harness `anthropic` (default) + runtime `""`/`tui` → `claude-code-tui`
- harness `anthropic` + runtime `apptainer`/`claude-agent-sdk` → `claude-agent-sdk`
- harness `openai` (either spelling of the key) → `openai-agents` (the harness axis wins)
- stated `harness`/`provider` disagreement → `HarnessKeyConflictError` (same as the loader)
- anything else → `UnmappableHarnessError` (a `ValueError`), naming **both spec values** and the card — the operator's errors-reach-the-caller directive. The "Unsupported runtime" phrasing is preserved, so the pre-existing pin `test_get_runtime_unsupported_runtime_raises` passes unmodified.

The registry is import-time-validated (dict key == entry key; no two same-family entries claiming one spelling) and is **code, not config** — no YAML surface in this step.

### Derived call sites (a fourth harness is now one dict entry)

- `config/_validation.py:63` — `_VALID_RUNTIMES = valid_runtime_spellings()` (name kept; `_relocate_probe_shell` imports it)
- `config/_harness_types.py:88` — `AGENT_HARNESSES = known_harnesses()`
- `runtimes/_apptainer_provider.py:250` — `_VALID_AGENT_HARNESSES = known_harnesses()`
- `_lifecycle/_runtime_select.py:102,110,116` — `_get_runtime` resolves through `resolve_harness_key` (AgentProxy resolves by launch mode alone — vendor-neutral, mirroring the #1039 guard's exemption)
- `runtimes/_apptainer_inner_argv.py:44,53` — `RUNNER_MODULE_AGENT` / `RUNNER_MODULE_OPENAI` from the entries; `:181,202` — both `build_inner_argv` branches build their runner tails via the entries' `inner_argv`
- `runtimes/_apptainer_build_argv.py:45,54` — `RUNNER_MODULE` / `RUNNER_MODULE_OPENAI` from the entries (the pre-built-argv module choice at `:470` now reads the derived constant)
- `_lifecycle/_sdk_heartbeat_loop.py:83` — `_TUI_RUNTIMES = host_probed_runtime_spellings()` (derived from the `beat_writer` axis: the spellings whose beats another loop owns)
- `_lifecycle/health.py:129` — `_is_tui_runtime` membership set
- `_lifecycle/_stop_escalate.py:245` — the tmux-remedy gate's membership set
- `runtimes/claude_session.py:225` + `runtimes/openai_session.py:88` — `_container_runtime_for` membership sets

**Left deliberately** (surveyed, not derived): single-literal `== "tui"` comparisons that are not duplicated sets and sit in step-5 territory or near it (`_tui_heartbeat_loop.py:143`, `_verdict_resolve.py:201`, `_verdict_state.py:133`, `_listen/_agent_exec_liveness.py:83`); the static typing `Literal["anthropic", "openai"]` (can't be runtime-derived); the `SAC_PROVIDER` ops env override (its own surface, listed follow-up). `_runners/session_daemon.py` and the heartbeat write internals are untouched — step 5 is running in parallel there.

### Behavior-preserving — the #1039 refusal is untouched

`ensure_harness_matches_claude_launch` still guards every launch path **before** any descriptor is consulted; a `harness: openai` spec resolves to a real key but still cannot start through the lifecycle (key-based launch is step 7). #1039's refusal tests pass unmodified. Same adapters selected, same argv built (`build_inner_argv` output verified token-identical via the embed test), same validation outcomes.

### Tests

New: `tests/scitex_agent_container/config/test__harness_registry.py` — 63 tests, no mocks/monkeypatch: the full mapping table (both input surfaces + surface-agreement sweep), conflict/unmappable errors naming values + card, entry contracts (hosted/beat_writer/can_resume/runner_module/prepare_home/env-builder identity), real argv builds for all three entries, and one derivation pin per formerly-hardcoded set.

**Pre-fix failure evidence** (src reverted to `82fe2db5` with the new module removed, verbatim):

```
ERROR collecting tests/scitex_agent_container/config/test__harness_registry.py
tests/scitex_agent_container/config/test__harness_registry.py:19: in <module>
    from scitex_agent_container.config._harness_registry import (
E   ModuleNotFoundError: No module named 'scitex_agent_container.config._harness_registry'
=========================== short test summary info ============================
ERROR tests/scitex_agent_container/config/test__harness_registry.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

**Suites** (worktree src via PYTHONPATH):

- `tests/scitex_agent_container/config` + `tests/scitex_agent_container/_lifecycle`: **3098 passed, 3 skipped** (76.7s)
- `tests/scitex_agent_container/runtimes`: **1877 passed, 20 skipped**, 22 red (3 failed + 19 errors) — all in `test__sdk_common.py` + `test__mcp_spec_env.py`. These are the same 22 pre-existing container-vantage reds PR #1040 documented; re-measured on baseline `82fe2db5` in the same environment and the sorted failure-id lists are **byte-identical** (`diff` empty) — not introduced here.
- New registry file: **63 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
