### PR TITLE
docs: sac manages agent processes, a harness owns the turn — de-vendor the user-facing prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </a>
 </p>
 
-<p align="center"><b>Declarative, on-prem-first lifecycle manager for Claude Code agents.</b></p>
+<p align="center"><b>Declarative, on-prem-first lifecycle manager for autonomous agent processes.</b></p>
 
 <p align="center">
   One YAML spec → one reproducible, sandboxed, fleet-addressable agent.<br/>
@@ -46,7 +46,7 @@
 |---|---|
 | 1 | **Declarative agents.** One `spec.yaml` per agent — the file IS the agent (dir-as-SSoT, no hidden state). Reproducible across hosts, version-controlled, diff-reviewable. [`spec-reference.md`](docs/spec-reference.md). |
 | 2 | **Rootless Apptainer isolation.** Runs where cloud sandboxes (E2B, Modal, etc.) can't — HPC login nodes, on-prem clusters, fully air-gapped boxes. No root, no daemon, no Docker socket. Hardened by default with `--containall` ([`isolation.md`](docs/isolation.md)). |
-| 3 | **Switchable backend, stable Claude Code harness.** Default: Anthropic OAuth. Alternatives include Codex/ChatGPT subscriptions through scitex-genai, DeepSeek, MiMo/Xiaomi, or any Anthropic-compatible endpoint via one `spec.claude.provider:` knob. Claude Code's TUI, hooks, skills, channels, flags, and `CLAUDE.md` stay in place. |
+| 3 | **Two independent axes, one spec.** sac owns the agent PROCESS; a *harness* owns only the TURN. **Which harness drives the turn** is `spec.harness:` — `anthropic` (default), `openai`, or `codex`. **Which endpoint answers it** is the separate `spec.claude.provider:` knob — Anthropic OAuth (default), Codex/ChatGPT via scitex-genai, DeepSeek, MiMo/Xiaomi, or any Anthropic-compatible `base_url`. Swapping the endpoint does not change the harness, and vice versa. The clearest proof the axes are different: `codex` is a legal value of **both**, and it means different things — as a *harness* the Codex agent program runs the loop; as a *provider* Claude Code still drives and Codex only answers. **[What actually starts today →](#which-harnesses-actually-start)** — the registry has four entries and only the `anthropic` ones can be started. [`spec-reference.md`](docs/spec-reference.md). |
 | 4 | **Fleet ops out of the box.** A2A push (`POST /v1/turn` per agent, native), health & heartbeat, restart policies, multi-account credential rotation with auto-quota-watch, MCP + CLI + Python surface, cross-host orchestration via `sac fleet`. |
 | 5 | **AGPL-3.0.** Research-freedom license — infrastructure stays open, modifications stay shareable. The [Four Freedoms for Research](#four-freedoms-for-research) below. |
 
@@ -126,9 +126,38 @@ sac agents delete hello-agent-1 hello-agent-2 -y
 
 [`examples/`](examples/) walks through the runtime in 15 lessons (image build, sandbox/update/freeze, versioning, run/send/tail, logs/exec, stop/remove, binds, env+user, writing your first spec.yaml, to_home/, A2A endpoint, health+restart, multi-host, debugging). Run them read-only with `bash examples/00_run_all.sh`, or `--apply` to execute the mutating ones. Pre-baked agent specs live in [`examples/agents/`](examples/agents/) (`hello-agent`, `minimal-agent`, `full-agent`, `codex-agent`, `deepseek-agent`, `proxy-agent`).
 
+### Which harnesses actually start
+
+The harness registry has **four** entries, and `spec.harness` accepts **three**
+values. Only the `anthropic` ones can be started today — a registry entry is a
+declaration, not a working launch path, and this table says which is which
+rather than letting the count imply support that is not there:
+
+| `spec.harness` | Registry entry     | Selected by                                       | `sac agents start`? |
+|----------------|--------------------|---------------------------------------------------|---------------------|
+| `anthropic` *(default)* | `claude-code-tui`  | `spec.runtime: tui`, or unset                     | **yes** |
+| `anthropic`    | `claude-agent-sdk` | `spec.runtime: claude-agent-sdk` (legacy alias `apptainer`) | **yes** |
+| `openai`       | `openai-agents`    | the harness axis alone                            | **no** — refused |
+| `codex`        | `codex-sdk`        | the harness axis alone                            | **no** — refused |
+
+A non-`anthropic` harness loads, validates and resolves to its registry entry,
+but every lifecycle launch path refuses it *loudly* rather than silently
+starting a Claude runner under a spec that asked for something else. The one
+working alternative today is `spec.a2a.handler: openai_session` for the OpenAI
+SDK; there is no equivalent A2A executor for `codex` yet.
+
+`spec.runtime` only discriminates *within* the `anthropic` family — the `openai`
+and `codex` families have a single entry each, so the runtime axis selects
+nothing for them.
+
 ### Models
 
-Pick the model per agent under `spec.claude.model`:
+`spec.claude.model` is the per-agent model knob. Be aware that sac resolves it
+to `sonnet` when a spec leaves it empty — for **every** agent, whichever harness
+the spec selects. That Anthropic-shaped default is real and not yet unwound by
+the harness/runtime/inference layering work.
+
+Anthropic aliases:
 
 | Alias    | Model (current)             | Use for                         |
 |----------|-----------------------------|---------------------------------|
@@ -138,25 +167,28 @@ Pick the model per agent under `spec.claude.model`:
 
 Aliases auto-track the latest version of each family; append `[1m]` for the 1M-token context window (`opus[1m]`, `sonnet[1m]`). Pin an exact build with a full ID like `claude-opus-4-7` or `claude-haiku-4-5-20251001`.
 
-**Non-Anthropic backend?** Set `spec.claude.provider: codex` with a GPT model
-to use the local scitex-genai ChatGPT-subscription gateway while retaining the
-Claude Code harness. Other bundled entries are `deepseek`, `mimo`, and
-`xiaomi`; a dict `{ base_url: "...", auth_token_env: "..." }` accepts any
-Anthropic-compatible endpoint. Codex setup and multi-account configuration are
-documented in [`docs/credentials.md`](docs/credentials.md). See
-[`examples/agents/deepseek-agent/`](examples/agents/deepseek-agent/) for the
-generic provider shape. **[Full model + provider reference →](docs/spec-reference.md)**
+**A non-Anthropic inference endpoint?** `spec.claude.provider` swaps the
+ENDPOINT, not the harness — the Claude-family harness keeps running, pointed
+somewhere else. Set `spec.claude.provider: codex` with a GPT model to use the
+local scitex-genai ChatGPT-subscription gateway. Other bundled entries are
+`deepseek`, `mimo`, and `xiaomi`; a dict `{ base_url: "...", auth_token_env:
+"..." }` accepts any Anthropic-compatible endpoint. Under an override the model
+id is the endpoint's own (e.g. `deepseek-chat`), so the `claude-*` alias check
+relaxes and the table above no longer applies. Codex setup and multi-account
+configuration are documented in [`docs/credentials.md`](docs/credentials.md).
+See [`examples/agents/deepseek-agent/`](examples/agents/deepseek-agent/) for the
+generic provider shape. **[Full harness + model + provider reference →](docs/spec-reference.md)**
 
 ## How it works
 
-`sac` materializes a `spec.yaml` into a long-lived, externally addressable Claude agent:
+`sac` materializes a `spec.yaml` into a long-lived, externally addressable agent process — whichever harness drives its turns:
 
 ```
   spec.yaml   ─┐
   to_home/    ─┴─→ sac agents start ──→ apptainer instance
                                           │
                                           ▼
-                              long-lived Claude SDK session
+                              long-lived harness session (TUI or SDK)
                               │
                               ├── <workdir>  (= spec.workdir, mounted rw)
                               ├── spec.mounts[]  ← host-path allowlist (ro/rw)
@@ -168,7 +200,7 @@ generic provider shape. **[Full model + provider reference →](docs/spec-refere
 
 **[Full architecture →](docs/how-sac-works.md)** — launch flow, to_home merge rules, A2A inbound, control plane, restart/health.
 
-**[YAML Spec Reference (v3) →](docs/spec-reference.md)** — annotated full example + field table (apiVersion, spec.apptainer.*, spec.claude.*, a2a, health, restart, provider).
+**[YAML Spec Reference (v3) →](docs/spec-reference.md)** — annotated full example + field table (apiVersion, spec.harness, spec.runtime, spec.apptainer.*, spec.claude.*, a2a, health, restart, provider).
 
 **[Talking to a Running Agent →](docs/talking-to-agents.md)** — three transports (A2A `POST /v1/turn`, `sac agents send`, host-level `sac listen`), when to use which, copy-pasteable curl examples.
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -62,8 +62,11 @@ configured on the gateway, not repeated in each agent's
 `claude.credentials_files`. The gateway key authenticates only the local SAC
 to gateway hop; Codex OAuth tokens remain in each `auth.json`.
 
-This document describes the on-disk files Claude Code manages for a user
-and which fields `scitex-agent-container` is allowed to read and surface.
+The remainder of this document is **Claude Code-specific reference
+material**: the on-disk files Claude Code manages for a user, and which
+fields `scitex-agent-container` is allowed to read and surface. It applies
+when an agent runs a Claude-family harness; the formats below are
+Anthropic's, not sac's.
 
 ## Claude Code files
 
@@ -114,8 +117,9 @@ skills are enabled.
 
 ## Fleet hosts
 
-Each fleet host runs exactly one Claude Code OAuth identity shared by
-all tmux-managed agents on that host:
+On hosts running the Claude Code harness, each fleet host carries
+exactly one Claude Code OAuth identity, shared by all tmux-managed
+agents on that host:
 
 | Host              | Domain role            | Credential home |
 |-------------------|------------------------|-----------------|

--- a/docs/directories.md
+++ b/docs/directories.md
@@ -10,7 +10,10 @@ Configuration is separated into user-scope and project-scope. Project-scope (`.s
 │                                listen.{host,port}, a2a.port_range
 ├── agents/<name>/             ← per-agent declarations (you write these)
 │   ├── spec.yaml              ← v3 Agent definition (the SSoT)
-│   └── to_home/               ← optional: mirrored into the agent $HOME at start
+│   └── to_home/               ← optional: mirrored into the agent $HOME at start.
+│                                Any path lands at the same relative path; the
+│                                entries below are the Claude Code harness's
+│                                filenames, shown as the worked example.
 │       ├── CLAUDE.md           (→ $HOME/CLAUDE.md, marker-protected)
 │       ├── .mcp.json           (→ $HOME/.mcp.json, full overwrite)
 │       ├── .env                (→ $HOME/.env, mode 0600)

--- a/docs/how-sac-works.md
+++ b/docs/how-sac-works.md
@@ -1,7 +1,7 @@
 # How sac works
 
 `scitex-agent-container` (`sac`) materializes a `spec.yaml` into a long-lived,
-externally addressable Claude agent.
+externally addressable agent process — whichever harness drives its turns.
 
 ## Launch flow
 
@@ -10,11 +10,11 @@ externally addressable Claude agent.
   to_home/    ─┴─→ sac agents start ──→ apptainer instance
                                           │
                                           ▼
-                              long-lived Claude SDK session
+                              long-lived harness session (TUI or SDK)
                               │
                               ├── $HOME  (= runtime/<name>/home/, bind-mounted)
-                              │     CLAUDE.md / .mcp.json / .env / state.md     ← from to_home/
-                              │     .claude/{commands,skills,hooks,...}         ← from to_home/.claude/
+                              │     e.g. CLAUDE.md / .mcp.json / .env / state.md ← from to_home/
+                              │     e.g. .claude/{commands,skills,hooks,...}     ← from to_home/.claude/
                               │
                               ├── spec.mounts[]  ← explicit host-path allowlist (ro/rw)
                               │
@@ -48,7 +48,9 @@ parent directory — no name field in the YAML. See [spec-reference.md](spec-ref
 
 A directory next to `spec.yaml`. At start, `sac` mirrors its contents into the
 agent's container `$HOME` (= `runtime/<name>/home/`). Every path under
-`to_home/` lands at the same relative path under `$HOME`:
+`to_home/` lands at the same relative path under `$HOME` — the mirror itself is
+harness-agnostic; the rows below are the Claude Code harness's filenames as the
+worked example:
 
 | Source                    | Destination                     | Merge rule             |
 |---------------------------|---------------------------------|------------------------|
@@ -67,13 +69,39 @@ agent's container `$HOME` (= `runtime/<name>/home/`). Every path under
 - env vars from `spec.apptainer.env`
 - optional GPU passthrough (`--nv` / `--rocm`)
 
-### Claude SDK session
+### Harness session
 
-Inside the container, `sac` launches `claude` (Claude Code CLI) as a long-lived
-SDK session. Session state persists in the host-side state dir so it survives
-container restarts. `spec.claude.session` controls whether to start fresh
-(`new-session`), continue the last session (`continue`), or resume a specific
-one (`resume <sid>`).
+Inside the container, `sac` launches the *harness* — the agent program that
+drives one turn. sac owns the process, its lifecycle, and its addressability;
+the harness owns only the turn. Session state persists in the host-side state
+dir so it survives container restarts.
+
+The harness is selected by `spec.harness` (family) plus `spec.runtime` (launch
+mode within that family). Four harnesses are registered; **only the `anthropic`
+ones can be started today.** A registry entry is a declaration, not a working
+launch path, so the table says which is which:
+
+| `spec.harness` | Registry entry     | Selected by                                       | Process shape                     | `sac agents start`? |
+|----------------|--------------------|---------------------------------------------------|-----------------------------------|---------------------|
+| `anthropic` *(default)* | `claude-code-tui`  | `runtime: tui`, or unset                  | external `claude` binary in a PTY | **yes** |
+| `anthropic`    | `claude-agent-sdk` | `runtime: claude-agent-sdk` (legacy alias `apptainer`) | sac-hosted session runner | **yes** |
+| `openai`       | `openai-agents`    | the harness axis alone                            | sac-hosted session runner         | **no** — refused |
+| `codex`        | `codex-sdk`        | the harness axis alone                            | sac-hosted session runner         | **no** — refused |
+
+`spec.runtime` only discriminates *within* the `anthropic` family; the `openai`
+and `codex` families have one entry each, so the runtime axis selects nothing
+for them.
+
+**Honest limit today:** a non-`anthropic` harness loads, validates and resolves
+to its registry entry, but every lifecycle launch path *refuses* it — loudly,
+rather than silently starting a Claude harness under a spec that asked for
+something else. The one working alternative is `spec.a2a.handler:
+openai_session` for the OpenAI SDK; there is no equivalent A2A executor for
+`codex` yet.
+
+`spec.claude.session` controls whether to start fresh (`new-session`), continue
+the last session (`continue`), or resume a specific one (`resume <sid>`) for the
+Claude-family harnesses.
 
 ### A2A inbound (`spec.a2a.port`)
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -9,6 +9,12 @@ Two `.def` recipes, layered:
 | `:base`   | Ubuntu 24.04 + dev tools (git, gh, rust CLIs, mermaid, prettier, eslint, jsonlint, uv, pipx, tree, node 20) | **Default** when `spec.image` is unset |
 | `:scitex` | `FROM :base` + ffmpeg + portaudio + `scitex[all]` + claude-agent-sdk + sac itself                           | Optional heavier layer                 |
 
+**Neither layer is harness-complete on its own.** `:base` ships no agent
+SDK at all; `:scitex` adds `claude-agent-sdk` only. Whichever harness your
+specs select has to be present in the image you point them at — an
+`openai` agent needs the `openai-agents` SDK on top, a `codex` agent needs
+`openai-codex` plus its ~285 MB pinned CLI-binary wheel.
+
 Recipes ship in the pip wheel — no need to clone the repo to run `sac image build`.
 Built artifacts live under `~/.scitex/agent-container/containers/`, never in git.
 

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -84,9 +84,11 @@ Default: the container **shares the host's network namespace**.
 should NOT be able to bypass sac listen's bearer auth by talking to
 its loopback directly. With shared netns it can.
 
-**Fix:** `--net --network=none` (full isolation; agent loses Claude
+**Fix:** `--net --network=none` (full isolation; agent loses inference
 API access) OR `--net --network=bridge` (independent netns + explicit
-egress allowlist for `api.anthropic.com`). Bridge + allowlist is the
+egress allowlist for the inference endpoint this agent is configured
+for — `api.anthropic.com` by default, the `spec.claude.provider`
+`base_url` host under an override). Bridge + allowlist is the
 realistic answer; pure isolation kills the agent.
 
 **Realistic trade-off (current sac default).** sac currently uses the
@@ -141,7 +143,7 @@ leak vector (previous-run state contaminates the next run):
 |---|---|
 | `/tmp` writes | accumulating garbage; race conditions if two runs overlap |
 | `~/.cache/pip`, build artifacts | unintended reproducibility break (same SIF, different overlay → different result) |
-| Claude session state | prior conversation leaks into next start |
+| agent session state | prior conversation leaks into next start |
 | accidentally shared overlay | horizontal contamination between agents |
 
 **Fix:**
@@ -300,8 +302,8 @@ spec:
       - "--containall"        # §1: filesystem isolation
       - "--cleanenv"          # §2: environment isolation
       # Network (§4): pick one based on workload —
-      #   --net --network=none  → no egress (most secure; agent can't reach Claude API)
-      #   --net --network=bridge  → bridged + allowlist (realistic for Claude agents)
+      #   --net --network=none  → no egress (most secure; agent can't reach its inference API)
+      #   --net --network=bridge  → bridged + allowlist (the realistic shape for any agent)
       # PID / IPC / UTS (§5): not in --containall; add if you need them.
       #   "--pid", "--ipc", "--uts"
 ```

--- a/docs/mcp-cold-start.md
+++ b/docs/mcp-cold-start.md
@@ -1,5 +1,10 @@
 # MCP cold-start connect race — root cause + fix
 
+> **Scope: the Claude Code harness.** Everything below is a property of
+> Claude Code's stdio-MCP *client*, not of sac or of MCP generally. An
+> agent on another harness has a different MCP client and does not
+> inherit these behaviours.
+
 ## The incident (2026-07-06)
 
 Agents' `scitex-agent-container` (`sac mcp start`) and `scitex-todo`

--- a/docs/mcp-load-resilience.md
+++ b/docs/mcp-load-resilience.md
@@ -5,6 +5,10 @@ Sibling of [`mcp-cold-start.md`](./mcp-cold-start.md). That doc covers the
 covers the **mid-session** failure: a healthy, connected stdio MCP that gets
 **dropped under host load** and never comes back.
 
+> **Scope: the Claude Code harness.** Like its sibling, this document
+> describes Claude Code's stdio-MCP *client* behaviour, not sac's and not
+> MCP's in general.
+
 ## The incident (2026-07-09)
 
 The `scitex-agent-container` MCP surface (`host_exec_local`, `agent_restart`,

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -6,6 +6,14 @@ a2a, health, restart, autonomous, listen, skills, telegram, hooks)
 stay at the top level. Every curated block has a `raw_*` escape hatch
 — the full underlying surface is always reachable.
 
+> **On the name `spec.claude`.** It is a legacy key name, not a scope
+> claim: the block carries the SDK-harness session/model knobs
+> generally, and its `provider` sub-key demonstrably configures
+> non-Anthropic endpoints. Do not read `spec.claude.*` as "the Claude
+> harness only" — and do not confuse `spec.claude.provider` (which
+> *inference endpoint* answers) with the top-level `spec.harness`
+> (which *agent program* drives the turn). The two axes compose.
+
 The agent name is the parent directory of `spec.yaml` (dir-as-SSoT —
 no `metadata.name` field).
 
@@ -128,7 +136,7 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 | Field                | Type                       | Description                                                              |
 |----------------------|----------------------------|--------------------------------------------------------------------------|
 | `runtime`            | `apptainer` (optional)     | Empty/unset defaults to `apptainer`; any other value is rejected. docker/podman were dropped 2026-05-13 |
-| `harness`            | `anthropic` (default) \| `openai` | **Which agent SDK runs the session** (NOT the same field as `spec.claude.provider`, which points the *Claude* SDK at an Anthropic-compatible inference gateway — the two axes compose). `openai` runs the agent on the `openai-agents` SDK: at launch sac injects `SAC_OPENAI_API_KEY` + `OPENAI_API_KEY` (resolved host-side, shell export > `$HOME/.env`, `SAC_OPENAI_API_KEY` preferred over `OPENAI_API_KEY`) and forwards `OPENAI_BASE_URL` / `OPENAI_ORG_ID` / `OPENAI_PROJECT_ID` / `SAC_OPENAI_MODEL` when set on the host; NO Anthropic OAuth env or credentials bind is emitted. Fail-loud when no key resolves or when composed with an active `spec.claude.provider` override. A2A serving uses the `openai_session` executor (`spec.a2a.handler`). **Ops-only override:** exporting `SAC_PROVIDER=openai` (or `anthropic`) in the shell that runs `sac agents start` overrides `spec.harness` for every launch from that shell — an operations escape hatch for emergency flips / A/B smoke tests, never a spec surface; unknown values are rejected loudly. (The env var keeps its older `SAC_PROVIDER` name.) |
+| `harness`            | `anthropic` (default) \| `openai` \| `codex` | **Which agent SDK runs the session** (NOT the same field as `spec.claude.provider`, which points the *Claude* SDK at an Anthropic-compatible inference gateway — the two axes compose). `openai` runs the agent on the `openai-agents` SDK: at launch sac injects `SAC_OPENAI_API_KEY` + `OPENAI_API_KEY` (resolved host-side, shell export > `$HOME/.env`, `SAC_OPENAI_API_KEY` preferred over `OPENAI_API_KEY`) and forwards `OPENAI_BASE_URL` / `OPENAI_ORG_ID` / `OPENAI_PROJECT_ID` / `SAC_OPENAI_MODEL` when set on the host; NO Anthropic OAuth env or credentials bind is emitted. Fail-loud when no key resolves or when composed with an active `spec.claude.provider` override. **Launch caveat today — read this before choosing a harness:** the registry has four entries (`claude-code-tui`, `claude-agent-sdk`, `openai-agents`, `codex-sdk`) and `spec.harness` accepts three values, but **only `anthropic` can be STARTED**. `openai` and `codex` both load, validate and resolve to their registry entries, and then every lifecycle launch path REFUSES them — loudly, rather than silently launching a Claude runner under a spec that asked for something else. A2A serving uses the `openai_session` executor (`spec.a2a.handler`), which is the working path for the OpenAI SDK meanwhile; there is no equivalent executor for `codex` yet. **`codex` is also a legal `spec.claude.provider` value and means something different there** — as a HARNESS the Codex agent program runs the loop; as a PROVIDER Claude Code still drives and Codex only answers. **Ops-only override:** exporting `SAC_PROVIDER=openai` (or `anthropic`) in the shell that runs `sac agents start` overrides `spec.harness` for every launch from that shell — an operations escape hatch for emergency flips / A/B smoke tests, never a spec surface; unknown values are rejected loudly. (The env var keeps its older `SAC_PROVIDER` name.) |
 | `provider`           | *(deprecated alias of `harness`)* | The spelling this field had before it was renamed. **Still honoured** — a spec carrying `provider:` loads unchanged and satisfies the explicit-fields requirement for `harness`; starting such an agent logs a one-line deprecation naming the agent. Writing BOTH keys is fine when they carry the same value; writing both with DIFFERENT values is a hard load error naming both, because a spec that says two things does not say which harness it wants. It was renamed because it never named a provider: it selects which agent PROGRAM drives the loop, while `spec.claude.provider` (unchanged, and still correctly named) selects which inference endpoint answers. |
 | `residency`          | `resident` (default) \| `one-shot` | **Does the daemon outlive its work?** (v4 residency axis.) `resident` — the fleet posture — keeps the session daemon alive after a conversation completes, parked awaiting more turns; a turn driver that returns on its own is then a residency VIOLATION (ExitRecord `harness-returned`/`crashed`, non-zero exit). `one-shot` makes a normal completion the PLAN: the mission turn carries `exit_after`, and the daemon exits `0` with ExitRecord reason `oneshot-complete` — for experiment trials and one-off workers. Absence/null defaults to `resident` (the axis postdates the live corpus; the v3→v4 converter materializes the explicit line — requiring it is that later step). Illegal values are rejected loudly naming the closed set. Only runner-hosted harnesses honour it: `one-shot` on the interactive TUI (`runtime: tui`, which has no session daemon) or on `kind: AgentProxy` is refused at validation time. |
 | `access`             | `full` (default) \| `capsule` | Host-access posture. `full` (the default; absent → `full`) binds the operator's WHOLE home rw at its canonical path (`/home/<user>:/home/<user>:rw`) so the agent reaches every project + config, and opens `--pwd` at the workdir's **canonical** path (the `/work` alias stays bound for back-compat). The agent's own `$HOME=/home/agent` (credentials / to_home / overlay wiring) is untouched. `capsule` restricts the agent to ONLY the binds explicitly listed in the spec + the `/work` alias (pre-2026-06-19 behaviour) — for leak-prevention agents. |
@@ -141,8 +149,8 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 | `host` / `hosts`     | string / list of strings   | Singleton on one peer / multi-instance one-per-peer (mutually exclusive). `hosts: "all"` = every fleet host. |
 | `session`            | string                     | Top-level shortcut overriding `spec.claude.session`; legacy aliases accepted (`continue-or-new`, `new`). |
 | `screen.name`        | string                     | Legacy metadata (agent display name in `sac fleet`). Default = agent name. Does NOT drive a multiplexer. |
-| `startup_commands[]` | list of `{delay, command}` | Run **before** Claude starts. Each item is a dict with optional `delay` (int seconds, default 0) and required `command` (string); bare strings are not accepted. |
-| `startup_prompts[]`  | list of strings            | Fed to Claude as first user message(s)                                   |
+| `startup_commands[]` | list of `{delay, command}` | Run **before** the harness process starts. Each item is a dict with optional `delay` (int seconds, default 0) and required `command` (string); bare strings are not accepted. |
+| `startup_prompts[]`  | list of strings            | Fed to the agent as first user message(s)                                |
 
 ### `spec.apptainer` — engine knobs
 
@@ -167,7 +175,7 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 
 | Field                       | Type                                  | Description                                                       |
 |-----------------------------|---------------------------------------|-------------------------------------------------------------------|
-| `model`                     | alias or full ID (default `sonnet`)   | Claude model — see **Available models** below |
+| `model`                     | alias or full ID (default `sonnet`)   | The model this agent's turns run on. Without a `provider` override it is a Claude model — see **Available models** below. WITH one it is the override endpoint's own id (e.g. `deepseek-chat`, `gpt-5.6-sol`) and the `claude-*` alias check relaxes. **The `sonnet` default is applied to every agent regardless of harness** — an Anthropic-shaped default the harness/runtime/inference layering work has not yet unwound. |
 | `account`                   | string                                | Pin this agent to a stored OAuth account (`sac accounts` store-name). Mutually exclusive with `provider`. |
 | `provider`                  | `{ base_url, auth_token_env }`        | Point the SDK session at any Anthropic-compatible endpoint (e.g. DeepSeek). `base_url` is the endpoint; `auth_token_env` is the NAME of the host env var holding the key (never the key). Mutually exclusive with `account`; relaxes the `claude-*` model-alias check. See ADR-0011. |
 | `session`                   | `continue` \| `new-session` \| `resume`| Session strategy (default `continue` — safe fallback). Legacy aliases `continue-or-new`, `new` accepted |
@@ -224,9 +232,9 @@ pinned regex catches this early.
 | `restart.backoff.multiplier`| exponential factor                                                                       |
 | `watchdog.enabled`          | parsed for back-compat; lifecycle managed via hooks                                      |
 | `autonomous.enabled`        | drive turns until `drive_until` token or `max_turns`                                     |
-| `autonomous.drive_until`    | string token Claude prints when done (default `DONE`)                                    |
+| `autonomous.drive_until`    | string token the agent prints when done (default `DONE`)                                 |
 | `autonomous.max_turns`      | int                                                                                      |
-| `autonomous.kick_text`      | nudge sent when Claude pauses                                                            |
+| `autonomous.kick_text`      | nudge sent when the agent pauses                                                         |
 
 ### `spec.a2a` / `spec.listen` — network endpoints
 
@@ -311,7 +319,7 @@ per-invocation tweak doesn't mutate the persistent default.
 ## `kind: AgentProxy` — HTTP forwarder agents
 
 A proxy agent forwards `POST /v1/turn` to an **external A2A
-endpoint** instead of running a Claude SDK conversation in-process.
+endpoint** instead of running an agent session in-process.
 There is no SDK in the container; the runner is a thin Starlette
 forwarder (image: `sac-proxy.sif`, lighter than `sac-scitex.sif` —
 no Python ML stack).

--- a/docs/sphinx/credentials.md
+++ b/docs/sphinx/credentials.md
@@ -62,8 +62,11 @@ configured on the gateway, not repeated in each agent's
 `claude.credentials_files`. The gateway key authenticates only the local SAC
 to gateway hop; Codex OAuth tokens remain in each `auth.json`.
 
-This document describes the on-disk files Claude Code manages for a user
-and which fields `scitex-agent-container` is allowed to read and surface.
+The remainder of this document is **Claude Code-specific reference
+material**: the on-disk files Claude Code manages for a user, and which
+fields `scitex-agent-container` is allowed to read and surface. It applies
+when an agent runs a Claude-family harness; the formats below are
+Anthropic's, not sac's.
 
 ## Claude Code files
 
@@ -114,8 +117,9 @@ skills are enabled.
 
 ## Fleet hosts
 
-Each fleet host runs exactly one Claude Code OAuth identity shared by
-all tmux-managed agents on that host:
+On hosts running the Claude Code harness, each fleet host carries
+exactly one Claude Code OAuth identity, shared by all tmux-managed
+agents on that host:
 
 | Host              | Domain role            | Credential home |
 |-------------------|------------------------|-----------------|

--- a/docs/sphinx/directories.md
+++ b/docs/sphinx/directories.md
@@ -10,7 +10,10 @@ Configuration is separated into user-scope and project-scope. Project-scope (`.s
 │                                listen.{host,port}, a2a.port_range
 ├── agents/<name>/             ← per-agent declarations (you write these)
 │   ├── spec.yaml              ← v3 Agent definition (the SSoT)
-│   └── to_home/               ← optional: mirrored into the agent $HOME at start
+│   └── to_home/               ← optional: mirrored into the agent $HOME at start.
+│                                Any path lands at the same relative path; the
+│                                entries below are the Claude Code harness's
+│                                filenames, shown as the worked example.
 │       ├── CLAUDE.md           (→ $HOME/CLAUDE.md, marker-protected)
 │       ├── .mcp.json           (→ $HOME/.mcp.json, full overwrite)
 │       ├── .env                (→ $HOME/.env, mode 0600)

--- a/docs/sphinx/how-sac-works.md
+++ b/docs/sphinx/how-sac-works.md
@@ -1,7 +1,7 @@
 # How sac works
 
 `scitex-agent-container` (`sac`) materializes a `spec.yaml` into a long-lived,
-externally addressable Claude agent.
+externally addressable agent process — whichever harness drives its turns.
 
 ## Launch flow
 
@@ -10,11 +10,11 @@ externally addressable Claude agent.
   to_home/    ─┴─→ sac agents start ──→ apptainer instance
                                           │
                                           ▼
-                              long-lived Claude SDK session
+                              long-lived harness session (TUI or SDK)
                               │
                               ├── $HOME  (= runtime/<name>/home/, bind-mounted)
-                              │     CLAUDE.md / .mcp.json / .env / state.md     ← from to_home/
-                              │     .claude/{commands,skills,hooks,...}         ← from to_home/.claude/
+                              │     e.g. CLAUDE.md / .mcp.json / .env / state.md ← from to_home/
+                              │     e.g. .claude/{commands,skills,hooks,...}     ← from to_home/.claude/
                               │
                               ├── spec.mounts[]  ← explicit host-path allowlist (ro/rw)
                               │
@@ -48,7 +48,9 @@ parent directory — no name field in the YAML. See [spec-reference.md](spec-ref
 
 A directory next to `spec.yaml`. At start, `sac` mirrors its contents into the
 agent's container `$HOME` (= `runtime/<name>/home/`). Every path under
-`to_home/` lands at the same relative path under `$HOME`:
+`to_home/` lands at the same relative path under `$HOME` — the mirror itself is
+harness-agnostic; the rows below are the Claude Code harness's filenames as the
+worked example:
 
 | Source                    | Destination                     | Merge rule             |
 |---------------------------|---------------------------------|------------------------|
@@ -67,13 +69,39 @@ agent's container `$HOME` (= `runtime/<name>/home/`). Every path under
 - env vars from `spec.apptainer.env`
 - optional GPU passthrough (`--nv` / `--rocm`)
 
-### Claude SDK session
+### Harness session
 
-Inside the container, `sac` launches `claude` (Claude Code CLI) as a long-lived
-SDK session. Session state persists in the host-side state dir so it survives
-container restarts. `spec.claude.session` controls whether to start fresh
-(`new-session`), continue the last session (`continue`), or resume a specific
-one (`resume <sid>`).
+Inside the container, `sac` launches the *harness* — the agent program that
+drives one turn. sac owns the process, its lifecycle, and its addressability;
+the harness owns only the turn. Session state persists in the host-side state
+dir so it survives container restarts.
+
+The harness is selected by `spec.harness` (family) plus `spec.runtime` (launch
+mode within that family). Four harnesses are registered; **only the `anthropic`
+ones can be started today.** A registry entry is a declaration, not a working
+launch path, so the table says which is which:
+
+| `spec.harness` | Registry entry     | Selected by                                       | Process shape                     | `sac agents start`? |
+|----------------|--------------------|---------------------------------------------------|-----------------------------------|---------------------|
+| `anthropic` *(default)* | `claude-code-tui`  | `runtime: tui`, or unset                  | external `claude` binary in a PTY | **yes** |
+| `anthropic`    | `claude-agent-sdk` | `runtime: claude-agent-sdk` (legacy alias `apptainer`) | sac-hosted session runner | **yes** |
+| `openai`       | `openai-agents`    | the harness axis alone                            | sac-hosted session runner         | **no** — refused |
+| `codex`        | `codex-sdk`        | the harness axis alone                            | sac-hosted session runner         | **no** — refused |
+
+`spec.runtime` only discriminates *within* the `anthropic` family; the `openai`
+and `codex` families have one entry each, so the runtime axis selects nothing
+for them.
+
+**Honest limit today:** a non-`anthropic` harness loads, validates and resolves
+to its registry entry, but every lifecycle launch path *refuses* it — loudly,
+rather than silently starting a Claude harness under a spec that asked for
+something else. The one working alternative is `spec.a2a.handler:
+openai_session` for the OpenAI SDK; there is no equivalent A2A executor for
+`codex` yet.
+
+`spec.claude.session` controls whether to start fresh (`new-session`), continue
+the last session (`continue`), or resume a specific one (`resume <sid>`) for the
+Claude-family harnesses.
 
 ### A2A inbound (`spec.a2a.port`)
 

--- a/docs/sphinx/images.md
+++ b/docs/sphinx/images.md
@@ -9,6 +9,12 @@ Two `.def` recipes, layered:
 | `:base`   | Ubuntu 24.04 + dev tools (git, gh, rust CLIs, mermaid, prettier, eslint, jsonlint, uv, pipx, tree, node 20) | **Default** when `spec.image` is unset |
 | `:scitex` | `FROM :base` + ffmpeg + portaudio + `scitex[all]` + claude-agent-sdk + sac itself                           | Optional heavier layer                 |
 
+**Neither layer is harness-complete on its own.** `:base` ships no agent
+SDK at all; `:scitex` adds `claude-agent-sdk` only. Whichever harness your
+specs select has to be present in the image you point them at — an
+`openai` agent needs the `openai-agents` SDK on top, a `codex` agent needs
+`openai-codex` plus its ~285 MB pinned CLI-binary wheel.
+
 Recipes ship in the pip wheel — no need to clone the repo to run `sac image build`.
 Built artifacts live under `~/.scitex/agent-container/containers/`, never in git.
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -4,7 +4,7 @@ scitex-agent-container — Declarative, On-Prem-First Agent Container Runtime
 ===========================================================================
 
 **scitex-agent-container** (``sac``) turns one ``spec.yaml`` into one
-long-lived, sandboxed, fleet-addressable Claude Code agent. Runs
+long-lived, sandboxed, fleet-addressable agent process. Runs
 anywhere Apptainer runs — laptop, HPC login node, on-prem cluster,
 air-gapped server. Part of `SciTeX <https://scitex.ai>`_.
 
@@ -44,7 +44,16 @@ Why sac
 - **Rootless Apptainer isolation.** Runs where Docker/cloud sandboxes
   cannot — HPC login nodes, on-prem, air-gapped. No root, no daemon,
   no Docker socket. Hardened by default via ``--containall``.
-- **LLM-agnostic / on-prem-capable.** Default: Anthropic OAuth.
+- **Two independent axes, one spec.** sac owns the agent *process*; a
+  *harness* owns only the *turn*. ``spec.harness`` picks the harness —
+  ``anthropic`` (default; ``spec.runtime`` then picks the Claude Code
+  TUI or the headless Claude Agent SDK), ``openai``, or ``codex``.
+  ``spec.claude.provider`` is the separate *inference* axis: which
+  endpoint answers the turn. **Only the ``anthropic`` harnesses can be
+  started today** — the other two validate and resolve, then the launch
+  path refuses them rather than silently running a Claude runner. See
+  :doc:`spec-reference` and :doc:`how-sac-works`.
+- **On-prem-capable inference.** Default: Anthropic OAuth.
   Alternative: any Anthropic-API-compatible backend (DeepSeek, MiMo /
   Xiaomi, a self-hosted LiteLLM / vLLM-with-Anthropic-shim gateway)
   via ``spec.claude.provider``. Data, code, and inference can stay

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -21,4 +21,9 @@ Requirements
 ------------
 
 - Python >= 3.10
-- Claude Code CLI installed
+- The harness your specs select, installed in the image: the Claude Code
+  CLI for ``harness: anthropic`` (the default), the ``openai-agents``
+  SDK for ``harness: openai``, the ``openai-codex`` SDK for
+  ``harness: codex``. sac itself requires none of them. Note that only
+  the ``anthropic`` harnesses can currently be started — see
+  :doc:`how-sac-works`.

--- a/docs/sphinx/isolation.md
+++ b/docs/sphinx/isolation.md
@@ -84,9 +84,11 @@ Default: the container **shares the host's network namespace**.
 should NOT be able to bypass sac listen's bearer auth by talking to
 its loopback directly. With shared netns it can.
 
-**Fix:** `--net --network=none` (full isolation; agent loses Claude
+**Fix:** `--net --network=none` (full isolation; agent loses inference
 API access) OR `--net --network=bridge` (independent netns + explicit
-egress allowlist for `api.anthropic.com`). Bridge + allowlist is the
+egress allowlist for the inference endpoint this agent is configured
+for — `api.anthropic.com` by default, the `spec.claude.provider`
+`base_url` host under an override). Bridge + allowlist is the
 realistic answer; pure isolation kills the agent.
 
 **Realistic trade-off (current sac default).** sac currently uses the
@@ -141,7 +143,7 @@ leak vector (previous-run state contaminates the next run):
 |---|---|
 | `/tmp` writes | accumulating garbage; race conditions if two runs overlap |
 | `~/.cache/pip`, build artifacts | unintended reproducibility break (same SIF, different overlay → different result) |
-| Claude session state | prior conversation leaks into next start |
+| agent session state | prior conversation leaks into next start |
 | accidentally shared overlay | horizontal contamination between agents |
 
 **Fix:**
@@ -240,8 +242,8 @@ spec:
       - "--containall"        # §1: filesystem isolation
       - "--cleanenv"          # §2: environment isolation
       # Network (§4): pick one based on workload —
-      #   --net --network=none  → no egress (most secure; agent can't reach Claude API)
-      #   --net --network=bridge  → bridged + allowlist (realistic for Claude agents)
+      #   --net --network=none  → no egress (most secure; agent can't reach its inference API)
+      #   --net --network=bridge  → bridged + allowlist (the realistic shape for any agent)
       # PID / IPC / UTS (§5): not in --containall; add if you need them.
       #   "--pid", "--ipc", "--uts"
 ```

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -12,7 +12,12 @@ Quickstart
    ``full-agent``, ``proxy-agent``). See :doc:`templates` for details.
 
 2. Create an agent definition directory with a ``spec.yaml`` manifest
-   plus an optional ``to_home/`` sibling (CLAUDE.md / .mcp.json / ...):
+   plus an optional ``to_home/`` sibling (e.g. CLAUDE.md / .mcp.json / ...).
+   The example below leaves ``spec.harness`` implicit, so it selects the
+   default ``anthropic`` harness. ``spec.harness`` and ``spec.runtime``
+   together choose which agent program drives the turn, and
+   ``spec.claude.provider`` separately chooses which inference endpoint
+   answers it — see :doc:`spec-reference`.
 
 .. code-block:: yaml
 
@@ -48,7 +53,7 @@ Quickstart
     sac agents tail my-agent
     sac agents recall my-agent
 
-4. (Optional) Wire Claude Code hooks so ``list --json`` can surface
-   recent tool calls, prompts, and sub-agent launches. See
-   :doc:`status_and_hooks` for the full ``.claude/settings.local.json``
-   snippet.
+4. (Optional, Claude Code harness only) Wire Claude Code hooks so
+   ``list --json`` can surface recent tool calls, prompts, and sub-agent
+   launches. See :doc:`status_and_hooks` for the full
+   ``.claude/settings.local.json`` snippet.

--- a/docs/sphinx/spec-reference.md
+++ b/docs/sphinx/spec-reference.md
@@ -6,6 +6,14 @@ a2a, health, restart, autonomous, listen, skills, telegram, hooks)
 stay at the top level. Every curated block has a `raw_*` escape hatch
 — the full underlying surface is always reachable.
 
+> **On the name `spec.claude`.** It is a legacy key name, not a scope
+> claim: the block carries the SDK-harness session/model knobs
+> generally, and its `provider` sub-key demonstrably configures
+> non-Anthropic endpoints. Do not read `spec.claude.*` as "the Claude
+> harness only" — and do not confuse `spec.claude.provider` (which
+> *inference endpoint* answers) with the top-level `spec.harness`
+> (which *agent program* drives the turn). The two axes compose.
+
 The agent name is the parent directory of `spec.yaml` (dir-as-SSoT —
 no `metadata.name` field).
 
@@ -127,7 +135,9 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 
 | Field                | Type                       | Description                                                              |
 |----------------------|----------------------------|--------------------------------------------------------------------------|
-| `runtime`            | `apptainer` (optional)     | Empty/unset defaults to `apptainer`; any other value is rejected. docker/podman were dropped 2026-05-13 |
+| `harness`            | `anthropic` (default) \| `openai` \| `codex` | **Which agent program drives the turn** — NOT `spec.claude.provider`, which points the SDK session at an Anthropic-compatible *inference* endpoint. The two axes compose, and `codex` is a legal value of BOTH: as a HARNESS the Codex agent program runs the loop, as a PROVIDER Claude Code still drives and Codex only answers. **Launch caveat today — read before choosing:** the registry has four entries (`claude-code-tui`, `claude-agent-sdk`, `openai-agents`, `codex-sdk`), but only `anthropic` can be STARTED. `openai` and `codex` load, validate and resolve to their registry entries, then every lifecycle launch path REFUSES them — loudly, rather than silently launching a Claude runner under a spec that asked for something else. The working path for the OpenAI SDK meanwhile is the `openai_session` A2A executor (`spec.a2a.handler`); there is no equivalent executor for `codex` yet. |
+| `provider`           | *(deprecated alias of `harness`)* | The spelling this field had before it was renamed. Still honoured: a spec carrying `provider:` loads unchanged; starting it logs a one-line deprecation. Both keys with the SAME value is fine; both with DIFFERENT values is a hard load error naming both. |
+| `runtime`            | `tui` (default) \| `claude-agent-sdk` \| `apptainer` | **Launch mode within the Anthropic harness family.** Empty/unset = `tui` (the interactive Claude Code TUI in a PTY); `claude-agent-sdk` = the headless SDK runner; `apptainer` is the back-compat spelling of the pre-2026-06-13 container-engine field and maps to `claude-agent-sdk`. docker/podman were dropped 2026-05-13. |
 | `workdir`            | path                       | Mounted rw at `/work` (default: `~/.scitex/agent-container/runtime/agents/<name>/`) |
 | `to_home`            | path                       | Mirrored into the agent's container `$HOME` (= `runtime/<name>/home/`) at start. Every path under `to_home/` lands at the same relative path under `$HOME`. Default `./to_home` — auto-discovers a sibling `to_home/` next to `spec.yaml`. |
 | `python-venv`        | string \| list             | Pre-activated for startup_commands; `auto` probes `~/.venv-3.11`, `~/.venv` |
@@ -137,8 +147,8 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 | `host` / `hosts`     | string / list of strings   | Singleton on one peer / multi-instance one-per-peer (mutually exclusive). `hosts: "all"` = every fleet host. |
 | `session`            | string                     | Top-level shortcut overriding `spec.claude.session`; legacy aliases accepted (`continue-or-new`, `new`). |
 | `screen.name`        | string                     | Legacy metadata (agent display name in `sac fleet`). Default = agent name. Does NOT drive a multiplexer. |
-| `startup_commands[]` | list of `{delay, command}` | Run **before** Claude starts. Each item is a dict with optional `delay` (int seconds, default 0) and required `command` (string); bare strings are not accepted. |
-| `startup_prompts[]`  | list of strings            | Fed to Claude as first user message(s)                                   |
+| `startup_commands[]` | list of `{delay, command}` | Run **before** the harness process starts. Each item is a dict with optional `delay` (int seconds, default 0) and required `command` (string); bare strings are not accepted. |
+| `startup_prompts[]`  | list of strings            | Fed to the agent as first user message(s)                                |
 
 ### `spec.apptainer` — engine knobs
 
@@ -161,7 +171,7 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 
 | Field                       | Type                                  | Description                                                       |
 |-----------------------------|---------------------------------------|-------------------------------------------------------------------|
-| `model`                     | alias or full ID (default `sonnet`)   | Claude model — see **Available models** below |
+| `model`                     | alias or full ID (default `sonnet`)   | The model this agent's turns run on. Without a `provider` override it is a Claude model — see **Available models** below. WITH one it is the override endpoint's own id (e.g. `deepseek-chat`, `gpt-5.6-sol`) and the `claude-*` alias check relaxes. **The `sonnet` default is applied to every agent regardless of harness** — an Anthropic-shaped default the harness/runtime/inference layering work has not yet unwound. |
 | `account`                   | string                                | Pin this agent to a stored OAuth account (`sac accounts` store-name). Mutually exclusive with `provider`. |
 | `provider`                  | `{ base_url, auth_token_env }`        | Point the SDK session at any Anthropic-compatible endpoint (e.g. DeepSeek). `base_url` is the endpoint; `auth_token_env` is the NAME of the host env var holding the key (never the key). Mutually exclusive with `account`; relaxes the `claude-*` model-alias check. See ADR-0011. |
 | `session`                   | `continue` \| `new-session` \| `resume`| Session strategy (default `continue` — safe fallback). Legacy aliases `continue-or-new`, `new` accepted |
@@ -218,9 +228,9 @@ pinned regex catches this early.
 | `restart.backoff.multiplier`| exponential factor                                                                       |
 | `watchdog.enabled`          | parsed for back-compat; lifecycle managed via hooks                                      |
 | `autonomous.enabled`        | drive turns until `drive_until` token or `max_turns`                                     |
-| `autonomous.drive_until`    | string token Claude prints when done (default `DONE`)                                    |
+| `autonomous.drive_until`    | string token the agent prints when done (default `DONE`)                                 |
 | `autonomous.max_turns`      | int                                                                                      |
-| `autonomous.kick_text`      | nudge sent when Claude pauses                                                            |
+| `autonomous.kick_text`      | nudge sent when the agent pauses                                                         |
 
 ### `spec.a2a` / `spec.listen` — network endpoints
 
@@ -305,7 +315,7 @@ per-invocation tweak doesn't mutate the persistent default.
 ## `kind: AgentProxy` — HTTP forwarder agents
 
 A proxy agent forwards `POST /v1/turn` to an **external A2A
-endpoint** instead of running a Claude SDK conversation in-process.
+endpoint** instead of running an agent session in-process.
 There is no SDK in the container; the runner is a thin Starlette
 forwarder (image: `sac-proxy.sif`, lighter than `sac-scitex.sif` —
 no Python ML stack).

--- a/docs/sphinx/status_and_hooks.rst
+++ b/docs/sphinx/status_and_hooks.rst
@@ -81,7 +81,9 @@ Selected fields:
     suitable for dashboards.
 
 ``quota_5h_used_pct``, ``quota_7d_used_pct``, ``quota_*_reset_at``
-    Claude usage (best-effort; cached between calls).
+    Anthropic subscription usage (best-effort; cached between calls).
+    Populated only on the Anthropic OAuth account axis — empty under a
+    ``spec.claude.provider`` override or a non-Anthropic harness.
 
 ``metrics``
     Host-level CPU / memory / load / disk (psutil).

--- a/docs/sphinx/talking-to-agents.md
+++ b/docs/sphinx/talking-to-agents.md
@@ -207,7 +207,7 @@ fleet, a contracted vendor). Wrapping it in a `kind: AgentProxy`
 agent lets the rest of sac (`sac agents send`, `sac listen`, the
 AgentCard discovery surface) treat it the same as a local SDK agent.
 
-The proxy agent has no Claude SDK; it just forwards `POST /v1/turn`
+The proxy agent has no agent SDK; it just forwards `POST /v1/turn`
 to its configured `spec.proxy.upstream` and re-projects the
 upstream AgentCard at its own `/.well-known/agent-card.json` so
 peers see one consistent skill list.

--- a/docs/sphinx/templates.rst
+++ b/docs/sphinx/templates.rst
@@ -25,9 +25,12 @@ Pattern Templates
      - Smallest valid ``spec.yaml``
      - Starting point. The fewest fields that load and start.
    * - ``hello-agent``
-     - claude-session inside an Apptainer SIF
-     - **Default**. F-CS17 made sac container-only; this is the
-       canonical single-turn pattern.
+     - ``claude-session`` runner inside an Apptainer SIF
+     - **Default harness** (``harness: anthropic``). F-CS17 made sac
+       container-only; this is the canonical single-turn pattern. It is
+       the default because it is the harness the fleet runs, not because
+       it is the only one sac knows — see :doc:`spec-reference` for
+       ``spec.harness``.
    * - ``full-agent``
      - Fully-featured agent
      - Health, restart, A2A, and ``to_home/`` wiring all enabled.

--- a/docs/talking-to-agents.md
+++ b/docs/talking-to-agents.md
@@ -207,7 +207,7 @@ fleet, a contracted vendor). Wrapping it in a `kind: AgentProxy`
 agent lets the rest of sac (`sac agents send`, `sac listen`, the
 AgentCard discovery surface) treat it the same as a local SDK agent.
 
-The proxy agent has no Claude SDK; it just forwards `POST /v1/turn`
+The proxy agent has no agent SDK; it just forwards `POST /v1/turn`
 to its configured `spec.proxy.upstream` and re-projects the
 upstream AgentCard at its own `/.well-known/agent-card.json` so
 peers see one consistent skill list.


### PR DESCRIPTION
Documentation only. No spec key, validator, loader, CLI verb or test is touched — the spec-schema migration is a separate, operator-blocked change and this PR deliberately does not race it.

Operator request 「ドキュメントも整備してください」, following 「claude の名前が出てきたら要注意…本当に claude 特有なのか、スコープは広すぎないか、特別視されていないか、と疑ってください」.

Rebased onto `develop` @ `04dac67b` after #1047 (codex harness) merged; all measurements below are from that tree.

## The framing that was wrong

`README.md:15` called sac a *"Declarative, on-prem-first lifecycle manager for **Claude Code agents**."* That is the origin of the coupling the v4 layering work is unwinding, and it was already false. `README.md:49` then fused two genuinely different questions into one row (*"Switchable backend, stable Claude Code harness"*). They are now stated as independent axes:

| axis | spec key | question |
|---|---|---|
| **harness** | `spec.harness` (+ `spec.runtime` as launch mode) | which agent PROGRAM drives the turn |
| **inference** | `spec.claude.provider` | which ENDPOINT answers it |

The sharpest proof they are different axes — and the validator already says so in its own error text — is that **`codex` is a legal value of both, meaning different things**: as a *harness* the Codex agent program runs the loop; as a *provider* Claude Code still drives and Codex only answers.

## Counting harnesses is not documenting support

The obvious way to write this PR after #1047 would be "sac supports four harnesses". That would replace one framing problem with another. Measured on this tree:

```
HARNESS_DESCRIPTORS keys = ['claude-agent-sdk', 'claude-code-tui',
                            'codex-sdk', 'openai-agents']
known_harnesses()        = ('anthropic', 'codex', 'openai')
```

Four registry entries, three accepted `spec.harness` values — and **only `anthropic` can actually be started.** `ensure_harness_matches_claude_launch` returns early for exactly the default family and raises for everything else, and `_get_runtime` calls it before any dispatch. Verified for all twelve harness × runtime combinations:

| `spec.harness` | Registry entry | `sac agents start` |
|---|---|---|
| `anthropic` *(default)* | `claude-code-tui` (`runtime: tui`/unset) | **yes** — `TuiSessionRuntime` |
| `anthropic` | `claude-agent-sdk` (`runtime: claude-agent-sdk`/`apptainer`) | **yes** — `ClaudeSessionRuntime` |
| `openai` | `openai-agents` | **no** — `HarnessRuntimeMismatchError` (×4 runtimes) |
| `codex` | `codex-sdk` | **no** — `HarnessRuntimeMismatchError` (×4 runtimes) |

So every page leads with a **launchability column, not a count**. A page advertising four harnesses while three of them refuse to start would be a new version of the problem this PR exists to fix.

The one working alternative is `spec.a2a.handler: openai_session` for the OpenAI SDK. There is **no** `codex_session` executor — `a2a/_handlers.py::HANDLERS` has no codex entry — so the docs say codex has no escape path rather than implying parity.

Also documented as-is, not as intended:

- **`spec.claude.model` defaults to `sonnet` for every agent regardless of harness** (`config/_loaders.py:305`, `config/_types.py:400`). Stated explicitly instead of presented as a neutral default.
- **`spec.harness` is canonical, `spec.provider` the honoured deprecated alias** — what `config/_harness_types.py` implements, whatever the live spec corpus is written in.
- `spec.runtime` only discriminates *within* the `anthropic` family; the `openai` and `codex` families have one entry each, so it selects nothing for them.

## Deliberately left alone — the word is TRUE there

Judged by three tests: (a) genuinely Claude-specific? (b) scope too broad? (c) unmarked default? Anything passing (a) keeps the word.

- `docs/credentials.md` — the whole `## Claude Code files` half (`~/.claude.json`, `~/.claude/.credentials.json`, `claudeAiOauth`, `claudeCodeFirstTokenDate`). Vendor-specific file formats; only a scope header added.
- `docs/sphinx/status_and_hooks.rst` hook integration — `PreToolUse`/`PostToolUse`/`UserPromptSubmit`/`Stop`, `.claude/settings.local.json`.
- README CLI block: `sac subagent get-state` (reads Claude Code Agent-tool transcripts), `sac event ingest` (Claude Code hook events), `sac accounts sync-live` (`claude /login`).
- `spec.claude.*` keys, `CLAUDE.md`, `.claude/{commands,skills,hooks}/`, `_runners.claude_session`, the `opus`/`sonnet`/`haiku` aliases and the `claude-*` regex.
- **`docs/adr/**` untouched.** ADRs are dated records of what was decided then; rewriting them would falsify the record.

## Corrected in passing

`docs/sphinx/spec-reference.md` (the RTD-published fork) carried **no `harness` row at all** and a `runtime` row asserting *"empty/unset defaults to `apptainer`; any other value is rejected"* — false for three valid spellings (`valid_runtime_spellings()` is `['', 'apptainer', 'claude-agent-sdk', 'tui']`, and unset resolves to `claude-code-tui`). A stale claim on the published page is the same defect this PR exists to fix.

## Verification

**Gate — `scitex-dev ecosystem audit-all scitex-agent-container`** (the pre-0.11 verbs in `quality-audit-on-ubuntu-latest.yml` all exit 2 `No such command`; that is carded separately as `sac-quality-audit-ci-gate-cannot-fail-20260802`):

| tree | exit | summary |
|---|---|---|
| `origin/develop` `04dac67b`, clean detached worktree | **1** | `0 unmasked error(s), 1 masked by skip-rules (1 declared); 14 lines inspected` |
| this branch, rebased | **1** | `0 unmasked error(s), 1 masked by skip-rules (1 declared); 14 lines inspected` |

Identical. The exit-1 baseline is pre-existing and not introduced here: `audit-cli: not-auditable: unknown` plus the declared PS-226 skip-rule.

**Sphinx build:** `python -m sphinx -b html docs/sphinx` → `build succeeded`, exit 0.

**Residual sweep:** zero hits for `Claude Code agent|Claude agent|Claude SDK session|for Claude Code` across `README.md` and `docs/` outside `adr/` and `legacy/`.

## Follow-ups carded, not fixed here

- `sac-docs-sphinx-fork-not-symlink-6of7-diverged-20260814` — `docs/sphinx/*.md` are forked copies, not symlinks; 6 of 7 diverged (isolation.md by 64 lines), and the published copy is the one that rots.
- `sac-docs-quickstart-spec-no-longer-loads-20260814` — every documented Quickstart `spec.yaml` fails `load_config` since the explicit-fields and explicit-placement rulings.
