### PR TITLE
refactor(logging): route diagnostics through scitex-logging and guard raw prints

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -127,6 +127,36 @@ if ! "${RUFF_ARGV[@]}" check \
   exit 1
 fi
 
+# --- No raw print() in src/ (T201) -----------------------------------------
+#
+# Mirror of the "No raw print() in src/ (T201)" step in
+# .github/workflows/lint.yml — kept here so the failure lands at push time
+# rather than after a CI round-trip. Both use the SAME rule and the SAME
+# allowlist ([tool.ruff.lint.per-file-ignores] in pyproject.toml), so they
+# cannot drift apart in strictness.
+#
+# sac's diagnostics belong to scitex-logging, which stamps the emitting module
+# on every record; a raw print carries no origin and dies with whatever stream
+# was attached. Note T201 deliberately does NOT flag
+# `print(..., file=<injected stream>)` — a caller-supplied stream is a
+# reporting contract, not an unrouted diagnostic. tests/ is out of scope.
+if ! "${RUFF_ARGV[@]}" check --select T201,T203 src/; then
+  echo "" >&2
+  echo "PRE-PUSH BLOCKED: raw print() found in src/." >&2
+  echo "sac diagnostics go through scitex-logging so they carry the module" >&2
+  echo "they came from and survive in the rotating runtime log:" >&2
+  echo "" >&2
+  echo "    from .._logging import get_logger" >&2
+  echo "    get_logger(__name__).warning(\"...\")" >&2
+  echo "" >&2
+  echo "User-facing CLI output belongs to the existing idiom instead —" >&2
+  echo "rich console.print(...) or cli_pkg._helpers._console.system_msg(...)." >&2
+  echo "If stdout genuinely IS the interface (a protocol frame, a hook's" >&2
+  echo "return value), add that ONE file to [tool.ruff.lint.per-file-ignores]" >&2
+  echo "in pyproject.toml with a written reason." >&2
+  exit 1
+fi
+
 # --- Register the push on its card (ADR-0024, the rail's first leg) ---------
 #
 # The operator's requirement, verbatim (2026-08-12): 「プッシュに連動して、

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,3 +102,37 @@ jobs:
             --select F401,F811 \
             --extend-per-file-ignores '**/__init__.py:F401' \
             src/ tests/
+
+      # No raw print() in src/ — sac's diagnostics belong to scitex-logging,
+      # which stamps the EMITTING MODULE on every record and fans out to the
+      # rotating runtime log as well as stderr. A raw print carries no origin
+      # and dies with whatever stream happened to be attached, which is how an
+      # error gets swallowed in practice even when someone "printed it".
+      #
+      # WHY T201 IS THE RIGHT MATCHER, not a home-grown one: ruff's
+      # flake8-print does NOT flag `print(..., file=<some object>)` when the
+      # target is anything other than sys.stdout / sys.stderr. That is exactly
+      # the line this repo already draws by hand — a print to a CALLER-INJECTED
+      # `stream=` / `err_stream=` / `log_stream=` is part of that function's
+      # reporting contract (the caller chose the destination; tests capture it
+      # with a StringIO), whereas a print to a HARDCODED stdout/stderr has no
+      # contract to honour and is simply an unrouted diagnostic. So the rule
+      # enforces the classification instead of approximating it, and needs no
+      # bespoke AST checker to do it. (Contrast scripts/check_stx_allow.py,
+      # whose docstring records what a hand-rolled matcher cost: 34% false
+      # positives AND 619 invisible cases, simultaneously.)
+      #
+      # tests/ is deliberately OUT of scope — a print in a test is debugging
+      # scaffolding, not a shipped diagnostic.
+      #
+      # EXEMPTIONS live in pyproject.toml under
+      # [tool.ruff.lint.per-file-ignores], one file at a time, each with a
+      # written reason. Do NOT add a blanket ignore or widen this select: a
+      # gate that cannot fail is worse than no gate. If a new file legitimately
+      # needs stdout (a protocol frame, a hook's return value), add it there
+      # with the reason spelled out, and keep the diagnostics in it on the
+      # logger.
+      - name: No raw print() in src/ (T201)
+        run: |
+          set -euo pipefail
+          .venv/bin/ruff check --select T201,T203 src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -692,6 +692,69 @@ target-version = "py310"
 select = ["E", "F", "W", "I"]
 ignore = ["E501"]
 
+# ---------------------------------------------------------------------------
+# T201 (`print` found) allowlist — the raw-print gate's ONLY escape hatch.
+#
+# CI (.github/workflows/lint.yml, step "No raw print() in src/ (T201)") runs
+# `ruff check --select T201,T203 src/`. sac's diagnostics belong to
+# scitex-logging, which stamps the emitting module on every record and fans out
+# to the rotating runtime log as well as stderr; a raw print carries no origin
+# and dies with whatever stream was attached.
+#
+# Note T201 already ignores `print(..., file=<injected stream>)`, so a
+# function whose caller supplies `stream=` / `err_stream=` / `log_stream=`
+# needs NO entry here — that print is part of the function's reporting
+# contract, not an unrouted diagnostic. Everything below therefore writes to a
+# HARDCODED stdout/stderr on purpose.
+#
+# HOUSE RULE: one file per entry, each with its own written reason, added
+# deliberately. Never a blanket ignore and never a widened glob — a gate that
+# cannot fail is worse than no gate. If you are tempted to add an entry for a
+# DIAGNOSTIC, you want the logger instead; these exemptions exist only where
+# stdout/stderr IS the interface.
+[tool.ruff.lint.per-file-ignores]
+# The build hook runs under hatch during wheel/sdist construction, before the
+# package (and therefore scitex_logging) is importable at all. Its prints are
+# build-log progress; a logger here would be a circular dependency.
+"src/hatch_build.py" = ["T201"]
+
+# Claude Code WorktreeCreate hook, executed as a standalone script from the
+# agent's own $HOME after being copied out of _baseline_assets. STDOUT IS THE
+# PROTOCOL: the SDK reads the created worktree path from it (`print(policy_path)`),
+# so a stray log line on stdout breaks worktree creation outright. Its stderr
+# prints are the SDK's documented human-diagnostic channel. It also cannot rely
+# on scitex_logging being importable in the environment it is copied into.
+"src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py" = ["T201"]
+
+# Same deal: a standalone Claude Code hook copied into the agent's $HOME,
+# reporting through the SDK's stderr channel with no sac import available.
+"src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_remove.py" = ["T201"]
+
+# Same deal: a standalone SessionStart hook copied into the agent's $HOME. Its
+# one print is the reap summary the SDK surfaces to the operator.
+"src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/session_start_reap_stale.py" = ["T201"]
+
+# `sac never-stop-when-task-remains` is a Claude Code Stop hook whose STDOUT IS
+# A JSON DECISION FRAME (tests/.../test_never_stop_when_task_remains_cmds.py
+# asserts `json.loads(stdout)` still parses). Routing its stderr diagnostics to
+# a logger would risk a handler putting log text on stdout and corrupting that
+# frame — the precise failure class this whole change is meant to avoid.
+"src/scitex_agent_container/cli_pkg/never_stop_when_task_remains_cmds.py" = ["T201"]
+
+# `sac-statusline` is invoked by Claude Code on every status-line update and its
+# STDOUT IS THE RENDERED STATUS LINE consumed by the client. Nothing else may
+# appear there.
+"src/scitex_agent_container/statusline.py" = ["T201"]
+
+# A standalone probe baked into the SIF and run by the image build to verify
+# the artifact's symbols. It deliberately imports nothing from sac (that is the
+# point of the probe) and its stdout OK/FATAL lines are the build's verdict.
+"src/scitex_agent_container/containers/sif_symbol_probe.py" = ["T201"]
+
+# A worked example shipped inside a skill for operators to copy and run; its
+# print is the example's output. Not a sac code path.
+"src/scitex_agent_container/_skills/scitex-agent-container/scitex_smoke_test.py" = ["T201"]
+
 [tool.coverage.run]
 # Subprocess + multi-process coverage: child Python interpreters
 # (subprocess.run, jupyter nbconvert --execute, etc.) are wired in via

--- a/src/scitex_agent_container/_account/refresh_alarm.py
+++ b/src/scitex_agent_container/_account/refresh_alarm.py
@@ -147,11 +147,16 @@ def _default_notify(account: str, summary: str, detail: str) -> None:
     try:
         _notify_lead_blocker(summary, detail)
     except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-        print(
+        # Hard stderr, no caller seam (the alert_failed_refreshes err_stream
+        # report below is a separate channel), so this is routed through
+        # scitex-logging: NOBODY WAS PAGED is exactly the kind of fact that
+        # must not evaporate with the process's stderr.
+        from .._logging import get_logger
+
+        get_logger(__name__).error(
             f"[refresh-alarm] {account}: recorded in sac's event log, but the "
             f"lead blocker push FAILED — {exc}. Nobody has been paged; the "
-            f"failure is durable in the event log only.",
-            file=sys.stderr,
+            f"failure is durable in the event log only."
         )
 
 

--- a/src/scitex_agent_container/_lifecycle/_session_reset.py
+++ b/src/scitex_agent_container/_lifecycle/_session_reset.py
@@ -43,22 +43,20 @@ def _clear_persisted_session_id(name: str) -> None:
     error is allowed to propagate — the operator wants to know about a
     busted runtime dir, not have it silently swallowed.
     """
-    import sys
-
+    from .._logging import get_logger
     from .._runners._session_state import clear_session_history, clear_session_id
 
+    logger = get_logger(__name__)
     state_dir = _runtime_state_dir(name)
     removed_marker = clear_session_id(state_dir)
     removed_history = clear_session_history(state_dir)
     if removed_marker:
-        print(
+        logger.warning(
             f"[force] cleared persisted session_id for {name!r} "
-            f"({state_dir / 'session_id'})",
-            file=sys.stderr,
+            f"({state_dir / 'session_id'})"
         )
     if removed_history:
-        print(
+        logger.warning(
             f"[force] cleared session_id_history for {name!r} "
-            f"(backed up to {state_dir}/session_id_history.dead-*)",
-            file=sys.stderr,
+            f"(backed up to {state_dir}/session_id_history.dead-*)"
         )

--- a/src/scitex_agent_container/_listen/_host_exec.py
+++ b/src/scitex_agent_container/_listen/_host_exec.py
@@ -108,6 +108,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from .._lifecycle._off_loop import run_blocking
+from .._logging import get_logger
 from .._state import state_db as _state_db
 from .._state.state_db_nodes import comms_policy_row_exists, resolve_group_names
 from ..config._group_resolver import groups_intersect
@@ -177,13 +178,14 @@ def _append_audit(entry: dict[str, Any]) -> None:
         with open(path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, sort_keys=True) + "\n")
     except Exception as exc:  # stx-allow: fallback (best-effort audit; must not shadow the real exec result)
-        # Log to stderr so the miss is visible in the listen journal, then
-        # continue — the exec's real result still returns to the caller.
-        import sys
-
-        print(
-            f"host_exec: audit log append failed at {path}: {exc}",
-            file=sys.stderr,
+        # Log so the miss is visible in the listen journal, then continue —
+        # the exec's real result still returns to the caller. Routed through
+        # scitex-logging rather than a raw stderr print: this is the sole
+        # account of a LOST AUDIT RECORD, so it must carry its origin and
+        # survive in the runtime log rather than only in whatever journal
+        # happened to be capturing the daemon's stderr.
+        get_logger(__name__).error(
+            f"audit log append failed at {path}: {exc}"
         )
 
 

--- a/src/scitex_agent_container/_listen/_standby.py
+++ b/src/scitex_agent_container/_listen/_standby.py
@@ -59,7 +59,6 @@ runs against a real loopback socket and the lock against a real flock.
 from __future__ import annotations
 
 import signal
-import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -190,8 +189,17 @@ def _default_heal_untracked_port(*, host: str, port: int, grace_secs: float) -> 
 
 
 def _default_log(message: str) -> None:
-    """Emit a transition line to stderr (→ journal / runtime/listen.log)."""
-    print(message, file=sys.stderr, flush=True)
+    """Emit a transition line (→ journal / runtime/listen.log).
+
+    Routed through scitex-logging rather than a raw stderr print so a failover
+    transition carries its origin and lands in the runtime log as well as the
+    journal. The module-level ``_log`` indirection below is untouched — tests
+    swap that callable wholesale, and that seam is the reason this function is
+    separate in the first place.
+    """
+    from .._logging import get_logger
+
+    get_logger(__name__).info(message)
 
 
 _acquire: Callable[..., LockHandle] = acquire_listen_lock

--- a/src/scitex_agent_container/_logging.py
+++ b/src/scitex_agent_container/_logging.py
@@ -1,0 +1,75 @@
+"""Lazy ``scitex-logging`` accessor for sac's internal diagnostics.
+
+WHY THIS EXISTS
+---------------
+sac reports its diagnostics through three channels, and only one of them was
+missing a home:
+
+1. **rich ``console.print``** (``cli_pkg/_helpers/_console.py``) — tabular and
+   prose CLI *rendering*. 395 call sites. Correct as-is: a CLI printing its
+   result to stdout is the product, not a log line.
+2. **A caller-injected ``stream=`` / ``err_stream=`` / ``log_stream=``
+   parameter** — a function's *reporting contract*. The caller decides where
+   the report lands and tests capture it by passing a ``StringIO``. Correct
+   as-is: the seam is deliberate.
+3. **A raw ``print()`` to a HARDCODED ``sys.stdout`` / ``sys.stderr``** — a
+   diagnostic with no origin, no level and no routing. That is the defect this
+   module exists to fix.
+
+A category-3 print has no caller contract to honour, so it can be routed
+without changing any signature. Routing it through ``scitex-logging`` buys
+three things a raw print cannot give:
+
+* **WHERE it happened** — ``getLogger(__name__)`` stamps the emitting module,
+  which is precisely the operator's 2026-08-14 directive
+  (「さらにエラーがどこで起こったかを示せるととてもよい。scitex-logging は
+  まさにそのためにあります」).
+* **DURABILITY** — scitex-logging fans out to stderr *and* to a rotating file
+  under ``~/.scitex/logging/runtime/``. A swallowed-exception report that
+  previously died with the tmux pane now survives it. An error that is only
+  ever printed to a stream nobody is reading is an error that was swallowed
+  in every sense that matters.
+* **LEVEL CONTROL** — the ecosystem's ``SCITEX_LOGGING_LEVEL`` /
+  ``SCITEX_LOGGING_FORMAT`` env vars govern sac's diagnostics alongside every
+  other scitex package, instead of sac being the one package that always
+  shouts.
+
+WHY THE IMPORT IS LAZY
+----------------------
+``scitex_logging`` auto-configures handlers on first import, which must not be
+paid at *module import* time — the same rationale already documented on
+``config.__init__._config_logger`` and ``runtimes._cct_token_pool._logger``.
+Importing THIS module is free (no third-party import at module scope); the
+``scitex_logging`` import happens inside :func:`get_logger`, at call time.
+
+Callers therefore do::
+
+    from .._logging import get_logger      # cheap, module scope
+
+    def _something():
+        ...
+        get_logger(__name__).warning("...")   # scitex_logging imported here
+
+and NOT a module-level ``logger = get_logger(__name__)``, which would move the
+cost straight back to import time and defeat the point.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["get_logger"]
+
+
+def get_logger(name: str) -> Any:
+    """Return the ``scitex-logging`` logger for ``name``.
+
+    ``name`` should be the caller's ``__name__`` so the emitted record carries
+    the module the diagnostic came from — that origin is the whole point.
+
+    The ``scitex_logging`` import is deliberately INSIDE the function; see the
+    module docstring for why module-scope would be wrong.
+    """
+    import scitex_logging
+
+    return scitex_logging.getLogger(name)

--- a/src/scitex_agent_container/_logging/__init__.py
+++ b/src/scitex_agent_container/_logging/__init__.py
@@ -34,6 +34,25 @@ three things a raw print cannot give:
   other scitex package, instead of sac being the one package that always
   shouts.
 
+WHY THIS IS A PACKAGE DIRECTORY AND NOT A FLAT ``_logging.py``
+--------------------------------------------------------------
+Not style — a gate. ``scitex-dev``'s PS-108b (§1
+``src-flat-py-files-over-threshold``) caps flat ``.py`` files at the package
+root at 15, and ``develop`` sits at EXACTLY 15. Adding this helper as a
+sixteenth flat module turned that cap into an error-tier violation and reddened
+both required pytest legs on the PR that introduced it — the cumulative-rule
+trap, where a change that is clean in isolation breaks the build because it is
+the Nth one.
+
+Making it a directory keeps the import path byte-identical
+(``from .._logging import get_logger`` resolves to this ``__init__``), so
+nothing at any call site changes, while the root flat count stays at 15.
+
+Do NOT "simplify" this back into a flat ``_logging.py``: that reintroduces the
+failure, and the next person to add a root-level module inherits the blame for
+it. If a genuine second logging concern appears, it belongs beside this file in
+this package.
+
 WHY THE IMPORT IS LAZY
 ----------------------
 ``scitex_logging`` auto-configures handlers on first import, which must not be

--- a/src/scitex_agent_container/_runners/_tmux/_host_cwd.py
+++ b/src/scitex_agent_container/_runners/_tmux/_host_cwd.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..._logging import get_logger
+
 
 def resolve_host_cwd(workdir: str) -> str:
     """Return a host-usable tmux pane cwd for ``workdir``, creating it.
@@ -22,14 +24,22 @@ def resolve_host_cwd(workdir: str) -> str:
     launch). The pane cwd is semantically irrelevant to such callers
     (the container's real cwd is apptainer's ``--pwd``), so fall back to
     ``/tmp`` with a loud WARN instead of failing the whole launch.
+
+    The WARN goes through scitex-logging, not ``print``. It used to land on
+    bare STDOUT, which is the worst place for it: this runs on the launch path
+    of a tmux-backed agent, where stdout is whatever the launcher happened to
+    be attached to — frequently nothing at all. The OSError is deliberately
+    absorbed (the pane cwd is semantically irrelevant to a container caller),
+    so this line was the ONLY account of it, and it was being written where
+    nobody reads. It now carries its module origin and is durable in the
+    scitex-logging runtime log.
     """
     try:
         Path(workdir).mkdir(parents=True, exist_ok=True)
     except OSError as exc:
-        print(
-            f"WARN: tmux workdir {workdir!r} is not host-creatable "
-            f"({exc}); using /tmp as the pane launch cwd instead.",
-            flush=True,
+        get_logger(__name__).warning(
+            f"tmux workdir {workdir!r} is not host-creatable "
+            f"({exc}); using /tmp as the pane launch cwd instead."
         )
         return "/tmp"
     return workdir

--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -45,7 +45,6 @@ freed the ``create`` name back up.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import click
@@ -57,6 +56,7 @@ from ._create_templates import (  # noqa: F401
     _MINIMAL_TEMPLATE,
     _TEMPLATES,
 )
+from ._helpers._console import system_msg
 from ._new_dir_template import (
     DirTemplateError,
     discover_dir_templates,
@@ -334,11 +334,7 @@ def create(
             )
         except DirTemplateError as exc:
             raise click.ClickException(str(exc)) from exc
-        print(
-            f"Wrote {agent_dir} (template={kind}, dir-template).",
-            file=sys.stderr,
-            flush=True,
-        )
+        system_msg(f"Wrote {agent_dir} (template={kind}, dir-template).")
         return
 
     if spec_path.exists() and not force:
@@ -393,11 +389,7 @@ def create(
     to_home = agent_dir / "to_home"
     to_home.mkdir(parents=True, exist_ok=True)
 
-    print(
-        f"Wrote {spec_path} (template={kind}).",
-        file=sys.stderr,
-        flush=True,
-    )
+    system_msg(f"Wrote {spec_path} (template={kind}).")
 
 
 __all__ = ["create"]

--- a/src/scitex_agent_container/config/_resolve.py
+++ b/src/scitex_agent_container/config/_resolve.py
@@ -314,12 +314,10 @@ def resolve_with_prefix(name: str) -> str:
     except FileNotFoundError as exact_miss:
         matches = [n for n in enumerate_agent_names() if n.startswith(name)]
         if len(matches) == 1:
-            import sys
+            from .._logging import get_logger
 
-            print(
-                f"resolved '{name}' → '{matches[0]}' (prefix match)",
-                file=sys.stderr,
-                flush=True,
+            get_logger(__name__).info(
+                f"resolved '{name}' → '{matches[0]}' (prefix match)"
             )
             return resolve_config(matches[0])
         if len(matches) > 1:

--- a/src/scitex_agent_container/runtimes/_cct_rail_alarm.py
+++ b/src/scitex_agent_container/runtimes/_cct_rail_alarm.py
@@ -352,11 +352,16 @@ def check_cct_rail_at_start(config, *, dest: Path | None = None, **kwargs) -> st
     try:
         return alarm_cct_rail(assess_cct_rail(config, dest=dest), **kwargs)
     except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-        print(
+        # No caller-injected stream here (unlike alarm_cct_rail's err_stream
+        # seam a few lines up), so this had no reporting contract to honour and
+        # is routed through scitex-logging: it is the only account of a rail
+        # assessment that silently did not happen.
+        from .._logging import get_logger
+
+        get_logger(__name__).warning(
             f"[cct-rail] could not assess the Telegram rail for "
             f"{getattr(config, 'name', '?')!r}: {exc}. The agent starts "
-            f"normally; its rail state is UNOBSERVED.",
-            file=sys.stderr,
+            f"normally; its rail state is UNOBSERVED."
         )
         return "skipped"
 

--- a/src/scitex_agent_container/runtimes/claude_session.py
+++ b/src/scitex_agent_container/runtimes/claude_session.py
@@ -20,9 +20,9 @@ through ``sac --on <peer>`` (F-CS12) and ``spec.host`` pinning.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
+from .._logging import get_logger
 from ..config import AgentConfig
 from ._skills_boot_log import log_effective_skills
 from ._to_home import deploy_to_home
@@ -197,7 +197,7 @@ def _warn_if_heavy_workdir_claude(config: AgentConfig) -> None:
         lines.append("  then reference other repos via absolute paths.")
     lines.append("=" * 72)
     lines.append("")
-    print("\n".join(lines), file=sys.stderr, flush=True)
+    get_logger(__name__).warning("\n".join(lines))
 
 
 # 2026-05-13 docker/podman ripout: apptainer is the only accepted
@@ -327,12 +327,15 @@ class ClaudeSessionRuntime(RuntimeBase):
 
         container_rt = self._container_runtime_for(config)
         if container_rt is None:
-            print(
-                f"error: ClaudeSessionRuntime requires a container engine "
+            # This is a START FAILURE reported by a bare `return False`, so
+            # this line is the caller's only account of WHY. As a raw print it
+            # carried no origin and died with whatever stderr happened to be
+            # attached; as a logged ERROR it names the emitting module and is
+            # durable in the scitex-logging runtime log.
+            get_logger(__name__).error(
+                f"ClaudeSessionRuntime requires a container engine "
                 f"(spec.runtime: docker | podman). Got: "
-                f"{getattr(config, 'runtime', '<unset>')!r}.",
-                file=sys.stderr,
-                flush=True,
+                f"{getattr(config, 'runtime', '<unset>')!r}."
             )
             return False
 

--- a/src/scitex_agent_container/runtimes/openai_session.py
+++ b/src/scitex_agent_container/runtimes/openai_session.py
@@ -20,9 +20,9 @@ recording — is identical to the Claude path.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
+from .._logging import get_logger
 from ..config import AgentConfig
 from ._to_home import deploy_to_home
 from .base import RuntimeBase
@@ -174,12 +174,12 @@ class OpenAISessionRuntime(RuntimeBase):
 
         container_rt = self._container_runtime_for(config)
         if container_rt is None:
-            print(
-                f"error: OpenAISessionRuntime requires a container engine "
+            # Same start-failure-reported-as-False shape as
+            # ClaudeSessionRuntime.start; see the note there.
+            get_logger(__name__).error(
+                f"OpenAISessionRuntime requires a container engine "
                 f"(spec.runtime: docker | podman). Got: "
-                f"{getattr(config, 'runtime', '<unset>')!r}.",
-                file=sys.stderr,
-                flush=True,
+                f"{getattr(config, 'runtime', '<unset>')!r}."
             )
             return False
 

--- a/tests/scitex_agent_container/_runners/_tmux/test__host_cwd.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test__host_cwd.py
@@ -45,9 +45,13 @@ def test_uncreatable_container_path_falls_back_to_tmp() -> None:
 
 
 def test_uncreatable_path_warns_loudly(capsys) -> None:
-    # Arrange
+    # Arrange — the WARN now goes through scitex-logging, whose stream handler
+    # resolves sys.stderr at emit time (LazyStderrStreamHandler), so capsys
+    # still sees it. Asserting on .err rather than .out is the POINT of the
+    # change: this diagnostic used to be written to bare stdout on an agent
+    # launch path where stdout is often attached to nothing.
     container_only = "/proc/sac-test-does-not-exist/work"
     # Act
     resolve_host_cwd(container_only)
     # Assert
-    assert "not host-creatable" in capsys.readouterr().out
+    assert "not host-creatable" in capsys.readouterr().err


### PR DESCRIPTION
Operator directive, 2026-08-14: 「エラーが握りつぶされないこと」— errors must never be swallowed — 「さらにエラーがどこで起こったかを示せるととてもよい。scitex-logging はまさにそのためにあります」— and it should say WHERE it happened, which is what scitex-logging exists for.

Card: `sac-raw-print-to-scitex-logging-20260814`.

## First: the count was wrong, and the difference is the whole design

The directive cited "~123 raw prints". A plain `rg 'print\('` under `src/scitex_agent_container/` returns **449** matches — but **395 of those are `console.print(...)` from rich**, the CLI rendering idiom this repo already standardised on (518 `click.echo` sites live alongside it). `\bprint\(` matches the attribute call too.

Parsing with `ast` instead of a regex, the real raw-`print(` count is **54**. Those 54 are not one problem, they are four, and only two of them are defects.

## Classification

| Category | Count | What it is | Disposition |
|---|---:|---|---|
| **rich `console.print` / `_err_console.print`** | 395 | The CLI's rendering layer. Tables, prose, `sac agents list`. | **Untouched.** A CLI printing its result to stdout is the product. |
| **Protocol / machine-parsed stdout** | 24 | Claude Code hook return values, `sac-statusline`, the SIF symbol probe, a skill's worked example. | **Untouched + allowlisted.** |
| **Caller-injected report stream** | 17 | `print(..., file=stream/err_stream/log_stream)` — the caller chose the destination and tests capture it with a `StringIO`. | **Untouched.** This is a reporting contract, not an unrouted diagnostic. |
| **Diagnostic on hardcoded stdout/stderr** | 11 | No caller contract, no origin, no level, no routing. | **Converted** to `scitex-logging`. |
| **CLI notice on hardcoded stderr** | 2 | User-facing "Wrote ..." lines bypassing the repo's own console helper. | **Converted** to `cli_pkg._helpers._console.system_msg`. |
| | **449** | | **13 call sites changed** |

The dividing line is deliberate and is stated once, in `_logging.py`: **a print to a caller-injected stream has a contract to honour; a print to a hardcoded stdout/stderr does not.** Only the latter can be re-routed without changing a signature, and only the latter is actually a defect.

That line is not invented here. `_lifecycle/_start_preflight.py` already carries a comment saying that a caller-supplied `log_stream` means the notice is being captured *to be discarded* and "must not reach a logger at all."

## What was actually hiding

The finding the directive is about — a raw print standing in for a swallowed error:

- **`runtimes/claude_session.py:330` and `runtimes/openai_session.py:177`** — the same bug in both runtimes. `start()` reports a **start failure** with a bare `return False`; no exception is raised, so the printed line was the caller's *only* account of why the agent did not come up. It carried no module origin and died with whatever stderr happened to be attached. Now a logged `ERROR` naming the emitting module.
- **`_runners/_tmux/_host_cwd.py:29`** — the worst of the set. An absorbed `OSError` on an agent **launch path**, reported to **bare stdout** (no `file=` at all), where a tmux-backed launcher frequently has stdout attached to nothing. The exception is deliberately swallowed, so this line was the sole record of it, written where nobody reads. Its test asserted on `capsys...out`, which is how the stdout target survived review.
- **`_listen/_host_exec.py:184`** — a **lost audit record** in the listen daemon, reported by a print to stderr and nothing else.
- **`_account/refresh_alarm.py:150`** — "NOBODY HAS BEEN PAGED", i.e. the alarm rail itself failed, reported by a raw print.

Beyond origin, conversion buys **durability**: scitex-logging fans out to stderr *and* to a rotating file under `~/.scitex/logging/runtime/`. A diagnostic that previously died with the pane now survives it. An error only ever written to a stream nobody is reading is swallowed in every sense that matters.

## The guard

**Mechanism: the existing lint job, not a new one.** `.github/workflows/lint.yml` already runs ruff; this adds one step, `ruff check --select T201,T203 src/`. The `.githooks/pre-push` hook that mirrors that job gets the identical check, so the failure lands at push time and the two cannot drift in strictness.

**Why ruff T201 rather than a bespoke checker** — and this is the part worth reading: **ruff's flake8-print does not flag `print(..., file=<object>)` when the target is anything other than `sys.stdout`/`sys.stderr`.** That is *exactly* the injected-stream-vs-hardcoded line drawn above. The rule enforces the classification natively instead of approximating it, and needs no AST checker of our own to do it. `scripts/check_stx_allow.py`'s docstring records what a hand-rolled matcher cost last time: 34% false positives and 619 invisible cases, simultaneously.

`tests/` is deliberately out of scope — a print in a test is scaffolding, not a shipped diagnostic.

**Allowlist: `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml`.** Eight files, one entry each, each with its own written reason. No blanket ignore, no widened glob. Every entry is a place where **stdout genuinely IS the interface**:

- `src/hatch_build.py` — runs under hatch before the package is importable.
- three `_baseline_assets/claude_worktree_hooks/*.py` — standalone hook scripts copied into an agent's `$HOME`; `print(policy_path)` **is** the SDK's return channel, and they cannot assume `scitex_logging` is importable there.
- `cli_pkg/never_stop_when_task_remains_cmds.py` — a Stop hook whose **stdout is a JSON decision frame** (`test_stdout_is_pure_json_when_blocking` asserts `json.loads(stdout)` still parses). Routing its stderr to a logger risks a handler putting log text on stdout and corrupting that frame — precisely the failure class this change exists to avoid.
- `statusline.py` — stdout is the rendered status line Claude Code consumes.
- `containers/sif_symbol_probe.py` — imports nothing from sac by design; its OK/FATAL lines are the build's verdict.
- `_skills/.../scitex_smoke_test.py` — a worked example, not a code path.

**Proof the gate can fail.** A gate that cannot fail is worse than no gate, so this was measured, not assumed: clean tree → `All checks passed!`, exit 0. Plant one `print()` in a new `src/` module → `T201 print found`, **exit 1**. Probe removed.

## Verification

- `ruff --select T201,T203 src/` — clean, exit 0; fails exit 1 on a planted print (above).
- `ruff --select F401,F811 ... src/ tests/` (the existing gate) — clean; three `sys` imports left unused by the conversion were removed.
- Targeted suite over every touched module — **116 passed**, including all seven tests that assert on the converted output via `capsys`.

One test changed: `tests/.../_tmux/test__host_cwd.py` moves its assertion from `capsys...out` to `.err`. That is not an accommodation, it is the point — the warning used to go to bare stdout.

A note for whoever migrates the next batch: `tests/.../test__start_creds_files_pool.py:462-497` documents a print→logging migration that lost `capsys` observability because a `logging.StreamHandler(sys.stderr)` **caches** the stream. scitex-logging uses a `LazyStderrStreamHandler` that resolves `sys.stderr` at emit time, so `capsys` still sees it — verified here, serially and under `-n 4`. The documented hazard is real but does not apply to this handler.

## Scope

Strictly logging discipline. **No renames**: no spec keys, CLI verb names, env var names or DB columns are touched — the vendor-neutral rename stays deferred to `sac-neutral-naming-decouple-from-claude-code-20260814`. Rebased onto `develop` immediately before opening.
