### PR TITLE
fix(tmux): -t prefix matching read siblings as the agent; exact targets everywhere + loud no-op start

### DIFF
--- a/src/scitex_agent_container/_account/interactive_login.py
+++ b/src/scitex_agent_container/_account/interactive_login.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from .._runners._tmux._target import exact_target
 from .._runners._tmux.tmux import TmuxManager, TuiInputNotReadyError
 
 # ---------------------------------------------------------------------------
@@ -176,7 +177,7 @@ def _capture_joined(session: str) -> str:
     sees the whole URL, not a truncated first fragment.
     """
     result = subprocess.run(
-        ["tmux", "capture-pane", "-t", session, "-p", "-J"],
+        ["tmux", "capture-pane", "-t", exact_target(session), "-p", "-J"],
         capture_output=True,
         text=True,
         check=False,
@@ -194,7 +195,16 @@ def _resize_wide(session: str, width: int = 400, height: int = 50) -> None:
     # is the real de-wrap safety net, so a resize failure is irrelevant.)
     try:
         subprocess.run(
-            ["tmux", "resize-window", "-t", session, "-x", str(width), "-y", str(height)],
+            [
+                "tmux",
+                "resize-window",
+                "-t",
+                exact_target(session),
+                "-x",
+                str(width),
+                "-y",
+                str(height),
+            ],
             capture_output=True,
             check=False,
         )

--- a/src/scitex_agent_container/_agentstate/_observe.py
+++ b/src/scitex_agent_container/_agentstate/_observe.py
@@ -34,6 +34,7 @@ import subprocess
 import time
 from typing import Callable, Sequence
 
+from .._runners._tmux._target import exact_target
 from ._state import AgentState
 
 __all__ = [
@@ -67,7 +68,7 @@ def tui_pane_pid(session: str) -> int | None:
     # stx-allow: fallback (reason: an unreadable pane pid must render None — a fabricated or guessed pid is strictly worse, since a recycled pid can vouch for a dead agent as alive)
     try:
         out = subprocess.run(
-            ["tmux", "display-message", "-p", "-t", session, "#{pane_pid}"],
+            ["tmux", "display-message", "-p", "-t", exact_target(session), "#{pane_pid}"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/src/scitex_agent_container/_authheal/_specimen.py
+++ b/src/scitex_agent_container/_authheal/_specimen.py
@@ -40,6 +40,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from .._runners._tmux._target import exact_target
+
 __all__ = [
     "Specimen",
     "capture_specimen",
@@ -107,7 +109,14 @@ def _run(argv: list[str]) -> str:
 
 def _pane_pid(agent: str) -> str:
     return _run(
-        ["tmux", "list-panes", "-t", f"{_TUI_PREFIX}{agent}", "-F", "#{pane_pid}"]
+        [
+            "tmux",
+            "list-panes",
+            "-t",
+            exact_target(f"{_TUI_PREFIX}{agent}"),
+            "-F",
+            "#{pane_pid}",
+        ]
     ).strip()
 
 
@@ -168,7 +177,7 @@ def capture_specimen(
         f"--- auth-status (full) ---\n{_auth_status_table(sac_bin)}\n"
         f"--- pane pid ---\n{pid}\n{_ps_line(pid)}\n"
         f"--- pane capture (full scrollback tail {_SCROLLBACK_LINES}) ---\n"
-        f"{_run(['tmux', 'capture-pane', '-t', f'{_TUI_PREFIX}{agent}', '-p', '-S', f'-{_SCROLLBACK_LINES}'])}\n"
+        f"{_run(['tmux', 'capture-pane', '-t', exact_target(f'{_TUI_PREFIX}{agent}'), '-p', '-S', f'-{_SCROLLBACK_LINES}'])}\n"
         f"--- state.db row ---\n{_state_db_row(agent)}\n"
     )
     target = specimen_path(agent, now=now, root=root)

--- a/src/scitex_agent_container/_lifecycle/_relocate_liveness.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_liveness.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+from .._runners._tmux._target import exact_target
 from ._relocate_execute import StepResult
 from ._relocate_shell import Shell
 
@@ -86,7 +87,10 @@ def observe_running(
         f"printf '{MARK_RUN}no-tmux\\n'; exit 0; fi\n"
         "if ! tmux list-sessions >/dev/null 2>&1; then "
         f"printf '{MARK_RUN}no-server\\n'; exit 0; fi\n"
-        f"if tmux has-session -t '{session}' 2>/dev/null; then "
+        # EXACT-match target (exact_target): a bare -t prefix-matches, so a
+        # sibling session (tui-foo-gui) would vouch tui-foo alive here and the
+        # transport would read a dead source as running (incident 2026-08-14).
+        f"if tmux has-session -t '{exact_target(session)}' 2>/dev/null; then "
         f"printf '{MARK_RUN}yes\\n'; else printf '{MARK_RUN}no\\n'; fi"
     )
     run = shell.run(body, exec_fn=exec_fn)

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -316,14 +316,17 @@ def agent_start(
         else:
             # INFO, not SUCC: the requested end state holds, but nothing was
             # launched — so the line must not read as an accomplishment.
-            # The verdict evidence stays: a no-op that says only "already
+            # The verdict evidence stays, and the notice NAMES the session
+            # (+ pane pid) it believed in: a no-op that says only "already
             # running" is unfalsifiable from the outside, and the operator
-            # could not tell an OBSERVED agent from a process-shaped shadow.
+            # could not tell an OBSERVED agent from a process-shaped shadow
+            # (incident 2026-08-14: a prefix-matched SIBLING session pinned
+            # this branch — see _start_noop_notice).
             from ..cli_pkg._helpers._console import system_msg
-            from ._start_noop_notice import render_already_running
+            from ._start_noop_notice import render_start_noop_notice
 
             system_msg(
-                render_already_running(config.name, verdict.render()),
+                render_start_noop_notice(config, verdict),
                 style="info",
             )
             from ._startup_failed import retract_marker_for

--- a/src/scitex_agent_container/_lifecycle/_start_noop_notice.py
+++ b/src/scitex_agent_container/_lifecycle/_start_noop_notice.py
@@ -2,19 +2,70 @@
 
 from __future__ import annotations
 
-__all__ = ["render_already_running"]
+from typing import Any
+
+__all__ = ["render_already_running", "render_start_noop_notice"]
 
 
-def render_already_running(name: str, evidence: str) -> str:
+def render_start_noop_notice(config: Any, verdict: Any) -> str:
+    """The full no-op notice for ``agent_start``'s already-running branch.
+
+    Resolves the tmux session sac owns for this agent (the SAME name the
+    liveness verdict probed) and its pane pid, then delegates to
+    :func:`render_already_running` so the notice NAMES what was found
+    rather than only that something was. Both lookups are best-effort —
+    a notice must never crash or block the no-op path it decorates.
+    """
+    from ._verdict_tmux import session_name_for_config
+
+    session = session_name_for_config(config)
+    # stx-allow: fallback (reason: the pane pid is best-effort colour on a
+    # NOTICE — an unreadable pid folds away rather than blocking the no-op
+    # path that is only telling the operator why nothing launched)
+    try:
+        from .._runners._tmux.tmux import TmuxManager
+
+        pane_pid = TmuxManager.pane_pid(session)
+    except Exception:  # stx-allow: fallback (reason: see above)
+        pane_pid = None
+    return render_already_running(
+        getattr(config, "name", ""),
+        verdict.render(),
+        session=session,
+        pane_pid=pane_pid,
+    )
+
+
+def render_already_running(
+    name: str,
+    evidence: str,
+    *,
+    session: str | None = None,
+    pane_pid: int | None = None,
+) -> str:
     """State + the commands that WOULD act, for the idempotent-start no-op.
+
+    The first line NAMES WHAT WAS FOUND — agent, tmux session, pane pid —
+    not just that something was. Incident 2026-08-14 (card
+    ``sac-tmux-prefix-match-false-alive-20260814``): tmux prefix matching
+    let a SIBLING session vouch for a dead agent, and a no-op that does not
+    say WHICH session it believed in cannot be caught lying. With the
+    session named, the operator reading "already running (tmux session
+    tui-scitex-cards-gui...)" for agent scitex-cards sees the mismatch at a
+    glance. ``session`` / ``pane_pid`` are best-effort: ``None`` folds the
+    clause away rather than printing a fabricated placeholder.
 
     Every hinted command is verified to run as written: ``restart`` refuses
     without ``-y``, ``stop`` does not (its ``-y`` gate covers only the
     fleet-wide selection flags).
     """
+    found = ""
+    if session:
+        pid_clause = f", pane pid {pane_pid}" if pane_pid else ""
+        found = f" (tmux session {session}{pid_clause})"
     return "\n".join(
         (
-            f"{name} is already running [{evidence}] — nothing launched",
+            f"{name} is already running{found} [{evidence}] — nothing launched",
             f"  - restart it:          sac agents restart {name} -y",
             f"  - force a fresh start: sac agents start {name} --force",
             f"  - stop, then start:    sac agents stop {name} "

--- a/src/scitex_agent_container/_lifecycle/_verdict_remote.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_remote.py
@@ -27,6 +27,7 @@ from ._verdict import (
     UNKNOWN,
     Signal,
 )
+from .._runners._tmux._target import exact_target
 from ._verdict_tmux import session_name_for_config
 
 __all__ = [
@@ -146,7 +147,12 @@ def remote_process_signal(
 
         peers = _load_host_config().peers
         argv = build_ssh_argv(
-            peer, ["tmux", "has-session", "-t", session], peers, extra_opts=["-n"]
+            # EXACT-match target: a bare -t prefix-matches on the peer's tmux,
+            # so a sibling session would vouch this agent ALIVE (2026-08-14).
+            peer,
+            ["tmux", "has-session", "-t", exact_target(session)],
+            peers,
+            extra_opts=["-n"],
         )
     except (
         Exception

--- a/src/scitex_agent_container/_runners/_tmux/_target.py
+++ b/src/scitex_agent_container/_runners/_tmux/_target.py
@@ -1,0 +1,61 @@
+"""``exact_target`` — render a tmux ``-t`` session target that matches EXACTLY.
+
+THE HAZARD (live incident 2026-08-14, card
+``sac-tmux-prefix-match-false-alive-20260814``): tmux's ``-t`` resolves a
+session name by PREFIX when no exact match exists. ``tmux has-session -t
+tui-scitex-cards`` matched the SIBLING session ``tui-scitex-cards-gui``, so
+``TmuxManager.exists`` reported the cards agent alive off the GUI agent's
+pane, ``sac agents start scitex-cards`` no-op'd having launched nothing, and
+a stop/restart would have prefix-match KILLED the innocent sibling. Every
+``-t`` that passes a bare session name carries this bug; this helper is the
+one place that closes it.
+
+THE FORM (measured against a real tmux 3.4 server, one PASS/FAIL per
+subcommand — see ``tests/.../test_tmux_exact_target.py`` which re-proves it
+in CI): a leading ``=`` forces exact session-name matching, but the BARE
+``=name`` form is NOT uniformly accepted — target-pane subcommands
+(``capture-pane``, ``send-keys``) reject it with ``can't find pane: =name``
+while ``has-session`` / ``kill-session`` / ``list-panes`` accept it. The
+UNIVERSAL form is ``=name:`` — the trailing colon marks the target as a
+session (active window, active pane), which every subcommand parses:
+``has-session``, ``kill-session``, ``rename-session``, ``capture-pane``,
+``send-keys``, ``list-panes``, ``display``, ``resize-window``. So this
+helper emits ``=name:``, not ``=name``.
+
+GUARDS — inputs that must NOT be blindly wrapped:
+
+* ``%5`` / ``@2`` / ``$3`` — pane / window / session IDs are already exact
+  by construction; prefixing would corrupt them.
+* ``=...`` — already exact; never double-prefix.
+* ``name:0`` / ``name:0.1`` — the caller supplied a window/pane part; the
+  ``=`` prefix still pins the SESSION portion (``=name:0``), and appending
+  another colon would change the meaning.
+* ``""`` — tmux reads an empty ``-t`` as "the current session"; wrapping it
+  would turn a deliberate default into a parse error.
+"""
+
+from __future__ import annotations
+
+__all__ = ["exact_target"]
+
+#: First characters that mark a target as already exact: ``=`` (explicit
+#: exact-match prefix), ``$`` (session id), ``@`` (window id), ``%`` (pane id).
+_ALREADY_EXACT_PREFIXES = ("=", "$", "@", "%")
+
+
+def exact_target(session_name: str) -> str:
+    """Return ``session_name`` as an EXACT-match tmux ``-t`` target.
+
+    ``"tui-foo"`` becomes ``"=tui-foo:"`` — exact session match, universal
+    across tmux subcommands (see module docstring for the measured why).
+    Targets that are already exact (ids, ``=``-prefixed) and the empty
+    string pass through untouched; a target carrying its own ``:window``
+    part keeps it (``"tui-foo:0"`` → ``"=tui-foo:0"``).
+    """
+    if not session_name:
+        return session_name
+    if session_name.startswith(_ALREADY_EXACT_PREFIXES):
+        return session_name
+    if ":" in session_name:
+        return f"={session_name}"
+    return f"={session_name}:"

--- a/src/scitex_agent_container/_runners/_tmux/_tmux_probe.py
+++ b/src/scitex_agent_container/_runners/_tmux/_tmux_probe.py
@@ -211,12 +211,13 @@ def _display_field(session_name: str, fmt: str) -> str | None:
     Local import of :class:`TmuxManager` keeps the existence check on the
     one canonical implementation without a module-level import cycle.
     """
+    from ._target import exact_target
     from .tmux import TmuxManager
 
     if not TmuxManager.exists(session_name):
         return None
     result = subprocess.run(  # pragma: no cover  -- requires live tmux, not available on CI runner
-        ["tmux", "display", "-p", "-t", session_name, fmt],
+        ["tmux", "display", "-p", "-t", exact_target(session_name), fmt],
         capture_output=True,
         text=True,
     )

--- a/src/scitex_agent_container/_runners/_tmux/auto/accept.py
+++ b/src/scitex_agent_container/_runners/_tmux/auto/accept.py
@@ -22,6 +22,7 @@ from scitex_agent_container._notify.login_relay import (
     extract_oauth_url,
     send_login_url_email,
 )
+from scitex_agent_container._runners._tmux._target import exact_target
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,16 @@ def _tmux_send(name: str, *keys: str) -> None:
     session = f"sac-{name}"
     for key in keys:
         subprocess.run(
-            ["tmux", "-L", _TMUX_SERVER, "send-keys", "-t", session, key, ""],
+            [
+                "tmux",
+                "-L",
+                _TMUX_SERVER,
+                "send-keys",
+                "-t",
+                exact_target(session),
+                key,
+                "",
+            ],
             check=False,
         )
         time.sleep(0.1)

--- a/src/scitex_agent_container/_runners/_tmux/pane_capture.py
+++ b/src/scitex_agent_container/_runners/_tmux/pane_capture.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import subprocess
 
+from ._target import exact_target
+
 _MAX_CHARS = 10_000
 _TMUX_SERVER = "sac"
 
@@ -21,7 +23,16 @@ def pane_capture(name: str, max_chars: int = _MAX_CHARS) -> str:
     session = f"sac-{name}"
     try:
         result = subprocess.run(
-            ["tmux", "-L", _TMUX_SERVER, "capture-pane", "-t", session, "-p", "-J"],
+            [
+                "tmux",
+                "-L",
+                _TMUX_SERVER,
+                "capture-pane",
+                "-t",
+                exact_target(session),
+                "-p",
+                "-J",
+            ],
             capture_output=True,
             text=True,
         )

--- a/src/scitex_agent_container/_runners/_tmux/tmux.py
+++ b/src/scitex_agent_container/_runners/_tmux/tmux.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Callable
 
 from ._host_cwd import resolve_host_cwd
+from ._target import exact_target
 
 # Inter-keystroke delay inside send_keys() and settle delay before
 # Enter inside send_text_and_submit(). These defeat the race where
@@ -63,9 +64,17 @@ class TmuxManager:
 
     @staticmethod
     def exists(session_name: str) -> bool:
-        """Check if a tmux session exists."""
+        """Check if a tmux session exists — by EXACT name.
+
+        The target goes through :func:`exact_target` because tmux's ``-t``
+        falls back to PREFIX matching: a bare ``has-session -t tui-foo``
+        answers 0 when only ``tui-foo-bar`` exists, which reported a dead
+        agent ALIVE off its sibling's pane and made ``sac agents start``
+        silently no-op (live incident 2026-08-14, card
+        ``sac-tmux-prefix-match-false-alive-20260814``).
+        """
         result = subprocess.run(
-            ["tmux", "has-session", "-t", session_name],
+            ["tmux", "has-session", "-t", exact_target(session_name)],
             capture_output=True,
             text=True,
         )
@@ -179,7 +188,7 @@ class TmuxManager:
             return False
 
         subprocess.run(
-            ["tmux", "kill-session", "-t", session_name],
+            ["tmux", "kill-session", "-t", exact_target(session_name)],
             capture_output=True,
             check=False,
         )
@@ -231,7 +240,7 @@ class TmuxManager:
     def capture_content(session_name: str) -> str:
         """Capture current pane content via capture-pane."""
         result = subprocess.run(
-            ["tmux", "capture-pane", "-t", session_name, "-p"],
+            ["tmux", "capture-pane", "-t", exact_target(session_name), "-p"],
             capture_output=True,
             text=True,
         )
@@ -245,7 +254,7 @@ class TmuxManager:
                 "tmux",
                 "capture-pane",
                 "-t",
-                session_name,
+                exact_target(session_name),
                 "-p",
                 "-S",
                 str(-lines),
@@ -275,7 +284,8 @@ class TmuxManager:
         Parameters
         ----------
         session_name:
-            tmux target passed verbatim to ``-t``.
+            tmux session name; targeted EXACTLY (via :func:`exact_target`)
+            so a prefix can never land keys in a sibling's pane.
         keys:
             One or more keystrokes / tmux keyword names (``"Enter"``,
             ``"C-c"``, etc.) or raw text arguments.
@@ -295,7 +305,7 @@ class TmuxManager:
         key_list = list(keys)
         for i, key in enumerate(key_list):
             subprocess.run(
-                ["tmux", "send-keys", "-t", session_name, key],
+                ["tmux", "send-keys", "-t", exact_target(session_name), key],
                 check=False,
                 capture_output=True,
             )
@@ -323,7 +333,7 @@ class TmuxManager:
         injection seam (tests pass a recording callable — no mocks).
         """
         runner(
-            ["tmux", "send-keys", "-t", session_name, "-l", text],
+            ["tmux", "send-keys", "-t", exact_target(session_name), "-l", text],
             check=False,
             capture_output=True,
         )
@@ -355,7 +365,7 @@ class TmuxManager:
         if settle > 0:
             sleep_fn(settle)
         runner(
-            ["tmux", "send-keys", "-t", session_name, "Enter"],
+            ["tmux", "send-keys", "-t", exact_target(session_name), "Enter"],
             check=False,
             capture_output=True,
         )
@@ -454,14 +464,14 @@ class TmuxManager:
         capture = capture_fn or TmuxManager.capture_content
         send_text = send_text_fn or (
             lambda session, payload: subprocess.run(
-                ["tmux", "send-keys", "-t", session, payload],
+                ["tmux", "send-keys", "-t", exact_target(session), payload],
                 check=False,
                 capture_output=True,
             )
         )
         send_enter = send_enter_fn or (
             lambda session: subprocess.run(
-                ["tmux", "send-keys", "-t", session, "Enter"],
+                ["tmux", "send-keys", "-t", exact_target(session), "Enter"],
                 check=False,
                 capture_output=True,
             )
@@ -498,4 +508,4 @@ class TmuxManager:
     @staticmethod
     def attach(session_name: str) -> None:
         """Attach to a tmux session (replaces current process)."""
-        os.execvp("tmux", ["tmux", "attach", "-t", session_name])
+        os.execvp("tmux", ["tmux", "attach", "-t", exact_target(session_name)])

--- a/src/scitex_agent_container/_state/_meta/pane.py
+++ b/src/scitex_agent_container/_state/_meta/pane.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import re
 import subprocess
 
+from ..._runners._tmux._target import exact_target
+
 _SUBAGENT_MARKER_RE = re.compile(
     r"(\d+)\s+local\s+agents?(?:\s+still)?\s+running",
     re.IGNORECASE,
@@ -45,7 +47,7 @@ def _subagent_count_from_pane(session: str, multiplexer: str) -> int:
     # correct "unknown" sentinel — never block a heartbeat on tmux error)
     try:
         pane = subprocess.run(
-            ["tmux", "capture-pane", "-t", session, "-p"],
+            ["tmux", "capture-pane", "-t", exact_target(session), "-p"],
             capture_output=True,
             text=True,
         ).stdout
@@ -63,7 +65,7 @@ def _capture_pane(session: str, multiplexer: str, max_chars: int = 10_000) -> st
     try:
         out = (
             subprocess.run(
-                ["tmux", "capture-pane", "-t", session, "-p", "-J"],
+                ["tmux", "capture-pane", "-t", exact_target(session), "-p", "-J"],
                 capture_output=True,
                 text=True,
             ).stdout

--- a/src/scitex_agent_container/_state/_meta/resources.py
+++ b/src/scitex_agent_container/_state/_meta/resources.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import subprocess
 from typing import Any
 
+from ..._runners._tmux._target import exact_target
+
 
 def _pids_from_session(session: str, multiplexer: str) -> tuple[int, int]:
     pid = 0
@@ -24,7 +26,7 @@ def _pids_from_session(session: str, multiplexer: str) -> tuple[int, int]:
     try:
         out = (
             subprocess.run(
-                ["tmux", "list-panes", "-t", session, "-F", "#{pane_pid}"],
+                ["tmux", "list-panes", "-t", exact_target(session), "-F", "#{pane_pid}"],
                 capture_output=True,
                 text=True,
             )

--- a/src/scitex_agent_container/_state/agent_meta.py
+++ b/src/scitex_agent_container/_state/agent_meta.py
@@ -24,14 +24,20 @@ from datetime import datetime, timezone
 from typing import Any
 
 from .._env import getenv as _sac_env
+from .._runners._tmux._target import exact_target
 
 
 def detect_multiplexer(session: str) -> str:
-    """Return 'tmux', 'screen', or '' if neither reports the session."""
+    """Return 'tmux', 'screen', or '' if neither reports the session.
+
+    The tmux probe targets the session EXACTLY (``exact_target``): a bare
+    ``-t`` prefix-matches, so ``tui-foo`` would read as tmux-hosted off a
+    sibling ``tui-foo-gui`` session (incident 2026-08-14).
+    """
     try:
         if (
             subprocess.run(
-                ["tmux", "has-session", "-t", session],
+                ["tmux", "has-session", "-t", exact_target(session)],
                 capture_output=True,
             ).returncode
             == 0

--- a/src/scitex_agent_container/_state/registry.py
+++ b/src/scitex_agent_container/_state/registry.py
@@ -36,12 +36,17 @@ def _default_session_probe(session: str) -> bool | None:
     """
     import subprocess
 
+    from .._runners._tmux._target import exact_target
+
     verdicts: list[bool] = []
     # stx-allow: fallback (reason: a missing/failing multiplexer binary is
     # UNKNOWN, never evidence of death -- see the docstring incident.)
     try:
+        # EXACT target: a bare -t prefix-matches, so a dead agent could be
+        # vouched alive by a sibling session (incident 2026-08-14).
         rc = subprocess.run(
-            ["tmux", "has-session", "-t", session], capture_output=True
+            ["tmux", "has-session", "-t", exact_target(session)],
+            capture_output=True,
         ).returncode
         verdicts.append(rc == 0)
     except Exception:  # stx-allow: fallback (reason: see inline comment)

--- a/src/scitex_agent_container/_state/snapshot/_io.py
+++ b/src/scitex_agent_container/_state/snapshot/_io.py
@@ -231,8 +231,10 @@ def _probe_tmux_pids(session: str | None) -> dict[str, int | None]:
     if not session:
         return {"server": None, "pane": None}
     try:
+        from ..._runners._tmux._target import exact_target
+
         r = subprocess.run(
-            ["tmux", "display", "-p", "-t", f"{session}:0", "#{pane_pid}"],
+            ["tmux", "display", "-p", "-t", exact_target(f"{session}:0"), "#{pane_pid}"],
             capture_output=True,
             text=True,
             timeout=3,

--- a/src/scitex_agent_container/cli_pkg/_auth_status.py
+++ b/src/scitex_agent_container/cli_pkg/_auth_status.py
@@ -37,6 +37,7 @@ import time
 import click
 from rich.table import Table
 
+from .._runners._tmux._target import exact_target
 from .._runners._tmux.auth_status import evaluate, probe_to_state
 from ._helpers import _json_flag, console
 
@@ -95,7 +96,7 @@ def _capture(session: str) -> str | None:
     # capture; None is the honest "could not read" sentinel — never a crash)
     try:
         out = subprocess.run(
-            ["tmux", "capture-pane", "-t", session, "-p", "-J"],
+            ["tmux", "capture-pane", "-t", exact_target(session), "-p", "-J"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
@@ -28,6 +28,7 @@ import subprocess
 
 import click
 
+from ..._runners._tmux._target import exact_target
 from .._helpers._completion import agent_name_complete
 from .._helpers._console import system_msg
 
@@ -125,7 +126,10 @@ def _remote_attach_argv(session: str, peer: str) -> list[str]:
         "tmux",
         "attach",
         "-t",
-        session,
+        # EXACT session target: a bare name prefix-matches on the peer, which
+        # would hand the operator a SIBLING agent's TUI when the named session
+        # is gone (incident 2026-08-14).
+        exact_target(session),
     ]
 
 
@@ -162,7 +166,7 @@ def attach(name: str) -> None:
     try:
         exists = (
             subprocess.run(
-                ["tmux", "has-session", "-t", session],
+                ["tmux", "has-session", "-t", exact_target(session)],
                 capture_output=True,
                 text=True,
             ).returncode
@@ -179,4 +183,4 @@ def attach(name: str) -> None:
         raise SystemExit(1)
 
     # Hand the terminal to tmux (replaces this process; detach with Ctrl-b d).
-    os.execvp("tmux", ["tmux", "attach", "-t", session])
+    os.execvp("tmux", ["tmux", "attach", "-t", exact_target(session)])

--- a/tests/scitex_agent_container/_lifecycle/test__start_noop_notice.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_noop_notice.py
@@ -86,3 +86,78 @@ def test_offers_the_force_escape_hatch(notice):
     actual = notice
     # Assert
     assert expected in actual
+
+
+# ---------------------------------------------------------------------------
+# The notice NAMES what it found (incident 2026-08-14, card
+# sac-tmux-prefix-match-false-alive-20260814): tmux prefix matching let a
+# SIBLING session pin the no-op branch, and a notice that does not say WHICH
+# session it believed in cannot be caught lying.
+# ---------------------------------------------------------------------------
+
+
+def test_names_the_session_it_believed_in():
+    # Arrange
+    expected = "(tmux session tui-dotfiles)"
+    # Act
+    actual = render_already_running(
+        "dotfiles", "ALIVE (process: session up)", session="tui-dotfiles"
+    )
+    # Assert
+    assert expected in actual
+
+
+def test_names_the_pane_pid_when_resolvable():
+    # Arrange
+    expected = "(tmux session tui-dotfiles, pane pid 12345)"
+    # Act
+    actual = render_already_running(
+        "dotfiles",
+        "ALIVE (process: session up)",
+        session="tui-dotfiles",
+        pane_pid=12345,
+    )
+    # Assert
+    assert expected in actual
+
+
+def test_omits_the_pid_clause_when_the_pid_is_unresolvable():
+    # Arrange — an honest notice folds an unknown away rather than printing
+    # a fabricated placeholder.
+    forbidden = "pane pid"
+    # Act
+    actual = render_already_running(
+        "dotfiles", "ALIVE (process: session up)", session="tui-dotfiles"
+    )
+    # Assert
+    assert forbidden not in actual
+
+
+def test_omits_the_found_clause_entirely_without_a_session(notice):
+    # Arrange — the plain two-arg call keeps its original first line.
+    forbidden = "tmux session"
+    # Act
+    actual = notice
+    # Assert
+    assert forbidden not in actual
+
+
+def test_render_start_noop_notice_names_the_agents_tui_session():
+    # Arrange — real config/verdict shapes (name attr; verdict.render()),
+    # a session name that cannot be running here.
+    from scitex_agent_container._lifecycle._start_noop_notice import (
+        render_start_noop_notice,
+    )
+
+    class _Cfg:
+        name = "zz-noop-notice-zz"
+
+    class _Verdict:
+        @staticmethod
+        def render() -> str:
+            return "ALIVE (delivery: 1 subscriber)"
+
+    # Act
+    actual = render_start_noop_notice(_Cfg(), _Verdict())
+    # Assert — the session sac owns for this agent is named on the first line.
+    assert "(tmux session tui-zz-noop-notice-zz)" in actual

--- a/tests/scitex_agent_container/_lifecycle/test__start_verdict.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_verdict.py
@@ -344,3 +344,47 @@ def test_an_alive_agent_no_op_returns_success(tmp_path, registry):
     # absence let a restart report success over an agent that never cycled
     # (incident 2026-07-12). See :mod:`._lifecycle._start_outcome`.
     assert bool(ok) is True and outcome_kind(ok) == KIND_ALREADY_RUNNING
+
+
+def test_an_alive_no_op_announces_agent_and_session_loudly(
+    tmp_path, registry, caplog
+):
+    """The no-op branch must EMIT what it found — never exit 0 in silence.
+
+    Incident 2026-08-14 (card sac-tmux-prefix-match-false-alive-20260814):
+    `sac agents start scitex-cards` exited 0 having done NOTHING, its
+    liveness pinned by a prefix-matched SIBLING tmux session. A start that
+    declines to launch must say so to the caller AND name the session it
+    believed in, so a mismatched session name is visible at a glance.
+    """
+    # Arrange
+    import logging as _logging
+
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    runtime = _Runtime(running=True, start_result=True)
+    alive = decide(
+        "alpha",
+        [
+            Signal(
+                SOURCE_DELIVERY,
+                ALIVE,
+                "1 live inbox subscriber",
+                INSTRUMENT_LISTEN_BROKER,
+            )
+        ],
+    )
+    caplog.set_level(_logging.INFO, logger="scitex_agent_container")
+    # Act
+    lc.agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=_Handover(),
+        sleep_fn=_no_sleep,
+        verdict_override=alive,
+    )
+    # Assert — one loud line naming the agent AND the tmux session it
+    # believed in ("(tmux session tui-alpha" — the pane-pid clause follows
+    # only when a live local pane resolves, so it is not pinned here).
+    assert "alpha is already running (tmux session tui-alpha" in caplog.text

--- a/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
@@ -578,8 +578,10 @@ def test_remote_process_signal_argv_uses_no_login_shell(spartan_config):
 
 
 def test_remote_process_signal_argv_probes_tmux_has_session_directly(spartan_config):
-    # Arrange
-    expected_tail = ["tmux", "has-session", "-t", "tui-spartan-dev"]
+    # Arrange — the target is the EXACT-match form (=name:): a bare -t
+    # prefix-matches on the peer's tmux, so a sibling session would vouch
+    # this agent ALIVE (incident 2026-08-14).
+    expected_tail = ["tmux", "has-session", "-t", "=tui-spartan-dev:"]
     # Act
     argv = _captured_remote_probe_argv()
     # Assert — a DIRECT peer runs `tmux has-session -t <session>` directly.
@@ -630,9 +632,10 @@ def test_remote_process_signal_multihop_argv_wraps_cmd_in_bash_c(spartan_config)
     compute_node = "spartan-bm043"
     # Act
     argv = _captured_remote_probe_argv(peer=compute_node, name="proj-x")
-    # Assert — one collapsed element carrying the preamble + the tmux probe.
+    # Assert — one collapsed element carrying the preamble + the tmux probe
+    # (exact-match =name: target; see the direct-peer test above).
     assert any(
-        el.startswith("bash -c ") and "tmux has-session -t tui-proj-x" in el
+        el.startswith("bash -c ") and "tmux has-session -t =tui-proj-x:" in el
         for el in argv
     )
 

--- a/tests/scitex_agent_container/_runners/_tmux/test_tmux_exact_target.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_tmux_exact_target.py
@@ -1,0 +1,307 @@
+"""tmux ``-t`` targets must match EXACTLY — never by prefix.
+
+Live incident 2026-08-14 (card ``sac-tmux-prefix-match-false-alive-20260814``):
+tmux resolves a bare ``-t <name>`` by PREFIX when no exact match exists, so
+``tmux has-session -t tui-scitex-cards`` matched the SIBLING session
+``tui-scitex-cards-gui``. ``TmuxManager.exists`` reported the cards agent
+ALIVE off the GUI agent's pane, ``sac agents start scitex-cards`` exited 0
+having launched NOTHING, and a stop/restart would have prefix-match KILLED
+the innocent sibling.
+
+The fix is :func:`scitex_agent_container._runners._tmux._target.exact_target`
+— every ``-t`` that passes a session name goes through it. The form it emits
+is ``=name:`` (exact-match ``=`` + trailing ``:`` marking a session target),
+because the BARE ``=name`` form is NOT uniformly accepted: measured on tmux
+3.4, target-pane subcommands (``capture-pane``, ``send-keys``) reject it with
+``can't find pane: =name`` while ``has-session`` accepts it. The
+per-subcommand acceptance tests below re-prove that ``=name:`` parses
+everywhere, against a REAL tmux (same pattern as ``test_tmux_pane_probe``).
+
+No mocks — pure-function cases, a recording-runner seam, and real ``tmux``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+import uuid
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._runners._tmux._target import exact_target
+from scitex_agent_container._runners._tmux.tmux import TmuxManager
+
+requires_tmux = pytest.mark.skipif(
+    shutil.which("tmux") is None, reason="tmux binary not on PATH"
+)
+
+
+# ---------------------------------------------------------------------------
+# exact_target — the pure rendering rule
+# ---------------------------------------------------------------------------
+
+
+class TestExactTargetRendering:
+    def test_bare_session_name_gains_equals_and_trailing_colon(self) -> None:
+        # Arrange
+        name = "tui-scitex-cards"
+        # Act
+        target = exact_target(name)
+        # Assert — the ONE universal exact form (``=name`` alone is rejected
+        # by capture-pane / send-keys; measured, tmux 3.4).
+        assert target == "=tui-scitex-cards:"
+
+    def test_already_exact_target_is_not_double_prefixed(self) -> None:
+        # Arrange
+        name = "=tui-x:"
+        # Act
+        target = exact_target(name)
+        # Assert
+        assert target == "=tui-x:"
+
+    @pytest.mark.parametrize("target_id", ["%5", "@2", "$3"])
+    def test_pane_window_session_ids_pass_through_untouched(
+        self, target_id: str
+    ) -> None:
+        # Arrange — ids are exact by construction; wrapping would corrupt them.
+        # Act
+        target = exact_target(target_id)
+        # Assert
+        assert target == target_id
+
+    def test_target_with_window_part_keeps_it_and_gains_only_equals(self) -> None:
+        # Arrange — a caller that already picked a window must keep it.
+        name = "tui-x:0"
+        # Act
+        target = exact_target(name)
+        # Assert
+        assert target == "=tui-x:0"
+
+    def test_empty_target_passes_through(self) -> None:
+        # Arrange — tmux reads an empty -t as "current session"; wrapping
+        # would turn that deliberate default into a parse error.
+        name = ""
+        # Act
+        target = exact_target(name)
+        # Assert
+        assert target == ""
+
+
+# ---------------------------------------------------------------------------
+# The seam-level proof: TmuxManager renders the exact form into its argv
+# ---------------------------------------------------------------------------
+
+
+class _RunnerRecorder:
+    def __init__(self) -> None:
+        self.argvs: list[list[str]] = []
+
+    def __call__(self, argv: list[str], **_kwargs: object) -> None:
+        self.argvs.append(list(argv))
+
+
+def test_send_text_literal_targets_the_exact_session_form() -> None:
+    # Arrange
+    runner = _RunnerRecorder()
+    # Act
+    TmuxManager.send_text_literal("tui-x", "hello", runner=runner)
+    # Assert — the argv carries "=tui-x:", so a prefix can never land the
+    # text in a sibling's pane.
+    assert runner.argvs[0][:4] == ["tmux", "send-keys", "-t", "=tui-x:"]
+
+
+# ---------------------------------------------------------------------------
+# Real-tmux regression: the incident shape, both halves
+# ---------------------------------------------------------------------------
+
+
+def _new_session(name: str, command: str = "sleep 600") -> None:
+    subprocess.run(
+        ["tmux", "new-session", "-d", "-s", name, *command.split()],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _kill_session(name: str) -> None:
+    subprocess.run(
+        ["tmux", "kill-session", "-t", f"={name}:"],
+        check=False,
+        capture_output=True,
+    )
+
+
+@pytest.fixture()
+def sibling_only() -> Iterator[str]:
+    """A running ``<base>-gui`` session with NO ``<base>`` session.
+
+    Yields ``base`` — the name whose liveness must NOT be vouched for by
+    the sibling. This is the incident's exact shape
+    (``tui-scitex-cards`` vs ``tui-scitex-cards-gui``).
+    """
+    base = f"tui-exact-{uuid.uuid4().hex[:8]}"
+    _new_session(f"{base}-gui")
+    try:
+        yield base
+    finally:
+        _kill_session(f"{base}-gui")
+
+
+@requires_tmux
+def test_exists_is_false_when_only_a_prefix_sibling_runs(sibling_only: str) -> None:
+    # Arrange — fixture: only "<base>-gui" is running.
+    base = sibling_only
+    # Act
+    alive = TmuxManager.exists(base)
+    # Assert — the incident regression: a bare -t here prefix-matched the
+    # sibling and reported the dead agent ALIVE, which silently no-op'd
+    # `sac agents start`.
+    assert alive is False
+
+
+@requires_tmux
+def test_exists_still_finds_the_exact_session(sibling_only: str) -> None:
+    # Arrange — both the sibling AND the exact session running.
+    base = sibling_only
+    _new_session(base)
+    try:
+        # Act
+        alive = TmuxManager.exists(base)
+        # Assert — exact matching must not throw away true positives.
+        assert alive is True
+    finally:
+        _kill_session(base)
+
+
+@requires_tmux
+def test_stop_never_prefix_kills_the_sibling(sibling_only: str) -> None:
+    # Arrange — only "<base>-gui" runs; stopping "<base>" must be a no-op.
+    base = sibling_only
+    # Act — the destructive half of the incident: a bare kill-session here
+    # would have torn down the innocent sibling.
+    TmuxManager.stop(base)
+    sibling_alive = TmuxManager.exists(f"{base}-gui")
+    # Assert
+    assert sibling_alive is True
+
+
+@requires_tmux
+def test_stop_kills_the_exact_session(sibling_only: str) -> None:
+    # Arrange — both sessions running; stop(base) must take exactly one.
+    base = sibling_only
+    _new_session(base)
+    try:
+        # Act
+        stopped = TmuxManager.stop(base)
+        # Assert
+        assert stopped is True and TmuxManager.exists(base) is False
+    finally:
+        _kill_session(base)
+
+
+# ---------------------------------------------------------------------------
+# Per-subcommand acceptance: the ``=name:`` form parses EVERYWHERE
+# ---------------------------------------------------------------------------
+#
+# This is the guard the coordinator's field data demanded: on the live host,
+# ``capture-pane -t =name`` FAILED ("can't find pane") while ``has-session -t
+# =name`` passed — an exists() made exact at the price of a broken capture /
+# send would be worse than the bug. Each case runs the REAL subcommand against
+# a REAL session using exactly what ``exact_target`` emits.
+
+
+@pytest.fixture()
+def live_session() -> Iterator[str]:
+    name = f"tui-exact-{uuid.uuid4().hex[:8]}"
+    _new_session(name)
+    try:
+        yield name
+    finally:
+        _kill_session(name)
+
+
+@requires_tmux
+@pytest.mark.parametrize(
+    "argv_for",
+    [
+        pytest.param(lambda t: ["has-session", "-t", t], id="has-session"),
+        pytest.param(lambda t: ["capture-pane", "-p", "-t", t], id="capture-pane"),
+        pytest.param(lambda t: ["send-keys", "-t", t, ""], id="send-keys"),
+        pytest.param(
+            lambda t: ["list-panes", "-t", t, "-F", "#{pane_pid}"], id="list-panes"
+        ),
+        pytest.param(
+            lambda t: ["display-message", "-p", "-t", t, "#{pane_pid}"],
+            id="display-message",
+        ),
+        pytest.param(
+            lambda t: ["resize-window", "-t", t, "-x", "200", "-y", "50"],
+            id="resize-window",
+        ),
+    ],
+)
+def test_exact_form_is_accepted_by_subcommand(live_session: str, argv_for) -> None:
+    # Arrange
+    target = exact_target(live_session)
+    # Act
+    result = subprocess.run(
+        ["tmux", *argv_for(target)], capture_output=True, text=True
+    )
+    # Assert — rc 0 with no "can't find" refusal: the exact form parses.
+    assert result.returncode == 0, result.stderr
+
+
+@requires_tmux
+def test_exact_form_is_accepted_by_rename_session(live_session: str) -> None:
+    # Arrange
+    renamed = f"{live_session}-renamed"
+    # Act — rename away and back, both legs on the exact form.
+    away = subprocess.run(
+        ["tmux", "rename-session", "-t", exact_target(live_session), renamed],
+        capture_output=True,
+        text=True,
+    )
+    back = subprocess.run(
+        ["tmux", "rename-session", "-t", exact_target(renamed), live_session],
+        capture_output=True,
+        text=True,
+    )
+    # Assert
+    assert (away.returncode, back.returncode) == (0, 0), (
+        away.stderr,
+        back.stderr,
+    )
+
+
+@requires_tmux
+def test_capture_content_reads_the_exact_sessions_pane(live_session: str) -> None:
+    """End-to-end through TmuxManager: capture must return REAL content.
+
+    ``capture_content`` returns ``""`` both for "no such session" and for a
+    failed parse, so asserting non-failure needs an observable marker in the
+    pane — proving the exact-form target reached the RIGHT pane, not merely
+    that nothing crashed.
+    """
+    # Arrange — a second session whose pane prints a marker.
+    name = f"tui-exact-{uuid.uuid4().hex[:8]}"
+    marker = f"MARK-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["tmux", "new-session", "-d", "-s", name, "bash", "-c", f"echo {marker}; sleep 600"],
+        check=True,
+        capture_output=True,
+    )
+    try:
+        # Act — poll briefly: the pane needs a beat to render the echo.
+        content = ""
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            content = TmuxManager.capture_content(name)
+            if marker in content:
+                break
+            time.sleep(0.1)
+        # Assert
+        assert marker in content
+    finally:
+        _kill_session(name)

--- a/tests/scitex_agent_container/_runners/_tmux/test_tmux_literal_send.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_tmux_literal_send.py
@@ -37,8 +37,12 @@ class TestSendTextLiteralUsesDashL:
         runner = _RunnerRecorder()
         # Act
         TmuxManager.send_text_literal("tui-x", "go work", runner=runner)
-        # Assert — one send-keys, ``-l`` immediately before the text.
-        assert runner.argvs == [["tmux", "send-keys", "-t", "tui-x", "-l", "go work"]]
+        # Assert — one send-keys, ``-l`` immediately before the text, on the
+        # EXACT-match target (=name: — a bare -t prefix-matches and can land
+        # keys in a SIBLING's pane; incident 2026-08-14).
+        assert runner.argvs == [
+            ["tmux", "send-keys", "-t", "=tui-x:", "-l", "go work"]
+        ]
 
     def test_literal_paste_sends_no_enter(self) -> None:
         # Arrange
@@ -59,8 +63,15 @@ class TestSendTextAndSubmitLiteralThenEnter:
         TmuxManager.send_text_and_submit(
             "tui-x", "mission", sleep_fn=_zero_sleep, runner=runner
         )
-        # Assert — first call pastes the text literally.
-        assert runner.argvs[0] == ["tmux", "send-keys", "-t", "tui-x", "-l", "mission"]
+        # Assert — first call pastes the text literally (exact =name: target).
+        assert runner.argvs[0] == [
+            "tmux",
+            "send-keys",
+            "-t",
+            "=tui-x:",
+            "-l",
+            "mission",
+        ]
 
     def test_enter_leg_is_named_key_without_dash_l(self) -> None:
         # Arrange
@@ -69,5 +80,6 @@ class TestSendTextAndSubmitLiteralThenEnter:
         TmuxManager.send_text_and_submit(
             "tui-x", "mission", sleep_fn=_zero_sleep, runner=runner
         )
-        # Assert — the submit is a SEPARATE named Enter, never ``-l``.
-        assert runner.argvs[-1] == ["tmux", "send-keys", "-t", "tui-x", "Enter"]
+        # Assert — the submit is a SEPARATE named Enter, never ``-l``
+        # (exact =name: target, same as the text leg).
+        assert runner.argvs[-1] == ["tmux", "send-keys", "-t", "=tui-x:", "Enter"]

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__attach.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__attach.py
@@ -56,8 +56,10 @@ def test_remote_attach_argv_runs_tmux_attach_on_the_named_session() -> None:
 
     # Act
     argv = _remote_attach_argv("tui-spartan-dev", "zzz-unknown-peer-zzz")
-    # Assert — tmux attach runs DIRECTLY on the peer (no `bash -lc` wrapper).
-    assert argv[-4:] == ["tmux", "attach", "-t", "tui-spartan-dev"]
+    # Assert — tmux attach runs DIRECTLY on the peer (no `bash -lc` wrapper),
+    # on the EXACT-match target (=name:): a bare -t prefix-matches, which
+    # would hand the operator a SIBLING agent's TUI (incident 2026-08-14).
+    assert argv[-4:] == ["tmux", "attach", "-t", "=tui-spartan-dev:"]
 
 
 def test_remote_attach_argv_uses_no_login_shell() -> None:


### PR DESCRIPTION
## Incident

Live incident 2026-08-14, card `sac-tmux-prefix-match-false-alive-20260814`: `sac agents start scitex-cards` exited 0 having done **nothing**. tmux's `-t` resolves a bare session name by **prefix** when no exact match exists, so `TmuxManager.exists` running `tmux has-session -t tui-scitex-cards` matched the sibling session `tui-scitex-cards-gui` → `is_running` True → start silently no-op'd, and liveness reported the cards agent ALIVE using the GUI agent's pane. The destructive half: a stop/restart would have prefix-match **killed the innocent sibling's session**.

## Fix (two parts)

**1. Exact matching everywhere.** New helper `src/scitex_agent_container/_runners/_tmux/_target.py::exact_target`. Field-verified against a real tmux 3.4 server before writing the helper: the bare `=name` form is **not** uniform — target-pane subcommands reject it (`capture-pane -t =name` / `send-keys -t =name` → `can't find pane`), while `=name:` (trailing colon marks a session target) is accepted by every subcommand sac invokes (`has-session`, `kill-session`, `rename-session`, `capture-pane`, `send-keys`, `list-panes`, `display`/`display-message`, `resize-window`). The helper emits `=name:` and guards inputs that must not be wrapped: already-exact `=...`, pane/window/session ids (`%5`/`@2`/`$3`), targets carrying their own `:window` part (`name:0` → `=name:0`), and the empty string.

**2. No silent no-op start.** The already-running branch of `agent_start` now announces **what it found**, not just that something was: `render_start_noop_notice` resolves the agent's tmux session (the same name the liveness verdict probed) and its pane pid, producing e.g. `alpha is already running (tmux session tui-alpha, pane pid 12345) [ALIVE (...)] — nothing launched` plus the existing remedy hints. A prefix-vouched sibling session is now visible at a glance in the emitted line.

## tmux call sites made exact

- `src/scitex_agent_container/_runners/_tmux/tmux.py` — `exists` (has-session), `stop` (kill-session), `capture_content`, `capture_logs`, `send_keys`, `send_text_literal`, `send_text_and_submit` (Enter leg), `send_text_and_submit_verified` (default send/enter runners), `attach`
- `src/scitex_agent_container/_runners/_tmux/_tmux_probe.py` — `_display_field` (backs `pane_pid` / `pane_dead` / `session_activity`)
- `src/scitex_agent_container/_runners/_tmux/pane_capture.py` — capture-pane on the `-L sac` server
- `src/scitex_agent_container/_runners/_tmux/auto/accept.py` — `_tmux_send` send-keys
- `src/scitex_agent_container/_state/agent_meta.py` — `detect_multiplexer` has-session
- `src/scitex_agent_container/_state/registry.py` — `_probe_session_alive` has-session
- `src/scitex_agent_container/_state/_meta/pane.py` — both capture-pane probes
- `src/scitex_agent_container/_state/_meta/resources.py` — list-panes pane-pid lookup
- `src/scitex_agent_container/_state/snapshot/_io.py` — `display -p -t <session>:0` pane-pid probe
- `src/scitex_agent_container/_agentstate/_observe.py` — `tui_pane_pid` display-message
- `src/scitex_agent_container/_authheal/_specimen.py` — list-panes + scrollback capture-pane
- `src/scitex_agent_container/_account/interactive_login.py` — capture-pane + resize-window
- `src/scitex_agent_container/cli_pkg/_auth_status.py` — capture-pane
- `src/scitex_agent_container/cli_pkg/lifecycle/_attach.py` — local has-session, local `tmux attach` execvp, and the remote `ssh … tmux attach` argv
- `src/scitex_agent_container/_lifecycle/_relocate_liveness.py` — remote shell-string has-session probe
- `src/scitex_agent_container/_lifecycle/_verdict_remote.py` — ssh has-session probe (build_ssh_argv)

Deliberately untouched: `new-session -s` (names, not targets) and advisory copy-paste hint strings in operator messages (kill-session/attach hints) — those are prose, not invocations; making them exact would churn several message-assertion tests and is a candidate follow-up.

## Tests

- `tests/scitex_agent_container/_runners/_tmux/test_tmux_exact_target.py` (new): `exact_target` unit cases; seam-level argv pin (`=tui-x:` in send-keys argv); **real-tmux incident regressions** — with only `tui-<uuid>-gui` running, `exists("tui-<uuid>")` is False; `stop` never prefix-kills the sibling and still kills the exact session; per-subcommand acceptance of the `=name:` form (has-session, capture-pane, send-keys, list-panes, display-message, resize-window, rename-session) against a live server; end-to-end capture reads a marker from the exact session's pane.
- Notice: session/pane-pid clauses in `test__start_noop_notice.py`; caplog test in `test__start_verdict.py` that the ALIVE no-op start path **emits** the loud line naming agent + session.
- Updated three argv-assertion tests to the exact form (strengthened, not weakened): `test__verdict_resolve.py` (remote probe tail + bash -c wrap), `test__attach.py` (remote attach argv), `test_tmux_literal_send.py` (literal-send argv).

Local runs (worktree source, real tmux 3.4): new/adjacent tmux + notice suites 41 passed; runtimes/tui + lifecycle batch 152 passed; broad batch across `_state`, `_runners/_tmux`, `_agentstate`, `_authheal`, `_lifecycle` verdict/relocate, cli attach/auth-status, interactive_login: **1682 passed, 3 skipped**.

Card: `sac-tmux-prefix-match-false-alive-20260814`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
