### PR TITLE
fix(jobs): host provisioning now applies AND arms every declared job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Nothing ever applied the declared JobSpecs to a host; provisioning now
+  does, and arming is collective.** sac declares nine periodic jobs and
+  registers them with scitex-dev correctly — `discover_jobs()` finds all
+  nine — but no code path in this repo had ever called an apply verb.
+  Measured before the change: `rg` over the whole tree for any
+  `ecosystem up|install` / `dev {timer,cron,service} install` invocation
+  returned **24 hits and zero of them executable** — READMEs, the
+  CHANGELOG, docstrings and test comments. `sac installation boot`, sac's
+  only host-provisioning path, listed seven steps and applied nothing.
+
+  Four states were being conflated, and only the first two were ever true:
+  **DECLARED** (a JobSpec in the repo), **REGISTERED** (`discover_jobs()`
+  can find it), **APPLIED** (a unit file exists on this host) and **ARMED**
+  (`systemctl enable`, the only state that fires). The mechanical cause of
+  the gap is that scitex-dev's `do_install` writes the unit files and then
+  merely PRINTS `systemctl --user enable --now <unit>` to stderr without
+  running it — so one `install` applied all nine timers and arming them
+  took nine hand-typed commands. On 2026-08-15 seven of ten sac timers
+  were duly found `disabled` on scitex-compute-04, including the sweep
+  that restarts agents wedged behind a frozen "Login expired" banner.
+
+  Two changes close the sac-side half. `sac dev timer enable` and
+  `sac dev cron enable` are now BULK verbs: given no NAME they arm every
+  declared job of that kind, exactly as `install` already did. `disable`
+  stays strictly per-name and the asymmetry is deliberate — bulk enable is
+  convergence, bulk disable is a fleet outage with one word of typing
+  (`sac.accounts-refresh` is the fleet's sole OAuth refresher against a
+  single-use token). And `sac installation boot` gained a step that
+  applies AND arms every declared job, reporting per-job APPLIED/ARMED
+  state and never aborting the bootstrap when a host cannot arm.
+
+  That step is the BASE CASE, stated as such: a convergence timer cannot
+  arm itself, so the recursion needs something that runs unconditionally
+  on a host with nothing. The periodic half that re-asserts the invariant
+  afterwards is deliberately NOT declared here — one job converging every
+  registered leaf belongs in scitex-dev's own provider, not as N copies in
+  N leaf packages. It is carded there
+  (`scitex-dev-collective-apply-and-convergence-for-declared-jobs-20260815`)
+  together with a second finding: `ecosystem up` lowers timer JobSpecs to
+  crontab lines while `ecosystem dev timer install` writes per-leaf units,
+  both surfaces are live, and calling the former on a host carrying the
+  latter would double-supervise all nine sac timers.
+
+### Changed
+
+- **`cli_pkg/_dev_jobs.py` split at the line it already had.** The
+  grammar tables (`GROUP_KINDS`, `GROUP_VERBS`, `Deprecation`, the verb
+  shape sets) move to `cli_pkg/_dev_jobs_grammar.py`; `_dev_jobs.py` keeps
+  the Click command builders and re-exports every public name, so
+  `_jobs_audit` and the existing tests are untouched. The file was at
+  512/512 lines; it is now 371.
+
 ### Removed
 
 - **`spec.container.runtime` — the container-ENGINE choice is abolished.**

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -4,6 +4,9 @@ THE GROUP NAME IS THE ``JobSpec.kind``. That is the whole design, it is
 the ecosystem-wide grammar (operator decision, 2026-08-11 — every SciTeX
 package exposes ``scitex-<pkg> dev {service,timer,cron} <verb>``), and it
 is the countermeasure to the outage below rather than a cosmetic rename.
+The tables that encode it now live in :mod:`._dev_jobs_grammar`; this
+module holds the Click command builders that consume them, and
+re-exports every public name so existing imports keep resolving.
 
 WHAT THE OLD SHAPE COST
 =======================
@@ -58,6 +61,21 @@ filtered ``kind="daemon"``, never legal, and delegated to an
 ``ecosystem daemon`` that does not exist). A long-running job is
 ``kind="service"``.
 
+INSTALL IS NOT ENABLE, WHICH IS WHY ``enable`` IS BULK
+======================================================
+``install`` and ``enable`` are both bulk verbs here: given no NAME they
+act on every job of the kind. That is not symmetry for its own sake.
+scitex-dev's ``_jobs_units.do_install`` writes the unit files and then
+merely PRINTS the ``systemctl --user enable --now`` line to stderr, so a
+host that has been "installed" carries N correct, INERT units. Arming
+them was N hand-typed commands until 2026-08-15, and seven of sac's ten
+timers were duly found ``disabled`` on scitex-compute-04. ``disable``
+stays strictly per-name — the reasoning for the asymmetry is on
+:data:`._dev_jobs_grammar._BULK_VERBS`.
+
+The collective apply that CALLS these verbs from host provisioning lives
+in :mod:`._dev_jobs_apply`.
+
 Graceful degradation: a scitex-dev that predates the ``scitex_dev.jobs``
 contract raises ``ImportError`` on the lazy import; every command catches
 it and prints an upgrade hint instead of a stack trace.
@@ -72,175 +90,20 @@ These commands are attached onto ``dev_group`` at import time via
 
 from __future__ import annotations
 
-import re
-from dataclasses import dataclass
-
 import click
 
 from .._jobs import _names
 from . import _dev_jobs_backend as _backend
-
-# The scitex-dev release that first ships ``scitex_dev.jobs`` (PR #91).
-# scitex-dev 0.15.0 is the last release WITHOUT it; the jobs contract is
-# in scitex-dev's Unreleased section -> first available in 0.16.0.
-_JOBS_MIN_VERSION = "0.16.0"
-
-#: ``sac dev <group>`` -> the ``JobSpec.kind`` values that group lists.
-#:
-#: THE SSOT for this mapping, and the reason it is module-level rather
-#: than inlined: ``_jobs_audit.audit_jobs`` imports THIS dict to check
-#: that every kind sac declares has a consumer able to see it, and that
-#: no group filters on a kind the validator would reject. If the audit
-#: re-declared the mapping instead of importing the one production uses,
-#: the audit would be checking its own opinion — a declaration with no
-#: live counterpart, i.e. the exact disease it exists to detect.
-#:
-#: Every entry except the deprecated alias maps a group to EXACTLY the
-#: kind of the same name. That identity is the invariant; it is checked,
-#: not trusted.
-GROUP_KINDS: dict[str, frozenset[str]] = {
-    "service": frozenset({"service"}),
-    "timer": frozenset({"timer"}),
-    "cron": frozenset({"cron"}),
-    # Deprecated alias — see DEPRECATED_GROUPS. Covers both unit kinds,
-    # which is what `scitex-dev ecosystem systemd` has always selected.
-    "systemd": frozenset({"service", "timer"}),
-}
-
-_YYYY_MM = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
-
-
-@dataclass(frozen=True)
-class Deprecation:
-    """A dated retirement plan for a CLI surface.
-
-    Every field is load-bearing and validated at construction, because a
-    deprecation with a missing or malformed date is indistinguishable
-    from no deprecation at all — which is how "temporary" aliases become
-    permanent API.
-    """
-
-    since: str
-    remove_after: str
-    replacement: str
-
-    def __post_init__(self) -> None:
-        for field, value in (
-            ("since", self.since),
-            ("remove_after", self.remove_after),
-        ):
-            if not _YYYY_MM.match(value):
-                raise ValueError(
-                    f"Deprecation.{field}={value!r} must be YYYY-MM — a vague "
-                    "date is the same as no date"
-                )
-        if self.remove_after <= self.since:
-            raise ValueError(
-                f"Deprecation.remove_after={self.remove_after!r} must be after "
-                f"since={self.since!r}"
-            )
-        if not self.replacement:
-            raise ValueError(
-                "Deprecation.replacement must name what to use instead — a "
-                "deprecation with no replacement is just a complaint"
-            )
-
-    def is_expired(self, today: str) -> bool:
-        """True once ``today`` (``YYYY-MM``) is past ``remove_after``."""
-        if not _YYYY_MM.match(today):
-            raise ValueError(f"today={today!r} must be YYYY-MM")
-        return today > self.remove_after
-
-    def notice(self, group: str) -> str:
-        """The stderr line printed on every use of the deprecated group."""
-        return (
-            f"DEPRECATED: `sac dev {group}` is deprecated since {self.since} "
-            f"and will be REMOVED after {self.remove_after}. "
-            f"Use: {self.replacement}. "
-            "(The group name is now the JobSpec kind — `systemd` is a "
-            "delivery mechanism, not a kind.)"
-        )
-
-
-#: Groups kept only for compatibility. A group listed here MUST also be
-#: in GROUP_KINDS; the audit checks that a deprecated alias never becomes
-#: the only way to reach a kind.
-DEPRECATED_GROUPS: dict[str, Deprecation] = {
-    "systemd": Deprecation(
-        since="2026-08",
-        remove_after="2026-10",
-        replacement="`sac dev service` / `sac dev timer`",
-    ),
-}
-
-#: Verbs that take a job NAME and act on ONE job.
-_NAMED_VERBS: frozenset[str] = frozenset(
-    {"status", "start", "stop", "restart", "enable", "disable"}
+from ._dev_jobs_grammar import (
+    _BULK_VERBS,
+    _JOBS_MIN_VERSION,
+    _NAMED_VERBS,
+    _VERB_SUMMARY,
+    DEPRECATED_GROUPS,
+    Deprecation,
+    GROUP_KINDS,
+    GROUP_VERBS,
 )
-
-#: How each verb reads at the start of its one-line help. Spelled out
-#: rather than ``verb.capitalize()`` because that produces "Status one of
-#: sac's timer jobs", which is not a sentence.
-_VERB_SUMMARY: dict[str, str] = {
-    "status": "Show the status of",
-    "start": "Start",
-    "stop": "Stop",
-    "restart": "Restart",
-    "enable": "Enable",
-    "disable": "Disable",
-    "install": "Install",
-    "uninstall": "Uninstall",
-}
-
-#: Verbs that act on EVERY job of the kind unless given an optional name,
-#: and mutate the host, so they require ``--yes``.
-_BULK_VERBS: frozenset[str] = frozenset({"install", "uninstall"})
-
-#: ``sac dev <group>`` -> its verbs. Per KIND, deliberately not uniform.
-#:
-#: MATCHED VERBATIM to scitex-dev's counterpart (PR #566), because the
-#: grammar is only worth anything if the two agree. A verb sac exposed
-#: that the shared layer will never serve is a permanent exit-4 — a
-#: declaration with no live counterpart, which is precisely what
-#: ``_jobs_audit`` exists to eliminate. Two deliberate consequences:
-#:
-#: * ``service`` has NO ``enable``/``disable``. systemd services support
-#:   them and an earlier revision here exposed them, but #566 does not,
-#:   so they would be inert. If #566 adds them, add them back.
-#: * ``cron`` has NO ``exec``, which #566 does have. sac declares no
-#:   ``kind="cron"`` job, and ``exec``'s argv shape is positional
-#:   (``exec <name> --apply``) rather than the uniform ``--name`` every
-#:   other verb takes — measured on scitex-dev 0.43.1. Wiring an
-#:   untestable special case for an empty group is the same disease in
-#:   the other direction; it belongs with the first cron job sac owns.
-#:
-#: The rest is per-kind reasoning:
-#:
-#: * ``service`` — a long-running unit: the runtime lifecycle applies.
-#: * ``timer``   — scheduled, not run by hand. ``enable``/``disable`` is
-#:   the systemd idiom for a timer (``enable --now`` starts it), so
-#:   ``start``/``stop``/``restart`` would be three ways to say the same
-#:   thing with different edge cases.
-#: * ``cron``    — a crontab line is present or commented out. There is
-#:   no runtime object to start, stop or ask for status, so those verbs
-#:   do not exist here instead of existing and erroring.
-#: * ``systemd`` — the deprecated alias keeps EXACTLY its historical
-#:   surface. New verbs are reachable only through the kind groups, so
-#:   nothing new can be built on the alias.
-GROUP_VERBS: dict[str, tuple[str, ...]] = {
-    "service": (
-        "list",
-        "status",
-        "start",
-        "stop",
-        "restart",
-        "install",
-        "uninstall",
-    ),
-    "timer": ("list", "status", "enable", "disable", "install", "uninstall"),
-    "cron": ("list", "enable", "disable", "install", "uninstall"),
-    "systemd": ("list", "install", "uninstall"),
-}
 
 
 def _degrade_msg() -> str:
@@ -377,7 +240,7 @@ def _add_list_command(grp, group: str) -> None:
 
 
 def _add_bulk_command(grp, group: str, verb: str) -> None:
-    """Attach ``install`` / ``uninstall``: every job of the kind, or one."""
+    """Attach a verb that acts on every job of the kind, or one named one."""
 
     @grp.command(verb)
     @click.argument("name", required=False)

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_apply.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_apply.py
@@ -1,0 +1,282 @@
+"""The BASE-CASE apply: sac's DECLARATIONS become ARMED units on this host.
+
+FOUR STATES, AND CONFLATING THEM IS THE BUG
+===========================================
+This module exists because four different things were being called "the
+job is set up", and only the first two were ever true:
+
+* **DECLARED** — a :class:`~scitex_dev.jobs.JobSpec` exists in this repo
+  (``_jobs._jobs_plugin.provide_jobs``). Nine of them, all
+  ``kind="timer"``.
+* **REGISTERED** — ``scitex_dev.jobs.discover_jobs()`` can FIND those
+  specs, via the ``scitex_dev.jobs`` entry point declared in
+  ``pyproject.toml``. Measured 2026-08-15: it finds all nine.
+* **APPLIED** — a unit file (or crontab line) for the job exists on THIS
+  host. Nothing in sac has ever produced one.
+* **ARMED** — the applied unit is ``enabled``, i.e. it will actually
+  fire. Nothing in sac has ever produced this either, and it is a
+  SEPARATE step from APPLIED rather than a consequence of it.
+
+The last point is the whole defect, and it is mechanical rather than
+philosophical. scitex-dev's ``_jobs_units.do_install`` writes the unit
+files and then merely PRINTS the arming command to stderr::
+
+    click.echo("Enable with:", err=True)
+    click.echo(f"  systemctl --user enable --now {enable_target(kind, job)}", err=True)
+
+It never runs it. So "install everything" leaves a host carrying N
+correct, inert unit files plus N stderr lines a human is expected to
+copy-paste one at a time. On 2026-08-15 seven of ten sac timers were
+sitting ``disabled`` on scitex-compute-04 — including the sweep that
+restarts agents wedged behind a frozen "Login expired" banner, the
+failure that had taken out three agents overnight. That is not an
+accident anyone made; it is the arithmetic of the surface.
+
+WHY THIS IS A BASE CASE AND NOT A TIMER
+=======================================
+The obvious fix is "declare a convergence job that re-asserts
+declared-equals-armed". That fix cannot stand alone, because a
+convergence timer is itself a declared job: nothing would arm IT either.
+So the recursion needs a base case, and the base case must be something
+that runs UNCONDITIONALLY on a host that has nothing yet — i.e. host
+provisioning. :func:`apply_declared_jobs` is that step, and
+``sac installation boot`` is where it is called from.
+
+The PERIODIC half — re-asserting the invariant so hand-disables and
+rebuilt hosts self-correct — is deliberately NOT declared here. One job
+that converges EVERY registered leaf belongs in scitex-dev's own
+provider; a copy of it in each leaf package is N copies of one job, which
+is the shape ``_dev_jobs_backend`` already argues against at length.
+
+WHAT THIS MODULE DOES NOT OWN
+=============================
+No ``systemctl`` call lives here. Every step is delegated through
+:func:`._dev_jobs._delegate`, the single mutation seam, which resolves
+and shells ``scitex-dev ecosystem <path...> <verb>``. sac decides WHICH
+jobs and IN WHAT ORDER; scitex-dev decides what a unit is and how a host
+is touched. That split is the fleet's standing pattern — the primitive
+lives in scitex-dev, the leaf declares its specifics — and it is the
+reason this file is ~200 lines instead of a second unit renderer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from . import _dev_jobs
+
+#: The kinds provisioning walks, in the order it walks them.
+#:
+#: Read off ``_dev_jobs.GROUP_KINDS`` rather than restated, minus the
+#: deprecated ``systemd`` alias — applying through an alias would apply
+#: its two real kinds a second time, and the double-supervision guard in
+#: scitex-dev would then refuse work that had just succeeded.
+APPLY_KINDS: tuple[str, ...] = ("service", "timer", "cron")
+
+#: The verbs that turn a declaration into a firing job, IN ORDER.
+#:
+#: ``install`` makes it APPLIED; ``enable`` makes it ARMED. Both, always,
+#: and in this order — the entire point of this module is that the second
+#: one is not optional and does not follow from the first.
+APPLY_SEQUENCE: tuple[str, ...] = ("install", "enable")
+
+
+@dataclass(frozen=True)
+class Step:
+    """One delegated verb, for one declared job, and what it returned.
+
+    ``rc`` is the exit code the delegation produced. It is recorded per
+    step rather than folded into a single boolean because "the unit was
+    written but could not be enabled" and "the unit was never written"
+    are different failures with different remedies, and a report that
+    cannot tell them apart sends the operator to the wrong place.
+    """
+
+    kind: str
+    verb: str
+    job: str
+    rc: int
+
+    @property
+    def ok(self) -> bool:
+        return self.rc == 0
+
+    def __str__(self) -> str:
+        state = "ok" if self.ok else f"rc={self.rc}"
+        return f"{self.kind} {self.verb} {self.job}: {state}"
+
+
+@dataclass(frozen=True)
+class ApplyReport:
+    """Everything one apply pass did, and everything it could not do."""
+
+    steps: tuple[Step, ...] = ()
+    #: ``"<kind>: <reason>"`` for a kind that was not attempted at all.
+    skipped: tuple[str, ...] = ()
+
+    @property
+    def failed(self) -> tuple[Step, ...]:
+        return tuple(s for s in self.steps if not s.ok)
+
+    @property
+    def ok(self) -> bool:
+        """True when every attempted step succeeded and none was skipped.
+
+        A skip counts against ``ok`` on purpose. A pass that could not
+        even look at a kind has not established the invariant for it, and
+        reporting that as success is the exact "the success value is also
+        the didn't-check value" shape this card is about.
+        """
+        return not self.failed and not self.skipped
+
+    @property
+    def jobs_armed(self) -> tuple[str, ...]:
+        """Jobs whose ``enable`` step returned 0 — the ARMED set."""
+        return tuple(
+            s.job for s in self.steps if s.verb == "enable" and s.ok
+        )
+
+    @property
+    def jobs_applied(self) -> tuple[str, ...]:
+        """Jobs whose ``install`` step returned 0 — the APPLIED set."""
+        return tuple(
+            s.job for s in self.steps if s.verb == "install" and s.ok
+        )
+
+    def summary(self) -> str:
+        """A one-line verdict that never says more than it measured."""
+        n_jobs = len({s.job for s in self.steps})
+        parts = [
+            f"{n_jobs} declared job(s): "
+            f"{len(self.jobs_applied)} applied, {len(self.jobs_armed)} armed"
+        ]
+        if self.failed:
+            parts.append(f"{len(self.failed)} step(s) FAILED")
+        if self.skipped:
+            parts.append(f"{len(self.skipped)} kind(s) skipped")
+        return "; ".join(parts)
+
+
+def apply_verbs(kind: str) -> tuple[str, ...]:
+    """The apply sequence restricted to verbs ``kind`` actually has.
+
+    Reads :data:`._dev_jobs.GROUP_VERBS` — the SSoT that is already
+    matched verbatim to scitex-dev's counterpart — rather than restating
+    it. The live consequence today is ``kind="service"``, which has no
+    ``enable`` verb (scitex-dev #566 does not serve one, so exposing it
+    would be a permanent exit-4): a service is APPLIED by this path and
+    NOT ARMED by it, and the report says so instead of implying
+    otherwise.
+    """
+    have = _dev_jobs.GROUP_VERBS.get(kind, ())
+    return tuple(v for v in APPLY_SEQUENCE if v in have)
+
+
+def apply_kind(
+    kind: str,
+    *,
+    yes: bool,
+    dry_run: bool = False,
+    delegate: Callable[..., int] | None = None,
+    echo: Callable[[str], None] | None = None,
+) -> ApplyReport:
+    """Apply + arm every job sac declares of one ``kind``.
+
+    ``delegate`` defaults to :func:`._dev_jobs._delegate`, the single
+    mutation seam. A test passes its own to capture the exact
+    ``(kind, verb, name, yes, dry_run)`` tuples without letting a real
+    ``scitex-dev`` rewrite the host's units.
+    """
+    run = delegate if delegate is not None else _dev_jobs._delegate
+    log = echo if echo is not None else (lambda _s: None)
+
+    try:
+        jobs = _dev_jobs._load_sac_jobs(_dev_jobs.GROUP_KINDS[kind])
+    except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — record a named skip, never a silent success)
+        reason = f"{kind}: scitex-dev is too old to serve `scitex_dev.jobs`"
+        log(reason)
+        return ApplyReport(skipped=(reason,))
+
+    if not jobs:
+        # Not a skip: there is genuinely nothing of this kind to apply, so
+        # the invariant holds vacuously. Recording it as skipped would
+        # make a correct host look unconverged forever.
+        return ApplyReport()
+
+    verbs = apply_verbs(kind)
+    if not verbs:
+        reason = f"{kind}: no apply verbs available on this grammar"
+        log(reason)
+        return ApplyReport(skipped=(reason,))
+
+    steps: list[Step] = []
+    for job in jobs:
+        for verb in verbs:
+            rc = _run_step(run, kind, verb, job.name, yes=yes, dry_run=dry_run)
+            step = Step(kind=kind, verb=verb, job=job.name, rc=rc)
+            steps.append(step)
+            log(f"  {step}")
+    return ApplyReport(steps=tuple(steps))
+
+
+def _run_step(
+    run: Callable[..., int],
+    kind: str,
+    verb: str,
+    name: str,
+    *,
+    yes: bool,
+    dry_run: bool,
+) -> int:
+    """Delegate one verb, converting an abort into a recorded exit code.
+
+    ``_delegate`` raises ``SystemExit(4)`` when the installed scitex-dev
+    cannot serve a verb. Letting that propagate would abandon the
+    remaining jobs mid-pass and leave the host in a state nobody
+    recorded — so it is caught, recorded, and the pass continues. An
+    unarmed job that is REPORTED is recoverable; an unarmed job nobody
+    counted is what this card is about.
+    """
+    try:
+        return int(run(kind, verb, name, yes, dry_run))
+    except SystemExit as exc:  # stx-allow: fallback (reason: a verb the installed scitex-dev cannot serve must not abandon the remaining jobs)
+        code = exc.code
+        return code if isinstance(code, int) else 1
+
+
+def apply_declared_jobs(
+    *,
+    yes: bool,
+    dry_run: bool = False,
+    kinds: Iterable[str] = APPLY_KINDS,
+    delegate: Callable[..., int] | None = None,
+    echo: Callable[[str], None] | None = None,
+) -> ApplyReport:
+    """Apply + arm EVERY job sac declares, across every kind.
+
+    This is the collective, idempotent, base-case step host provisioning
+    calls. It is safe to re-run: scitex-dev's ``install`` refuses to
+    write over an existing supervisor rather than creating a second one,
+    and ``enable`` on an already-enabled unit is a no-op.
+    """
+    steps: list[Step] = []
+    skipped: list[str] = []
+    for kind in kinds:
+        report = apply_kind(
+            kind, yes=yes, dry_run=dry_run, delegate=delegate, echo=echo
+        )
+        steps.extend(report.steps)
+        skipped.extend(report.skipped)
+    return ApplyReport(steps=tuple(steps), skipped=tuple(skipped))
+
+
+__all__ = [
+    "APPLY_KINDS",
+    "APPLY_SEQUENCE",
+    "ApplyReport",
+    "Step",
+    "apply_declared_jobs",
+    "apply_kind",
+    "apply_verbs",
+]

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_grammar.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_grammar.py
@@ -1,0 +1,227 @@
+"""The SSoT tables for the ``sac dev <group> <verb>`` job grammar.
+
+Extracted from :mod:`._dev_jobs`, which now holds only the Click command
+builders. The split is along the line that already existed: these tables
+are IMPORTED BY ``_jobs_audit`` to machine-check the grammar, so they
+were never private detail of the command builders — they are a shared
+declaration that the builders happen to be the first consumer of.
+
+THE GROUP NAME IS THE ``JobSpec.kind``. That identity is the whole design
+(operator decision, 2026-08-11 — every SciTeX package exposes
+``scitex-<pkg> dev {service,timer,cron} <verb>``) and it is a
+countermeasure, not a rename: the groups used to be named after the
+DELIVERY MECHANISM (``cron``/``systemd``) while the filter was the KIND,
+and ``_load_sac_jobs`` was then called with the GROUP NAME. ``sac dev
+systemd list`` therefore asked for ``kind="systemd"``, a value
+``JobSpec.validate()`` rejects, so every timer sac owns was invisible to
+its own CLI while reporting "No sac systemd-kind jobs." and exit 0.
+
+``_jobs_audit.audit_jobs`` imports :data:`GROUP_KINDS` from here rather
+than re-declaring it, because an audit that restated the mapping would be
+checking its own opinion — a declaration with no live counterpart, i.e.
+the exact disease it exists to detect.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# The scitex-dev release that first ships ``scitex_dev.jobs`` (PR #91).
+# scitex-dev 0.15.0 is the last release WITHOUT it; the jobs contract is
+# in scitex-dev's Unreleased section -> first available in 0.16.0.
+_JOBS_MIN_VERSION = "0.16.0"
+
+#: ``sac dev <group>`` -> the ``JobSpec.kind`` values that group lists.
+#:
+#: Every entry except the deprecated alias maps a group to EXACTLY the
+#: kind of the same name. That identity is the invariant; it is checked
+#: by ``_jobs_audit`` (``Form.GROUP_IS_NOT_ITS_KIND``), not trusted.
+GROUP_KINDS: dict[str, frozenset[str]] = {
+    "service": frozenset({"service"}),
+    "timer": frozenset({"timer"}),
+    "cron": frozenset({"cron"}),
+    # Deprecated alias — see DEPRECATED_GROUPS. Covers both unit kinds,
+    # which is what `scitex-dev ecosystem systemd` has always selected.
+    "systemd": frozenset({"service", "timer"}),
+}
+
+_YYYY_MM = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
+
+
+@dataclass(frozen=True)
+class Deprecation:
+    """A dated retirement plan for a CLI surface.
+
+    Every field is load-bearing and validated at construction, because a
+    deprecation with a missing or malformed date is indistinguishable
+    from no deprecation at all — which is how "temporary" aliases become
+    permanent API.
+    """
+
+    since: str
+    remove_after: str
+    replacement: str
+
+    def __post_init__(self) -> None:
+        for field, value in (
+            ("since", self.since),
+            ("remove_after", self.remove_after),
+        ):
+            if not _YYYY_MM.match(value):
+                raise ValueError(
+                    f"Deprecation.{field}={value!r} must be YYYY-MM — a vague "
+                    "date is the same as no date"
+                )
+        if self.remove_after <= self.since:
+            raise ValueError(
+                f"Deprecation.remove_after={self.remove_after!r} must be after "
+                f"since={self.since!r}"
+            )
+        if not self.replacement:
+            raise ValueError(
+                "Deprecation.replacement must name what to use instead — a "
+                "deprecation with no replacement is just a complaint"
+            )
+
+    def is_expired(self, today: str) -> bool:
+        """True once ``today`` (``YYYY-MM``) is past ``remove_after``."""
+        if not _YYYY_MM.match(today):
+            raise ValueError(f"today={today!r} must be YYYY-MM")
+        return today > self.remove_after
+
+    def notice(self, group: str) -> str:
+        """The stderr line printed on every use of the deprecated group."""
+        return (
+            f"DEPRECATED: `sac dev {group}` is deprecated since {self.since} "
+            f"and will be REMOVED after {self.remove_after}. "
+            f"Use: {self.replacement}. "
+            "(The group name is now the JobSpec kind — `systemd` is a "
+            "delivery mechanism, not a kind.)"
+        )
+
+
+#: Groups kept only for compatibility. A group listed here MUST also be
+#: in GROUP_KINDS; the audit checks that a deprecated alias never becomes
+#: the only way to reach a kind.
+#:
+#: The notice goes to STDERR, never stdout: ``sac`` commands are parsed by
+#: machines, and a courtesy message on stdout is indistinguishable from
+#: data. "当面" becomes permanent unless a date is written down, and a
+#: date nobody enforces is the same thing — so ``test__dev_jobs.py``
+#: fails the build once ``remove_after`` passes.
+DEPRECATED_GROUPS: dict[str, Deprecation] = {
+    "systemd": Deprecation(
+        since="2026-08",
+        remove_after="2026-10",
+        replacement="`sac dev service` / `sac dev timer`",
+    ),
+}
+
+#: Verbs that take a job NAME and act on ONE job.
+#:
+#: ``enable`` is DELIBERATELY ABSENT and ``disable`` deliberately present
+#: — see :data:`_BULK_VERBS` for why the two halves of one switch are not
+#: symmetric.
+_NAMED_VERBS: frozenset[str] = frozenset(
+    {"status", "start", "stop", "restart", "disable"}
+)
+
+#: How each verb reads at the start of its one-line help. Spelled out
+#: rather than ``verb.capitalize()`` because that produces "Status one of
+#: sac's timer jobs", which is not a sentence.
+_VERB_SUMMARY: dict[str, str] = {
+    "status": "Show the status of",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "enable": "Enable",
+    "disable": "Disable",
+    "install": "Install",
+    "uninstall": "Uninstall",
+}
+
+#: Verbs that act on EVERY job of the kind unless given an optional name,
+#: and mutate the host, so they require ``--yes``.
+#:
+#: WHY ``enable`` IS HERE AND ``disable`` IS NOT
+#: ============================================
+#: ``install`` has always been bulk; ``enable`` was per-name until
+#: 2026-08-15. That asymmetry was not cosmetic, because APPLIED and ARMED
+#: are different states and only the second one fires: scitex-dev's
+#: ``_jobs_units.do_install`` writes the unit files and then merely
+#: PRINTS ``systemctl --user enable --now <unit>`` to stderr without
+#: running it. So ONE ``install`` command applied all nine of sac's
+#: timers, and arming them took NINE more commands typed by hand — which
+#: is how seven of ten came to be sitting ``disabled`` on
+#: scitex-compute-04 while every declaration, registration and unit file
+#: was perfectly correct. A collective apply whose arming half is
+#: per-name is not a collective apply.
+#:
+#: ``disable`` stays strictly per-name, and that asymmetry is the point.
+#: Bulk ENABLE is convergence: it drives the host toward the DECLARED
+#: state, it is idempotent, and its worst case is a job that was already
+#: running. Bulk DISABLE is not its inverse — it is a fleet outage with
+#: one word of typing. ``sac.accounts-refresh`` is the fleet's SOLE OAuth
+#: refresher against a single-use refresh token, and every account
+#: expires within one access-token lifetime once it stops. No convergence
+#: story requires disarming everything at once, so the verb does not
+#: offer it.
+_BULK_VERBS: frozenset[str] = frozenset({"install", "uninstall", "enable"})
+
+#: ``sac dev <group>`` -> its verbs. Per KIND, deliberately not uniform.
+#:
+#: MATCHED VERBATIM to scitex-dev's counterpart (PR #566), because the
+#: grammar is only worth anything if the two agree. A verb sac exposed
+#: that the shared layer will never serve is a permanent exit-4 — a
+#: declaration with no live counterpart, which is precisely what
+#: ``_jobs_audit`` exists to eliminate. Two deliberate consequences:
+#:
+#: * ``service`` has NO ``enable``/``disable``. systemd services support
+#:   them and an earlier revision here exposed them, but #566 does not,
+#:   so they would be inert. If #566 adds them, add them back. The live
+#:   cost is recorded in ``_dev_jobs_apply.apply_verbs``: a service is
+#:   APPLIED by the provisioning path and NOT ARMED by it.
+#: * ``cron`` has NO ``exec``, which #566 does have. sac declares no
+#:   ``kind="cron"`` job, and ``exec``'s argv shape is positional rather
+#:   than the uniform ``--name`` every other verb takes — measured on
+#:   scitex-dev 0.43.1. Wiring an untestable special case for an empty
+#:   group is the same disease in the other direction; it belongs with
+#:   the first cron job sac owns.
+#:
+#: The rest is per-kind reasoning:
+#:
+#: * ``service`` — a long-running unit: the runtime lifecycle applies.
+#: * ``timer``   — scheduled, not run by hand. ``enable``/``disable`` is
+#:   the systemd idiom for a timer (``enable --now`` starts it), so
+#:   ``start``/``stop``/``restart`` would be three ways to say the same
+#:   thing with different edge cases.
+#: * ``cron``    — a crontab line is present or commented out. There is
+#:   no runtime object to start, stop or ask for status, so those verbs
+#:   do not exist here instead of existing and erroring.
+#: * ``systemd`` — the deprecated alias keeps EXACTLY its historical
+#:   surface. New verbs are reachable only through the kind groups, so
+#:   nothing new can be built on the alias. In particular it does NOT
+#:   gain the bulk ``enable``.
+GROUP_VERBS: dict[str, tuple[str, ...]] = {
+    "service": (
+        "list",
+        "status",
+        "start",
+        "stop",
+        "restart",
+        "install",
+        "uninstall",
+    ),
+    "timer": ("list", "status", "enable", "disable", "install", "uninstall"),
+    "cron": ("list", "enable", "disable", "install", "uninstall"),
+    "systemd": ("list", "install", "uninstall"),
+}
+
+
+__all__ = [
+    "DEPRECATED_GROUPS",
+    "Deprecation",
+    "GROUP_KINDS",
+    "GROUP_VERBS",
+]

--- a/src/scitex_agent_container/cli_pkg/installation_group.py
+++ b/src/scitex_agent_container/cli_pkg/installation_group.py
@@ -86,7 +86,22 @@ def boot(dry_run: bool) -> None:  # noqa: C901
       4. Verify tmux is on PATH (prints instructions if missing).
       5. Create ~/.scitex/agent-container/{agents,skills,runtime/{logs,cron}}/.
       6. Copy bundled post-merge-pull.sh to the cron dir (chmod +x).
-      7. Print "boot OK" and the installed sac version.
+      7. Apply AND ARM every job this package declares (see below).
+      8. Print "boot OK" and the installed sac version.
+
+    \b
+    Step 7 is the BASE CASE of the declared-job invariant, and it is the
+    reason this command is the right place for it. A JobSpec in the repo
+    is DECLARED; the `scitex_dev.jobs` entry point makes it REGISTERED;
+    neither of those puts anything on a host. The step that does — write
+    the unit, then ENABLE it — had no caller at all until 2026-08-15, so
+    every host was armed by hand and a rebuilt one started bare. It
+    cannot be fixed by declaring a convergence timer, because nothing
+    would arm THAT timer either; the recursion needs a step that runs
+    unconditionally on a host with nothing, which is this one. The
+    periodic half that re-asserts the invariant afterwards belongs to
+    scitex-dev, so that one job converges every registered package
+    instead of each package shipping its own copy.
 
     \b
     Example:
@@ -177,7 +192,12 @@ def boot(dry_run: bool) -> None:  # noqa: C901
     _deploy_cron_script(dry_run=dry_run, tag=tag)
 
     # ------------------------------------------------------------------
-    # Step 7 — summary
+    # Step 7 — apply + ARM every job this package declares
+    # ------------------------------------------------------------------
+    _apply_declared_jobs_step(dry_run=dry_run, tag=tag)
+
+    # ------------------------------------------------------------------
+    # Step 8 — summary
     # ------------------------------------------------------------------
     if dry_run:
         console.print("[dim]dry-run complete — no changes were made.[/dim]")
@@ -192,6 +212,62 @@ def boot(dry_run: bool) -> None:  # noqa: C901
         console.print(f"[green bold]boot OK[/green bold] — {ver}")
         console.print(
             "[dim]Re-source your shell or open a new terminal to pick up the PATH change.[/dim]"
+        )
+
+
+def _apply_declared_jobs_step(dry_run: bool, tag: str) -> None:
+    """Turn this package's DECLARED jobs into APPLIED, ARMED units.
+
+    Four states, and the whole point of this step is that the last two do
+    not follow from the first two: a JobSpec in the repo is DECLARED, the
+    ``scitex_dev.jobs`` entry point makes it REGISTERED, a unit file on
+    this host makes it APPLIED, and ``systemctl enable`` makes it ARMED.
+    Only ARMED fires. Nothing in sac produced either of the last two
+    until this step existed.
+
+    Delegated wholesale to :func:`._dev_jobs_apply.apply_declared_jobs`,
+    which routes every verb through scitex-dev. Nothing here knows what a
+    unit file is.
+
+    NEVER FATAL. A failure to arm is reported loudly and does not abort
+    the bootstrap: the venv, PATH and shared dirs from steps 1-6 are what
+    every other recovery path needs, and throwing them away because a
+    timer would not enable would turn a degraded host into an unusable
+    one. The report is the deliverable — an unarmed job that is COUNTED
+    is recoverable; an unarmed job nobody counted is the defect this step
+    exists to end.
+    """
+    from ._dev_jobs_apply import apply_declared_jobs
+
+    console.print(f"{tag}Applying + arming declared jobs…")
+    try:
+        report = apply_declared_jobs(
+            yes=not dry_run,
+            dry_run=dry_run,
+            echo=lambda line: console.print(f"{tag}{line}"),
+        )
+    except Exception as exc:  # noqa: BLE001 — see NEVER FATAL above
+        console.print(
+            f"[yellow]WARNING:[/yellow] could not apply declared jobs: {exc}\n"
+            "  Steps 1-6 completed. Re-run `sac installation boot` once "
+            "scitex-dev is healthy, or apply by hand with "
+            "`sac dev timer install --yes && sac dev timer enable --yes`."
+        )
+        return
+
+    console.print(f"{tag}jobs: {report.summary()}")
+    for line in report.skipped:
+        console.print(f"[yellow]WARNING:[/yellow] skipped {line}")
+    for step in report.failed:
+        console.print(f"[red]FAILED:[/red] {step}")
+    if report.failed:
+        # Naming the remedy matters more than the failure: `install`
+        # refusing because a supervisor already exists is a SAFE outcome,
+        # while `enable` failing means the job genuinely will not fire.
+        console.print(
+            "[dim]  `install` may refuse when a supervisor already exists — "
+            "that is safe. A failed `enable` is not: the job will not "
+            "fire.[/dim]"
         )
 
 

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
@@ -1,0 +1,476 @@
+"""A DECLARED job must become an APPLIED, ARMED one — proven, not parsed.
+
+WHY A PARSE TEST WOULD BE THE BUG, NOT THE PROOF
+================================================
+``tests/.../_jobs/test__jobs_plugin.py`` already proves sac's nine
+JobSpecs are well-formed, correctly kinded and discoverable. Every one of
+those tests was GREEN throughout the whole period in which seven of ten
+sac timers sat ``disabled`` on scitex-compute-04 — because a JobSpec
+being valid says nothing about whether anything ever applies it. A test
+that only checks the declaration parses is a restatement of the defect.
+
+These tests assert the LINK instead: that for every job sac actually
+declares, the provisioning path emits BOTH an ``install`` (→ APPLIED) and
+an ``enable`` (→ ARMED) delegation, and that scitex-dev's real renderer
+turns each declaration into a real systemd unit carrying the declared
+command.
+
+WHAT IS PROVEN HERE, AND WHAT IS NOT
+====================================
+PROVEN, with no mocks: every declared job reaches BOTH verbs, in order;
+the bulk ``enable`` surface exists so arming is collective; ``disable``
+is still per-name so the convergence verb has no fleet-wide off switch;
+``sac installation boot`` — the one host-provisioning path — really
+drives that sequence; and scitex-dev's real renderer materialises each
+declaration into a ``.timer``/``.service`` pair whose ``ExecStart`` is
+the declared command.
+
+NOT PROVEN HERE, stated rather than glossed: that ``systemctl`` then
+really arms the unit on a host. That needs a live ``systemd --user``
+manager, which CI does not have, and scitex-dev's installer refuses with
+exit 3 where none exists. The proof for that step is the replay the card
+specifies — take a host with none armed, run the provisioning path,
+confirm every declared job comes up ``enabled``, then disable one by hand
+and confirm the convergence job restores it. The convergence half is
+carded to scitex-dev, so that replay cannot be run from this repo alone.
+
+SEAM, NOT MOCK (PA-306): the one injected callable is
+``_dev_jobs._delegate``, exactly as ``test__dev_jobs.py`` already does.
+It is the boundary where sac stops deciding and scitex-dev starts
+touching the host; capturing it observes the delegation ARGUMENTS
+without letting a real ``scitex-dev`` rewrite the machine's units.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner
+
+pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+import scitex_agent_container.cli_pkg._dev_jobs as dj  # noqa: E402
+from scitex_agent_container.cli_pkg._dev_jobs_apply import (  # noqa: E402
+    APPLY_SEQUENCE,
+    ApplyReport,
+    Step,
+    apply_declared_jobs,
+    apply_kind,
+    apply_verbs,
+)
+from scitex_agent_container.cli_pkg.installation_group import boot  # noqa: E402
+
+
+def _declared_timers() -> list[str]:
+    """Canonical names of every kind='timer' job sac really declares.
+
+    Read through the production loader so this tracks the package's
+    actual declarations. A hard-coded list here would be another
+    declaration with no live counterpart — the disease, not the cure.
+    """
+    return [j.name for j in dj._load_sac_jobs(dj.GROUP_KINDS["timer"])]
+
+
+class _Recorder:
+    """Capture every ``(kind, verb, name, yes, dry_run)`` delegation."""
+
+    def __init__(self, rc: int = 0) -> None:
+        self.calls: list[tuple] = []
+        self._rc = rc
+
+    def __call__(self, kind, verb, name, yes, dry_run=False) -> int:
+        self.calls.append((kind, verb, name, yes, dry_run))
+        return self._rc
+
+    def names_for(self, verb: str) -> list[str]:
+        return sorted(c[2] for c in self.calls if c[1] == verb)
+
+    def verbs_for(self, name: str) -> list[str]:
+        return [c[1] for c in self.calls if c[2] == name]
+
+
+@contextmanager
+def _delegating_to(recorder) -> Iterator[None]:
+    """Swap the single mutation seam for the duration of one test."""
+    original = dj._delegate
+    dj._delegate = recorder  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        dj._delegate = original  # type: ignore[assignment]
+
+
+@contextmanager
+def _home(path) -> Iterator[None]:
+    """Point ``$HOME`` at a scratch dir so `boot` cannot touch the real one."""
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(path)
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def declared_timers() -> list[str]:
+    names = _declared_timers()
+    assert names, "sac declares no kind='timer' jobs — the fixture is blind"
+    return names
+
+
+@pytest.fixture
+def applied_timers() -> _Recorder:
+    """One successful ``apply_kind('timer')`` pass, and what it delegated."""
+    recorder = _Recorder()
+    apply_kind("timer", yes=True, delegate=recorder)
+    return recorder
+
+
+# ---------------------------------------------------------------------------
+# the link: DECLARED -> APPLIED -> ARMED
+# ---------------------------------------------------------------------------
+
+
+def test_every_declared_timer_is_applied(applied_timers, declared_timers) -> None:
+    # Arrange — APPLIED means a unit file gets written for it.
+    expected = sorted(declared_timers)
+    # Act
+    installed = applied_timers.names_for("install")
+    # Assert
+    assert installed == expected
+
+
+def test_every_declared_timer_is_armed(applied_timers, declared_timers) -> None:
+    # Arrange — ARMED is the state that actually fires, and the one the
+    # host was missing: install writes the unit, enable is what starts it.
+    expected = sorted(declared_timers)
+    # Act
+    enabled = applied_timers.names_for("enable")
+    # Assert
+    assert enabled == expected
+
+
+def test_no_declared_timer_stops_at_applied(applied_timers, declared_timers) -> None:
+    # Arrange — the exact defect: a complete APPLIED set with an empty
+    # ARMED set is what scitex-compute-04 was found in.
+    # Act
+    unarmed = set(declared_timers) - set(applied_timers.names_for("enable"))
+    # Assert
+    assert unarmed == set()
+
+
+def test_each_job_is_installed_before_it_is_enabled(
+    applied_timers, declared_timers
+) -> None:
+    # Arrange — enabling a unit that was never written fails.
+    expected = list(APPLY_SEQUENCE)
+    # Act
+    out_of_order = [n for n in declared_timers if applied_timers.verbs_for(n) != expected]
+    # Assert
+    assert out_of_order == []
+
+
+def test_the_report_counts_every_declared_job_as_armed(declared_timers) -> None:
+    # Arrange
+    recorder = _Recorder()
+    # Act
+    report = apply_kind("timer", yes=True, delegate=recorder)
+    # Assert
+    assert sorted(report.jobs_armed) == sorted(declared_timers)
+
+
+def test_the_collective_entry_point_arms_the_timers(declared_timers) -> None:
+    # Arrange — apply_declared_jobs walks every kind, not just one.
+    recorder = _Recorder()
+    # Act
+    report = apply_declared_jobs(yes=True, delegate=recorder)
+    # Assert
+    assert sorted(report.jobs_armed) == sorted(declared_timers)
+
+
+def test_the_collective_entry_point_skips_no_kind() -> None:
+    # Arrange
+    recorder = _Recorder()
+    # Act
+    report = apply_declared_jobs(yes=True, delegate=recorder)
+    # Assert
+    assert report.skipped == ()
+
+
+def test_yes_is_forwarded_to_every_delegation(applied_timers) -> None:
+    # Arrange — dropping the guard flag would unguard a guarded command.
+    # Act
+    unconfirmed = [c for c in applied_timers.calls if c[3] is not True]
+    # Assert
+    assert unconfirmed == []
+
+
+def test_dry_run_is_forwarded_to_every_delegation() -> None:
+    # Arrange
+    recorder = _Recorder()
+    # Act
+    apply_kind("timer", yes=True, dry_run=True, delegate=recorder)
+    # Assert
+    assert all(call[4] is True for call in recorder.calls)
+
+
+def test_a_service_is_applied_but_not_claimed_to_be_armed() -> None:
+    # Arrange — scitex-dev #566 serves no `service enable`, so sac exposes
+    # none; this path must say APPLIED and stop rather than imply arming.
+    # Act
+    verbs = apply_verbs("service")
+    # Assert
+    assert verbs == ("install",)
+
+
+def test_a_timer_is_armed_as_well_as_applied() -> None:
+    # Arrange
+    # Act
+    verbs = apply_verbs("timer")
+    # Assert
+    assert verbs == ("install", "enable")
+
+
+# ---------------------------------------------------------------------------
+# a failure must never read as success
+# ---------------------------------------------------------------------------
+
+
+def test_a_failing_enable_is_not_reported_ok() -> None:
+    # Arrange
+    recorder = _Recorder(rc=1)
+    # Act
+    report = apply_kind("timer", yes=True, delegate=recorder)
+    # Assert
+    assert report.ok is False
+
+
+def test_a_failing_enable_arms_nothing() -> None:
+    # Arrange
+    recorder = _Recorder(rc=1)
+    # Act
+    report = apply_kind("timer", yes=True, delegate=recorder)
+    # Assert
+    assert report.jobs_armed == ()
+
+
+def test_a_skipped_kind_is_not_ok() -> None:
+    # Arrange — "could not look" must not render as "found nothing wrong";
+    # that is the success-value-is-also-the-didnt-check-value shape.
+    report = ApplyReport(skipped=("timer: scitex-dev too old",))
+    # Act
+    verdict = report.ok
+    # Assert
+    assert verdict is False
+
+
+def test_a_clean_pass_is_ok() -> None:
+    # Arrange
+    report = ApplyReport(steps=(Step("timer", "enable", "j", 0),))
+    # Act
+    verdict = report.ok
+    # Assert
+    assert verdict is True
+
+
+def test_an_unservable_verb_still_reaches_every_job(declared_timers) -> None:
+    # Arrange — `_delegate` aborts with SystemExit(4) when the installed
+    # scitex-dev cannot serve a verb. If that escaped, the first refusal
+    # would leave every later job untouched AND uncounted.
+    seen: list[str] = []
+
+    def _refuse(kind, verb, name, yes, dry_run=False):
+        seen.append(name)
+        raise SystemExit(4)
+
+    # Act
+    apply_kind("timer", yes=True, delegate=_refuse)
+    # Assert
+    assert sorted(set(seen)) == sorted(declared_timers)
+
+
+def test_an_unservable_verb_is_recorded_as_failed() -> None:
+    # Arrange
+    def _refuse(kind, verb, name, yes, dry_run=False):
+        raise SystemExit(4)
+
+    # Act
+    report = apply_kind("timer", yes=True, delegate=_refuse)
+    # Assert
+    assert all(step.rc == 4 for step in report.failed)
+
+
+# ---------------------------------------------------------------------------
+# the CLI surface: arming is collective, disarming is not
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_enable_arms_every_declared_timer(declared_timers) -> None:
+    # Arrange — until 2026-08-15 this invocation was a click usage error,
+    # so arming the fleet's timers took one hand-typed command per job.
+    recorder = _Recorder()
+    # Act
+    with _delegating_to(recorder):
+        CliRunner().invoke(dj._make_group("timer"), ["enable", "--yes"])
+    # Assert
+    assert recorder.names_for("enable") == sorted(declared_timers)
+
+
+def test_bulk_enable_still_accepts_one_name() -> None:
+    # Arrange — the per-name form is the surgical verb; it must survive.
+    recorder = _Recorder()
+    # Act
+    with _delegating_to(recorder):
+        CliRunner().invoke(
+            dj._make_group("timer"), ["enable", "accounts-refresh", "--yes"]
+        )
+    # Assert
+    assert recorder.names_for("enable") == ["sac.accounts-refresh"]
+
+
+def test_disable_has_no_bulk_form() -> None:
+    # Arrange — disabling every timer at once stops sac.accounts-refresh,
+    # the fleet's SOLE OAuth refresher against a single-use token.
+    # Convergence only ever needs the ENABLE direction.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dj._make_group("timer"), ["disable", "--yes"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_the_deprecated_alias_does_not_gain_bulk_enable() -> None:
+    # Arrange — nothing new is ever built on the `systemd` alias.
+    group = dj._make_group("systemd")
+    # Act
+    verbs = set(group.commands)
+    # Assert
+    assert "enable" not in verbs
+
+
+# ---------------------------------------------------------------------------
+# the base case: host provisioning drives the sequence
+# ---------------------------------------------------------------------------
+
+
+def test_installation_boot_applies_every_declared_job(
+    tmp_path, declared_timers
+) -> None:
+    # Arrange — `sac installation boot` is sac's ONE provisioning path,
+    # and until now its seven steps touched no declared job at all.
+    recorder = _Recorder()
+    # Act
+    with _home(tmp_path), _delegating_to(recorder):
+        CliRunner().invoke(boot, ["--dry-run"])
+    # Assert
+    assert recorder.names_for("install") == sorted(declared_timers)
+
+
+def test_installation_boot_arms_every_declared_job(tmp_path, declared_timers) -> None:
+    # Arrange — applying without arming is the defect, so provisioning
+    # must reach the ENABLE verb too, not just write unit files.
+    recorder = _Recorder()
+    # Act
+    with _home(tmp_path), _delegating_to(recorder):
+        CliRunner().invoke(boot, ["--dry-run"])
+    # Assert
+    assert recorder.names_for("enable") == sorted(declared_timers)
+
+
+def test_boot_still_succeeds_when_arming_cannot_run(tmp_path) -> None:
+    # Arrange — a host that cannot arm must still finish bootstrapping:
+    # the venv, PATH and shared dirs are what every recovery path needs.
+    def _explode(kind, verb, name, yes, dry_run=False):
+        raise RuntimeError("no scitex-dev here")
+
+    # Act
+    with _home(tmp_path), _delegating_to(_explode):
+        result = CliRunner().invoke(boot, ["--dry-run"])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_boot_says_so_when_arming_cannot_run(tmp_path) -> None:
+    # Arrange — an unarmed job that is REPORTED is recoverable; an
+    # unarmed job nobody counted is the defect this step exists to end.
+    def _explode(kind, verb, name, yes, dry_run=False):
+        raise RuntimeError("no scitex-dev here")
+
+    # Act
+    with _home(tmp_path), _delegating_to(_explode):
+        result = CliRunner().invoke(boot, ["--dry-run"])
+    # Assert
+    assert "could not apply declared jobs" in result.output
+
+
+# ---------------------------------------------------------------------------
+# APPLIED, for real: the declaration materialises into a systemd unit
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rendered_units() -> dict[str, tuple[str, str]]:
+    """``{job name: (timer unit text, service unit text)}`` from scitex-dev.
+
+    Calls the same ``scitex_dev.jobs._systemd`` functions ``do_install``
+    writes to disk with — real code, no fake — so these assertions are
+    about the artifact a host would receive.
+    """
+    from scitex_dev.jobs import _systemd as sd
+
+    jobs = dj._load_sac_jobs(dj.GROUP_KINDS["timer"])
+    return {
+        j.name: (sd.build_timer_unit(j), sd.build_service_unit(j)) for j in jobs
+    }
+
+
+def test_every_declared_timer_renders_a_timer_unit(rendered_units) -> None:
+    # Arrange
+    # Act
+    without = [n for n, (timer, _svc) in rendered_units.items() if "[Timer]" not in timer]
+    # Assert
+    assert without == []
+
+
+def test_every_rendered_timer_points_at_its_own_service(rendered_units) -> None:
+    # Arrange — a timer owns the oneshot service it fires; a mismatch here
+    # is the `sac.listen` double-supervisor hazard (docs/adr/0022) forming.
+    # Act
+    mismatched = [
+        n for n, (timer, _svc) in rendered_units.items() if f"{n}.service" not in timer
+    ]
+    # Assert
+    assert mismatched == []
+
+
+def test_every_declared_command_survives_into_its_unit(rendered_units) -> None:
+    # Arrange — the point of APPLIED: the unit runs what was DECLARED.
+    jobs = {j.name: j.command for j in dj._load_sac_jobs(dj.GROUP_KINDS["timer"])}
+    # Act
+    missing = [
+        name
+        for name, (_timer, service) in rendered_units.items()
+        if jobs[name].split()[0].rsplit("/", 1)[-1] not in service
+    ]
+    # Assert
+    assert missing == []
+
+
+def test_every_rendered_service_has_an_execstart(rendered_units) -> None:
+    # Arrange — a unit with no ExecStart is applied and inert, which is
+    # the same non-check as a declaration nobody applies.
+    # Act
+    without = [n for n, (_t, service) in rendered_units.items() if "ExecStart=" not in service]
+    # Assert
+    assert without == []


### PR DESCRIPTION
## The operator's three criteria, and which this PR satisfies

> 「変なごちゃごちゃしたのではなくて、scitex-agent-container dev の下に定期ジョブとして書かれているか、scitex-dev にプラグイン登録されているか、scitex-dev からまとめて呼ばれているか。これが重要です、これ以外には再現性もメンテナンス性のスケールも難しいです」

| # | Criterion | Before | After this PR |
|---|---|---|---|
| 1 | 定期ジョブとして書かれている — declared as a job under sac's own `dev` surface | **PASS** | PASS (unchanged) |
| 2 | scitex-dev にプラグイン登録されている — registered as a scitex-dev plugin | **PASS** | PASS (unchanged) |
| 3 | scitex-dev からまとめて呼ばれている — invoked COLLECTIVELY from scitex-dev | **FAIL** | **PARTIAL** — see below |

Criterion 3 had two independent halves. This PR closes one of them entirely and cannot close the other from inside a leaf package.

- **Closed here:** nothing on any code path ever called an apply verb, and the arming verb had no collective form at all. Both are fixed.
- **NOT closed here, carded to scitex-dev:** the *recurring* ecosystem-wide convergence job. One job that converges every registered leaf belongs in scitex-dev's own provider; N leaves each declaring their own copy is the primitive in the wrong package, which is the thing the operator's pattern exists to prevent.

## Phase 1 — what was measured

Four states, kept strictly apart, because conflating them **is** the bug:

| State | Meaning | sac before this PR |
|---|---|---|
| **DECLARED** | a `JobSpec` exists in the repo | 9 jobs, all `kind="timer"` |
| **REGISTERED** | `scitex_dev.jobs.discover_jobs()` can find it | all 9 found (measured) |
| **APPLIED** | a unit file exists on this host | only by hand |
| **ARMED** | `systemctl enable` — the only state that fires | only by hand, one command per job |

- **Registration already worked.** `discover_jobs()` (`scitex_dev/jobs/__init__.py:405`) is an entry-point aggregator over the `scitex_dev.jobs` group; sac registers at `pyproject.toml:407`. Measured on scitex-compute-04: 33 JobSpecs from 3 providers, all 9 sac jobs present.
- **Invocation count from any provisioning path: ZERO.** Search run:
  ```
  rg -n --hidden -g '!.git' -g '!*.lock' -e 'ecosystem["\x27 ]+(up|install)' \
     -e 'dev (timer|cron|service|systemd) install' -e 'timer install' .
  ```
  24 hits, **every one non-executable** — `scripts/systemd/README.md`, `CHANGELOG.md`, `docs/worktree-gc.md`, a skills `.md`, docstrings, and test comments. sac's one host-provisioning path, `sac installation boot`, listed seven steps (venv, pip, PATH, tmux, dirs, cron script, print version) and applied nothing.
- **The mechanical cause of "installed but disabled".** scitex-dev's `_jobs_units.py::do_install` (:179-188) writes the unit files and then merely *echoes* the arming command:
  ```python
  click.echo("Enable with:", err=True)
  click.echo(f"  systemctl --user enable --now {enable_target(kind, job)}", err=True)
  ```
  It never runs it. Combined with sac's own verb shapes (`install` bulk, `enable` per-name), the arithmetic was exact: **one** command applied all nine timers, **nine** hand-typed commands armed them. On 2026-08-15 seven of ten sac timers were found `disabled` on scitex-compute-04 — including the sweep that restarts agents wedged behind a frozen "Login expired" banner.
- **Host reality (measured on the host, not in a container).** `crontab -l` empty; `systemctl --user list-unit-files 'scitex-dev-ecosystem*'` → *0 unit files* — so `ecosystem up --yes` has **never run there** — while 9 per-leaf sac timers exist as units.
- **Why provisioning does NOT call `ecosystem up`.** Proven in-process: `collect_cron_jobs(discover_jobs(), allow_lossy=True)` returns 31 crontab entries (18 cron-native + 13 timer-lowered), and the 13 include **all nine sac timers** — 8 of which already run as enabled systemd timers. Calling it would double-supervise every one, including `sac.accounts-refresh`, the fleet's sole OAuth refresher against a single-use token. That contradiction between scitex-dev's two apply surfaces is carded, not worked around.

## Phase 2 — what changed

1. **`enable` becomes a BULK verb** on the `timer` and `cron` groups: given no NAME it arms every declared job of that kind, exactly as `install` already did.
   `disable` **stays strictly per-name**, and the asymmetry is the point: bulk enable is convergence (idempotent, worst case a job already running); bulk disable is a fleet outage with one word of typing. The deprecated `systemd` alias does not gain it.
2. **`sac installation boot` gains step 7** — apply **and arm** every declared job, via the new `cli_pkg/_dev_jobs_apply.py`. It reports per-job APPLIED/ARMED state, distinguishes a safe `install` refusal from a failed `enable`, and never aborts the bootstrap when a host cannot arm (steps 1-6 are what every recovery path needs).
3. **Refactor:** `_dev_jobs.py` was at 512/512 lines, so the grammar tables moved to `_dev_jobs_grammar.py`; `_dev_jobs.py` re-exports them and is now 371 lines. No behaviour change; `_jobs_audit` and existing tests untouched.

### The base case, stated explicitly

A convergence timer **cannot arm itself** — nothing would install *that* timer either. So the recursion needs a step that runs unconditionally on a host with nothing, and that is host provisioning. `sac installation boot` is the **base case**; the **periodic convergence job** that re-asserts declared-equals-armed afterwards is the recurring half, and it lives in scitex-dev.

## Phase 3 — proof

`tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py`, 29 tests, all green.

**A test that only checks the declaration parses would be a restatement of the defect** — `test__jobs_plugin.py` was green throughout the entire period the timers sat disabled. So these assert the *link*:

- every declared job reaches **both** `install` and `enable`, **in that order**, per job;
- no declared timer stops at APPLIED (the exact state the host was found in);
- `sac installation boot` really drives that sequence (through the real CLI, real declarations);
- a failed `enable` is never reported as ok, and a skipped kind is not ok either;
- a `SystemExit(4)` on one job does not abandon the remaining jobs *uncounted*;
- bulk enable arms all of them; bulk disable does not exist;
- **APPLIED, for real:** scitex-dev's *real* renderer (`scitex_dev.jobs._systemd.build_timer_unit` / `build_service_unit`, the same functions `do_install` writes to disk with) materialises every declaration into a `.timer`/`.service` pair whose `ExecStart` carries the declared command.

Seam not mock (PA-306): the one injected callable is `_dev_jobs._delegate`, exactly as `test__dev_jobs.py` already does.

### What I could NOT prove, stated plainly

**That `systemctl` then really arms the unit on a host.** That needs a live `systemd --user` manager, which CI does not have; scitex-dev's installer refuses with exit 3 where none exists, and its `guard_existing_supervisors` probes the real host, so a real-`do_install` test would be environment-dependent in both directions.

What would prove it is the replay the card specifies: **take a host with none of these armed, run the provisioning path, confirm every declared job comes up `enabled`; then disable one by hand and confirm the convergence job restores it.** The second half of that replay needs the scitex-dev convergence job, so it cannot be run from this repo alone.

## Follow-up

Carded to scitex-dev: `scitex-dev-collective-apply-and-convergence-for-declared-jobs-20260815` — decide the single apply mechanism (the `ecosystem up` cron-lowering model vs the per-leaf unit model, both currently live and mutually duplicating), ship a collective apply that *enables* rather than printing the enable command, and declare **one** convergence job in scitex-dev's own provider.

Noted there but deliberately not implemented: the Claude accounts now carry month-by-month subscriptions with hard end dates that nothing in the fleet can see. The natural home for a pre-expiry warning is that convergence job — it already runs periodically and already walks every declaration — rather than a fifth bespoke timer nobody arms either.

Card: `sac-nothing-applies-the-declared-jobspecs-20260815`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
