### PR TITLE
refactor(openai): move the openai runner onto the shared session daemon (v4 step 7)

### DIFF
--- a/src/scitex_agent_container/_runners/_openai_session_cli.py
+++ b/src/scitex_agent_container/_runners/_openai_session_cli.py
@@ -1,175 +1,254 @@
 """Command-line entrypoint for the OpenAI-family session runner.
 
-Split out of :mod:`openai_session` because that module crossed the repo's
-512-line cap once this entrypoint landed on top of it. The split follows the
-cap's own instruction: one cohesive responsibility per file. The session
-LIBRARY stays in ``openai_session``; only argument parsing and the process
-lifecycle live here.
+v4 migration step 7 (card
+``sac-v4-layering-refactor-harness-runtime-inference-20260813``): this
+entrypoint hands the process to the SHARED residency daemon
+(:func:`.session_daemon.run_session_daemon`) with the OpenAI turn
+driver (:func:`._openai_turn_driver.run_openai_conversation`) as the
+harness seam. Before this step the module ran one ad-hoc mission turn
+and returned, while advertising eight "accepted for parity" flags its
+own comments called lies — and its ``asyncio.run`` call had no
+``import asyncio`` at all (the 2e3602c4 split left the import behind in
+``openai_session.py``), so every real ``python -m`` invocation
+NameError'd after argparse. The daemon handoff makes the flags REAL:
+``--state-root`` / ``--tick-seconds`` feed the daemon's heartbeat,
+``--a2a-*`` bind the vendor-neutral inbound-turn sidecar,
+``--residency`` selects the step-6 axis, and the autonomous flags drive
+the daemon's harness-agnostic drive-until-done loop.
 
-``openai_session`` re-exports :func:`main` and :func:`_parse_argv`, so both
-``python -m scitex_agent_container._runners.openai_session`` (what the
-apptainer argv builder emits) and every existing import keep resolving.
+The ONE flag that stays refused is ``--resume-session-id``: the harness
+registry's ``openai-agents`` descriptor declares ``can_resume=False``
+(the ``SQLiteSession`` db persists turns under the agent's own name,
+but sac's resume contract — rehydrate a PRIOR conversation from a
+caller-supplied id — is not implemented for this harness). The refusal
+reads the registry rather than hardcoding the answer, so flipping the
+descriptor is the single edit that would thread the id through.
+
+``openai_session`` re-exports :func:`main` and :func:`_parse_argv`, so
+both ``python -m scitex_agent_container._runners.openai_session`` (what
+the apptainer argv builder emits) and every existing import keep
+resolving. The runtime adapter (``runtimes/openai_session.py``) is the
+only sane caller; humans should use ``sac agents start`` instead.
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
 
-from .openai_session import Message, OpenAIAgentsSession
+from ..config._residency_types import AGENT_RESIDENCIES, RESIDENT
+from ._session_state import DEFAULT_TICK_SECONDS
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["_parse_argv", "main"]
+
 
 def _parse_argv(argv: list[str] | None = None) -> argparse.Namespace:
-    """Argparse mirror of the claude-session parser."""
-    import argparse as _argparse
-    from pathlib import Path as _Path
-
-    from ._session_state import DEFAULT_TICK_SECONDS
-
-    p = _argparse.ArgumentParser(
+    """Argparse mirror of the claude-session parser (shared daemon argv)."""
+    p = argparse.ArgumentParser(
         prog="python -m scitex_agent_container._runners.openai_session",
-        description="openai-session runner.",
+        description="openai-session runtime daemon.",
     )
     p.add_argument("--name", required=True, help="Agent name (state-dir leaf).")
     p.add_argument(
         "--state-root",
-        type=_Path,
+        type=Path,
         default=None,
-        help="Accepted for parity; OpenAI runner has no state directory.",  # no heartbeat/PID
+        help=(
+            "Override the per-agent state root "
+            "(default: $SCITEX_AGENT_CONTAINER_RUNTIME_DIR)."
+        ),
     )
     p.add_argument(
         "--tick-seconds",
         type=float,
         default=DEFAULT_TICK_SECONDS,
-        help="Accepted for parity; no heartbeat loop.",  # no daemon loop
+        help="Heartbeat interval in seconds (default: 10).",
     )
     p.add_argument(
         "--mission",
         type=str,
         default=None,
-        help="Initial user prompt (first user message).",
+        help=(
+            "Initial user prompt. With this flag the daemon drives one "
+            "conversation turn and then honours the residency axis. "
+            "Without it the daemon just heartbeats."
+        ),
     )
     p.add_argument(
         "--resume-session-id",
         type=str,
         default=None,
-        help="Accepted for parity; maps to session_id on the state db.",  # maps to session_id
+        help=(
+            "REFUSED for this harness: the registry's openai-agents "
+            "descriptor declares can_resume=False (exit 2, error names "
+            "the contract)."
+        ),
     )
     p.add_argument(
         "--a2a-port",
         type=int,
         default=None,
-        help="Accepted for parity; no HTTP sidecar.",  # no HTTP server
+        help=(
+            "If set, serve the inbound-turn endpoint on this port. "
+            'POST /v1/turn with {"text": "..."} drops the prompt onto '
+            "the runner's persistent conversation and returns the reply."
+        ),
     )
     p.add_argument(
         "--a2a-host",
         type=str,
         default="127.0.0.1",
-        help="Accepted for parity; no a2a-port sidecar.",  # no HTTP server
+        help="Bind address for --a2a-port (default: 127.0.0.1, loopback only).",
     )
     p.add_argument(
         "--a2a-card-yaml",
         type=str,
         default="",
-        help="Accepted for parity; no card publishing.",  # no HTTP server
+        help=(
+            "Path (in-container) to the agent's spec.yaml. When set, the "
+            "sidecar publishes the A2A AgentCard at "
+            "/.well-known/agent-card.json so peers can discover the "
+            "agent's capabilities."
+        ),
     )
     p.add_argument(
         "--channels",
         action="append",
         default=None,
         metavar="CHANNEL",
-        help="Accepted for parity; channel wiring is claude-SDK-specific.",  # no SDK channel system
-    )
-    p.add_argument(
-        "--print-stream",
-        action="store_true",
-        help="Mirror assistant text to stdout.",
+        help=(
+            "spec.claude.channels passthrough. Channel adapters are "
+            "Claude-SDK-specific; the OpenAI turn driver warns LOUDLY "
+            "and ignores them rather than degrading silently."
+        ),
     )
     p.add_argument(
         "--residency",
         type=str,
-        choices=("one-shot", "resident"),
-        default="resident",
-        help="Accepted for parity; this single-turn runner is one-shot-shaped either way.",  # daemon adoption is v4 step 7
+        choices=sorted(AGENT_RESIDENCIES),
+        default=RESIDENT,
+        help=(
+            "spec.residency passthrough (v4 residency axis). 'resident' "
+            "(default): the daemon parks awaiting more work after a "
+            "conversation completes. 'one-shot': the daemon exits "
+            "cleanly (ExitRecord reason oneshot-complete) when its "
+            "conversation completes."
+        ),
+    )
+    p.add_argument(
+        "--print-stream",
+        action="store_true",
+        help=(
+            "Mirror assistant text chunks to stdout as they arrive, and "
+            "exit when the mission turn completes (--foreground starts)."
+        ),
     )
     p.add_argument(
         "--autonomous-enabled",
         action="store_true",
-        help="Accepted for parity; no autonomous loop.",  # single-turn mission only
+        help=(
+            "Drive turns until --autonomous-drive-until matches an "
+            "assistant reply or --autonomous-max-turns is reached. "
+            "Requires --mission. The loop is the daemon's own, "
+            "harness-agnostic."
+        ),
     )
     p.add_argument(
         "--autonomous-drive-until",
         type=str,
         default="DONE",
-        help="Accepted for parity; no autonomous loop.",  # single-turn mission only
+        help="Substring; assistant reply containing it ends the loop with exit 0.",
     )
     p.add_argument(
         "--autonomous-max-turns",
         type=int,
         default=50,
-        help="Turn cap; forwarded to OpenAIAgentsSession.max_turns.",
+        help="Cap on autonomous turns. Hitting it without a match exits non-zero.",
     )
     p.add_argument(
         "--autonomous-kick-text",
         type=str,
         default="Continue. Print DONE when finished.",
-        help="Accepted for parity; no autonomous loop.",  # single-turn mission only
+        help="Text submitted as the next user turn after a non-matching reply.",
     )
     p.add_argument(
         "--max-restarts",
         type=int,
         default=0,
-        help="Accepted for parity; no restart logic.",  # no supervisor loop
+        help=(
+            "Accepted per the shared runner argv; the OpenAI turn driver "
+            "has no persistent vendor client to supervise-restart (each "
+            "turn is an independent chat-completions exchange)."
+        ),
     )
     p.add_argument(
         "--restart-backoff-s",
         type=float,
         default=1.0,
-        help="Accepted for parity; no restart logic.",  # no supervisor loop
+        help="Accepted per the shared runner argv; see --max-restarts.",
     )
     return p.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI entry point — construct an :class:`OpenAIAgentsSession`, run one
-    mission turn (if any), then tear down."""
-    import sys
+def main(argv: list[str] | None = None, *, turn_driver: Any | None = None) -> int:
+    """CLI entry point — run the shared session daemon with the OpenAI driver.
 
+    ``turn_driver`` is the test seam (mirrors ``claude_session.run``'s
+    ``run_conversation_fn``): ``None`` selects the production
+    :func:`._openai_turn_driver.run_openai_conversation`.
+    """
     args = _parse_argv(argv)
 
-    # BOOT ASSERTION — same contract as claude_session's main().
+    # BOOT ASSERTION — same overlay-venv contract as claude_session's main().
     from .._maintenance._venv_dist_assertion import assert_venv_distributions_unique
 
     assert_venv_distributions_unique(args.name)
 
-    session = OpenAIAgentsSession(
-        args.name,
-        session_id=args.resume_session_id or args.name,
-        max_turns=args.autonomous_max_turns
-        if args.autonomous_enabled
-        else None,
+    # Registry-derived resume gate (v4 step 4 descriptor contract): the
+    # answer lives in the openai-agents entry, not in this file.
+    from ..config._harness_registry import HARNESS_DESCRIPTORS, OPENAI_AGENTS
+
+    descriptor = HARNESS_DESCRIPTORS[OPENAI_AGENTS]
+    if args.resume_session_id and not descriptor.can_resume:
+        logger.error(
+            "refusing --resume-session-id=%s: harness %r declares "
+            "can_resume=False in the harness registry "
+            "(config/_harness_registry.py) — this harness cannot resume a "
+            "prior conversation by id. Start without the flag instead.",
+            args.resume_session_id,
+            OPENAI_AGENTS,
+        )
+        return 2
+
+    if turn_driver is None:
+        from ._openai_turn_driver import run_openai_conversation as turn_driver
+
+    from .session_daemon import run_session_daemon
+
+    return asyncio.run(
+        run_session_daemon(
+            args.name,
+            turn_driver=turn_driver,
+            residency=args.residency,
+            state_root=args.state_root,
+            tick_seconds=args.tick_seconds,
+            mission=args.mission,
+            resume_session_id=args.resume_session_id,
+            print_stream=args.print_stream,
+            a2a_host=args.a2a_host,
+            a2a_port=args.a2a_port,
+            a2a_card_yaml=args.a2a_card_yaml,
+            channels=args.channels,
+            autonomous_enabled=args.autonomous_enabled,
+            autonomous_drive_until=args.autonomous_drive_until,
+            autonomous_max_turns=args.autonomous_max_turns,
+            autonomous_kick_text=args.autonomous_kick_text,
+            max_restarts=args.max_restarts,
+            restart_backoff_s=args.restart_backoff_s,
+        )
     )
-
-    async def _run() -> int:
-        print_stream = args.print_stream
-        await session.start()
-        try:
-            if args.mission:
-                async for event in session.send(
-                    Message(role="user", content=args.mission)
-                ):
-                    if print_stream and event.kind == "text_delta":
-                        sys.stdout.write(event.text)
-                        sys.stdout.flush()
-                    if event.kind == "result":
-                        return 0
-                    if event.kind == "error":
-                        print(f"error: {event.error}", file=sys.stderr)
-                        return 1
-                return 0
-            else:
-                return 0
-        finally:
-            await session.close()
-
-    return asyncio.run(_run())
-
-

--- a/src/scitex_agent_container/_runners/_openai_turn_driver.py
+++ b/src/scitex_agent_container/_runners/_openai_turn_driver.py
@@ -1,0 +1,322 @@
+"""The OpenAI-family turn driver for the shared session daemon.
+
+v4 migration step 7 (card
+``sac-v4-layering-refactor-harness-runtime-inference-20260813``): the
+``openai-agents`` runner no longer owns any process machinery. The
+daemon (:mod:`.session_daemon`) owns the PROCESS — pid file, signals,
+heartbeat side-task, residency parking, the a2a sidecar, exit
+accounting; this module owns only the TURN, exactly like
+:mod:`._session_conversation` does for the Claude harness. Its single
+public callable, :func:`run_openai_conversation`, satisfies the
+daemon's turn-driver contract (see the :mod:`.session_daemon` module
+docstring for the call shape).
+
+WHAT THE DRIVER MAY TOUCH: the inbox (drain envelopes), the per-turn
+transcript (``session.jsonl`` via ``append_session_message``), the
+quota totals (``accumulate_quota``), the BUSY/READY beats it testifies
+to as :data:`~._incarnation.WRITER_TURN_DRIVER`, and the vendor session
+(:class:`~.openai_session.OpenAIAgentsSession`). WHAT IT MUST NOT
+TOUCH: the pid file, the periodic heartbeat loop, the a2a sidecar,
+``exit.json`` — those are the daemon's, and duplicating them here is
+the drift step 7 exists to delete.
+
+Registry contract (v4 step 4, ``config._harness_registry``): the
+``openai-agents`` descriptor declares ``hosted="runner"`` (this daemon
+hosts it), ``beat_writer="in-process"`` (the beats below), and
+``can_resume=False`` — so a ``resume_session_id`` is REFUSED loudly
+here (and earlier, in :mod:`._openai_session_cli`), never silently
+remapped. The ``SQLiteSession`` state db does persist turns across
+process lifetimes under the agent's own name, but sac's resume
+contract — rehydrate a PRIOR incarnation's conversation from a
+caller-supplied session id — is not implemented for this harness;
+honouring the flag would promise continuity the transcript format
+cannot prove.
+
+API surface (#1035, ``_openai_api_surface``): before the first turn the
+driver points the SDK at ``chat_completions`` when ``OPENAI_BASE_URL``
+names a self-hosted gateway — the fleet's gpt-oss/qwen endpoints route
+``/v1/chat/completions`` only, and the SDK's Responses default turns a
+healthy endpoint into an opaque 404.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from ..config._harness_registry import HARNESS_DESCRIPTORS, OPENAI_AGENTS
+from ._harness_session import Message
+from ._incarnation import WRITER_TURN_DRIVER
+from ._openai_api_surface import select_api_surface
+from ._session_state import (
+    STATE_BUSY,
+    STATE_READY,
+    accumulate_quota,
+    append_session_message,
+    report_sdk_error,
+    write_heartbeat,
+)
+from ._session_supervisor_helpers import _drain_failed_inbox
+from ._session_turn import _safe_repr
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["run_openai_conversation"]
+
+
+def _default_session_factory() -> Any:
+    """The production session class, imported call-time.
+
+    Lazy so importing THIS module never pulls the (optional)
+    ``openai-agents`` dependency chain, and so the module import order
+    between :mod:`.openai_session` and :mod:`._openai_session_cli`
+    stays acyclic.
+    """
+    from .openai_session import OpenAIAgentsSession
+
+    return OpenAIAgentsSession
+
+
+def _select_api_surface_if_possible() -> None:
+    """Apply the #1035 chat-completions fix when the SDK is importable.
+
+    A missing SDK is not swallowed here — ``session.start()`` raises the
+    actionable install hint moments later; this helper only avoids
+    raising a SECOND, less specific error first.
+    """
+    try:
+        import agents as agents_mod
+    except Exception:  # stx-allow: fallback (reason: optional dep — start() raises the actionable install hint; selecting a surface on an absent SDK is meaningless)
+        return
+    select_api_surface(agents_mod)
+
+
+async def _drive_openai_turn(
+    session: Any,
+    env: Any,
+    *,
+    state_dir: Path,
+    pid: int,
+    stop: asyncio.Event,
+    print_stream: bool,
+    name: str,
+    host: str | None,
+) -> None:
+    """Run ONE turn against the vendor session, resolving ``env.response``.
+
+    Mirrors :func:`._session_turn._drive_turn`'s bookkeeping: a BUSY
+    beat stamped :data:`WRITER_TURN_DRIVER` (self-testimony the daemon's
+    periodic loop preserves), transcript appends per event, quota
+    accumulation on the terminal result, and a READY beat once the turn
+    closes. An ``error`` event is turn-ending per the HarnessSession
+    contract: the awaiting future resolves with the failure instead of a
+    silent empty reply. An EXCEPTION out of ``session.send`` is outside
+    that contract — it propagates to the daemon, whose done-callback
+    records ``crashed`` honestly.
+    """
+    write_heartbeat(
+        state_dir,
+        pid=pid,
+        state=STATE_BUSY,
+        name=name,
+        host=host,
+        writer=WRITER_TURN_DRIVER,
+    )
+    append_session_message(state_dir, {"type": "user", "text": env.text})
+    chunks: list[str] = []
+    error_detail: str | None = None
+    try:
+        async for event in session.send(Message(role="user", content=env.text)):
+            if stop.is_set():
+                break
+            if event.kind == "text_delta":
+                chunks.append(event.text)
+                append_session_message(
+                    state_dir, {"type": "assistant", "text": event.text}
+                )
+                if print_stream:
+                    sys.stdout.write(event.text)
+                    sys.stdout.flush()
+            elif event.kind == "tool_call":
+                append_session_message(
+                    state_dir,
+                    {
+                        "type": "tool_call",
+                        "tool": event.tool_name,
+                        "input": _safe_repr(event.tool_input),
+                    },
+                )
+            elif event.kind == "tool_result":
+                append_session_message(
+                    state_dir,
+                    {"type": "tool_result", "output": _safe_repr(event.tool_output)},
+                )
+            elif event.kind in ("reasoning", "task"):
+                append_session_message(
+                    state_dir, {"type": event.kind, "text": event.text}
+                )
+            elif event.kind == "result":
+                result = event.result
+                sid = getattr(result, "session_id", None)
+                if sid:
+                    # Echoed to the /v1/turn caller by the sidecar; set
+                    # BEFORE the future resolves (finally below) so the
+                    # awaiter sees a consistent (text, session_id).
+                    env.session_id = sid
+                usage = dict(getattr(result, "usage", None) or {})
+                accumulate_quota(state_dir, usage)
+                append_session_message(
+                    state_dir,
+                    {"type": "result", "session_id": sid, "usage": usage},
+                )
+            elif event.kind == "error":
+                error_detail = str(event.error)
+                logger.error("openai turn failed for %s: %s", name, error_detail)
+                append_session_message(
+                    state_dir,
+                    {"type": "error", "kind": "harness_turn", "detail": error_detail},
+                )
+                if host:
+                    report_sdk_error(
+                        name=name,
+                        host=host,
+                        cause="harness-turn",
+                        detail=error_detail,
+                    )
+                break
+        if error_detail is not None and not env.response.done():
+            env.response.set_exception(RuntimeError(error_detail))
+    finally:
+        if not env.response.done():
+            env.response.set_result("".join(chunks))
+        if not stop.is_set():
+            write_heartbeat(
+                state_dir,
+                pid=pid,
+                state=STATE_READY,
+                name=name,
+                host=host,
+                writer=WRITER_TURN_DRIVER,
+            )
+
+
+async def run_openai_conversation(
+    name: str,
+    state_dir: Path,
+    *,
+    pid: int,
+    inbox: "asyncio.Queue",
+    resume_session_id: str | None,
+    stop: asyncio.Event,
+    print_stream: bool = False,
+    max_restarts: int = 0,
+    restart_backoff_s: float = 1.0,
+    host: str | None = None,
+    channels: list[str] | None = None,
+    a2a_port: int | None = None,
+    session_factory: Any | None = None,
+) -> None:
+    """Drive an inbox-fed conversation against one ``OpenAIAgentsSession``.
+
+    The daemon's turn-driver seam for the ``openai-agents`` harness:
+    drains :class:`~._session_inbox.TurnEnvelope` items until a
+    :class:`~._session_inbox.ShutdownEnvelope` (or an ``exit_after``
+    turn — the one-shot handshake) ends the run. One vendor session is
+    held open for the whole conversation; its ``SQLiteSession`` state db
+    (keyed by the agent's name) carries multi-turn memory.
+
+    ``max_restarts`` / ``restart_backoff_s`` are accepted per the
+    turn-driver contract but intentionally unused: unlike the Claude
+    SDK's long-lived subprocess there is no persistent vendor client to
+    supervise — every turn is an independent chat-completions HTTP
+    exchange, so a mid-session "client crash" has no equivalent here.
+    ``channels`` likewise names Claude-SDK channel adapters that this
+    harness does not implement; a spec that asks for them gets a LOUD
+    warning, not a silent degradation.
+
+    ``session_factory`` is the test seam (defaults to
+    :class:`~.openai_session.OpenAIAgentsSession`); it is called as
+    ``factory(name, mcp_servers=..., **{})`` and must return an object
+    with the HarnessSession ``start`` / ``send`` / ``close`` surface.
+    """
+    from ._session_inbox import ShutdownEnvelope, TurnEnvelope
+
+    del max_restarts, restart_backoff_s, a2a_port  # contract params; see docstring
+
+    descriptor = HARNESS_DESCRIPTORS[OPENAI_AGENTS]
+    if resume_session_id and not descriptor.can_resume:
+        detail = (
+            f"harness {OPENAI_AGENTS!r} declares can_resume=False in the "
+            f"harness registry; refusing resume_session_id="
+            f"{resume_session_id!r} for agent {name!r} rather than "
+            "silently starting a conversation that does not continue the "
+            "one the caller named."
+        )
+        logger.error("%s", detail)
+        append_session_message(
+            state_dir, {"type": "error", "kind": "resume_refused", "detail": detail}
+        )
+        if host:
+            report_sdk_error(name=name, host=host, cause="resume-refused", detail=detail)
+        _drain_failed_inbox(inbox, RuntimeError(detail))
+        return
+
+    if channels:
+        logger.warning(
+            "openai harness has no channel adapters; --channels %r ignored "
+            "for agent %s (channel wiring is Claude-SDK-specific)",
+            channels,
+            name,
+        )
+
+    _select_api_surface_if_possible()
+
+    from ..runtimes._openai_sdk_common import resolve_agent_workspace
+
+    factory = session_factory if session_factory is not None else _default_session_factory()
+    mcp_servers, _workspace_cwd = resolve_agent_workspace(name)
+    try:
+        session = factory(name, mcp_servers=mcp_servers)
+        await session.start()
+    except Exception as exc:  # stx-allow: fallback (reason: init failure is terminal — record + drain so producers don't hang, mirroring the Claude driver's sdk-missing/options path; the daemon accounts the early return)
+        logger.error("openai session failed to open for %s: %s", name, exc)
+        append_session_message(
+            state_dir, {"type": "error", "kind": "session_open", "detail": str(exc)}
+        )
+        if host:
+            report_sdk_error(
+                name=name, host=host, cause="session-open", detail=str(exc)
+            )
+        _drain_failed_inbox(inbox, exc)
+        return
+
+    try:
+        while True:
+            env = await inbox.get()
+            if isinstance(env, ShutdownEnvelope):
+                return
+            if not isinstance(env, TurnEnvelope):
+                continue
+            await _drive_openai_turn(
+                session,
+                env,
+                state_dir=state_dir,
+                pid=pid,
+                stop=stop,
+                print_stream=print_stream,
+                name=name,
+                host=host,
+            )
+            if env.exit_after:
+                stop.set()
+                return
+            if stop.is_set():
+                return
+    finally:
+        try:
+            await session.close()
+        except Exception as exc:  # stx-allow: fallback (reason: teardown must not mask the conversation's own outcome; the failure is still logged loudly)
+            logger.error("openai session close failed for %s: %s", name, exc)

--- a/src/scitex_agent_container/config/_harness_registry.py
+++ b/src/scitex_agent_container/config/_harness_registry.py
@@ -37,8 +37,9 @@ WHAT THIS STEP DOES NOT CHANGE (behavior-preserving by contract):
     a ``harness: openai`` spec resolves to a real registry key here, but
     the lifecycle launch path still cannot START it —
     ``ensure_harness_matches_claude_launch`` refuses before any dispatch
-    site consults a descriptor. Key-based launch of non-Anthropic
-    harnesses is migration step 7.
+    site consults a descriptor. Step 7 moved the openai RUNNER onto the
+    shared session daemon; key-based LAUNCH of non-Anthropic harnesses
+    stays behind that refusal until the canary step proves the runner.
   * The ``SAC_PROVIDER`` ops-only env override keeps its own surface
     (``runtimes/_apptainer_provider.resolve_agent_harness``); this
     resolver reads the SPEC axes only.
@@ -153,11 +154,12 @@ def _session_runner_inner_argv(
 ) -> list[str]:
     """Shared ``tini → python -m <module>`` tail for runner-hosted entries.
 
-    Both runner-hosted SDK families take the SAME argv surface today
-    (``--name`` / ``--state-root`` / supervisor caps / ``--mission`` /
-    ``--a2a-*`` / ``--channels`` / autonomous flags — the openai session
-    CLI accepts every one of them for parity), so the builder is shared
-    and only the module differs.
+    Both runner-hosted SDK families take the SAME argv surface — the
+    shared session-daemon flags (``--name`` / ``--state-root`` /
+    supervisor caps / ``--mission`` / ``--a2a-*`` / ``--channels`` /
+    ``--residency`` / autonomous) that both CLIs thread into
+    ``run_session_daemon`` (v4 step 7) — so the builder is shared and
+    only the module differs.
     """
     options = options or {}
     from ..runtimes._apptainer_inner_argv import _TINI_PREFIX, _agent_runner_argv
@@ -181,9 +183,11 @@ def _openai_agents_inner_argv(
 ) -> list[str]:
     """Inner argv for the ``openai-agents`` session runner.
 
-    REAL but not yet lifecycle-reachable: the step-2 refusal
-    (``ensure_harness_matches_claude_launch``) still guards every launch
-    path, so nothing dispatches this until migration step 7.
+    The runner itself is daemon-hosted since v4 step 7 (its CLI hands
+    the process to ``run_session_daemon`` with the OpenAI turn driver),
+    but the step-2 refusal (``ensure_harness_matches_claude_launch``)
+    still guards every LAUNCH path — nothing dispatches this argv until
+    the canary step lifts that guard.
     """
     return _session_runner_inner_argv(config, _OPENAI_SESSION_RUNNER, options)
 
@@ -316,9 +320,14 @@ HARNESS_DESCRIPTORS: dict[str, HarnessDescriptor] = {
             spec_runtimes=frozenset(),
             runner_module=_OPENAI_SESSION_RUNNER,
             inner_argv=_openai_agents_inner_argv,
-            hosted="runner",
-            beat_writer="in-process",
-            can_resume=False,  # single-turn CLI today; resume flags are parity-only
+            hosted="runner",  # shared session daemon since v4 step 7
+            beat_writer="in-process",  # daemon + turn-driver beats, self-stamped
+            # The SQLiteSession db persists turns under the agent's own
+            # name, but sac's resume contract (rehydrate a PRIOR
+            # conversation from a caller-supplied session id) is not
+            # implemented for this harness — the runner CLI and turn
+            # driver both REFUSE --resume-session-id, reading this field.
+            can_resume=False,
             env_and_binds=_openai_env_and_binds,
         ),
     )

--- a/tests/scitex_agent_container/_runners/test_openai_session_daemon.py
+++ b/tests/scitex_agent_container/_runners/test_openai_session_daemon.py
@@ -1,0 +1,515 @@
+"""The OpenAI runner on the shared session daemon (v4 step 7).
+
+Card ``sac-v4-layering-refactor-harness-runtime-inference-20260813``:
+the openai-agents runner's process lifetime now runs through
+``run_session_daemon`` with :func:`run_openai_conversation` as the turn
+driver — no ad-hoc loop, no lying parity flags, and the CLI entrypoint
+actually runs (the pre-fix ``_openai_session_cli`` called
+``asyncio.run`` with no ``import asyncio`` in the module, so every real
+invocation NameError'd after argparse).
+
+Mirrors the ``test_session_daemon_zombie_exit.py`` /
+``test_session_daemon_residency.py`` harness patterns: bounded
+``asyncio.wait_for`` so a regression to parking fails as a
+TimeoutError; hand-rolled stand-in sessions (the ``_ScriptedClient``
+idiom), never mocks; STX-TQ002 AAA + one assert per test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._runners import session_daemon
+from scitex_agent_container._runners._harness_session import (
+    NormalizedEvent,
+    RunResult,
+)
+from scitex_agent_container._runners._incarnation import (
+    EXIT_CRASHED,
+    EXIT_HARNESS_RETURNED,
+    EXIT_ONESHOT_COMPLETE,
+    WRITER_TURN_DRIVER,
+    read_exit_record,
+)
+from scitex_agent_container._runners._openai_session_cli import main as cli_main
+from scitex_agent_container._runners._openai_turn_driver import (
+    run_openai_conversation,
+)
+from scitex_agent_container._runners._session_inbox import (
+    ShutdownEnvelope,
+    TurnEnvelope,
+    make_inbox,
+)
+from scitex_agent_container._runners._session_state import (
+    STATE_BUSY,
+    read_heartbeat,
+)
+
+#: Generous ceiling for "the daemon must EXIT on its own" — a regression
+#: back to parking turns into a visible TimeoutError, not a hang.
+_EXIT_DEADLINE_S = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Stand-in vendor sessions — the HarnessSession surface, hand-rolled.
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedOpenAISession:
+    """Answers every turn with a scripted delta + terminal result."""
+
+    def __init__(self, agent_name: str, **kwargs: Any) -> None:
+        self.agent_name = agent_name
+        self.kwargs = kwargs
+        self.closed = False
+
+    async def start(self) -> None:
+        return None
+
+    async def send(self, message: Any):
+        yield NormalizedEvent(kind="text_delta", text="ack")
+        yield NormalizedEvent(
+            kind="result",
+            result=RunResult(
+                text="ack",
+                session_id=self.agent_name,
+                usage={"input_tokens": 3, "output_tokens": 2},
+            ),
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _ErroringOpenAISession(_ScriptedOpenAISession):
+    """Yields a turn-ending ``kind="error"`` event (the Protocol contract)."""
+
+    async def send(self, message: Any):
+        yield NormalizedEvent(kind="error", error="endpoint said no")
+
+
+class _SendRaisesOpenAISession(_ScriptedOpenAISession):
+    """Raises OUTSIDE the Protocol contract — must surface as a crash."""
+
+    async def send(self, message: Any):
+        raise RuntimeError("vendor SDK fell over mid-turn")
+        yield  # pragma: no cover — makes this an async generator
+
+
+def _refusing_factory(agent_name: str, **kwargs: Any) -> Any:
+    """A session that cannot even be constructed (no key, no SDK...)."""
+    raise RuntimeError("no OpenAI auth available")
+
+
+def _openai_driver_with(factory: Any) -> Any:
+    """The REAL turn driver with the vendor session swapped for a stand-in."""
+    return functools.partial(run_openai_conversation, session_factory=factory)
+
+
+def _run_daemon_bounded(
+    tmp_path: Path, name: str, driver: Any, *, residency: str
+) -> int:
+    """Run a headless mission daemon under ``residency`` with a deadline."""
+
+    async def _scenario() -> int:
+        return await asyncio.wait_for(
+            session_daemon.run_session_daemon(
+                name,
+                turn_driver=driver,
+                residency=residency,
+                state_root=tmp_path,
+                tick_seconds=0.01,
+                mission="boot",
+            ),
+            timeout=_EXIT_DEADLINE_S,
+        )
+
+    return asyncio.run(_scenario())
+
+
+# ---------------------------------------------------------------------------
+# Daemon-level: the real openai driver under the residency axis
+# ---------------------------------------------------------------------------
+
+
+def test_one_shot_openai_daemon_exits_zero_on_clean_completion(
+    tmp_path: Path,
+) -> None:
+    # Arrange: the real driver over a scripted session, declared one-shot.
+    driver = _openai_driver_with(_ScriptedOpenAISession)
+    # Act: mission turn completes; the driver honours exit_after.
+    rc = _run_daemon_bounded(tmp_path, "ag-oa-rc", driver, residency="one-shot")
+    # Assert: the declared plan is a SUCCESS exit.
+    assert rc == 0
+
+
+def test_one_shot_openai_completion_writes_oneshot_complete_exit_record(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    driver = _openai_driver_with(_ScriptedOpenAISession)
+    # Act
+    _run_daemon_bounded(tmp_path, "ag-oa-rec", driver, residency="one-shot")
+    rec = read_exit_record(tmp_path / "ag-oa-rec")
+    # Assert: the ExitRecord names the PLANNED end, not a violation.
+    assert rec is not None and rec["reason"] == EXIT_ONESHOT_COMPLETE
+
+
+def test_resident_openai_daemon_records_harness_returned_when_session_refuses(
+    tmp_path: Path,
+) -> None:
+    # Arrange: session construction fails (no key / no SDK) → the driver
+    # records + drains + RETURNS, which under resident is the residency
+    # violation the daemon must account, never a green-heartbeat zombie.
+    driver = _openai_driver_with(_refusing_factory)
+    # Act
+    _run_daemon_bounded(tmp_path, "ag-oa-hr", driver, residency="resident")
+    rec = read_exit_record(tmp_path / "ag-oa-hr")
+    # Assert
+    assert rec is not None and rec["reason"] == EXIT_HARNESS_RETURNED
+
+
+def test_resident_openai_daemon_records_crashed_when_send_raises(
+    tmp_path: Path,
+) -> None:
+    # Arrange: an exception out of send() is outside the HarnessSession
+    # contract (errors travel as events) — it must propagate to the
+    # daemon and be recorded as a crash, not swallowed.
+    driver = _openai_driver_with(_SendRaisesOpenAISession)
+    # Act
+    _run_daemon_bounded(tmp_path, "ag-oa-cr", driver, residency="resident")
+    rec = read_exit_record(tmp_path / "ag-oa-cr")
+    # Assert
+    assert rec is not None and rec["reason"] == EXIT_CRASHED
+
+
+# ---------------------------------------------------------------------------
+# CLI: argparse → asyncio.run → daemon handoff (the NameError regression gate)
+# ---------------------------------------------------------------------------
+
+
+async def _stub_cli_driver(name: str, state_dir: Path, **kwargs: Any) -> None:
+    """Minimal residency-honouring driver for CLI smoke runs."""
+    inbox = kwargs["inbox"]
+    stop = kwargs["stop"]
+    while True:
+        env = await inbox.get()
+        if isinstance(env, ShutdownEnvelope):
+            return
+        if isinstance(env, TurnEnvelope):
+            if not env.response.done():
+                env.response.set_result("ok")
+            if env.exit_after:
+                stop.set()
+                return
+
+
+def test_cli_main_reaches_daemon_handoff_and_exits_zero(tmp_path: Path) -> None:
+    # Arrange: the full entrypoint — argparse through asyncio.run to
+    # run_session_daemon — with only the vendor turn driver stubbed.
+    # Pre-fix code NameError'd here on the missing asyncio import before
+    # any daemon work; this pins the whole invoke path, not the lint.
+    argv = [
+        "--name",
+        "ag-oa-cli",
+        "--state-root",
+        str(tmp_path),
+        "--tick-seconds",
+        "0.01",
+        "--mission",
+        "hi",
+        "--residency",
+        "one-shot",
+    ]
+    # Act
+    rc = cli_main(argv, turn_driver=_stub_cli_driver)
+    # Assert
+    assert rc == 0
+
+
+def test_cli_main_one_shot_writes_oneshot_complete_exit_record(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    argv = [
+        "--name",
+        "ag-oa-cli-rec",
+        "--state-root",
+        str(tmp_path),
+        "--tick-seconds",
+        "0.01",
+        "--mission",
+        "hi",
+        "--residency",
+        "one-shot",
+    ]
+    # Act
+    cli_main(argv, turn_driver=_stub_cli_driver)
+    rec = read_exit_record(tmp_path / "ag-oa-cli-rec")
+    # Assert: the CLI threads --residency into the daemon for real.
+    assert rec is not None and rec["reason"] == EXIT_ONESHOT_COMPLETE
+
+
+def test_cli_main_refuses_resume_because_registry_declares_no_resume(
+    tmp_path: Path,
+) -> None:
+    # Arrange: can_resume=False in the openai-agents descriptor — the
+    # CLI must refuse the flag (exit 2) instead of silently remapping it.
+    argv = [
+        "--name",
+        "ag-oa-resume",
+        "--state-root",
+        str(tmp_path),
+        "--resume-session-id",
+        "11111111-2222-3333-4444-555555555555",
+    ]
+    # Act
+    rc = cli_main(argv, turn_driver=_stub_cli_driver)
+    # Assert
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# Driver-level: turn bookkeeping, beats, transcript, refusals
+# ---------------------------------------------------------------------------
+
+
+def _drive_one_turn(
+    tmp_path: Path,
+    name: str,
+    factory: Any,
+    *,
+    resume_session_id: str | None = None,
+) -> TurnEnvelope:
+    """Feed the driver one exit_after turn; return the resolved envelope."""
+
+    async def _go() -> TurnEnvelope:
+        stop = asyncio.Event()
+        inbox = make_inbox()
+        loop = asyncio.get_running_loop()
+        env = TurnEnvelope(
+            text="hi", response=loop.create_future(), exit_after=True
+        )
+        await inbox.put(env)
+        await asyncio.wait_for(
+            run_openai_conversation(
+                name,
+                tmp_path / name,
+                pid=os.getpid(),
+                inbox=inbox,
+                resume_session_id=resume_session_id,
+                stop=stop,
+                session_factory=factory,
+            ),
+            timeout=_EXIT_DEADLINE_S,
+        )
+        return env
+
+    return asyncio.run(_go())
+
+
+def test_driver_resolves_the_turn_future_with_streamed_text(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    factory = _ScriptedOpenAISession
+    # Act
+    env = _drive_one_turn(tmp_path, "ag-drv-txt", factory)
+    # Assert: the /v1/turn awaiter gets the assistant reply.
+    assert env.response.result() == "ack"
+
+
+def test_driver_tags_the_envelope_with_the_session_id(tmp_path: Path) -> None:
+    # Arrange
+    factory = _ScriptedOpenAISession
+    # Act
+    env = _drive_one_turn(tmp_path, "ag-drv-sid", factory)
+    # Assert: set before the future resolves, from the terminal result.
+    assert env.session_id == "ag-drv-sid"
+
+
+def test_driver_appends_result_record_to_the_transcript(tmp_path: Path) -> None:
+    # Arrange
+    factory = _ScriptedOpenAISession
+    # Act
+    _drive_one_turn(tmp_path, "ag-drv-jsonl", factory)
+    lines = (
+        (tmp_path / "ag-drv-jsonl" / "session.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    )
+    kinds = [json.loads(line).get("type") for line in lines if line.strip()]
+    # Assert: user + assistant + result all reached session.jsonl.
+    assert kinds.count("result") == 1 and "user" in kinds and "assistant" in kinds
+
+
+def test_driver_accumulates_turn_usage_into_quota(tmp_path: Path) -> None:
+    # Arrange
+    from scitex_agent_container._runners._session_state import read_quota
+
+    # Act
+    _drive_one_turn(tmp_path, "ag-drv-quota", _ScriptedOpenAISession)
+    quota = read_quota(tmp_path / "ag-drv-quota")
+    # Assert: the result usage fed the same totals the beats report.
+    assert quota.get("turns") == 1
+
+
+def test_driver_busy_beat_is_stamped_by_the_turn_driver_writer(
+    tmp_path: Path,
+) -> None:
+    # Arrange: a session that reads the heartbeat MID-TURN, when the
+    # busy beat written just before send() is the latest testimony.
+    captured: dict[str, Any] = {}
+    state_dir = tmp_path / "ag-drv-beat"
+
+    class _BeatPeekSession(_ScriptedOpenAISession):
+        async def send(self, message: Any):
+            captured.update(read_heartbeat(state_dir) or {})
+            async for event in super().send(message):
+                yield event
+
+    # Act
+    _drive_one_turn(tmp_path, "ag-drv-beat", _BeatPeekSession)
+    # Assert: the beat names the ACTUAL writer per the #1042 vocabulary.
+    assert captured.get("writer") == WRITER_TURN_DRIVER
+
+
+def test_driver_busy_beat_carries_the_busy_state(tmp_path: Path) -> None:
+    # Arrange
+    captured: dict[str, Any] = {}
+    state_dir = tmp_path / "ag-drv-busy"
+
+    class _BeatPeekSession(_ScriptedOpenAISession):
+        async def send(self, message: Any):
+            captured.update(read_heartbeat(state_dir) or {})
+            async for event in super().send(message):
+                yield event
+
+    # Act
+    _drive_one_turn(tmp_path, "ag-drv-busy", _BeatPeekSession)
+    # Assert
+    assert captured.get("state") == STATE_BUSY
+
+
+def test_driver_error_event_resolves_the_future_with_the_failure(
+    tmp_path: Path,
+) -> None:
+    # Arrange: a turn-ending kind="error" event must surface to the
+    # awaiter as the real cause, never as a silent empty reply.
+    factory = _ErroringOpenAISession
+    # Act
+    env = _drive_one_turn(tmp_path, "ag-drv-err", factory)
+    # Assert
+    with pytest.raises(RuntimeError, match="endpoint said no"):
+        env.response.result()
+
+
+def test_driver_refuses_resume_session_id_per_registry(tmp_path: Path) -> None:
+    # Arrange: can_resume=False → the queued turn must fail LOUDLY with
+    # the refusal instead of silently starting an unrelated conversation.
+    resume_id = "deadbeef-0000-0000-0000-000000000000"
+    # Act
+    env = _drive_one_turn(
+        tmp_path,
+        "ag-drv-resume",
+        _ScriptedOpenAISession,
+        resume_session_id=resume_id,
+    )
+    # Assert
+    with pytest.raises(RuntimeError, match="can_resume=False"):
+        env.response.result()
+
+
+def test_driver_closes_the_vendor_session_on_shutdown(tmp_path: Path) -> None:
+    # Arrange: a ShutdownEnvelope (the daemon's stop path) must reach
+    # session.close() so MCP subprocesses are never orphaned.
+    sessions: list[_ScriptedOpenAISession] = []
+
+    def _factory(agent_name: str, **kwargs: Any) -> _ScriptedOpenAISession:
+        session = _ScriptedOpenAISession(agent_name, **kwargs)
+        sessions.append(session)
+        return session
+
+    async def _go() -> bool:
+        stop = asyncio.Event()
+        inbox = make_inbox()
+        await inbox.put(ShutdownEnvelope())
+        await asyncio.wait_for(
+            run_openai_conversation(
+                "ag-drv-close",
+                tmp_path / "ag-drv-close",
+                pid=os.getpid(),
+                inbox=inbox,
+                resume_session_id=None,
+                stop=stop,
+                session_factory=_factory,
+            ),
+            timeout=_EXIT_DEADLINE_S,
+        )
+        return sessions[0].closed
+
+    # Act
+    closed = asyncio.run(_go())
+    # Assert
+    assert closed is True
+
+
+# ---------------------------------------------------------------------------
+# #1035 — a self-hosted endpoint needs chat-completions, not Responses
+# ---------------------------------------------------------------------------
+
+_API_ENV_KEYS = ("SAC_OPENAI_API", "OPENAI_BASE_URL")
+
+
+@pytest.fixture
+def self_hosted_env():
+    """Real env pointing OPENAI_BASE_URL at a self-hosted gateway."""
+    saved = {key: os.environ.get(key) for key in _API_ENV_KEYS}
+    for key in _API_ENV_KEYS:
+        os.environ.pop(key, None)
+    os.environ["OPENAI_BASE_URL"] = "http://127.0.0.1:18770/v1"
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture
+def recording_agents_module():
+    """A stand-in ``agents`` module recording set_default_openai_api calls."""
+    module = types.ModuleType("agents")
+    module.calls = []  # type: ignore[attr-defined]
+    module.set_default_openai_api = module.calls.append  # type: ignore[attr-defined]
+    real = sys.modules.get("agents")
+    sys.modules["agents"] = module
+    try:
+        yield module
+    finally:
+        if real is None:
+            sys.modules.pop("agents", None)
+        else:
+            sys.modules["agents"] = real
+
+
+def test_driver_selects_chat_completions_for_a_self_hosted_endpoint(
+    tmp_path: Path, self_hosted_env, recording_agents_module
+) -> None:
+    # Arrange: the fleet's gpt-oss/qwen gateways serve only
+    # /v1/chat/completions; the SDK's Responses default 404s (#1035).
+    # Act: one driven turn through the real driver.
+    _drive_one_turn(tmp_path, "ag-drv-api", _ScriptedOpenAISession)
+    # Assert: the driver reconfigured the SDK before the first turn.
+    assert recording_agents_module.calls == ["chat_completions"]


### PR DESCRIPTION
## v4 migration step 7 — the openai runner on the shared session daemon

Card: `sac-v4-layering-refactor-harness-runtime-inference-20260813`.

Per the v4 doctrine ("sac owns the PROCESS; a harness owns only the TURN"), the openai-agents runner's session lifetime now runs through `run_session_daemon` (#1040) — the same daemon the Claude SDK runner already rides. No stop/park/beat/exit code remains in the openai path.

### What changed

- **New `_runners/_openai_turn_driver.py`** — `run_openai_conversation(...)`, the daemon's turn-driver seam for this harness. It owns ONLY the turn: drain `TurnEnvelope`s, run each against one long-lived `OpenAIAgentsSession` (chat-completions endpoint + MCP tool loop), append transcript records to `session.jsonl` (`user`/`assistant`/`tool_call`/`tool_result`/`reasoning`/`task`/`result`/`error` — same shapes the runtime adapter's `logs` renderer already reads), accumulate `quota.json` (which feeds `turns_completed` on beats), resolve each envelope's response future, honour the `exit_after` handshake and `ShutdownEnvelope`. It never touches the pid file, the heartbeat loop, the a2a sidecar, or `exit.json` — those are the daemon's.
- **`_runners/_openai_session_cli.py` rewritten** — argparse mirrors `_session_cli` and hands the process to `run_session_daemon` with the openai driver. The eight "accepted for parity" flags its own comments called lies become REAL daemon flags: `--state-root`/`--tick-seconds` (heartbeats), `--a2a-*` (the vendor-neutral inbound-turn sidecar now works for openai agents), `--residency` (#1043 axis), autonomous flags (the daemon's harness-agnostic drive loop).
- **Registry comments** in `config/_harness_registry.py` updated to match reality (daemon-hosted since step 7; launch dispatch still guarded — see below).

### The carded NameError, fixed structurally

`_openai_session_cli.py` called `asyncio.run(...)` with **no `import asyncio` in the module** since the 2e3602c4 CLI split — the standalone entrypoint NameError'd on any real invocation (carded on the v4 card by the step-6 agent). The rewrite imports `asyncio` at module top, and the regression gate is behavioural, not lint: `test_cli_main_reaches_daemon_handoff_and_exits_zero` executes the full entrypoint — argparse through `asyncio.run` to the daemon handoff — with a stub driver, so a missing import can never again survive collection.

### HarnessDescriptor respected (read, not hardcoded)

- `hosted="runner"` — true now: the runner hosts the shared daemon.
- `beat_writer="in-process"` — the daemon writes its beats as `writer=session-daemon`; the driver stamps its own BUSY/READY beats as **`writer=turn-driver`** (`WRITER_TURN_DRIVER`). No new vocabulary needed: #1042's closed set already names the actual writer for this path, and the daemon's state machine already preserves turn-driver BUSY testimony.
- `can_resume=False` — **resume is refused, in the registry's direction.** The old CLI silently remapped `--resume-session-id` to the SQLiteSession key ("maps to session_id on the state db"), i.e. reality implemented an ad-hoc resume the registry declares unsupported. Fixed toward the registry: the CLI exits 2 (naming the descriptor) and the driver double-refuses (queued futures fail loudly with the reason), both by READING `HARNESS_DESCRIPTORS[OPENAI_AGENTS].can_resume` — flipping the descriptor is the single edit that would thread the id through. Note the `SQLiteSession` db does persist turns under the agent's own name across process lifetimes (implicit continuity), but sac's resume contract — rehydrate a PRIOR conversation from a caller-supplied id — is not implemented for this transcript format, so honouring the flag would promise continuity it cannot prove.

### Residency (#1043)

One-shot and resident both work through the same `--residency` plumbing: a clean mission completion under one-shot exits 0 with ExitRecord `oneshot-complete`; under resident, a driver that returns on its own (e.g. session open refused) is `harness-returned`, and an exception out of `send()` (outside the HarnessSession error-event contract) propagates and records `crashed`.

### #1035 — no Responses API regression

The driver calls `select_api_surface(agents)` before opening the session, so a self-hosted `OPENAI_BASE_URL` (the fleet's gpt-oss/qwen litellm gateways) selects `chat_completions` on the daemon path exactly as the a2a handler already does. Pinned by a test with a recording stand-in `agents` module.

### Deliberately NOT in this PR

- Key-based LAUNCH of the openai harness: `ensure_harness_matches_claude_launch` (#1039) still refuses before any dispatch site consults the descriptor. Lifting it is the canary step's job, after this runner is proven.
- `max_restarts`/`restart_backoff_s` are accepted per the shared argv and documented unused: there is no persistent vendor client process to supervise-restart — each turn is an independent chat-completions HTTP exchange. `--channels` (Claude-SDK channel adapters) warns loudly and is ignored, never a silent degradation.

### Tests

17 new no-mock tests (`tests/scitex_agent_container/_runners/test_openai_session_daemon.py`) mirroring the `test_session_daemon_zombie_exit.py` / `test_session_daemon_residency.py` patterns with hand-rolled stand-in vendor sessions: daemon-level one-shot/`harness-returned`/`crashed` through the REAL driver, CLI smoke + residency threading + resume refusal, driver-level future resolution, session-id tagging, transcript/quota bookkeeping, beat writer identity + BUSY state, error-event surfacing, session close on shutdown, chat-completions selection.

Local: new suite 17/17; `_runners` + `config` 1729 passed / 15 skipped; `runtimes` + `a2a` 2117 passed / 20 skipped with exactly the 23 documented pre-existing in-container vantage reds (`test__sdk_common` / `test__mcp_spec_env` / `test_claude_session_reads_model_env_for_options`, all `SpecEnvUnresolvedError` container artifacts — untouched by this PR). CI ruff gate (`--select F401,F811`) reproduced green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
