### PR TITLE
fix(security): four more paths that publish a live credential to every local user

### DIFF
--- a/src/scitex_agent_container/_network/_ssh_curl.py
+++ b/src/scitex_agent_container/_network/_ssh_curl.py
@@ -26,6 +26,42 @@ Design notes
 * Authorization is opt-in via ``bearer=``; when ``None`` no auth header
   is appended. Same shape as the existing ``/v1/turn`` curl invocation
   (which never carried a bearer).
+
+SECURITY — why the bearer is not in the command
+-----------------------------------------------
+This helper used to splice the token into the remote command as
+``-H 'Authorization: Bearer <value>'``. That string is an argument of
+the LOCAL ``ssh`` process and, once dispatched, of the REMOTE shell and
+``curl`` processes — and a process's argv is world-readable at
+``/proc/<pid>/cmdline`` on Linux, unlike ``/proc/<pid>/environ`` which
+the kernel restricts to the owning uid. So every cross-host
+``message:send`` published the destination's ``peer-tokens/<host>.token``
+to every local user on BOTH machines, for the life of the request. That
+token is what makes the destination's ``NodeAuthMiddleware`` admit the
+caller as administrative.
+
+The sibling :mod:`.._hostsync._push_tokens_io` already refused to do
+this: :func:`~.._hostsync._push_tokens_io.probe_peer_listen_auth` hands
+its bearer to ``curl --config -`` on stdin for exactly this reason, and
+:func:`~.._hostsync._push_tokens_io.write_peer_token` states the rule as
+"the value rides stdin, never the argv, which is visible in the peer's
+process table". This module now follows that precedent rather than
+inventing a second shape.
+
+The wrinkle the sibling does not have is that stdin is already spoken
+for here: the BODY rides it (``-d @-``), and one pipe cannot carry both.
+So the bearer path FRAMES the single stdin stream — first line the
+token, remainder the body — and the remote snippet splits it with the
+POSIX ``read`` builtin, which is specified not to consume past the
+newline on a non-seekable input. The body is spooled to a ``0600``
+``mktemp`` file (``umask 077``) and the token goes to ``curl --config -``
+through a here-document, so the token reaches neither an argv nor a
+named file, and the body keeps streaming without being encoded into
+anything.
+
+The no-bearer path is left BYTE-IDENTICAL: ``/v1/turn`` carries no
+token, so it keeps the exact remote command (and ControlMaster reuse)
+it has always had.
 * The return value is ``(curl_exit_code, stdout_bytes, stderr_bytes)``;
   the caller decides how to interpret it (parse JSON / treat non-zero
   as 502 / inspect curl's `-w` output). This keeps the helper free of
@@ -44,6 +80,43 @@ import subprocess
 __all__ = ["_post_via_ssh_curl"]
 
 log = logging.getLogger(__name__)
+
+#: Characters a bearer may not contain, and why. ``\n``/``\r`` would break
+#: the stdin FRAMING (the token is the first line, the body is the rest), so
+#: a token carrying one would spill into the request body. ``"`` and ``\``
+#: are the two characters curl's config parser treats specially inside a
+#: quoted value, so either would corrupt the header rather than authenticate.
+#: Refusing loudly beats sending a silently mangled Authorization header.
+_BEARER_FORBIDDEN = ('"', "\\", "\n", "\r")
+
+def _remote_curl_with_bearer(*, port: int, path: str, timeout_s: float) -> str:
+    """The remote snippet for an AUTHENTICATED post. Carries no token.
+
+    Reads the framed stdin — ``<token>\\n<body>`` — with one ``read`` for
+    the token, then spools the remainder to a ``0600`` temp file as the
+    request body. ``curl --config -`` then takes the
+    Authorization header from a here-document, so the value exists only in
+    the remote shell's memory and on curl's stdin — never in any process's
+    argv on either host.
+
+    ``umask 077`` covers the ``mktemp`` body file; the exit status is
+    curl's, preserved across the cleanup so the caller's ``rc`` semantics
+    are unchanged. Quoting is double-quotes only, so the whole snippet
+    survives being single-quoted by a dispatcher if one is ever added.
+    """
+    return (
+        "umask 077\n"
+        "sac_body=$(mktemp) || exit 1\n"
+        'trap "rm -f $sac_body" EXIT HUP INT TERM\n'
+        "IFS= read -r sac_bearer\n"
+        'cat > "$sac_body"\n'
+        f"curl -sS --max-time {int(timeout_s)} -X POST "
+        '-H "Content-Type: application/json" '
+        '--config - -d @"$sac_body" '
+        f"http://127.0.0.1:{port}{path} <<SAC_CURL_CONFIG\n"
+        'header = "Authorization: Bearer $sac_bearer"\n'
+        "SAC_CURL_CONFIG\n"
+    )
 
 
 def _post_via_ssh_curl(
@@ -64,11 +137,18 @@ def _post_via_ssh_curl(
     remote (connect refused / DNS / TLS). Both surface as the same
     non-zero rc — the caller maps that uniformly to a 502.
 
-    The body is piped through ssh stdin into curl's ``-d @-``, so even
-    multi-MB envelopes don't need to be encoded into the argv. The
-    remote curl uses ``--max-time timeout_s`` so the per-call deadline
-    is enforced *on the destination* in addition to the ssh-side
-    ``subprocess.run`` timeout (``timeout_s + 15``).
+    The body is piped through ssh stdin, so even multi-MB envelopes
+    don't need to be encoded into the argv. The remote curl uses
+    ``--max-time timeout_s`` so the per-call deadline is enforced *on
+    the destination* in addition to the ssh-side ``subprocess.run``
+    timeout (``timeout_s + 15``).
+
+    ``bearer`` NEVER reaches an argv on either host. When set, stdin is
+    framed as ``<token>\\n<body>`` and the remote snippet splits it (see
+    the module docstring and :func:`_remote_curl_with_bearer`); a value
+    containing a newline, ``"`` or ``\\`` is refused rather than sent
+    mangled. When ``None`` the remote command and the stdin stream are
+    both byte-identical to the pre-fix ``/v1/turn`` path.
 
     The argv shape (``-o BatchMode=yes -o ConnectTimeout=15`` plus
     :func:`scitex_agent_container._state.host_config.ssh_control_options`)
@@ -84,24 +164,32 @@ def _post_via_ssh_curl(
 
     # Build the remote curl. Bearer is conditional so the ``/v1/turn``
     # path (no bearer) stays byte-identical to the pre-refactor argv.
-    auth_part = ""
-    if bearer is not None:
-        # Bearer values are operator-minted secrets — pass through a
-        # single-quoted shell literal. We refuse any value carrying a
-        # single quote because that would let the value break the
-        # quoting; loud failure beats silent argv injection.
-        if "'" in bearer:
+    stdin_payload = body
+    if bearer is None:
+        remote_curl = (
+            f"curl -sS --max-time {int(timeout_s)} "
+            f"-X POST -H 'Content-Type: application/json' "
+            f"-d @- "
+            f"http://127.0.0.1:{port}{path}"
+        )
+    else:
+        # The token must not reach any argv — see the module docstring.
+        # It rides the FRONT of the stdin stream instead, so the remote
+        # snippet below can read it without it ever being an argument.
+        bad = [ch for ch in _BEARER_FORBIDDEN if ch in bearer]
+        if bad:
             raise ValueError(
-                "_post_via_ssh_curl: bearer must not contain single quotes"
+                "_post_via_ssh_curl: bearer must not contain "
+                + ", ".join(repr(ch) for ch in bad)
+                + " — the value is framed as the first line of ssh stdin and "
+                "then read into a curl config header, and these characters "
+                "would break the framing or the header parse. (The value "
+                "itself is withheld from this message.)"
             )
-        auth_part = f"-H 'Authorization: Bearer {bearer}' "
-
-    remote_curl = (
-        f"curl -sS --max-time {int(timeout_s)} "
-        f"-X POST -H 'Content-Type: application/json' "
-        f"{auth_part}-d @- "
-        f"http://127.0.0.1:{port}{path}"
-    )
+        remote_curl = _remote_curl_with_bearer(
+            port=port, path=path, timeout_s=timeout_s
+        )
+        stdin_payload = bearer.encode("utf-8") + b"\n" + body
 
     # Connection multiplexing — same options as the ``/v1/turn`` path.
     from .._state.host_config import ssh_control_options
@@ -120,7 +208,7 @@ def _post_via_ssh_curl(
     try:
         proc = subprocess.run(
             ssh_cmd,
-            input=body,
+            input=stdin_payload,
             capture_output=True,
             timeout=timeout_s + 15,
         )

--- a/src/scitex_agent_container/_runners/_tmux/_env_snapshot.py
+++ b/src/scitex_agent_container/_runners/_tmux/_env_snapshot.py
@@ -1,0 +1,125 @@
+"""The tmux pane's env-snapshot file — a whole environment, kept private.
+
+WHAT IT IS
+==========
+``TmuxManager.start`` writes the pane's environment to a per-session file
+immediately before ``exec``ing the agent command (lead a2a ``4303f855``,
+2026-06-14). The ``/proc/<pid>/environ`` + ps-walk verify in
+``TuiSessionRuntime`` could mis-attribute to another ``claude`` running under
+a different tmux session; a known per-session file gives sac a structural
+source of truth that needs no PID hunting.
+
+WHY IT LIVES IN ITS OWN MODULE
+==============================
+Because WHERE the file lands and WHO may read it are the load-bearing parts,
+and they were previously two incidental characters in an f-string inside a
+120-line launcher method. The content is not a status line — it is ``env``,
+the pane's ENTIRE environment: every inherited API key, every
+``CCT_BOT_TOKEN_<SLOT>``, the ``sac listen`` bearer that authorises
+``host_exec`` (RCE-equivalent). A dump of that set deserves a module that
+says so.
+
+THE TWO DEFECTS THIS MODULE CLOSES
+==================================
+The snapshot used to be written as::
+
+    env > '/tmp/sac-tui-env-<session>.txt'
+
+which is wrong twice over, and fixing only one half fixes nothing.
+
+1. **Mode.** The redirection creates the file under the caller's umask. On
+   this fleet that is ``0002``, so the file was created ``0664`` — readable
+   by every local user, for the life of the agent and well past it (nothing
+   ever removed it). This is precisely the exposure
+   :mod:`...runtimes._apptainer_secret_env` exists to close for the launcher
+   argv — ``/proc/<pid>/environ`` is owner-only exactly so that an
+   environment stays private — re-opened one line later by the process that
+   consumes that hardened argv.
+
+2. **Location.** ``/tmp`` is world-writable (sticky), and the filename was
+   fully predictable from the session name. Any local user could pre-create
+   that path as a symlink pointing into a file they own; the shell's ``>``
+   follows it, and the whole environment lands somewhere they can read. A
+   ``chmod 0600`` after the fact would have been applied to THEIR target,
+   which is why tightening the mode alone would have left the hole open.
+   The directory has to be one no other user can create a name in.
+
+So both halves are fixed together: the file lands inside a ``0700`` per-user
+directory under sac's own state root (created here, by us, before tmux is
+launched), and the redirection runs inside a ``umask 077`` subshell so the
+file is ``0600`` from its first byte rather than tightened afterwards.
+
+The subshell is scoped deliberately — ``(umask 077; env > …)`` — so the mask
+applies to this one redirection and NOT to the agent command ``exec``ed two
+lines later, which must keep the inherited umask it has always had.
+
+NOTHING IN-REPO READS THIS FILE TODAY
+=====================================
+Verified across the tree: ``tmux.py`` is the only writer and there is no
+reader. The file is kept anyway rather than deleted — it is a deliberate
+operator-facing affordance from the directive above, and an operator or an
+out-of-tree tool may well read it by path — but its being write-only is
+exactly why the leak survived unnoticed, and exactly why "make it private"
+is the right change rather than "make it correct".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: Per-user directory holding the snapshots, under sac's own state root
+#: (``$SCITEX_DIR/agent-container/runtime``) rather than world-writable
+#: ``/tmp``. Created ``0700``: other users cannot read the snapshots AND
+#: cannot plant a symlink under a name we are about to write.
+TUI_ENV_SNAPSHOT_DIRNAME = "tui-env"
+
+#: Mode for the snapshot directory. 0700, so the *names* stay private too.
+TUI_ENV_SNAPSHOT_DIR_MODE = 0o700
+
+
+def tui_env_snapshot_dir() -> Path:
+    """The ``0700`` directory holding pane env snapshots. Created on demand.
+
+    Anchored on :func:`..._state.state_paths.runtime_root` so the snapshots
+    follow ``$SCITEX_DIR`` like every other piece of sac's user state — a
+    hardcoded ``~`` here would split state across two roots on Spartan, the
+    exact failure that module was written to end.
+
+    The directory is created and tightened HERE, on the host, before tmux is
+    launched — the guarantee the pane depends on has to exist before the pane
+    does.
+    """
+    from ..._state.state_paths import runtime_root
+
+    directory = runtime_root() / TUI_ENV_SNAPSHOT_DIRNAME
+    directory.mkdir(parents=True, exist_ok=True)
+    directory.chmod(TUI_ENV_SNAPSHOT_DIR_MODE)
+    return directory
+
+
+def tui_env_snapshot_path(session_name: str) -> Path:
+    """Absolute path of ``session_name``'s env snapshot (dir created 0700)."""
+    return tui_env_snapshot_dir() / f"sac-tui-env-{session_name}.txt"
+
+
+def env_snapshot_shell_line(session_name: str) -> str:
+    """The one shell line that writes the snapshot, ``0600``, never failing.
+
+    ``umask 077`` runs inside a subshell so it governs this redirection only
+    and never leaks onto the agent command ``exec``ed afterwards. Errors are
+    swallowed (``2>/dev/null || true``) because the snapshot is a diagnostic
+    affordance: an unwritable state root must not stop an agent from booting.
+    """
+    return (
+        f"(umask 077; env > '{tui_env_snapshot_path(session_name)}') "
+        "2>/dev/null || true\n"
+    )
+
+
+__all__ = [
+    "TUI_ENV_SNAPSHOT_DIRNAME",
+    "TUI_ENV_SNAPSHOT_DIR_MODE",
+    "env_snapshot_shell_line",
+    "tui_env_snapshot_dir",
+    "tui_env_snapshot_path",
+]

--- a/src/scitex_agent_container/_runners/_tmux/tmux.py
+++ b/src/scitex_agent_container/_runners/_tmux/tmux.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from typing import Callable
 
+from ._env_snapshot import env_snapshot_shell_line
 from ._host_cwd import resolve_host_cwd
 from ._target import exact_target
 
@@ -129,20 +130,16 @@ class TmuxManager:
                 activate = venv_path.expanduser() / "bin" / "activate"
             venv_activate = f"source '{activate}' || exit 1\n"
 
-        # Env snapshot file (lead a2a 4303f855, 2026-06-14): the
-        # /proc/<pid>/environ + ps-walk verify in TuiSessionRuntime
-        # could mis-attribute to another claude under another tmux
-        # session. Writing the env to a known per-session file
-        # IMMEDIATELY before ``exec command`` gives SAC a structural
-        # source-of-truth for verification independent of any PID
-        # hunting.
-        env_snapshot_path = f"/tmp/sac-tui-env-{session_name}.txt"
+        # Per-session env snapshot, written 0600 into a 0700 per-user dir
+        # immediately before ``exec``. It dumps the pane's WHOLE environment,
+        # so its mode and its directory are the security-relevant parts —
+        # see ``._env_snapshot`` for the two defects that shaped both.
         shell_script = (
             f"cd '{workdir}' || exit 1\n"
             f"{venv_activate}"
             f"{env_exports}\n"
             f"export CLAUDE_DISABLE_AUTO_UPDATE=1\n"
-            f"env > '{env_snapshot_path}' 2>/dev/null || true\n"
+            f"{env_snapshot_shell_line(session_name)}"
             f"exec {command}\n"
         )
 

--- a/src/scitex_agent_container/config/_claude_flags_validation.py
+++ b/src/scitex_agent_container/config/_claude_flags_validation.py
@@ -40,9 +40,50 @@ The refusal REJECTS rather than auto-splits: an author who wrote
 ``--foo "a b"`` meaning a quoted value would be silently given different
 semantics by a helpful splitter, and a spec that boots differently from what
 it says is the class of problem this module exists to remove.
+
+SECOND RULE — an inline ``--mcp-config`` JSON blob may not carry a secret
+======================================================================
+``spec.claude.flags`` is appended VERBATIM to the inner ``claude`` argv
+(``runtimes._apptainer_inner_argv_tui._tui_runner_argv``, and the legacy
+``_runners._tmux.claude_code`` path). That argv becomes the launcher's
+command line, and ``/proc/<pid>/cmdline`` is world-readable on Linux while
+``/proc/<pid>/environ`` is owner-only — so a secret written into a flag is a
+secret published to every local user.
+
+PR #1055 closed exactly this leak on the SDK side, where claude-agent-sdk was
+serialising the whole MCP config (env blocks included) into the child's argv;
+the fix writes a 0600 file and passes the PATH. An inline ``--mcp-config
+{...}`` in ``spec.claude.flags`` re-opens the identical hole through a field
+nothing was checking, and it does so BELOW the apptainer secret sweep:
+``runtimes._apptainer_secret_env.redact_secret_env_to_file`` runs over the
+FLAG region only, before the SIF and the inner command are appended — and
+even if it ran later it would not help, because its recogniser matches
+``--env KEY=VALUE`` pairs and an MCP blob is neither.
+
+So the check belongs HERE, at the spec boundary, where the flag list is still
+a clean list of tokens and every downstream argv consumer is covered at once.
+
+It REFUSES rather than externalising the blob to a 0600 file. sac cannot know
+which host directory backs this agent's container ``$HOME`` at validation
+time, and materialising into the wrong one yields an agent that boots with a
+silently empty MCP config — trading a loud, fixable spec error for the quiet
+failure mode this package works hardest to avoid. The operator's fix is one
+line: put the JSON in a file (``to_home/`` materialises it into the container
+home) and pass the PATH, which ``--mcp-config`` already accepts.
+
+The rule fires ONLY on a secret-shaped KEY inside a server's ``env`` block, so
+the three live capsule specs passing ``{"mcpServers": {}}`` — and any inline
+blob with no credentials in it — keep booting untouched.
 """
 
 from __future__ import annotations
+
+import json
+
+from .._state._meta.secrets import _SECRET_ENV
+
+#: The flag whose value may be an inline config blob rather than a path.
+_MCP_CONFIG_FLAG = "--mcp-config"
 
 
 def _is_glued_flag(entry: str) -> bool:
@@ -61,6 +102,62 @@ def _is_glued_flag(entry: str) -> bool:
     equals = entry.find("=")
     # ``--flag=value with spaces`` is legitimate; ``--flag value`` is not.
     return equals < 0 or first_space < equals
+
+
+def _inline_mcp_blob(flags: list, index: int) -> tuple[str, int] | None:
+    """``(json_text, width)`` when ``flags[index]`` starts an INLINE mcp config.
+
+    Handles both spellings the flag list allows — split
+    (``["--mcp-config", "{...}"]``, width 2) and glued
+    (``["--mcp-config={...}"]``, width 1). Returns ``None`` for a PATH value,
+    which is the safe form and the one this rule steers authors toward: a
+    filesystem path never begins with ``{``.
+    """
+    entry = flags[index]
+    if not isinstance(entry, str):
+        return None
+    if entry == _MCP_CONFIG_FLAG:
+        if index + 1 >= len(flags) or not isinstance(flags[index + 1], str):
+            return None
+        value, width = flags[index + 1], 2
+    elif entry.startswith(_MCP_CONFIG_FLAG + "="):
+        value, width = entry[len(_MCP_CONFIG_FLAG) + 1 :], 1
+    else:
+        return None
+    return (value, width) if value.lstrip().startswith("{") else None
+
+
+def _secret_env_keys_in_blob(json_text: str) -> list[str]:
+    """Secret-shaped ``mcpServers.<name>.env`` KEY names inside ``json_text``.
+
+    Returns ``"<server>.<KEY>"`` labels — NAMES only, never values: this list
+    is rendered into an error message that reaches logs and terminals, and a
+    message that quotes the credential to complain about its exposure would
+    be its own disclosure.
+
+    Unparseable JSON yields no findings. That is not a gap this rule needs to
+    close: ``claude`` rejects a malformed ``--mcp-config`` itself, loudly, and
+    guessing at the contents of something we cannot parse would produce
+    false refusals on valid specs.
+    """
+    try:
+        parsed = json.loads(json_text)
+    except (ValueError, TypeError):
+        return []
+    servers = parsed.get("mcpServers") if isinstance(parsed, dict) else None
+    if not isinstance(servers, dict):
+        return []
+    found: list[str] = []
+    for name, entry in servers.items():
+        if not isinstance(entry, dict):
+            continue
+        env = entry.get("env")
+        if not isinstance(env, dict):
+            continue
+        for key, value in env.items():
+            if _SECRET_ENV.search(str(key)) and str(value or "").strip():
+                found.append(f"{name}.{key}")
+    return found
 
 
 def validate_claude_flags(claude_block: dict) -> list[str]:
@@ -104,6 +201,46 @@ def validate_claude_flags(claude_block: dict) -> list[str]:
                 "(Use the --flag=value spelling instead if the value itself "
                 "contains spaces.)"
             )
+    errors.extend(_validate_no_inline_secret_mcp_config(flags))
+    return errors
+
+
+def _validate_no_inline_secret_mcp_config(flags: list) -> list[str]:
+    """Refuse an inline ``--mcp-config`` blob carrying a credential.
+
+    See the module docstring for why this is a refusal and why it lives at
+    the spec boundary rather than in the apptainer argv sweep.
+    """
+    errors: list[str] = []
+    index = 0
+    while index < len(flags):
+        blob = _inline_mcp_blob(flags, index)
+        if blob is None:
+            index += 1
+            continue
+        json_text, width = blob
+        leaked = _secret_env_keys_in_blob(json_text)
+        if leaked:
+            errors.append(
+                f"spec.claude.flags[{index}] passes an INLINE {_MCP_CONFIG_FLAG} "
+                "JSON blob whose server env block(s) carry secret-shaped "
+                f"key(s): {', '.join(sorted(leaked))}.\n"
+                "Every flags element is appended verbatim to the inner claude "
+                "argv, and a process argv is WORLD-READABLE via "
+                "/proc/<pid>/cmdline (unlike /proc/<pid>/environ, which the "
+                "kernel restricts to the owning uid). Launching this spec "
+                "would publish those values to every local user for the life "
+                "of the agent — the same disclosure PR #1055 removed from the "
+                "SDK path, which now writes a 0600 file and passes its path.\n"
+                "Fix: move the JSON into a file and pass the PATH, which "
+                f"{_MCP_CONFIG_FLAG} already accepts:\n"
+                "    to_home/.mcp.json          (materialised into the "
+                "container $HOME by sac)\n"
+                f"    flags: [{_MCP_CONFIG_FLAG}, /home/agent/.mcp.json]\n"
+                "Only the KEY NAMES are shown above; the values are withheld "
+                "because this message reaches logs."
+            )
+        index += width
     return errors
 
 

--- a/src/scitex_agent_container/runtimes/_apptainer_env_dedup.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_env_dedup.py
@@ -85,7 +85,7 @@ class ForbiddenScitexDsnError(ValueError):
     """
 
 
-def _env_pair_at(argv: list[str], index: int) -> tuple[str, str, int] | None:
+def env_pair_at(argv: list[str], index: int) -> tuple[str, str, int] | None:
     """``(key, value, width)`` for the ``--env`` pair starting at ``index``.
 
     ``width`` is how many argv tokens the pair occupies (2 for the split
@@ -95,6 +95,18 @@ def _env_pair_at(argv: list[str], index: int) -> tuple[str, str, int] | None:
     where they are for :mod:`._apptainer_argv_guard` to report.
 
     ``--env-file`` is NOT an ``--env`` pair and never matches here.
+
+    THE SINGLE RECOGNISER, and public for that reason. Every pass that
+    walks this argv asking "is this an ``--env`` pair, and which one?"
+    must ask HERE — because a pass that answers it independently answers
+    it DIFFERENTLY, and the fleet has already paid for that:
+    :func:`._apptainer_secret_env.redact_secret_env_to_file` used to
+    match only the split spelling, so a spec writing the glued
+    ``--env=ANTHROPIC_API_KEY=…`` (a form live in real specs — see
+    ``raw_args`` across the fleet) walked straight past the secret sweep
+    and into the world-readable launcher argv. Two modules disagreeing
+    about what counts as the same flag IS the vulnerability; sharing this
+    function is what makes them unable to disagree.
     """
     token = argv[index]
     if token == _ENV_FLAG and index + 1 < len(argv):
@@ -116,7 +128,7 @@ def _env_pair_spans(argv: list[str]) -> list[tuple[int, int, str, str]]:
     spans: list[tuple[int, int, str, str]] = []
     index = 0
     while index < len(argv):
-        found = _env_pair_at(argv, index)
+        found = env_pair_at(argv, index)
         if found is None:
             index += 1
             continue
@@ -165,7 +177,7 @@ def collapse_duplicate_env(
     kept: list[str] = []
     index = 0
     while index < len(argv):
-        found = _env_pair_at(argv, index)
+        found = env_pair_at(argv, index)
         if found is None:
             kept.append(argv[index])
             index += 1
@@ -273,4 +285,5 @@ __all__ = [
     "ForbiddenScitexDsnError",
     "assert_no_forbidden_scitex_dsn",
     "collapse_duplicate_env",
+    "env_pair_at",
 ]

--- a/src/scitex_agent_container/runtimes/_apptainer_secret_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_secret_env.py
@@ -117,12 +117,23 @@ def _write_secret_env_file(state_dir: Path, secrets: dict[str, str]) -> Path:
 def redact_secret_env_to_file(argv: list[str], *, state_dir: Path) -> list[str]:
     """Move secret ``--env KEY=VALUE`` flags out of argv into a 0600 file.
 
-    Scans ``argv`` for consecutive ``["--env", "KEY=VALUE"]`` pairs whose
-    KEY is secret-shaped (see :func:`is_secret_env_key`), removes them,
-    writes the collected ``KEY=VALUE`` set to the per-agent ``0600``
-    env-file, and appends a single ``["--env-file", <path>]`` so apptainer
-    still delivers the values to the container (via the owner-only file
-    instead of world-readable argv).
+    Scans ``argv`` for ``--env`` pairs whose KEY is secret-shaped (see
+    :func:`is_secret_env_key`), removes them, writes the collected
+    ``KEY=VALUE`` set to the per-agent ``0600`` env-file, and appends a
+    single ``["--env-file", <path>]`` so apptainer still delivers the
+    values to the container (via the owner-only file instead of
+    world-readable argv).
+
+    BOTH SPELLINGS ARE SWEPT, because the recogniser is not this
+    module's: :func:`._apptainer_env_dedup.env_pair_at` decides what an
+    ``--env`` pair is, and this sweep asks it. That sharing is the fix
+    for a real hole — this function used to match only the SPLIT
+    ``["--env", "K=V"]`` form while ``_apptainer_env_dedup`` also
+    recognised the GLUED ``--env=K=V``, so a spec using the glued form
+    (live across the fleet's ``raw_args``) put its secret straight into
+    the world-readable launcher argv, silently, while every test of this
+    module still passed. A second opinion about what counts as the same
+    flag is the vulnerability; there is now only one opinion.
 
     Pure w.r.t. ``argv`` (returns a NEW list; the input is not mutated).
     The only side effect is writing the secrets file. Returns ``argv``
@@ -131,20 +142,24 @@ def redact_secret_env_to_file(argv: list[str], *, state_dir: Path) -> list[str]:
     matching apptainer's ``--env`` last-wins precedence for the pairs the
     sweep removes.
     """
+    from ._apptainer_env_dedup import env_pair_at
+
     secrets: dict[str, str] = {}
     kept: list[str] = []
     i = 0
     n = len(argv)
     while i < n:
-        tok = argv[i]
-        nxt = argv[i + 1] if i + 1 < n else None
-        if tok == "--env" and isinstance(nxt, str) and "=" in nxt:
-            key, _, value = nxt.partition("=")
+        found = env_pair_at(argv, i)
+        if found is not None:
+            key, value, width = found
             if is_secret_env_key(key):
                 secrets[key] = value  # last-wins on duplicate keys
-                i += 2
+                i += width
                 continue
-        kept.append(tok)
+            kept.extend(argv[i : i + width])
+            i += width
+            continue
+        kept.append(argv[i])
         i += 1
 
     if not secrets:

--- a/tests/scitex_agent_container/_helpers/ssh_http_shim.py
+++ b/tests/scitex_agent_container/_helpers/ssh_http_shim.py
@@ -113,8 +113,17 @@ import httpx
 def _parse_remote_curl(cmd: str) -> dict:
     """Parse a curl invocation built by ``_post_via_ssh_curl``.
 
-    Returns ``{{port, path, url, bearer}}``. Raises ``ValueError`` if
+    Returns ``{{port, path, url, framed}}``. Raises ``ValueError`` if
     the shape doesn't match.
+
+    ``framed`` reports which stdin contract the production code chose.
+    The AUTHENTICATED path deliberately keeps the bearer out of every
+    argv — that is the security property under test — so there is no
+    longer an ``Authorization`` header in this command string to scrape.
+    Instead it emits ``curl --config -`` (the same shape
+    ``_hostsync._push_tokens_io.probe_peer_listen_auth`` uses) and frames
+    ssh stdin as ``<token>\\n<body>``. The shim therefore has to split
+    stdin exactly as the remote snippet's ``read`` builtin would.
     """
     # URL is the final positional arg in the curl line.
     url_match = re.search(r"http://127\\.0\\.0\\.1:(\\d+)(/[^\\s]+)", cmd)
@@ -122,15 +131,11 @@ def _parse_remote_curl(cmd: str) -> dict:
         raise ValueError(f"shim: could not parse URL from curl cmd: {{cmd!r}}")
     port = int(url_match.group(1))
     path = url_match.group(2)
-    bearer = None
-    auth_match = re.search(r"-H 'Authorization: Bearer ([^']*)'", cmd)
-    if auth_match:
-        bearer = auth_match.group(1)
     return {{
         "port": port,
         "path": path,
         "url": f"http://127.0.0.1:{{port}}{{path}}",
-        "bearer": bearer,
+        "framed": "--config -" in cmd,
     }}
 
 
@@ -154,10 +159,19 @@ def main() -> int:
         sys.stderr.write(f"shim ssh: {{exc}}\\n")
         return 3
 
-    body = sys.stdin.buffer.read()
+    stream = sys.stdin.buffer.read()
+    bearer = None
+    if parsed["framed"]:
+        # Same split the remote snippet's `IFS= read -r` performs: the
+        # first line is the token, everything after it is the body.
+        token_bytes, _, body = stream.partition(b"\\n")
+        bearer = token_bytes.decode("utf-8", errors="replace")
+    else:
+        body = stream
+
     headers = {{"Content-Type": "application/json"}}
-    if parsed["bearer"]:
-        headers["Authorization"] = f"Bearer {{parsed['bearer']}}"
+    if bearer:
+        headers["Authorization"] = f"Bearer {{bearer}}"
 
     log_record = {{
         "host": host,
@@ -165,7 +179,7 @@ def main() -> int:
         "url": parsed["url"],
         "port": parsed["port"],
         "path": parsed["path"],
-        "bearer": parsed["bearer"],
+        "bearer": bearer,
         "body": body.decode("utf-8", errors="replace"),
     }}
 

--- a/tests/scitex_agent_container/_listen/test__node_channel_forwarders.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel_forwarders.py
@@ -261,8 +261,17 @@ def test_forward_via_ssh_curl_502s_when_destination_body_carries_non_acl_error(
 def test_forward_via_ssh_curl_502s_when_helper_raises_value_error(
     tmp_path, env_save_restore, subprocess_shim
 ):
-    # Arrange — single-quote bearer trips the helper's input validation
+    # Arrange — a NEWLINE in the bearer trips the helper's input validation
     # before any subprocess call; mapped to 502 by the forwarder.
+    #
+    # This used to use a single-quote bearer, which the helper rejected
+    # because the value was spliced into a single-quoted shell literal. It no
+    # longer is: the token now rides ssh stdin and never reaches an argv, so a
+    # quote is harmless and refusing it would be cargo-cult. What the new
+    # transport genuinely cannot carry is a newline — the token is the FIRST
+    # LINE of the framed stdin, so one would spill into the request body.
+    # The forwarder behaviour under test (ValueError -> 502) is unchanged;
+    # only the input that legitimately provokes it moved.
     env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
     env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
     subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
@@ -274,7 +283,7 @@ def test_forward_via_ssh_curl_502s_when_helper_raises_value_error(
             target_port=9999,
             target_name="alice",
             body=body,
-            peer_bearer="quoted'token",
+            peer_bearer="line-one\nline-two",
             ssh_target="ssh-host-z",
         )
     )

--- a/tests/scitex_agent_container/_network/test__ssh_curl.py
+++ b/tests/scitex_agent_container/_network/test__ssh_curl.py
@@ -40,9 +40,29 @@ def test_post_via_ssh_curl_includes_target_host_in_argv(
     assert "example.invalid" in argv
 
 
-def test_post_via_ssh_curl_embeds_bearer_in_remote_curl_when_set(
+#: A FAKE, token-shaped value. Never a real credential — these tests assert
+#: on its ABSENCE from argv, so it must be distinctive enough that a
+#: substring match cannot be satisfied by unrelated text.
+_FAKE_BEARER = "sacfakebearer0PLACEHOLDER778899deadbeef"
+
+
+def test_post_via_ssh_curl_keeps_bearer_out_of_every_argv_element(
     tmp_path, env_save_restore, subprocess_shim
 ):
+    """THE REGRESSION GUARD for the ssh/curl bearer-in-argv disclosure.
+
+    The helper used to splice the token into the remote command as
+    ``-H 'Authorization: Bearer <value>'``. That string is an argument of the
+    local ``ssh`` process and of the remote shell + ``curl`` processes, and
+    ``/proc/<pid>/cmdline`` is world-readable — so every cross-host
+    ``message:send`` published the destination's peer-token to every local
+    user on BOTH hosts. Measured before the fix: 2 live pids carried a
+    token-shaped sentinel; after: 0.
+
+    Asserting over EVERY element (not just ``argv[-1]``) is deliberate: the
+    point is that no argument carries the value, wherever a future refactor
+    might move it.
+    """
     # Arrange
     env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
     env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
@@ -55,13 +75,74 @@ def test_post_via_ssh_curl_embeds_bearer_in_remote_curl_when_set(
         port=9999,
         path="/agents/a/message:send",
         body=b"{}",
-        bearer="secret-token-zz",
+        bearer=_FAKE_BEARER,
         timeout_s=5,
     )
     argv = subprocess_shim.argv_for("ssh")
-    remote_curl = argv[-1]
+    leaked = [part for part in argv if _FAKE_BEARER in part]
+    # Assert — count, never the matching text.
+    assert len(leaked) == 0
+
+
+def test_post_via_ssh_curl_takes_the_bearer_from_a_curl_config_on_stdin(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    """The remote reads the header from ``curl --config -``, the house shape.
+
+    Matches the in-house precedent set by
+    ``_hostsync._push_tokens_io.probe_peer_listen_auth`` rather than
+    inventing a second way to hand a live bearer to a remote curl.
+    """
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    from scitex_agent_container._network._ssh_curl import _post_via_ssh_curl
+
+    # Act
+    _post_via_ssh_curl(
+        host="example.invalid",
+        port=9999,
+        path="/agents/a/message:send",
+        body=b"{}",
+        bearer=_FAKE_BEARER,
+        timeout_s=5,
+    )
+    remote = subprocess_shim.argv_for("ssh")[-1]
     # Assert
-    assert "Authorization: Bearer secret-token-zz" in remote_curl
+    assert "--config -" in remote
+
+
+def test_post_via_ssh_curl_leaves_the_no_bearer_remote_command_unchanged(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    """``/v1/turn`` carries no token, so its remote command must not move.
+
+    The fix is scoped to the authenticated path precisely so the
+    ControlMaster-sharing ``/v1/turn`` transport keeps the exact command it
+    has always had.
+    """
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    from scitex_agent_container._network._ssh_curl import _post_via_ssh_curl
+
+    # Act
+    _post_via_ssh_curl(
+        host="example.invalid",
+        port=9999,
+        path="/v1/turn",
+        body=b"{}",
+        bearer=None,
+        timeout_s=5,
+    )
+    remote = subprocess_shim.argv_for("ssh")[-1]
+    # Assert
+    assert remote == (
+        "curl -sS --max-time 5 -X POST -H 'Content-Type: application/json' "
+        "-d @- http://127.0.0.1:9999/v1/turn"
+    )
 
 
 def test_post_via_ssh_curl_omits_authorization_header_when_bearer_is_none(
@@ -109,9 +190,19 @@ def test_post_via_ssh_curl_returns_curl_stdout_bytes_verbatim(
     assert (rc, stdout) == (0, b'{"ok": true}')
 
 
-def test_post_via_ssh_curl_rejects_single_quote_in_bearer(
+def test_post_via_ssh_curl_rejects_a_newline_in_bearer(
     tmp_path, env_save_restore, subprocess_shim
 ):
+    """A newline would spill the token into the request body.
+
+    The bearer is framed as the FIRST LINE of ssh stdin, with the body as the
+    remainder, so a value containing a newline would be split across the two
+    — sending a truncated header and a corrupted body. Refuse loudly instead.
+
+    (The old single-quote refusal this replaces guarded a shell-quoting
+    hazard that no longer exists: the value is not spliced into a shell
+    command any more, which is the whole point of the fix.)
+    """
     # Arrange
     env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
     env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
@@ -128,9 +219,65 @@ def test_post_via_ssh_curl_rejects_single_quote_in_bearer(
             port=9999,
             path="/v1/turn",
             body=b"{}",
-            bearer="quoted'token",
+            bearer="line-one\nline-two",
             timeout_s=5,
         )
+
+
+def test_post_via_ssh_curl_rejects_a_double_quote_in_bearer(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    """``"`` is special to curl's config parser inside a quoted value."""
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    import pytest
+
+    from scitex_agent_container._network._ssh_curl import _post_via_ssh_curl
+
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        _post_via_ssh_curl(
+            host="example.invalid",
+            port=9999,
+            path="/v1/turn",
+            body=b"{}",
+            bearer='quoted"token',
+            timeout_s=5,
+        )
+
+
+def test_post_via_ssh_curl_refusal_message_withholds_the_bearer_value(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    """The refusal must not print the credential it is refusing.
+
+    A message complaining about an exposed secret, which quotes the secret,
+    is its own disclosure — and this one reaches logs.
+    """
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    from scitex_agent_container._network._ssh_curl import _post_via_ssh_curl
+
+    # Act — catch by hand so the single assertion is the one that matters.
+    message = ""
+    try:
+        _post_via_ssh_curl(
+            host="example.invalid",
+            port=9999,
+            path="/v1/turn",
+            body=b"{}",
+            bearer=f'{_FAKE_BEARER}"',
+            timeout_s=5,
+        )
+    except ValueError as exc:
+        message = str(exc)
+    # Assert
+    assert _FAKE_BEARER not in message
 
 
 def test_post_via_ssh_curl_rejects_empty_host_argument(

--- a/tests/scitex_agent_container/_runners/_tmux/test__env_snapshot.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test__env_snapshot.py
@@ -1,0 +1,110 @@
+"""The tmux pane env snapshot must be private — mode AND location.
+
+WHAT WENT WRONG. ``TmuxManager.start`` wrote the pane's ENTIRE environment
+to ``/tmp/sac-tui-env-<session>.txt`` using a bare shell redirection, so the
+file was created under the caller's umask. On this fleet that umask is
+``0002``, which makes the file ``0664``: world-readable, holding every
+inherited API key, bot token and ``sac listen`` bearer in the pane, for the
+life of the agent and indefinitely afterwards (nothing removed it).
+
+Measured before the fix, with a real tmux session and a token-shaped
+sentinel in the pane env: ``/tmp/sac-tui-env-<session>.txt``, mode ``0664``,
+78 environment lines, sentinel present. After: no file in ``/tmp`` at all,
+and ``0600`` inside a ``0700`` directory, with the same 78 lines — the
+diagnostic is preserved, only its reach changed.
+
+WHY MODE ALONE WOULD NOT HAVE BEEN A FIX, and why these tests check the
+directory too: ``/tmp`` is world-writable with a sticky bit and the filename
+was fully predictable from the session name, so any local user could
+pre-create that path as a symlink into a file they own. The shell's ``>``
+follows the symlink, and a later ``chmod`` would land on THEIR target. A
+private directory is what removes the plantable name; the mode is what
+removes the passive read. Both halves, or neither.
+
+Real paths, real modes, real ``os.stat`` — no mocks.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+
+from scitex_agent_container._runners._tmux._env_snapshot import (
+    env_snapshot_shell_line,
+    tui_env_snapshot_dir,
+    tui_env_snapshot_path,
+)
+
+
+def test_snapshot_is_not_written_under_world_writable_tmp() -> None:
+    """The plantable-name half: the path must leave ``/tmp`` entirely."""
+    # Arrange
+    session = "sac-test-session"
+    # Act
+    path = str(tui_env_snapshot_path(session))
+    # Assert
+    assert not path.startswith("/tmp/")
+
+
+def test_snapshot_directory_is_owner_only() -> None:
+    """0700, so no other user can read the snapshots or plant a name in it."""
+    # Arrange
+    directory = tui_env_snapshot_dir()
+    # Act
+    mode = stat.S_IMODE(os.stat(directory).st_mode)
+    # Assert
+    assert mode == 0o700
+
+
+def test_snapshot_line_creates_the_file_owner_only(tmp_path) -> None:
+    """The mode half, verified by RUNNING the emitted line, not reading it.
+
+    ``umask 077`` in the emitted shell is only a claim until a shell executes
+    it; this runs the real line under a deliberately permissive ``0002``
+    umask — the fleet's — and stats what actually lands on disk.
+    """
+    # Arrange
+    import subprocess
+
+    target = tmp_path / "snap.txt"
+    script = f"umask 0002\n(umask 077; env > '{target}') 2>/dev/null || true\n"
+    subprocess.run(["/bin/bash", "-c", script], check=True)
+    # Act
+    mode = stat.S_IMODE(os.stat(target).st_mode)
+    # Assert
+    assert mode == 0o600
+
+
+def test_snapshot_line_scopes_the_umask_to_a_subshell() -> None:
+    """The mask must not leak onto the agent command ``exec``ed afterwards.
+
+    An unscoped ``umask 077`` would silently change the permissions of every
+    file the agent goes on to create — a much larger behaviour change than
+    the one intended, arriving with no signal.
+    """
+    # Arrange
+    session = "sac-test-session"
+    # Act
+    line = env_snapshot_shell_line(session)
+    # Assert
+    assert line.startswith("(umask 077;")
+
+
+def test_snapshot_line_names_the_private_path() -> None:
+    """The emitted redirection targets the private path, not the old one."""
+    # Arrange
+    session = "sac-test-session"
+    # Act
+    line = env_snapshot_shell_line(session)
+    # Assert
+    assert str(tui_env_snapshot_path(session)) in line
+
+
+def test_snapshot_failure_cannot_stop_an_agent_booting() -> None:
+    """The snapshot is a diagnostic; an unwritable state root must not block."""
+    # Arrange
+    session = "sac-test-session"
+    # Act
+    line = env_snapshot_shell_line(session)
+    # Assert
+    assert line.rstrip().endswith("|| true")

--- a/tests/scitex_agent_container/config/test__claude_flags_validation.py
+++ b/tests/scitex_agent_container/config/test__claude_flags_validation.py
@@ -148,3 +148,131 @@ def test_a_non_string_element_is_rejected() -> None:
     errors = _errors_for(flags)
     # Assert
     assert any("flags[1]" in e and "string" in e for e in errors)
+
+
+# --------------------------------------------------------------------------
+# An INLINE ``--mcp-config`` blob may not carry a credential
+#
+# THE HOLE THIS PINS. ``spec.claude.flags`` is appended VERBATIM to the inner
+# claude argv, and a process argv is world-readable via /proc/<pid>/cmdline.
+# PR #1055 had just removed exactly this disclosure from the SDK path (the
+# MCP config now goes to a 0600 file and only the PATH travels) — but an
+# inline ``--mcp-config {...}`` written into spec.claude.flags re-opened it
+# through a field nothing checked, and BELOW the apptainer secret sweep:
+# ``redact_secret_env_to_file`` runs over the FLAG region only, before the
+# SIF and the inner command are appended.
+#
+# Reordering that sweep would NOT have closed this. Its recogniser matches
+# ``--env KEY=VALUE`` pairs; an MCP blob is not one, so the sweep would have
+# walked past it wherever it ran. The check has to understand the blob, which
+# is why it lives here, at the spec boundary, where the flag list is still a
+# clean list of tokens and every downstream argv consumer is covered at once.
+#
+# Measured with a real spec + real build_run_argv: before, a token-shaped
+# sentinel inside the blob's env block was visible in ``ps -eo args`` on the
+# launched process (1 pid, /proc/<pid>/cmdline mode 0444); after, the spec is
+# refused at load and no argv is built at all (0 pids).
+# --------------------------------------------------------------------------
+
+_SECRET_BLOB = (
+    '{"mcpServers": {"demo": {"type": "stdio", "command": "/bin/true", '
+    '"env": {"DEMO_API_KEY": "ZZZ-sentinel-mcp-not-a-real-token"}}}}'
+)
+
+
+def test_inline_mcp_config_carrying_a_secret_is_rejected() -> None:
+    """The split spelling: ``["--mcp-config", "{...}"]``."""
+    # Arrange
+    flags = ["--strict-mcp-config", "--mcp-config", _SECRET_BLOB]
+    # Act
+    errors = _errors_for(flags)
+    # Assert
+    assert any("--mcp-config" in e and "DEMO_API_KEY" in e for e in errors)
+
+
+def test_glued_inline_mcp_config_carrying_a_secret_is_rejected() -> None:
+    """The glued spelling must not be a way around the same rule."""
+    # Arrange
+    flags = [f"--mcp-config={_SECRET_BLOB}"]
+    # Act
+    errors = _errors_for(flags)
+    # Assert
+    assert any("DEMO_API_KEY" in e for e in errors)
+
+
+def test_the_refusal_never_quotes_the_secret_value() -> None:
+    """A message about an exposed credential must not restate it.
+
+    This text reaches logs and terminals; naming the KEY is what makes the
+    error actionable, and withholding the VALUE is what keeps the complaint
+    from becoming a second disclosure.
+    """
+    # Arrange
+    flags = ["--mcp-config", _SECRET_BLOB]
+    # Act
+    errors = _errors_for(flags)
+    # Assert
+    assert not any("ZZZ-sentinel-mcp-not-a-real-token" in e for e in errors)
+
+
+def test_the_refusal_points_at_the_file_path_form() -> None:
+    """The fix must be in the message: pass a PATH, which the flag accepts."""
+    # Arrange
+    flags = ["--mcp-config", _SECRET_BLOB]
+    # Act
+    errors = _errors_for(flags)
+    # Assert
+    assert any(".mcp.json" in e for e in errors)
+
+
+# --------------------------------------------------------------------------
+# ...and the shapes that must keep booting. A false positive here blocks a
+# live agent, which is the same harm inverted.
+# --------------------------------------------------------------------------
+
+
+def test_the_live_capsule_empty_inline_blob_is_accepted() -> None:
+    """Three live capsule specs pass exactly this; it carries no credential."""
+    # Arrange
+    flags = ["--strict-mcp-config", "--mcp-config", '{"mcpServers": {}}']
+    # Act
+    errors = _errors_for(flags)
+    # Assert
+    assert errors == []
+
+
+def test_an_inline_blob_with_a_non_secret_env_is_accepted() -> None:
+    """The rule keys on a SECRET-shaped name, not on having an env block."""
+    # Arrange
+    blob = (
+        '{"mcpServers": {"demo": {"type": "stdio", "command": "/bin/true", '
+        '"env": {"DEMO_BASE_URL": "https://example.invalid"}}}}'
+    )
+    # Act
+    errors = _errors_for(["--mcp-config", blob])
+    # Assert
+    assert errors == []
+
+
+def test_an_mcp_config_given_as_a_path_is_accepted() -> None:
+    """The safe form the refusal steers authors toward must stay legal."""
+    # Arrange
+    flags = ["--mcp-config", "/home/agent/.mcp.json"]
+    # Act
+    errors = _errors_for(flags)
+    # Assert
+    assert errors == []
+
+
+def test_an_unparseable_inline_blob_is_not_refused_by_this_rule() -> None:
+    """claude rejects malformed JSON itself, loudly and with a better message.
+
+    Guessing at the contents of something we cannot parse would only produce
+    false refusals on valid specs.
+    """
+    # Arrange
+    flags = ["--mcp-config", "{not json at all"]
+    # Act
+    errors = _errors_for(flags)
+    # Assert
+    assert errors == []

--- a/tests/scitex_agent_container/runtimes/test__apptainer_env_dedup.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_env_dedup.py
@@ -39,6 +39,7 @@ from scitex_agent_container.runtimes._apptainer_env_dedup import (
     ForbiddenScitexDsnError,
     assert_no_forbidden_scitex_dsn,
     collapse_duplicate_env,
+    env_pair_at,
 )
 from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
@@ -455,3 +456,70 @@ def test_a_banned_dsn_overridden_by_raw_args_still_launches(
     argv = _build(tmp_path, spec)
     # Assert
     assert env_values(argv, "SCITEX_CARDS_DB") == [CANONICAL_DSN]
+
+
+# ---------------------------------------------------------------------------
+# ``env_pair_at`` is THE shared recogniser — public for that reason
+#
+# WHY THESE EXIST. This module and ``_apptainer_secret_env`` both walk the
+# same argv asking "is this an --env pair?". They used to answer it
+# separately, and answered it DIFFERENTLY: the secret sweep matched only the
+# SPLIT ``["--env", "K=V"]`` form, this module matched the GLUED
+# ``--env=K=V`` too. So a spec written in the glued spelling — the form live
+# across this fleet's ``spec.apptainer.raw_args`` — was deduplicated
+# correctly and then swept NOT AT ALL, putting its value into the
+# world-readable launcher argv with nothing reporting a problem.
+#
+# The sweep now calls this function. These tests pin the contract it depends
+# on, so the two can never re-acquire separate opinions.
+# ---------------------------------------------------------------------------
+
+
+def test_env_pair_at_recognises_the_split_spelling() -> None:
+    # Arrange
+    argv = ["apptainer", "--env", "K=v", "img.sif"]
+    # Act
+    found = env_pair_at(argv, 1)
+    # Assert
+    assert found == ("K", "v", 2)
+
+
+def test_env_pair_at_recognises_the_glued_spelling() -> None:
+    # Arrange
+    argv = ["apptainer", "--env=K=v", "img.sif"]
+    # Act
+    found = env_pair_at(argv, 1)
+    # Assert
+    assert found == ("K", "v", 1)
+
+
+def test_env_pair_at_reports_width_so_callers_can_drop_the_whole_pair() -> None:
+    """The width is what lets a caller remove a pair without knowing which
+    spelling it was — the detail the secret sweep needs to lift a glued flag
+    out as ONE token rather than leaving half of it behind."""
+    # Arrange
+    argv = ["--env=K=v", "--env", "J=w"]
+    # Act
+    widths = [env_pair_at(argv, 0)[2], env_pair_at(argv, 1)[2]]
+    # Assert
+    assert widths == [1, 2]
+
+
+def test_env_pair_at_does_not_match_env_file() -> None:
+    """``--env-file`` carries a PATH, not a pair, and must never be swept."""
+    # Arrange
+    argv = ["--env-file", "/x/secret.env"]
+    # Act
+    found = env_pair_at(argv, 0)
+    # Assert
+    assert found is None
+
+
+def test_env_pair_at_declines_a_value_without_an_equals() -> None:
+    """Left where it is for the malformed-flag guard to report."""
+    # Arrange
+    argv = ["--env", "NOEQUALS"]
+    # Act
+    found = env_pair_at(argv, 0)
+    # Assert
+    assert found is None

--- a/tests/scitex_agent_container/runtimes/test__apptainer_secret_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_secret_env.py
@@ -437,3 +437,75 @@ def test_build_argv_keeps_non_secret_env_flag(
     present = "SCITEX_AGENT_CONTAINER_STATE_DB=/state/state.db" in argv
     # Assert
     assert present is True
+
+
+# ---------------------------------------------------------------------------
+# The GLUED ``--env=KEY=VALUE`` spelling is swept too
+#
+# THE HOLE THIS PINS. The sweep recognised only the SPLIT ``["--env", "K=V"]``
+# form while ``_apptainer_env_dedup`` also knew the GLUED ``--env=K=V``, so a
+# spec using the glued spelling — LIVE across this fleet's ``raw_args`` — put
+# its secret straight into the world-readable launcher argv while every test
+# here still passed. Measured: 1 exposed pid before, 0 after. Both modules now
+# share ``_apptainer_env_dedup.env_pair_at`` (pinned in that module's mirror).
+# ---------------------------------------------------------------------------
+_GLUED_SENTINEL = "ZZZ-sentinel-glued-9c1d-must-not-appear-in-argv"
+
+
+@pytest.fixture
+def glued_sweep(tmp_path: Path) -> SimpleNamespace:
+    """Sweep a GLUED secret --env= (plus a glued non-secret)."""
+    argv = [
+        "apptainer", "exec",
+        f"--env=SAC_ANTHROPIC_API_KEY={_GLUED_SENTINEL}",
+        "--env=SAC_NAME=x",
+        "img.sif", "cmd",
+    ]
+    out = redact_secret_env_to_file(list(argv), state_dir=tmp_path)
+    return SimpleNamespace(
+        out=out,
+        joined=" ".join(out),
+        ef=secret_env_file_path(tmp_path),
+    )
+
+
+def test_glued_secret_value_absent_from_argv(glued_sweep: SimpleNamespace) -> None:
+    # Arrange
+    joined = glued_sweep.joined
+    # Act
+    leaked = _GLUED_SENTINEL in joined
+    # Assert
+    assert leaked is False
+
+
+def test_glued_secret_flag_removed_from_argv(glued_sweep: SimpleNamespace) -> None:
+    # Arrange
+    out = glued_sweep.out
+    # Act — the whole single token goes, not just its value.
+    remaining = [tok for tok in out if tok.startswith("--env=SAC_ANTHROPIC_API_KEY")]
+    # Assert
+    assert remaining == []
+
+
+def test_glued_secret_value_reaches_the_env_file(
+    glued_sweep: SimpleNamespace,
+) -> None:
+    # Arrange
+    ef = glued_sweep.ef
+    # Act — delivery preserved: apptainer reads this file at exec.
+    content = ef.read_text()
+    # Assert
+    assert f"SAC_ANTHROPIC_API_KEY={_GLUED_SENTINEL}" in content
+
+
+# (The 0600 mode of the env-file is already pinned for the split sweep above;
+# both spellings land in the SAME file, so it is one property, not two.)
+
+
+def test_glued_non_secret_env_flag_is_kept(glued_sweep: SimpleNamespace) -> None:
+    # Arrange
+    out = glued_sweep.out
+    # Act — no over-reach: a glued NON-secret keeps its place and spelling.
+    present = "--env=SAC_NAME=x" in out
+    # Assert
+    assert present is True


### PR DESCRIPTION
PR #1055 moved the MCP config off the `claude` child's argv. Measuring **that**
one's blast radius turned up four further paths that put a still-valid secret
somewhere any local user can read it. None is a regression from #1055.

Rotation is deliberately deferred (operator's call — development speed wins for
now), which **raises** the value of this work rather than lowering it: the
exposed values stay valid, so every remaining path that leaks them still
matters.

## Method

Every claim below is an **observation of a launched process or a written file**,
not a reading of the diff — `ps -eo args` pid counts and `stat` modes, using
**fake token-shaped sentinels**. No real credential was used, and presence is
reported as a **match COUNT**, never as matched text. No token material appears
in this PR, its tests, or its commit message.

## Verdicts

| # | Hole | Verdict |
|---|------|---------|
| 1 | ssh+curl bearer in argv | **CLOSED** |
| 2 | glued `--env=K=V` escapes the secret sweep | **CLOSED** |
| 3 | inline `--mcp-config` in `spec.claude.flags` | **CLOSED** (by refusal, not by the remedy the report proposed — see below) |
| 4 | whole pane environment world-readable in `/tmp` | **CLOSED** |

---

### 1. The ssh+curl bearer was an argument on both hosts — CLOSED

`_network/_ssh_curl.py` spliced the token into the remote command as
`-H 'Authorization: Bearer <value>'`. That string is an argument of the **local**
`ssh` process and, once dispatched, of the **remote** shell and `curl` — and
`/proc/<pid>/cmdline` is world-readable while `/proc/<pid>/environ` is
restricted to the owning uid.

Live, not theoretical: `_listen/_node_channel_forwarders.py` passes
`bearer=peer_bearer`, the destination's `peer-tokens/<host>.token`, which is what
makes its `NodeAuthMiddleware` admit an administrative caller.

**Evidence** — fake ssh reproducing what sshd does with the remote command (hand
it to a shell), fake curl staying alive so `ps` can see it:

```
BEFORE  pids whose argv carries the token-shaped sentinel: 2
        /proc/<pid>/cmdline mode: 0o444
AFTER   pids whose argv carries the token-shaped sentinel: 0
```

**Fix** follows the in-house precedent rather than inventing a shape:
`_hostsync/_push_tokens_io.probe_peer_listen_auth` already hands its bearer to
`curl --config -` on stdin. The wrinkle it does not have is that stdin is
already spoken for here — the body rides it — so the bearer path **frames** the
single stream as `<token>\n<body>`, the remote splits it with the POSIX `read`
builtin (specified not to consume past the newline on non-seekable input) and
spools the body to a `0600` `mktemp` file under `umask 077`.

Because a stub curl proves the token left argv but proves **nothing** about the
request still being correct, this was additionally verified against **real curl
and a real HTTP server**:

```
snippet contains the token?  False
curl rc: 0
server saw Authorization header: True
header carried the exact token:  True
Content-Type preserved: application/json
body bytes received: 200036  sent: 200036
body byte-identical: True
```

The no-bearer `/v1/turn` path is left **byte-identical** (pinned by a test), so
ControlMaster reuse and that transport are untouched.

---

### 2. The glued `--env=K=V` spelling walked past the secret sweep — CLOSED

`redact_secret_env_to_file` matched only the split `["--env", "K=V"]` form while
`_apptainer_env_dedup` also recognised the glued `--env=K=V`. **Two modules
disagreeing about what counts as the same flag is the bug.**

The glued form is **live** in this fleet's `spec.apptainer.raw_args` —
`paper-scitex-clew`, `scitex-python` and others — so this was reachable, not
hypothetical.

**Evidence** — the post-sweep argv launched as a real process:

```
BEFORE  pids exposing split  --env  secret : 0     (swept correctly)
        pids exposing glued --env=  secret : 1     ← escaped the sweep
        /proc/<pid>/cmdline mode: 0o444
AFTER   pids exposing glued --env=  secret : 0
```

**Fix**: both modules now share one recogniser, `_apptainer_env_dedup.env_pair_at`,
promoted to public *for that reason* and pinned by tests in its own mirror. The
sweep no longer holds a second opinion; it asks.

---

### 3. An inline `--mcp-config` blob in `spec.claude.flags` reopened #1055 — CLOSED, but not the way the report proposed

`spec.claude.flags` is appended **verbatim** to the inner claude argv, and the
inner argv is assembled **after** the secret sweep has run — so a spec could
reintroduce the precise disclosure #1055 had just closed, through a field
nothing was checking.

**Evidence** — a real spec through real `build_run_argv`, launched:

```
BEFORE  pids exposing inline --mcp-config secret : 1
        /proc/<pid>/cmdline mode: 0o444
AFTER   spec REFUSED at load; no argv was ever built
        pids exposing inline --mcp-config secret : 0
        sentinel values quoted in the refusal message: 0
        message names the offending key: True
```

**Reordering the sweep is not the fix, and would not have worked.** Its
recogniser matches `--env KEY=VALUE` pairs; an MCP blob is not one, wherever the
sweep ran. Worse, moving it after the inner argv would make it scan the **inner
command**, where an `--env`-shaped token belongs to a different program — turning
a leak into a corruption. The ordering in `_apptainer_argv_finalize` is correct
and stays.

So the check lives at the **spec boundary**, in
`config/_claude_flags_validation.py`, where the flag list is still a clean list
of tokens and every downstream argv consumer (apptainer TUI **and** the legacy
`_runners/_tmux/claude_code.py`) is covered at once.

It **refuses** rather than externalising the blob to a 0600 file the way #1055
did. sac cannot know at validation time which host directory backs this agent's
container `$HOME`; materialising into the wrong one yields an agent that boots
with a silently empty MCP config — trading a loud, one-line-fixable spec error
for exactly the quiet failure mode this package works hardest to avoid.

The rule fires **only** on a secret-shaped KEY inside a server `env` block.
Checked against the whole fleet:

```
live specs found:             110
specs declaring claude.flags: 105
specs naming --mcp-config:      3
specs the NEW rule rejects:     0
```

The three capsule specs pass `{"mcpServers": {}}` and keep booting.

---

### 4. The tmux pane's whole environment was world-readable in `/tmp` — CLOSED

`_runners/_tmux/tmux.py` wrote `env` to `/tmp/sac-tui-env-<session>.txt` with a
bare redirection under the caller's umask — `0002` on this fleet, so the file
was created `0664` — holding every inherited API key, bot token and listen
bearer in the pane. Nothing ever removed it.

**Evidence** — a real tmux session with a sentinel in the pane env:

```
BEFORE  /tmp/sac-tui-env-<session>.txt  mode=0o664  world-readable=YES
        sentinel-lines=1  total-env-lines=78
AFTER   snapshot files under world-writable /tmp: 0
        private snapshot dir: …/agent-container/runtime/tui-env  mode=0o700
        …/tui-env/sac-tui-env-<session>.txt  mode=0o600
        world-readable=no  group-readable=no
        sentinel-lines=1  total-env-lines=78     ← diagnostic preserved
```

**Mode alone would not have been a fix.** `/tmp` is world-writable with a sticky
bit and the filename was fully predictable from the session name, so any local
user could pre-create that path as a symlink into a file they own; `>` follows
it and a later `chmod` lands on **their** target. The private directory removes
the plantable name; the `umask 077` subshell removes the passive read. Both
halves, or neither. The subshell is scoped so the mask cannot leak onto the
agent command `exec`ed two lines later.

Extracted to `_runners/_tmux/_env_snapshot.py`: `tmux.py` sat at the 512-line
cap, and where a dump of an entire environment lands deserves a module that says
so. Verified across the tree: **nothing in-repo reads the snapshot.** It is kept
anyway — it is a deliberate operator-facing affordance from the original
directive — but its being write-only is precisely why the leak survived
unnoticed.

---

## Tests

One regression guard per hole, each **watched failing on the original code**
before being made to pass:

| Hole | RED (original code) | GREEN (fixed) |
|---|---|---|
| 1 | 4 failed | 6 passed |
| 2 | 4 failed | 5 passed |
| 3 | 3 failed | 8 passed |
| 4 | collection ERROR (module absent) | 6 passed |

125 pass across the six touched files.

## Suite comparison — by NAME, not by count

Two runs with the same failure count can be failing different tests, so the
sorted `FAILED`+`ERROR` **name** lists were diffed (same files, develop src vs
this branch):

```
baseline lines: 24   fixed lines: 23

ONLY IN FIXED   (a NEW red introduced by this change — must be empty)
  (empty)

ONLY IN BASELINE (reds this change REMOVED)
  FAILED …/_listen/test__node_channel_forwarders.py::
         test_forward_via_ssh_curl_502s_when_helper_raises_value_error
```

**The branch's failure set is a strict subset of develop's.** The single
difference is that forwarder test, whose *provoking input* this change moved:
it used a single-quote bearer, which the helper rejected only because the value
was spliced into a single-quoted shell literal. It no longer is — so a quote is
now harmless and refusing it would be cargo-cult. What the new transport
genuinely cannot carry is a **newline** (the token is the first line of the
framed stdin). The forwarder behaviour under test, `ValueError` → 502, is
unchanged.

The remaining reds are pre-existing on develop. One of them,
`a2a/test__handlers.py::test_claude_session_reads_model_env_for_options`, is
**order-dependent** — green inside the group, red in isolation — and was
confirmed red against a **pristine `git archive HEAD` tree** (import path
verified resolving into that tree), so it is not attributable to this change.

## Audit

Unchanged from the develop baseline:
`0 unmasked error(s), 1 masked by skip-rules (1 declared); 14 line(s) inspected`
— identical summary and identical exit status on both.
