### PR TITLE
fix(identity): a host that IS this machine under another name resolves local

### DIFF
--- a/src/scitex_agent_container/_state/host_registry.py
+++ b/src/scitex_agent_container/_state/host_registry.py
@@ -14,8 +14,11 @@ ssh ``via:`` ProxyJump chains, ``env_preamble`` (Lmod on HPC), a2a
 ports, peer tokens, the ``lead:`` block. Those stay in
 ``~/.scitex/agent-container/config.yaml`` (:mod:`.host_config`).
 
-What sac now DEFERS to the registry: "where is host X, and where is
-its scitex root".
+What sac now DEFERS to the registry: "where is host X, where is its
+scitex root", and — since 2026-08-14 — "which of those rows is THIS
+machine" (:func:`registry_local_names`). The last one used to be answered
+by string-comparing ``hostname -s`` against a sac-local alias table, which
+left ``scitex-nas-03`` unable to start agents pinned to its own fleet name.
 
 The ``~`` trap — this is the whole point of the module
 --------------------------------------------------------
@@ -63,11 +66,13 @@ a fresh machine still resolves Spartan's declared root. That is why the
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass
 
 __all__ = [
     "HostView",
     "registry_hosts",
+    "registry_local_names",
     "registry_scitex_root",
     "registry_ssh_alias",
     "remote_state_root",
@@ -78,17 +83,26 @@ __all__ = [
 class HostView:
     """sac's read-only view of one registry row.
 
-    Deliberately mirrors ``scitex_dev.hosts.HostRecord``'s four fields
-    and deliberately OMITS ``scitex_root_path`` — the expanding property
-    is the footgun this module exists to keep out of sac (see the module
-    docstring). ``scitex_root`` is always the RAW registry string and may
-    contain a leading ``~`` meaning *that host's* home, not ours.
+    Deliberately mirrors ``scitex_dev.hosts.HostRecord``'s identity +
+    location fields and deliberately OMITS ``scitex_root_path`` — the
+    expanding property is the footgun this module exists to keep out of sac
+    (see the module docstring). ``scitex_root`` is always the RAW registry
+    string and may contain a leading ``~`` meaning *that host's* home, not
+    ours.
+
+    ``aliases`` are the registry's OTHER spellings of ``name`` — the field
+    the port's own ``resolve()`` falls back to, so a former or alternate
+    name keeps resolving to this record. sac reads them for two things:
+    resolving a row by any spelling (:func:`_find`) and answering "which
+    fleet name is THIS machine?" (:func:`registry_local_names`). Absent on
+    a pre-0.4x ``scitex_dev`` — the reader degrades to ``()``, never fails.
     """
 
     name: str
     kind: str
     ssh_alias: str | None
     scitex_root: str
+    aliases: tuple[str, ...] = ()
 
 
 def _hosts_from_port() -> list[HostView] | None:
@@ -104,6 +118,10 @@ def _hosts_from_port() -> list[HostView] | None:
                 kind=h.kind,
                 ssh_alias=h.ssh_alias,
                 scitex_root=h.scitex_root,
+                # ``aliases`` landed in scitex-dev 0.4x; getattr keeps an
+                # older port readable rather than making sac's identity
+                # resolution depend on the consumer's install date.
+                aliases=tuple(getattr(h, "aliases", ()) or ()),
             )
             for h in list_hosts()
         ]
@@ -138,12 +156,16 @@ def _hosts_from_yaml() -> list[HostView] | None:
             if not root:
                 continue
             alias = spec.get("ssh_alias")
+            raw_aliases = spec.get("aliases") or ()
+            if isinstance(raw_aliases, str):
+                raw_aliases = (raw_aliases,)
             out.append(
                 HostView(
                     name=str(name),
                     kind=str(spec.get("kind") or "workstation"),
                     ssh_alias=str(alias) if alias else None,
                     scitex_root=str(root),
+                    aliases=tuple(str(a) for a in raw_aliases if a),
                 )
             )
         return out or None
@@ -157,15 +179,75 @@ def registry_hosts() -> list[HostView]:
 
 
 def _find(host: str) -> HostView | None:
-    """Resolve one row by registry name, else by ssh_alias."""
+    """Resolve one row by registry name, then by alias, then by ssh_alias.
+
+    Canonical names are tried FIRST and exhaustively — the port's own
+    ``resolve()`` rule — so a name that is somebody's canonical key can never
+    be captured by another record's alias list. ``ssh_alias`` is tried last
+    because it is a ROUTE, not an identity (``hosts.yaml`` says so in as many
+    words); it stays in the chain only because sac has always resolved roots
+    through it.
+    """
     rows = registry_hosts()
     for row in rows:
         if row.name == host:
             return row
     for row in rows:
+        if host in row.aliases:
+            return row
+    for row in rows:
         if row.ssh_alias and row.ssh_alias == host:
             return row
     return None
+
+
+def registry_local_names(spellings: Collection[str]) -> set[str]:
+    """Fleet names the LEDGER records for the machine known by ``spellings``.
+
+    The identity question, asked of the registry: *given every name this
+    machine already answers to, what does the fleet call it?* Returns the
+    matched row's canonical name plus its aliases, or an EMPTY set when the
+    registry cannot answer.
+
+    Why this exists (measured on ``scitex-nas-03``, 2026-08-14)
+    ----------------------------------------------------------
+    That machine's ``hostname -s`` is ``DXP480TPLUS-994`` — the appliance's
+    factory name — while every spec pins ``host: scitex-nas-03``. sac decided
+    "is this me?" by STRING-COMPARING the pin against the resolved hostname
+    and the sac-local ``host.aliases``, so on the machine itself the pin
+    matched nothing and ``sac agents start scitex-hub`` refused with
+    *"spec.host 'scitex-nas-03' is neither this machine nor a registered
+    peer"*, needing ``--no-redispatch`` on every single start. The name is not
+    wrong and the machine is not misnamed; the comparison was missing the one
+    authority that already knows both spellings belong to one machine.
+
+    Identity, not route
+    -------------------
+    Only ``name`` and ``aliases`` are matched — the two fields the ledger
+    defines as spellings OF the host. ``ssh_alias`` is deliberately NOT
+    consulted here: it answers "how do I reach that machine", and a machine
+    that can reach a name is not thereby that name.
+
+    Ambiguity refuses rather than guesses
+    ------------------------------------
+    A machine is ONE host. If more than one row claims one of ``spellings``
+    the registry is inconsistent, and answering would mean picking a fleet
+    identity by coin-flip — so the answer is the empty set and the caller's
+    existing loud failure stands. Same stance as the port's ``resolve()``,
+    which raises on a doubly-claimed alias.
+    """
+    known = {s for s in spellings if s}
+    if not known:
+        return set()
+    claimants = [
+        row
+        for row in registry_hosts()
+        if row.name in known or any(alias in known for alias in row.aliases)
+    ]
+    if len(claimants) != 1:
+        return set()
+    row = claimants[0]
+    return {row.name, *row.aliases}
 
 
 def registry_scitex_root(host: str) -> str | None:

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
@@ -5,21 +5,30 @@
 Holds module-level helpers used by more than one verb in the
 ``lifecycle/`` package — agent discovery, singleton host-skip logic,
 and the foreground-tail multiplexer.
+
+HOST IDENTITY LIVES IN :mod:`._host_identity` (``classify_dispatch_host`` /
+``_resolve_dispatch_peer`` / ``_local_host_names``), extracted when this
+file reached its per-file cap. It is re-exported below so every existing
+``from ._common import ...`` keeps resolving — the same pattern
+``_state/host_config`` uses for its own extractions.
 """
 
 from __future__ import annotations
 
-import socket
-from collections.abc import Collection, Mapping
+from collections.abc import Collection
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import Callable
 
 import click
 
 from ...config import AgentConfig
 
-if TYPE_CHECKING:
-    from ..._state.host_config import PeerSpec
+# Re-export (see the module docstring): identity is defined ONCE, next door.
+from ._host_identity import (  # noqa: F401
+    _local_host_names,
+    _resolve_dispatch_peer,
+    classify_dispatch_host,
+)
 
 # (name, host) -> True iff the registry holds an active instances row
 # for ``name`` on ``host``. Used by :func:`_resolve_singleton_skip` to
@@ -27,123 +36,6 @@ if TYPE_CHECKING:
 BoundHostLivenessOracle = Callable[[str, str], bool]
 
 _SKIP_DIR_NAMES = {"legacy-agents", "shared", "GITIGNORED"}
-
-
-def classify_dispatch_host(
-    target_host: str | None,
-    current_host: str,
-    peers: Mapping[str, "PeerSpec"],
-    *,
-    local_names: Collection[str] = (),
-) -> tuple[str, str | None]:
-    """Classify a concrete ``spec.host`` into local / remote / unknown.
-
-    Pure resolver — never raises, never logs, never reads files (the
-    caller supplies ``local_names`` and ``peers``). This is the operator's
-    "resolution layer": a concrete canonical hostname is mapped to WHERE
-    that host is, so ``host: <this-machine>`` launches locally and
-    ``host: <peer>`` dispatches over ssh.
-
-    Returns a ``(kind, peer)`` tuple:
-
-    * ``("local", None)``  — run on the caller. Fires when ``target_host``
-      is unset (empty ``host:`` / absent, normalized to ``""`` → ``None``),
-      equals ``current_host``, or is any spelling in ``local_names``
-      (the canonical name + aliases that denote THIS machine per
-      ``host_config``). LOCAL is checked BEFORE the peer table so a machine
-      that is ALSO registered as a peer (e.g. ``ywata-note-win: {ssh:
-      localhost}`` so remote hosts can reach it) is never ssh-dispatched
-      to itself.
-    * ``("remote", <peer>)`` — dispatch to that peer over ssh. Fires when
-      ``target_host`` is a known peer key distinct from the local machine
-      (glob peer entries like ``spartan-*`` match here via ``PeersMap``).
-    * ``("unknown", None)`` — ``target_host`` names neither the local
-      machine nor a peer. This classifier stays a PURE resolver and never
-      raises; the REACTION is the caller's. Since operator directive
-      2026-07-10 the lifecycle dispatchers fail LOUD on it
-      (``_host_routing.format_unknown_host_error`` — peer list + fixes)
-      instead of silently falling through to a local start; either way an
-      unknown host is never routed to ssh.
-    """
-    if target_host is None:
-        return ("local", None)
-    if target_host == current_host or target_host in local_names:
-        return ("local", None)
-    if target_host in peers:
-        return ("remote", target_host)
-    return ("unknown", None)
-
-
-def _resolve_dispatch_peer(
-    target_host: str | None,
-    current_host: str,
-    peers: Mapping[str, "PeerSpec"],
-    *,
-    local_names: Collection[str] = (),
-) -> str | None:
-    """Return the peer name to dispatch to, or None for local execution.
-
-    Thin wrapper over :func:`classify_dispatch_host` preserving the historic
-    "peer-name-or-None" contract used by :func:`try_dispatch`. Returns a peer
-    name only for a ``remote`` classification; both ``local`` and ``unknown``
-    yield ``None`` (the caller decides what an unknown host means). With the
-    default empty ``local_names`` the behaviour is byte-identical to the
-    pre-hardening resolver — the alias-of-self short-circuit only engages
-    when the caller passes the machine's local spellings.
-    """
-    _kind, peer = classify_dispatch_host(
-        target_host, current_host, peers, local_names=local_names
-    )
-    return peer
-
-
-def _local_host_names(current_host: str | None = None) -> set[str]:
-    """Return every host spelling that denotes THIS machine.
-
-    Unions the two hostname authorities so ``host: <canonical-or-alias>``
-    resolves to a LOCAL launch regardless of which registry the operator
-    configured, and — critically — regardless of drift between them:
-
-      * ``host_config`` (F-CS12 ``~/.scitex/agent-container/config.yaml``):
-        ``canonical_host()`` plus the ``host.aliases`` entry keyed by this
-        machine's short hostname.
-      * ``config/_host.resolve_hostname()`` (the value dispatch already
-        passes as ``current_host``) and the bare ``socket`` short hostname.
-
-    Only the alias entry for THIS machine's short hostname is included, so a
-    peer machine's alias is never mistaken for local. Best-effort — a
-    missing / broken config degrades to the short hostname (plus
-    ``current_host`` when supplied); it never raises.
-    """
-    names: set[str] = set()
-    if current_host:
-        names.add(current_host)
-    short = socket.gethostname().split(".")[0]
-    if short:
-        names.add(short)
-    # config/_host resolver (env override → spec.hostname_aliases → short).
-    try:
-        from ...config._host import resolve_hostname
-
-        rn = resolve_hostname()
-        if rn:
-            names.add(rn)
-    except Exception:  # stx-allow: fallback (reason: hostname resolution must never block dispatch; short hostname already captured)
-        pass
-    # host_config F-CS12 registry (env override → host.canonical → aliases).
-    try:
-        from ..._state.host_config import load as _load_host_config
-
-        cfg = _load_host_config()
-        canonical = cfg.canonical_host()
-        if canonical:
-            names.add(canonical)
-        alias = cfg.host.aliases.get(short)
-        if alias:
-            names.add(alias)
-    except Exception:  # stx-allow: fallback (reason: absent/malformed config.yaml must not break the local-vs-remote decision; the two hostname sources above suffice)
-        pass
-    return {n for n in names if n}
 
 
 def _bound_hosts(config: AgentConfig) -> list[str]:
@@ -214,6 +106,7 @@ def _resolve_singleton_skip(
     *,
     no_redispatch: bool,
     liveness_oracle: BoundHostLivenessOracle | None = None,
+    local_names: Collection[str] | None = None,
 ) -> str | None:
     """Liveness-gated wrapper around :func:`_singleton_skip_reason`.
 
@@ -249,10 +142,18 @@ def _resolve_singleton_skip(
             checking whether the agent is already active on its bound
             host. Defaults to :func:`_registry_active_on` (real state.db
             read).
+        local_names: Every OTHER spelling that denotes THIS machine, so a
+            pin naming this machine under a different name is not read as
+            "the wrong host". Defaults to
+            :func:`._host_identity._local_host_names` — the SAME default
+            ``_dispatch.try_dispatch`` uses, so the skip and the routing
+            decision can never disagree about who this machine is.
     """
     if no_redispatch:
         return None
-    reason = _singleton_skip_reason(config, hostname)
+    if local_names is None:
+        local_names = _local_host_names(hostname)
+    reason = _singleton_skip_reason(config, hostname, local_names=local_names)
     if reason is None:
         return None
     bound = _bound_hosts(config)
@@ -271,14 +172,29 @@ def _resolve_singleton_skip(
     return reason
 
 
-def _singleton_skip_reason(config: AgentConfig, hostname: str) -> str | None:
+def _singleton_skip_reason(
+    config: AgentConfig,
+    hostname: str,
+    *,
+    local_names: Collection[str] = (),
+) -> str | None:
     """Return a human-readable skip reason if ``config`` is a singleton on
     the wrong host, else None.
 
     Multi-instance (``hosts:`` set or per-host scheduling) never skips.
     Singleton with no host preference launches anywhere. Singleton with
     ``host:``/``preferred-host`` set skips when the current host doesn't match.
+
+    Pure — ``local_names`` (the machine's OTHER spellings, from
+    :func:`._host_identity._local_host_names`) arrives from the caller, the
+    same seam :func:`classify_dispatch_host` uses. It is load-bearing because
+    "the wrong host" is an IDENTITY question that this function answered by
+    string equality: on ``scitex-nas-03`` (``hostname -s`` =
+    ``DXP480TPLUS-994``) a spec pinned to its own fleet name read as
+    pinned-elsewhere, and a skip here is a SILENT no-start. With the empty
+    default the comparison is byte-identical to the historical one.
     """
+    local = {hostname, *local_names}
     # v3 config: use hosts_spec
     spec = config.hosts_spec
     if spec.hosts:  # multi-instance
@@ -286,9 +202,9 @@ def _singleton_skip_reason(config: AgentConfig, hostname: str) -> str | None:
     host = spec.host
     if host:
         chain = [host] if isinstance(host, str) else list(host)
-        if not chain or hostname == chain[0]:
+        if not chain or chain[0] in local:
             return None
-        if hostname in chain[1:]:
+        if any(entry in local for entry in chain[1:]):
             return None
         fallback_str = (
             f" (fallback-hosts: {', '.join(chain[1:])})" if len(chain) > 1 else ""
@@ -300,7 +216,7 @@ def _singleton_skip_reason(config: AgentConfig, hostname: str) -> str | None:
         return None
     if not sched.preferred_host:
         return None
-    if sched.preferred_host == hostname:
+    if sched.preferred_host in local:
         return None
     fallback = (
         f" (fallback-hosts: {', '.join(sched.fallback_hosts)})"

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_host_identity.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_host_identity.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""WHICH MACHINE IS WHICH — the one place a host name is matched to a machine.
+
+Extracted from :mod:`._common` (a grab-bag at its 512-line cap) because
+this is one cohesive responsibility, and because a defect measured on
+2026-08-14 showed it needed a name of its own: sac decided "is this host
+name ME?" by STRING-COMPARING the pin against ``hostname -s`` and a
+sac-local alias table. On ``scitex-nas-03`` — whose ``hostname -s`` is the
+appliance's factory name ``DXP480TPLUS-994`` — every spec pinned to its own
+fleet name was therefore "neither this machine nor a registered peer", and
+``sac agents start scitex-hub`` ON THAT MACHINE refused unless a human
+remembered ``--no-redispatch``. The name is not wrong and the machine is
+not misnamed; the comparison was missing an authority.
+
+Two questions, one module
+-------------------------
+* :func:`_local_host_names` — *what is this machine called?* Unions every
+  authority that can answer, and is the ONLY place that list is assembled.
+* :func:`classify_dispatch_host` — *given a pin, is it me, a peer, or
+  nothing I know?* Pure; the caller supplies both ``peers`` and the answer
+  to the first question.
+
+Authorities, and why the ledger is one of them
+----------------------------------------------
+The two sac-local authorities (``config/_host.resolve_hostname`` and
+``_state/host_config``'s ``host.aliases``) can both express "this machine
+is also called X" — ``host.aliases`` documents ``DXP480TPLUS-994: nas-03``
+as its example, in as many words. But they are PER-MACHINE files, so the
+mapping only exists where someone remembered to write it, and its absence
+is silent until an agent will not start. The ecosystem host registry
+(``scitex_dev.hosts``, adapted by ``_state/host_registry``) is the record
+every host in the fleet already shares, so identity resolves through it
+too — see ``host_registry.registry_local_names``.
+
+Adding it here rather than in a new resolver is deliberate: the union
+already existed, and a FOURTH place that knows about host names is exactly
+what a fleet with this many name spellings does not need.
+
+What did NOT change: an unroutable pin still fails LOUD. A name that
+denotes no machine sac can identify and no peer it can reach is still
+``unknown``, and the lifecycle dispatchers still refuse on it
+(``_host_routing.format_unknown_host_error``). The case fixed is "you
+pinned this to a machine that IS this one, under a different name" — not
+"you pinned this somewhere unreachable", which must keep failing.
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Collection, Mapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..._state.host_config import PeerSpec
+
+__all__ = [
+    "_local_host_names",
+    "_resolve_dispatch_peer",
+    "classify_dispatch_host",
+]
+
+
+def classify_dispatch_host(
+    target_host: str | None,
+    current_host: str,
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    local_names: Collection[str] = (),
+) -> tuple[str, str | None]:
+    """Classify a concrete ``spec.host`` into local / remote / unknown.
+
+    Pure resolver — never raises, never logs, never reads files (the
+    caller supplies ``local_names`` and ``peers``). This is the operator's
+    "resolution layer": a concrete canonical hostname is mapped to WHERE
+    that host is, so ``host: <this-machine>`` launches locally and
+    ``host: <peer>`` dispatches over ssh.
+
+    Returns a ``(kind, peer)`` tuple:
+
+    * ``("local", None)``  — run on the caller. Fires when ``target_host``
+      is unset (empty ``host:`` / absent, normalized to ``""`` → ``None``),
+      equals ``current_host``, or is any spelling in ``local_names``
+      (the canonical name + aliases that denote THIS machine per
+      ``host_config`` AND per the fleet host registry). LOCAL is checked
+      BEFORE the peer table so a machine that is ALSO registered as a
+      peer (e.g. ``ywata-note-win: {ssh: localhost}`` so remote hosts can
+      reach it, or a NAS whose own fleet name is a routable peer name) is
+      never ssh-dispatched to itself.
+    * ``("remote", <peer>)`` — dispatch to that peer over ssh. Fires when
+      ``target_host`` is a known peer key distinct from the local machine
+      (glob peer entries like ``spartan-*`` match here via ``PeersMap``).
+    * ``("unknown", None)`` — ``target_host`` names neither the local
+      machine nor a peer. This classifier stays a PURE resolver and never
+      raises; the REACTION is the caller's. Since operator directive
+      2026-07-10 the lifecycle dispatchers fail LOUD on it
+      (``_host_routing.format_unknown_host_error`` — peer list + fixes)
+      instead of silently falling through to a local start; either way an
+      unknown host is never routed to ssh.
+    """
+    if target_host is None:
+        return ("local", None)
+    if target_host == current_host or target_host in local_names:
+        return ("local", None)
+    if target_host in peers:
+        return ("remote", target_host)
+    return ("unknown", None)
+
+
+def _resolve_dispatch_peer(
+    target_host: str | None,
+    current_host: str,
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    local_names: Collection[str] = (),
+) -> str | None:
+    """Return the peer name to dispatch to, or None for local execution.
+
+    Thin wrapper over :func:`classify_dispatch_host` preserving the historic
+    "peer-name-or-None" contract used by ``_dispatch.try_dispatch``. Returns a
+    peer name only for a ``remote`` classification; both ``local`` and
+    ``unknown`` yield ``None`` (the caller decides what an unknown host
+    means). With the default empty ``local_names`` the behaviour is
+    byte-identical to the pre-hardening resolver — the alias-of-self
+    short-circuit only engages when the caller passes the machine's local
+    spellings.
+    """
+    _kind, peer = classify_dispatch_host(
+        target_host, current_host, peers, local_names=local_names
+    )
+    return peer
+
+
+def _local_host_names(current_host: str | None = None) -> set[str]:
+    """Return every host spelling that denotes THIS machine.
+
+    Unions the THREE hostname authorities so ``host: <canonical-or-alias>``
+    resolves to a LOCAL launch regardless of which registry the operator
+    configured, and — critically — regardless of drift between them:
+
+      * ``host_config`` (F-CS12 ``~/.scitex/agent-container/config.yaml``):
+        ``canonical_host()`` plus the ``host.aliases`` entry keyed by this
+        machine's short hostname.
+      * ``config/_host.resolve_hostname()`` (the value dispatch already
+        passes as ``current_host``) and the bare ``socket`` short hostname.
+      * the ECOSYSTEM HOST REGISTRY (``scitex_dev.hosts`` via
+        :func:`..._state.host_registry.registry_local_names`) — the fleet
+        LEDGER, which knows that one machine answers to several names.
+
+    The registry is consulted LAST and is FED the spellings the first two
+    produced, because it answers a pivot: the fleet row claiming one of my
+    names hands back that row's other names. It is what lets a machine whose
+    ``hostname -s`` looks nothing like its fleet name recognise its own pin —
+    ``scitex-nas-03`` reports ``DXP480TPLUS-994`` — without a hand-edited
+    per-machine alias table.
+
+    Only the alias entry for THIS machine's short hostname is included, so a
+    peer machine's alias is never mistaken for local; likewise the registry
+    contributes only when a row claims a name this machine already answers
+    to. Best-effort — a missing / broken config or registry degrades to the
+    short hostname (plus ``current_host`` when supplied); it never raises.
+    """
+    names: set[str] = set()
+    if current_host:
+        names.add(current_host)
+    short = socket.gethostname().split(".")[0]
+    if short:
+        names.add(short)
+    # config/_host resolver (env override → spec.hostname_aliases → short).
+    try:
+        from ...config._host import resolve_hostname
+
+        rn = resolve_hostname()
+        if rn:
+            names.add(rn)
+    except Exception:  # stx-allow: fallback (reason: hostname resolution must never block dispatch; short hostname already captured)
+        pass
+    # host_config F-CS12 registry (env override → host.canonical → aliases).
+    try:
+        from ..._state.host_config import load as _load_host_config
+
+        cfg = _load_host_config()
+        canonical = cfg.canonical_host()
+        if canonical:
+            names.add(canonical)
+        alias = cfg.host.aliases.get(short)
+        if alias:
+            names.add(alias)
+    except Exception:  # stx-allow: fallback (reason: absent/malformed config.yaml must not break the local-vs-remote decision; the two hostname sources above suffice)
+        pass
+    # Ecosystem host REGISTRY (the fleet ledger). Fed the spellings above so
+    # it can pivot from a name this machine already answers to onto the fleet
+    # name(s) for the same machine. Contributes nothing when no row claims
+    # this machine, so a host absent from the ledger behaves exactly as before.
+    try:
+        from ..._state.host_registry import registry_local_names
+
+        names |= registry_local_names(names)
+    except Exception:  # stx-allow: fallback (reason: no scitex-dev / no hosts.yaml on this box is a legitimate state — the two authorities above stand, and identity must never become a hard dependency on an optional [dev] extra)
+        pass
+    return {n for n in names if n}
+
+
+# EOF

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_host_routing.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_host_routing.py
@@ -69,21 +69,40 @@ def format_unknown_host_error(
     peers: Mapping[str, "PeerSpec"],
     *,
     verb: str = "start",
+    local_names: Collection[str] = (),
 ) -> str:
     """Actionable message for a spec.host that resolves to nowhere.
 
     Lists the registered peers (the ``sac host list`` view) so the operator
     can immediately see whether the fix is a typo correction or a missing
     ``peers:`` entry in ``~/.scitex/agent-container/config.yaml``.
+
+    ``local_names`` — every spelling that DOES denote this machine — is
+    printed alongside, because the refusal has two very different causes and
+    the operator cannot tell them apart without it: the pin names a machine
+    that is genuinely elsewhere (fix the pin or register the peer), or the
+    pin names THIS machine under a name nothing here recognises (fix the
+    ledger). The second is what took ``scitex-nas-03`` down on 2026-08-14 —
+    the message said only "neither this machine nor a registered peer",
+    which is true and unhelpful when the machine IS the pinned host.
     """
     peer_names = ", ".join(sorted(peers)) if peers else "(none registered)"
     lines = [
         f"Cannot {verb} agent {name!r}: spec.host {target_host!r} is neither "
         f"this machine nor a registered peer.",
+    ]
+    known = sorted({n for n in local_names if n})
+    if known:
+        lines.append(f"This machine answers to: {', '.join(known)}")
+    lines += [
         f"Registered peers: {peer_names}",
         "  (from ~/.scitex/agent-container/config.yaml `peers:`; "
         "inspect with `sac host list`)",
         "Fix ONE of:",
+        f"  * if this machine IS {target_host!r}, say so in the host REGISTRY "
+        f"— add this machine's `hostname -s` to that host's `aliases:` in "
+        f"$SCITEX_DIR/dev/hosts.yaml (inspect with `scitex-dev host show "
+        f"{target_host}`); sac reads identity from there, so no spec changes,",
         "  * correct spec.host to this machine's resolved hostname "
         "(`hostname -s`) or a registered peer name,",
         f"  * register {target_host!r} under `peers:` (glob patterns like "
@@ -184,6 +203,7 @@ def format_route_error(
     *,
     verb: str,
     current_host: str = "",
+    local_names: Collection[str] = (),
 ) -> str:
     """Pick the right unroutable message for ``spec_host``'s shape.
 
@@ -199,7 +219,9 @@ def format_route_error(
     sequence type and explain a refusal the resolver never made.
     """
     if isinstance(spec_host, str):
-        return format_unknown_host_error(name, spec_host, peers, verb=verb)
+        return format_unknown_host_error(
+            name, spec_host, peers, verb=verb, local_names=local_names
+        )
     return format_unroutable_chain_error(
         name, route, peers, verb=verb, current_host=current_host
     )
@@ -253,6 +275,7 @@ def resolve_start_dispatch_peer(
                 peers,
                 verb="start",
                 current_host=current_host,
+                local_names=local_names,
             )
         )
     kind, peer = route_to_legacy_kind(route)
@@ -347,6 +370,7 @@ def resolve_spec_host_peer(
                 peers,
                 verb=verb,
                 current_host=current_host or "",
+                local_names=local_names,
             )
         )
     kind, peer = route_to_legacy_kind(route)

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_bulk.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_bulk.py
@@ -21,7 +21,7 @@ from ..._lifecycle.lifecycle import agent_start
 from ...config import load_config
 from ...config._host import resolve_hostname
 from .._helpers import console
-from ._common import _singleton_skip_reason
+from ._common import _local_host_names, _singleton_skip_reason
 
 
 def run_bulk_path(
@@ -69,7 +69,9 @@ def run_bulk_path(
         # bulk-safe behavior)
         try:
             config = load_config(yaml_path)
-            skip = _singleton_skip_reason(config, current_host)
+            skip = _singleton_skip_reason(
+                config, current_host, local_names=_local_host_names(current_host)
+            )
             if skip:
                 console.print(f"  [yellow]SKIP[/yellow] {config.name}: {skip}")
                 continue

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_bulk.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_bulk.py
@@ -61,6 +61,9 @@ def run_bulk_path(
         current_host = resolve_hostname()
     except RuntimeError:
         current_host = ""
+    # Resolved ONCE for the whole bulk run: this machine's identity cannot
+    # change mid-loop, and each call reads the fleet host registry off disk.
+    local_names = _local_host_names(current_host)
     console.print(f"=== [blue]Starting {len(yamls)} agents...[/blue] ===")
     for yaml_path in yamls:
         # stx-allow: fallback (reason: one agent's config parse or
@@ -70,7 +73,7 @@ def run_bulk_path(
         try:
             config = load_config(yaml_path)
             skip = _singleton_skip_reason(
-                config, current_host, local_names=_local_host_names(current_host)
+                config, current_host, local_names=local_names
             )
             if skip:
                 console.print(f"  [yellow]SKIP[/yellow] {config.name}: {skip}")

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
@@ -87,6 +87,39 @@ class TestSingletonSkipReason:
         # Assert
         assert msg and "alpha" in msg and "beta" in msg
 
+    def test_v3_host_pin_naming_this_machine_by_another_name_returns_none(self):
+        # Arrange — the nas-03 shape: the pin IS this machine, spelled the way
+        # the fleet spells it, while `hostname -s` is the appliance's factory
+        # name. A skip here would be a SILENT no-start on the agent's own host.
+        cfg = _cfg(host="scitex-nas-03")
+        # Act
+        msg = _singleton_skip_reason(
+            cfg, "DXP480TPLUS-994", local_names={"scitex-nas-03"}
+        )
+        # Assert
+        assert msg is None
+
+    def test_v3_host_pin_naming_a_different_machine_still_returns_reason(self):
+        # Arrange — the case that must KEEP skipping: the pin names a machine
+        # this one is not, under any of its spellings.
+        cfg = _cfg(host="scitex-nas-03")
+        # Act
+        msg = _singleton_skip_reason(cfg, "DXP480TPLUS-994", local_names={"nas-99"})
+        # Assert
+        assert msg and "scitex-nas-03" in msg
+
+    def test_v2_preferred_host_naming_this_machine_by_another_name_returns_none(
+        self,
+    ):
+        # Arrange — same identity question on the v2 scheduling spec.
+        cfg = _cfg(sched_mode="singleton", pref="scitex-nas-03")
+        # Act
+        msg = _singleton_skip_reason(
+            cfg, "DXP480TPLUS-994", local_names={"scitex-nas-03"}
+        )
+        # Assert
+        assert msg is None
+
     def test_v3_host_chain_primary_match_returns_none(self):
         # Arrange
         cfg = _cfg(host=["a", "b", "c"])

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_identity.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_identity.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for lifecycle host IDENTITY — "which machine is which".
+
+The regression is concrete and was MEASURED on ``scitex-nas-03``
+(2026-08-14, while restoring scitex-hub during a live outage): that
+machine's ``hostname -s`` is the appliance's factory name
+``DXP480TPLUS-994``, every spec pins ``host: scitex-nas-03``, and the
+machine has no sac ``config.yaml`` at all (its path is a dangling symlink),
+so ``sac agents start scitex-hub`` ON THAT MACHINE refused with
+
+    spec.host 'scitex-nas-03' is neither this machine nor a registered peer
+
+and proceeded only with ``--no-redispatch``, typed by hand, every time.
+
+NO MOCKS. Every test drives the real seam: a real ``hosts.yaml`` written to
+a real ``$SCITEX_DIR/dev/`` (the ecosystem local-state cascade the registry
+port itself resolves), a real absent ``config.yaml`` via
+``$SCITEX_AGENT_CONTAINER_CONFIG``, and this test process's REAL
+``socket.gethostname()`` standing in for the factory name — the same device
+``test__common.py::TestLocalHostNames`` already uses.
+
+Both halves are covered on purpose, because a fix to one that breaks the
+other is the dangerous outcome: a pin naming THIS machine under another
+name must resolve LOCAL, and a pin naming a machine that is neither this
+one nor a peer must still fail LOUD.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import textwrap
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state.host_registry import registry_local_names
+from scitex_agent_container.cli_pkg.lifecycle._host_identity import (
+    _local_host_names,
+    classify_dispatch_host,
+)
+from scitex_agent_container.cli_pkg.lifecycle._host_routing import (
+    UnknownSpecHostError,
+    resolve_start_dispatch_peer,
+)
+
+#: This machine's raw short hostname — the stand-in for ``DXP480TPLUS-994``.
+FACTORY_NAME = socket.gethostname().split(".")[0]
+
+#: The fleet name the ledger gives that machine.
+FLEET_NAME = "scitex-nas-03"
+
+
+def _hosts_yaml(aliases: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        hosts:
+          {FLEET_NAME}:
+            kind: storage
+            ssh_alias: {FLEET_NAME}
+            aliases: [{aliases}]
+            scitex_root: "~/.scitex"
+          mba:
+            kind: workstation
+            ssh_alias: mba
+            scitex_root: "~/.scitex"
+        """
+    )
+
+
+def _install_registry(tmp_path: Path, body: str) -> Iterator[None]:
+    """Install ``body`` as the real hosts.yaml and point $SCITEX_DIR at it."""
+    hosts_dir = tmp_path / "dev"
+    hosts_dir.mkdir(parents=True, exist_ok=True)
+    (hosts_dir / "hosts.yaml").write_text(body)
+    sentinel = object()
+    previous: object = os.environ.get("SCITEX_DIR", sentinel)
+    os.environ["SCITEX_DIR"] = str(tmp_path)
+    try:
+        yield
+    finally:
+        if previous is sentinel:
+            os.environ.pop("SCITEX_DIR", None)
+        else:
+            os.environ["SCITEX_DIR"] = str(previous)
+
+
+@pytest.fixture()
+def ledger_knows_this_machine(tmp_path: Path, env_save_restore) -> Iterator[None]:
+    """The nas-03 shape: the ledger claims this machine's factory hostname.
+
+    The sac-local ``config.yaml`` is pointed at a path that does not exist —
+    exactly nas-03's state, where it is a dangling symlink — so the ONLY
+    authority that can connect the two names is the registry.
+    """
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_CONFIG", str(tmp_path / "absent.yaml")
+    )
+    yield from _install_registry(tmp_path, _hosts_yaml(f"nas-03, {FACTORY_NAME}"))
+
+
+@pytest.fixture()
+def ledger_does_not_know_this_machine(
+    tmp_path: Path, env_save_restore
+) -> Iterator[None]:
+    """A registry that exists but claims nothing about this machine."""
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_CONFIG", str(tmp_path / "absent.yaml")
+    )
+    yield from _install_registry(tmp_path, _hosts_yaml("nas-03"))
+
+
+@pytest.fixture()
+def ledger_claims_this_machine_twice(
+    tmp_path: Path, env_save_restore
+) -> Iterator[None]:
+    """An INCONSISTENT ledger: two rows claim this machine's hostname."""
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_CONFIG", str(tmp_path / "absent.yaml")
+    )
+    body = textwrap.dedent(
+        f"""\
+        hosts:
+          box-a:
+            kind: storage
+            ssh_alias: box-a
+            aliases: [{FACTORY_NAME}]
+            scitex_root: "~/.scitex"
+          box-b:
+            kind: storage
+            ssh_alias: box-b
+            aliases: [{FACTORY_NAME}]
+            scitex_root: "~/.scitex"
+        """
+    )
+    yield from _install_registry(tmp_path, body)
+
+
+# ---------------------------------------------------------------------------
+# registry_local_names — the ledger pivot, in isolation.
+# ---------------------------------------------------------------------------
+
+
+def test_registry_pivots_from_the_factory_name_to_the_fleet_name(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange — the ledger row claims this machine's factory hostname.
+    spellings = {FACTORY_NAME}
+    # Act
+    names = registry_local_names(spellings)
+    # Assert
+    assert FLEET_NAME in names
+
+
+def test_registry_also_returns_the_rows_other_aliases(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange
+    spellings = {FACTORY_NAME}
+    # Act
+    names = registry_local_names(spellings)
+    # Assert — every spelling of that row denotes this machine.
+    assert "nas-03" in names
+
+
+def test_registry_says_nothing_about_an_unclaimed_machine(
+    ledger_does_not_know_this_machine,
+) -> None:
+    # Arrange
+    spellings = {FACTORY_NAME}
+    # Act
+    names = registry_local_names(spellings)
+    # Assert — no row claims this machine, so the ledger adds no identity.
+    assert names == set()
+
+
+def test_registry_refuses_to_guess_when_two_rows_claim_this_machine(
+    ledger_claims_this_machine_twice,
+) -> None:
+    # Arrange — a machine is ONE host; two claimants means answering would
+    # pick a fleet identity by coin-flip.
+    spellings = {FACTORY_NAME}
+    # Act
+    names = registry_local_names(spellings)
+    # Assert
+    assert names == set()
+
+
+def test_registry_never_claims_identity_from_a_route(
+    ledger_does_not_know_this_machine,
+) -> None:
+    # Arrange — being able to REACH a name is not being that name, so a
+    # spelling that only matches an ssh_alias must contribute nothing.
+    spellings = {"mba"}
+    # Act
+    names = registry_local_names(spellings) - {"mba"}
+    # Assert
+    assert names == set()
+
+
+def test_registry_answers_nothing_for_an_empty_question(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange
+    spellings: set[str] = set()
+    # Act
+    names = registry_local_names(spellings)
+    # Assert
+    assert names == set()
+
+
+# ---------------------------------------------------------------------------
+# _local_host_names — the union, with the ledger as third authority.
+# ---------------------------------------------------------------------------
+
+
+def test_local_names_include_the_fleet_name_from_the_ledger(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange — sac's own config.yaml is absent; only the ledger can say it.
+    expected = FLEET_NAME
+    # Act
+    names = _local_host_names()
+    # Assert
+    assert expected in names
+
+
+def test_local_names_still_include_the_raw_hostname(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange
+    expected = FACTORY_NAME
+    # Act
+    names = _local_host_names()
+    # Assert
+    assert expected in names
+
+
+def test_local_names_unchanged_when_the_ledger_claims_nothing(
+    ledger_does_not_know_this_machine,
+) -> None:
+    # Arrange — a host absent from the ledger must behave exactly as before.
+    unexpected = FLEET_NAME
+    # Act
+    names = _local_host_names()
+    # Assert
+    assert unexpected not in names
+
+
+# ---------------------------------------------------------------------------
+# The measured failure, end to end: start on the machine its spec pins.
+# ---------------------------------------------------------------------------
+
+
+def test_pin_naming_this_machine_under_its_fleet_name_is_local(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange — nas-03's exact situation: no peers registered anywhere.
+    peers: dict = {}
+    # Act
+    classification = classify_dispatch_host(
+        FLEET_NAME,
+        FACTORY_NAME,
+        peers,
+        local_names=_local_host_names(FACTORY_NAME),
+    )
+    # Assert
+    assert classification == ("local", None)
+
+
+def test_start_dispatch_runs_locally_without_no_redispatch(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange — before the fix this RAISED, and the only way through was the
+    # hand-typed --no-redispatch escape, on every single start.
+    local_names = _local_host_names(FACTORY_NAME)
+    # Act
+    peer = resolve_start_dispatch_peer(
+        "scitex-hub", FLEET_NAME, FACTORY_NAME, {}, local_names=local_names
+    )
+    # Assert — None means "run here".
+    assert peer is None
+
+
+def test_a_pin_to_a_machine_that_is_not_this_one_still_fails_loud(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange — the case that MUST keep failing: a host that is neither this
+    # machine (the ledger does not claim it for us) nor a registered peer.
+    local_names = _local_host_names(FACTORY_NAME)
+    # Act
+    # Assert
+    with pytest.raises(UnknownSpecHostError):
+        resolve_start_dispatch_peer(
+            "scitex-hub",
+            "some-other-box",
+            FACTORY_NAME,
+            {},
+            local_names=local_names,
+        )
+
+
+def test_the_loud_refusal_names_the_identities_it_checked(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange — "neither this machine nor a registered peer" is true and
+    # unhelpful when the machine IS the pinned host under another name, so
+    # the refusal must show what this machine does answer to.
+    local_names = _local_host_names(FACTORY_NAME)
+    # Act
+    try:
+        resolve_start_dispatch_peer(
+            "scitex-hub",
+            "some-other-box",
+            FACTORY_NAME,
+            {},
+            local_names=local_names,
+        )
+        message = ""
+    except UnknownSpecHostError as exc:
+        message = str(exc)
+    # Assert
+    assert f"This machine answers to: " in message  # noqa: F541
+
+
+def test_the_loud_refusal_lists_the_fleet_name_among_them(
+    ledger_knows_this_machine,
+) -> None:
+    # Arrange
+    local_names = _local_host_names(FACTORY_NAME)
+    # Act
+    try:
+        resolve_start_dispatch_peer(
+            "scitex-hub",
+            "some-other-box",
+            FACTORY_NAME,
+            {},
+            local_names=local_names,
+        )
+        message = ""
+    except UnknownSpecHostError as exc:
+        message = str(exc)
+    # Assert
+    assert FLEET_NAME in message
+
+
+def test_the_loud_refusal_points_at_the_registry_as_the_fix(
+    ledger_does_not_know_this_machine,
+) -> None:
+    # Arrange — the operator standing on nas-03 needs to be told WHERE to
+    # record "this machine is scitex-nas-03", not just that it is not known.
+    local_names = _local_host_names(FACTORY_NAME)
+    # Act
+    try:
+        resolve_start_dispatch_peer(
+            "scitex-hub", FLEET_NAME, FACTORY_NAME, {}, local_names=local_names
+        )
+        message = ""
+    except UnknownSpecHostError as exc:
+        message = str(exc)
+    # Assert
+    assert "hosts.yaml" in message
+
+
+# EOF


### PR DESCRIPTION
## The defect, measured on the machine

`scitex-nas-03`'s `hostname -s` is `DXP480TPLUS-994` — the appliance's factory
name — while every spec pins `host: scitex-nas-03`. sac decided "is this host
name ME?" by STRING-COMPARING the pin against the resolved hostname and a
sac-local alias table, so **on the machine itself** the pin matched nothing:

```
$ sac agents start <agent>          # ON nas-03, no --no-redispatch
Cannot start agent '...': spec.host 'scitex-nas-03' is neither this machine nor a registered peer.
```

It proceeded only with `--no-redispatch`, typed by hand, every time. That is
how `scitex-hub` sat down for a day on 2026-08-14.

**Why it is urgent now.** The auth-heal sweep restarts through the normal start
path. Installing the heal units on nas-03 before this fix would install a
restarter that refuses every five minutes — a drumbeat of failure that trains
everyone to ignore the log, which is the same defect class as the always-green
audit workflow deleted in #1054. This PR is the prerequisite for that rollout.

The NAS is **not renamed** and no spec changed. Names belong in the ledger; the
string comparison is the part that was wrong.

## Identity is decided by resolution, not string equality

* `_state/host_registry`: `HostView` now carries the registry row's `aliases`,
  and a new **`registry_local_names(spellings)`** answers the ledger's identity
  question — *given every name this machine already answers to, what does the
  fleet call it?* Only `name` + `aliases` are matched; `ssh_alias` is
  deliberately excluded, because it answers "how do I reach that machine", and
  being able to reach a name is not being that name. Two rows claiming the same
  machine returns the **empty set** rather than picking a fleet identity by
  coin-flip. `_find` also resolves by alias now, which is what `hosts.yaml`'s
  own comment says aliases are for.

* `cli_pkg/lifecycle/_host_identity` (new): host identity extracted out of
  `_common`, which was at its per-file cap. `_local_host_names` gains the
  ecosystem host registry as a **third authority** beside the two sac-local
  ones (`config/_host.resolve_hostname`, `_state/host_config`'s
  `host.aliases`). Deliberately **not** a fourth place that knows about host
  names: the union already existed, the ledger joins it. `_common` re-exports
  every moved symbol, so existing imports are untouched.

* `_singleton_skip_reason` takes `local_names` and compares against the set
  rather than one string. Load-bearing on its own: a skip there is a **silent
  no-start**, the worst shape this bug can take. The empty default keeps the
  historical comparison byte-identical.

* `format_unknown_host_error` now prints `This machine answers to: ...` and
  offers the registry as the first fix. "Neither this machine nor a registered
  peer" is true and useless when the machine IS the pinned host, and the
  operator standing on nas-03 needs to be told WHERE to record it.

## What must NOT change, and is pinned by test

A pin naming a machine that is neither this one nor a reachable peer still
**fails loud**. The case fixed is "you pinned this to a machine that IS this
one, under a different name" — never "you pinned this somewhere unreachable".

## Verification on the real machine

`sac agents start <probe> --dry-run` on nas-03, on a throwaway spec pinned
`host: scitex-nas-03`, **without** `--no-redispatch` (`--dry-run` still runs
`try_dispatch`, which is where the refusal was raised). The live `scitex-hub`
agent was never touched.

| run | code | ledger claims this machine | result |
|---|---|---|---|
| before | installed `g427641a1` | no | **refused** — the exact production message |
| control | this branch | no | **refused**, now naming what this machine answers to and pointing at `hosts.yaml` |
| after | this branch | yes | **routing gate passed**, start proceeded into the local pipeline |
| wrong-pin control | this branch | yes | `host: some-other-box` still **refused** |

The "after" run reached an unrelated `no fresh account` preflight — i.e. it was
executing the LOCAL start path, which is the point.

`764 passed` across `cli_pkg/lifecycle/` + `_state/test_host_registry.py` +
`_state/test_host_config.py`. `scitex-dev ecosystem audit-all` is **byte-identical**
to `develop` after path/SHA normalization: 0 unmasked errors, 1 masked (PS-226,
pre-existing declared skip-rule) on both.

## One state change outside this repo

nas-03's `~/.scitex/dev/hosts.yaml` gained `DXP480TPLUS-994` in
`scitex-nas-03`'s `aliases:` (backup kept alongside). That is the ledger entry
this code reads; without it the fix correctly still refuses. It is inert under
the currently-deployed sac, so it is safe ahead of the merge.
