### PR TITLE
fix(security)!: the MCP config leaves argv for a 0600 file — every secret in every server env block was world-readable

### DIFF
--- a/src/scitex_agent_container/runtimes/_mcp_config_file.py
+++ b/src/scitex_agent_container/runtimes/_mcp_config_file.py
@@ -1,0 +1,253 @@
+"""Per-agent MCP config FILE — keep secret material out of the child argv.
+
+THE DEFECT THIS MODULE CLOSES
+=============================
+``claude-agent-sdk`` serialises ``ClaudeAgentOptions.mcp_servers`` when it
+builds the ``claude`` child's command line
+(``_internal/transport/subprocess_cli.py``)::
+
+    if isinstance(self._options.mcp_servers, dict):
+        cmd.extend(["--mcp-config", json.dumps({"mcpServers": servers_for_cli})])
+
+That JSON embeds **every server entry's ``env`` block**, values included. On
+Linux ``/proc/<pid>/cmdline`` is world-readable while ``/proc/<pid>/environ``
+is restricted to the owning uid — so serialising an env block into argv takes
+a value the kernel was protecting and publishes it to every local user. A
+plain ``ps -eo args`` on scitex-compute-04 (2026-08-14) printed a live
+Telegram bot token exactly this way (card
+``sac-bot-token-plaintext-in-process-argv-20260814``).
+
+This is NOT one agent's or one secret's problem. Two independent mechanisms
+put resolved literals into those env blocks for EVERY agent:
+
+  * :func:`._sdk_channels.merge_home_mcp_servers` →
+    :func:`._sdk_channels._resolve_env_refs_local` expands ``${CCT_BOT_TOKEN}``
+    (and any other ``${VAR}``) out of ``$HOME/.mcp.json`` into a literal;
+  * :func:`._mcp_spec_env.bake_spec_env_into_servers` bakes the whole
+    ``SAC_SPEC_ENV_KEYS`` manifest into **every** stdio entry's ``env``.
+
+So the exposed set is "every value of every spec-env key, plus every
+``${VAR}`` an agent's ``.mcp.json`` references" — an open-ended list that no
+per-secret patch can bound.
+
+THE FIX
+=======
+The SDK's own ``else`` branch passes a ``str``/``Path`` through verbatim::
+
+    cmd.extend(["--mcp-config", str(self._options.mcp_servers)])
+
+and ``claude --mcp-config <path>`` loads a file in the ordinary ``.mcp.json``
+shape. So writing the SAME assembled config to a per-agent file with mode
+0600 and handing over the PATH changes nothing about what ``claude`` loads
+while removing the argv exposure entirely — and it removes it for every
+current and future secret KIND at once, because argv stops carrying values
+at all.
+
+WHY NOT RESOLVE-IN-THE-CHILD
+============================
+Letting the child re-resolve its own secret (the ``CCT_BOT_TOKEN_<SLOT>``
+pool, so only the slot NAME travels) is the narrower and more elegant-looking
+option, but it is wrong here on two counts. It addresses one secret KIND
+while the mechanism leaks all of them; and the values are baked into the
+``env`` block precisely BECAUSE inheritance is not reachable there — the MCP
+stdio transport respawns a reconnecting server with a sanitised allowlist
+(``HOME``/``LOGNAME``/``PATH``/``SHELL``/``TERM``/``USER``) plus the entry's
+own ``env``, so a value that is not in the block is simply gone mid-session.
+Removing it would re-open card
+``sac-env-injection-lost-on-mcp-reconnect-20260721``. The file keeps the bake
+intact and moves only the TRANSPORT.
+
+IN-PROCESS SERVERS
+==================
+``type: "sdk"`` entries carry a live Python object (``instance``) and cannot
+be serialised to a file at all; the SDK must keep receiving them as a dict.
+sac never builds one today, so :func:`externalize_mcp_servers` declines the
+rewrite when it sees one rather than crashing an agent that starts using
+them. Nothing is lost by declining: an in-process server has no ``env`` block
+to leak.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+#: Directory (under the in-container ``$HOME``) holding per-agent MCP configs.
+#: Created 0700 — the file itself is 0600, the directory keeps the *names*
+#: private too.
+MCP_CONFIG_DIRNAME = ".sac/mcp"
+
+#: Mode for the config file. It holds resolved secret literals, so it must be
+#: readable by the owning uid only — the whole point of moving off argv.
+MCP_CONFIG_FILE_MODE = 0o600
+MCP_CONFIG_DIR_MODE = 0o700
+
+#: ``type`` values naming an in-process (non-serialisable) MCP server.
+_INPROCESS_TYPES = frozenset({"sdk"})
+
+_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class McpConfigWriteError(RuntimeError):
+    """No writable location was found for the per-agent MCP config file.
+
+    Raised instead of silently falling back to the dict form: that fallback
+    would put every server's env block back on the world-readable child argv,
+    which is the defect this module exists to remove. A loud boot failure is
+    strictly better than a quiet secret disclosure.
+    """
+
+
+def has_inprocess_servers(servers: Mapping[str, Any] | None) -> bool:
+    """True when any entry is an in-process (``type: "sdk"``) server."""
+    if not servers:
+        return False
+    return any(
+        isinstance(entry, dict)
+        and str(entry.get("type") or "").lower() in _INPROCESS_TYPES
+        for entry in servers.values()
+    )
+
+
+def _slug(agent_name: str) -> str:
+    """Filesystem-safe stem for ``agent_name`` (never empty)."""
+    slug = _SLUG_RE.sub("-", str(agent_name or "").strip()).strip("-")
+    return slug or "agent"
+
+
+def _candidate_dirs() -> list[Path]:
+    """Writable-directory candidates, most preferred first.
+
+    ``$HOME`` is the agent's own (per-agent overlay) home inside the
+    container, so a config there is already isolated to this agent; the
+    tempdir is the fallback for a read-only or unset home.
+    """
+    out: list[Path] = []
+    home = os.environ.get("HOME")
+    if home:
+        out.append(Path(home) / MCP_CONFIG_DIRNAME)
+    out.append(Path(tempfile.gettempdir()) / "sac-mcp")
+    return out
+
+
+def write_mcp_config_file(
+    agent_name: str,
+    servers: Mapping[str, Any],
+    *,
+    dirs: list[Path] | None = None,
+) -> str:
+    """Write ``{"mcpServers": servers}`` to a 0600 per-agent file; return its path.
+
+    The file is created with the restrictive mode BEFORE any content is
+    written (``os.open`` with ``O_CREAT|O_EXCL``-free truncation plus an
+    explicit ``chmod``), so a pre-existing world-readable file from an older
+    sac is tightened rather than reused as-is.
+
+    Raises :class:`McpConfigWriteError` when no candidate directory accepts
+    the write.
+    """
+    payload = json.dumps({"mcpServers": dict(servers)}, indent=2) + "\n"
+    name = f"{_slug(agent_name)}.mcp.json"
+    errors: list[str] = []
+    for directory in dirs if dirs is not None else _candidate_dirs():
+        path = directory / name
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+            os.chmod(directory, MCP_CONFIG_DIR_MODE)
+            fd = os.open(
+                path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                MCP_CONFIG_FILE_MODE,
+            )
+            try:
+                os.write(fd, payload.encode("utf-8"))
+            finally:
+                os.close(fd)
+            # An inherited file predating this fix may be 0644; O_CREAT's mode
+            # only applies on creation, so tighten unconditionally.
+            os.chmod(path, MCP_CONFIG_FILE_MODE)
+        except OSError as exc:
+            errors.append(f"{path}: {exc}")
+            continue
+        logger.debug(
+            "mcp config externalised for agent %r: %d server(s) → %s (mode 0600)",
+            agent_name,
+            len(servers),
+            path,
+        )
+        return str(path)
+    raise McpConfigWriteError(
+        f"cannot write the MCP config file for agent {agent_name!r}; tried: "
+        + "; ".join(errors)
+        + ". Refusing to pass the config as an inline --mcp-config JSON "
+        "argument instead: that argument is visible to every local user via "
+        "/proc/<pid>/cmdline and would disclose every secret in every MCP "
+        "server's env block (card "
+        "sac-bot-token-plaintext-in-process-argv-20260814). Fix: make $HOME "
+        "or the temp dir writable inside the container, then restart."
+    )
+
+
+def externalize_mcp_servers(kwargs: dict, agent_name: str) -> bool:
+    """Replace ``kwargs['mcp_servers']`` dict with a 0600 file PATH.
+
+    The last step of ``build_sdk_options`` — it must run AFTER every entry is
+    assembled and after the spec-env bake, so the file carries exactly what
+    the inline JSON would have carried.
+
+    Returns True when the rewrite happened. No-op (returns False) when there
+    are no servers, when the value is already a path/string, or when any
+    entry is an in-process ``type: "sdk"`` server (not serialisable, and
+    carrying no env block to leak).
+    """
+    servers = kwargs.get("mcp_servers")
+    if not servers or not isinstance(servers, dict):
+        return False
+    if has_inprocess_servers(servers):
+        logger.debug(
+            "mcp config NOT externalised for agent %r: an in-process "
+            "(type: sdk) server is present, which cannot be serialised to a "
+            "file. In-process servers carry no env block, so no secret is "
+            "exposed by the inline form.",
+            agent_name,
+        )
+        return False
+    kwargs["mcp_servers"] = write_mcp_config_file(agent_name, servers)
+    return True
+
+
+def read_mcp_servers(value: Any) -> dict[str, Any]:
+    """Return the effective ``mcpServers`` table behind ``value``.
+
+    ``ClaudeAgentOptions.mcp_servers`` is a PATH after
+    :func:`externalize_mcp_servers` runs, so anything that wants to inspect
+    what ``claude`` will actually load — tests, diagnostics — must go through
+    the file. Accepts either shape: a dict is returned as-is (in-process
+    servers, or a pre-externalisation call), a path/str is read back.
+    """
+    if isinstance(value, dict):
+        return dict(value)
+    if not value:
+        return {}
+    raw = json.loads(Path(str(value)).read_text(encoding="utf-8"))
+    servers = raw.get("mcpServers") if isinstance(raw, dict) else None
+    return dict(servers) if isinstance(servers, dict) else {}
+
+
+__all__ = [
+    "MCP_CONFIG_DIRNAME",
+    "MCP_CONFIG_DIR_MODE",
+    "MCP_CONFIG_FILE_MODE",
+    "McpConfigWriteError",
+    "externalize_mcp_servers",
+    "has_inprocess_servers",
+    "read_mcp_servers",
+    "write_mcp_config_file",
+]

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -462,4 +462,20 @@ def build_sdk_options(
 
     bake_spec_env_into_servers(kwargs.get("mcp_servers"), os.environ)
 
+    # ARGV IS PUBLIC — the assembled config must not ride on it. The SDK
+    # serialises an ``mcp_servers`` DICT into ``--mcp-config <json>`` on the
+    # ``claude`` child's command line, env blocks and all, and
+    # ``/proc/<pid>/cmdline`` is world-readable (``/proc/<pid>/environ`` is
+    # not). Every bake above therefore lands in a string any local user can
+    # read with ``ps`` — measured on scitex-compute-04 2026-08-14, a live
+    # Telegram bot token in cleartext (card
+    # sac-bot-token-plaintext-in-process-argv-20260814). Writing the same
+    # config to a 0600 per-agent file and passing the PATH keeps what claude
+    # loads identical while argv stops carrying values at all. Runs LAST, so
+    # the file holds exactly what the inline JSON would have held. See
+    # runtimes/_mcp_config_file.
+    from ._mcp_config_file import externalize_mcp_servers
+
+    externalize_mcp_servers(kwargs, agent_name)
+
     return ClaudeAgentOptions(**kwargs)

--- a/src/scitex_agent_container/runtimes/mcp_config.py
+++ b/src/scitex_agent_container/runtimes/mcp_config.py
@@ -108,6 +108,14 @@ def _setup_mcp_from_servers(
 
     mcp_path.parent.mkdir(parents=True, exist_ok=True)
     mcp_path.write_text(json.dumps(existing, indent=2) + "\n")
+    # The file now holds RESOLVED secret literals (``${VAR}`` expansion above
+    # plus the spec-env bake), so it must not be world-readable — the same
+    # rule that moved the SDK's MCP config off the child argv (see
+    # runtimes/_mcp_config_file). ``write_text`` applies the ambient umask,
+    # which is commonly 0022 → 0644; tighten unconditionally.
+    from ._mcp_config_file import MCP_CONFIG_FILE_MODE
+
+    os.chmod(mcp_path, MCP_CONFIG_FILE_MODE)
 
     logger.info(
         "Generated .mcp.json for agent '%s' at %s (servers: %s)",

--- a/tests/scitex_agent_container/runtimes/test__mcp_config_file.py
+++ b/tests/scitex_agent_container/runtimes/test__mcp_config_file.py
@@ -1,0 +1,385 @@
+"""Secret material must never reach the ``claude`` child's command line.
+
+Card ``sac-bot-token-plaintext-in-process-argv-20260814``: a plain
+``ps -eo args`` on scitex-compute-04 printed a live Telegram bot token,
+because ``claude-agent-sdk`` serialises an ``mcp_servers`` DICT into
+``--mcp-config <json>`` — env blocks and all — and ``/proc/<pid>/cmdline`` is
+world-readable while ``/proc/<pid>/environ`` is uid-restricted.
+
+THE GUARD THAT ACTUALLY CATCHES IT
+==================================
+The exposure is a property of the LAUNCHED PROCESS, not of sac's own data
+structures, so asserting on ``options.mcp_servers`` alone would keep passing
+if the SDK changed how it serialises. :func:`_sdk_argv` therefore drives the
+SDK's REAL argv builder (``SubprocessCLITransport._build_command``) — the
+exact code that produced the leaked command line — and the assertions search
+every argv element for a token-shaped sentinel.
+
+``test_dict_form_puts_the_secret_on_the_child_argv`` pins the OLD behaviour
+as still-true of the SDK, so the pair reads as cause and cure: the dict form
+leaks, the externalised form does not. Deleting the
+``externalize_mcp_servers`` call from ``build_sdk_options`` turns
+``test_build_sdk_options_child_argv_carries_no_secret`` red.
+
+The sentinel is a FAKE, deliberately shaped like a Telegram bot token
+(``<digits>:<base64ish>``) so it matches the same pattern a real one would.
+No real secret appears in this file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scitex_agent_container.runtimes import _sdk_common
+from scitex_agent_container.runtimes._mcp_config_file import (
+    MCP_CONFIG_DIR_MODE,
+    MCP_CONFIG_FILE_MODE,
+    McpConfigWriteError,
+    externalize_mcp_servers,
+    has_inprocess_servers,
+    read_mcp_servers,
+    write_mcp_config_file,
+)
+from scitex_agent_container.runtimes._mcp_spec_env import SPEC_ENV_KEYS_VAR
+
+#: A fake, token-SHAPED value. Never a real credential — the point is that it
+#: matches what a scanner looking for a bot token would match.
+SENTINEL = "1234567890:FAKE-not-a-real-token-000000000000000"
+
+#: The env key the live leak travelled under (the telegrammer bot token).
+SENTINEL_KEY = "CCT_BOT_TOKEN"
+
+
+def _server_with_secret() -> dict[str, Any]:
+    """One stdio MCP entry whose env block carries the sentinel."""
+    return {
+        "claude-code-telegrammer": {
+            "type": "stdio",
+            "command": "/usr/bin/true",
+            "args": [],
+            "env": {SENTINEL_KEY: SENTINEL},
+        }
+    }
+
+
+class _Env:
+    """Records env / attribute mutations and reverses them (PA-306, no mocks)."""
+
+    def __init__(self) -> None:
+        self._env: dict[str, str | None] = {}
+        self._attrs: list[tuple[Any, str, Any]] = []
+
+    def setenv(self, key: str, value: str) -> None:
+        self._env.setdefault(key, os.environ.get(key))
+        os.environ[key] = value
+
+    def delenv(self, key: str) -> None:
+        self._env.setdefault(key, os.environ.get(key))
+        os.environ.pop(key, None)
+
+    def setattr_module(self, obj: Any, name: str, value: Any) -> None:
+        if not any(o is obj and n == name for o, n, _ in self._attrs):
+            self._attrs.append((obj, name, getattr(obj, name)))
+        setattr(obj, name, value)
+
+    def restore(self) -> None:
+        for key, prev in self._env.items():
+            if prev is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prev
+        for obj, name, prev in self._attrs:
+            setattr(obj, name, prev)
+
+
+@pytest.fixture
+def env():
+    helper = _Env()
+    try:
+        yield helper
+    finally:
+        helper.restore()
+
+
+# ---------------------------------------------------------------------------
+# The argv guard — driven through the SDK's own command builder
+# ---------------------------------------------------------------------------
+
+
+def _sdk_argv(mcp_servers: Any) -> list[str]:
+    """Return the real ``claude`` child argv the SDK would exec.
+
+    Uses the SDK's own ``SubprocessCLITransport._build_command`` so the
+    assertion covers the actual serialisation that leaked, not a
+    reimplementation of it. ``cli_path`` short-circuits binary discovery, so
+    nothing is spawned and no ``claude`` install is needed.
+    """
+    from claude_agent_sdk import ClaudeAgentOptions
+    from claude_agent_sdk._internal.transport.subprocess_cli import (
+        SubprocessCLITransport,
+    )
+
+    options = ClaudeAgentOptions(cli_path="/usr/bin/true", mcp_servers=mcp_servers)
+    return SubprocessCLITransport(prompt="", options=options)._build_command()
+
+
+def test_dict_form_puts_the_secret_on_the_child_argv() -> None:
+    """The defect, pinned: a dict ``mcp_servers`` leaks env values into argv.
+
+    Not a wish — a statement about the installed SDK. If this ever goes red,
+    the SDK stopped inlining the config and the fix below may be relaxed;
+    until then it is the reason the fix exists.
+    """
+    # Arrange
+    servers = _server_with_secret()
+    # Act
+    argv = _sdk_argv(servers)
+    # Assert
+    assert any(SENTINEL in arg for arg in argv)
+
+
+def test_externalized_form_keeps_the_secret_off_the_child_argv(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    kwargs: dict[str, Any] = {"mcp_servers": _server_with_secret()}
+    externalize_mcp_servers(kwargs, "telegrammer-agent")
+    # Act
+    argv = _sdk_argv(kwargs["mcp_servers"])
+    # Assert
+    assert not any(SENTINEL in arg for arg in argv)
+
+
+def test_externalized_form_still_passes_an_mcp_config_flag() -> None:
+    """Removing the leak must not remove the config — claude still loads it."""
+    # Arrange
+    kwargs: dict[str, Any] = {"mcp_servers": _server_with_secret()}
+    externalize_mcp_servers(kwargs, "telegrammer-agent")
+    # Act
+    argv = _sdk_argv(kwargs["mcp_servers"])
+    # Assert
+    assert "--mcp-config" in argv
+
+
+def test_externalized_argv_value_is_the_config_path() -> None:
+    # Arrange
+    kwargs: dict[str, Any] = {"mcp_servers": _server_with_secret()}
+    externalize_mcp_servers(kwargs, "telegrammer-agent")
+    argv = _sdk_argv(kwargs["mcp_servers"])
+    # Act
+    value = argv[argv.index("--mcp-config") + 1]
+    # Assert
+    assert value == kwargs["mcp_servers"]
+
+
+def test_file_named_in_argv_still_carries_the_server_entry() -> None:
+    """The config claude reads is unchanged — only its transport moved."""
+    # Arrange
+    kwargs: dict[str, Any] = {"mcp_servers": _server_with_secret()}
+    externalize_mcp_servers(kwargs, "telegrammer-agent")
+    # Act
+    servers = read_mcp_servers(kwargs["mcp_servers"])
+    # Assert
+    assert servers["claude-code-telegrammer"]["env"][SENTINEL_KEY] == SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# File / directory permissions — argv is public, this file must not be
+# ---------------------------------------------------------------------------
+
+
+def test_config_file_is_readable_by_owner_only(tmp_path: Path) -> None:
+    # Arrange
+    directory = tmp_path / "d"
+    # Act
+    path = write_mcp_config_file("a", _server_with_secret(), dirs=[directory])
+    # Assert
+    assert stat.S_IMODE(os.stat(path).st_mode) == MCP_CONFIG_FILE_MODE
+
+
+def test_config_dir_is_traversable_by_owner_only(tmp_path: Path) -> None:
+    # Arrange
+    directory = tmp_path / "d"
+    # Act
+    write_mcp_config_file("a", _server_with_secret(), dirs=[directory])
+    # Assert
+    assert stat.S_IMODE(os.stat(directory).st_mode) == MCP_CONFIG_DIR_MODE
+
+
+def test_preexisting_world_readable_file_is_tightened(tmp_path: Path) -> None:
+    """An 0644 file left by an older sac must not be reused as-is."""
+    # Arrange
+    directory = tmp_path / "d"
+    directory.mkdir()
+    stale = directory / "a.mcp.json"
+    stale.write_text("{}")
+    os.chmod(stale, 0o644)
+    # Act
+    path = write_mcp_config_file("a", _server_with_secret(), dirs=[directory])
+    # Assert
+    assert stat.S_IMODE(os.stat(path).st_mode) == MCP_CONFIG_FILE_MODE
+
+
+def test_written_payload_uses_the_mcp_json_shape(tmp_path: Path) -> None:
+    # Arrange
+    directory = tmp_path / "d"
+    # Act
+    path = write_mcp_config_file("a", _server_with_secret(), dirs=[directory])
+    # Assert
+    assert "mcpServers" in json.loads(Path(path).read_text())
+
+
+def test_unwritable_location_raises_instead_of_falling_back(tmp_path: Path) -> None:
+    """No silent fallback: the dict form would re-publish every secret."""
+    # Arrange: a FILE where the code wants a directory → mkdir raises OSError.
+    blocker = tmp_path / "blocked"
+    blocker.write_text("not a directory")
+    servers = _server_with_secret()
+    # Act
+    def write():
+        write_mcp_config_file("a", servers, dirs=[blocker / "sub"])
+
+    # Assert
+    with pytest.raises(McpConfigWriteError):
+        write()
+
+
+# ---------------------------------------------------------------------------
+# externalize_mcp_servers — the narrow no-op cases
+# ---------------------------------------------------------------------------
+
+
+def test_no_servers_is_a_noop() -> None:
+    # Arrange
+    kwargs: dict[str, Any] = {}
+    # Act
+    changed = externalize_mcp_servers(kwargs, "a")
+    # Assert
+    assert changed is False
+
+
+def test_inprocess_server_declines_the_rewrite() -> None:
+    """``type: sdk`` entries hold a live object and cannot be serialised."""
+    # Arrange
+    kwargs: dict[str, Any] = {
+        "mcp_servers": {"inproc": {"type": "sdk", "instance": object()}}
+    }
+    # Act
+    changed = externalize_mcp_servers(kwargs, "a")
+    # Assert
+    assert changed is False
+
+
+def test_inprocess_detector_ignores_stdio_entries() -> None:
+    # Arrange
+    servers = _server_with_secret()
+    # Act
+    detected = has_inprocess_servers(servers)
+    # Assert
+    assert detected is False
+
+
+def test_already_a_path_is_left_alone(tmp_path: Path) -> None:
+    # Arrange
+    kwargs: dict[str, Any] = {"mcp_servers": str(tmp_path / "x.mcp.json")}
+    # Act
+    changed = externalize_mcp_servers(kwargs, "a")
+    # Assert
+    assert changed is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: build_sdk_options is where the wiring must live
+# ---------------------------------------------------------------------------
+
+
+def _valid_creds_json() -> str:
+    expires_at_ms = int((time.time() + 86_400) * 1_000)
+    return json.dumps(
+        {
+            "claudeAiOauth": {
+                "accessToken": "tok",
+                "refreshToken": "ref",
+                "expiresAt": expires_at_ms,
+                "scopes": ["user:inference"],
+                "subscriptionType": "max",
+            }
+        }
+    )
+
+
+@pytest.fixture
+def _built_options(env: _Env, tmp_path: Path):
+    """``build_sdk_options`` for an agent whose MCP entry holds a secret."""
+    # Arrange: hermetic auth (no touch of the operator's real credentials).
+    cfg_dir = tmp_path / "cfg"
+    cfg_dir.mkdir()
+    (cfg_dir / ".credentials.json").write_text(_valid_creds_json())
+    env.setenv("CLAUDE_CONFIG_DIR", str(cfg_dir))
+    env.delenv("ANTHROPIC_API_KEY")
+    env.delenv(_sdk_common._SAC_API_KEY_ENV)
+    # Arrange: drop the spec-env manifest this test process inherited from
+    # its own sac container. Left in place, ``bake_spec_env_into_servers``
+    # fails loud on the HOST agent's keys and the fixture errors before it
+    # can say anything about argv.
+    env.delenv(SPEC_ENV_KEYS_VAR)
+    # Arrange: HOME redirected so the merge of $HOME/.mcp.json and the config
+    # file this fix writes both stay inside tmp_path.
+    home = tmp_path / "home"
+    home.mkdir()
+    env.setenv("HOME", str(home))
+    # Arrange: a registered workspace whose .mcp.json carries the sentinel.
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".mcp.json").write_text(json.dumps({"mcpServers": _server_with_secret()}))
+
+    import scitex_agent_container._state.registry as reg_mod
+    import scitex_agent_container.config as cfg_mod
+
+    class _FakeRegistry:
+        def get(self, _name):
+            return {"config": "cfg.yaml"}
+
+    env.setattr_module(reg_mod, "Registry", _FakeRegistry)
+    env.setattr_module(
+        cfg_mod,
+        "load_config",
+        lambda _path: SimpleNamespace(expanded_workdir=str(ws)),
+    )
+    return _sdk_common.build_sdk_options("telegrammer-agent")
+
+
+def test_build_sdk_options_child_argv_carries_no_secret(_built_options) -> None:
+    """THE regression guard: remove the wiring and this goes red."""
+    # Arrange
+    configured = _built_options.mcp_servers
+    # Act
+    argv = _sdk_argv(configured)
+    # Assert
+    assert not any(SENTINEL in arg for arg in argv)
+
+
+def test_build_sdk_options_still_delivers_the_server_entry(_built_options) -> None:
+    # Arrange
+    configured = _built_options.mcp_servers
+    # Act
+    servers = read_mcp_servers(configured)
+    # Assert
+    assert servers["claude-code-telegrammer"]["env"][SENTINEL_KEY] == SENTINEL
+
+
+def test_build_sdk_options_config_file_is_owner_only(_built_options) -> None:
+    # Arrange
+    path = str(_built_options.mcp_servers)
+    # Act
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    # Assert
+    assert mode == MCP_CONFIG_FILE_MODE

--- a/tests/scitex_agent_container/runtimes/test__mcp_spec_env.py
+++ b/tests/scitex_agent_container/runtimes/test__mcp_spec_env.py
@@ -25,6 +25,7 @@ import pytest
 from scitex_agent_container.runtimes._board_identity_env import (
     UnexpandedEnvValueError,
 )
+from scitex_agent_container.runtimes._mcp_config_file import read_mcp_servers
 from scitex_agent_container.runtimes._mcp_spec_env import (
     SPEC_ENV_KEYS_VAR,
     SpecEnvUnresolvedError,
@@ -346,7 +347,10 @@ def test_build_sdk_options_bakes_manifested_spec_env_into_servers(
     # Act
     opts = _sdk_common.build_sdk_options("alpha")
     # Assert: the entry the respawner reads carries the literal value.
-    assert opts.mcp_servers["stx"]["env"]["SCITEX_CARDS_DB"] == "/shared/cards.db"
+    # ``mcp_servers`` is a 0600 FILE PATH now (secrets must not ride the child
+    # argv — see runtimes/_mcp_config_file), so read the effective table back.
+    servers = read_mcp_servers(opts.mcp_servers)
+    assert servers["stx"]["env"]["SCITEX_CARDS_DB"] == "/shared/cards.db"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -36,6 +36,7 @@ from typing import Any
 import pytest
 
 from scitex_agent_container.runtimes import _sdk_common
+from scitex_agent_container.runtimes._mcp_config_file import read_mcp_servers
 from scitex_agent_container.runtimes._sdk_common import (
     SDKCommonError,
     build_sdk_options,
@@ -608,7 +609,7 @@ class TestBuildOptions:
         # Arrange
         opts, _ = _composed_opts
         # Act
-        servers = opts.mcp_servers  # type: ignore[operator]
+        servers = read_mcp_servers(opts.mcp_servers)
         # Assert
         assert "stx" in servers
 
@@ -921,7 +922,9 @@ class TestChannelSidecar:
 
     def test_registers_sac_stdio_mcp(self, _sac_channel_opts, _fake_sac_bin):
         # Arrange
-        servers = _sac_channel_opts.mcp_servers  # type: ignore[operator]
+        # ``mcp_servers`` is a 0600 FILE PATH now — the assembled config must
+        # not ride the world-readable child argv (runtimes/_mcp_config_file).
+        servers = read_mcp_servers(_sac_channel_opts.mcp_servers)
         # Act
         sac = servers.get("sac")
         # Assert — resolver wires the SAC_BIN-overridden absolute path
@@ -929,7 +932,7 @@ class TestChannelSidecar:
 
     def test_sidecar_args_subscribe_to_named_agent_inbox(self, _sac_channel_opts):
         # Arrange
-        sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
+        sac = read_mcp_servers(_sac_channel_opts.mcp_servers)["sac"]
         # Act
         args = sac["args"]
         # Assert
@@ -937,7 +940,7 @@ class TestChannelSidecar:
 
     def test_sidecar_args_omit_a2a_port_listen_url(self, _sac_channel_opts):
         # Arrange
-        sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
+        sac = read_mcp_servers(_sac_channel_opts.mcp_servers)["sac"]
         args = sac["args"]
         # Act — find the --listen-url value, if any.
         if "--listen-url" in args:
@@ -955,7 +958,7 @@ class TestChannelSidecar:
         POST received bus events to the agent's own /v1/turn and WAKE an idle
         session (push ≡ Telegram)."""
         # Arrange
-        sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
+        sac = read_mcp_servers(_sac_channel_opts.mcp_servers)["sac"]
         args = sac["args"]
         # Act
         turn_url = args[args.index("--turn-url") + 1] if "--turn-url" in args else None
@@ -964,7 +967,7 @@ class TestChannelSidecar:
 
     def test_sidecar_listen_url_when_present_is_not_a2a_port(self, _sac_channel_opts):
         # Arrange
-        sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
+        sac = read_mcp_servers(_sac_channel_opts.mcp_servers)["sac"]
         args = sac["args"]
         # Act: if a --listen-url is emitted at all, it must be the bus, never
         # the agent's own a2a sidecar port.
@@ -989,4 +992,4 @@ class TestChannelSidecar:
         # must NOT raise — the adapter resolves the bus from env at runtime.
         opts = build_sdk_options("lead", extra={"_channels": ["server:sac"]})
         # Assert
-        assert "sac" in opts.mcp_servers  # type: ignore[operator]
+        assert "sac" in read_mcp_servers(opts.mcp_servers)


### PR DESCRIPTION
## The defect

A plain `ps -eo args` on scitex-compute-04 printed a **live Telegram bot token in cleartext**.

It reaches the command line because `claude-agent-sdk` serialises an `mcp_servers` **dict** directly into the `claude` child's argv:

```python
# claude_agent_sdk/_internal/transport/subprocess_cli.py
if isinstance(self._options.mcp_servers, dict):
    cmd.extend(["--mcp-config", json.dumps({"mcpServers": servers_for_cli})])
```

That JSON embeds every server entry's `env` block, values included. On Linux `/proc/<pid>/cmdline` is **world-readable**; `/proc/<pid>/environ` is restricted to the owning uid. Serialising an env block into argv therefore takes a value the kernel was protecting and publishes it to every local user — the exact inversion of the intended direction.

## Scope — measured, not assumed

**It is not one agent and not one secret.** Two independent mechanisms fill those env blocks for *every* SDK-runtime agent:

| Mechanism | What it puts in `env` |
|---|---|
| `_sdk_channels.merge_home_mcp_servers` → `_resolve_env_refs_local` | expands `${CCT_BOT_TOKEN}` (and every other `${VAR}`) out of `$HOME/.mcp.json` into a **literal** |
| `_mcp_spec_env.bake_spec_env_into_servers` | bakes the whole `SAC_SPEC_ENV_KEYS` manifest into **every** stdio entry |

So the exposed set is "every value of every spec-env key, plus every `${VAR}` an agent's `.mcp.json` references" — an open-ended list no per-secret patch can bound.

**Live process-table survey (scitex-compute-04, /proc scan of all ~200 non-kernel pids, values never printed):**

| Measure | Count |
|---|---|
| pids carrying `--mcp-config` | 5 |
| pids exposing secret-shaped material in argv **at survey time** | 0 |
| distinct secret kinds involved | 0 |

Zero, because the agents running right then were all `spec.runtime: tui`, whose `--mcp-config` values are a **path** plus an env-less inline channel JSON. The leak is specific to the **SDK runtime** (`kind: Agent`), and no SDK agent happened to be up. The controlled reproduction below shows what a running one does.

Separately audited and found **already correct** (no change needed): the apptainer `--env KEY=VALUE` flags, which `_apptainer_secret_env.redact_secret_env_to_file` sweeps into a 0600 env-file before launch; and `_cct_token_pool`, which delivers the bot token via `$HOME/.env` + `--env-file` and never via argv. Findings outside this PR's scope are listed at the bottom.

## The fix

`build_sdk_options` now writes the fully-assembled config to a **per-agent 0600 file** (`$HOME/.sac/mcp/<agent>.mcp.json`, directory 0700) and passes the **path**. The SDK's own `else` branch already forwards a `str`/`Path` verbatim, and `claude --mcp-config <path>` loads an ordinary `.mcp.json` — so what `claude` loads is unchanged and argv simply stops carrying values. **One move covers every current and future secret kind**, which a per-secret fix cannot.

It runs **last**, after every entry is assembled and after the spec-env bake, so the file holds exactly what the inline JSON would have held.

### Why not "have the child resolve the secret itself"

Re-resolving the token in the child from the existing `CCT_BOT_TOKEN_<SLOT>` pool (so only the slot NAME travels) is the narrower, more elegant-looking option and was the preferred candidate. It is wrong here on two counts:

1. **It addresses one KIND while the mechanism leaks all of them.** The `spec.env` bake is the larger surface and is entirely untouched by a bot-token-specific fix.
2. **It re-opens a closed incident.** The values are baked into the `env` block *precisely because* inheritance is unreachable there: the MCP stdio transport respawns a reconnecting server with a sanitised allowlist (`HOME`/`LOGNAME`/`PATH`/`SHELL`/`TERM`/`USER`) plus the entry's own `env` and nothing else. A value not in the block is gone mid-session — card `sac-env-injection-lost-on-mcp-reconnect-20260721`. The file keeps the bake intact and moves only the *transport*.

### Fail-loud, not fall-back

An unwritable location raises `McpConfigWriteError` instead of quietly reverting to the inline form — a silent fallback would re-publish every secret, which is the defect itself. `type: "sdk"` in-process entries decline the rewrite (they hold a live object and cannot be serialised; they also carry no `env` block to leak).

### Also hardened

`mcp_config.setup_mcp_config` wrote **resolved secret literals** to `.mcp.json` under the ambient umask (commonly 0644). Now 0600.

## Verification by observation

The exposure is a property of the launched process, so a code review cannot demonstrate the fix. Two **real, running, channel-attached SDK-runtime agents** were started from the same throwaway spec — identical but for which `scitex_agent_container` was on `PYTHONPATH` — each with a fake, token-**shaped** sentinel in an MCP `env` block. Measured on the bare host with `ps -eo args` (snapshot taken before the matcher exists, so the measuring command cannot count itself) and a `/proc/*/cmdline` scan that excludes its own pid:

| | `ps -eo args` lines with the sentinel | pids exposing it | its `--mcp-config` value |
|---|---|---|---|
| **before** (installed sac) | **1** | **1** (`comm: claude`) | inline JSON, 4195 chars |
| **after** (this branch) | **0** | **0** | path, 54 chars |

The file that path points at, on disk in the agent's container home:

```
-rw------- 5134 .../home/agent/.sac/mcp/argv-fix-canary-20260814.mcp.json
```

A controlled launched-process reproduction agrees: same driver, installed sac → `mcp_servers_kind: dict`, 1 pid exposing the sentinel; worktree sac → `mcp_servers_kind: str`, 0 pids. Both canaries and every artefact were removed afterwards (0 residual processes, 0 residual specs).

## Test

`tests/.../test__mcp_config_file.py` (17 tests). The guard drives the SDK's **real** argv builder (`SubprocessCLITransport._build_command`) rather than asserting on sac's own data structures, so it covers the serialisation that actually leaked and keeps meaning if sac's internals change. `test_dict_form_puts_the_secret_on_the_child_argv` pins the old behaviour as still-true of the installed SDK, so the pair reads as cause and cure.

Failing-then-passing, with the wiring removed and restored:

```
fix disabled:  2 failed, 15 passed
fix restored:  17 passed
```

Full `tests/scitex_agent_container/runtimes/`: **1916 passed, 20 skipped**.

The three `test__sdk_common` / `test__mcp_spec_env` errors seen on a first run were pre-existing non-hermeticity — those modules inherit `SAC_SPEC_ENV_KEYS` from the container they run in. The new module's fixture clears it; the older ones are untouched by this PR.

## Breaking change

`build_sdk_options(...).mcp_servers` is now a path **string**, not a dict. No production consumer read it (only tests did); use `_mcp_config_file.read_mcp_servers()` to inspect the effective table. Eight test assertions updated accordingly.

## For the operator — two decisions, not actioned here

1. **Rotation.** The bot token has been readable by any local user for as long as SDK-runtime agents have been running. Whether to rotate is the operator's call: rotation breaks every agent still holding the old value. Nothing was rotated.
2. **Follow-ups found while measuring scope, out of this PR's scope** (each is a separate card): `_network/_ssh_curl.py:97` splices a bearer into an `ssh`/`curl` command line, visible in the process table on **both** ends — the sibling `_hostsync/_push_tokens_io.py` deliberately feeds the same kind of bearer via `curl --config -` on stdin to avoid exactly this; `_apptainer_secret_env.redact_secret_env_to_file` matches only the split `--env K=V` form while `_apptainer_env_dedup` recognises the glued `--env=K=V` too, so the glued spelling survives the sweep; the inner argv (including verbatim `spec.claude.flags`, which may legally carry inline `--mcp-config` JSON) is appended *after* the sweep runs; and `_runners/_tmux/tmux.py:145` dumps the pane's entire environment to a default-permission file in `/tmp`.

Card: `sac-bot-token-plaintext-in-process-argv-20260814`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
