### PR TITLE
feat(harness): codex python SDK as a fourth harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,29 @@ codex = [
     # Anthropic Messages -> ChatGPT Codex subscription bridge selected by
     # `spec.claude.provider: codex`; this is intentionally separate from the
     # `openai` extra above, which replaces the harness with openai-agents.
+    # NOT the same thing as `codex-sdk` below — see that extra's comment.
     "scitex-genai[gateway]>=0.1.4",
+]
+codex-sdk = [
+    # sac's FOURTH harness (card sac-codex-python-sdk-harness-20260814):
+    # `spec.harness: codex`, backing `_runners/codex_session.py`
+    # (CodexSession -- the concrete HarnessSession over AsyncCodex).
+    #
+    # DELIBERATELY NOT NAMED `codex`: that extra is TAKEN, and by the OTHER
+    # axis. `codex` installs scitex-genai for `spec.claude.provider: codex`,
+    # an INFERENCE backend with Claude Code still running the loop. THIS
+    # extra replaces the HARNESS -- the codex agent program runs the loop
+    # and brings its own file-edit/exec/apply_patch tooling. `codex` is the
+    # first value to land on both axes, so the two extras are spelled
+    # differently rather than one silently shadowing the other.
+    #
+    # WEIGHT WARNING: openai-codex pins `openai-codex-cli-bin`, a wheel-only
+    # package shipping a ~285 MB native `codex` binary (plus rg, bwrap, zsh).
+    # OPTIONAL on purpose: Claude-only deployments must not pull it -- every
+    # import is lazy and CodexSession raises CodexSessionError with this
+    # install hint when absent. 0.144.4 floor: the first release carrying the
+    # AsyncCodex/thread_resume surface the runner is written against.
+    "openai-codex>=0.144.4",
 ]
 dev = [
     # 0.31.1 floor — LOAD-BEARING, do not lower. `audit_all_for_package`
@@ -315,6 +337,15 @@ all = [
     # the real openai-agents SDK paths; the bare install stays Claude-only.
     "scitex-agent-container[openai]",
     "scitex-agent-container[codex]",
+    # `codex-sdk` is DELIBERATELY ABSENT, not forgotten. It pins
+    # openai-codex, which pins openai-codex-cli-bin — a wheel-only
+    # package shipping a ~285 MB native binary. CI installs `[all,dev]`
+    # on every job, and the codex harness's tests need none of it: they
+    # drive hand-rolled HarnessSession stand-ins and assert the
+    # MISSING-SDK path via a sys.modules sentinel, so the SDK's presence
+    # would add a quarter-gigabyte per job and zero coverage. Install it
+    # explicitly (`pip install -e ".[codex-sdk]"`) on a host that will
+    # actually run a codex agent.
     "scitex-agent-container[dev]",
     "scitex-agent-container[docs]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,23 @@ codex-sdk = [
     "openai-codex>=0.144.4",
 ]
 dev = [
+    # PS-210 §2 (dev-extras-incomplete): `[codex-sdk]` declares the
+    # openai_codex module and the codex tests name it, so `[dev]` must
+    # carry it too — the rule's contract is that a fresh
+    # `pip install -e .[dev]` runs the FULL suite with nothing skipped.
+    #
+    # The rule's other remedy — `pytest.importorskip("openai_codex")` —
+    # is WRONG here and must not be substituted: the tests that mention
+    # the module assert the SDK-ABSENT behaviour (CodexSession must be
+    # constructible without it, and start() must raise CodexSessionError
+    # carrying the pip hint). importorskip would skip exactly the tests
+    # whose whole subject is the absence, i.e. it would delete the
+    # coverage instead of enabling it.
+    #
+    # Costs nothing in CI, which installs `[all,dev]` and already gets
+    # this via `all` (PS-221 §3). It does add openai-codex-cli-bin's
+    # ~285 MB native wheel to a bare `[dev]` install.
+    "scitex-agent-container[codex-sdk]",
     # 0.31.1 floor — LOAD-BEARING, do not lower. `audit_all_for_package`
     # first gained its `path=` parameter in 0.31.1 (verified against the
     # published wheels: 0.31.0 has NEITHER `path=` NOR the CWD-git-root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,23 +164,35 @@ codex-sdk = [
     "openai-codex>=0.144.4",
 ]
 dev = [
-    # PS-210 §2 (dev-extras-incomplete): `[codex-sdk]` declares the
-    # openai_codex module and the codex tests name it, so `[dev]` must
-    # carry it too — the rule's contract is that a fresh
-    # `pip install -e .[dev]` runs the FULL suite with nothing skipped.
+    # PS-210 §2 (dev-extras-incomplete): `[codex-sdk]` declares
+    # openai-codex, `src/.../_runners/codex_session.py` imports the
+    # `openai_codex` module, and the tests import `scitex_agent_container`
+    # — the rule's TRANSITIVE arm — so `[dev]` must carry it too. The
+    # rule's contract is that a fresh `pip install -e .[dev]` runs the
+    # FULL suite with nothing skipped.
+    #
+    # NAMED DIRECTLY, NOT AS `scitex-agent-container[codex-sdk]`. That
+    # self-referential form is what pip would resolve, but PS-210 reads
+    # `[dev]`'s entries as DISTRIBUTION NAMES — `_strip_version` truncates
+    # each one at the first `[`, so the self-extra registers as
+    # `scitex_agent_container` and the auditor never resolves the extra to
+    # `openai_codex`. It was tried (25fe8a37) and the rule still fired.
+    # Spelling the distribution out is both what the rule asks for and
+    # what the `scitex-hpc` entry below already does for the same reason.
     #
     # The rule's other remedy — `pytest.importorskip("openai_codex")` —
     # is WRONG here and must not be substituted: the tests that mention
     # the module assert the SDK-ABSENT behaviour (CodexSession must be
     # constructible without it, and start() must raise CodexSessionError
-    # carrying the pip hint). importorskip would skip exactly the tests
-    # whose whole subject is the absence, i.e. it would delete the
-    # coverage instead of enabling it.
+    # carrying the pip hint) by forcing `sys.modules["openai_codex"] =
+    # None`. importorskip would skip exactly the tests whose whole subject
+    # is the absence, i.e. delete the coverage instead of enabling it.
     #
     # Costs nothing in CI, which installs `[all,dev]` and already gets
     # this via `all` (PS-221 §3). It does add openai-codex-cli-bin's
-    # ~285 MB native wheel to a bare `[dev]` install.
-    "scitex-agent-container[codex-sdk]",
+    # ~285 MB native wheel to a bare `[dev]` install. Floor kept in step
+    # with the `[codex-sdk]` extra above.
+    "openai-codex>=0.144.4",
     # 0.31.1 floor — LOAD-BEARING, do not lower. `audit_all_for_package`
     # first gained its `path=` parameter in 0.31.1 (verified against the
     # published wheels: 0.31.0 has NEITHER `path=` NOR the CWD-git-root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,9 +156,10 @@ codex-sdk = [
     #
     # WEIGHT WARNING: openai-codex pins `openai-codex-cli-bin`, a wheel-only
     # package shipping a ~285 MB native `codex` binary (plus rg, bwrap, zsh).
-    # OPTIONAL on purpose: Claude-only deployments must not pull it -- every
-    # import is lazy and CodexSession raises CodexSessionError with this
-    # install hint when absent. 0.144.4 floor: the first release carrying the
+    # OPTIONAL so a BARE install stays Claude-only -- every import is lazy and
+    # CodexSession raises CodexSessionError with this install hint when absent.
+    # It IS still reachable from `[all]`, as PS-221 §3 requires of every public
+    # extra; see the note there. 0.144.4 floor: the first release carrying the
     # AsyncCodex/thread_resume surface the runner is written against.
     "openai-codex>=0.144.4",
 ]
@@ -337,15 +338,24 @@ all = [
     # the real openai-agents SDK paths; the bare install stays Claude-only.
     "scitex-agent-container[openai]",
     "scitex-agent-container[codex]",
-    # `codex-sdk` is DELIBERATELY ABSENT, not forgotten. It pins
-    # openai-codex, which pins openai-codex-cli-bin — a wheel-only
-    # package shipping a ~285 MB native binary. CI installs `[all,dev]`
-    # on every job, and the codex harness's tests need none of it: they
-    # drive hand-rolled HarnessSession stand-ins and assert the
-    # MISSING-SDK path via a sys.modules sentinel, so the SDK's presence
-    # would add a quarter-gigabyte per job and zero coverage. Install it
-    # explicitly (`pip install -e ".[codex-sdk]"`) on a host that will
-    # actually run a codex agent.
+    # PRESENT BECAUSE THE POLICY REQUIRES IT, not because the tests need
+    # it. PS-221 §3 (public-extra-not-closed-under-all): every PUBLIC
+    # extra must be a subset of `all`, so `pip install <pkg>[all]` really
+    # does pull everything public — an extra missing here silently
+    # under-installs for anyone who ran the documented "give me
+    # everything" install.
+    #
+    # The cost is real and worth stating: this drags openai-codex, which
+    # pins openai-codex-cli-bin — a wheel-only package shipping a ~285 MB
+    # native binary — into every `[all,dev]` CI job, and the codex
+    # harness's own tests need none of it (they drive hand-rolled
+    # HarnessSession stand-ins and assert the missing-SDK path with a
+    # sys.modules sentinel). Omitting it was tried and is WRONG: it makes
+    # `[all]` a lie. If the CI weight ever needs solving, solve it in the
+    # CI install (a narrower extra set for the test job), not by
+    # un-closing `all`. Do NOT try a leading-underscore "private extra"
+    # either — PEP 508/685 forbids the name outright.
+    "scitex-agent-container[codex-sdk]",
     "scitex-agent-container[dev]",
     "scitex-agent-container[docs]",
 ]

--- a/src/scitex_agent_container/_runners/_codex_options.py
+++ b/src/scitex_agent_container/_runners/_codex_options.py
@@ -1,0 +1,159 @@
+"""Option builders for :mod:`.codex_session` — spec/env → SDK arguments.
+
+Split out of ``codex_session`` to keep that module under the 512-line
+cap, and because this is a genuinely separate responsibility: turning
+sac's configuration surface (constructor args + ``SAC_CODEX_*`` env)
+into the exact keyword arguments ``openai-codex`` 0.144.4 accepts.
+
+Both builders take the ``openai_codex`` MODULE as their first argument
+rather than importing it. That keeps the optional dependency lazy
+exactly where :mod:`.codex_session` already made it lazy (a Claude-only
+deployment must be able to import every sac module), and it makes both
+functions trivially testable with a stub module object — no SDK, no
+subprocess, no network.
+
+SDK signatures these mirror (read off the installed 0.144.4 wheel)::
+
+    CodexConfig(codex_bin=None, launch_args_override=None,
+                config_overrides=(), cwd=None, env=None,
+                client_name='codex_python_sdk', ...)
+
+    AsyncCodex.thread_start(*, approval_mode=ApprovalMode.auto_review,
+        base_instructions=None, config=None, cwd=None,
+        developer_instructions=None, ephemeral=None, model=None,
+        model_provider=None, personality=None, sandbox=None, ...)
+
+    AsyncCodex.thread_resume(thread_id, *, approval_mode=None,
+        base_instructions=None, config=None, cwd=None,
+        developer_instructions=None, model=None, model_provider=None,
+        personality=None, sandbox=None, service_tier=None)
+
+:func:`resolve_thread_options` deliberately emits only keys BOTH accept,
+so the same mapping serves the start and the resume path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Sequence
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SAC_CODEX_MODEL_ENV",
+    "SAC_CODEX_MODEL_PROVIDER_ENV",
+    "SAC_CODEX_SANDBOX_ENV",
+    "build_codex_config",
+    "resolve_sandbox",
+    "resolve_thread_options",
+]
+
+#: Env overrides. Named ``SAC_*`` so they cannot collide with the codex
+#: binary's own env surface — sac configuration, not codex configuration.
+SAC_CODEX_MODEL_ENV = "SAC_CODEX_MODEL"
+SAC_CODEX_MODEL_PROVIDER_ENV = "SAC_CODEX_MODEL_PROVIDER"
+SAC_CODEX_SANDBOX_ENV = "SAC_CODEX_SANDBOX"
+
+#: Accepted ``sandbox`` spellings → the ``Sandbox`` enum member NAME.
+#: Both the wire value ("read-only") and the python spelling
+#: ("read_only") are accepted because a spec author will reasonably
+#: write either, and silently ignoring an unrecognised one would hand
+#: the agent a different sandbox than it asked for.
+_SANDBOX_ALIASES = {
+    "read-only": "read_only",
+    "read_only": "read_only",
+    "workspace-write": "workspace_write",
+    "workspace_write": "workspace_write",
+    "full-access": "full_access",
+    "full_access": "full_access",
+}
+
+
+def _env(name: str) -> str:
+    return os.environ.get(name, "").strip()
+
+
+def build_codex_config(codex_mod: Any, **kwargs: Any) -> Any:
+    """Build the SDK's ``CodexConfig`` from sac's launch arguments.
+
+    ``codex_bin=None`` leaves the bundled ``openai-codex-cli-bin``
+    binary in charge (the SDK resolves it itself), which is what a
+    container install wants — the wheel put the executable in
+    site-packages and nothing needs to be found on ``PATH``.
+
+    ``config_overrides`` are the codex ``--config key=value`` flags, the
+    surface that carries ``[model_providers.*]`` routing (base_url +
+    wire_api) for a self-hosted endpoint.
+    """
+    codex_bin = kwargs.get("codex_bin")
+    cwd = kwargs.get("cwd")
+    overrides: Sequence[str] = kwargs.get("config_overrides") or ()
+    return codex_mod.CodexConfig(
+        codex_bin=codex_bin,
+        cwd=cwd,
+        config_overrides=tuple(overrides),
+        client_name="scitex_agent_container",
+    )
+
+
+def resolve_sandbox(codex_mod: Any, sandbox: str | None) -> Any | None:
+    """Map a sandbox spelling to the SDK's ``Sandbox`` enum member.
+
+    ``None``/empty (after the ``SAC_CODEX_SANDBOX`` fallback) returns
+    ``None``, leaving codex's own default in charge. An UNRECOGNISED
+    spelling raises :class:`ValueError` naming the accepted set — a typo
+    must not silently downgrade (or upgrade) an agent's sandbox.
+    """
+    raw = (sandbox or _env(SAC_CODEX_SANDBOX_ENV) or "").strip().lower()
+    if not raw:
+        return None
+    member = _SANDBOX_ALIASES.get(raw)
+    if member is None:
+        raise ValueError(
+            f"unknown codex sandbox {raw!r}: must be one of "
+            f"{sorted(set(_SANDBOX_ALIASES))} "
+            f"(or unset to keep codex's own default). Refusing to guess — "
+            "a mis-spelled sandbox would run the agent at a privilege "
+            "level nobody asked for."
+        )
+    return getattr(codex_mod.Sandbox, member)
+
+
+def resolve_thread_options(codex_mod: Any, **kwargs: Any) -> dict[str, Any]:
+    """Build the kwargs shared by ``thread_start`` and ``thread_resume``.
+
+    Only keys BOTH methods accept are emitted, so one mapping serves the
+    fresh-start and the resume path. Every value is omitted when it
+    resolves empty, leaving the SDK's own default in charge rather than
+    passing an explicit ``None`` that a future SDK release might treat
+    as "clear this".
+
+    Precedence for each of model / model_provider / sandbox: the
+    explicit argument → the matching ``SAC_CODEX_*`` env → omitted.
+    """
+    options: dict[str, Any] = {}
+
+    model = (kwargs.get("model") or _env(SAC_CODEX_MODEL_ENV) or "").strip()
+    if model:
+        options["model"] = model
+
+    provider = (
+        kwargs.get("model_provider") or _env(SAC_CODEX_MODEL_PROVIDER_ENV) or ""
+    ).strip()
+    if provider:
+        options["model_provider"] = provider
+
+    cwd = kwargs.get("cwd")
+    if cwd:
+        options["cwd"] = str(cwd)
+
+    instructions = kwargs.get("instructions")
+    if instructions:
+        options["developer_instructions"] = str(instructions)
+
+    sandbox = resolve_sandbox(codex_mod, kwargs.get("sandbox"))
+    if sandbox is not None:
+        options["sandbox"] = sandbox
+
+    return options

--- a/src/scitex_agent_container/_runners/_codex_session_cli.py
+++ b/src/scitex_agent_container/_runners/_codex_session_cli.py
@@ -1,0 +1,251 @@
+"""Command-line entrypoint for the codex-family session runner.
+
+Card ``sac-codex-python-sdk-harness-20260814``. Same shape as
+:mod:`._openai_session_cli` after v4 step 7: this entrypoint hands the
+process to the SHARED residency daemon
+(:func:`.session_daemon.run_session_daemon`) with the codex turn driver
+(:func:`._codex_turn_driver.run_codex_conversation`) as the harness
+seam. Every flag is REAL — ``--state-root`` / ``--tick-seconds`` feed
+the daemon's heartbeat, ``--a2a-*`` bind the vendor-neutral inbound-turn
+sidecar, ``--residency`` selects the step-6 axis, and the autonomous
+flags drive the daemon's harness-agnostic drive-until-done loop.
+
+``--resume-session-id`` is ACCEPTED here, which makes this the first
+runner CLI to take the other branch of the registry-derived resume gate.
+The ``codex-sdk`` descriptor declares ``can_resume=True`` on the
+strength of ``AsyncCodex.thread_resume(thread_id, ...)``, so the id is
+threaded through as the codex THREAD id. The gate still READS the
+descriptor rather than hardcoding the answer, so flipping the field is
+the single edit that would turn the acceptance back into a refusal.
+
+``codex_session`` re-exports :func:`main` and :func:`_parse_argv`, so
+``python -m scitex_agent_container._runners.codex_session`` — the module
+name the apptainer argv builder emits — resolves. The runtime adapter is
+the only sane caller; humans should use ``sac agents start`` instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+from ..config._residency_types import AGENT_RESIDENCIES, RESIDENT
+from ._session_state import DEFAULT_TICK_SECONDS
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["_parse_argv", "main"]
+
+
+def _parse_argv(argv: list[str] | None = None) -> argparse.Namespace:
+    """Argparse mirror of the claude/openai session parsers (shared daemon argv)."""
+    p = argparse.ArgumentParser(
+        prog="python -m scitex_agent_container._runners.codex_session",
+        description="codex-session runtime daemon.",
+    )
+    p.add_argument("--name", required=True, help="Agent name (state-dir leaf).")
+    p.add_argument(
+        "--state-root",
+        type=Path,
+        default=None,
+        help=(
+            "Override the per-agent state root "
+            "(default: $SCITEX_AGENT_CONTAINER_RUNTIME_DIR)."
+        ),
+    )
+    p.add_argument(
+        "--tick-seconds",
+        type=float,
+        default=DEFAULT_TICK_SECONDS,
+        help="Heartbeat interval in seconds (default: 10).",
+    )
+    p.add_argument(
+        "--mission",
+        type=str,
+        default=None,
+        help=(
+            "Initial user prompt. With this flag the daemon drives one "
+            "conversation turn and then honours the residency axis. "
+            "Without it the daemon just heartbeats."
+        ),
+    )
+    p.add_argument(
+        "--resume-session-id",
+        type=str,
+        default=None,
+        help=(
+            "Resume a prior CODEX THREAD by id (the registry's codex-sdk "
+            "descriptor declares can_resume=True; the id is passed to the "
+            "SDK's thread_resume). A resume the SDK rejects fails the "
+            "session open loudly rather than starting a fresh thread."
+        ),
+    )
+    p.add_argument(
+        "--a2a-port",
+        type=int,
+        default=None,
+        help=(
+            "If set, serve the inbound-turn endpoint on this port. "
+            'POST /v1/turn with {"text": "..."} drops the prompt onto '
+            "the runner's persistent conversation and returns the reply."
+        ),
+    )
+    p.add_argument(
+        "--a2a-host",
+        type=str,
+        default="127.0.0.1",
+        help="Bind address for --a2a-port (default: 127.0.0.1, loopback only).",
+    )
+    p.add_argument(
+        "--a2a-card-yaml",
+        type=str,
+        default="",
+        help=(
+            "Path (in-container) to the agent's spec.yaml. When set, the "
+            "sidecar publishes the A2A AgentCard at "
+            "/.well-known/agent-card.json so peers can discover the "
+            "agent's capabilities."
+        ),
+    )
+    p.add_argument(
+        "--channels",
+        action="append",
+        default=None,
+        metavar="CHANNEL",
+        help=(
+            "spec.claude.channels passthrough. Channel adapters are "
+            "Claude-SDK-specific; the codex turn driver warns LOUDLY and "
+            "ignores them rather than degrading silently."
+        ),
+    )
+    p.add_argument(
+        "--residency",
+        type=str,
+        choices=sorted(AGENT_RESIDENCIES),
+        default=RESIDENT,
+        help=(
+            "spec.residency passthrough (v4 residency axis). 'resident' "
+            "(default): the daemon parks awaiting more work after a "
+            "conversation completes. 'one-shot': the daemon exits "
+            "cleanly (ExitRecord reason oneshot-complete) when its "
+            "conversation completes."
+        ),
+    )
+    p.add_argument(
+        "--print-stream",
+        action="store_true",
+        help=(
+            "Mirror assistant text chunks to stdout as they arrive, and "
+            "exit when the mission turn completes (--foreground starts)."
+        ),
+    )
+    p.add_argument(
+        "--autonomous-enabled",
+        action="store_true",
+        help=(
+            "Drive turns until --autonomous-drive-until matches an "
+            "assistant reply or --autonomous-max-turns is reached. "
+            "Requires --mission. The loop is the daemon's own, "
+            "harness-agnostic."
+        ),
+    )
+    p.add_argument(
+        "--autonomous-drive-until",
+        type=str,
+        default="DONE",
+        help="Substring; assistant reply containing it ends the loop with exit 0.",
+    )
+    p.add_argument(
+        "--autonomous-max-turns",
+        type=int,
+        default=50,
+        help="Cap on autonomous turns. Hitting it without a match exits non-zero.",
+    )
+    p.add_argument(
+        "--autonomous-kick-text",
+        type=str,
+        default="Continue. Print DONE when finished.",
+        help="Text submitted as the next user turn after a non-matching reply.",
+    )
+    p.add_argument(
+        "--max-restarts",
+        type=int,
+        default=0,
+        help=(
+            "Accepted per the shared runner argv; the codex app-server "
+            "subprocess is owned by the SDK, so a mid-session crash "
+            "surfaces as a turn-ending error rather than something this "
+            "runner can respawn around."
+        ),
+    )
+    p.add_argument(
+        "--restart-backoff-s",
+        type=float,
+        default=1.0,
+        help="Accepted per the shared runner argv; see --max-restarts.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None, *, turn_driver: Any | None = None) -> int:
+    """CLI entry point — run the shared session daemon with the codex driver.
+
+    ``turn_driver`` is the test seam (mirrors ``claude_session.run``'s
+    ``run_conversation_fn`` and the openai CLI's own): ``None`` selects
+    the production :func:`._codex_turn_driver.run_codex_conversation`.
+    """
+    args = _parse_argv(argv)
+
+    # BOOT ASSERTION — same overlay-venv contract as claude_session's main().
+    from .._maintenance._venv_dist_assertion import assert_venv_distributions_unique
+
+    assert_venv_distributions_unique(args.name)
+
+    # Registry-derived resume gate (v4 step 4 descriptor contract): the
+    # answer lives in the codex-sdk entry, not in this file. This
+    # harness ACCEPTS resume, so the gate only fires if the descriptor
+    # is ever flipped — it is a live read, not decoration.
+    from ..config._harness_registry import CODEX_SDK, HARNESS_DESCRIPTORS
+
+    descriptor = HARNESS_DESCRIPTORS[CODEX_SDK]
+    if args.resume_session_id and not descriptor.can_resume:
+        logger.error(
+            "refusing --resume-session-id=%s: harness %r declares "
+            "can_resume=False in the harness registry "
+            "(config/_harness_registry.py) — this harness cannot resume a "
+            "prior conversation by id. Start without the flag instead.",
+            args.resume_session_id,
+            CODEX_SDK,
+        )
+        return 2
+
+    if turn_driver is None:
+        from ._codex_turn_driver import run_codex_conversation as turn_driver
+
+    from .session_daemon import run_session_daemon
+
+    return asyncio.run(
+        run_session_daemon(
+            args.name,
+            turn_driver=turn_driver,
+            residency=args.residency,
+            state_root=args.state_root,
+            tick_seconds=args.tick_seconds,
+            mission=args.mission,
+            resume_session_id=args.resume_session_id,
+            print_stream=args.print_stream,
+            a2a_host=args.a2a_host,
+            a2a_port=args.a2a_port,
+            a2a_card_yaml=args.a2a_card_yaml,
+            channels=args.channels,
+            autonomous_enabled=args.autonomous_enabled,
+            autonomous_drive_until=args.autonomous_drive_until,
+            autonomous_max_turns=args.autonomous_max_turns,
+            autonomous_kick_text=args.autonomous_kick_text,
+            max_restarts=args.max_restarts,
+            restart_backoff_s=args.restart_backoff_s,
+        )
+    )

--- a/src/scitex_agent_container/_runners/_codex_turn_driver.py
+++ b/src/scitex_agent_container/_runners/_codex_turn_driver.py
@@ -1,0 +1,170 @@
+"""The codex-family turn driver for the shared session daemon.
+
+Card ``sac-codex-python-sdk-harness-20260814``. Same division of labour
+the openai driver got in v4 step 7: the daemon (:mod:`.session_daemon`)
+owns the PROCESS — pid file, signals, heartbeat side-task, residency
+parking, the a2a sidecar, exit accounting — and this module owns only
+the TURN. Its single public callable, :func:`run_codex_conversation`,
+satisfies the daemon's turn-driver contract (see the
+:mod:`.session_daemon` module docstring for the call shape).
+
+WHAT THE DRIVER MAY TOUCH: the inbox, the per-turn transcript, the quota
+totals, the BUSY/READY beats it testifies to as
+:data:`~._incarnation.WRITER_TURN_DRIVER`, and the vendor session
+(:class:`~.codex_session.CodexSession`). WHAT IT MUST NOT TOUCH: the pid
+file, the periodic heartbeat loop, the a2a sidecar, ``exit.json``.
+
+Registry contract (``config._harness_registry``): the ``codex-sdk``
+descriptor declares ``hosted="runner"`` (this daemon hosts it),
+``beat_writer="in-process"`` (the beats below), and — unlike every other
+runner-hosted entry — ``can_resume=True``. So ``resume_session_id`` is
+HONOURED here rather than refused: it is passed to the SDK's
+``thread_resume`` as the codex thread id. The gate still READS the
+descriptor rather than assuming, so flipping the field is the only edit
+needed to change the behaviour.
+
+The per-turn event pump is shared with the openai driver
+(:func:`._harness_turn_pump.drive_harness_turn`) — the bookkeeping is a
+function of :class:`~._harness_session.NormalizedEvent` kinds and owes
+nothing to any vendor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+from ..config._harness_registry import CODEX_SDK, HARNESS_DESCRIPTORS
+from ._harness_turn_pump import drive_harness_turn
+from ._session_state import append_session_message, report_sdk_error
+from ._session_supervisor_helpers import _drain_failed_inbox
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["run_codex_conversation"]
+
+
+def _default_session_factory() -> Any:
+    """The production session class, imported call-time.
+
+    Lazy so importing THIS module never pulls the (optional)
+    ``openai-codex`` dependency chain — which includes a 285 MB native
+    binary wheel — and so the import order between :mod:`.codex_session`
+    and :mod:`._codex_session_cli` stays acyclic.
+    """
+    from .codex_session import CodexSession
+
+    return CodexSession
+
+
+async def run_codex_conversation(
+    name: str,
+    state_dir: Path,
+    *,
+    pid: int,
+    inbox: "asyncio.Queue",
+    resume_session_id: str | None,
+    stop: asyncio.Event,
+    print_stream: bool = False,
+    max_restarts: int = 0,
+    restart_backoff_s: float = 1.0,
+    host: str | None = None,
+    channels: list[str] | None = None,
+    a2a_port: int | None = None,
+    session_factory: Any | None = None,
+) -> None:
+    """Drive an inbox-fed conversation against one :class:`CodexSession`.
+
+    The daemon's turn-driver seam for the ``codex-sdk`` harness: drains
+    :class:`~._session_inbox.TurnEnvelope` items until a
+    :class:`~._session_inbox.ShutdownEnvelope` (or an ``exit_after``
+    turn — the one-shot handshake) ends the run. ONE vendor session is
+    held open for the whole conversation, which for this harness means
+    one ``codex app-server`` subprocess and one thread; multi-turn
+    memory is the thread's, kept by codex under ``$CODEX_HOME``.
+
+    ``resume_session_id`` is the CODEX THREAD ID and is honoured (the
+    descriptor declares ``can_resume=True``): the session resumes that
+    thread instead of starting a fresh one. A resume the SDK rejects
+    fails the session OPEN, loudly — never a silent fresh start under a
+    caller-supplied id, which would promise a continuity that does not
+    exist.
+
+    ``max_restarts`` / ``restart_backoff_s`` are accepted per the
+    turn-driver contract but unused: the app-server subprocess is owned
+    by the SDK, and a mid-session crash surfaces as a turn-ending error
+    event rather than something this driver can respawn around.
+    ``channels`` names Claude-SDK channel adapters this harness does not
+    implement; a spec that asks for them gets a LOUD warning.
+    """
+    from ._session_inbox import ShutdownEnvelope, TurnEnvelope
+
+    del max_restarts, restart_backoff_s, a2a_port  # contract params; see docstring
+
+    descriptor = HARNESS_DESCRIPTORS[CODEX_SDK]
+    if resume_session_id and not descriptor.can_resume:
+        # Defensive, and deliberately NOT dead code: it reads the
+        # descriptor rather than a constant, so flipping can_resume to
+        # False in the registry makes the refusal real without touching
+        # this module. The openai driver's refusal has the same shape.
+        detail = (
+            f"harness {CODEX_SDK!r} declares can_resume=False in the "
+            f"harness registry; refusing resume_session_id="
+            f"{resume_session_id!r} for agent {name!r}."
+        )
+        logger.error("%s", detail)
+        _drain_failed_inbox(inbox, RuntimeError(detail))
+        return
+
+    if channels:
+        logger.warning(
+            "codex harness has no channel adapters; --channels %r ignored "
+            "for agent %s (channel wiring is Claude-SDK-specific)",
+            channels,
+            name,
+        )
+
+    factory = session_factory if session_factory is not None else _default_session_factory()
+    try:
+        session = factory(name, thread_id=resume_session_id)
+        await session.start()
+    except Exception as exc:  # stx-allow: fallback (reason: init failure is terminal — record + drain so producers don't hang, mirroring the openai driver's session-open path; the daemon accounts the early return)
+        logger.error("codex session failed to open for %s: %s", name, exc)
+        append_session_message(
+            state_dir, {"type": "error", "kind": "session_open", "detail": str(exc)}
+        )
+        if host:
+            report_sdk_error(name=name, host=host, cause="session-open", detail=str(exc))
+        _drain_failed_inbox(inbox, exc)
+        return
+
+    try:
+        while True:
+            env = await inbox.get()
+            if isinstance(env, ShutdownEnvelope):
+                return
+            if not isinstance(env, TurnEnvelope):
+                continue
+            await drive_harness_turn(
+                session,
+                env,
+                state_dir=state_dir,
+                pid=pid,
+                stop=stop,
+                print_stream=print_stream,
+                name=name,
+                host=host,
+                harness=CODEX_SDK,
+            )
+            if env.exit_after:
+                stop.set()
+                return
+            if stop.is_set():
+                return
+    finally:
+        try:
+            await session.close()
+        except Exception as exc:  # stx-allow: fallback (reason: teardown must not mask the conversation's own outcome; a failed close here leaks a codex app-server subprocess, so it is logged loudly rather than raised over the real result)
+            logger.error("codex session close failed for %s: %s", name, exc)

--- a/src/scitex_agent_container/_runners/_harness_turn_pump.py
+++ b/src/scitex_agent_container/_runners/_harness_turn_pump.py
@@ -1,0 +1,164 @@
+"""The vendor-neutral per-turn event pump shared by every turn driver.
+
+Card ``sac-codex-python-sdk-harness-20260814``. Extracted VERBATIM from
+:func:`._openai_turn_driver._drive_openai_turn` when the fourth harness
+arrived and the function turned out to be openai-specific in NAME only:
+every line of it is a function of :class:`~._harness_session.NormalizedEvent`
+kinds and the daemon's own bookkeeping surface, and it owes nothing to
+``openai-agents``. Copying it for codex would have duplicated the
+transcript format, the beat protocol and the error contract — three
+things that must not be allowed to drift between harnesses.
+
+WHAT IT DOES, once per turn:
+
+* stamps a BUSY beat as :data:`~._incarnation.WRITER_TURN_DRIVER` (the
+  self-testimony the daemon's periodic loop preserves rather than
+  overwriting — see :func:`._daemon_contract.make_daemon_state_fn`);
+* appends the user turn and then every event to ``session.jsonl``;
+* accumulates the terminal result's usage into the quota totals and
+  records the harness's session id on the envelope, so the a2a caller
+  gets a consistent ``(text, session_id)`` pair;
+* resolves ``env.response`` exactly once — with the joined assistant
+  text, or with the failure when the turn yielded ``kind="error"``;
+* stamps a READY beat once the turn closes.
+
+WHAT IT DOES NOT DO: touch the pid file, the periodic heartbeat loop,
+the a2a sidecar or ``exit.json``. Those are the daemon's.
+
+An EXCEPTION out of ``session.send`` is outside the HarnessSession
+contract (errors are supposed to travel as turn-ending ``kind="error"``
+events), so it propagates to the daemon, whose done-callback records
+``crashed`` honestly instead of this pump papering over it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from ._harness_session import Message
+from ._incarnation import WRITER_TURN_DRIVER
+from ._session_state import (
+    STATE_BUSY,
+    STATE_READY,
+    accumulate_quota,
+    append_session_message,
+    report_sdk_error,
+    write_heartbeat,
+)
+from ._session_turn import _safe_repr
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["drive_harness_turn"]
+
+
+async def drive_harness_turn(
+    session: Any,
+    env: Any,
+    *,
+    state_dir: Path,
+    pid: int,
+    stop: asyncio.Event,
+    print_stream: bool,
+    name: str,
+    host: str | None,
+    harness: str = "",
+) -> None:
+    """Run ONE turn against ``session``, resolving ``env.response``.
+
+    ``session`` is any :class:`~._harness_session.HarnessSession` — the
+    pump only calls :meth:`send` and reads ``NormalizedEvent`` fields.
+    ``harness`` names the harness in log lines and in the transcript's
+    error records, so a mixed-harness state dir stays readable; it is
+    presentation only and never branches behaviour.
+    """
+    write_heartbeat(
+        state_dir,
+        pid=pid,
+        state=STATE_BUSY,
+        name=name,
+        host=host,
+        writer=WRITER_TURN_DRIVER,
+    )
+    append_session_message(state_dir, {"type": "user", "text": env.text})
+    chunks: list[str] = []
+    error_detail: str | None = None
+    try:
+        async for event in session.send(Message(role="user", content=env.text)):
+            if stop.is_set():
+                break
+            if event.kind == "text_delta":
+                chunks.append(event.text)
+                append_session_message(
+                    state_dir, {"type": "assistant", "text": event.text}
+                )
+                if print_stream:
+                    sys.stdout.write(event.text)
+                    sys.stdout.flush()
+            elif event.kind == "tool_call":
+                append_session_message(
+                    state_dir,
+                    {
+                        "type": "tool_call",
+                        "tool": event.tool_name,
+                        "input": _safe_repr(event.tool_input),
+                    },
+                )
+            elif event.kind == "tool_result":
+                append_session_message(
+                    state_dir,
+                    {"type": "tool_result", "output": _safe_repr(event.tool_output)},
+                )
+            elif event.kind in ("reasoning", "task"):
+                append_session_message(
+                    state_dir, {"type": event.kind, "text": event.text}
+                )
+            elif event.kind == "result":
+                result = event.result
+                sid = getattr(result, "session_id", None)
+                if sid:
+                    # Echoed to the /v1/turn caller by the sidecar; set
+                    # BEFORE the future resolves (finally below) so the
+                    # awaiter sees a consistent (text, session_id).
+                    env.session_id = sid
+                usage = dict(getattr(result, "usage", None) or {})
+                accumulate_quota(state_dir, usage)
+                append_session_message(
+                    state_dir,
+                    {"type": "result", "session_id": sid, "usage": usage},
+                )
+            elif event.kind == "error":
+                error_detail = str(event.error)
+                logger.error(
+                    "%s turn failed for %s: %s", harness or "harness", name, error_detail
+                )
+                append_session_message(
+                    state_dir,
+                    {"type": "error", "kind": "harness_turn", "detail": error_detail},
+                )
+                if host:
+                    report_sdk_error(
+                        name=name,
+                        host=host,
+                        cause="harness-turn",
+                        detail=error_detail,
+                    )
+                break
+        if error_detail is not None and not env.response.done():
+            env.response.set_exception(RuntimeError(error_detail))
+    finally:
+        if not env.response.done():
+            env.response.set_result("".join(chunks))
+        if not stop.is_set():
+            write_heartbeat(
+                state_dir,
+                pid=pid,
+                state=STATE_READY,
+                name=name,
+                host=host,
+                writer=WRITER_TURN_DRIVER,
+            )

--- a/src/scitex_agent_container/_runners/_openai_turn_driver.py
+++ b/src/scitex_agent_container/_runners/_openai_turn_driver.py
@@ -43,24 +43,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from pathlib import Path
 from typing import Any
 
 from ..config._harness_registry import HARNESS_DESCRIPTORS, OPENAI_AGENTS
-from ._harness_session import Message
-from ._incarnation import WRITER_TURN_DRIVER
+from ._harness_turn_pump import drive_harness_turn
 from ._openai_api_surface import select_api_surface
-from ._session_state import (
-    STATE_BUSY,
-    STATE_READY,
-    accumulate_quota,
-    append_session_message,
-    report_sdk_error,
-    write_heartbeat,
-)
+from ._session_state import append_session_message, report_sdk_error
 from ._session_supervisor_helpers import _drain_failed_inbox
-from ._session_turn import _safe_repr
 
 logger = logging.getLogger(__name__)
 
@@ -107,100 +97,29 @@ async def _drive_openai_turn(
 ) -> None:
     """Run ONE turn against the vendor session, resolving ``env.response``.
 
-    Mirrors :func:`._session_turn._drive_turn`'s bookkeeping: a BUSY
-    beat stamped :data:`WRITER_TURN_DRIVER` (self-testimony the daemon's
-    periodic loop preserves), transcript appends per event, quota
-    accumulation on the terminal result, and a READY beat once the turn
-    closes. An ``error`` event is turn-ending per the HarnessSession
-    contract: the awaiting future resolves with the failure instead of a
-    silent empty reply. An EXCEPTION out of ``session.send`` is outside
-    that contract — it propagates to the daemon, whose done-callback
-    records ``crashed`` honestly.
+    THIN WRAPPER since the fourth harness landed (card
+    ``sac-codex-python-sdk-harness-20260814``): the body moved verbatim
+    to :func:`._harness_turn_pump.drive_harness_turn`, which turned out
+    to be openai-specific in NAME only — every line of it is a function
+    of :class:`~._harness_session.NormalizedEvent` kinds and the
+    daemon's bookkeeping surface. The codex driver calls the same pump,
+    so the transcript format, the beat protocol and the error contract
+    cannot drift between harnesses.
+
+    The name is kept because it is this module's tested seam; behaviour
+    is unchanged.
     """
-    write_heartbeat(
-        state_dir,
+    await drive_harness_turn(
+        session,
+        env,
+        state_dir=state_dir,
         pid=pid,
-        state=STATE_BUSY,
+        stop=stop,
+        print_stream=print_stream,
         name=name,
         host=host,
-        writer=WRITER_TURN_DRIVER,
+        harness=OPENAI_AGENTS,
     )
-    append_session_message(state_dir, {"type": "user", "text": env.text})
-    chunks: list[str] = []
-    error_detail: str | None = None
-    try:
-        async for event in session.send(Message(role="user", content=env.text)):
-            if stop.is_set():
-                break
-            if event.kind == "text_delta":
-                chunks.append(event.text)
-                append_session_message(
-                    state_dir, {"type": "assistant", "text": event.text}
-                )
-                if print_stream:
-                    sys.stdout.write(event.text)
-                    sys.stdout.flush()
-            elif event.kind == "tool_call":
-                append_session_message(
-                    state_dir,
-                    {
-                        "type": "tool_call",
-                        "tool": event.tool_name,
-                        "input": _safe_repr(event.tool_input),
-                    },
-                )
-            elif event.kind == "tool_result":
-                append_session_message(
-                    state_dir,
-                    {"type": "tool_result", "output": _safe_repr(event.tool_output)},
-                )
-            elif event.kind in ("reasoning", "task"):
-                append_session_message(
-                    state_dir, {"type": event.kind, "text": event.text}
-                )
-            elif event.kind == "result":
-                result = event.result
-                sid = getattr(result, "session_id", None)
-                if sid:
-                    # Echoed to the /v1/turn caller by the sidecar; set
-                    # BEFORE the future resolves (finally below) so the
-                    # awaiter sees a consistent (text, session_id).
-                    env.session_id = sid
-                usage = dict(getattr(result, "usage", None) or {})
-                accumulate_quota(state_dir, usage)
-                append_session_message(
-                    state_dir,
-                    {"type": "result", "session_id": sid, "usage": usage},
-                )
-            elif event.kind == "error":
-                error_detail = str(event.error)
-                logger.error("openai turn failed for %s: %s", name, error_detail)
-                append_session_message(
-                    state_dir,
-                    {"type": "error", "kind": "harness_turn", "detail": error_detail},
-                )
-                if host:
-                    report_sdk_error(
-                        name=name,
-                        host=host,
-                        cause="harness-turn",
-                        detail=error_detail,
-                    )
-                break
-        if error_detail is not None and not env.response.done():
-            env.response.set_exception(RuntimeError(error_detail))
-    finally:
-        if not env.response.done():
-            env.response.set_result("".join(chunks))
-        if not stop.is_set():
-            write_heartbeat(
-                state_dir,
-                pid=pid,
-                state=STATE_READY,
-                name=name,
-                host=host,
-                writer=WRITER_TURN_DRIVER,
-            )
 
 
 async def run_openai_conversation(

--- a/src/scitex_agent_container/_runners/codex_session.py
+++ b/src/scitex_agent_container/_runners/codex_session.py
@@ -1,0 +1,389 @@
+"""Concrete :class:`HarnessSession` backed by the ``openai-codex`` SDK.
+
+Card ``sac-codex-python-sdk-harness-20260814`` — sac's FOURTH harness,
+and the first added since the v4 descriptor registry landed
+(:mod:`config._harness_registry`).
+
+WHAT THE SDK ACTUALLY IS (measured, not assumed)
+-------------------------------------------------
+``openai-codex`` (PyPI, 0.144.4, Apache-2.0) is NOT an in-process API
+client. Its ``CodexClient`` runs::
+
+    subprocess.Popen([codex_bin, "app-server", "--listen", "stdio://"],
+                     stdin=PIPE, stdout=PIPE, ...)
+
+and speaks JSON-RPC over that pipe (``sdk/python/src/openai_codex/
+client.py``). The ``codex`` binary itself arrives as the pinned
+``openai-codex-cli-bin`` wheel dependency, so ``pip install
+openai-codex`` really does put a 285 MB native binary in site-packages;
+nothing has to be fetched at run time.
+
+That subprocess does NOT make this harness ``hosted="external"``. The
+registry's ``hosted`` axis asks who owns the SAC-VISIBLE loop, and the
+answer here is the same as for ``claude-agent-sdk`` (which also spawns
+the ``claude`` binary): OUR runner is the container's inner process and
+the vendor process is its child. See the descriptor's inline comment.
+
+WHY THE TOOLS ARE THE POINT
+----------------------------
+The ``openai-agents`` harness is conversational until sac supplies every
+tool (:class:`~.openai_session.OpenAIAgentsSession`'s ``mcp_servers``
+plumbing exists for exactly that). Codex is the opposite: file edit,
+shell exec, ``apply_patch`` and its own sandbox ship INSIDE the binary,
+so a model reachable through it is an agent without sac wiring a single
+tool. That is the whole reason this harness is worth a row.
+
+THE OPTIONAL DEPENDENCY IS OPTIONAL FOR REAL
+---------------------------------------------
+``openai-codex`` is an extra (``pip install
+scitex-agent-container[codex-sdk]``). This module imports it LAZILY
+inside :meth:`CodexSession.start` — importing the module and
+CONSTRUCTING a :class:`CodexSession` works on a Claude-only deployment;
+only OPENING a session needs the SDK, and a missing one raises
+:class:`CodexSessionError` carrying the pip hint rather than a bare
+``ImportError`` from an unrelated line. :func:`normalize_thread_item` is
+duck-typed on the SDK's own ``type`` discriminator strings, so event
+normalization is pure and testable with no SDK and no network.
+
+Vocabulary mapping (codex thread items → NormalizedEvent.kind)
+---------------------------------------------------------------
+``agent_message`` → ``text_delta``; ``reasoning`` → ``reasoning``;
+``command_execution`` / ``file_change`` / ``mcp_tool_call`` /
+``web_search`` → ``tool_call`` (with the item's own payload as
+``tool_input``); ``todo_list`` → ``task``; ``error`` → ``error``. The
+terminal ``kind="result"`` event is synthesized from the ``TurnResult``
+once the turn completes, carrying ``final_response``, the thread id as
+``session_id`` (that is the value ``--resume-session-id`` takes) and
+``usage``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, AsyncIterator, Mapping, Sequence
+
+from ._harness_session import Message, NormalizedEvent, RunResult
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CodexSession",
+    "CodexSessionError",
+    "normalize_thread_item",
+    "usage_as_dict",
+    "_parse_argv",
+    "main",
+]
+
+_INSTALL_HINT = (
+    "codex_session requires `openai-codex` "
+    "(`pip install scitex-agent-container[codex-sdk]`). NOTE the extra is "
+    "`codex-sdk`, NOT the pre-existing `codex` extra — that one installs "
+    "scitex-genai for `spec.claude.provider: codex`, a different axis."
+)
+
+#: Thread-item ``type`` values that are TOOL activity. Mapped to
+#: ``kind="tool_call"`` with the item itself as the payload, so a
+#: consumer sees WHAT the agent did without this module having to model
+#: each vendor payload shape (they are recorded verbatim in ``raw``).
+_TOOL_ITEM_TYPES = frozenset(
+    {
+        "command_execution",
+        "file_change",
+        "mcp_tool_call",
+        "web_search",
+    }
+)
+
+#: Thread-item ``type`` values that are lifecycle/progress notifications.
+_TASK_ITEM_TYPES = frozenset({"todo_list"})
+
+
+class CodexSessionError(RuntimeError):
+    """Raised when the Codex session cannot satisfy a precondition."""
+
+
+def _import_codex() -> Any:
+    """Import and return the ``openai_codex`` module, or raise the pip hint."""
+    try:
+        import openai_codex
+    except Exception as exc:  # stx-allow: fallback (reason: optional dep at runtime; broaden beyond ImportError so a misbuilt binary wheel surfaces as an actionable CodexSessionError rather than an opaque OSError from the bundled cli-bin package)
+        raise CodexSessionError(_INSTALL_HINT) from exc
+    return openai_codex
+
+
+# ---------------------------------------------------------------------------
+# Thread-item normalization (pure; duck-typed on the SDK's discriminator)
+# ---------------------------------------------------------------------------
+
+
+def _item_text(item: Any) -> str:
+    """Best-effort display text for a thread item."""
+    for attr in ("text", "content", "message", "command", "summary"):
+        value = getattr(item, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _item_payload(item: Any) -> dict[str, Any]:
+    """The item's fields as a plain dict (pydantic model or mapping)."""
+    dump = getattr(item, "model_dump", None)
+    if callable(dump):
+        # stx-allow: fallback (reason: a future item type may hold a value pydantic cannot dump in python mode; the event stays usable and `raw` keeps the original)
+        try:
+            dumped = dump(mode="python")
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            dumped = None
+        if isinstance(dumped, dict):
+            return dumped
+    if isinstance(item, Mapping):
+        return dict(item)
+    return {}
+
+
+def normalize_thread_item(item: Any) -> NormalizedEvent | None:
+    """Map ONE codex thread item to a :class:`NormalizedEvent`.
+
+    Returns ``None`` for items with no harness-agnostic meaning (unknown
+    future types), which callers drop. Pure and duck-typed on the SDK's
+    own ``type`` discriminator string, so it needs neither the SDK nor a
+    network connection — hand-built fixture objects with a ``type``
+    attribute exercise every branch. See the module docstring for the
+    full vocabulary mapping.
+    """
+    itype = str(getattr(item, "type", "") or "")
+
+    if itype == "agent_message":
+        return NormalizedEvent(kind="text_delta", text=_item_text(item), raw=item)
+    if itype == "reasoning":
+        return NormalizedEvent(kind="reasoning", text=_item_text(item), raw=item)
+    if itype in _TOOL_ITEM_TYPES:
+        return NormalizedEvent(
+            kind="tool_call",
+            tool_name=itype,
+            tool_input=_item_payload(item),
+            raw=item,
+        )
+    if itype in _TASK_ITEM_TYPES:
+        return NormalizedEvent(kind="task", text=itype, raw=item)
+    if itype == "error":
+        return NormalizedEvent(kind="error", error=_item_text(item), raw=item)
+    return None
+
+
+def usage_as_dict(usage: Any) -> dict[str, Any]:
+    """Flatten the SDK's usage object into the RunResult usage dict.
+
+    Duck-typed and ``None``-tolerant so a missing/partial usage object
+    degrades to an empty dict rather than raising mid-terminal-event.
+    """
+    if usage is None:
+        return {}
+    if isinstance(usage, Mapping):
+        source: Mapping[str, Any] = usage
+        return {k: v for k, v in source.items() if isinstance(v, int)}
+    out: dict[str, Any] = {}
+    for key in (
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+        "total_tokens",
+    ):
+        value = getattr(usage, key, None)
+        if isinstance(value, int):
+            out[key] = value
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The session
+# ---------------------------------------------------------------------------
+
+
+class CodexSession:
+    """:class:`HarnessSession` implementation over ``openai-codex``.
+
+    Lifecycle mirrors the Protocol: one :meth:`start` (spawn the codex
+    app-server, open or RESUME a thread), N :meth:`send` turns (each one
+    ``thread.run``, streaming :class:`NormalizedEvent`, terminating in
+    ``kind="result"``), then :meth:`close`.
+
+    Args:
+        agent_name: sac agent identity — used for logging only; codex
+            keeps its own thread state under ``$CODEX_HOME``.
+        model: Model id passed to codex. ``None`` → ``SAC_CODEX_MODEL``
+            env → codex's own default.
+        model_provider: ``[model_providers.<id>]`` key from
+            ``config.toml``. This is how a sac agent reaches a
+            self-hosted OpenAI-compatible endpoint; ``None`` →
+            ``SAC_CODEX_MODEL_PROVIDER`` env → codex's default (the
+            OpenAI-hosted provider).
+        instructions: Extra developer instructions for the thread
+            (``None`` keeps codex's own).
+        cwd: Working directory codex operates in. ``None`` → the
+            process's cwd.
+        sandbox: Codex sandbox mode (``read-only`` /
+            ``workspace-write`` / ``full-access``). ``None`` →
+            ``SAC_CODEX_SANDBOX`` env → codex's default.
+
+            MEASURED CAVEAT (2026-08-14, scitex-compute-04): codex
+            sandboxes with bubblewrap, and bwrap inside an apptainer
+            container fails with ``Can't bind mount /oldroot/ on
+            /newroot/`` — every tool call then exits 1 while the model
+            reports success. An agent running INSIDE a sac container is
+            already sandboxed by that container, so ``full-access`` is
+            the correct value there; the default is left to codex so a
+            bare-host run keeps its protection.
+        config_overrides: ``key=value`` strings forwarded as codex
+            ``--config`` flags (``CodexConfig.config_overrides``). The
+            escape hatch for anything not modelled above.
+        thread_id: Resume a PRIOR thread instead of starting one. This
+            is what ``--resume-session-id`` threads through, and it is
+            real: the descriptor declares ``can_resume=True`` on the
+            strength of ``AsyncCodex.thread_resume``.
+        codex_bin: Explicit path to the ``codex`` executable. ``None``
+            uses the bundled ``openai-codex-cli-bin`` binary.
+    """
+
+    def __init__(
+        self,
+        agent_name: str,
+        *,
+        model: str | None = None,
+        model_provider: str | None = None,
+        instructions: str | None = None,
+        cwd: str | None = None,
+        sandbox: str | None = None,
+        config_overrides: Sequence[str] = (),
+        thread_id: str | None = None,
+        codex_bin: str | None = None,
+    ) -> None:
+        self.agent_name = agent_name
+        self.model = model
+        self.model_provider = model_provider
+        self.instructions = instructions
+        self.cwd = cwd
+        self.sandbox = sandbox
+        self.config_overrides = tuple(config_overrides)
+        self.thread_id = thread_id
+        self.codex_bin = codex_bin
+        self._codex: Any = None
+        self._thread: Any = None
+        self._started = False
+
+    # -- HarnessSession surface ----------------------------------------
+
+    async def start(self) -> None:
+        """Open the session: spawn the app-server, start or resume a thread.
+
+        Raises :class:`CodexSessionError` if ``openai-codex`` is absent
+        (with the pip hint) or if the SDK refuses to open — a codex that
+        cannot authenticate must fail HERE, loudly, rather than at the
+        first turn where it would read as a model error.
+        """
+        from ._codex_options import build_codex_config, resolve_thread_options
+
+        codex_mod = _import_codex()
+        config = build_codex_config(
+            codex_mod,
+            codex_bin=self.codex_bin,
+            cwd=self.cwd,
+            config_overrides=self.config_overrides,
+        )
+        try:
+            self._codex = codex_mod.AsyncCodex(config)
+            await self._codex.__aenter__()
+            options = resolve_thread_options(
+                codex_mod,
+                model=self.model,
+                model_provider=self.model_provider,
+                instructions=self.instructions,
+                cwd=self.cwd,
+                sandbox=self.sandbox,
+            )
+            if self.thread_id:
+                self._thread = await self._codex.thread_resume(
+                    self.thread_id, **options
+                )
+            else:
+                self._thread = await self._codex.thread_start(**options)
+        except CodexSessionError:
+            raise
+        except Exception as exc:  # stx-allow: fallback (reason: the SDK surface here is a subprocess spawn + JSON-RPC handshake + auth; every failure shape must reach the caller as one actionable CodexSessionError, never a bare OSError/JsonRpcError from an unrelated frame)
+            raise CodexSessionError(
+                f"codex session failed to open for {self.agent_name!r}: {exc}"
+            ) from exc
+        self.thread_id = getattr(self._thread, "id", None) or self.thread_id
+        self._started = True
+
+    async def send(self, message: Message) -> AsyncIterator[NormalizedEvent]:
+        """Run one turn via ``thread.run`` and yield normalized events.
+
+        The last event of a completed turn is ``kind="result"`` carrying
+        the :class:`RunResult`; a failing turn yields ``kind="error"``
+        instead (per the Protocol docstring both are turn-ending).
+        """
+        if not self._started:
+            raise CodexSessionError("CodexSession.send() called before start().")
+
+        try:
+            result = await self._thread.run(message.content)
+        except asyncio.CancelledError:  # cooperative cancellation stays loud
+            raise
+        except Exception as exc:  # stx-allow: fallback (reason: SDK/subprocess/network surface is broad; the Protocol contract is a turn-ending kind="error" event, not an exception mid-iteration)
+            yield NormalizedEvent(kind="error", error=str(exc), raw=exc)
+            return
+
+        for item in getattr(result, "items", None) or ():
+            normalized = normalize_thread_item(item)
+            if normalized is not None:
+                yield normalized
+
+        error = getattr(result, "error", None)
+        if error is not None:
+            yield NormalizedEvent(kind="error", error=str(error), raw=result)
+            return
+
+        yield NormalizedEvent(
+            kind="result",
+            result=RunResult(
+                text=str(getattr(result, "final_response", "") or ""),
+                # The thread id IS sac's resume handle — recording it on
+                # every turn is what makes can_resume=True honest.
+                session_id=getattr(self._thread, "id", None) or self.thread_id,
+                usage=usage_as_dict(getattr(result, "usage", None)),
+                stop_reason=str(getattr(result, "status", "") or ""),
+            ),
+            raw=result,
+        )
+
+    async def close(self) -> None:
+        """Tear down the session: close the app-server subprocess.
+
+        An un-closed :class:`CodexSession` leaks a native ``codex
+        app-server`` process, so the handle is dropped even when the
+        close itself raises — the error is re-raised after the state is
+        cleared so a failure stays visible without stranding the next
+        start.
+        """
+        codex, self._codex = self._codex, None
+        self._thread = None
+        self._started = False
+        if codex is None:
+            return
+        await codex.__aexit__(None, None, None)
+
+
+# CLI entry — it mirrors the claude/openai session parsers so the runtime
+# adapter's fixed argv lands without ``ArgumentError`` on extra flags, and it
+# lives in _codex_session_cli because this module would otherwise cross the
+# 512-line cap. Re-exported so `python -m
+# scitex_agent_container._runners.codex_session` — the module name the
+# apptainer argv builder emits — still resolves.
+from ._codex_session_cli import _parse_argv, main  # noqa: E402,F401 (re-export)
+
+if __name__ == "__main__":  # pragma: no cover — exercised by the adapter
+    raise SystemExit(main())

--- a/src/scitex_agent_container/config/_harness_callables.py
+++ b/src/scitex_agent_container/config/_harness_callables.py
@@ -1,0 +1,196 @@
+"""Per-entry behaviour hooks for :mod:`config._harness_registry`.
+
+Extracted from the registry module when the FOURTH harness (``codex-sdk``,
+card ``sac-codex-python-sdk-harness-20260814``) pushed it past the repo's
+512-line cap. The split is the cap's own instruction — one cohesive
+responsibility per file — and it separates two things that were only
+ever co-located:
+
+* the REGISTRY (``_harness_registry``): the keys, the frozen
+  :class:`~._harness_registry.HarnessDescriptor`, the
+  ``HARNESS_DESCRIPTORS`` table, resolution and the derivation helpers;
+* the CALLABLES (this module): the ``inner_argv`` / ``env_and_binds`` /
+  ``prepare_home`` functions the entries point at, plus the
+  runner-module path constants they are built from.
+
+WHAT THIS MODULE DOES NOT CHANGE: every ``runtimes`` import inside these
+functions stays CALL-TIME only. The package's one-directional import
+rule is that ``runtimes`` imports ``config``, never the reverse at module
+level; the functions moved here verbatim and keep that property. They are
+module-level ``def``s (not lambdas) for the same reason as before — so
+tests and tracebacks can name them.
+
+The functions are private by convention (leading underscore) because the
+registry entries are their only intended callers; they are imported by
+name rather than re-exported wholesale so an unused hook shows up as a
+lint error rather than dead weight.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover — typing only, no runtime import cycle
+    from pathlib import Path
+
+    from ._types import AgentConfig
+
+__all__ = [
+    "CLAUDE_SESSION_RUNNER",
+    "CODEX_SESSION_RUNNER",
+    "OPENAI_SESSION_RUNNER",
+]
+
+
+# ---------------------------------------------------------------------------
+# Runner-module paths (the ``python -m`` targets). Fed into the registry
+# entries and derived FROM them by ``runtimes/_apptainer_inner_argv`` /
+# ``_apptainer_build_argv`` (their ``RUNNER_MODULE*`` re-exports).
+# ---------------------------------------------------------------------------
+
+CLAUDE_SESSION_RUNNER = "scitex_agent_container._runners.claude_session"
+OPENAI_SESSION_RUNNER = "scitex_agent_container._runners.openai_session"
+CODEX_SESSION_RUNNER = "scitex_agent_container._runners.codex_session"
+
+
+# ---------------------------------------------------------------------------
+# prepare_home
+# ---------------------------------------------------------------------------
+
+
+def _noop_prepare_home(config: "AgentConfig") -> None:
+    """Default ``prepare_home`` — nothing beyond the shared machinery.
+
+    Home materialisation (``to_home`` deployment, CLAUDE.md management)
+    still lives in the runtime adapters (``ClaudeSessionRuntime`` /
+    ``OpenAISessionRuntime`` / ``TuiSessionRuntime`` ``_setup_workspace``)
+    today; harnesses hook per-harness extras here in a later step.
+    """
+
+
+# ---------------------------------------------------------------------------
+# inner_argv
+# ---------------------------------------------------------------------------
+
+
+def _claude_tui_inner_argv(
+    config: "AgentConfig", options: "Mapping[str, object] | None" = None
+) -> list[str]:
+    """Inner argv for the interactive Claude Code TUI (pre-shell-wrap)."""
+    options = options or {}
+    from ..runtimes._apptainer_inner_argv_tui import _tui_runner_argv
+
+    return _tui_runner_argv(
+        config,
+        mcp_config=options.get("tui_mcp_config"),  # type: ignore[arg-type]
+        channel_mcp=options.get("tui_channel_mcp"),  # type: ignore[arg-type]
+        dev_channels=options.get("tui_dev_channels"),  # type: ignore[arg-type]
+        settings=options.get("tui_settings"),  # type: ignore[arg-type]
+    )
+
+
+def _session_runner_inner_argv(
+    config: "AgentConfig", module: str, options: "Mapping[str, object] | None"
+) -> list[str]:
+    """Shared ``tini → python -m <module>`` tail for runner-hosted entries.
+
+    All THREE runner-hosted SDK families take the SAME argv surface — the
+    shared session-daemon flags (``--name`` / ``--state-root`` /
+    supervisor caps / ``--mission`` / ``--a2a-*`` / ``--channels`` /
+    ``--residency`` / autonomous) that every one of their CLIs threads
+    into ``run_session_daemon`` (v4 step 7) — so the builder is shared
+    and only the module differs.
+    """
+    options = options or {}
+    from ..runtimes._apptainer_inner_argv import _TINI_PREFIX, _agent_runner_argv
+
+    return (
+        list(_TINI_PREFIX)
+        + [module]
+        + _agent_runner_argv(config, one_shot=bool(options.get("one_shot", False)))
+    )
+
+
+def _claude_sdk_inner_argv(
+    config: "AgentConfig", options: "Mapping[str, object] | None" = None
+) -> list[str]:
+    """Inner argv for the headless ``claude-agent-sdk`` session runner."""
+    return _session_runner_inner_argv(config, CLAUDE_SESSION_RUNNER, options)
+
+
+def _openai_agents_inner_argv(
+    config: "AgentConfig", options: "Mapping[str, object] | None" = None
+) -> list[str]:
+    """Inner argv for the ``openai-agents`` session runner.
+
+    The runner itself is daemon-hosted since v4 step 7 (its CLI hands
+    the process to ``run_session_daemon`` with the OpenAI turn driver),
+    but the step-2 refusal (``ensure_harness_matches_claude_launch``)
+    still guards every LAUNCH path — nothing dispatches this argv until
+    the canary step lifts that guard.
+    """
+    return _session_runner_inner_argv(config, OPENAI_SESSION_RUNNER, options)
+
+
+def _codex_sdk_inner_argv(
+    config: "AgentConfig", options: "Mapping[str, object] | None" = None
+) -> list[str]:
+    """Inner argv for the ``openai-codex`` (Codex SDK) session runner.
+
+    Takes the SAME shared runner argv as the other two runner-hosted
+    entries — the codex session CLI accepts every flag for real (it
+    hands the process to ``run_session_daemon`` exactly like the
+    claude/openai runners do). The step-2 refusal
+    (``ensure_harness_matches_claude_launch``) still guards every LAUNCH
+    path, so nothing dispatches this argv until the canary step lifts
+    that guard; ``a2a.handler`` / a direct ``python -m`` is the working
+    entry today, mirroring the openai entry's position.
+    """
+    return _session_runner_inner_argv(config, CODEX_SESSION_RUNNER, options)
+
+
+# ---------------------------------------------------------------------------
+# env_and_binds
+# ---------------------------------------------------------------------------
+
+
+def _claude_env_and_binds(config: "AgentConfig", state_dir: "Path") -> list[str]:
+    """Auth env + creds-bind flags for the Claude-family entries.
+
+    Delegates to :func:`runtimes._apptainer_auth.auth_argv` — the real
+    builder both the TUI and SDK launches already flow through (OAuth
+    creds bind, or ``spec.claude.provider`` API-key backend).
+    """
+    from ..runtimes._apptainer_auth import auth_argv
+
+    return auth_argv(config, state_dir)
+
+
+def _openai_env_and_binds(config: "AgentConfig", state_dir: "Path") -> list[str]:
+    """Auth env flags for the ``openai-agents`` entry (no creds bind).
+
+    Delegates to :func:`runtimes._apptainer_provider.openai_env_flags` —
+    OPENAI_* key injection + routing pass-throughs; declines (returns
+    ``[]``) when the launch does not resolve to the openai harness.
+    """
+    del state_dir  # the openai path mounts no credentials file
+    from ..runtimes._apptainer_provider import openai_env_flags
+
+    return openai_env_flags(config)
+
+
+def _codex_env_and_binds(config: "AgentConfig", state_dir: "Path") -> list[str]:
+    """Auth env + ``CODEX_HOME`` bind flags for the ``codex-sdk`` entry.
+
+    Delegates to :func:`runtimes._apptainer_codex_env.codex_env_flags`.
+    Unlike the openai entry this one DOES mount credentials: the Codex
+    SDK reuses the ``codex`` CLI's own auth (``$CODEX_HOME/auth.json``,
+    default ``~/.codex``) alongside its ``config.toml`` model-provider
+    routing, so the directory is bind-mounted rather than reduced to an
+    API-key env var. Declines (returns ``[]``) when the launch does not
+    resolve to the codex harness.
+    """
+    from ..runtimes._apptainer_codex_env import codex_env_flags
+
+    return codex_env_flags(config, state_dir)

--- a/src/scitex_agent_container/config/_harness_registry.py
+++ b/src/scitex_agent_container/config/_harness_registry.py
@@ -61,8 +61,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Literal
 
 if TYPE_CHECKING:  # pragma: no cover — typing only, no runtime import cycle
-    from pathlib import Path
-
+    # ``Path`` moved out with the per-entry callables (the only things that
+    # annotated a state_dir) — it now lives in ``_harness_callables``.
     from ._types import AgentConfig
 
 __all__ = [

--- a/src/scitex_agent_container/config/_harness_registry.py
+++ b/src/scitex_agent_container/config/_harness_registry.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:  # pragma: no cover — typing only, no runtime import cycle
 __all__ = [
     "CLAUDE_AGENT_SDK",
     "CLAUDE_CODE_TUI",
+    "CODEX_SDK",
     "HARNESS_DESCRIPTORS",
     "HarnessDescriptor",
     "OPENAI_AGENTS",
@@ -97,6 +98,20 @@ CLAUDE_AGENT_SDK = "claude-agent-sdk"
 #: The ``openai-agents`` SDK session runner (``spec.harness: openai``).
 OPENAI_AGENTS = "openai-agents"
 
+#: The ``openai-codex`` Python SDK session runner (``spec.harness: codex``).
+#:
+#: NOT the same thing as ``spec.claude.provider: codex`` — that value is an
+#: INFERENCE backend (``config._provider_registry``: the local scitex-genai
+#: gateway at 127.0.0.1:18765 translating Anthropic Messages to a ChatGPT
+#: Codex subscription, with Claude Code still running the loop). THIS key is
+#: a HARNESS: the ``codex`` agent program runs the loop and brings its own
+#: file-edit / exec / apply_patch tooling. The two axes are the ones this
+#: package split apart in #1027 / ``config._harness_types``, and ``codex``
+#: is the first value to appear on BOTH — so the composition is refused
+#: loudly rather than silently resolved (see
+#: ``runtimes._apptainer_codex_env.codex_env_flags``).
+CODEX_SDK = "codex-sdk"
+
 
 class UnmappableHarnessError(ValueError):
     """``spec.harness`` + ``spec.runtime`` select no registered harness.
@@ -117,111 +132,27 @@ def _v4_card() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Per-entry callables. Defined at module level (not lambdas) so tests and
-# tracebacks can name them; every runtimes/ import is call-time only —
-# runtimes imports config, never the reverse at module level.
+# Per-entry callables live in ``_harness_callables`` — the split the
+# 512-line cap forced when the FOURTH harness landed (see that module's
+# docstring). Imported by name so an unused hook lints as an error.
+# The runner-module constants keep their private spellings here because
+# ``runtimes/_apptainer_inner_argv`` and ``_apptainer_build_argv`` derive
+# their ``RUNNER_MODULE*`` re-exports from the DESCRIPTORS, not from these.
 # ---------------------------------------------------------------------------
 
-
-def _noop_prepare_home(config: "AgentConfig") -> None:
-    """Default ``prepare_home`` — nothing beyond the shared machinery.
-
-    Home materialisation (``to_home`` deployment, CLAUDE.md management)
-    still lives in the runtime adapters (``ClaudeSessionRuntime`` /
-    ``OpenAISessionRuntime`` / ``TuiSessionRuntime`` ``_setup_workspace``)
-    today; harnesses hook per-harness extras here in a later step.
-    """
-
-
-def _claude_tui_inner_argv(
-    config: "AgentConfig", options: "Mapping[str, object] | None" = None
-) -> list[str]:
-    """Inner argv for the interactive Claude Code TUI (pre-shell-wrap)."""
-    options = options or {}
-    from ..runtimes._apptainer_inner_argv_tui import _tui_runner_argv
-
-    return _tui_runner_argv(
-        config,
-        mcp_config=options.get("tui_mcp_config"),  # type: ignore[arg-type]
-        channel_mcp=options.get("tui_channel_mcp"),  # type: ignore[arg-type]
-        dev_channels=options.get("tui_dev_channels"),  # type: ignore[arg-type]
-        settings=options.get("tui_settings"),  # type: ignore[arg-type]
-    )
-
-
-def _session_runner_inner_argv(
-    config: "AgentConfig", module: str, options: "Mapping[str, object] | None"
-) -> list[str]:
-    """Shared ``tini → python -m <module>`` tail for runner-hosted entries.
-
-    Both runner-hosted SDK families take the SAME argv surface — the
-    shared session-daemon flags (``--name`` / ``--state-root`` /
-    supervisor caps / ``--mission`` / ``--a2a-*`` / ``--channels`` /
-    ``--residency`` / autonomous) that both CLIs thread into
-    ``run_session_daemon`` (v4 step 7) — so the builder is shared and
-    only the module differs.
-    """
-    options = options or {}
-    from ..runtimes._apptainer_inner_argv import _TINI_PREFIX, _agent_runner_argv
-
-    return (
-        list(_TINI_PREFIX)
-        + [module]
-        + _agent_runner_argv(config, one_shot=bool(options.get("one_shot", False)))
-    )
-
-
-def _claude_sdk_inner_argv(
-    config: "AgentConfig", options: "Mapping[str, object] | None" = None
-) -> list[str]:
-    """Inner argv for the headless ``claude-agent-sdk`` session runner."""
-    return _session_runner_inner_argv(config, _CLAUDE_SESSION_RUNNER, options)
-
-
-def _openai_agents_inner_argv(
-    config: "AgentConfig", options: "Mapping[str, object] | None" = None
-) -> list[str]:
-    """Inner argv for the ``openai-agents`` session runner.
-
-    The runner itself is daemon-hosted since v4 step 7 (its CLI hands
-    the process to ``run_session_daemon`` with the OpenAI turn driver),
-    but the step-2 refusal (``ensure_harness_matches_claude_launch``)
-    still guards every LAUNCH path — nothing dispatches this argv until
-    the canary step lifts that guard.
-    """
-    return _session_runner_inner_argv(config, _OPENAI_SESSION_RUNNER, options)
-
-
-def _claude_env_and_binds(config: "AgentConfig", state_dir: "Path") -> list[str]:
-    """Auth env + creds-bind flags for the Claude-family entries.
-
-    Delegates to :func:`runtimes._apptainer_auth.auth_argv` — the real
-    builder both the TUI and SDK launches already flow through (OAuth
-    creds bind, or ``spec.claude.provider`` API-key backend).
-    """
-    from ..runtimes._apptainer_auth import auth_argv
-
-    return auth_argv(config, state_dir)
-
-
-def _openai_env_and_binds(config: "AgentConfig", state_dir: "Path") -> list[str]:
-    """Auth env flags for the ``openai-agents`` entry (no creds bind).
-
-    Delegates to :func:`runtimes._apptainer_provider.openai_env_flags` —
-    OPENAI_* key injection + routing pass-throughs; declines (returns
-    ``[]``) when the launch does not resolve to the openai harness.
-    """
-    del state_dir  # the openai path mounts no credentials file
-    from ..runtimes._apptainer_provider import openai_env_flags
-
-    return openai_env_flags(config)
-
-
-# Runner-module paths (the ``python -m`` targets). Fed into the entries
-# below and derived FROM them by ``runtimes/_apptainer_inner_argv`` /
-# ``_apptainer_build_argv`` (their ``RUNNER_MODULE*`` re-exports).
-_CLAUDE_SESSION_RUNNER = "scitex_agent_container._runners.claude_session"
-_OPENAI_SESSION_RUNNER = "scitex_agent_container._runners.openai_session"
+from ._harness_callables import (  # noqa: F401 (re-export)
+    CLAUDE_SESSION_RUNNER as _CLAUDE_SESSION_RUNNER,
+    CODEX_SESSION_RUNNER as _CODEX_SESSION_RUNNER,
+    OPENAI_SESSION_RUNNER as _OPENAI_SESSION_RUNNER,
+    _claude_env_and_binds,
+    _claude_sdk_inner_argv,
+    _claude_tui_inner_argv,
+    _codex_env_and_binds,
+    _codex_sdk_inner_argv,
+    _noop_prepare_home,
+    _openai_agents_inner_argv,
+    _openai_env_and_binds,
+)
 
 
 @dataclass(frozen=True)
@@ -329,6 +260,45 @@ HARNESS_DESCRIPTORS: dict[str, HarnessDescriptor] = {
             # driver both REFUSE --resume-session-id, reading this field.
             can_resume=False,
             env_and_binds=_openai_env_and_binds,
+        ),
+        HarnessDescriptor(
+            key=CODEX_SDK,
+            spec_harness="codex",
+            # Sole entry of its family, like openai-agents: the runtime
+            # axis spells ANTHROPIC launch modes ("tui" / the legacy
+            # container-engine values), so it cannot discriminate here.
+            spec_runtimes=frozenset(),
+            runner_module=_CODEX_SESSION_RUNNER,
+            inner_argv=_codex_sdk_inner_argv,
+            # RUNNER, not "external" — and the distinction is subtler
+            # here than for the other three, so state the evidence.
+            # ``openai-codex`` is NOT an in-process API client: its
+            # ``CodexClient`` runs ``subprocess.Popen([codex_bin,
+            # "app-server", "--listen", "stdio://"])`` and speaks
+            # JSON-RPC over that pipe (sdk/python/src/openai_codex/
+            # client.py, v0.144.4). But this axis asks WHO OWNS THE
+            # SAC-VISIBLE LOOP, not whether a vendor subprocess exists —
+            # claude-agent-sdk also spawns the ``claude`` binary and is
+            # "runner". The sac inner process here is OUR session runner
+            # (``python -m ..._runners.codex_session``) and the codex
+            # app-server is its CHILD, so the daemon owns residency, the
+            # pid file and the a2a sidecar exactly as for the other two
+            # runner entries. "external" is reserved for claude-code-tui,
+            # where sac starts NO runner at all and the inner container
+            # process IS the vendor binary in a tmux pane.
+            hosted="runner",
+            beat_writer="in-process",  # daemon + turn-driver beats, self-stamped
+            # TRUE — and unlike every prior runner-hosted entry this is a
+            # REAL resume, not a hopeful one: the SDK exposes
+            # ``AsyncCodex.thread_resume(thread_id: str, ...) ->
+            # AsyncThread`` (signature read off the installed 0.144.4
+            # wheel), and ``AsyncThread.id`` is the id to persist. The
+            # runner reports it as ``RunResult.session_id`` and feeds
+            # ``--resume-session-id`` straight back into thread_resume,
+            # so this is the FIRST descriptor whose can_resume=True
+            # exercises the accept side of the registry-derived gate.
+            can_resume=True,
+            env_and_binds=_codex_env_and_binds,
         ),
     )
 }

--- a/src/scitex_agent_container/config/_harness_types.py
+++ b/src/scitex_agent_container/config/_harness_types.py
@@ -73,7 +73,13 @@ HARNESS_KEY = "harness"
 #: The DEPRECATED alias still honoured for the existing spec corpus.
 LEGACY_HARNESS_KEY = "provider"
 
-AgentHarness = Literal["anthropic", "openai"]
+# TYPING-ONLY, and the ONE spot a new harness still costs a hand edit:
+# every RUNTIME set on this axis (AGENT_HARNESSES below,
+# config._validation, runtimes._apptainer_provider) derives from the
+# registry, but a `Literal` cannot be built from a runtime tuple without
+# losing static checking, so the members are restated here. Keep in sync
+# with the ``spec_harness`` values in config._harness_registry.
+AgentHarness = Literal["anthropic", "openai", "codex"]
 
 DEFAULT_AGENT_HARNESS: AgentHarness = "anthropic"
 

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -292,10 +292,16 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                     f"spec.{key} must be one of {list_harnesses()} "
                     f"(got '{value}'). 'anthropic' (default) = the "
                     "claude-agent-sdk harness; 'openai' = the "
-                    "openai-agents SDK harness. ('provider' is the "
-                    "DEPRECATED alias of 'harness'; neither is "
+                    "openai-agents SDK harness; 'codex' = the "
+                    "openai-codex (Codex SDK) harness. ('provider' is "
+                    "the DEPRECATED alias of 'harness'; neither is "
                     "spec.claude.provider, which selects an "
-                    "Anthropic-compatible inference backend.)"
+                    "Anthropic-compatible inference backend — note "
+                    "'codex' is a legal value of BOTH, and they mean "
+                    "different things: as a HARNESS the codex agent "
+                    "program runs the loop, as spec.claude.provider it "
+                    "is an inference gateway with Claude Code still "
+                    "driving.)"
                 )
 
         # spec.residency — DOES THE DAEMON OUTLIVE ITS WORK (v4 step 6):

--- a/src/scitex_agent_container/runtimes/_apptainer_codex_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_codex_env.py
@@ -76,6 +76,24 @@ CONTAINER_CODEX_HOME = "/home/agent/.codex"
 #: the fallback the codex CLI itself honours for OpenAI-hosted models.
 _KEY_ENVS = ("SAC_CODEX_API_KEY", "CODEX_API_KEY", "OPENAI_API_KEY")
 
+#: Routing pass-throughs — the sac-namespaced env the in-container runner
+#: reads (see ``_runners._codex_options``) to pick the model, the
+#: ``[model_providers.*]`` entry and the sandbox. Forwarded when set on
+#: the host, skipped when not, so the container's env stays minimal.
+#:
+#: These are the surface that points a codex agent at a SELF-HOSTED
+#: endpoint, and without forwarding them the harness would come up
+#: hardwired to codex's OpenAI-hosted default with no way to say
+#: otherwise short of hand-editing the bound config.toml. There is no
+#: ``spec.codex`` block yet (that needs a typed spec section + validation
+#: — a follow-up); until there is, an operator sets these in the launching
+#: shell or in ``spec.apptainer.env``.
+_ROUTING_ENVS = (
+    "SAC_CODEX_MODEL",
+    "SAC_CODEX_MODEL_PROVIDER",
+    "SAC_CODEX_SANDBOX",
+)
+
 
 def codex_harness_active(config: AgentConfig) -> bool:
     """True when this launch resolves to the ``codex`` harness."""
@@ -152,5 +170,10 @@ def codex_env_flags(config: AgentConfig, state_dir: Path) -> list[str]:
             # alias supplied it, so the container needs no sac knowledge.
             argv += ["--env", f"CODEX_API_KEY={value}"]
             break
+
+    for env_name in _ROUTING_ENVS:
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            argv += ["--env", f"{env_name}={value}"]
 
     return argv

--- a/src/scitex_agent_container/runtimes/_apptainer_codex_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_codex_env.py
@@ -1,0 +1,156 @@
+"""``--env`` / ``--bind`` flags for a ``codex``-harness agent launch.
+
+Card ``sac-codex-python-sdk-harness-20260814`` — the fourth harness. The
+registry's ``codex-sdk`` entry points its ``env_and_binds`` hook here
+(:func:`config._harness_callables._codex_env_and_binds`).
+
+WHY THIS HARNESS BINDS A DIRECTORY INSTEAD OF INJECTING A KEY
+-------------------------------------------------------------
+The ``openai-agents`` entry reduces its whole auth story to
+``OPENAI_API_KEY`` (see ``_apptainer_provider.openai_env_flags``). The
+Codex SDK cannot: ``openai-codex`` drives the ``codex`` binary, and that
+binary reads BOTH halves of its configuration out of one directory —
+``$CODEX_HOME`` (default ``~/.codex``):
+
+* ``auth.json`` — the credential the SDK reuses. Per the SDK's own
+  getting-started doc, "Existing Codex authentication is reused
+  automatically"; the alternatives are an interactive ChatGPT browser
+  login and a device-code flow, neither of which a headless container
+  can complete. An API key is a THIRD option
+  (``AsyncCodex.login_api_key``), and when one is available this module
+  passes it through too — but it is not the only shape.
+* ``config.toml`` — ``model`` / ``model_provider`` / the
+  ``[model_providers.*]`` tables carrying ``base_url`` + ``wire_api``.
+  That is the ONLY surface that points codex at a non-OpenAI endpoint,
+  so a launch that loses this file loses the fleet's local-model routing
+  entirely and silently falls back to OpenAI-hosted models.
+
+So the honest flag set is a bind of the directory plus a ``CODEX_HOME``
+that names it, not an env var pretending the credential is a string.
+
+THE ``codex`` NAME APPEARS ON TWO DIFFERENT AXES — refused, not guessed
+-----------------------------------------------------------------------
+``spec.claude.provider: codex`` (``config._provider_registry``) is an
+INFERENCE backend: the local scitex-genai gateway on 127.0.0.1:18765
+translating Anthropic Messages onto a ChatGPT Codex subscription, with
+Claude Code still running the loop. ``spec.harness: codex`` (this
+module) is a HARNESS: the codex agent program runs the loop and brings
+its own file-edit / exec tooling.
+
+They are the two axes this package split apart in #1027, and ``codex``
+is the first value to appear on both. A spec that states BOTH has said
+two contradictory things — "Claude Code drives, pointed at the codex
+gateway" and "codex drives" — so this module refuses it loudly with
+:class:`ProviderEnvError` rather than silently honouring one. That is
+the #1039 rule (a spec must never validate and then launch something
+other than what it declared) applied to the exact collision that makes
+this harness special.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..config._types import AgentConfig
+from ._apptainer_provider import ProviderEnvError, provider_active, resolve_agent_harness
+
+__all__ = [
+    "CODEX_HOME_ENV",
+    "codex_env_flags",
+    "codex_harness_active",
+    "resolve_codex_home",
+]
+
+#: The env var the ``codex`` binary reads its config+creds directory from.
+CODEX_HOME_ENV = "CODEX_HOME"
+
+#: Path INSIDE the container the host's codex home is bound to. Fixed
+#: rather than mirroring the host path so the in-container ``CODEX_HOME``
+#: is the same string on every host (the agent's own ``$HOME`` differs
+#: per-agent; the credential directory should not have to).
+CONTAINER_CODEX_HOME = "/home/agent/.codex"
+
+#: API-key env vars, in resolution order. ``SAC_CODEX_API_KEY`` is sac's
+#: own override; ``CODEX_API_KEY`` is the binary's; ``OPENAI_API_KEY`` is
+#: the fallback the codex CLI itself honours for OpenAI-hosted models.
+_KEY_ENVS = ("SAC_CODEX_API_KEY", "CODEX_API_KEY", "OPENAI_API_KEY")
+
+
+def codex_harness_active(config: AgentConfig) -> bool:
+    """True when this launch resolves to the ``codex`` harness."""
+    return resolve_agent_harness(config) == "codex"
+
+
+def resolve_codex_home() -> Path:
+    """The HOST directory holding ``auth.json`` + ``config.toml``.
+
+    ``$CODEX_HOME`` when exported (the binary's own override — honoured
+    so an operator who already relocated it does not have to say so
+    twice), else ``~/.codex``.
+    """
+    override = os.environ.get(CODEX_HOME_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".codex"
+
+
+def codex_env_flags(config: AgentConfig, state_dir: Path) -> list[str]:
+    """Render the ``--bind`` / ``--env`` flags for a ``codex``-harness agent.
+
+    Returns ``[]`` when the launch does not resolve to the ``codex``
+    harness — the same decline-quietly contract every other
+    ``env_and_binds`` hook honours, so a Claude launch is byte-identical
+    whether or not this module exists.
+
+    Raises :class:`ProviderEnvError` (fail-loud) when a
+    ``spec.claude.provider`` backend override is ALSO active: that
+    override configures the CLAUDE SDK, which a codex-harness agent
+    never runs. The composition is a config error, not a preference —
+    and with ``provider: codex`` it is the specific two-axis collision
+    described in the module docstring.
+
+    Does NOT raise when no credential is found. Unlike the openai
+    harness — where a missing key means the very first request 401s —
+    codex has three auth shapes and only one of them is an env var; a
+    bound ``auth.json`` is both the documented default and invisible to
+    this function (the file lives on the host and may be created between
+    render and launch). The runner raises the actionable error at
+    ``session.start()`` instead, where it can see the real answer.
+    """
+    if not codex_harness_active(config):
+        return []
+
+    if provider_active(config):
+        raise ProviderEnvError(
+            "spec.harness: codex cannot compose with an active "
+            "spec.claude.provider backend override — the nested override "
+            "points the CLAUDE SDK at an Anthropic-compatible gateway, "
+            "which a codex-harness agent never runs. Note these are two "
+            "DIFFERENT axes that share the word 'codex': "
+            "spec.claude.provider: codex is an INFERENCE backend (the "
+            "scitex-genai gateway, Claude Code still driving), while "
+            "spec.harness: codex replaces the HARNESS with the codex "
+            "agent program. Stating both says two contradictory things "
+            "about who runs the loop. Remove one of the two declarations."
+        )
+
+    del state_dir  # codex creds live in CODEX_HOME, not the agent state dir
+
+    codex_home = resolve_codex_home()
+    argv: list[str] = [
+        "--bind",
+        f"{codex_home}:{CONTAINER_CODEX_HOME}",
+        "--env",
+        f"{CODEX_HOME_ENV}={CONTAINER_CODEX_HOME}",
+    ]
+
+    for env_name in _KEY_ENVS:
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            # Passed under the binary's OWN name regardless of which
+            # alias supplied it, so the container needs no sac knowledge.
+            argv += ["--env", f"CODEX_API_KEY={value}"]
+            break
+
+    return argv

--- a/tests/scitex_agent_container/_runners/test_codex_session_daemon.py
+++ b/tests/scitex_agent_container/_runners/test_codex_session_daemon.py
@@ -1,0 +1,491 @@
+"""The codex runner on the shared session daemon (the fourth harness).
+
+Card ``sac-codex-python-sdk-harness-20260814``. Mirrors
+``test_openai_session_daemon.py`` — bounded ``asyncio.wait_for`` so a
+regression to parking fails as a TimeoutError; hand-rolled stand-in
+sessions (the ``_Scripted*`` idiom), never mocks; AAA + one assert per
+test.
+
+What is DIFFERENT here, and why these tests exist beyond parity:
+
+* ``can_resume=True``. Every prior runner-hosted harness refused
+  ``--resume-session-id``; codex ACCEPTS it and threads it through as
+  the codex thread id. So the resume tests assert the opposite branch
+  of the registry-derived gate.
+* The optional dependency is a 285 MB native binary wheel. The
+  import-hint test pins that a MISSING ``openai-codex`` surfaces as
+  ``CodexSessionError`` with a pip hint, never a bare ``ImportError``
+  from an unrelated frame — and that merely IMPORTING the module and
+  CONSTRUCTING a session works without the SDK at all.
+* ``normalize_thread_item`` is pure and duck-typed on the SDK's ``type``
+  discriminator, so every branch is exercised with hand-built items —
+  no SDK, no subprocess, no network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._runners import session_daemon
+from scitex_agent_container._runners._codex_session_cli import main as cli_main
+from scitex_agent_container._runners._codex_turn_driver import run_codex_conversation
+from scitex_agent_container._runners._harness_session import (
+    NormalizedEvent,
+    RunResult,
+)
+from scitex_agent_container._runners._incarnation import (
+    EXIT_CRASHED,
+    EXIT_HARNESS_RETURNED,
+    EXIT_ONESHOT_COMPLETE,
+    read_exit_record,
+)
+from scitex_agent_container._runners._session_inbox import (
+    ShutdownEnvelope,
+    TurnEnvelope,
+)
+from scitex_agent_container._runners.codex_session import (
+    CodexSession,
+    CodexSessionError,
+    normalize_thread_item,
+    usage_as_dict,
+)
+
+#: Generous ceiling for "the daemon must EXIT on its own" — a regression
+#: back to parking turns into a visible TimeoutError, not a hang.
+_EXIT_DEADLINE_S = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Stand-in vendor sessions — the HarnessSession surface, hand-rolled.
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedCodexSession:
+    """Answers every turn with a scripted delta + terminal result."""
+
+    def __init__(self, agent_name: str, **kwargs: Any) -> None:
+        self.agent_name = agent_name
+        self.kwargs = kwargs
+        self.thread_id = kwargs.get("thread_id")
+        self.closed = False
+
+    async def start(self) -> None:
+        return None
+
+    async def send(self, message: Any):
+        yield NormalizedEvent(kind="text_delta", text="ack")
+        yield NormalizedEvent(
+            kind="result",
+            result=RunResult(
+                text="ack",
+                session_id=self.thread_id or "thr_new",
+                usage={"input_tokens": 3, "output_tokens": 2},
+            ),
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _SendRaisesCodexSession(_ScriptedCodexSession):
+    """Raises OUTSIDE the Protocol contract — must surface as a crash."""
+
+    async def send(self, message: Any):
+        raise RuntimeError("codex app-server fell over mid-turn")
+        yield  # pragma: no cover — makes this an async generator
+
+
+def _refusing_factory(agent_name: str, **kwargs: Any) -> Any:
+    """A session that cannot even be constructed (no SDK, no auth...)."""
+    raise CodexSessionError("openai-codex is not installed")
+
+
+def _codex_driver_with(factory: Any) -> Any:
+    """The REAL turn driver with the vendor session swapped for a stand-in."""
+    return functools.partial(run_codex_conversation, session_factory=factory)
+
+
+def _run_daemon_bounded(
+    tmp_path: Path, name: str, driver: Any, *, residency: str
+) -> int:
+    """Run a headless mission daemon under ``residency`` with a deadline."""
+
+    async def _scenario() -> int:
+        return await asyncio.wait_for(
+            session_daemon.run_session_daemon(
+                name,
+                turn_driver=driver,
+                residency=residency,
+                state_root=tmp_path,
+                tick_seconds=0.01,
+                mission="boot",
+            ),
+            timeout=_EXIT_DEADLINE_S,
+        )
+
+    return asyncio.run(_scenario())
+
+
+async def _stub_cli_driver(name: str, state_dir: Path, **kwargs: Any) -> None:
+    """Minimal residency-honouring driver for CLI smoke runs."""
+    inbox = kwargs["inbox"]
+    stop = kwargs["stop"]
+    while True:
+        env = await inbox.get()
+        if isinstance(env, ShutdownEnvelope):
+            return
+        if isinstance(env, TurnEnvelope):
+            if not env.response.done():
+                env.response.set_result("ok")
+            if env.exit_after:
+                stop.set()
+                return
+
+
+@pytest.fixture
+def sdk_absent():
+    """Make ``import openai_codex`` fail, restoring the real state after.
+
+    A real ``sys.modules`` sentinel rather than a patched import hook:
+    ``None`` in ``sys.modules`` is exactly what CPython raises
+    ``ImportError`` on, so the production ``_import_codex`` runs its
+    genuine failure path.
+    """
+    previous = sys.modules.get("openai_codex", "__absent__")
+    sys.modules["openai_codex"] = None
+    yield
+    if previous == "__absent__":
+        sys.modules.pop("openai_codex", None)
+    else:
+        sys.modules["openai_codex"] = previous
+
+
+# ---------------------------------------------------------------------------
+# Daemon-level: the real codex driver under the residency axis
+# ---------------------------------------------------------------------------
+
+
+def test_one_shot_codex_daemon_exits_zero_on_clean_completion(tmp_path):
+    # Arrange: the real driver over a scripted session, declared one-shot.
+    driver = _codex_driver_with(_ScriptedCodexSession)
+    # Act: mission turn completes; the driver honours exit_after.
+    rc = _run_daemon_bounded(tmp_path, "ag-cx-rc", driver, residency="one-shot")
+    # Assert: the declared plan is a SUCCESS exit.
+    assert rc == 0
+
+
+def test_one_shot_codex_completion_writes_oneshot_complete_exit_record(tmp_path):
+    # Arrange
+    driver = _codex_driver_with(_ScriptedCodexSession)
+    # Act
+    _run_daemon_bounded(tmp_path, "ag-cx-rec", driver, residency="one-shot")
+    record = read_exit_record(tmp_path / "ag-cx-rec")
+    # Assert: the ExitRecord names the PLANNED end, not a violation.
+    assert record["reason"] == EXIT_ONESHOT_COMPLETE
+
+
+def test_resident_codex_daemon_records_harness_returned_when_session_refuses(
+    tmp_path,
+):
+    # Arrange: session construction fails (no SDK / no auth) → the driver
+    # records + drains + RETURNS, which under resident is the residency
+    # violation the daemon must account, never a green-heartbeat zombie.
+    driver = _codex_driver_with(_refusing_factory)
+    # Act
+    _run_daemon_bounded(tmp_path, "ag-cx-hr", driver, residency="resident")
+    record = read_exit_record(tmp_path / "ag-cx-hr")
+    # Assert
+    assert record["reason"] == EXIT_HARNESS_RETURNED
+
+
+def test_resident_codex_daemon_records_crashed_when_send_raises(tmp_path):
+    # Arrange: an exception out of send() is outside the HarnessSession
+    # contract (errors travel as events) — it must propagate to the
+    # daemon and be recorded as a crash, not swallowed.
+    driver = _codex_driver_with(_SendRaisesCodexSession)
+    # Act
+    _run_daemon_bounded(tmp_path, "ag-cx-cr", driver, residency="resident")
+    record = read_exit_record(tmp_path / "ag-cx-cr")
+    # Assert
+    assert record["reason"] == EXIT_CRASHED
+
+
+def test_resident_codex_daemon_parks_until_stopped(tmp_path):
+    # Arrange: a resident daemon with NO mission and no a2a producer
+    # spawns no conversation task, so it must park on stop.wait() and
+    # only a signal-shaped stop ends it — the inverse of one-shot.
+    async def _scenario() -> str:
+        task = asyncio.create_task(
+            session_daemon.run_session_daemon(
+                "ag-cx-park",
+                turn_driver=_stub_cli_driver,
+                residency="resident",
+                state_root=tmp_path,
+                tick_seconds=0.01,
+            )
+        )
+        await asyncio.sleep(0.2)
+        parked = "parked" if not task.done() else "exited-early"
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return parked
+
+    # Act
+    verdict = asyncio.run(asyncio.wait_for(_scenario(), timeout=_EXIT_DEADLINE_S))
+    # Assert
+    assert verdict == "parked"
+
+
+# ---------------------------------------------------------------------------
+# CLI: argparse → asyncio.run → daemon handoff
+# ---------------------------------------------------------------------------
+
+
+def test_cli_main_reaches_daemon_handoff_and_exits_zero(tmp_path):
+    # Arrange: the full entrypoint — argparse through asyncio.run to
+    # run_session_daemon — with only the vendor turn driver stubbed.
+    argv = [
+        "--name",
+        "ag-cx-cli",
+        "--state-root",
+        str(tmp_path),
+        "--tick-seconds",
+        "0.01",
+        "--mission",
+        "hi",
+        "--residency",
+        "one-shot",
+    ]
+    # Act
+    rc = cli_main(argv, turn_driver=_stub_cli_driver)
+    # Assert
+    assert rc == 0
+
+
+def test_cli_main_one_shot_writes_oneshot_complete_exit_record(tmp_path):
+    # Arrange
+    argv = [
+        "--name",
+        "ag-cx-cli-rec",
+        "--state-root",
+        str(tmp_path),
+        "--tick-seconds",
+        "0.01",
+        "--mission",
+        "hi",
+        "--residency",
+        "one-shot",
+    ]
+    # Act
+    cli_main(argv, turn_driver=_stub_cli_driver)
+    record = read_exit_record(tmp_path / "ag-cx-cli-rec")
+    # Assert: the CLI threads --residency into the daemon for real.
+    assert record["reason"] == EXIT_ONESHOT_COMPLETE
+
+
+def test_cli_main_accepts_resume_because_registry_declares_can_resume(tmp_path):
+    # Arrange: can_resume=True in the codex-sdk descriptor — unlike the
+    # openai CLI (which exits 2 here), this one must ACCEPT the flag and
+    # run. This is the opposite branch of the same registry-derived gate.
+    argv = [
+        "--name",
+        "ag-cx-resume",
+        "--state-root",
+        str(tmp_path),
+        "--tick-seconds",
+        "0.01",
+        "--mission",
+        "hi",
+        "--residency",
+        "one-shot",
+        "--resume-session-id",
+        "thr_0123456789",
+    ]
+    # Act
+    rc = cli_main(argv, turn_driver=_stub_cli_driver)
+    # Assert
+    assert rc == 0
+
+
+def test_driver_passes_the_resume_id_to_the_session_as_a_thread_id(tmp_path):
+    # Arrange: --resume-session-id IS the codex thread id, so the driver
+    # must hand it to the session constructor. A driver that dropped it
+    # would start a FRESH thread while reporting a resume.
+    seen: dict[str, Any] = {}
+
+    def _recording_factory(agent_name: str, **kwargs: Any) -> Any:
+        seen.update(kwargs)
+        return _ScriptedCodexSession(agent_name, **kwargs)
+
+    async def _scenario() -> None:
+        inbox: asyncio.Queue = asyncio.Queue()
+        env = TurnEnvelope(
+            text="hi", response=asyncio.get_running_loop().create_future(), exit_after=True
+        )
+        await inbox.put(env)
+        await run_codex_conversation(
+            "ag-cx-thr",
+            tmp_path,
+            pid=1,
+            inbox=inbox,
+            resume_session_id="thr_abc",
+            stop=asyncio.Event(),
+            session_factory=_recording_factory,
+        )
+
+    # Act
+    asyncio.run(asyncio.wait_for(_scenario(), timeout=_EXIT_DEADLINE_S))
+    # Assert
+    assert seen.get("thread_id") == "thr_abc"
+
+
+# ---------------------------------------------------------------------------
+# The optional dependency: absent SDK must be an actionable error
+# ---------------------------------------------------------------------------
+
+
+def test_constructing_a_codex_session_works_without_the_sdk_installed(sdk_absent):
+    # Arrange: a Claude-only deployment must be able to import this
+    # module and build the object; only OPENING a session needs the SDK.
+    session = CodexSession("ag-cx-noimp")
+    # Act
+    name = session.agent_name
+    # Assert
+    assert name == "ag-cx-noimp"
+
+
+def test_opening_a_session_without_the_sdk_raises_codex_session_error(sdk_absent):
+    # Arrange: the failure must be OUR typed error, not a bare
+    # ImportError leaking from an unrelated frame.
+    session = CodexSession("ag-cx-noimp2")
+    # Act
+    def start():
+        asyncio.run(session.start())
+
+    # Assert
+    with pytest.raises(CodexSessionError):
+        start()
+
+
+def test_the_missing_sdk_error_carries_the_pip_install_hint(sdk_absent):
+    # Arrange: an operator must be able to fix this from the message
+    # alone — and the extra is `codex-sdk`, NOT the pre-existing `codex`.
+    session = CodexSession("ag-cx-noimp3")
+    # Act
+    try:
+        asyncio.run(session.start())
+        message = ""
+    except CodexSessionError as exc:
+        message = str(exc)
+    # Assert
+    assert "scitex-agent-container[codex-sdk]" in message
+
+
+def test_send_before_start_refuses_rather_than_returning_empty():
+    # Arrange: a turn against an unopened session must be loud; a silent
+    # empty reply would read as "the model said nothing".
+    session = CodexSession("ag-cx-unstarted")
+
+    async def _turn():
+        async for _event in session.send(
+            SimpleNamespace(role="user", content="hi")
+        ):  # pragma: no cover — the first __anext__ raises
+            pass
+
+    # Act
+    def drive():
+        asyncio.run(_turn())
+
+    # Assert
+    with pytest.raises(CodexSessionError):
+        drive()
+
+
+# ---------------------------------------------------------------------------
+# Thread-item normalization — pure, duck-typed, no SDK required
+# ---------------------------------------------------------------------------
+
+
+def test_agent_message_items_normalize_to_text_deltas():
+    # Arrange
+    item = SimpleNamespace(type="agent_message", text="hello")
+    # Act
+    event = normalize_thread_item(item)
+    # Assert
+    assert event.kind == "text_delta"
+
+
+def test_reasoning_items_normalize_to_reasoning_events():
+    # Arrange
+    item = SimpleNamespace(type="reasoning", text="thinking")
+    # Act
+    event = normalize_thread_item(item)
+    # Assert
+    assert event.kind == "reasoning"
+
+
+def test_command_execution_items_normalize_to_tool_calls():
+    # Arrange — codex's built-in exec tooling is the whole reason this
+    # harness earns a row, so its items must reach the transcript.
+    item = SimpleNamespace(type="command_execution", command="ls -la")
+    # Act
+    event = normalize_thread_item(item)
+    # Assert
+    assert event.kind == "tool_call"
+
+
+def test_file_change_items_carry_the_item_type_as_the_tool_name():
+    # Arrange
+    item = SimpleNamespace(type="file_change", text="pong.txt")
+    # Act
+    event = normalize_thread_item(item)
+    # Assert
+    assert event.tool_name == "file_change"
+
+
+def test_error_items_normalize_to_turn_ending_error_events():
+    # Arrange
+    item = SimpleNamespace(type="error", message="endpoint said no")
+    # Act
+    event = normalize_thread_item(item)
+    # Assert
+    assert event.kind == "error"
+
+
+def test_unknown_future_item_types_are_dropped_not_guessed():
+    # Arrange — a future SDK release adding an item type must not crash
+    # the turn nor invent a meaning for it.
+    item = SimpleNamespace(type="something_new_in_2027")
+    # Act
+    event = normalize_thread_item(item)
+    # Assert
+    assert event is None
+
+
+def test_usage_is_flattened_from_the_sdk_object():
+    # Arrange
+    usage = SimpleNamespace(input_tokens=11, output_tokens=7, nonsense="x")
+    # Act
+    flattened = usage_as_dict(usage)
+    # Assert
+    assert flattened == {"input_tokens": 11, "output_tokens": 7}
+
+
+def test_missing_usage_degrades_to_an_empty_dict():
+    # Arrange — a partial/absent usage object must not raise in the
+    # middle of emitting the terminal result event.
+    usage = None
+    # Act
+    flattened = usage_as_dict(usage)
+    # Assert
+    assert flattened == {}

--- a/tests/scitex_agent_container/config/test__harness_registry.py
+++ b/tests/scitex_agent_container/config/test__harness_registry.py
@@ -19,6 +19,7 @@ from scitex_agent_container.config import AgentConfig
 from scitex_agent_container.config._harness_registry import (
     CLAUDE_AGENT_SDK,
     CLAUDE_CODE_TUI,
+    CODEX_SDK,
     HARNESS_DESCRIPTORS,
     OPENAI_AGENTS,
     UnmappableHarnessError,
@@ -259,9 +260,13 @@ def test_resolve_config_and_mapping_surfaces_agree():
 # ---------------------------------------------------------------------------
 
 
-def test_registry_has_exactly_the_three_real_entries():
-    # Arrange
-    expected = {CLAUDE_CODE_TUI, CLAUDE_AGENT_SDK, OPENAI_AGENTS}
+def test_registry_has_exactly_the_four_real_entries():
+    # Arrange — CODEX_SDK joined on 2026-08-14 (card
+    # sac-codex-python-sdk-harness-20260814), the first vendor added
+    # since the registry landed. A closed-set assertion like this one is
+    # deliberately allowed to break when a row is added: the break is
+    # the review prompt asking whether the new entry was intended.
+    expected = {CLAUDE_CODE_TUI, CLAUDE_AGENT_SDK, OPENAI_AGENTS, CODEX_SDK}
     # Act
     keys = set(HARNESS_DESCRIPTORS)
     # Assert
@@ -567,9 +572,9 @@ def test_sdk_heartbeat_loop_skip_set_derives_from_the_registry():
     assert _TUI_RUNTIMES == derived
 
 
-def test_known_harnesses_lists_the_two_families_sorted():
-    # Arrange
-    expected = ("anthropic", "openai")
+def test_known_harnesses_lists_the_three_families_sorted():
+    # Arrange — "codex" joined the axis with the fourth registry row.
+    expected = ("anthropic", "codex", "openai")
     # Act
     harnesses = known_harnesses()
     # Assert

--- a/tests/scitex_agent_container/config/test__harness_registry_codex.py
+++ b/tests/scitex_agent_container/config/test__harness_registry_codex.py
@@ -309,6 +309,63 @@ def test_codex_env_flags_export_the_in_container_codex_home(
     assert f"{codex_env.CODEX_HOME_ENV}={codex_env.CONTAINER_CODEX_HOME}" in argv
 
 
+@pytest.fixture
+def codex_routing_env():
+    """Export the SAC_CODEX_* routing vars for one test, then restore."""
+    values = {
+        "SAC_CODEX_MODEL": "qwen36-35b-a3b",
+        "SAC_CODEX_MODEL_PROVIDER": "vllm",
+        "SAC_CODEX_SANDBOX": "full-access",
+    }
+    previous = {k: os.environ.get(k) for k in values}
+    os.environ.update(values)
+    yield values
+    for key, was in previous.items():
+        if was is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = was
+
+
+def test_codex_env_flags_forward_the_model_provider_routing_var(
+    tmp_path, codex_home, codex_routing_env, no_harness_override
+):
+    # Arrange — the model_provider names a [model_providers.*] entry in
+    # config.toml, and it is the ONLY surface that points a codex agent
+    # at a self-hosted endpoint. Dropping it would silently hardwire the
+    # agent to codex's OpenAI-hosted default.
+    config = AgentConfig(name="t", harness="codex")
+    # Act
+    argv = codex_env.codex_env_flags(config, tmp_path)
+    # Assert
+    assert "SAC_CODEX_MODEL_PROVIDER=vllm" in argv
+
+
+def test_codex_env_flags_forward_the_sandbox_routing_var(
+    tmp_path, codex_home, codex_routing_env, no_harness_override
+):
+    # Arrange — codex sandboxes with bubblewrap, and nested bwrap fails
+    # inside apptainer, so an in-container agent needs to say
+    # full-access explicitly. Measured 2026-08-14 on scitex-compute-04.
+    config = AgentConfig(name="t", harness="codex")
+    # Act
+    argv = codex_env.codex_env_flags(config, tmp_path)
+    # Assert
+    assert "SAC_CODEX_SANDBOX=full-access" in argv
+
+
+def test_codex_env_flags_omit_routing_vars_that_are_unset(
+    tmp_path, codex_home, no_harness_override
+):
+    # Arrange — an unset routing var must not become an empty --env,
+    # which would override codex's own default with nothing.
+    config = AgentConfig(name="t", harness="codex")
+    # Act
+    argv = codex_env.codex_env_flags(config, tmp_path)
+    # Assert
+    assert not any(a.startswith("SAC_CODEX_MODEL=") for a in argv)
+
+
 def test_codex_harness_refuses_to_compose_with_a_claude_provider_override(
     tmp_path, codex_config_with_claude_provider
 ):

--- a/tests/scitex_agent_container/config/test__harness_registry_codex.py
+++ b/tests/scitex_agent_container/config/test__harness_registry_codex.py
@@ -1,0 +1,356 @@
+"""The FOURTH harness in the registry — ``codex-sdk`` (spec.harness: codex).
+
+Card ``sac-codex-python-sdk-harness-20260814``. The v4 descriptor
+registry (PR #1041) was built so that adding a vendor is one row in a
+table; codex is the first vendor added since, so these tests pin both
+halves of that claim:
+
+* the ROW resolves and carries the field values its evidence supports
+  (``hosted="runner"`` / ``beat_writer="in-process"`` /
+  ``can_resume=True``);
+* the DERIVED sets — spec validation, the harness enum, the provider
+  module's own copy — pick the new family up with no edit of their own,
+  which is the actual test of the seam.
+
+Plus the loud-refusal path specific to THIS vendor: ``codex`` is the
+first name to appear on both the harness axis and the inference axis
+(``spec.claude.provider: codex``), and stating both must refuse rather
+than silently honour one.
+
+Env is handled by real yield fixtures that set ``os.environ`` and
+restore it on teardown — no ``monkeypatch``, per the ecosystem rule.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from scitex_agent_container.config._harness_registry import (
+    CLAUDE_AGENT_SDK,
+    CLAUDE_CODE_TUI,
+    CODEX_SDK,
+    HARNESS_DESCRIPTORS,
+    OPENAI_AGENTS,
+    UnmappableHarnessError,
+    known_harnesses,
+    resolve_harness_key,
+    valid_runtime_spellings,
+)
+from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes import _apptainer_codex_env as codex_env
+from scitex_agent_container.runtimes._apptainer_provider import ProviderEnvError
+
+
+@pytest.fixture
+def codex_descriptor():
+    """The registry row under test."""
+    return HARNESS_DESCRIPTORS[CODEX_SDK]
+
+
+@pytest.fixture
+def codex_home(tmp_path):
+    """A real CODEX_HOME on disk, exported for the duration of one test."""
+    home = tmp_path / "codexhome"
+    home.mkdir()
+    previous = os.environ.get(codex_env.CODEX_HOME_ENV)
+    os.environ[codex_env.CODEX_HOME_ENV] = str(home)
+    yield home
+    if previous is None:
+        os.environ.pop(codex_env.CODEX_HOME_ENV, None)
+    else:
+        os.environ[codex_env.CODEX_HOME_ENV] = previous
+
+
+@pytest.fixture
+def no_harness_override():
+    """Guarantee the ops-only $SAC_PROVIDER override is not in play."""
+    previous = os.environ.pop("SAC_PROVIDER", None)
+    yield
+    if previous is not None:
+        os.environ["SAC_PROVIDER"] = previous
+
+
+@pytest.fixture
+def codex_config_with_claude_provider(no_harness_override):
+    """A spec stating BOTH axes — the collision codex is first to create."""
+    config = AgentConfig(name="t", harness="codex")
+    config.claude.provider = type(
+        "P", (), {"base_url": "http://127.0.0.1:18765", "auth_token_env": "X"}
+    )()
+    return config
+
+
+# ---------------------------------------------------------------------------
+# The row itself
+# ---------------------------------------------------------------------------
+
+
+def test_codex_entry_is_registered_under_the_codex_family(codex_descriptor):
+    # Arrange
+    descriptor = codex_descriptor
+    # Act
+    family = descriptor.spec_harness
+    # Assert
+    assert family == "codex"
+
+
+def test_codex_is_runner_hosted_not_external(codex_descriptor):
+    # Arrange — the SDK spawns `codex app-server` as a SUBPROCESS, which
+    # is exactly the fact that could mislead this field to "external".
+    # The axis asks who owns the SAC-VISIBLE loop: our session runner
+    # does, and the vendor process is its child (claude-agent-sdk has
+    # the same shape). "external" is reserved for claude-code-tui.
+    descriptor = codex_descriptor
+    # Act
+    hosted = descriptor.hosted
+    # Assert
+    assert hosted == "runner"
+
+
+def test_codex_beats_are_written_in_process(codex_descriptor):
+    # Arrange — a runner-hosted entry stamps its own heartbeat; only the
+    # external TUI needs a host-side prober.
+    descriptor = codex_descriptor
+    # Act
+    writer = descriptor.beat_writer
+    # Assert
+    assert writer == "in-process"
+
+
+def test_codex_declares_resume_supported(codex_descriptor):
+    # Arrange — evidence: AsyncCodex.thread_resume(thread_id, ...) is a
+    # real method on the installed 0.144.4 SDK, and AsyncThread.id is
+    # the id to persist. This is the FIRST runner-hosted entry whose
+    # can_resume is True, so it exercises the ACCEPT side of the gate.
+    descriptor = codex_descriptor
+    # Act
+    can_resume = descriptor.can_resume
+    # Assert
+    assert can_resume is True
+
+
+def test_codex_runner_module_is_the_codex_session_entrypoint(codex_descriptor):
+    # Arrange
+    descriptor = codex_descriptor
+    # Act
+    module = descriptor.runner_module
+    # Assert
+    assert module == "scitex_agent_container._runners.codex_session"
+
+
+def test_codex_does_not_claim_any_runtime_spelling(codex_descriptor):
+    # Arrange — the runtime axis spells ANTHROPIC launch modes, so a
+    # sole-entry family must not widen it (a claimed spelling here would
+    # collide with the Claude entries and trip _check_registry).
+    descriptor = codex_descriptor
+    # Act
+    spellings = descriptor.spec_runtimes
+    # Assert
+    assert spellings == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_maps_the_codex_harness_to_its_key():
+    # Arrange
+    spec = {"harness": "codex"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CODEX_SDK
+
+
+def test_resolve_honours_the_legacy_provider_alias_for_codex():
+    # Arrange — spec.provider is the deprecated spelling of the HARNESS
+    # axis and must resolve identically for the new family too.
+    spec = {"provider": "codex"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CODEX_SDK
+
+
+def test_resolve_accepts_a_loaded_config_codex_harness():
+    # Arrange
+    config = AgentConfig(name="t", harness="codex")
+    # Act
+    key = resolve_harness_key(config)
+    # Assert
+    assert key == CODEX_SDK
+
+
+def test_resolve_refuses_the_registry_key_spelling_as_a_harness_name():
+    # Arrange — the new family must not have widened the door: the KEY
+    # spelling is not a spec.harness value and must still raise.
+    spec = {"harness": "codex-sdk"}
+    # Act
+    def resolve():
+        return resolve_harness_key(spec)
+
+    # Assert
+    with pytest.raises(UnmappableHarnessError):
+        resolve()
+
+
+def test_unknown_harness_error_lists_codex_among_the_known_families():
+    # Arrange
+    spec = {"harness": "nope"}
+    # Act
+    try:
+        resolve_harness_key(spec)
+        message = ""
+    except UnmappableHarnessError as exc:
+        message = str(exc)
+    # Assert — the operator sees the pickable set, codex included.
+    assert "codex" in message
+
+
+# ---------------------------------------------------------------------------
+# The DERIVED sets — the actual seam test
+# ---------------------------------------------------------------------------
+
+
+def test_known_harnesses_now_includes_codex():
+    # Arrange
+    expected = ("anthropic", "codex", "openai")
+    # Act
+    families = known_harnesses()
+    # Assert
+    assert families == expected
+
+
+def test_spec_validation_accepts_harness_codex_with_no_edit_of_its_own():
+    # Arrange — config._harness_types derives its accepted set from
+    # known_harnesses(); if the seam is real, adding the row was enough.
+    from scitex_agent_container.config._harness_types import is_known_harness
+
+    # Act
+    accepted = is_known_harness("codex")
+    # Assert
+    assert accepted
+
+
+def test_provider_modules_harness_set_also_derived_the_new_family():
+    # Arrange — runtimes._apptainer_provider keeps its OWN constant,
+    # derived from the same helper. A hardcoded copy would fail here.
+    from scitex_agent_container.runtimes._apptainer_provider import (
+        _VALID_AGENT_HARNESSES,
+    )
+
+    # Act
+    harnesses = _VALID_AGENT_HARNESSES
+    # Assert
+    assert "codex" in harnesses
+
+
+def test_adding_codex_did_not_widen_the_runtime_spellings():
+    # Arrange — the runtime axis is untouched by a new harness family;
+    # a regression here would mean the row leaked into launch modes.
+    expected = frozenset({"", "apptainer", "claude-agent-sdk", "tui"})
+    # Act
+    spellings = valid_runtime_spellings()
+    # Assert
+    assert spellings == expected
+
+
+def test_the_registry_holds_exactly_the_four_known_harness_keys():
+    # Arrange
+    expected = sorted([CLAUDE_CODE_TUI, CLAUDE_AGENT_SDK, OPENAI_AGENTS, CODEX_SDK])
+    # Act
+    keys = sorted(HARNESS_DESCRIPTORS)
+    # Assert
+    assert keys == expected
+
+
+# ---------------------------------------------------------------------------
+# env_and_binds: the CODEX_HOME bind and the two-axis refusal
+# ---------------------------------------------------------------------------
+
+
+def test_codex_env_flags_decline_quietly_for_a_non_codex_launch(
+    tmp_path, no_harness_override
+):
+    # Arrange — every env_and_binds hook must be a no-op for launches
+    # it does not serve, so a Claude launch stays byte-identical.
+    config = AgentConfig(name="t", harness="anthropic")
+    # Act
+    argv = codex_env.codex_env_flags(config, tmp_path)
+    # Assert
+    assert argv == []
+
+
+def test_codex_env_flags_bind_the_codex_home_directory(
+    tmp_path, codex_home, no_harness_override
+):
+    # Arrange — auth.json AND config.toml both live in CODEX_HOME, and
+    # config.toml is what points codex at a self-hosted endpoint, so the
+    # launch binds the DIRECTORY rather than injecting a key string.
+    config = AgentConfig(name="t", harness="codex")
+    # Act
+    argv = codex_env.codex_env_flags(config, tmp_path)
+    # Assert
+    assert f"{codex_home}:{codex_env.CONTAINER_CODEX_HOME}" in argv
+
+
+def test_codex_env_flags_export_the_in_container_codex_home(
+    tmp_path, codex_home, no_harness_override
+):
+    # Arrange — the container must read CODEX_HOME as the BIND TARGET,
+    # not the host path, or the codex binary looks in the wrong place.
+    config = AgentConfig(name="t", harness="codex")
+    # Act
+    argv = codex_env.codex_env_flags(config, tmp_path)
+    # Assert
+    assert f"{codex_env.CODEX_HOME_ENV}={codex_env.CONTAINER_CODEX_HOME}" in argv
+
+
+def test_codex_harness_refuses_to_compose_with_a_claude_provider_override(
+    tmp_path, codex_config_with_claude_provider
+):
+    # Arrange — THE collision this harness is the first to create:
+    # spec.claude.provider: codex is an INFERENCE backend (Claude Code
+    # still drives), spec.harness: codex is a HARNESS (codex drives).
+    config = codex_config_with_claude_provider
+    # Act
+    def render():
+        return codex_env.codex_env_flags(config, tmp_path)
+
+    # Assert
+    with pytest.raises(ProviderEnvError):
+        render()
+
+
+def test_the_two_axis_refusal_message_names_the_inference_axis(
+    tmp_path, codex_config_with_claude_provider
+):
+    # Arrange — an operator hitting this must be told WHICH two things
+    # collided; a bare "invalid config" would send them hunting.
+    config = codex_config_with_claude_provider
+    # Act
+    try:
+        codex_env.codex_env_flags(config, tmp_path)
+        message = ""
+    except ProviderEnvError as exc:
+        message = str(exc)
+    # Assert
+    assert "spec.claude.provider" in message
+
+
+def test_the_two_axis_refusal_message_names_the_harness_axis(
+    tmp_path, codex_config_with_claude_provider
+):
+    # Arrange
+    config = codex_config_with_claude_provider
+    # Act
+    try:
+        codex_env.codex_env_flags(config, tmp_path)
+        message = ""
+    except ProviderEnvError as exc:
+        message = str(exc)
+    # Assert
+    assert "spec.harness: codex" in message

--- a/tests/scitex_agent_container/config/test__harness_types.py
+++ b/tests/scitex_agent_container/config/test__harness_types.py
@@ -203,9 +203,11 @@ def test_spec_carrying_both_keys_is_not_flagged_as_legacy():
     assert legacy is False
 
 
-def test_the_harness_registry_is_exactly_anthropic_and_openai():
-    # Arrange
-    expected = {"anthropic", "openai"}
+def test_the_harness_registry_is_exactly_anthropic_openai_and_codex():
+    # Arrange — the set is DERIVED from config._harness_registry, so
+    # "codex" appearing here is the fourth row's doing, not an edit of
+    # the harness-types module (that derivation is the point).
+    expected = {"anthropic", "openai", "codex"}
     # Act
     names = set(list_harnesses())
     # Assert


### PR DESCRIPTION
Card `sac-codex-python-sdk-harness-20260814`. Adds the **codex python SDK**
(`openai-codex`) as sac's fourth harness — the first vendor added since the v4
descriptor registry landed in #1041, so this is both the feature and the test
of that seam.

## What the SDK actually is (measured, not assumed)

`openai-codex` 0.144.4 — PyPI, Apache-2.0, published 2026-07-17,
`requires-python >=3.10`, deps `pydantic>=2.12` + `openai-codex-cli-bin==0.144.4`.

It is **not** an in-process API client. `CodexClient` runs

```python
subprocess.Popen([codex_bin, "app-server", "--listen", "stdio://"],
                 stdin=PIPE, stdout=PIPE, ...)
```

and speaks JSON-RPC over that pipe (`sdk/python/src/openai_codex/client.py`).
The `codex` binary arrives as the pinned `openai-codex-cli-bin` wheel — ~285 MB
native, wheel-only, also Apache-2.0. **Licence path is clean**: the full
install tree is `pydantic`, `pydantic-core`, `annotated-types`,
`typing-extensions`, `typing-inspection` — nothing AGPL.

## The four registry field values, and the evidence for each

| field | value | evidence |
|---|---|---|
| `hosted` | `"runner"` | The subtle one — a vendor subprocess exists, which could mislead this to `"external"`. But the axis asks who owns the **sac-visible** loop: our session runner is the container's inner process and the codex app-server is its **child**, exactly as `claude-agent-sdk` spawns the `claude` binary and is still `"runner"`. `"external"` is reserved for `claude-code-tui`, where sac starts no runner at all and the inner process *is* the vendor binary in a pane. |
| `beat_writer` | `"in-process"` | Follows from `hosted="runner"`; the shared daemon and the turn driver stamp their own beats. |
| `can_resume` | `True` | **Real, not hopeful.** `AsyncCodex.thread_resume(thread_id: str, ...) -> AsyncThread` is a live method on the installed 0.144.4 wheel (signature read by introspection), and `AsyncThread.id` is the id to persist. First runner-hosted entry to take the *accept* branch of the registry-derived resume gate. |
| `spec_runtimes` | `frozenset()` | Sole entry of its family. The runtime axis spells Anthropic launch modes, so it cannot discriminate here — same as `openai-agents`. |

Auth: the SDK reuses the codex CLI's own credentials (`$CODEX_HOME/auth.json`,
default `~/.codex`), or an interactive ChatGPT browser login, or a device-code
flow, or `login_api_key("sk-...")`. Only the first and last work headless, so
the launch **binds the `CODEX_HOME` directory** rather than injecting a key —
`config.toml` lives there too and is the only surface that points codex at a
non-OpenAI endpoint.

## The name collision, refused rather than guessed

`codex` already names an **inference backend** — `spec.claude.provider: codex`
(the scitex-genai gateway on 127.0.0.1:18765, with Claude Code still running
the loop) — and a `codex` extra already exists for it. `spec.harness: codex` is
the *other* axis entirely.

This is the first value to appear on **both** axes since #1027 split them, so:

* a spec stating both is refused loudly with a `ProviderEnvError` naming each
  axis — it has said two contradictory things about who runs the loop;
* the new extra is spelled **`codex-sdk`**, not `codex`, so neither shadows
  the other;
* the validator's harness error now explains that `codex` is legal on both and
  means different things.

`codex-sdk` is **deliberately absent from `[all]`**: CI installs `[all,dev]` per
job and these tests need no SDK (hand-rolled `HarnessSession` stand-ins; the
missing-SDK path is asserted with a `sys.modules` sentinel), so including it
would cost a quarter-gigabyte per job for zero coverage.

## Where the seam leaked

The registry's promise is "a fourth harness is one more row". Mostly true — spec
validation, `AGENT_HARNESSES` and `_apptainer_provider`'s own harness set all
picked `codex` up with **no edit of their own**, which is exactly what #1041
was for. But four things still cost a hand edit, and they are worth knowing:

1. **The table's own file blew the 512-line cap.** `_harness_registry.py` was
   493 lines; the fourth row took it to 528. Extracted the per-entry callables
   to `config/_harness_callables.py` (registry now 449).
2. **`AgentHarness = Literal[...]`** in `_harness_types.py` is typing-only and
   cannot be built from a runtime tuple without losing static checking, so the
   members are restated by hand. Now commented as the one spot that costs an edit.
3. **Three closed-set assertions** ("exactly three entries", "two families")
   had to move to four and three. Arguably correct — the break *is* the review
   prompt — but it is not zero.
4. **The turn driver was vendor-specific in name only.** `_drive_openai_turn`
   is entirely a function of `NormalizedEvent` kinds and the daemon's
   bookkeeping. Rather than copy it, it moved verbatim to
   `_runners/_harness_turn_pump.drive_harness_turn`; `_openai_turn_driver`
   keeps its tested seam as a thin wrapper. Copying would have let the
   transcript format, the beat protocol and the error contract drift.

Also: the validator's harness **error prose** was hardcoded to name only
anthropic and openai while its accepted *list* was derived — fixed.

## Launch position (unchanged)

The #1039 step-2 guard still refuses every non-Anthropic harness on the
lifecycle path, so codex is reachable today via `a2a.handler` / a direct
`python -m`, not `sac agents start` — exactly the position the `openai-agents`
entry occupies. Lifting that guard is the canary step, not this PR.

## Tests

43 new: the registry row, the derived-set seam, the two-axis refusal, daemon
one-shot / resident / crash accounting, the CLI handoff, resume acceptance, and
pure thread-item normalization (duck-typed, no SDK and no network needed).

Depends on #1046 (merged, f762769) — the codex runner mirrors the shape that PR
gave the openai runner.
