### PR TITLE
feat(accounts): fleet-wide list, and a listing that cannot rotate a credential

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_list_build.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_build.py
@@ -56,8 +56,28 @@ def _per_account_usage_cache_path(name: str):
     return _store_path(None, Path.home()) / name / "usage.json"
 
 
-def usage_for_account(acct_meta: dict, *, refresh: bool = False) -> dict | None:
+def usage_for_account(
+    acct_meta: dict, *, refresh: bool = False, passive: bool = False
+) -> dict | None:
     """Live PER-ACCOUNT usage fetch (5-min cache); ``--refresh`` busts it.
+
+    ``passive=True`` READS AND NOTHING ELSE — the cache, never the network.
+
+    That mode exists because THIS FUNCTION CAN ROTATE A CREDENTIAL. The
+    ``fetch_usage_for_credentials`` call below refreshes the OAuth token when it
+    is expired (and again on a 401), and that refresh rewrites the account's
+    ``.credentials.json`` in place. The refresh token is SINGLE USE: the server
+    invalidates the previous one, so every agent still holding the old access
+    token — on this host and on every other host that binds the same snapshot —
+    starts getting 401s. That is INCIDENT 2026-08-09, written up in
+    :mod:`._account_refresh_gate`, whose ``needs_refresh`` gate guards
+    ``sac accounts refresh`` and never guarded this path.
+
+    A LISTING MUST NOT ROTATE ANYTHING, and a listing that fans out across the
+    fleet must not do it N times at once, which is why the fleet view passes
+    ``passive=True`` for every host including this one. The local single-host
+    view keeps its historical behaviour so nothing an operator relies on
+    changes silently.
 
     The snapshot lives at
     ``~/.scitex/agent-container/accounts/<name>/.credentials.json``
@@ -85,6 +105,12 @@ def usage_for_account(acct_meta: dict, *, refresh: bool = False) -> dict | None:
     name = acct_meta.get("name")
     if not name:
         return None
+    if passive:
+        # The ONLY statement on this branch, deliberately: everything below can
+        # reach the network and can rewrite the credential. Returning here makes
+        # the passivity a property of the control flow rather than a promise in
+        # prose that a later edit could quietly break.
+        return read_account_usage_cache(name)
     store = _store_path(None, Path.home())
     creds_path = store / name / ".credentials.json"
     if not creds_path.is_file():
@@ -148,7 +174,12 @@ def verify_stored_identities(accounts: list[dict], *, opener=None) -> dict:
 
 
 def build_stored_rows(
-    accounts: list[dict], *, refresh: bool = False, opener=None
+    accounts: list[dict],
+    *,
+    refresh: bool = False,
+    opener=None,
+    passive: bool = False,
+    host: str = "",
 ) -> list[AccountRow]:
     """Convert stored-account dicts into :class:`AccountRow` for rendering.
 
@@ -176,11 +207,12 @@ def build_stored_rows(
     for acct in accounts:
         name = acct["name"]
         fresh = account_freshness(name)
-        usage = usage_for_account(acct, refresh=refresh) or {}
+        usage = usage_for_account(acct, refresh=refresh, passive=passive) or {}
         ident = identities.get(name)
         reading = classify_usage(usage, ident)
         rows.append(
             AccountRow(
+                host=host,
                 name=name,
                 freshness_state=fresh.state,
                 freshness_hours=fresh.hours,
@@ -202,7 +234,12 @@ def build_stored_rows(
 
 
 def build_stored_json(
-    accounts: list[dict], *, refresh: bool = False, opener=None
+    accounts: list[dict],
+    *,
+    refresh: bool = False,
+    opener=None,
+    passive: bool = False,
+    host: str = "",
 ) -> list[dict]:
     """Enrich stored-account dicts for ``sac accounts list --json``.
 
@@ -229,11 +266,17 @@ def build_stored_json(
         name = acct["name"]
         entry["provider"] = "claude-code"
         entry["qualified_id"] = f"claude-code:{name}"
+        # WHICH MACHINE this credential lives on. Empty on the historical
+        # single-host path (nothing there had a second machine to disambiguate
+        # from); the fleet view stamps it, because a credential is a per-host
+        # FILE and the same account is routinely valid here and expired there.
+        if host:
+            entry["host"] = host
         entry.update(read_account_plan(name))
         fresh = account_freshness(name)
         entry["freshness"] = fresh.state
         entry["freshness_hours"] = fresh.hours
-        usage = usage_for_account(acct, refresh=refresh)
+        usage = usage_for_account(acct, refresh=refresh, passive=passive)
         entry["usage"] = usage
         ident = identities.get(name)
         reading = classify_usage(usage or {}, ident)

--- a/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
@@ -28,8 +28,24 @@ from __future__ import annotations
 
 import click
 
+from ._account_list_fleet import fleet_account_options, run_fleet_account_list
+
 
 @click.command("list")
+@fleet_account_options
+@click.option(
+    "--passive",
+    "passive",
+    is_flag=True,
+    default=False,
+    help=(
+        "Read ONLY: credential freshness from expiresAt and usage from the "
+        "on-disk cache, never the network. Without it, listing an account whose "
+        "token has expired REFRESHES that token — which rotates a single-use "
+        "credential every other host is still using (INCIDENT 2026-08-09). The "
+        "fleet view sets this for every host, including this one."
+    ),
+)
 @click.option(
     "--json",
     "as_json",
@@ -50,8 +66,28 @@ import click
         "column always shows the snapshot age so a stale number is obvious."
     ),
 )
-def account_list(as_json: bool, refresh: bool) -> None:
-    """List stored accounts and show the currently active one.
+def account_list(
+    as_json: bool,
+    refresh: bool,
+    passive: bool,
+    hosts: tuple[str, ...],
+    no_fanout: bool,
+    host_timeout: float,
+) -> None:
+    """List stored accounts across the fleet, and show this host's active one.
+
+    FLEET-WIDE by default: every host this machine can reach (``sac host
+    list``), each row naming its machine, above a MANDATORY header saying which
+    hosts answered and which did not, with the reason. A credential is a
+    per-host FILE outside the sync rail, so the same account is routinely VALID
+    here and EXPIRED there — that difference is the whole point of the Host
+    column, and a host that could not be reached is REPORTED rather than
+    dropped, because an unreachable host must never look like an empty one.
+
+    The fleet view is PASSIVE by construction: it never refreshes a token. Use
+    ``--host localhost`` for this machine's full local view (active-credential
+    blocks and the usage bars), and ``--refresh`` there to force a live
+    usage refetch.
 
     The human view splits its two surfaces without duplication
     (operator directive 2026-07-11): the accounts table is exactly
@@ -96,7 +132,6 @@ def account_list(as_json: bool, refresh: bool) -> None:
         render_stored_table,
     )
     from ._account_openai import format_openai_account_block
-    from ._account_usage_bars import render_usage_bars_block
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
 
@@ -130,23 +165,30 @@ def account_list(as_json: bool, refresh: bool) -> None:
             active = read_credentials_metadata()
         except (OSError, _json.JSONDecodeError):
             active = {}
-        stored_json = build_stored_json(accounts, refresh=refresh)
-        click.echo(
-            _json.dumps(
-                {
-                    "active": active,
-                    "openai": openai_meta,
-                    "openai_accounts": openai_accounts,
-                    "openai_error": openai_error,
-                    "stored": stored_json,
-                    "accounts": build_provider_accounts_json(
-                        stored_json, openai_accounts
-                    ),
-                },
-                ensure_ascii=False,
-                indent=2,
+        # The five historical keys are unchanged and stay LOCAL by meaning:
+        # `active` is whoever THIS machine is logged in as, and the OpenAI
+        # block is this machine's Codex store. Only `stored` (and the new
+        # sibling `hosts`) become fleet-wide.
+        extras = {
+            "active": active,
+            "openai": openai_meta,
+            "openai_accounts": openai_accounts,
+            "openai_error": openai_error,
+        }
+        if not refresh:
+            run_fleet_account_list(
+                use_json=True,
+                hosts=hosts,
+                no_fanout=no_fanout,
+                host_timeout=host_timeout,
+                local_extras=extras,
+                openai_accounts=openai_accounts,
             )
-        )
+            return
+        stored_json = build_stored_json(accounts, refresh=refresh, passive=passive)
+        extras["stored"] = stored_json
+        extras["accounts"] = build_provider_accounts_json(stored_json, openai_accounts)
+        click.echo(_json.dumps(extras, ensure_ascii=False, indent=2))
         return
 
     # Active credentials block
@@ -176,7 +218,24 @@ def account_list(as_json: bool, refresh: bool) -> None:
         if openai_lines:
             console.print("")
 
-    rows = build_stored_rows(accounts, refresh=refresh)
+    if not refresh:
+        # FLEET view: every reachable host's credentials in one table, above
+        # the mandatory reachability header. The active-credential and OpenAI
+        # blocks above describe THIS machine and have already been printed;
+        # the usage bars below stay local for the same reason (they are this
+        # host's capacity picture, and each peer's own cache is its own).
+        run_fleet_account_list(
+            use_json=False,
+            hosts=hosts,
+            no_fanout=no_fanout,
+            host_timeout=host_timeout,
+            openai_accounts=openai_accounts,
+        )
+        rows = build_stored_rows(accounts, passive=True)
+        _print_usage_bars(rows)
+        return
+
+    rows = build_stored_rows(accounts, refresh=refresh, passive=passive)
     all_rows = rows + build_openai_rows(openai_accounts)
     if not all_rows:
         click.echo(
@@ -184,16 +243,18 @@ def account_list(as_json: bool, refresh: bool) -> None:
             "scitex-agent-container account save <name>"
         )
         return
+    console.print(
+        "[dim]--refresh is LOCAL-ONLY: it refetches usage, and a refetch can "
+        "rotate an expired token. Doing that on every host at once is not "
+        "something a listing may do, so the fleet view never carries it.[/dim]"
+    )
     console.print(render_stored_table(all_rows))
     # Operator directive 2026-07-11: the bars own the percentages AND
     # their reset hints; the table above holds only what the bars
     # cannot express. Emitted via click.echo (NOT console.print) so
     # the `[..]` bar brackets render literally instead of being parsed
     # as rich markup.
-    bars_block = render_usage_bars_block(rows)
-    if bars_block:
-        click.echo("")
-        click.echo(bars_block)
+    _print_usage_bars(rows)
     # Legend and the `Fleet 7d capacity used:` line both DROPPED
     # (operator 2026-07-30). The legend explained a rolling-window
     # contract the per-line `(in ...)` hints already carry, and the fleet
@@ -204,6 +265,21 @@ def account_list(as_json: bool, refresh: bool) -> None:
     # `needs_rolling_legend` / `rolling_legend_line` are intentionally left
     # in _account_list_render for now: they are exported and separately
     # tested, and deleting them is a wider change than the display request.
+
+
+def _print_usage_bars(rows) -> None:
+    """Emit the local usage-bars block, if there is one.
+
+    ``click.echo`` (NOT ``console.print``) so the ``[..]`` bar brackets render
+    literally instead of being parsed as rich markup — the reason this was
+    always a separate call, now named so both render paths share it.
+    """
+    from ._account_usage_bars import render_usage_bars_block
+
+    bars_block = render_usage_bars_block(rows)
+    if bars_block:
+        click.echo("")
+        click.echo(bars_block)
 
 
 def register_list_command(group: click.Group) -> None:

--- a/src/scitex_agent_container/cli_pkg/_account_list_fleet.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_fleet.py
@@ -1,0 +1,284 @@
+"""Fleet-wide ``sac accounts list`` — the same fan-out, a different payload.
+
+Operator, 2026-08-14: *"agents list だけでなく、accounts list もホスト間で同期
+されているもので ACL が許すものを表してください."* So this rides the fan-out
+``sac agents list`` already uses — :func:`.._helpers._agent_list_fleet.collect_fleet`
+for the concurrency and the per-host reports,
+:mod:`.._helpers._agent_list_fleet_render` for the mandatory header — rather
+than growing a second mechanism beside it. Only two things here are
+accounts-specific: WHAT we ask each host for, and how its answer becomes a row.
+
+WHY ACCOUNTS NEED THIS MORE THAN AGENTS DO
+------------------------------------------
+An agent lives on one machine. A CREDENTIAL is a per-host FILE that is NOT on
+the sync rail, so the SAME account is routinely valid on one host and expired
+on another — and nothing showed you both at once. Measured 2026-08-14: a
+restart on one host refused with *"no healthy stored account"* because all
+three accounts had expired THERE, while the identical three were +4.9h / +4.9h
+/ +2.9h fresh on another host. A fleet view would have shown that at a glance
+instead of costing an outage. That is why every row names its host and carries
+its own time-to-expiry.
+
+TWO SAFETY PROPERTIES THIS FILE EXISTS TO HOLD
+----------------------------------------------
+1. **It never rotates a credential.** ``sac accounts list`` normally fetches
+   usage, and that fetch refreshes an expired OAuth token, rewriting
+   ``.credentials.json`` in place. The refresh token is single-use, so the
+   server invalidates the old one and every agent still holding the old access
+   token starts getting 401s — on that host AND on every host binding the same
+   snapshot (INCIDENT 2026-08-09; see :mod:`._account_refresh_gate`). Doing
+   that once is bad; a fleet fan-out would do it on every machine at once. So
+   the fan-out passes ``--passive`` to each peer and uses ``passive=True``
+   locally: freshness comes from :func:`.._account.creds_sync.account_freshness`
+   (a pure read of ``expiresAt``) and usage from the on-disk cache. The header
+   says the view is passive, so nobody mistakes a cached percentage for a live
+   one.
+
+2. **It never prints token material.** Rows carry the account slug, the
+   provider, the freshness state and hours, the verified identity, and the
+   host. Not the access token, not the refresh token, not the file's contents.
+   The upstream builders already whitelist their fields and assert no secret
+   escapes; this module adds no new field that could carry one, and the
+   peer-payload reader below picks keys by NAME rather than copying the
+   envelope through.
+"""
+
+from __future__ import annotations
+
+import json as json_mod
+
+import click
+
+__all__ = ["fleet_account_options", "run_fleet_account_list", "rows_from_stored"]
+
+# What we ask each peer for. ``--passive`` is the safety flag (property 1
+# above); ``--no-fanout`` is the recursion guard, since the peer runs its own
+# sac and would otherwise fan out again.
+_REMOTE_ARGV = ("sac", "accounts", "list", "--json", "--passive", "--no-fanout")
+
+
+def fleet_account_options(func):
+    """Attach ``--host`` / ``--host-timeout`` / ``--no-fanout`` to the command.
+
+    Deliberately the same three spellings ``sac agents list`` grew, with the
+    same semantics, so an operator learns the fleet vocabulary once.
+    """
+    from ._helpers._agent_list_fleet_model import DEFAULT_HOST_TIMEOUT_S
+
+    func = click.option(
+        "--host-timeout",
+        "host_timeout",
+        type=float,
+        default=DEFAULT_HOST_TIMEOUT_S,
+        show_default=True,
+        help=(
+            "Fleet view: seconds to wait for EACH host. A host that exceeds it "
+            "is reported as timed-out in the header and never blocks the rest "
+            "of the listing."
+        ),
+    )(func)
+    func = click.option(
+        "--no-fanout",
+        "no_fanout",
+        is_flag=True,
+        default=False,
+        hidden=True,
+        help=(
+            "Fleet view: do not query peers; list only this host. Primarily the "
+            "recursion guard the fan-out passes to each peer. The header always "
+            "states when it is in force."
+        ),
+    )(func)
+    func = click.option(
+        "--host",
+        "hosts",
+        multiple=True,
+        metavar="HOSTNAME",
+        help=(
+            "Fleet view: only this host. Repeatable; exact match on the "
+            "resolved hostname. 'localhost' / 'local' are accepted and RESOLVED "
+            "at parse time, with the header echoing the resolution. An unknown "
+            "name fails loudly, naming every host this machine can reach."
+        ),
+    )(func)
+    return func
+
+
+def rows_from_stored(stored: list[dict], host: str) -> list:
+    """Turn one host's ``--json`` ``stored`` entries into renderable rows.
+
+    Keys are read BY NAME rather than by copying the entry through, so a field
+    this module has never heard of — including anything a hand-edited
+    ``account.json`` might contain — cannot ride along into the table.
+
+    ``used_pct_*`` is carried ONLY when the peer's own ``usage_state`` is
+    ``known``. That mirrors the gate the local builder already applies: a
+    percentage read with a credential that turns out to belong to a different
+    account is not this account's usage, however freshly it was fetched, and it
+    must not be rendered under the wrong name just because it survived an ssh
+    hop.
+    """
+    from ._account_list_render import AccountRow
+
+    rows = []
+    for entry in stored:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        usage = entry.get("usage") if isinstance(entry.get("usage"), dict) else {}
+        state = entry.get("usage_state") or "unknown"
+        known = state == "known"
+        identity = entry.get("identity") if isinstance(entry.get("identity"), dict) else {}
+        rows.append(
+            AccountRow(
+                host=host,
+                name=name,
+                provider=str(entry.get("provider") or "claude-code"),
+                freshness_state=str(entry.get("freshness") or "ABSENT"),
+                freshness_hours=_as_float(entry.get("freshness_hours")),
+                used_pct_5h=_as_float(usage.get("used_pct_5h")) if known else None,
+                used_pct_7d=_as_float(usage.get("used_pct_7d")) if known else None,
+                snapshot_as_of=_as_str(usage.get("as_of")),
+                reset_at_5h=_as_str(usage.get("reset_at_5h")),
+                reset_at_7d=_as_str(usage.get("reset_at_7d")),
+                usage_state=str(state),
+                usage_age_seconds=_as_int(entry.get("usage_age_seconds")),
+                usage_reason=_as_str(entry.get("usage_unknown_reason")),
+                identity_state=str(identity.get("state") or "unverified"),
+                verified_email=_as_str(identity.get("verified_email")),
+                duplicate_of=_as_str(identity.get("duplicate_of")),
+            )
+        )
+    return rows
+
+
+def _as_float(value) -> float | None:
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _as_int(value) -> int | None:
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def _as_str(value) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _peer_probe(target, timeout_s: float):
+    """Ask ONE peer for its accounts over ssh. Returns ``(report, entries)``.
+
+    Delegates every transport concern — the ``via:`` ProxyJump chain, the
+    timeout mapping, the stale-peer retry, the RESPONDED / TIMED_OUT /
+    UNREACHABLE / SAC_MISSING / MALFORMED verdicts — to the shared ssh probe.
+    Only the argv and the envelope key differ from the agents leg.
+    """
+    from ._helpers._agent_list_fleet_probe import ssh_json_probe
+
+    return ssh_json_probe(
+        target,
+        timeout_s,
+        argv=list(_REMOTE_ARGV),
+        envelope_key="stored",
+        # ``--passive`` is load-bearing for SAFETY, so a peer that rejects it
+        # must be REPORTED (sac_too_old), never re-asked without it: the
+        # fallback would be the very credential rotation the flag prevents.
+        required_flags=("--passive",),
+    )
+
+
+def _local_accounts(host: str):
+    """This host's accounts, read PASSIVELY. Never refreshes a credential."""
+    from .._state.account_store import list_accounts
+    from ._account_list_build import build_stored_json
+
+    return build_stored_json(list_accounts(), passive=True, host=host)
+
+
+def run_fleet_account_list(
+    *,
+    use_json: bool,
+    hosts: tuple[str, ...] = (),
+    no_fanout: bool = False,
+    host_timeout: float | None = None,
+    local_extras: dict | None = None,
+    openai_accounts: list[dict] | None = None,
+) -> None:
+    """Collect every reachable host's accounts, print the header, then the rows.
+
+    The header comes FIRST and unconditionally, in both surfaces: it is what
+    makes an empty listing legible. With every host answered, no accounts means
+    the fleet has none; with a host missing, it means the fleet is UNOBSERVED,
+    and those two must never render the same way.
+
+    An unreachable host never changes the exit code — a credential inventory
+    that exits non-zero would break every caller that parses it, and the header
+    already carries the truth.
+    """
+    from ._account_list_render import render_stored_table
+    from ._helpers._agent_list_fleet import DEFAULT_HOST_TIMEOUT_S, collect_fleet
+    from ._helpers._agent_list_fleet_model import UnknownHostFilter
+    from ._helpers._agent_list_fleet_render import hosts_payload, print_fleet_header
+    from ._helpers._console import console
+    from ._helpers._agent_list_host import _resolve_display_host
+
+    local_host = _resolve_display_host()
+    try:
+        listing = collect_fleet(
+            hosts=hosts,
+            no_fanout=no_fanout,
+            host_timeout_s=(
+                DEFAULT_HOST_TIMEOUT_S if host_timeout is None else host_timeout
+            ),
+            local_lister=lambda: _local_accounts(local_host),
+            peer_probe=_peer_probe,
+        )
+    except UnknownHostFilter as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    if use_json:
+        from ._account_list_build import build_provider_accounts_json
+
+        payload = dict(local_extras or {})
+        # Same six keys the schema has always had, in the same order; `stored`
+        # and the cross-provider `accounts` now span the fleet, and `hosts` is
+        # the sibling that says whose answers are in them. A consumer that
+        # reads `stored` without reading `hosts.responded` vs `hosts.total` is
+        # treating a partial fleet as the whole one.
+        payload["stored"] = listing.agents
+        payload["accounts"] = build_provider_accounts_json(
+            listing.agents, openai_accounts or []
+        )
+        payload["hosts"] = hosts_payload(listing)
+        click.echo(json_mod.dumps(payload, ensure_ascii=False, indent=2))
+        return
+
+    print_fleet_header(console, listing)
+    console.print(
+        "[dim]passive read: freshness from each host's expiresAt, usage from "
+        "its cache. Nothing here refreshes a token (a refresh rotates a "
+        "single-use credential every other host is still using).[/dim]"
+    )
+    rows = []
+    for entry in listing.agents:
+        rows.extend(rows_from_stored([entry], str(entry.get("host") or "—")))
+    if not rows:
+        # WHICH empty is this? With every host answered, the fleet genuinely has
+        # no accounts and the operator wants the next step. With a host missing,
+        # the same blank table is an UNOBSERVED fleet, and telling him to go
+        # create an account would be advice derived from a reading nobody took.
+        if listing.responded == listing.total:
+            click.echo(
+                "No accounts stored or active. Use: "
+                "scitex-agent-container account save <name>"
+            )
+        else:
+            missing = ", ".join(r.host for r in listing.unanswered)
+            console.print(
+                f"[yellow]No accounts on the host(s) that answered — but "
+                f"{missing} did not answer, so this is NOT evidence that the "
+                f"fleet has none.[/yellow]"
+            )
+        return
+    console.print(render_stored_table(rows))

--- a/src/scitex_agent_container/cli_pkg/_account_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_render.py
@@ -135,6 +135,14 @@ class AccountRow:
     identity_state: str = "unverified"
     verified_email: str | None = None
     duplicate_of: str | None = None
+    # WHICH MACHINE this credential lives on. Empty on the single-host path,
+    # which is why the Host column only appears once something fills it in.
+    # A credential is a per-host FILE and is not on the sync rail, so the same
+    # account is routinely VALID on one machine and EXPIRED on another —
+    # measured 2026-08-14, when a restart on one host refused with "no healthy
+    # stored account" while the identical three accounts were hours-fresh on
+    # another. Without this field the fleet table cannot say which is which.
+    host: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -225,20 +233,28 @@ def render_stored_table(
     the Last-Update cell deterministically without monkeypatching
     ``datetime.now``.
     """
+    # The Host column appears ONLY when a row carries a host — i.e. in the
+    # fleet view. Adding it unconditionally would put a column of one repeated
+    # name in front of every single-host listing, and a column that always says
+    # the same thing teaches the eye to skip the place where the answer lives.
+    with_host = any(r.host for r in rows)
     table = Table(title="Stored accounts", title_justify="left", show_lines=False)
+    if with_host:
+        table.add_column("Host", style="cyan")
     table.add_column("Provider")
     table.add_column("Account", style="bold")
     table.add_column("Status")
     table.add_column("Identity")
     table.add_column("Usage as of")
     for r in rows:
-        table.add_row(
+        cells = [
             r.provider,
             r.name,
             _fmt_status(r.freshness_state, r.freshness_hours),
             _fmt_identity_cell(r),
             _fmt_last_update_cell(r.snapshot_as_of, now=now),
-        )
+        ]
+        table.add_row(*([r.host or "—", *cells] if with_host else cells))
     return table
 
 

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet.py
@@ -39,7 +39,11 @@ from ._agent_list_fleet_model import (  # noqa: F401 (re-export)
     resolve_host_filter,
     resolve_targets,
 )
-from ._agent_list_fleet_probe import local_probe, ssh_peer_probe  # noqa: F401
+from ._agent_list_fleet_probe import (  # noqa: F401 (re-export)
+    local_probe,
+    ssh_json_probe,
+    ssh_peer_probe,
+)
 from ._agent_list_host import _resolve_display_host
 
 __all__ = [
@@ -63,6 +67,7 @@ __all__ = [
     "local_probe",
     "resolve_host_filter",
     "resolve_targets",
+    "ssh_json_probe",
     "ssh_peer_probe",
 ]
 

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_model.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_model.py
@@ -19,6 +19,13 @@ and an unanswered report carries ``agents=None``, never ``0``:
   UNREACHABLE on purpose: a host that is merely slow (or behind a wedged
   ProxyJump) has not refused us, and the two want different remedies.
 * :data:`UNREACHABLE` — the probe RAN and positively failed (ssh non-zero).
+* :data:`SAC_TOO_OLD` — we reached the host, sac is there, and it rejected an
+  option this query REQUIRES for safety. Its own state because the retry that
+  saves a merely-stale peer is forbidden here: ``sac accounts list`` sends
+  ``--passive`` so the peer does not refresh (and thereby ROTATE) a credential
+  every other host is still using, so re-asking without it would do the exact
+  damage the flag prevents. Upgrading sac there is the remedy, and only a
+  distinct state can say so.
 * :data:`SAC_MISSING` — we REACHED the host and ``sac`` is not on its PATH.
   Measured live on two NAS boxes the first time this shipped. Folding it into
   UNREACHABLE would send the operator to debug a network that is fine; the
@@ -64,6 +71,7 @@ __all__ = [
     "NOT_QUERIED",
     "RESPONDED",
     "SAC_MISSING",
+    "SAC_TOO_OLD",
     "TIMED_OUT",
     "UNREACHABLE",
     "UnknownHostFilter",
@@ -78,6 +86,7 @@ RESPONDED = "responded"
 TIMED_OUT = "timed_out"
 UNREACHABLE = "unreachable"
 SAC_MISSING = "sac_missing"
+SAC_TOO_OLD = "sac_too_old"
 MALFORMED = "malformed"
 NOT_QUERIED = "not_queried"
 

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py
@@ -40,13 +40,14 @@ from ._agent_list_fleet_model import (
     MALFORMED,
     RESPONDED,
     SAC_MISSING,
+    SAC_TOO_OLD,
     TIMED_OUT,
     UNREACHABLE,
     HostReport,
     HostTarget,
 )
 
-__all__ = ["local_probe", "ssh_peer_probe"]
+__all__ = ["local_probe", "ssh_json_probe", "ssh_peer_probe"]
 
 # The peer runs its OWN sac, which would fan out again — and its peers would fan
 # out after that. ``--no-fanout`` is the recursion guard, and it is the same flag
@@ -104,16 +105,16 @@ def _remote_argv(
     return argv
 
 
-def _parse_rows(stdout: str) -> list[dict]:
+def _parse_rows(stdout: str, envelope_key: str = "agents") -> list[dict]:
     """Read a peer's ``--json`` payload. Raises ``ValueError`` when unreadable.
 
-    Accepts BOTH shapes this codebase emits: the CLI's ``{"agents": [...]}``
-    envelope and the bare list ``print_agent_list_json`` writes.
+    Accepts BOTH shapes this codebase emits: an ``{"<key>": [...]}`` envelope
+    and a bare list (which ``print_agent_list_json`` writes).
     """
     payload = json_mod.loads(stdout)
-    rows = payload.get("agents") if isinstance(payload, dict) else payload
+    rows = payload.get(envelope_key) if isinstance(payload, dict) else payload
     if not isinstance(rows, list):
-        raise ValueError("payload carries no 'agents' list")
+        raise ValueError(f"payload carries no {envelope_key!r} list")
     return [row for row in rows if isinstance(row, dict)]
 
 
@@ -135,12 +136,12 @@ def _stamp_host(rows: list[dict], target: HostTarget) -> list[dict]:
     """
     out: list[dict] = []
     for row in rows:
-        declared = row.get("host_display")
-        host = (
-            declared
-            if isinstance(declared, str) and declared not in ("", "local", "localhost")
-            else target.name
-        )
+        host = target.name
+        for key in ("host_display", "host"):
+            declared = row.get(key)
+            if isinstance(declared, str) and declared not in ("", "local", "localhost"):
+                host = declared
+                break
         stamped = dict(row)
         stamped["host"] = host
         stamped["host_display"] = host
@@ -208,7 +209,44 @@ def ssh_peer_probe(
     peers: dict | None = None,
     runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
 ) -> tuple[HostReport, list[dict]]:
-    """Ask ONE peer for its own listing over ssh. Returns ``(report, rows)``.
+    """Ask ONE peer for its AGENT listing over ssh. Returns ``(report, rows)``.
+
+    A thin argv-builder over :func:`ssh_json_probe`, which owns every transport
+    concern. Kept as its own name because the agent listing's label filters
+    (``--capability`` / ``--machine`` / ``--group``) travel with the request.
+    """
+    return ssh_json_probe(
+        target,
+        timeout_s,
+        argv=_remote_argv(
+            capability=capability, machine=machine, group=group, guard=True
+        ),
+        envelope_key="agents",
+        peers=peers,
+        runner=runner,
+    )
+
+
+def ssh_json_probe(
+    target: HostTarget,
+    timeout_s: float,
+    *,
+    argv: list[str],
+    envelope_key: str = "agents",
+    guard_flag: str = "--no-fanout",
+    required_flags: tuple[str, ...] = (),
+    peers: dict | None = None,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> tuple[HostReport, list[dict]]:
+    """Run ``argv`` on ONE peer and read a JSON envelope back.
+
+    THE one cross-host read in this package: ``sac agents list`` and
+    ``sac accounts list`` differ only in the argv they send and the envelope key
+    they read, so they share this body rather than growing two transports that
+    drift apart in their failure mapping. Everything that makes the fan-out
+    honest lives here — the ternary verdicts, the timeout that is not an
+    unreachability, the ``sac_missing`` that is not a network fault, the
+    stale-peer retry.
 
     Rides :func:`..._state.host_config.build_ssh_argv` — the fleet's single ssh
     choke point, which already renders ``via:`` ProxyJump chains, the Lmod
@@ -227,11 +265,10 @@ def ssh_peer_probe(
 
     connect = int(max(2, min(timeout_s, 15)))
     started = time.monotonic()
+    full_argv = list(argv)
     guard = True
     while True:
-        argv = _remote_argv(
-            capability=capability, machine=machine, group=group, guard=guard
-        )
+        argv = full_argv if guard else [a for a in full_argv if a != guard_flag]
         # stx-allow: fallback (reason: every transport failure is a REPORTED
         # host state — an exception here would drop the host from the listing.)
         try:
@@ -270,9 +307,30 @@ def ssh_peer_probe(
             )
         rc = int(getattr(proc, "returncode", 1) or 0)
         stderr = (getattr(proc, "stderr", "") or "").strip()
-        if rc != 0 and guard and _looks_like_unknown_flag(stderr):
-            guard = False  # older sac there: it cannot recurse, so ask again
-            continue
+        if rc != 0 and _looks_like_unknown_flag(stderr):
+            if required_flags:
+                # DO NOT RETRY WITHOUT THEM. The retry that rescues a merely
+                # stale peer is forbidden when a flag is load-bearing for
+                # SAFETY: dropping ``--passive`` would let that host refresh —
+                # and thereby rotate — a credential every other host is still
+                # using. Report the host and name the remedy instead.
+                named = ", ".join(required_flags)
+                return (
+                    HostReport(
+                        host=target.name,
+                        status=SAC_TOO_OLD,
+                        instrument=INSTRUMENT_SSH,
+                        detail=(
+                            f"its sac does not accept {named}; re-asking without "
+                            f"it is unsafe — upgrade sac on this host"
+                        ),
+                        elapsed_ms=_ms_since(started),
+                    ),
+                    [],
+                )
+            if guard:
+                guard = False  # older sac there: it cannot recurse, so ask again
+                continue
         break
 
     if rc != 0:
@@ -295,7 +353,9 @@ def ssh_peer_probe(
     # parse is MALFORMED, not unreachable — the transport demonstrably worked,
     # and saying "unreachable" sends the operator to debug the wrong layer.)
     try:
-        rows = _stamp_host(_parse_rows(getattr(proc, "stdout", "") or ""), target)
+        rows = _stamp_host(
+            _parse_rows(getattr(proc, "stdout", "") or "", envelope_key), target
+        )
     except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
         return (
             HostReport(
@@ -312,7 +372,7 @@ def ssh_peer_probe(
             host=target.name,
             status=RESPONDED,
             instrument=INSTRUMENT_SSH,
-            detail="sac agents list --json over ssh",
+            detail=f"{' '.join(argv[:3])} --json over ssh",
             elapsed_ms=_ms_since(started),
             agents=len(rows),
         ),

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_fleet.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_fleet.py
@@ -1,0 +1,330 @@
+"""Tests for the fleet-wide ``sac accounts list``.
+
+The one that matters most is at the top: a listing MUST NOT rotate a
+credential. It is asserted BEHAVIOURALLY — the credential file's bytes before
+and after — rather than by watching for a call, because the property the fleet
+needs is "the file did not change", and only the file can testify to that.
+
+No mocks and no ``monkeypatch``: ``$HOME`` is redirected with the documented
+env var (``Path.home()`` reads it on POSIX), and every fan-out seam is a real
+callable.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scitex_agent_container.cli_pkg._account_list_build import usage_for_account
+from scitex_agent_container.cli_pkg._account_list_fleet import rows_from_stored
+from scitex_agent_container.cli_pkg._account_list_render import (
+    render_stored_table_to_str,
+)
+from scitex_agent_container.cli_pkg._helpers._agent_list_fleet_model import (
+    SAC_TOO_OLD,
+    HostTarget,
+)
+from scitex_agent_container.cli_pkg._helpers._agent_list_fleet_probe import (
+    ssh_json_probe,
+)
+
+_EXPIRED_MS = 1_000_000_000_000  # long past, so a live path WOULD refresh
+
+
+@pytest.fixture
+def sandbox_home(tmp_path, env_save_restore):
+    """Redirect ``$HOME`` so ``Path.home()`` resolves inside ``tmp_path``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def expired_account(sandbox_home):
+    """An account whose token is EXPIRED — the state that triggers a refresh.
+
+    Returns the credential path. Its bytes are what the passivity tests watch:
+    the live path rewrites this file in place when it refreshes.
+    """
+    acct = sandbox_home / ".scitex" / "agent-container" / "accounts" / "acct-a"
+    acct.mkdir(parents=True)
+    (acct / "account.json").write_text(json.dumps({"name": "acct-a"}))
+    (acct / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-EXPIRED",
+                    "refreshToken": "refresh-single-use",
+                    "clientId": "client-1",
+                    "expiresAt": _EXPIRED_MS,
+                }
+            }
+        )
+    )
+    (acct / "usage.json").write_text(json.dumps({"used_pct_5h": 12.0}))
+    return acct / ".credentials.json"
+
+
+# ===========================================================================
+# A LISTING MUST NOT ROTATE A CREDENTIAL
+# ===========================================================================
+
+
+def test_passive_read_leaves_the_credential_file_byte_identical(expired_account):
+    # Arrange -- an EXPIRED token: exactly the state the live path refreshes,
+    # and a refresh rewrites this file and invalidates the single-use refresh
+    # token every other host is still holding (INCIDENT 2026-08-09).
+    before = expired_account.read_bytes()
+    # Act
+    usage_for_account({"name": "acct-a"}, passive=True)
+    # Assert
+    assert expired_account.read_bytes() == before
+
+
+def test_passive_read_returns_the_cached_usage(expired_account):
+    # Arrange
+    del expired_account
+    # Act
+    usage = usage_for_account({"name": "acct-a"}, passive=True)
+    # Assert
+    assert usage == {"used_pct_5h": 12.0}
+
+
+def test_passive_read_returns_none_when_there_is_no_cache(sandbox_home):
+    # Arrange -- no usage.json; passive must not go and fetch one.
+    acct = sandbox_home / ".scitex" / "agent-container" / "accounts" / "acct-b"
+    acct.mkdir(parents=True)
+    (acct / "account.json").write_text(json.dumps({"name": "acct-b"}))
+    # Act
+    usage = usage_for_account({"name": "acct-b"}, passive=True)
+    # Assert
+    assert usage is None
+
+
+def test_the_fleet_leg_asks_every_peer_to_be_passive():
+    # Arrange
+    from scitex_agent_container.cli_pkg._account_list_fleet import _REMOTE_ARGV
+
+    # Act
+    argv = list(_REMOTE_ARGV)
+    # Assert -- without this the fan-out would rotate a token on every machine.
+    assert "--passive" in argv
+
+
+def test_the_fleet_leg_also_carries_the_recursion_guard():
+    # Arrange
+    from scitex_agent_container.cli_pkg._account_list_fleet import _REMOTE_ARGV
+
+    # Act
+    argv = list(_REMOTE_ARGV)
+    # Assert
+    assert "--no-fanout" in argv
+
+
+# ===========================================================================
+# A peer too old to answer SAFELY is reported, never re-asked unsafely
+# ===========================================================================
+
+
+class _Peer:
+    def __init__(self, ssh: str) -> None:
+        self.name = ssh
+        self.ssh = ssh
+        self.via: tuple[str, ...] = ()
+
+    def jump_chain(self, peers):
+        return []
+
+    def joined_preamble(self) -> str:
+        return ""
+
+
+class _Proc:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+_TARGET = HostTarget(name="peer", ssh="peer")
+_PEERS = {"peer": _Peer("peer")}
+
+
+def _runner(*results, record: list | None = None):
+    queue = list(results)
+
+    def run(argv, **kwargs):
+        if record is not None:
+            record.append(list(argv))
+        return queue.pop(0)
+
+    return run
+
+
+def _old_peer_probe(record: list | None = None):
+    return ssh_json_probe(
+        _TARGET,
+        8.0,
+        argv=["sac", "accounts", "list", "--json", "--passive", "--no-fanout"],
+        envelope_key="stored",
+        required_flags=("--passive",),
+        peers=_PEERS,
+        runner=_runner(
+            _Proc(2, "", "Usage: sac accounts list\nError: No such option: --passive"),
+            _Proc(0, '{"stored": [{"name": "leaked"}]}'),
+            record=record,
+        ),
+    )
+
+
+def test_a_peer_that_rejects_the_safety_flag_reads_too_old():
+    # Arrange
+    # Act
+    report, _ = _old_peer_probe()
+    # Assert -- not "unreachable": we got there, and the remedy is an upgrade.
+    assert report.status == SAC_TOO_OLD
+
+
+def test_the_too_old_report_names_the_flag_and_the_remedy():
+    # Arrange
+    # Act
+    report, _ = _old_peer_probe()
+    # Assert
+    assert "--passive" in report.detail and "upgrade sac" in report.detail
+
+
+def test_a_peer_that_rejects_the_safety_flag_is_never_re_asked_without_it():
+    # Arrange -- the retry that rescues a merely-stale peer is forbidden here:
+    # re-asking without --passive would do the exact damage the flag prevents.
+    seen: list = []
+    # Act
+    _old_peer_probe(record=seen)
+    # Assert
+    assert len(seen) == 1
+
+
+def test_a_too_old_peer_contributes_no_rows():
+    # Arrange
+    # Act
+    _, rows = _old_peer_probe()
+    # Assert
+    assert rows == []
+
+
+# ===========================================================================
+# Reading a peer's payload: by NAME, and honouring its own usage gate
+# ===========================================================================
+
+
+def _entry(**over) -> dict:
+    base = {
+        "name": "acct-a",
+        "provider": "claude-code",
+        "freshness": "VALID",
+        "freshness_hours": 4.9,
+        "usage": {"used_pct_5h": 30.0, "used_pct_7d": 40.0},
+        "usage_state": "known",
+        "identity": {"state": "verified", "verified_email": "a@example.com"},
+    }
+    base.update(over)
+    return base
+
+
+def test_a_peer_row_is_stamped_with_its_host():
+    # Arrange
+    stored = [_entry()]
+    # Act
+    rows = rows_from_stored(stored, "nas-03")
+    # Assert
+    assert rows[0].host == "nas-03"
+
+
+def test_a_peer_row_carries_its_own_freshness_hours():
+    # Arrange -- the whole point: the SAME account differs host to host.
+    stored = [_entry(freshness_hours=-1.1, freshness="EXPIRED")]
+    # Act
+    rows = rows_from_stored(stored, "nas-03")
+    # Assert
+    assert (rows[0].freshness_state, rows[0].freshness_hours) == ("EXPIRED", -1.1)
+
+
+def test_a_percentage_is_kept_when_the_peer_vouches_for_it():
+    # Arrange
+    stored = [_entry()]
+    # Act
+    rows = rows_from_stored(stored, "h")
+    # Assert
+    assert rows[0].used_pct_5h == 30.0
+
+
+def test_a_percentage_is_dropped_when_the_peer_does_not_vouch_for_it():
+    # Arrange -- a figure read with a credential that may belong to another
+    # account is not this account's usage, however well it survived the ssh hop.
+    stored = [_entry(usage_state="unknown")]
+    # Act
+    rows = rows_from_stored(stored, "h")
+    # Assert
+    assert rows[0].used_pct_5h is None
+
+
+def test_an_unknown_key_in_a_peer_payload_does_not_ride_along():
+    # Arrange -- keys are read BY NAME, so a hand-edited account.json cannot
+    # smuggle a field (token material included) into the table.
+    stored = [_entry(accessToken="sk-ant-SECRET")]
+    # Act
+    rows = rows_from_stored(stored, "h")
+    # Assert
+    assert not hasattr(rows[0], "accessToken")
+
+
+def test_a_secret_in_a_peer_payload_never_reaches_the_rendered_table():
+    # Arrange
+    rows = rows_from_stored([_entry(accessToken="sk-ant-SECRET")], "h")
+    # Act
+    rendered = render_stored_table_to_str(rows, width=200)
+    # Assert
+    assert "sk-ant-SECRET" not in rendered
+
+
+def test_a_malformed_peer_entry_is_skipped_rather_than_crashing():
+    # Arrange
+    stored = [{"no": "name"}, _entry()]
+    # Act
+    rows = rows_from_stored(stored, "h")
+    # Assert
+    assert [r.name for r in rows] == ["acct-a"]
+
+
+# ===========================================================================
+# The Host column appears exactly when it says something
+# ===========================================================================
+
+
+def test_the_table_gains_a_host_column_for_a_fleet_listing():
+    # Arrange
+    rows = rows_from_stored([_entry()], "nas-03")
+    # Act
+    rendered = render_stored_table_to_str(rows, width=200)
+    # Assert
+    assert "Host" in rendered
+
+
+def test_the_host_cell_names_the_machine():
+    # Arrange
+    rows = rows_from_stored([_entry()], "nas-03")
+    # Act
+    rendered = render_stored_table_to_str(rows, width=200)
+    # Assert
+    assert "nas-03" in rendered
+
+
+def test_a_single_host_listing_keeps_its_columns_unchanged():
+    # Arrange -- a column that always says the same thing teaches the eye to
+    # skip the place where the answer lives.
+    rows = rows_from_stored([_entry()], "")
+    # Act
+    rendered = render_stored_table_to_str(rows, width=200)
+    # Assert
+    assert "Host" not in rendered


### PR DESCRIPTION
Follow-up to #1050. Operator, 2026-08-14: *"agents list だけでなく、accounts list もホスト間で同期されているもので ACL が許すものを表してください."*

Card: `sac-accounts-list-fleet-wide-20260814`.

It rides the **same** fan-out `sac agents list` uses rather than growing a second mechanism: `ssh_peer_probe` was generalised into `ssh_json_probe`, and the two commands now differ only in the argv they send and the envelope key they read. The concurrency, the shared batch deadline, the ternary host verdicts and the mandatory header are all shared.

## Why accounts need this more than agents do

An agent lives on one machine. A **credential is a per-host file** that is not on the sync rail, so the same account is routinely valid here and expired there — and nothing showed both at once.

Measured 2026-08-14: a restart on one host refused with `no healthy stored account` because all three accounts had expired **there**, while the identical three were +4.9h / +4.9h / +2.9h fresh on another host. Every row now names its host and carries its own time-to-expiry.

## A listing must not rotate a credential — and it did

This is the part worth reviewing closely, because it was **already true before this PR**:

```
accounts list → usage_for_account → fetch_usage_for_credentials
    if _is_token_expired(expires_at_ms):
        new_token = _refresh_access_token_at(creds, refresh_token, client_id, ...)
```

That refresh rewrites `.credentials.json` in place. The refresh token is **single-use**: the server invalidates the old one, so every agent still holding the old access token starts getting 401s — on that host *and* on every host binding the same snapshot. That is INCIDENT 2026-08-09, written up in `_account_refresh_gate`, whose `needs_refresh` gate guards `sac accounts refresh` and **never guarded this path**.

Doing that once is bad. A fleet fan-out would do it on every machine at once, which is why this could not ship without fixing it.

`--passive` reads and nothing else — freshness from `account_freshness` (a pure read of `expiresAt`), usage from the on-disk cache. It is the **first statement on its branch**, so passivity is a property of the control flow rather than a promise in prose that a later edit could quietly break. The fleet view sets it for every host including the local one, and says so in the output. The single-host `--refresh` path keeps its historical live behaviour and is now explicitly local-only, with the reason printed.

The test asserts this **behaviourally** — the credential file's bytes before and after a passive read of an *expired* account — because the property the fleet needs is "the file did not change", and only the file can testify to that.

## `sac_too_old`: the retry that had to be refused

#1050 added a stale-peer retry: a peer that rejects `--no-fanout` proves it cannot recurse, so it is re-asked without it. That reasoning **does not transfer** to `--passive` — re-asking without it would do the exact damage the flag prevents. So a peer that rejects a `required_flag` gets its own state instead.

The first live run found five of them immediately:

```
1/10 hosts responded — nas-03: ssh timed out after 8s; ywata-note-win: its sac does not
accept --passive; re-asking without it is unsafe — upgrade sac on this host;
scitex-compute-01: its sac does not accept --passive; ...; mba: ssh exit 255: ssh: connect
to host 192.168.11.145 port 22: No route to host; scitex-nas-01: ssh exit 127: sh: sac:
command not found; scitex-nas-02: ssh exit 127: sh: sac: command not found
instruments: scitex-compute-04=local_registry, nas-03=ssh (no answer), ywata-note-win=ssh
(no answer), ...
passive read: freshness from each host's expiresAt, usage from its cache. Nothing here
refreshes a token (a refresh rotates a single-use credential every other host is still using).
No accounts on the host(s) that answered — but nas-03, ywata-note-win, scitex-compute-01,
scitex-compute-02, scitex-compute-03, mba, spartan, scitex-nas-01, scitex-nas-02 did not
answer, so this is NOT evidence that the fleet has none.
```

Without the new state those five would have silently rotated five machines' credentials. They resolve themselves as this PR propagates.

## Also here

* Every peer row is read **by name**, so a hand-edited `account.json` cannot smuggle a field — token material included — into the table. Tested with a seeded `sk-ant-SECRET`.
* A percentage crosses the ssh hop only when the peer's own `usage_state` vouches for it, mirroring the local identity gate (a figure read with a credential belonging to another account is not this account's usage, however well it survived the hop).
* The `Host` column appears only when a row carries a host, so single-host listings render exactly as before. A column that always says the same thing teaches the eye to skip the place where the answer lives.
* The empty listing distinguishes its two causes: with every host answered it keeps the historical `use account save <name>` guidance; with a host missing it says so and refuses to call the fleet empty.

## Compatibility

The `--json` envelope keeps all six historical keys (`active`, `openai`, `openai_accounts`, `openai_error`, `stored`, `accounts`). `active` and the OpenAI block stay **local by meaning** — they describe whoever *this* machine is logged in as. `stored` and `accounts` now span the fleet; `hosts` is the sibling that says whose answers are in them.

## Verification

* 19 new tests, including the byte-identical credential proof and the never-re-asked-unsafely proof.
* **5002 passed, 23 skipped, 0 failed** across `cli_pkg` + `_account` + `integration`.
* CI's ruff selection clean.
* Live run on `scitex-compute-04` (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
