### PR TITLE
feat(agents): fleet-wide list with an honest reachability header

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,19 @@ sac agents forget <name> [--force]        # local-only state.db cleanup for the
                                            # (no ssh, no signal)
 sac agents send   <name> "<prompt>"       # send a follow-up turn to a running session
 sac agents send   <name> --key ESC        # interrupt current turn
-sac agents status [<name>] [--snapshot] [--priority]   # fleet view if no name; per-agent
-                                                       # JSON payload otherwise
+sac agents status [<name>] [--snapshot] [--priority]   # FLEET-WIDE view if no name;
+                                                       # per-agent JSON payload otherwise
 sac agents list   [<name>]                # alias of `status` (same renderer)
+sac agents list   --host <hostname>       # one host; repeatable, exact match.
+                                           # `localhost` is resolved at parse time and
+                                           # the header echoes the resolution.
+                                           # The fleet view ALWAYS prints a header saying
+                                           # which hosts answered and which did not, with
+                                           # the reason ("5/6 hosts responded — spartan:
+                                           # ssh timed out after 8s"). A host that could
+                                           # not be reached is REPORTED, never dropped:
+                                           # `agents: []` means an EMPTY fleet only when
+                                           # `hosts.responded == hosts.total` in --json.
 sac agents health <name>
 sac agents tail   <name>                  # render session.jsonl (structured transcript)
 sac agents recall <name>                  # human-readable session summary

--- a/src/scitex_agent_container/cli_pkg/_agents_list_fleet.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_list_fleet.py
@@ -1,0 +1,145 @@
+"""CLI wiring for the FLEET-WIDE default of ``sac agents list``.
+
+``status_cmds.py`` sits four lines under the per-file cap, so the three new
+options and the fleet branch live here and are attached with one decorator.
+
+WHAT CHANGED, AND WHY IT IS A DEFAULT
+-------------------------------------
+``sac agents list`` used to answer only for the machine it was typed on, so
+finding the fleet meant ssh-ing host by host — and every listing quietly
+rendered every other host as *nothing there*. Fleet-wide is therefore the
+DEFAULT, not a flag: an operator must not have to opt in to being told the
+truth about his own fleet, and the exit code never changes because a peer was
+unreachable (that would break every caller that parses this command).
+
+``--host`` is the single filter, repeatable, exact-match. There is no
+``--here``: ``--host localhost`` covers that case and is RESOLVED at parse
+time, with the header echoing the resolution, so no output ever records the
+ambiguous claim ``localhost`` — the same ruling that BANNED ``spec.host: local``
+("placement must carry the RESOLVED hostname"), applied to a query filter.
+
+``--no-fanout`` is hidden because it is plumbing, not a user-facing filter: the
+peer leg runs the peer's OWN ``sac agents list``, which would fan out again,
+and again. It is the recursion guard. It doubles as the escape hatch for a
+caller that genuinely wants a local-only listing, and the header always says
+when it is in force.
+"""
+
+from __future__ import annotations
+
+import json as json_mod
+
+import click
+
+__all__ = ["fleet_list_options", "run_fleet_list"]
+
+
+def fleet_list_options(func):
+    """Attach ``--host`` / ``--no-fanout`` / ``--host-timeout`` to a command."""
+    from ._helpers._agent_list_fleet_model import DEFAULT_HOST_TIMEOUT_S
+
+    func = click.option(
+        "--host-timeout",
+        "host_timeout",
+        type=float,
+        default=DEFAULT_HOST_TIMEOUT_S,
+        show_default=True,
+        help=(
+            "Fleet view: seconds to wait for EACH host. A host that exceeds it "
+            "is reported as timed-out in the header and never blocks the rest "
+            "of the listing."
+        ),
+    )(func)
+    func = click.option(
+        "--no-fanout",
+        "no_fanout",
+        is_flag=True,
+        default=False,
+        hidden=True,
+        help=(
+            "Fleet view: do not query peers; list only this host. Primarily the "
+            "recursion guard the fan-out passes to each peer (the peer runs its "
+            "own sac, which would fan out again). The header always states when "
+            "it is in force, so a local-only listing is never silent."
+        ),
+    )(func)
+    func = click.option(
+        "--host",
+        "hosts",
+        multiple=True,
+        metavar="HOSTNAME",
+        help=(
+            "Fleet view: only this host. Repeatable; exact match on the "
+            "resolved hostname. 'localhost' / 'local' are accepted and RESOLVED "
+            "at parse time, with the header echoing the resolution. An unknown "
+            "name fails loudly, naming every host this machine can reach."
+        ),
+    )(func)
+    return func
+
+
+def run_fleet_list(
+    registry,
+    *,
+    use_json: bool,
+    hosts: tuple[str, ...] = (),
+    no_fanout: bool = False,
+    host_timeout: float | None = None,
+    capability: str | None = None,
+    machine: str | None = None,
+    group: str | None = None,
+    verbose: bool = False,
+    show_all: bool = False,
+) -> None:
+    """Collect the fleet, print the header, then the rows.
+
+    The header comes FIRST and unconditionally, in both surfaces. It is what
+    makes ``agents == []`` legible: with every host answered it means the fleet
+    is empty; with a host missing it means the fleet is UNOBSERVED, and those
+    two must never render the same way.
+    """
+    from ._helpers._agent_list import print_agent_list
+    from ._helpers._agent_list_fleet import DEFAULT_HOST_TIMEOUT_S, collect_fleet
+    from ._helpers._agent_list_fleet_model import UnknownHostFilter
+    from ._helpers._agent_list_fleet_render import hosts_payload, print_fleet_header
+    from ._helpers._console import console
+
+    show_full = verbose or show_all
+    try:
+        listing = collect_fleet(
+            registry,
+            capability=capability,
+            machine=machine,
+            group=group,
+            # The human default hides non-live rows, so the LOCAL leg may skip
+            # their (expensive) account + movement enrichment. --json shows
+            # every row, so it must stay fully enriched.
+            running_only=(not use_json) and not show_full,
+            hosts=hosts,
+            no_fanout=no_fanout,
+            host_timeout_s=(
+                DEFAULT_HOST_TIMEOUT_S if host_timeout is None else host_timeout
+            ),
+        )
+    except UnknownHostFilter as exc:
+        # Loud, and it names every host that WOULD have worked. A silent empty
+        # listing here would render "no such host" exactly like "that host has
+        # no agents" — the collapse this whole feature exists to prevent.
+        raise click.UsageError(str(exc)) from exc
+
+    if use_json:
+        click.echo(
+            json_mod.dumps(
+                {"agents": listing.agents, "hosts": hosts_payload(listing)},
+                indent=2,
+            )
+        )
+        return
+
+    print_fleet_header(console, listing)
+    print_agent_list(
+        None,
+        verbose=verbose,
+        show_all=show_all,
+        rows=listing.agents,
+    )

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet.py
@@ -134,8 +134,12 @@ def collect_fleet(
     all_targets = (
         list(targets) if targets is not None else resolve_targets(local_host=local_host)
     )
-    peers_known = sum(1 for t in all_targets if not t.local)
     selected, resolutions = resolve_host_filter(hosts, all_targets, local_host)
+    # Peers IN SCOPE for this listing, i.e. after ``--host``. Counted post-filter
+    # so the header's "N peers NOT queried" note describes what this run meant to
+    # do: an operator who asked for one host does not need to be told about nine
+    # machines he deliberately excluded.
+    peers_known = sum(1 for t in selected if not t.local)
 
     suppressed = fanout_suppressed_reason(no_fanout)
     skipped: list[HostTarget] = []

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet.py
@@ -1,0 +1,262 @@
+"""Fleet-wide agent listing — ask every host CONCURRENTLY, report all of them.
+
+The orchestrator. The vocabulary (host states, instruments, targets, reports,
+``--host`` resolution) lives in :mod:`._agent_list_fleet_model`; the two
+instruments that take the readings live in :mod:`._agent_list_fleet_probe`.
+Both are re-exported here so a caller has one import to reach for.
+
+The one rule this module adds on top of theirs: **a host that could not be
+reached never changes the exit code and is never dropped.** A listing that
+exited non-zero on an unreachable peer would break every caller that parses it,
+and a listing that omitted the peer would render *unknown* as *empty*. The
+header carries the truth instead — see :mod:`._agent_list_fleet_render`.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as _FuturesTimeout
+from typing import Callable, Sequence
+
+from ._agent_list_fleet_model import (  # noqa: F401 (re-export)
+    DEFAULT_HOST_TIMEOUT_S,
+    INSTRUMENT_LOCAL_REGISTRY,
+    INSTRUMENT_NO_OBSERVATION,
+    INSTRUMENT_SSH,
+    MALFORMED,
+    NOT_QUERIED,
+    RESPONDED,
+    SAC_MISSING,
+    TIMED_OUT,
+    UNREACHABLE,
+    FleetListing,
+    HostReport,
+    HostTarget,
+    UnknownHostFilter,
+    every_name,
+    fanout_suppressed_reason,
+    resolve_host_filter,
+    resolve_targets,
+)
+from ._agent_list_fleet_probe import local_probe, ssh_peer_probe  # noqa: F401
+from ._agent_list_host import _resolve_display_host
+
+__all__ = [
+    "DEFAULT_HOST_TIMEOUT_S",
+    "FleetListing",
+    "HostReport",
+    "HostTarget",
+    "INSTRUMENT_LOCAL_REGISTRY",
+    "INSTRUMENT_NO_OBSERVATION",
+    "INSTRUMENT_SSH",
+    "MALFORMED",
+    "NOT_QUERIED",
+    "RESPONDED",
+    "SAC_MISSING",
+    "TIMED_OUT",
+    "UNREACHABLE",
+    "UnknownHostFilter",
+    "collect_fleet",
+    "every_name",
+    "fanout_suppressed_reason",
+    "local_probe",
+    "resolve_host_filter",
+    "resolve_targets",
+    "ssh_peer_probe",
+]
+
+# Enough workers that the whole fleet is in flight at once (this fleet has ~12
+# hosts), capped so a pathological topology cannot spawn an unbounded pool.
+_MAX_PARALLEL_HOSTS = 16
+
+# Margin on the shared batch deadline, covering process teardown AFTER each
+# probe's own inner subprocess timeout has already fired. Deliberately small
+# and ADDITIVE rather than generous: a large fixed margin becomes the effective
+# floor of the whole fan-out, so `--host-timeout 0.5` would still cost seconds.
+_BATCH_MARGIN_S = 2.0
+
+
+def _default_local_lister(registry, *, capability, machine, group, running_only):
+    from ._agent_list import get_agent_list_data
+
+    def lister() -> list[dict]:
+        return get_agent_list_data(
+            registry,
+            capability=capability,
+            machine=machine,
+            group=group,
+            running_only=running_only,
+        )
+
+    return lister
+
+
+def collect_fleet(
+    registry=None,
+    *,
+    capability: str | None = None,
+    machine: str | None = None,
+    group: str | None = None,
+    running_only: bool = False,
+    hosts: Sequence[str] = (),
+    no_fanout: bool = False,
+    host_timeout_s: float = DEFAULT_HOST_TIMEOUT_S,
+    max_parallel_hosts: int = _MAX_PARALLEL_HOSTS,
+    targets: Sequence[HostTarget] | None = None,
+    local_lister: Callable[[], list[dict]] | None = None,
+    peer_probe: Callable[..., tuple[HostReport, list[dict]]] | None = None,
+) -> FleetListing:
+    """Query every permitted host and return the merged rows + per-host reports.
+
+    Wall-clock is bounded by the SLOWEST host, not by their sum: every peer is
+    submitted BEFORE any result is collected, and the deadline is ONE shared
+    budget rather than one restarted per future. That distinction is not
+    theoretical — restarting the deadline per future makes n stalled peers cost
+    ``ceil(n / workers) * T`` even though the pool is parallel, which is the
+    exact defect ``_probe_remote_statuses`` and ``get_agent_list_data`` each had
+    to fix in their own pools.
+
+    ``targets`` / ``local_lister`` / ``peer_probe`` are injection seams so tests
+    drive real callables instead of mocks, matching the ``remote_status_probe``
+    / ``remote_run_ssh`` seams the sibling row builders already expose.
+    """
+    if local_lister is None:
+        local_lister = _default_local_lister(
+            registry,
+            capability=capability,
+            machine=machine,
+            group=group,
+            running_only=running_only,
+        )
+
+    local_host = _resolve_display_host()
+    all_targets = (
+        list(targets) if targets is not None else resolve_targets(local_host=local_host)
+    )
+    peers_known = sum(1 for t in all_targets if not t.local)
+    selected, resolutions = resolve_host_filter(hosts, all_targets, local_host)
+
+    suppressed = fanout_suppressed_reason(no_fanout)
+    skipped: list[HostTarget] = []
+    if suppressed:
+        skipped = [t for t in selected if not t.local]
+        selected = [t for t in selected if t.local]
+
+    reports: list[HostReport] = []
+    rows: list[dict] = []
+    for target in (t for t in selected if t.local):
+        report, local_rows = local_probe(local_lister, target)
+        reports.append(report)
+        rows.extend(local_rows)
+
+    # A host the caller NAMED and we then did not ask gets its own row. The
+    # aggregate "N peers NOT queried" note in the header covers the unnamed
+    # majority, but an operator who typed `--host spartan` and saw nothing must
+    # be told spartan was not asked — otherwise the silence reads as "spartan
+    # is empty", which is the whole failure mode this feature removes.
+    if hosts:
+        for target in skipped:
+            reports.append(
+                HostReport(
+                    host=target.name,
+                    status=NOT_QUERIED,
+                    instrument=INSTRUMENT_NO_OBSERVATION,
+                    detail=f"not queried ({suppressed})",
+                )
+            )
+
+    remote_targets = [t for t in selected if not t.local]
+    if remote_targets:
+        probe = peer_probe or _default_peer_probe(
+            capability=capability, machine=machine, group=group
+        )
+        report_rows = _fan_out(
+            remote_targets,
+            probe,
+            host_timeout_s=host_timeout_s,
+            max_parallel_hosts=max_parallel_hosts,
+        )
+        for report, peer_rows in report_rows:
+            reports.append(report)
+            rows.extend(peer_rows)
+
+    return FleetListing(
+        agents=rows,
+        reports=reports,
+        resolutions=resolutions,
+        suppressed_reason=suppressed,
+        peers_known=peers_known,
+    )
+
+
+def _default_peer_probe(*, capability, machine, group):
+    def probe(target: HostTarget, timeout_s: float):
+        return ssh_peer_probe(
+            target,
+            timeout_s,
+            capability=capability,
+            machine=machine,
+            group=group,
+        )
+
+    return probe
+
+
+def _fan_out(
+    remote_targets: list[HostTarget],
+    probe: Callable[..., tuple[HostReport, list[dict]]],
+    *,
+    host_timeout_s: float,
+    max_parallel_hosts: int,
+) -> list[tuple[HostReport, list[dict]]]:
+    """Submit every peer, THEN collect against one shared deadline.
+
+    ``shutdown(wait=False)`` rather than a ``with`` block: the context manager's
+    ``__exit__`` joins every worker, which would defeat the very timeout this
+    function exists to enforce (the same reason, and the same comment, as the
+    local probe pool in ``_agent_list``).
+    """
+    out: list[tuple[HostReport, list[dict]]] = []
+    workers = max(1, min(len(remote_targets), max_parallel_hosts))
+    pool = ThreadPoolExecutor(max_workers=workers)
+    try:
+        futures = {
+            pool.submit(probe, target, host_timeout_s): target
+            for target in remote_targets
+        }
+        deadline = time.monotonic() + host_timeout_s + _BATCH_MARGIN_S
+        for future, target in futures.items():
+            remaining = max(0.0, deadline - time.monotonic())
+            # stx-allow: fallback (reason: a probe that never came back is a
+            # TIMED_OUT host — a first-class answer, never an absent row.)
+            try:
+                out.append(future.result(timeout=remaining))
+            except _FuturesTimeout:  # stx-allow: fallback (expected failure)
+                future.cancel()
+                out.append(
+                    (
+                        HostReport(
+                            host=target.name,
+                            status=TIMED_OUT,
+                            instrument=INSTRUMENT_SSH,
+                            detail=f"no answer within {host_timeout_s:g}s",
+                        ),
+                        [],
+                    )
+                )
+            except Exception as exc:  # stx-allow: fallback (see inline comment)
+                out.append(
+                    (
+                        HostReport(
+                            host=target.name,
+                            status=UNREACHABLE,
+                            instrument=INSTRUMENT_NO_OBSERVATION,
+                            detail=f"probe raised: {type(exc).__name__}: {exc}",
+                        ),
+                        [],
+                    )
+                )
+    finally:
+        pool.shutdown(wait=False)
+    return out

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_model.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_model.py
@@ -1,0 +1,298 @@
+"""The fleet-listing VOCABULARY: host states, instruments, targets, reports.
+
+``sac agents list`` used to show only what the CALLING host could see, so the
+operator had to ssh machine-by-machine to find his own fleet — and, worse, a
+listing taken from one host rendered every OTHER host as *nothing there*. This
+module holds the words that stop that collapse; :mod:`._agent_list_fleet_probe`
+takes the readings and :mod:`._agent_list_fleet` orchestrates them.
+
+UNKNOWN IS NOT EMPTY (constitution §2)
+-------------------------------------
+A fan-out that silently drops an unreachable peer reports the same thing for
+"that machine runs no agents" and "we could not ask that machine". Those are
+different facts and only the first may be acted on. So every host we INTENDED
+to query gets a :class:`HostReport` — including the ones that never answered —
+and an unanswered report carries ``agents=None``, never ``0``:
+
+* :data:`RESPONDED`   — the host answered; its rows are in the listing.
+* :data:`TIMED_OUT`   — the probe RAN and hit the deadline. Distinct from
+  UNREACHABLE on purpose: a host that is merely slow (or behind a wedged
+  ProxyJump) has not refused us, and the two want different remedies.
+* :data:`UNREACHABLE` — the probe RAN and positively failed (ssh non-zero).
+* :data:`SAC_MISSING` — we REACHED the host and ``sac`` is not on its PATH.
+  Measured live on two NAS boxes the first time this shipped. Folding it into
+  UNREACHABLE would send the operator to debug a network that is fine; the
+  remedy is to install sac there, and only a distinct state says so.
+* :data:`MALFORMED`   — the host answered, but not with a listing we can read
+  (an ancient sac, a shell banner on stdout, a truncated pipe). It is NOT
+  unreachable — the transport demonstrably worked — and calling it so would
+  send the operator to debug the wrong layer.
+* :data:`NOT_QUERIED` — we never asked, because the fan-out was switched off.
+  Also an unknown, and it earns a row for the same reason the others do: an
+  operator who typed ``--host spartan`` and got silence must be told the host
+  was not asked, not left to read the silence as "spartan is empty".
+
+WHICH INSTRUMENT ANSWERED
+-------------------------
+Each report also names the SENSOR behind it, mirroring the
+``evidence[].instrument`` vocabulary the per-agent liveness verdict already
+publishes (:mod:`..._lifecycle._verdict_instruments`). It is deliberately a
+SEPARATE vocabulary: that module's :class:`~..._lifecycle._verdict.Signal`
+classifies instruments observing an AGENT's liveness against a closed
+whitelist, and its destruction gate counts DISTINCT instruments. Letting a
+host-transport reading borrow one of those names would let it pose as an
+independent witness in that gate — the precise confusion the gate exists to
+stop. Same discipline, separate axis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Sequence
+
+from ._agent_list_host import _resolve_display_host
+
+__all__ = [
+    "DEFAULT_HOST_TIMEOUT_S",
+    "FleetListing",
+    "HostReport",
+    "HostTarget",
+    "INSTRUMENT_LOCAL_REGISTRY",
+    "INSTRUMENT_NO_OBSERVATION",
+    "INSTRUMENT_SSH",
+    "MALFORMED",
+    "NOT_QUERIED",
+    "RESPONDED",
+    "SAC_MISSING",
+    "TIMED_OUT",
+    "UNREACHABLE",
+    "UnknownHostFilter",
+    "every_name",
+    "fanout_suppressed_reason",
+    "resolve_host_filter",
+    "resolve_targets",
+]
+
+# --- host-reachability states (never a bool; see the module docstring) -----
+RESPONDED = "responded"
+TIMED_OUT = "timed_out"
+UNREACHABLE = "unreachable"
+SAC_MISSING = "sac_missing"
+MALFORMED = "malformed"
+NOT_QUERIED = "not_queried"
+
+# --- instruments: WHAT PHYSICALLY ANSWERED for this host -------------------
+INSTRUMENT_LOCAL_REGISTRY = "local_registry"
+INSTRUMENT_SSH = "ssh"
+INSTRUMENT_NO_OBSERVATION = "no_observation"
+
+# Bounded by default so one wedged ProxyJump can never hold the whole listing.
+# 8s rather than build_ssh_argv's 10s ConnectTimeout: the remote leg also has to
+# RUN ``sac agents list``, and an operator staring at a prompt would rather be
+# told "spartan timed out" than wait.
+DEFAULT_HOST_TIMEOUT_S = 8.0
+
+_LOCALHOST_ALIASES = ("localhost", "local")
+
+
+class UnknownHostFilter(ValueError):
+    """``--host X`` named a host no route on this machine can reach."""
+
+
+@dataclass(frozen=True)
+class HostTarget:
+    """One machine the listing intends to query.
+
+    ``ssh`` is the DEDUPE key, not ``name``: this fleet reaches one NAS through
+    two peer keys (``nas-03`` from config.yaml and ``scitex-nas-03`` from the
+    scitex-dev registry) that render the identical ssh argv. Querying both would
+    ssh twice and print every agent on that box twice. ``aliases`` keeps the
+    collapsed names addressable, so ``--host scitex-nas-03`` still selects it.
+    """
+
+    name: str
+    ssh: str
+    local: bool = False
+    aliases: tuple[str, ...] = ()
+
+    def matches(self, wanted: str) -> bool:
+        return wanted == self.name or wanted in self.aliases
+
+
+@dataclass(frozen=True)
+class HostReport:
+    """What we learned about ONE host, and how we learned it."""
+
+    host: str
+    status: str
+    instrument: str
+    detail: str
+    elapsed_ms: int = 0
+    agents: int | None = None
+
+    @property
+    def responded(self) -> bool:
+        return self.status == RESPONDED
+
+    def to_dict(self) -> dict:
+        return {
+            "host": self.host,
+            "status": self.status,
+            "instrument": self.instrument,
+            "detail": self.detail,
+            "elapsed_ms": self.elapsed_ms,
+            # None, NEVER 0. A host that did not answer has an UNKNOWN agent
+            # count; writing 0 would be the same lie as omitting the row.
+            "agents": self.agents,
+        }
+
+
+@dataclass(frozen=True)
+class FleetListing:
+    """The merged rows plus the per-host reachability record behind them."""
+
+    agents: list[dict] = field(default_factory=list)
+    reports: list[HostReport] = field(default_factory=list)
+    resolutions: tuple[tuple[str, str], ...] = ()
+    suppressed_reason: str = ""
+    peers_known: int = 0
+
+    @property
+    def responded(self) -> int:
+        return sum(1 for r in self.reports if r.responded)
+
+    @property
+    def total(self) -> int:
+        return len(self.reports)
+
+    @property
+    def unanswered(self) -> list[HostReport]:
+        return [r for r in self.reports if not r.responded]
+
+
+def fanout_suppressed_reason(no_fanout: bool) -> str:
+    """Why peers will not be queried, in words, or ``""`` when they will.
+
+    The env form exists so a sandbox (this repo's own test suite, a laptop
+    cron) can keep a listing local WITHOUT the caller having to remember a
+    flag. Whichever way it is switched off, the header says so out loud — a
+    quietly-local listing is the exact ambiguity this feature removes.
+    """
+    if no_fanout:
+        return "--no-fanout"
+    from ..._env import getenv as _sac_env
+
+    raw = (_sac_env("AGENTS_LIST_NO_FANOUT") or "").strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return "SAC_AGENTS_LIST_NO_FANOUT"
+    return ""
+
+
+def _is_glob(name: str) -> bool:
+    return any(ch in name for ch in "*?[")
+
+
+def _load_peers() -> dict:
+    # stx-allow: fallback (reason: a listing must still render THIS host when
+    # the peer topology is missing or malformed — the header then says only one
+    # host was known, which is honest, instead of crashing the command.)
+    try:
+        from ..._state._peer_resolve import peers_with_registry
+        from ..._state.host_config import load as _load_host_config
+
+        return dict(peers_with_registry(_load_host_config().peers))
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return {}
+
+
+def resolve_targets(
+    peers: dict | None = None, local_host: str | None = None
+) -> list[HostTarget]:
+    """Every machine this host may query — local first, then its peers.
+
+    Peers come from :func:`..._state._peer_resolve.peers_with_registry`, i.e.
+    config.yaml UNION the scitex-dev host registry: the same set ``sac host
+    list`` prints and ``sac host exec`` accepts, so the listing's reach is the
+    topology the operator already declared rather than a second one invented
+    here. Glob keys (``spartan-*``) are skipped — they are PATTERNS whose ssh
+    target is synthesised per concrete node name, so there is no one machine to
+    ask.
+    """
+    local = local_host or _resolve_display_host()
+    if peers is None:
+        peers = _load_peers()
+
+    targets: list[HostTarget] = [HostTarget(name=local, ssh="", local=True)]
+    by_ssh: dict[str, int] = {}
+    for name, spec in peers.items():
+        if _is_glob(name) or name == local:
+            continue
+        ssh = getattr(spec, "ssh", "") or ""
+        if not ssh:
+            continue
+        seen = by_ssh.get(ssh)
+        if seen is not None:
+            prior = targets[seen]
+            targets[seen] = HostTarget(
+                name=prior.name,
+                ssh=prior.ssh,
+                local=prior.local,
+                aliases=prior.aliases + (name,),
+            )
+            continue
+        by_ssh[ssh] = len(targets)
+        targets.append(HostTarget(name=name, ssh=ssh))
+    return targets
+
+
+def every_name(targets: Iterable[HostTarget]) -> set[str]:
+    """Every name that ``--host`` will accept for ``targets``."""
+    out: set[str] = set()
+    for t in targets:
+        out.add(t.name)
+        out.update(t.aliases)
+    return out
+
+
+def resolve_host_filter(
+    wanted: Sequence[str],
+    targets: Sequence[HostTarget],
+    local_host: str,
+) -> tuple[list[HostTarget], tuple[tuple[str, str], ...]]:
+    """Apply ``--host`` — exact match, with ``localhost`` resolved AT PARSE TIME.
+
+    Returns ``(selected_targets, resolutions)`` where ``resolutions`` records
+    every ``requested → resolved`` rewrite so the header can ECHO it.
+
+    ``localhost`` / ``local`` name a DIFFERENT machine depending on where they
+    are typed, which is exactly why ``spec.host: local`` is BANNED on the spec
+    side ("placement must carry the RESOLVED hostname"). A live query filter may
+    accept the word — the operator typing it knows which machine he is on — but
+    the OUTPUT must never record the ambiguous claim. So it is resolved here and
+    the resolution is SHOWN, not hidden.
+
+    An unknown name raises :class:`UnknownHostFilter` naming every host that
+    WOULD have worked. Quietly returning nothing would render "no such host"
+    identically to "that host has no agents" — the same collapse again, one
+    layer up.
+    """
+    if not wanted:
+        return list(targets), ()
+    selected: list[HostTarget] = []
+    resolutions: list[tuple[str, str]] = []
+    for raw in wanted:
+        name = raw.strip()
+        resolved = local_host if name.lower() in _LOCALHOST_ALIASES else name
+        if resolved != name:
+            resolutions.append((name, resolved))
+        hit = next((t for t in targets if t.matches(resolved)), None)
+        if hit is None:
+            known = ", ".join(sorted(every_name(targets)))
+            raise UnknownHostFilter(
+                f"--host {raw!r} names no host this machine can reach"
+                + (f" (resolved to {resolved!r})" if resolved != name else "")
+                + f". Known hosts: {known}. See: sac host list"
+            )
+        if hit not in selected:
+            selected.append(hit)
+    return selected, tuple(resolutions)

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_model.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_model.py
@@ -155,6 +155,9 @@ class FleetListing:
     reports: list[HostReport] = field(default_factory=list)
     resolutions: tuple[tuple[str, str], ...] = ()
     suppressed_reason: str = ""
+    # Peers IN SCOPE for this listing (i.e. after ``--host``), NOT the whole
+    # topology: the header's "N peers NOT queried" note should describe what
+    # this run meant to do, not enumerate machines the caller excluded.
     peers_known: int = 0
 
     @property

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py
@@ -1,0 +1,320 @@
+"""The two INSTRUMENTS behind a fleet listing: the local read and the ssh leg.
+
+Split from :mod:`._agent_list_fleet` (512-line per-file cap) so the readings
+live next to their vocabulary in :mod:`._agent_list_fleet_model` while
+``collect_fleet`` stays a pure orchestrator.
+
+WHY ``ssh`` AND NOT EACH PEER'S ``sac listen`` HTTP SURFACE
+-----------------------------------------------------------
+ADR-0015 already settled that question for the whole fleet: there is no overlay
+net between these machines, a peer's listen binds ``127.0.0.1`` by default, and
+nothing in ``config.yaml`` declares a peer's listen base URL (only the single
+``lead:`` block does, for itself). That is why sac's own cross-host channel
+forwarder runs over ssh + curl rather than plain HTTP. Asking the peer's OWN
+``sac`` over ssh reaches the same state without inventing a second discovery
+mechanism — and the report says ``instrument="ssh"`` so no reader has to guess
+which rail answered.
+
+The LOCAL host needs no transport at all, so it is read in-process and says so
+(``instrument="local_registry"``). It deliberately does NOT proxy to this host's
+own ``sac listen`` even when ``SAC_LISTEN_BASE_URL`` is set: the fleet view has
+never proxied (``test_fleet_view_does_not_proxy`` pins that), and ``GET
+/agents`` returns registry/comms-node rows in a different shape from the
+enriched list rows — preferring it would silently change what the table means.
+
+Every function here is TOTAL: a failure is a reported host STATE, never an
+exception. An exception would drop the host from the listing, which is the
+collapse this whole feature exists to prevent.
+"""
+
+from __future__ import annotations
+
+import json as json_mod
+import subprocess
+import time
+from typing import Callable
+
+from ._agent_list_fleet_model import (
+    INSTRUMENT_LOCAL_REGISTRY,
+    INSTRUMENT_SSH,
+    MALFORMED,
+    RESPONDED,
+    SAC_MISSING,
+    TIMED_OUT,
+    UNREACHABLE,
+    HostReport,
+    HostTarget,
+)
+
+__all__ = ["local_probe", "ssh_peer_probe"]
+
+# The peer runs its OWN sac, which would fan out again — and its peers would fan
+# out after that. ``--no-fanout`` is the recursion guard, and it is the same flag
+# an operator can type to keep a listing local.
+_REMOTE_BASE_ARGV = ("sac", "agents", "list", "--json")
+_NO_FANOUT_ARGV = ("--no-fanout",)
+
+# A peer running an OLDER sac rejects a flag it has never heard of. That refusal
+# is proof it CANNOT recurse, so retrying without the guard is safe — and
+# without the retry every not-yet-upgraded peer in the fleet would read
+# UNREACHABLE, which is precisely the false negative this feature exists to
+# kill. (sac hosts routinely run a stale build; the fleet has been bitten.)
+_LEGACY_FLAG_MARKERS = ("no such option", "unrecognized arguments")
+
+
+def _ms_since(started: float) -> int:
+    return int((time.monotonic() - started) * 1000)
+
+
+def _first_line(text: str) -> str:
+    stripped = text.strip()
+    return stripped.splitlines()[0][:160] if stripped else ""
+
+
+def _looks_like_unknown_flag(stderr: str) -> bool:
+    low = stderr.lower()
+    return any(marker in low for marker in _LEGACY_FLAG_MARKERS)
+
+
+def _looks_like_missing_sac(rc: int, stderr: str) -> bool:
+    """rc 127 (or the shell saying so) — we ARRIVED, sac was not there."""
+    return rc == 127 or "command not found" in stderr.lower()
+
+
+def _remote_argv(
+    *, capability: str | None, machine: str | None, group: str | None, guard: bool
+) -> list[str]:
+    """The command run ON the peer.
+
+    The label filters travel WITH the request so the peer applies them itself
+    (one listing, filtered at the source) rather than shipping its whole roster
+    back to be discarded here. ``-v`` / ``--all`` deliberately do NOT travel:
+    those choose what the READER sees, and that decision belongs to the local
+    render layer which holds every host's rows at once.
+    """
+    argv = list(_REMOTE_BASE_ARGV)
+    if guard:
+        argv += list(_NO_FANOUT_ARGV)
+    if capability:
+        argv += ["--capability", capability]
+    if machine:
+        argv += ["--machine", machine]
+    if group:
+        argv += ["--group", group]
+    return argv
+
+
+def _parse_rows(stdout: str) -> list[dict]:
+    """Read a peer's ``--json`` payload. Raises ``ValueError`` when unreadable.
+
+    Accepts BOTH shapes this codebase emits: the CLI's ``{"agents": [...]}``
+    envelope and the bare list ``print_agent_list_json`` writes.
+    """
+    payload = json_mod.loads(stdout)
+    rows = payload.get("agents") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise ValueError("payload carries no 'agents' list")
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _stamp_host(rows: list[dict], target: HostTarget) -> list[dict]:
+    """Rewrite each remote row's host so it names the MACHINE, not the peer's
+    own point of view.
+
+    A peer's ``sac agents list --json`` describes its agents as
+    ``host="local"`` — true THERE, a lie HERE. Left alone, a fleet table would
+    print a column of ``local`` and the operator would be back to ssh-ing host
+    by host, which is the entire problem. The peer's ``host_display`` is its own
+    resolved canonical name, so prefer that and fall back to the peer key we
+    routed through.
+
+    Rewriting ``host`` off the ``"local"`` sentinel also (correctly) exempts
+    remote rows from ``_is_ghost_row``, which only ever means to hide a LOCAL
+    registry row whose spec file is gone: a "File not found" measured HERE says
+    nothing about a file on another machine.
+    """
+    out: list[dict] = []
+    for row in rows:
+        declared = row.get("host_display")
+        host = (
+            declared
+            if isinstance(declared, str) and declared not in ("", "local", "localhost")
+            else target.name
+        )
+        stamped = dict(row)
+        stamped["host"] = host
+        stamped["host_display"] = host
+        out.append(stamped)
+    return out
+
+
+def local_probe(
+    local_lister: Callable[[], list[dict]], target: HostTarget
+) -> tuple[HostReport, list[dict]]:
+    """Read THIS host in-process. Reported, never assumed."""
+    started = time.monotonic()
+    # stx-allow: fallback (reason: even the LOCAL host is reported rather than
+    # assumed — a local read that blew up must not render as "no agents here".)
+    try:
+        rows = list(local_lister())
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        return (
+            HostReport(
+                host=target.name,
+                status=UNREACHABLE,
+                instrument=INSTRUMENT_LOCAL_REGISTRY,
+                detail=f"local read failed: {type(exc).__name__}: {exc}",
+                elapsed_ms=_ms_since(started),
+            ),
+            [],
+        )
+    return (
+        HostReport(
+            host=target.name,
+            status=RESPONDED,
+            instrument=INSTRUMENT_LOCAL_REGISTRY,
+            detail="read in-process; no transport needed",
+            elapsed_ms=_ms_since(started),
+            agents=len(rows),
+        ),
+        rows,
+    )
+
+
+def _peers_or_report(target: HostTarget):
+    # stx-allow: fallback (reason: an unreadable peer topology is reported as an
+    # unreachable host, not as an exception that kills the whole listing.)
+    try:
+        from ..._state._peer_resolve import peers_with_registry
+        from ..._state.host_config import load as _load_host_config
+
+        return peers_with_registry(_load_host_config().peers), None
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        return None, HostReport(
+            host=target.name,
+            status=UNREACHABLE,
+            instrument=INSTRUMENT_SSH,
+            detail=f"peer topology unreadable: {type(exc).__name__}: {exc}",
+        )
+
+
+def ssh_peer_probe(
+    target: HostTarget,
+    timeout_s: float,
+    *,
+    capability: str | None = None,
+    machine: str | None = None,
+    group: str | None = None,
+    peers: dict | None = None,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> tuple[HostReport, list[dict]]:
+    """Ask ONE peer for its own listing over ssh. Returns ``(report, rows)``.
+
+    Rides :func:`..._state.host_config.build_ssh_argv` — the fleet's single ssh
+    choke point, which already renders ``via:`` ProxyJump chains, the Lmod
+    ``env_preamble`` and the registry ``SCITEX_DIR`` pin — rather than
+    hand-rolling an ssh command line beside it.
+
+    Never raises. ``runner`` is the injection seam: a test drives the whole
+    rc / timeout / legacy-peer mapping through a real callable, no mocks.
+    """
+    from ..._state.host_config import build_ssh_argv
+
+    if peers is None:
+        peers, failure = _peers_or_report(target)
+        if failure is not None:
+            return failure, []
+
+    connect = int(max(2, min(timeout_s, 15)))
+    started = time.monotonic()
+    guard = True
+    while True:
+        argv = _remote_argv(
+            capability=capability, machine=machine, group=group, guard=guard
+        )
+        # stx-allow: fallback (reason: every transport failure is a REPORTED
+        # host state — an exception here would drop the host from the listing.)
+        try:
+            proc = runner(
+                build_ssh_argv(
+                    target.name,
+                    argv,
+                    peers,
+                    extra_opts=["-o", f"ConnectTimeout={connect}"],
+                ),
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+        except subprocess.TimeoutExpired:  # stx-allow: fallback (expected)
+            return (
+                HostReport(
+                    host=target.name,
+                    status=TIMED_OUT,
+                    instrument=INSTRUMENT_SSH,
+                    detail=f"ssh timed out after {timeout_s:g}s",
+                    elapsed_ms=_ms_since(started),
+                ),
+                [],
+            )
+        except Exception as exc:  # stx-allow: fallback (reason: see comment)
+            return (
+                HostReport(
+                    host=target.name,
+                    status=UNREACHABLE,
+                    instrument=INSTRUMENT_SSH,
+                    detail=f"ssh could not run: {type(exc).__name__}: {exc}",
+                    elapsed_ms=_ms_since(started),
+                ),
+                [],
+            )
+        rc = int(getattr(proc, "returncode", 1) or 0)
+        stderr = (getattr(proc, "stderr", "") or "").strip()
+        if rc != 0 and guard and _looks_like_unknown_flag(stderr):
+            guard = False  # older sac there: it cannot recurse, so ask again
+            continue
+        break
+
+    if rc != 0:
+        tail = f": {_first_line(stderr)}" if stderr else ""
+        return (
+            HostReport(
+                host=target.name,
+                # rc 127 is the SHELL saying it could not find `sac` — we got
+                # all the way onto that machine. Measured live on two NAS boxes
+                # the first time this shipped; calling it "unreachable" would
+                # send the operator to debug a network that is fine.
+                status=SAC_MISSING if _looks_like_missing_sac(rc, stderr) else UNREACHABLE,
+                instrument=INSTRUMENT_SSH,
+                detail=f"ssh exit {rc}{tail}",
+                elapsed_ms=_ms_since(started),
+            ),
+            [],
+        )
+    # stx-allow: fallback (reason: a peer that answered with something we cannot
+    # parse is MALFORMED, not unreachable — the transport demonstrably worked,
+    # and saying "unreachable" sends the operator to debug the wrong layer.)
+    try:
+        rows = _stamp_host(_parse_rows(getattr(proc, "stdout", "") or ""), target)
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        return (
+            HostReport(
+                host=target.name,
+                status=MALFORMED,
+                instrument=INSTRUMENT_SSH,
+                detail=f"answered, but the listing was unreadable ({exc})",
+                elapsed_ms=_ms_since(started),
+            ),
+            [],
+        )
+    return (
+        HostReport(
+            host=target.name,
+            status=RESPONDED,
+            instrument=INSTRUMENT_SSH,
+            detail="sac agents list --json over ssh",
+            elapsed_ms=_ms_since(started),
+            agents=len(rows),
+        ),
+        rows,
+    )

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_render.py
@@ -56,9 +56,9 @@ def _suppression_note(listing: FleetListing) -> str:
     if not listing.suppressed_reason:
         return ""
     named = sum(1 for r in listing.reports if r.status == NOT_QUERIED)
-    n = max(0, listing.peers_known - named)
-    if not n:
-        return "" if named else f"peers not queried ({listing.suppressed_reason})"
+    n = listing.peers_known - named
+    if n <= 0:
+        return ""
     noun = "peer" if n == 1 else "peers"
     return f"{n} {noun} NOT queried ({listing.suppressed_reason})"
 

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_render.py
@@ -1,0 +1,148 @@
+"""The MANDATORY header above a fleet listing — who answered, who did not, why.
+
+This is the hard requirement of the whole fleet-list change, not decoration.
+Without it a table of agents is an unattributed pile: a host that could not be
+reached contributes no rows, and *no rows* is indistinguishable from *no agents
+there*. The header is what makes an EMPTY fleet and an UNREACHABLE fleet
+distinguishable at a glance — and it renders in BOTH surfaces, table and
+``--json``, because a machine consumer needs the same distinction a human does.
+
+Three lines, in this order, and the first two only when they have something to
+say:
+
+1. ``--host localhost → scitex-compute-04`` — the resolution echo. ``localhost``
+   names a different machine depending on where it is typed, so the OUTPUT must
+   record the resolved name rather than the ambiguous one.
+2. ``5/6 hosts responded — spartan: ssh timed out after 8s`` — the count AND
+   every host that did not answer, each with its reason. Green only when the
+   whole fleet answered.
+3. ``instruments: scitex-compute-04=local_registry, mba=ssh, …`` — WHICH sensor
+   produced each host's row set, mirroring the ``evidence[].instrument``
+   vocabulary the per-agent liveness verdict publishes. "Unobserved" has been
+   reported as "dead" here before; naming the instrument is how a reader tells
+   a reading from an assumption.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._agent_list_fleet_model import NOT_QUERIED, FleetListing
+
+__all__ = [
+    "fleet_header_lines",
+    "hosts_payload",
+    "print_fleet_header",
+    "resolution_echo",
+    "summary_line",
+]
+
+
+def resolution_echo(listing: FleetListing) -> list[str]:
+    """``--host localhost → scitex-compute-04`` for every rewrite that happened."""
+    return [
+        f"--host {requested} → {resolved}"
+        for requested, resolved in listing.resolutions
+    ]
+
+
+def _suppression_note(listing: FleetListing) -> str:
+    """Say that peers were NOT ASKED — never let silence imply they were empty.
+
+    Counts only the peers that got NO row of their own: a host the caller named
+    with ``--host`` already carries a ``not_queried`` report, and saying it
+    twice would make the header noisier without making it truer.
+    """
+    if not listing.suppressed_reason:
+        return ""
+    named = sum(1 for r in listing.reports if r.status == NOT_QUERIED)
+    n = max(0, listing.peers_known - named)
+    if not n:
+        return "" if named else f"peers not queried ({listing.suppressed_reason})"
+    noun = "peer" if n == 1 else "peers"
+    return f"{n} {noun} NOT queried ({listing.suppressed_reason})"
+
+
+def summary_line(listing: FleetListing) -> str:
+    """``5/6 hosts responded — spartan: ssh timed out after 8s`` (no markup)."""
+    total = listing.total
+    noun = "host" if total == 1 else "hosts"
+    head = f"{listing.responded}/{total} {noun} responded"
+    parts = [f"{r.host}: {r.detail}" for r in listing.unanswered]
+    note = _suppression_note(listing)
+    if note:
+        parts.append(note)
+    return head + (" — " + "; ".join(parts) if parts else "")
+
+
+def instrument_line(listing: FleetListing) -> str:
+    """``instruments: <host>=<sensor>`` for every host, answered or not."""
+    if not listing.reports:
+        return ""
+    cells = [
+        f"{r.host}={r.instrument}" + ("" if r.responded else " (no answer)")
+        for r in listing.reports
+    ]
+    return "instruments: " + ", ".join(cells)
+
+
+def fleet_header_lines(listing: FleetListing) -> list[str]:
+    """Every header line as PLAIN text, in order — the shape ``--json`` echoes.
+
+    Kept separate from :func:`print_fleet_header` so the JSON payload carries
+    the exact strings a human is shown. A machine consumer that must decide
+    "empty or unobserved?" should read ``hosts.responded`` vs ``hosts.total``;
+    these lines are so that a human reading a log of the JSON sees what the
+    terminal would have said.
+    """
+    lines = resolution_echo(listing)
+    lines.append(summary_line(listing))
+    instruments = instrument_line(listing)
+    if instruments:
+        lines.append(instruments)
+    return lines
+
+
+def print_fleet_header(console: Any, listing: FleetListing) -> None:
+    """Print the header ABOVE the table. Always — there is no quiet mode.
+
+    Colour carries the same three-valued discipline as the text: green only
+    when EVERY intended host answered, yellow the moment one did not. It is not
+    red — an unreachable peer is not an error, it is an unknown, and dressing it
+    as a failure would train the operator to ignore it.
+    """
+    for line in resolution_echo(listing):
+        console.print(f"[cyan]{line}[/cyan]")
+    complete = listing.responded == listing.total and not listing.suppressed_reason
+    colour = "green" if complete else "yellow"
+    console.print(f"[{colour}]{summary_line(listing)}[/{colour}]")
+    instruments = instrument_line(listing)
+    if instruments:
+        console.print(f"[dim]{instruments}[/dim]")
+
+
+def hosts_payload(listing: FleetListing) -> dict:
+    """The ``hosts`` block of ``--json``.
+
+    ``responded`` vs ``total`` is the machine-readable form of the whole point:
+    ``agents == []`` with ``responded == total`` is an EMPTY fleet, while
+    ``agents == []`` with ``responded < total`` is an UNOBSERVED one. Each
+    report additionally carries ``agents: null`` when that host never answered —
+    never ``0``, which would be the same lie as omitting it.
+    """
+    return {
+        "responded": listing.responded,
+        "total": listing.total,
+        "summary": summary_line(listing),
+        "header": fleet_header_lines(listing),
+        "fanout_suppressed_by": listing.suppressed_reason or None,
+        "peers_known": listing.peers_known,
+        "filter": {
+            "resolutions": [
+                {"requested": requested, "resolved": resolved}
+                for requested, resolved in listing.resolutions
+            ],
+            "echo": resolution_echo(listing),
+        },
+        "reports": [r.to_dict() for r in listing.reports],
+    }

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
@@ -231,13 +231,14 @@ def _print_hidden_footer(
 
 
 def print_agent_list(
-    registry: Registry,
+    registry: Registry | None,
     capability: str | None = None,
     machine: str | None = None,
     group: str | None = None,
     *,
     verbose: bool = False,
     show_all: bool = False,
+    rows: list[dict] | None = None,
 ) -> None:
     """Print a rich table of registered agents.
 
@@ -251,21 +252,33 @@ def print_agent_list(
     detail — and adds the spec ``Path`` column. ``show_all=True`` (``--all``)
     also shows the full list AND additionally includes dead spec-missing
     registry ghosts (see :func:`_is_ghost_row`), which stay hidden otherwise.
+
+    ``rows`` renders a listing that was ALREADY assembled — the fleet-wide path,
+    whose rows come from several hosts and therefore cannot be re-derived from
+    one local ``registry``. It changes only WHERE the data came from: every
+    filter, column and footer below behaves identically. The empty-listing text
+    differs deliberately, because "registry empty, no specs on disk" is a claim
+    about THIS machine and would be false about a fleet whose hosts answered.
     """
     from ._agent_list import get_agent_list_data
 
-    # PERF: the default view discards non-running rows, so let the data layer
-    # skip their account/movement enrichment. `-v`/`--all` show every row, so
-    # they must stay fully enriched.
-    data = get_agent_list_data(
-        registry,
-        capability=capability,
-        machine=machine,
-        group=group,
-        running_only=not (verbose or show_all),
-    )
+    if rows is not None:
+        data = list(rows)
+        empty_msg = "[dim]No agents on the host(s) that answered.[/dim]"
+    else:
+        # PERF: the default view discards non-running rows, so let the data
+        # layer skip their account/movement enrichment. `-v`/`--all` show every
+        # row, so they must stay fully enriched.
+        data = get_agent_list_data(
+            registry,
+            capability=capability,
+            machine=machine,
+            group=group,
+            running_only=not (verbose or show_all),
+        )
+        empty_msg = "[dim]No agents found (registry empty, no specs on disk).[/dim]"
     if not data:
-        console.print("[dim]No agents found (registry empty, no specs on disk).[/dim]")
+        console.print(empty_msg)
         return
 
     # `--all` reveals dead spec-missing registry ghosts; hidden otherwise.

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -13,11 +13,11 @@ from .._lifecycle.health import health_check
 from .._lifecycle.lifecycle import agent_status
 from .._state.registry import Registry
 from ..config import load_config
+from ._agents_list_fleet import fleet_list_options, run_fleet_list
 from ._helpers import (
     _json_flag,
     agent_name_complete,
     console,
-    print_agent_list,
 )
 from ._timefmt import format_jst
 
@@ -137,6 +137,7 @@ def _format_claude_account_block(meta: dict) -> list[str]:
 
 
 @click.command(name="show-status")
+@fleet_list_options
 @click.argument("name", required=False, shell_complete=agent_name_complete)
 @click.option(
     "--json",
@@ -237,20 +238,30 @@ def status(
     with_snapshot: bool,
     with_priority: bool,
     with_workdir_audit: bool,
+    hosts: tuple[str, ...],
+    no_fanout: bool,
+    host_timeout: float,
 ) -> None:
     """Show agent status.
 
-    Without ``NAME``: fleet view — every registered agent in a table,
-    optionally filtered by ``--capability`` / ``--machine`` / ``--group``.
+    Without ``NAME``: FLEET-WIDE view — every host this machine can reach
+    (``sac host list``), every row naming its machine, above a MANDATORY header
+    saying which hosts answered and which did not, with the reason. A host that
+    could not be reached is REPORTED, never dropped: omitting it would render
+    ``unknown`` as ``empty``, and an unreachable fleet must never look like an
+    empty one. Filter with ``--host`` (repeatable, exact match; ``localhost``
+    resolves at parse time and the header echoes the resolution).
 
     With ``NAME``: rich per-agent payload (registry entry + config-derived
     fields + resource snapshot).
 
     \b
     Example:
-      $ sac agent status                            # fleet view
+      $ sac agent status                            # fleet-wide view
+      $ sac agent status --host localhost           # this machine only
+      $ sac agent status --host mba --host spartan  # two named hosts
       $ sac agent status orchestrator               # rich per-agent
-      $ sac agent status --json                     # fleet view, JSON
+      $ sac agent status --json                     # fleet-wide, JSON
       $ sac agent status --capability HPC           # fleet view, filtered
       $ sac agent status --group active            # fleet view, by group
     """
@@ -378,31 +389,22 @@ def status(
         # moved to `sac accounts list` — different noun, different
         # concern. Keeping both here turned every status print into a
         # crowded mix of "what's running" + "who I'm logged in as".
-        if use_json:
-            from ._helpers import get_agent_list_data
-
-            click.echo(
-                json_mod.dumps(
-                    {
-                        "agents": get_agent_list_data(
-                            registry,
-                            capability=capability,
-                            machine=machine,
-                            group=group,
-                        ),
-                    },
-                    indent=2,
-                )
-            )
-        else:
-            print_agent_list(
-                registry,
-                capability=capability,
-                machine=machine,
-                group=group,
-                verbose=verbose,
-                show_all=show_all,
-            )
+        # FLEET-WIDE by default (see ``._agents_list_fleet``): every reachable
+        # host, above a mandatory header naming the ones that did not answer.
+        # The ``{"agents": [...]}`` envelope is unchanged; a sibling ``"hosts"``
+        # block carries the reachability record.
+        run_fleet_list(
+            registry,
+            use_json=use_json,
+            hosts=hosts,
+            no_fanout=no_fanout,
+            host_timeout=host_timeout,
+            capability=capability,
+            machine=machine,
+            group=group,
+            verbose=verbose,
+            show_all=show_all,
+        )
 
 
 @click.command(name="check-health")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,6 +189,26 @@ _SAC_CARDS_DB = _SAC_STATE_FLOOR / "cards" / "cards.db"
 os.environ["SCITEX_CARDS_DB"] = str(_SAC_CARDS_DB)
 os.environ["SCITEX_TODO_DB"] = str(_SAC_CARDS_DB)
 
+# --- NEVER let a test ssh into the operator's REAL fleet -------------------
+# `sac agents list` is FLEET-WIDE by default: with no flags it fans out over
+# every peer in `~/.scitex/agent-container/config.yaml` UNION the scitex-dev
+# host registry. On the operator's own machines that is ~12 live hosts, and
+# `scitex_dev.hosts.list_hosts()` SEEDS a default registry from its built-ins
+# on any box where the file is absent — so even a fresh CI runner resolves
+# mba / spartan / the NAS row set and would try to reach them.
+#
+# Six existing tests invoke the fleet view (`runner.invoke(status, ["--json"])`
+# and friends). Without this floor each of them would open real ssh
+# connections, take a per-host timeout to fail, and make its assertions a
+# function of the operator's network. Same reasoning, same shape, as the state
+# / event-log / card floors above: force-set, so it does not depend on any
+# fixture remembering to opt in.
+#
+# Tests that exercise the fan-out ITSELF clear this via `env_save_restore` (or
+# pass explicit `targets=` / `peer_probe=` seams), which is the intended way to
+# reach the peer leg deliberately rather than by accident.
+os.environ["SAC_AGENTS_LIST_NO_FANOUT"] = "1"
+
 
 def _ensure_subprocess_coverage_shim() -> None:
     """Drop an idempotent ``.pth`` shim in site-packages so every child

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_fleet.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_fleet.py
@@ -558,6 +558,36 @@ def test_suppressed_fanout_says_so_in_the_header():
     assert "2 peers NOT queried (--no-fanout)" in line
 
 
+def test_a_localhost_only_listing_does_not_mention_the_peers_it_excluded():
+    # Arrange -- the caller asked for one host; the others are not news, and a
+    # note about them would train him to skim the line that matters.
+    listing = collect_fleet(
+        targets=_targets("mba", "spartan"),
+        local_lister=_one_local,
+        hosts=["localhost"],
+        no_fanout=True,
+    )
+    # Act
+    line = summary_line(listing)
+    # Assert
+    assert "NOT queried" not in line
+
+
+def test_a_named_peer_is_not_also_counted_in_the_aggregate_note():
+    # Arrange -- it already has its own not_queried row; saying it twice makes
+    # the header noisier without making it truer.
+    listing = collect_fleet(
+        targets=_targets("mba", "spartan"),
+        local_lister=_one_local,
+        hosts=["localhost", "spartan"],
+        no_fanout=True,
+    )
+    # Act
+    line = summary_line(listing)
+    # Assert
+    assert "NOT queried" not in line
+
+
 def test_a_named_host_that_was_not_queried_gets_its_own_row():
     # Arrange -- the operator ASKED for spartan; silence would read "empty".
     listing = collect_fleet(

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_fleet.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_fleet.py
@@ -1,0 +1,595 @@
+"""Tests for the fleet fan-out and its mandatory reachability header.
+
+No mocks (PA-306), and no ``monkeypatch``: every seam is a REAL callable —
+``local_lister`` is a plain function returning rows, ``peer_probe`` is a plain
+function returning ``(HostReport, rows)`` — and the local hostname is pinned
+through the documented ``SCITEX_AGENT_CONTAINER_HOSTNAME`` env var that
+``resolve_hostname`` already honours. That matters more than usual here: the
+whole feature is about not confusing "I could not observe" with "there is
+nothing", and a fixture that answers every call cannot exercise that.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from scitex_agent_container.cli_pkg._helpers._agent_list_fleet import (
+    RESPONDED,
+    TIMED_OUT,
+    UNREACHABLE,
+    HostReport,
+    HostTarget,
+    UnknownHostFilter,
+    collect_fleet,
+    resolve_host_filter,
+)
+from scitex_agent_container.cli_pkg._helpers._agent_list_fleet_model import (
+    INSTRUMENT_LOCAL_REGISTRY,
+    INSTRUMENT_SSH,
+    NOT_QUERIED,
+)
+from scitex_agent_container.cli_pkg._helpers._agent_list_fleet_render import (
+    fleet_header_lines,
+    hosts_payload,
+    summary_line,
+)
+
+LOCAL = "test-local-host"
+
+
+@pytest.fixture(autouse=True)
+def fleet_env(env_save_restore):
+    """Pin this machine's name and lift the suite-wide local-only floor.
+
+    ``tests/conftest.py`` force-sets ``SAC_AGENTS_LIST_NO_FANOUT=1`` so no test
+    ever ssh's into the operator's real fleet by accident. Everything here
+    drives the peer leg through explicit ``targets=`` / ``peer_probe=`` seams,
+    which never touch the network, so the floor is deliberately lifted.
+    """
+    env_save_restore.delete("SAC_AGENTS_LIST_NO_FANOUT")
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_AGENTS_LIST_NO_FANOUT")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", LOCAL)
+    return env_save_restore
+
+
+def _targets(*peers: str) -> list[HostTarget]:
+    return [HostTarget(name=LOCAL, ssh="", local=True)] + [
+        HostTarget(name=p, ssh=p) for p in peers
+    ]
+
+
+def _row(name: str, host: str = "local") -> dict:
+    return {"name": name, "status": "running", "host": host, "host_display": host}
+
+
+def _no_local() -> list[dict]:
+    return []
+
+
+def _one_local() -> list[dict]:
+    return [_row("local-agent")]
+
+
+def _responded(host: str, rows: list[dict]) -> tuple[HostReport, list[dict]]:
+    return (
+        HostReport(
+            host=host,
+            status=RESPONDED,
+            instrument=INSTRUMENT_SSH,
+            detail="sac agents list --json over ssh",
+            agents=len(rows),
+        ),
+        rows,
+    )
+
+
+def _timed_out(host: str, seconds: float = 8.0) -> tuple[HostReport, list[dict]]:
+    return (
+        HostReport(
+            host=host,
+            status=TIMED_OUT,
+            instrument=INSTRUMENT_SSH,
+            detail=f"ssh timed out after {seconds:g}s",
+        ),
+        [],
+    )
+
+
+def _probe_pair(answers: dict[str, tuple[HostReport, list[dict]]]):
+    def probe(target: HostTarget, timeout_s: float):
+        return answers[target.name]
+
+    return probe
+
+
+@pytest.fixture
+def five_of_six():
+    """One local host plus five peers, exactly one of which never answers."""
+    return collect_fleet(
+        targets=_targets("mba", "spartan", "nas-03", "compute-01", "compute-02"),
+        local_lister=_one_local,
+        peer_probe=_probe_pair(
+            {
+                "mba": _responded("mba", [_row("mba-agent", "mba")]),
+                "spartan": _timed_out("spartan"),
+                "nas-03": _responded("nas-03", []),
+                "compute-01": _responded("compute-01", []),
+                "compute-02": _responded("compute-02", []),
+            }
+        ),
+    )
+
+
+def _instrument_line(listing) -> str:
+    return next(ln for ln in fleet_header_lines(listing) if ln.startswith("instruments:"))
+
+
+# ===========================================================================
+# The header: the responded / unresponsive split, with the reason
+# ===========================================================================
+
+
+def test_summary_line_counts_responded_over_total(five_of_six):
+    # Arrange
+    listing = five_of_six
+    # Act
+    line = summary_line(listing)
+    # Assert
+    assert line.startswith("5/6 hosts responded")
+
+
+def test_summary_line_names_the_host_that_did_not_answer(five_of_six):
+    # Arrange
+    listing = five_of_six
+    # Act
+    line = summary_line(listing)
+    # Assert
+    assert "spartan" in line
+
+
+def test_summary_line_carries_the_reason_not_just_the_name(five_of_six):
+    # Arrange -- a bare name would tell the operator nothing actionable.
+    listing = five_of_six
+    # Act
+    line = summary_line(listing)
+    # Assert
+    assert "ssh timed out after 8s" in line
+
+
+def test_header_names_the_instrument_for_the_local_host(five_of_six):
+    # Arrange
+    listing = five_of_six
+    # Act
+    line = _instrument_line(listing)
+    # Assert
+    assert f"{LOCAL}={INSTRUMENT_LOCAL_REGISTRY}" in line
+
+
+def test_header_names_the_instrument_for_a_peer(five_of_six):
+    # Arrange
+    listing = five_of_six
+    # Act
+    line = _instrument_line(listing)
+    # Assert
+    assert "mba=ssh" in line
+
+
+def test_header_marks_the_unanswered_host_in_the_instrument_line(five_of_six):
+    # Arrange
+    listing = five_of_six
+    # Act
+    line = _instrument_line(listing)
+    # Assert
+    assert "spartan=ssh (no answer)" in line
+
+
+def test_json_payload_reports_the_responded_over_total_split(five_of_six):
+    # Arrange
+    listing = five_of_six
+    # Act
+    payload = hosts_payload(listing)
+    # Assert
+    assert (payload["responded"], payload["total"]) == (5, 6)
+
+
+def test_json_payload_repeats_the_header_lines_verbatim(five_of_six):
+    # Arrange -- a log of the JSON must read like the terminal did.
+    listing = five_of_six
+    # Act
+    payload = hosts_payload(listing)
+    # Assert
+    assert payload["header"] == fleet_header_lines(listing)
+
+
+def test_json_report_for_a_responding_host_counts_its_agents(five_of_six):
+    # Arrange
+    payload = hosts_payload(five_of_six)
+    # Act
+    mba = next(r for r in payload["reports"] if r["host"] == "mba")
+    # Assert
+    assert mba["agents"] == 1
+
+
+def test_json_report_for_a_timed_out_host_leaves_the_count_unknown(five_of_six):
+    # Arrange -- None, NEVER 0: zero is the same lie as omitting the row.
+    payload = hosts_payload(five_of_six)
+    # Act
+    spartan = next(r for r in payload["reports"] if r["host"] == "spartan")
+    # Assert
+    assert spartan["agents"] is None
+
+
+def test_json_report_keeps_the_timed_out_status_distinct(five_of_six):
+    # Arrange
+    payload = hosts_payload(five_of_six)
+    # Act
+    spartan = next(r for r in payload["reports"] if r["host"] == "spartan")
+    # Assert
+    assert spartan["status"] == TIMED_OUT
+
+
+# ===========================================================================
+# UNKNOWN is not EMPTY -- the two must be distinguishable
+# ===========================================================================
+
+
+def test_a_timed_out_host_is_present_in_the_reports_not_absent():
+    # Arrange
+    probe = _probe_pair({"spartan": _timed_out("spartan")})
+    # Act
+    listing = collect_fleet(
+        targets=_targets("spartan"), local_lister=_no_local, peer_probe=probe
+    )
+    # Assert
+    assert [r.host for r in listing.reports] == [LOCAL, "spartan"]
+
+
+@pytest.fixture
+def empty_beside_silent():
+    """Two peers contributing zero rows: one answered, one never did."""
+    return collect_fleet(
+        targets=_targets("empty-host", "silent-host"),
+        local_lister=_no_local,
+        peer_probe=_probe_pair(
+            {
+                "empty-host": _responded("empty-host", []),
+                "silent-host": _timed_out("silent-host"),
+            }
+        ),
+    )
+
+
+def test_an_answered_but_empty_host_reports_zero_agents(empty_beside_silent):
+    # Arrange
+    by_host = {r.host: r for r in empty_beside_silent.reports}
+    # Act
+    empty = by_host["empty-host"]
+    # Assert
+    assert empty.agents == 0
+
+
+def test_a_silent_host_reports_an_unknown_agent_count(empty_beside_silent):
+    # Arrange -- same zero rows in the table; only the report tells them apart.
+    by_host = {r.host: r for r in empty_beside_silent.reports}
+    # Act
+    silent = by_host["silent-host"]
+    # Assert
+    assert silent.agents is None
+
+
+def test_an_empty_fleet_reports_every_host_as_answered():
+    # Arrange
+    probe = _probe_pair({"peer": _responded("peer", [])})
+    # Act
+    payload = hosts_payload(
+        collect_fleet(targets=_targets("peer"), local_lister=_no_local, peer_probe=probe)
+    )
+    # Assert
+    assert (payload["responded"], payload["total"]) == (2, 2)
+
+
+def test_an_unobserved_fleet_reports_a_short_count_on_the_same_empty_rows():
+    # Arrange -- byte-identical `agents: []`; the header is the only difference.
+    probe = _probe_pair({"peer": _timed_out("peer")})
+    # Act
+    payload = hosts_payload(
+        collect_fleet(targets=_targets("peer"), local_lister=_no_local, peer_probe=probe)
+    )
+    # Assert
+    assert (payload["responded"], payload["total"]) == (1, 2)
+
+
+def test_a_probe_that_raises_becomes_a_reported_host_not_a_crash():
+    # Arrange
+    def exploding(target: HostTarget, timeout_s: float):
+        raise RuntimeError("probe blew up")
+
+    # Act
+    listing = collect_fleet(
+        targets=_targets("boom"), local_lister=_no_local, peer_probe=exploding
+    )
+    # Assert
+    assert next(r for r in listing.reports if r.host == "boom").status == UNREACHABLE
+
+
+def test_a_local_read_that_fails_is_reported_rather_than_rendered_as_empty():
+    # Arrange
+    def broken() -> list[dict]:
+        raise OSError("registry is gone")
+
+    # Act
+    listing = collect_fleet(targets=_targets(), local_lister=broken)
+    # Assert
+    assert "registry is gone" in listing.reports[0].detail
+
+
+# ===========================================================================
+# Fan-out is CONCURRENT: bounded by the slowest peer, not by their sum
+# ===========================================================================
+
+
+def test_fan_out_wall_clock_is_bounded_by_the_slowest_peer_not_their_sum():
+    # Arrange -- five peers, each taking 0.30s. Sequentially that is 1.50s.
+    delay = 0.30
+    peers = [f"peer-{i}" for i in range(5)]
+
+    def slow_probe(target: HostTarget, timeout_s: float):
+        time.sleep(delay)
+        return _responded(target.name, [])
+
+    # Act
+    started = time.monotonic()
+    collect_fleet(
+        targets=_targets(*peers), local_lister=_no_local, peer_probe=slow_probe
+    )
+    elapsed = time.monotonic() - started
+    # Assert
+    assert elapsed < delay * len(peers) / 2, f"took {elapsed:.2f}s, not concurrent"
+
+
+def test_every_peer_still_answers_when_the_fan_out_is_concurrent():
+    # Arrange
+    peers = [f"peer-{i}" for i in range(5)]
+
+    def slow_probe(target: HostTarget, timeout_s: float):
+        time.sleep(0.05)
+        return _responded(target.name, [])
+
+    # Act
+    listing = collect_fleet(
+        targets=_targets(*peers), local_lister=_no_local, peer_probe=slow_probe
+    )
+    # Assert
+    assert listing.responded == len(peers) + 1
+
+
+def _stalling_probe(target: HostTarget, timeout_s: float):
+    if target.name == "stalled":
+        time.sleep(5.0)
+    return _responded(target.name, [])
+
+
+def _stalled_listing():
+    return collect_fleet(
+        targets=_targets("stalled", "quick-1", "quick-2"),
+        local_lister=_no_local,
+        peer_probe=_stalling_probe,
+        host_timeout_s=0.2,
+    )
+
+
+def test_one_stalled_peer_does_not_hold_the_batch_past_the_shared_budget():
+    # Arrange
+    started = time.monotonic()
+    # Act
+    _stalled_listing()
+    elapsed = time.monotonic() - started
+    # Assert
+    assert elapsed < 3.5, f"the stalled peer held the batch for {elapsed:.2f}s"
+
+
+def test_a_stalled_peer_is_reported_as_timed_out_rather_than_dropped():
+    # Arrange
+    listing = _stalled_listing()
+    # Act
+    stalled = next(r for r in listing.reports if r.host == "stalled")
+    # Assert
+    assert stalled.status == TIMED_OUT
+
+
+# ===========================================================================
+# --host: exact match, localhost resolved at parse time, unknown fails loud
+# ===========================================================================
+
+
+def test_host_localhost_selects_this_machine():
+    # Arrange
+    targets = _targets("mba")
+    # Act
+    selected, _ = resolve_host_filter(["localhost"], targets, LOCAL)
+    # Assert
+    assert [t.name for t in selected] == [LOCAL]
+
+
+def test_host_localhost_is_recorded_as_a_resolution():
+    # Arrange -- the OUTPUT must never keep the ambiguous word.
+    targets = _targets("mba")
+    # Act
+    _, resolutions = resolve_host_filter(["localhost"], targets, LOCAL)
+    # Assert
+    assert resolutions == (("localhost", LOCAL),)
+
+
+def test_host_local_is_accepted_as_the_same_alias():
+    # Arrange
+    targets = _targets("mba")
+    # Act
+    _, resolutions = resolve_host_filter(["local"], targets, LOCAL)
+    # Assert
+    assert resolutions == (("local", LOCAL),)
+
+
+def test_a_concrete_hostname_is_not_recorded_as_a_resolution():
+    # Arrange -- nothing was rewritten, so nothing is echoed.
+    targets = _targets("mba")
+    # Act
+    _, resolutions = resolve_host_filter(["mba"], targets, LOCAL)
+    # Assert
+    assert resolutions == ()
+
+
+def test_host_is_repeatable_and_selects_exactly_those_hosts():
+    # Arrange
+    targets = _targets("mba", "spartan", "nas-03")
+    # Act
+    selected, _ = resolve_host_filter(["mba", "spartan"], targets, LOCAL)
+    # Assert
+    assert [t.name for t in selected] == ["mba", "spartan"]
+
+
+def test_an_unknown_host_fails_loud_rather_than_returning_nothing():
+    # Arrange -- silence would render "no such host" exactly like
+    # "that host has no agents".
+    targets = _targets("mba", "spartan")
+    # Act
+    attempt = lambda: resolve_host_filter(["nope"], targets, LOCAL)  # noqa: E731
+    # Assert
+    with pytest.raises(UnknownHostFilter):
+        attempt()
+
+
+def test_the_unknown_host_error_names_every_host_that_would_have_worked():
+    # Arrange
+    targets = _targets("mba", "spartan")
+    # Act
+    try:
+        resolve_host_filter(["nope"], targets, LOCAL)
+        message = ""
+    except UnknownHostFilter as exc:
+        message = str(exc)
+    # Assert
+    assert all(name in message for name in (LOCAL, "mba", "spartan"))
+
+
+def test_an_alias_of_a_deduped_host_still_selects_it():
+    # Arrange -- one machine reached through two peer keys.
+    targets = [
+        HostTarget(name=LOCAL, ssh="", local=True),
+        HostTarget(name="nas-03", ssh="scitex-nas-03", aliases=("scitex-nas-03",)),
+    ]
+    # Act
+    selected, _ = resolve_host_filter(["scitex-nas-03"], targets, LOCAL)
+    # Assert
+    assert [t.name for t in selected] == ["nas-03"]
+
+
+def test_the_header_echoes_the_localhost_resolution():
+    # Arrange
+    listing = collect_fleet(
+        targets=_targets("mba"), local_lister=_one_local, hosts=["localhost"]
+    )
+    # Act
+    first = fleet_header_lines(listing)[0]
+    # Assert
+    assert first == f"--host localhost → {LOCAL}"
+
+
+def test_the_json_filter_block_records_the_resolution():
+    # Arrange
+    listing = collect_fleet(
+        targets=_targets("mba"), local_lister=_one_local, hosts=["localhost"]
+    )
+    # Act
+    payload = hosts_payload(listing)
+    # Assert
+    assert payload["filter"]["resolutions"] == [
+        {"requested": "localhost", "resolved": LOCAL}
+    ]
+
+
+def test_filtering_to_one_host_queries_only_that_host():
+    # Arrange
+    asked: list[str] = []
+
+    def probe(target: HostTarget, timeout_s: float):
+        asked.append(target.name)
+        return _responded(target.name, [])
+
+    # Act
+    collect_fleet(
+        targets=_targets("mba", "spartan"),
+        local_lister=_no_local,
+        hosts=["spartan"],
+        peer_probe=probe,
+    )
+    # Assert
+    assert asked == ["spartan"]
+
+
+def test_filtering_to_one_host_reports_only_that_host():
+    # Arrange
+    probe = _probe_pair({"spartan": _responded("spartan", [])})
+    # Act
+    listing = collect_fleet(
+        targets=_targets("mba", "spartan"),
+        local_lister=_no_local,
+        hosts=["spartan"],
+        peer_probe=probe,
+    )
+    # Assert
+    assert [r.host for r in listing.reports] == ["spartan"]
+
+
+# ===========================================================================
+# Fan-out suppression is announced, never silent
+# ===========================================================================
+
+
+def test_suppressed_fanout_says_so_in_the_header():
+    # Arrange
+    listing = collect_fleet(
+        targets=_targets("mba", "spartan"), local_lister=_one_local, no_fanout=True
+    )
+    # Act
+    line = summary_line(listing)
+    # Assert
+    assert "2 peers NOT queried (--no-fanout)" in line
+
+
+def test_a_named_host_that_was_not_queried_gets_its_own_row():
+    # Arrange -- the operator ASKED for spartan; silence would read "empty".
+    listing = collect_fleet(
+        targets=_targets("mba", "spartan"),
+        local_lister=_one_local,
+        hosts=["spartan"],
+        no_fanout=True,
+    )
+    # Act
+    spartan = next(r for r in listing.reports if r.host == "spartan")
+    # Assert
+    assert spartan.status == NOT_QUERIED
+
+
+def test_a_host_that_was_not_queried_has_an_unknown_agent_count():
+    # Arrange
+    listing = collect_fleet(
+        targets=_targets("spartan"),
+        local_lister=_one_local,
+        hosts=["spartan"],
+        no_fanout=True,
+    )
+    # Act
+    spartan = next(r for r in listing.reports if r.host == "spartan")
+    # Assert
+    assert spartan.agents is None
+
+
+def test_the_env_switch_is_named_in_the_header_so_it_is_never_silent(fleet_env):
+    # Arrange
+    fleet_env.set("SAC_AGENTS_LIST_NO_FANOUT", "1")
+    # Act
+    line = summary_line(collect_fleet(targets=_targets("mba"), local_lister=_one_local))
+    # Assert
+    assert "SAC_AGENTS_LIST_NO_FANOUT" in line

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_fleet_probe.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_fleet_probe.py
@@ -1,0 +1,404 @@
+"""Tests for the ssh leg of the fleet listing, and for target enumeration.
+
+No mocks and no ``monkeypatch``: ``ssh_peer_probe``'s ``runner`` seam is a real
+callable with ``subprocess.run``'s signature, so every rc / timeout / legacy-peer
+branch is driven through the production mapping rather than around it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from scitex_agent_container.cli_pkg._helpers._agent_list_fleet_model import (
+    INSTRUMENT_SSH,
+    MALFORMED,
+    RESPONDED,
+    SAC_MISSING,
+    TIMED_OUT,
+    UNREACHABLE,
+    HostTarget,
+    resolve_targets,
+)
+from scitex_agent_container.cli_pkg._helpers._agent_list_fleet_probe import (
+    ssh_peer_probe,
+)
+
+LOCAL = "test-local-host"
+_PEER_NAME = "mba"
+_TARGET = HostTarget(name=_PEER_NAME, ssh=_PEER_NAME)
+
+
+class _Peer:
+    """The one attribute ``resolve_targets`` / ``build_ssh_argv`` read."""
+
+    def __init__(self, ssh: str) -> None:
+        self.name = ssh or "unnamed"
+        self.ssh = ssh
+        self.via: tuple[str, ...] = ()
+
+    def jump_chain(self, peers):
+        return []
+
+    def joined_preamble(self) -> str:
+        return ""
+
+
+_PEERS = {_PEER_NAME: _Peer(_PEER_NAME)}
+
+
+class _Proc:
+    """The three attributes the probe reads off a CompletedProcess."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _runner(*results, record: list | None = None):
+    """A real callable with ``subprocess.run``'s signature, answering in turn."""
+    queue = list(results)
+
+    def run(argv, **kwargs):
+        if record is not None:
+            record.append(list(argv))
+        outcome = queue.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    return run
+
+
+def _probe(*results, record: list | None = None, **kwargs):
+    return ssh_peer_probe(
+        _TARGET,
+        8.0,
+        peers=_PEERS,
+        runner=_runner(*results, record=record),
+        **kwargs,
+    )
+
+
+# ===========================================================================
+# The happy path
+# ===========================================================================
+
+
+def test_ssh_probe_reports_the_host_as_responded():
+    # Arrange
+    proc = _Proc(0, '{"agents": [{"name": "remote-agent"}]}')
+    # Act
+    report, _ = _probe(proc)
+    # Assert
+    assert report.status == RESPONDED
+
+
+def test_ssh_probe_names_ssh_as_the_instrument():
+    # Arrange
+    proc = _Proc(0, '{"agents": []}')
+    # Act
+    report, _ = _probe(proc)
+    # Assert
+    assert report.instrument == INSTRUMENT_SSH
+
+
+def test_ssh_probe_returns_the_peers_rows():
+    # Arrange
+    proc = _Proc(0, '{"agents": [{"name": "remote-agent"}]}')
+    # Act
+    _, rows = _probe(proc)
+    # Assert
+    assert [r["name"] for r in rows] == ["remote-agent"]
+
+
+def test_ssh_probe_accepts_the_bare_list_shape_too():
+    # Arrange -- print_agent_list_json emits a bare list, not the envelope.
+    proc = _Proc(0, '[{"name": "remote-agent"}]')
+    # Act
+    _, rows = _probe(proc)
+    # Assert
+    assert [r["name"] for r in rows] == ["remote-agent"]
+
+
+def test_ssh_probe_counts_the_agents_it_actually_received():
+    # Arrange
+    proc = _Proc(0, '{"agents": [{"name": "a"}, {"name": "b"}]}')
+    # Act
+    report, _ = _probe(proc)
+    # Assert
+    assert report.agents == 2
+
+
+# ===========================================================================
+# A remote row must name its MACHINE, not the peer's own point of view
+# ===========================================================================
+
+
+def test_a_remote_row_is_stamped_with_the_machine_not_the_peers_own_local():
+    # Arrange -- the peer describes its agents as host="local": true THERE,
+    # a lie HERE, and a whole column of "local" is the original problem.
+    proc = _Proc(0, '{"agents": [{"name": "a", "host": "local"}]}')
+    # Act
+    _, rows = _probe(proc)
+    # Assert
+    assert rows[0]["host"] == _PEER_NAME
+
+
+def test_a_remote_rows_display_host_is_stamped_too():
+    # Arrange
+    proc = _Proc(0, '{"agents": [{"name": "a", "host": "local"}]}')
+    # Act
+    _, rows = _probe(proc)
+    # Assert
+    assert rows[0]["host_display"] == _PEER_NAME
+
+
+def test_a_remote_row_keeps_the_peers_own_resolved_hostname_when_it_has_one():
+    # Arrange
+    proc = _Proc(
+        0,
+        '{"agents": [{"name": "a", "host": "local", '
+        '"host_display": "ywata-note-win"}]}',
+    )
+    # Act
+    _, rows = _probe(proc)
+    # Assert
+    assert rows[0]["host"] == "ywata-note-win"
+
+
+# ===========================================================================
+# Failure modes stay DISTINCT -- each one has a different remedy
+# ===========================================================================
+
+
+def test_ssh_timeout_is_reported_as_timed_out_not_unreachable():
+    # Arrange -- a slow host has not refused us.
+    expired = subprocess.TimeoutExpired(cmd="ssh", timeout=8.0)
+    # Act
+    report, _ = _probe(expired)
+    # Assert
+    assert report.status == TIMED_OUT
+
+
+def test_a_timed_out_probe_says_how_long_it_waited():
+    # Arrange
+    expired = subprocess.TimeoutExpired(cmd="ssh", timeout=8.0)
+    # Act
+    report, _ = _probe(expired)
+    # Assert
+    assert "timed out after 8s" in report.detail
+
+
+def test_a_timed_out_probe_returns_no_rows():
+    # Arrange
+    expired = subprocess.TimeoutExpired(cmd="ssh", timeout=8.0)
+    # Act
+    _, rows = _probe(expired)
+    # Assert
+    assert rows == []
+
+
+def test_a_nonzero_ssh_exit_is_reported_as_unreachable():
+    # Arrange
+    proc = _Proc(255, "", "ssh: connect to host x port 22: No route to host")
+    # Act
+    report, _ = _probe(proc)
+    # Assert
+    assert report.status == UNREACHABLE
+
+
+def test_an_unreachable_host_carries_the_ssh_error_as_its_reason():
+    # Arrange
+    proc = _Proc(255, "", "ssh: connect to host x port 22: No route to host")
+    # Act
+    report, _ = _probe(proc)
+    # Assert
+    assert "No route to host" in report.detail
+
+
+def test_a_host_we_reached_without_sac_is_not_called_unreachable():
+    # Arrange -- measured live on two NAS boxes: we arrived, sac was missing,
+    # and the remedy is "install sac there", not "fix the network".
+    proc = _Proc(127, "", "sh: sac: command not found")
+    # Act
+    report, _ = _probe(proc)
+    # Assert
+    assert report.status == SAC_MISSING
+
+
+def test_an_unparseable_answer_is_malformed_not_unreachable():
+    # Arrange -- the transport demonstrably worked.
+    proc = _Proc(0, "Welcome to Ubuntu!\n")
+    # Act
+    report, _ = _probe(proc)
+    # Assert
+    assert report.status == MALFORMED
+
+
+def test_an_ssh_binary_that_cannot_run_is_reported_not_raised():
+    # Arrange
+    missing = FileNotFoundError("no ssh here")
+    # Act
+    report, _ = _probe(missing)
+    # Assert
+    assert report.status == UNREACHABLE
+
+
+# ===========================================================================
+# The recursion guard, and the stale-peer retry
+# ===========================================================================
+
+
+def test_the_peer_leg_passes_the_recursion_guard():
+    # Arrange -- without it the peer's own sac would fan out again.
+    seen: list = []
+    # Act
+    _probe(_Proc(0, '{"agents": []}'), record=seen)
+    # Assert
+    assert "--no-fanout" in seen[0]
+
+
+def test_a_peer_on_an_older_sac_is_retried_without_the_guard():
+    # Arrange -- an old sac rejects the flag, which PROVES it cannot recurse.
+    seen: list = []
+    # Act
+    _probe(
+        _Proc(2, "", "Error: No such option: --no-fanout"),
+        _Proc(0, '{"agents": [{"name": "old-peer-agent"}]}'),
+        record=seen,
+    )
+    # Assert
+    assert "--no-fanout" not in seen[1]
+
+
+def test_a_stale_peer_still_reads_as_responded_after_the_retry():
+    # Arrange -- without the retry every not-yet-upgraded peer in the fleet
+    # would read UNREACHABLE, which is the false negative this feature kills.
+    # Act
+    report, _ = _probe(
+        _Proc(2, "", "Error: No such option: --no-fanout"),
+        _Proc(0, '{"agents": [{"name": "old-peer-agent"}]}'),
+    )
+    # Assert
+    assert report.status == RESPONDED
+
+
+def test_a_stale_peers_rows_are_still_returned():
+    # Arrange
+    # Act
+    _, rows = _probe(
+        _Proc(2, "", "Error: No such option: --no-fanout"),
+        _Proc(0, '{"agents": [{"name": "old-peer-agent"}]}'),
+    )
+    # Assert
+    assert [r["name"] for r in rows] == ["old-peer-agent"]
+
+
+def test_the_capability_filter_travels_to_the_peer():
+    # Arrange -- filtered at the source, not shipped back and discarded.
+    seen: list = []
+    # Act
+    _probe(_Proc(0, '{"agents": []}'), record=seen, capability="HPC")
+    # Assert
+    assert seen[0][-2:] == ["--capability", "HPC"]
+
+
+def test_the_group_filter_travels_to_the_peer():
+    # Arrange
+    seen: list = []
+    # Act
+    _probe(_Proc(0, '{"agents": []}'), record=seen, group="active")
+    # Assert
+    assert seen[0][-2:] == ["--group", "active"]
+
+
+def test_the_verbose_view_choice_does_not_travel_to_the_peer():
+    # Arrange -- what the READER sees is decided locally, where every host's
+    # rows are held at once.
+    seen: list = []
+    # Act
+    _probe(_Proc(0, '{"agents": []}'), record=seen)
+    # Assert
+    assert "-v" not in seen[0]
+
+
+# ===========================================================================
+# Target enumeration
+# ===========================================================================
+
+
+def test_the_local_host_is_the_first_target():
+    # Arrange
+    peers = {"mba": _Peer("mba")}
+    # Act
+    targets = resolve_targets(peers, local_host=LOCAL)
+    # Assert
+    assert targets[0].local is True
+
+
+def test_glob_peer_keys_are_not_queried():
+    # Arrange -- `spartan-*` is a PATTERN; there is no one machine to ask.
+    peers = {"spartan": _Peer("spartan"), "spartan-*": _Peer("")}
+    # Act
+    targets = resolve_targets(peers, local_host=LOCAL)
+    # Assert
+    assert [t.name for t in targets] == [LOCAL, "spartan"]
+
+
+def test_the_local_host_is_never_also_queried_as_a_peer():
+    # Arrange -- this fleet's config.yaml lists the local box among its peers.
+    peers = {LOCAL: _Peer(LOCAL), "mba": _Peer("mba")}
+    # Act
+    targets = resolve_targets(peers, local_host=LOCAL)
+    # Assert
+    assert [t.name for t in targets] == [LOCAL, "mba"]
+
+
+def test_two_peer_keys_sharing_one_ssh_route_collapse_to_one_target():
+    # Arrange -- `nas-03` (config.yaml) and `scitex-nas-03` (registry) render
+    # the identical ssh argv; querying both would print every agent twice.
+    peers = {"nas-03": _Peer("scitex-nas-03"), "scitex-nas-03": _Peer("scitex-nas-03")}
+    # Act
+    targets = resolve_targets(peers, local_host=LOCAL)
+    # Assert
+    assert [t.name for t in targets] == [LOCAL, "nas-03"]
+
+
+def test_the_collapsed_peer_key_survives_as_an_alias():
+    # Arrange
+    peers = {"nas-03": _Peer("scitex-nas-03"), "scitex-nas-03": _Peer("scitex-nas-03")}
+    # Act
+    targets = resolve_targets(peers, local_host=LOCAL)
+    # Assert
+    assert targets[1].aliases == ("scitex-nas-03",)
+
+
+def test_a_peer_with_no_ssh_route_is_not_offered_as_a_target():
+    # Arrange -- the registry records ssh_alias null for ywata-note-win.
+    peers = {"unroutable": _Peer("")}
+    # Act
+    targets = resolve_targets(peers, local_host=LOCAL)
+    # Assert
+    assert [t.name for t in targets] == [LOCAL]
+
+
+def test_an_unreadable_peer_topology_still_yields_the_local_host():
+    # Arrange -- a listing must never crash because config.yaml is broken.
+    broken: dict = {}
+    # Act
+    targets = resolve_targets(broken, local_host=LOCAL)
+    # Assert
+    assert [t.name for t in targets] == [LOCAL]
+
+
+@pytest.mark.parametrize("rc", [126, 127])
+def test_a_shell_that_could_not_launch_sac_is_distinguished_by_its_message(rc):
+    # Arrange
+    proc = _Proc(rc, "", "sh: sac: command not found")
+    # Act
+    report, _ = _probe(proc)
+    # Assert
+    assert report.status == SAC_MISSING

--- a/tests/scitex_agent_container/cli_pkg/test__agents_list_fleet.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_list_fleet.py
@@ -1,0 +1,262 @@
+"""CLI-level tests for the fleet-wide default of ``sac agents list``.
+
+No mocks and no ``monkeypatch``: the peer topology is a REAL ``config.yaml``
+written into ``tmp_path`` and pointed at by the documented
+``SCITEX_AGENT_CONTAINER_CONFIG`` env var, and the local hostname is pinned
+through ``SCITEX_AGENT_CONTAINER_HOSTNAME`` — the same two knobs production
+reads.
+
+These tests never open a network connection. ``tests/conftest.py`` force-sets
+``SAC_AGENTS_LIST_NO_FANOUT=1`` precisely so that no test ssh's into the
+operator's real fleet, and the behaviour under test here — ``--host``
+resolution, the loud unknown-host failure, the ``hosts`` block in ``--json`` —
+is all decided before any transport would run. The fan-out itself is covered by
+``_helpers/test__agent_list_fleet.py`` through explicit probe seams.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.status_cmds import status
+
+LOCAL = "fleet-test-local"
+PEER = "fleet-test-peer"
+
+
+@pytest.fixture
+def fleet_config(tmp_path, env_save_restore):
+    """A real config.yaml with one peer, plus a pinned local hostname."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "host:\n"
+        f"  canonical: {LOCAL}\n"
+        "peers:\n"
+        f"  {PEER}:\n"
+        f"    ssh: {PEER}.invalid\n"
+    )
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", LOCAL)
+    return cfg
+
+
+def _hosts(result) -> dict:
+    # `result.output` folds stderr in (click 8.4 dropped mix_stderr), so an
+    # ambient WARN logged during config load would land ahead of the payload.
+    return json.loads(result.stdout)["hosts"]
+
+
+# ===========================================================================
+# The envelope stays what every consumer already parses
+# ===========================================================================
+
+
+def test_fleet_json_still_carries_the_agents_key(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json"])
+    # Assert
+    assert isinstance(json.loads(result.stdout)["agents"], list)
+
+
+def test_fleet_json_exits_zero_even_with_peers_unqueried(fleet_config):
+    # Arrange -- a listing that exited non-zero on an unreachable peer would
+    # break every caller that parses it.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_fleet_json_carries_a_hosts_block(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json"])
+    # Assert
+    assert "reports" in _hosts(result)
+
+
+def test_the_local_host_is_reported_by_its_resolved_name(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json"])
+    # Assert
+    assert any(r["host"] == LOCAL for r in _hosts(result)["reports"])
+
+
+def test_the_local_host_names_the_instrument_that_answered(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json"])
+    local = next(r for r in _hosts(result)["reports"] if r["host"] == LOCAL)
+    # Assert
+    assert local["instrument"] == "local_registry"
+
+
+# ===========================================================================
+# --host localhost resolves at parse time, and the header says so
+# ===========================================================================
+
+
+def test_host_localhost_is_accepted(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json", "--host", "localhost"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_host_localhost_is_resolved_to_the_real_hostname(fleet_config):
+    # Arrange -- `localhost` names a different machine depending on where it
+    # is typed, so the OUTPUT must record the resolved name.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json", "--host", "localhost"])
+    # Assert
+    assert _hosts(result)["filter"]["resolutions"] == [
+        {"requested": "localhost", "resolved": LOCAL}
+    ]
+
+
+def test_the_json_header_echoes_the_localhost_resolution(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json", "--host", "localhost"])
+    # Assert
+    assert f"--host localhost → {LOCAL}" in _hosts(result)["header"]
+
+
+def test_the_table_header_echoes_the_localhost_resolution(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--host", "localhost"])
+    # Assert
+    assert f"--host localhost → {LOCAL}" in result.output
+
+
+def test_the_table_header_reports_the_responded_split(fleet_config):
+    # Arrange -- mandatory, and it renders above the table every time.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--host", "localhost"])
+    # Assert
+    assert "1/1 host responded" in result.output
+
+
+# ===========================================================================
+# --host is repeatable, exact-match, and fails loud on an unknown name
+# ===========================================================================
+
+
+def test_host_selects_only_the_named_hosts(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json", "--host", "localhost"])
+    # Assert
+    assert [r["host"] for r in _hosts(result)["reports"]] == [LOCAL]
+
+
+def test_host_is_repeatable(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        status, ["--json", "--host", "localhost", "--host", PEER]
+    )
+    # Assert
+    assert {r["host"] for r in _hosts(result)["reports"]} == {LOCAL, PEER}
+
+
+def test_a_named_peer_that_was_not_queried_is_reported_not_dropped(fleet_config):
+    # Arrange -- the operator ASKED for it; silence would read "it is empty".
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        status, ["--json", "--host", "localhost", "--host", PEER]
+    )
+    peer = next(r for r in _hosts(result)["reports"] if r["host"] == PEER)
+    # Assert
+    assert peer["status"] == "not_queried"
+
+
+def test_a_host_that_was_not_queried_has_an_unknown_agent_count(fleet_config):
+    # Arrange -- None, NEVER 0.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        status, ["--json", "--host", "localhost", "--host", PEER]
+    )
+    peer = next(r for r in _hosts(result)["reports"] if r["host"] == PEER)
+    # Assert
+    assert peer["agents"] is None
+
+
+def test_an_unknown_host_fails_rather_than_listing_nothing(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json", "--host", "no-such-machine"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_the_unknown_host_error_names_the_known_peers(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json", "--host", "no-such-machine"])
+    # Assert
+    assert PEER in result.output
+
+
+def test_the_unknown_host_error_names_the_local_host_too(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json", "--host", "no-such-machine"])
+    # Assert
+    assert LOCAL in result.output
+
+
+# ===========================================================================
+# Suppression is announced; the per-agent view is untouched
+# ===========================================================================
+
+
+def test_the_header_names_what_switched_the_fan_out_off(fleet_config):
+    # Arrange -- a quietly-local listing is the exact ambiguity this removes.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json"])
+    # Assert
+    assert _hosts(result)["fanout_suppressed_by"] == "SAC_AGENTS_LIST_NO_FANOUT"
+
+
+def test_the_peer_count_is_reported_even_when_peers_were_not_queried(fleet_config):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["--json"])
+    # Assert
+    assert _hosts(result)["peers_known"] >= 1
+
+
+def test_the_per_agent_view_takes_no_hosts_block(fleet_config):
+    # Arrange -- `list <NAME>` is unchanged; only the fleet view gained one.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["no-such-agent", "--json"])
+    # Assert
+    assert "hosts" not in json.loads(result.output)


### PR DESCRIPTION
`sac agents list` answered only for the machine it was typed on, so finding the fleet meant ssh-ing host by host — and every listing quietly rendered every OTHER host as "nothing there". Fleet-wide is now the **default**, and the listing says who answered.

Operator-approved 2026-08-14 (card `sac-agents-list-fleet-wide-default-20260814`).

## What it looks like

Real run on `scitex-compute-04`, 2026-08-14, against the live fleet:

```
6/10 hosts responded — nas-03: ssh timed out after 8s; mba: ssh exit 255: ssh: connect to host 192.168.11.145 port 22: No route to host; scitex-nas-01: ssh exit 127: sh: sac: command not found; scitex-nas-02: ssh exit 127: sh: sac: command not found
instruments: scitex-compute-04=local_registry, nas-03=ssh (no answer), ywata-note-win=ssh, scitex-compute-01=ssh, scitex-compute-02=ssh, scitex-compute-03=ssh, mba=ssh (no answer), spartan=ssh, scitex-nas-01=ssh (no answer), scitex-nas-02=ssh (no answer)
                                               Agents
┏━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name         ┃ Status  ┃ YAML ┃ Host              ┃ Account             ┃ Started                ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
│ grant        │ running │ ✓    │ ywata-note-win    │ ywatanabe-scitex-ai │ 2026-08-15 00:29 (JST) │
│ scitex-cards │ running │ ✓    │ scitex-compute-04 │ wyusuuke-gmail-com  │ 2026-08-11 15:02 (JST) │
└──────────────┴─────────┴──────┴───────────────────┴─────────────────────┴────────────────────────┘
```

```
$ sac agents list --host localhost
--host localhost → scitex-compute-04
1/1 host responded
instruments: scitex-compute-04=local_registry

$ sac agents list --host nope
Error: --host 'nope' names no host this machine can reach. Known hosts: mba, nas-03,
scitex-compute-01, scitex-compute-02, scitex-compute-03, scitex-compute-04,
scitex-nas-01, scitex-nas-02, scitex-nas-03, spartan, ywata-note-win. See: sac host list
```

## UNKNOWN is not EMPTY (constitution §2)

Every host we *intended* to query gets a report — including the ones that never answered — and an unanswered report carries `agents: null`, never `0`, which would be the same lie as omitting the row. So `agents == []` means an **empty** fleet only when `hosts.responded == hosts.total`; short of that the fleet is **unobserved**, and the two are distinguishable at a glance in the table and in `--json` alike.

The non-responding states stay distinct because their remedies differ:

| status | means | remedy |
|---|---|---|
| `timed_out` | the probe ran and hit the deadline | look at the host / the jump chain |
| `unreachable` | the probe ran and ssh positively failed | fix the network / the route |
| `sac_missing` | we **arrived**; `sac` is not on that host's PATH | install sac there |
| `malformed` | it answered, the payload did not parse | look at the peer's sac, not the network |
| `not_queried` | we never asked (fan-out off) | — |

`sac_missing` is not hypothetical: two NAS boxes answered `sh: sac: command not found` on the very first live run, and calling that "unreachable" would have sent the operator to debug a network that is fine.

Each report also names the **instrument** that produced it, mirroring the `evidence[].instrument` vocabulary the per-agent liveness verdict publishes. It is deliberately a *separate* vocabulary: `_verdict_instruments.Signal` validates against a closed whitelist and the destruction gate counts distinct instruments, so letting a host-transport reading borrow one of those names would let it pose as an independent witness there.

## Which instrument, and why ssh

* **local host** → `local_registry`, read in-process, no transport. It deliberately does not proxy to this host's own `sac listen` even when `SAC_LISTEN_BASE_URL` is set: the fleet view has never proxied (`test_fleet_view_does_not_proxy` pins it), and `GET /agents` returns registry/comms-node rows in a different shape from the enriched list rows.
* **peers** → `ssh`, through the existing `build_ssh_argv` choke point (so `via:` ProxyJump chains, Spartan's Lmod `env_preamble`, and the registry `SCITEX_DIR` pin all come for free).

Not each peer's `sac listen` HTTP surface, and that is a finding rather than a shortcut: ADR-0015 already settled it for the whole fleet — there is no overlay net between these machines, a peer's listen binds `127.0.0.1`, and nothing in `config.yaml` declares a peer's listen base URL (only the single `lead:` block does, for itself). That is exactly why sac's own cross-host channel forwarder runs over ssh + curl. Asking the peer's own `sac` over ssh reaches the same state without inventing a second discovery mechanism.

## Flags

* `--host <hostname>` — repeatable, exact match on the resolved hostname. `localhost` / `local` are accepted but **resolved at parse time**, with the header echoing `--host localhost → scitex-compute-04`, so no output ever records the ambiguous claim — the same ruling that banned `spec.host: local` ("placement must carry the RESOLVED hostname"), applied to a query filter. An unknown name fails loud (exit 2), naming every host that would have worked. There is no `--here`.
* `--host-timeout` (default 8s) bounds **each** host. The fan-out is concurrent against **one shared batch deadline**, so wall-clock tracks the slowest peer rather than their sum, and one wedged ProxyJump never holds the listing. (Restarting the deadline per future makes n stalled peers cost `ceil(n/workers)·T` — the exact defect `_probe_remote_statuses` and `get_agent_list_data` each had to fix in their own pools.)
* `--no-fanout` (hidden) is the recursion guard passed to each peer — the peer runs its own `sac agents list`, which would fan out again — and doubles as a local-only escape hatch. Either way the header says so, so a local-only listing is never silent. A peer on an **older** sac rejects the flag; that refusal proves it cannot recurse, so it is retried without it rather than being written off as unreachable (sac hosts routinely run a stale build).

Every remote row is stamped with its machine — the peer's own resolved `host_display`, else the peer key — because a peer reports its agents as `host="local"`: true there, a lie here, and a whole column of `local` is the original problem. Two peer keys that render the same ssh argv (`nas-03` from config.yaml and `scitex-nas-03` from the registry) collapse to one target, with the collapsed name kept addressable as an alias.

## Unchanged

`sac agents list <NAME>` (the per-agent view and its in-SIF proxy), the `{"agents": [...]}` envelope, every column, filter and footer. The reachability record is a sibling `"hosts"` block. 378 existing tests in the affected suites pass unchanged.

## Test isolation

`tests/conftest.py` force-sets `SAC_AGENTS_LIST_NO_FANOUT=1` alongside the existing state / event-log / card floors. `scitex_dev.hosts.list_hosts()` **seeds** a default registry on any box where the file is absent, so without this floor a fresh CI runner would open real ssh connections to mba / spartan / the NAS rows, and six existing fleet-view tests would become a function of the operator's network. The new tests lift it explicitly and drive the peer leg through injection seams that never touch the network.

## Pre-existing problems found, filed not fixed here

* `sac agents list`'s **auth verdict is computed per row and then thrown away** — `_agent_list.py:396` binds `auth` from `resolve_auth(...)` and never merges it into the row, so `-v`'s Auth column reads `never` for every live agent and the footer's "a green agent is NOT verified working" alarm is permanently on. Card `sac-agents-list-auth-keys-never-merged-20260814`.
* `_mcp/_tools/_agent.py` is **513 lines**, one over the 512 cap, so the write hook refuses any edit — which blocked adding the `host=` passthrough and a `hosts`-block warning to the MCP `agent_list` docstring. Card `sac-mcp-agent-tools-over-line-cap-20260814`.

Both are separate PRs so this one stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
