### PR TITLE
fix(ci-rail): stop recording a routing guess as the pusher — three-valued attribution

### DIFF
--- a/.github/ci/ci_card_rail.py
+++ b/.github/ci/ci_card_rail.py
@@ -44,7 +44,6 @@ import argparse
 import os
 import sys
 import urllib.error
-from typing import Any
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -76,47 +75,42 @@ from ci_rail_listen import (  # noqa: E402 — sibling module, path fixed up abo
     reachability_of,
 )
 
+# ADDRESSING lives in its own module — see its docstring for why "the
+# verdict reached the wrong agent" is its own failure domain. Re-exported
+# here (and named in ``__all__``) because this file is the rail's public
+# face: the git hook, the workflow and the tests all reach it through
+# ``ci_card_rail``.
+from ci_rail_recipient import (  # noqa: E402 — sibling module
+    AGENT_ID_ENV_VARS,
+    HOW_FALLBACK,
+    HOW_NONE,
+    HOW_RECORDED,
+    NOT_A_PUSHER,
+    attribution,
+    pushing_agent,
+    resolve_recipient,
+)
+
 # A verdict is only reported for conclusions that ARE a verdict. A
 # cancelled run means a newer push superseded this one (the gate sets
 # ``cancel-in-progress``), not a statement about the code; reporting it
 # would train the fleet to ignore this rail.
 TERMINAL_CONCLUSIONS = frozenset({"success", "failure"})
 
-# The identity of the pushing agent, in precedence order.
-# ``$SCITEX_TODO_AGENT_ID`` is the card package's own canonical variable
-# and so leads — but it is NOT reliably present: measured unset in this
-# container's shell, and present in the cards MCP server process as the
-# literal, unexpanded string ``${SCITEX_TODO_AGENT_ID}``. The sac-side
-# names are set by the runtime that launched the container and were
-# measured correct, so they are working fallbacks rather than decoration.
-# An owner-less card is REJECTED by the store — there is no silent
-# fallback there — so resolving this is what makes the push half work.
-AGENT_ID_ENV_VARS = (
-    "SCITEX_TODO_AGENT_ID",
-    "SAC_NAME",
-    "SCITEX_AGENT_CONTAINER_AGENT",
-    "CLAUDE_AGENT_ID",
-)
-
 __all__ = [
+    "AGENT_ID_ENV_VARS",
+    "HOW_FALLBACK",
+    "HOW_NONE",
+    "HOW_RECORDED",
+    "NOT_A_PUSHER",
     "TERMINAL_CONCLUSIONS",
+    "attribution",
     "main",
     "pushing_agent",
     "record_verdict",
     "resolve_recipient",
     "verdict_text",
 ]
-
-
-def pushing_agent() -> str | None:
-    """First non-empty, non-template agent identity from the environment."""
-    for var in AGENT_ID_ENV_VARS:
-        value = (os.environ.get(var) or "").strip()
-        # Reject an unexpanded shell template rather than filing cards
-        # owned by an agent literally named "${SCITEX_TODO_AGENT_ID}".
-        if value and not value.startswith("${"):
-            return value
-    return None
 
 
 def _warn(msg: str) -> None:
@@ -133,49 +127,6 @@ def _die(msg: str, code: int = 1) -> int:
     print(f"::error::{msg}", file=sys.stderr, flush=True)
     print(f"::error::{msg}", flush=True)
     return code
-
-
-def resolve_recipient(
-    *, card: dict[str, Any] | None, repo: str, agents: list[dict[str, Any]]
-) -> tuple[str | None, str]:
-    """Who should hear this verdict? Returns ``(name, how_it_was_decided)``.
-
-    Precedence, and the reason for each step:
-
-    1. **The card's own agent**, set by ``pre-push`` to whoever actually
-       pushed. A verdict belongs to the pusher, and no inference beats a
-       record of the fact.
-    2. **An agent spec whose ``project`` matches the repo, PREFERRING one
-       that is reachable right now.** sac's ``_ci_owner.resolve_owner``
-       makes the same match but takes the first hit in sorted filename
-       order, which on this very repo deterministically selects
-       ``scitex-agent-container-04`` — zero inbox subscribers since
-       2026-08-10. Sorting reachable candidates first is the whole
-       difference between a delivered verdict and a silent one, and is
-       why this does not simply call that function.
-
-    ``None`` means nobody could be resolved; the caller must treat that
-    as an error, never as a quiet skip.
-    """
-    if card:
-        named = card.get("agent") or card.get("assignee")
-        if isinstance(named, str) and named.strip():
-            return named.strip(), "card"
-
-    base = repo_basename(repo)
-    matches = [a for a in agents if str(a.get("project", "")).strip() == base]
-    if not matches:
-        return None, "unresolved"
-    matches.sort(
-        key=lambda a: (
-            a.get("inbox_reachable") != "reachable",
-            -int(a.get("inbox_subscribers") or 0),
-            str(a.get("started_at") or ""),
-        )
-    )
-    name = matches[0].get("name")
-    return (str(name) if name else None), "spec"
-
 
 
 def record_verdict(
@@ -222,6 +173,11 @@ def record_verdict(
     # Only a red verdict needs the log read; a green one has nothing to
     # name and the API call would be pure latency.
     detail = summarize_failures(repo, run_id) if conclusion == "failure" else ""
+    # THE DECISION THE WHOLE FIX TURNS ON, taken in one place. `owner` is
+    # what may be RECORDED as authorship; `recipient` is only who we TELL.
+    # They diverge exactly when the pusher is unknown.
+    owner, routing = attribution(recipient=recipient, how=how, repo=repo)
+    pusher_known = how == HOW_RECORDED
     body = verdict_text(
         repo=repo,
         branch=branch,
@@ -234,6 +190,7 @@ def record_verdict(
         # Derived from the checkout at verdict time, so a workflow added
         # later cannot silently drop out of the disclaimer.
         unobserved=sibling_workflow_names(workflow),
+        routing=routing,
     )
     upsert_card(
         pkg,
@@ -256,14 +213,40 @@ def record_verdict(
         kind="task",
         repo=repo_basename(repo),
         project=repo_basename(repo),
-        agent=recipient,
-        assignee=recipient,
+        # `owner`, NOT `recipient`. These two fields are the store's
+        # statement of WHO DID THIS, and the rail may only fill them from a
+        # measurement. When the pusher is unknown they get the unclaimed
+        # sentinel instead, so the card is visibly unattributed rather than
+        # confidently attributed to whoever happens to own the repo. The
+        # agent the rail actually notified is recorded below as a
+        # SUBSCRIBER — told, but not made responsible, and not laundered
+        # into an authorship claim the next run would read back as fact.
+        agent=owner,
+        assignee=owner,
         note=(
             f"CI {conclusion} for {sha[:8]} ({leg or 'gate'}) at {now_stamp()} "
-            f"— {run_url}"
+            f"— {run_url}. Pusher: "
+            + (
+                f"{recipient} (recorded by pre-push)."
+                if pusher_known
+                else f"UNKNOWN — no pre-push record; notified {recipient} "
+                f"because its spec declares project={repo_basename(repo)!r}, "
+                "which is a routing guess, not an attribution."
+            )
         ),
         last_activity=now_stamp(),
     )
+    if not pusher_known:
+        # SUBSCRIBER, NOT ASSIGNEE — the whole point, in one call. It is
+        # exactly the right weight for "tell me, but this is not my job":
+        # the agent still hears the verdict, and the board still shows the
+        # card as nobody's work. Best-effort by design: a notify list is a
+        # courtesy, and failing the verdict step over it would trade a
+        # recorded verdict for a cosmetic one.
+        try:
+            pkg.set_subscriber(task_id=card_id, who=recipient, action="add")
+        except Exception as exc:  # noqa: BLE001 — see the comment above
+            _warn(f"could not subscribe {recipient} to {card_id}: {exc}")
     pkg.comment_task(task_id=card_id, text=body, by="ci")
     # READ BACK THE FIELD, NOT THE CARD'S EXISTENCE. A presence check
     # passes straight through the failure this guards against.
@@ -309,8 +292,12 @@ def record_verdict(
     print(f"card {card_id}: recorded {conclusion} (status={expected}, read back)")
 
     reach, subs = reachability_of(agents, recipient)
+    # NAME BOTH, ALWAYS. The recipient is who we TOLD; the owner is what we
+    # RECORDED. They differ exactly when the pusher is unknown, and a run log
+    # that printed only one of them is how nobody noticed for 118 cards.
     print(
-        f"recipient {recipient} (via {how}); inbox_reachable={reach} subscribers={subs}",
+        f"recipient {recipient} (via {how}); card owner={owner}; "
+        f"inbox_reachable={reach} subscribers={subs}",
         flush=True,
     )
 

--- a/.github/ci/ci_rail_cards.py
+++ b/.github/ci/ci_rail_cards.py
@@ -81,8 +81,41 @@ BLOCKER_CLEARED = ""
 # fails exactly where it was supposed to be the safety net.
 VERDICT_ACTOR = "ci"
 
+# THE OWNER OF A CARD WHOSE PUSHER IS NOT KNOWN -- the third value, and the
+# whole point of this constant existing at all.
+#
+# "The pusher is X", "we guessed X" and "we do not know" are three different
+# facts, and this store has exactly one field to say them in. Collapsing them
+# was the defect: the verdict half resolved a recipient by matching agent
+# specs against the repo name -- an INFERENCE from the repository, not an
+# observation of the push -- and then wrote it to `agent`/`assignee`, which is
+# the field `record_push` uses to state a MEASURED identity. The next reader
+# could not tell the two apart, and neither could the rail: on a second
+# verdict for the same sha it read its own guess back and reported provenance
+# "card", i.e. "recorded by the pusher".
+#
+# MEASURED ON THE LIVE STORE, 2026-08-15: of 121 rail-shaped cards
+# (`ci-<repo>-<12 hex>`), 118 -- 97.5% -- were created by the verdict half
+# (`created_by = "ci"`), meaning no pusher was ever on record, and every one
+# of those 118 had `agent` written to a repo-owner guess. 117 named this
+# repo's owning agent. So the fallback was not an edge case; it was the path.
+#
+# WHY A SENTINEL RATHER THAN AN EMPTY FIELD. `add_task` REFUSES an owner-less
+# card -- "assignee is required ... an owner-less card is rejected (no silent
+# fallback; see constitution)" (scitex_cards/_store_mutate.py). So "leave it
+# blank" is not available; the honest options are a real identity or a name
+# that is visibly not one. This is the latter: it is not an agent, no agent
+# spec declares it, and it never resolves to an inbox -- so a verdict filed
+# against it is VISIBLY unrouted rather than confidently misrouted, and
+# `list_tasks(assignee=...)` for a real agent stops returning other people's
+# pushes. The agent the rail notified is recorded as a SUBSCRIBER instead:
+# told, but not made responsible.
+UNCLAIMED_OWNER = "ci-unclaimed"
+
 __all__ = [
     "STATUS_FOR_CONCLUSION",
+    "UNCLAIMED_OWNER",
+    "VERDICT_ACTOR",
     "card_id_for",
     "card_title",
     "cards",

--- a/.github/ci/ci_rail_message.py
+++ b/.github/ci/ci_rail_message.py
@@ -84,6 +84,7 @@ def verdict_text(
     card_id: str,
     detail: str = "",
     unobserved: list[str] | None = None,
+    routing: str = "",
 ) -> str:
     """The message a woken human reads.
 
@@ -93,9 +94,20 @@ def verdict_text(
     reached nobody. Arriving is not the fix; arriving with the failing
     test named is.
 
-    Deliberately NO attribution. The rail reports the verdict and quotes
-    the log; it never says WHY, because it cannot know, and a rail that
-    guesses causes teaches people to distrust the ones it gets right.
+    ``routing`` says WHY THIS REACHED YOU, and is empty exactly when the
+    answer is "because you pushed". It is non-empty when the rail could
+    not identify the pusher and addressed the verdict by repo-owner
+    fallback instead -- a routing guess, not an attribution. Saying so IN
+    THE MESSAGE is the half of the fix the card cannot do: a reader is
+    told the verdict and its provenance in the same breath, rather than
+    receiving an unqualified "your CI failed" for somebody else's push.
+    Same rule as ``unobserved`` below -- state what was observed, state
+    what was not, and decline to draw the conclusion the reader wants.
+
+    Deliberately NO attribution of CAUSE. The rail reports the verdict and
+    quotes the log; it never says WHY it broke, because it cannot know,
+    and a rail that guesses causes teaches people to distrust the ones it
+    gets right.
     """
     head = f"CI {conclusion.upper()} — {_repo_basename(repo)} `{branch}` ({sha[:8]})"
     if leg:
@@ -116,6 +128,10 @@ def verdict_text(
     parts = [f"{head}.", tail]
     if detail.strip():
         parts.append(detail.strip())
+    # ABOVE the run link, not appended after it. A reader who stops at the
+    # first link must already have been told this verdict may not be theirs.
+    if routing.strip():
+        parts.append(routing.strip())
     parts.append(f"Run: {run_url}")
     parts.append(f"Card: {card_id}")
     return "\n".join(parts)

--- a/.github/ci/ci_rail_recipient.py
+++ b/.github/ci/ci_rail_recipient.py
@@ -1,0 +1,218 @@
+"""WHO the verdict is for, and HOW SURE the rail is about that.
+
+Companion to :mod:`ci_card_rail` (orchestration + CLI), :mod:`ci_rail_cards`
+(the card contract), :mod:`ci_rail_listen` (delivery) and
+:mod:`ci_rail_message` (the text). Like them, this module is a FAILURE
+DOMAIN rather than a size bucket: "the verdict reached the wrong agent" is a
+different bug, with different evidence, from "the store was wrong" or "the
+bus was deaf", and until now it was the only one of the four with no home.
+
+THE DEFECT THIS MODULE WAS CARVED OUT TO FIX. Addressing had two sources of
+truth and one field to write them in. ``pre-push`` records a MEASURED
+identity — the pushing process's own environment. When that record is
+missing, the verdict half INFERRED one by matching agent specs against the
+repository name. Both then went into ``agent``/``assignee``, so an inference
+became indistinguishable from an observation the instant it was written; and
+because the next run read that field back as "the recorded pusher", the
+rail's own guess was promoted to its own evidence one run later.
+
+Measured on the live store 2026-08-15: 118 of 121 rail-shaped cards (97.5%)
+carried an inferred owner recorded as fact, 117 of them naming this repo's
+owning agent. See ``UNCLAIMED_OWNER`` in :mod:`ci_rail_cards`.
+
+So the answer this module returns is a PAIR, always, and the second half is
+not commentary — it is the part that decides whether the first half may be
+written down as authorship.
+
+DEPENDENCIES: standard library, plus the two sentinels from
+:mod:`ci_rail_cards`. No network and no store: every function here is a pure
+decision over data the caller already fetched, which is what makes the
+addressing rules testable without a postgres or a daemon.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from ci_rail_cards import (  # noqa: E402 — sibling module, path fixed up above
+    UNCLAIMED_OWNER,
+    VERDICT_ACTOR,
+    repo_basename,
+)
+
+# The identity of the pushing agent, in precedence order.
+# ``$SCITEX_TODO_AGENT_ID`` is the card package's own canonical variable
+# and so leads — but it is NOT reliably present: measured unset in this
+# container's shell, and present in the cards MCP server process as the
+# literal, unexpanded string ``${SCITEX_TODO_AGENT_ID}``. The sac-side
+# names are set by the runtime that launched the container and were
+# measured correct, so they are working fallbacks rather than decoration.
+# An owner-less card is REJECTED by the store — there is no silent
+# fallback there — so resolving this is what makes the push half work.
+AGENT_ID_ENV_VARS = (
+    "SCITEX_TODO_AGENT_ID",
+    "SAC_NAME",
+    "SCITEX_AGENT_CONTAINER_AGENT",
+    "CLAUDE_AGENT_ID",
+)
+
+# HOW THE RECIPIENT WAS DECIDED — three values, because there are three
+# facts. Returned by :func:`resolve_recipient` and consumed by
+# ``record_verdict``, which writes a DIFFERENT card for each.
+#
+#   HOW_RECORDED  the pusher is KNOWN     -> record it as authorship
+#   HOW_FALLBACK  the pusher is UNKNOWN   -> route to a guess, record NOTHING
+#   HOW_NONE      nobody at all           -> fail loudly
+#
+# Named constants rather than bare strings so the branch in ``record_verdict``
+# cannot silently stop matching after a rename — a string typo there would
+# make every verdict take the "unknown" path, or worse, the "known" one.
+#
+# THE VALUES ARE THE ORIGINAL WIRE STRINGS, deliberately. They already
+# appear in run logs and in the existing suite's assertions; renaming them
+# would churn a neighbouring 739-line test file for no behavioural gain,
+# and this change is about what gets WRITTEN TO THE CARD, not about what
+# the provenance is spelled. The constant NAMES carry the meaning at every
+# call site, which is where a reader decides whether a value may be
+# recorded as authorship.
+HOW_RECORDED = "card"
+HOW_FALLBACK = "spec"
+HOW_NONE = "unresolved"
+
+# Names this rail writes ITSELF, which therefore prove nothing about who
+# pushed. Reading either back as a recorded pusher is how an inference
+# becomes a fact one run later. See :func:`resolve_recipient`.
+NOT_A_PUSHER = (UNCLAIMED_OWNER, VERDICT_ACTOR)
+
+__all__ = [
+    "AGENT_ID_ENV_VARS",
+    "HOW_FALLBACK",
+    "HOW_NONE",
+    "HOW_RECORDED",
+    "NOT_A_PUSHER",
+    "attribution",
+    "pushing_agent",
+    "resolve_recipient",
+]
+
+
+def attribution(*, recipient: str, how: str, repo: str) -> tuple[str, str]:
+    """Turn ``(recipient, how)`` into ``(card_owner, routing_disclaimer)``.
+
+    THE DECISION THE DEFECT GOT WRONG, ISOLATED SO IT CAN BE MEASURED. The
+    old code had no such step: ``record_verdict`` wrote ``agent=recipient,
+    assignee=recipient`` unconditionally, which is correct on one of the two
+    paths and a fabricated fact on the other. Naming the choice makes the
+    two paths visible, and makes them testable without a store, a bus or a
+    runner -- the reason it is a pure function over three strings.
+
+    ``card_owner`` is what goes in ``agent``/``assignee``. It is
+    ``recipient`` ONLY when ``how`` says the pusher was recorded; otherwise
+    it is :data:`~ci_rail_cards.UNCLAIMED_OWNER`, because the store refuses
+    an owner-less card and a sentinel is the only remaining way to say "we
+    do not know" in a field that has no empty state.
+
+    ``routing_disclaimer`` is empty exactly when the honest answer to "why
+    did this reach me?" is "because you pushed". Otherwise it is the
+    sentence the recipient needs in order to not act on somebody else's
+    verdict -- the half of the fix a card field cannot carry, since only the
+    message reaches a person.
+    """
+    if how == HOW_RECORDED:
+        return recipient, ""
+    return UNCLAIMED_OWNER, (
+        "ROUTING — THE PUSHING AGENT IS UNKNOWN for this commit. No pre-push "
+        "record exists, so this reached you because your agent spec declares "
+        f"project={repo_basename(repo)!r}, NOT because you pushed. The card "
+        f"is filed under {UNCLAIMED_OWNER!r} and you are a subscriber on it, "
+        "not its owner. If this push was not yours, this is not your verdict "
+        "to act on."
+    )
+
+
+def pushing_agent() -> str | None:
+    """First non-empty, non-template agent identity from the environment."""
+    for var in AGENT_ID_ENV_VARS:
+        value = (os.environ.get(var) or "").strip()
+        # Reject an unexpanded shell template rather than filing cards
+        # owned by an agent literally named "${SCITEX_TODO_AGENT_ID}".
+        if value and not value.startswith("${"):
+            return value
+    return None
+
+
+def resolve_recipient(
+    *, card: dict[str, Any] | None, repo: str, agents: list[dict[str, Any]]
+) -> tuple[str | None, str]:
+    """Who should hear this verdict? Returns ``(name, how_it_was_decided)``.
+
+    ``how`` IS PART OF THE ANSWER, NOT COMMENTARY ON IT. It is the only
+    thing separating "the pusher is X" from "we picked X off the repo
+    name", and the caller must not write the second into a field that
+    means the first. Exactly three values, and the caller handles each
+    differently:
+
+    ``HOW_RECORDED`` — **the card's own agent**, set by ``pre-push`` from
+        the pushing process's own environment. A MEASURED identity. A
+        verdict belongs to the pusher, and no inference beats a record of
+        the fact.
+    ``HOW_FALLBACK`` — **an agent spec whose ``project`` matches the repo,
+        PREFERRING one reachable right now.** This is an inference FROM THE
+        REPOSITORY: it answers "who usually owns this repo", never "who
+        pushed this commit". sac's ``_ci_owner.resolve_owner`` makes the
+        same match but takes the first hit in sorted filename order, which
+        on this very repo deterministically selects
+        ``scitex-agent-container-04`` — zero inbox subscribers since
+        2026-08-10. Sorting reachable candidates first is the difference
+        between a delivered verdict and a silent one, and is why this does
+        not simply call that function. It is still only a ROUTING choice;
+        popularity is not authorship, and the caller records none of it.
+    ``HOW_NONE`` — nobody at all. ``name`` is ``None`` and the caller must
+        treat it as an error, never as a quiet skip.
+
+    WHY THE FALLBACK IS NOT SIMPLY DELETED. It is load-bearing today: 118
+    of 121 rail cards on the live store had no recorded pusher, because
+    ``.githooks/pre-push`` only runs where ``core.hooksPath`` has been
+    pointed at it (unset in this worktree, and absent by construction on
+    every human and GitHub-side push). Removing the fallback would send
+    ``record_verdict`` down its ``_die`` path for ~97% of pushes — turning
+    the gate red and DESTROYING the verdict instead of delivering it. So
+    the fallback still chooses a recipient; the fix is that the caller no
+    longer launders that choice into ``agent``/``assignee``.
+
+    A CARD OWNED BY THE UNCLAIMED SENTINEL IS NOT A RECORDED PUSHER. This
+    rail writes ``UNCLAIMED_OWNER`` itself when the pusher is unknown, so
+    reading it back as ``HOW_RECORDED`` would let one run's guess become
+    the next run's "fact" — the exact laundering this function exists to
+    stop — and would then address a verdict to a name that owns no inbox.
+    The same applies to ``VERDICT_ACTOR``. Both are rejected here, and
+    that rejection is not hypothetical: the same sha is judged twice
+    whenever a branch has an open PR (the ``push`` and ``pull_request``
+    events each fire this workflow), so the second run reads exactly what
+    the first one wrote.
+    """
+    if card:
+        named = card.get("agent") or card.get("assignee")
+        if isinstance(named, str) and named.strip() not in ("", *NOT_A_PUSHER):
+            return named.strip(), HOW_RECORDED
+
+    base = repo_basename(repo)
+    matches = [a for a in agents if str(a.get("project", "")).strip() == base]
+    if not matches:
+        return None, HOW_NONE
+    matches.sort(
+        key=lambda a: (
+            a.get("inbox_reachable") != "reachable",
+            -int(a.get("inbox_subscribers") or 0),
+            str(a.get("started_at") or ""),
+        )
+    )
+    name = matches[0].get("name")
+    return (str(name) if name else None), HOW_FALLBACK
+
+
+# EOF

--- a/tests/integration/test_ci_rail_recipient.py
+++ b/tests/integration/test_ci_rail_recipient.py
@@ -1,0 +1,366 @@
+"""The CI rail must not record a guess as a measurement (ADR-0024).
+
+THE DEFECT THESE TESTS PIN. ``resolve_recipient`` has always had two very
+different sources for "who should hear this verdict": a MEASUREMENT taken by
+``pre-push`` from the pushing process's own environment, and an INFERENCE
+drawn from the repository name when no such measurement exists. It has always
+returned WHICH of the two it used. ``record_verdict`` then threw that away and
+wrote ``agent=recipient, assignee=recipient`` either way -- into the fields
+that mean "this is who did it". Once written, an inference was
+indistinguishable from an observation, and self-reinforcing besides: the next
+verdict for the same sha read the guess back out of the card and reported it
+as the recorded pusher.
+
+MEASURED ON THE LIVE STORE 2026-08-15: of 121 rail-shaped cards
+(``ci-<repo>-<12 hex>``), 118 -- 97.5% -- were created by the verdict half
+(``created_by = "ci"``, so no pusher was ever recorded) and every one of those
+carried an inferred ``agent``. 117 named this repo's owning agent.
+
+WHY THE RESOLVER IS NOT THE SUBJECT. The resolver was never the liar; six
+tests in ``test_ci_card_rail.py`` already cover it, and every one of them
+passes on the broken code. The defect is in what the rail DOES with the
+provenance, which is why these tests target :func:`attribution` -- the
+decision extracted from ``record_verdict`` -- and then assert that
+``record_verdict`` is actually wired to it.
+
+The happy path (a pusher the hook really recorded) is deliberately kept as a
+CONTROL, so that "attribute nothing, ever" cannot pass for a fix.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_DIR = REPO_ROOT / ".github" / "ci"
+REPO = "scitex-ai/sac"
+OWNER = "repo-owning-agent"
+PUSHER = "the-actual-pusher"
+
+
+def _load(module_name: str):
+    """Import a rail module by path, the same way the runner does.
+
+    The rail is deliberately NOT an installed package: it runs under
+    ``uv run --with scitex-cards`` on a runner with no sac install, and from
+    a git hook inside an agent container.
+    """
+    sys.path.insert(0, str(CI_DIR))
+    spec = importlib.util.spec_from_file_location(
+        module_name, CI_DIR / f"{module_name}.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rail():
+    return _load("ci_card_rail")
+
+
+@pytest.fixture(scope="module")
+def rail_cards():
+    return _load("ci_rail_cards")
+
+
+@pytest.fixture(scope="module")
+def verdict_half() -> str:
+    """The source of ``record_verdict`` — for the WIRING assertions.
+
+    The behavioural tests below prove :func:`attribution` decides correctly.
+    These prove ``record_verdict`` asks it, rather than keeping a second copy
+    of the old rule. Same idiom the neighbouring suite already uses for
+    ``blocker=BLOCKER_CLEARED`` and ``create_only=``: an invariant about a
+    call this suite cannot make without a postgres, a bus and a runner.
+    """
+    source = (CI_DIR / "ci_card_rail.py").read_text(encoding="utf-8")
+    return source.split("def record_verdict", 1)[1]
+
+
+@pytest.fixture(scope="module")
+def card_write(verdict_half) -> str:
+    """Just the ``upsert_card`` call — the CARD WRITE, and nothing else.
+
+    Scoping matters here and the first draft of this test got it wrong. A
+    naive search of the whole function for ``agent=recipient`` also matches
+    ``notify_agent(token, agent=recipient, ...)``, which is CORRECT and must
+    stay: the recipient is exactly who we notify. The defect is writing that
+    same name into the CARD. Testing the two together produced a test that
+    could never pass, which is its own kind of dishonest assertion.
+    """
+    return verdict_half.split("upsert_card(", 1)[1].split("pkg.comment_task", 1)[0]
+
+
+def _agent(name: str, *, project: str = "sac", reachable: bool = True) -> dict:
+    return {
+        "name": name,
+        "project": project,
+        "inbox_reachable": "reachable" if reachable else "unreachable",
+        "inbox_subscribers": 1 if reachable else 0,
+        "started_at": "2026-08-14",
+    }
+
+
+# ---------------------------------------------------------------------------
+# THE DEFECT: an unknown pusher must not be recorded as a known one
+# ---------------------------------------------------------------------------
+def test_an_unknown_pusher_is_not_recorded_as_the_repo_owner(rail) -> None:
+    """THE regression test — fails on the pre-fix code.
+
+    No card exists, so no pusher was ever recorded. The rail still has to
+    route the verdict somewhere and the only candidate is the agent whose
+    spec claims this repo. Routing there is defensible; RECORDING it states
+    a fact nobody measured.
+    """
+    # Arrange
+    how = rail.HOW_FALLBACK
+    # Act
+    owner, _routing = rail.attribution(recipient=OWNER, how=how, repo=REPO)
+    # Assert
+    assert owner != OWNER
+
+
+def test_an_unknown_pusher_is_recorded_as_unclaimed(rail, rail_cards) -> None:
+    """The third value, written down.
+
+    Not blank — ``add_task`` refuses an owner-less card ("assignee is
+    required ... an owner-less card is rejected") — but a name that is
+    visibly not an agent, so the card reads as unattributed rather than as
+    attributed to whoever happens to own the repo.
+    """
+    # Arrange
+    how = rail.HOW_FALLBACK
+    # Act
+    owner, _routing = rail.attribution(recipient=OWNER, how=how, repo=REPO)
+    # Assert
+    assert owner == rail_cards.UNCLAIMED_OWNER
+
+
+def test_an_unknown_pusher_produces_a_routing_disclaimer(rail) -> None:
+    """Only the message reaches a person; the card cannot say this."""
+    # Arrange
+    how = rail.HOW_FALLBACK
+    # Act
+    _owner, routing = rail.attribution(recipient=OWNER, how=how, repo=REPO)
+    # Assert
+    assert "UNKNOWN" in routing
+
+
+def test_the_disclaimer_says_why_it_arrived(rail) -> None:
+    """"Because your spec claims this repo" — not "because you pushed"."""
+    # Arrange
+    how = rail.HOW_FALLBACK
+    # Act
+    _owner, routing = rail.attribution(recipient=OWNER, how=how, repo=REPO)
+    # Assert
+    assert "sac" in routing and "not because you pushed" in routing.lower()
+
+
+def test_an_unresolved_provenance_is_also_never_attributed(rail, rail_cards) -> None:
+    """Anything that is not a RECORD is a guess. Only one value is a record."""
+    # Arrange
+    how = rail.HOW_NONE
+    # Act
+    owner, _routing = rail.attribution(recipient=OWNER, how=how, repo=REPO)
+    # Assert
+    assert owner == rail_cards.UNCLAIMED_OWNER
+
+
+# ---------------------------------------------------------------------------
+# THE CONTROL: a pusher that WAS measured must still be attributed
+# ---------------------------------------------------------------------------
+def test_a_recorded_pusher_is_still_recorded_as_the_owner(rail) -> None:
+    """Never attributing anything is not a fix, it is the opposite failure."""
+    # Arrange
+    how = rail.HOW_RECORDED
+    # Act
+    owner, _routing = rail.attribution(recipient=PUSHER, how=how, repo=REPO)
+    # Assert
+    assert owner == PUSHER
+
+
+def test_a_recorded_pusher_gets_no_routing_disclaimer(rail) -> None:
+    """The disclaimer must be absent exactly when "you pushed" is the truth."""
+    # Arrange
+    how = rail.HOW_RECORDED
+    # Act
+    _owner, routing = rail.attribution(recipient=PUSHER, how=how, repo=REPO)
+    # Assert
+    assert routing == ""
+
+
+# ---------------------------------------------------------------------------
+# THE LOOP: the rail must not read its own guess back as a fact
+# ---------------------------------------------------------------------------
+def test_the_unclaimed_sentinel_is_not_read_back_as_a_recorded_pusher(
+    rail, rail_cards
+) -> None:
+    """The laundering, closed.
+
+    The same sha is judged twice whenever a branch has an open PR — the
+    ``push`` and ``pull_request`` events each fire the gate — so the second
+    run reads exactly what the first one wrote. If the sentinel counted as a
+    recorded pusher, one run's guess would become the next run's evidence,
+    and the verdict would be addressed to a name that owns no inbox at all.
+    """
+    # Arrange
+    card = {"agent": rail_cards.UNCLAIMED_OWNER}
+    # Act
+    who, how = rail.resolve_recipient(card=card, repo=REPO, agents=[_agent(OWNER)])
+    # Assert
+    assert (who, how) == (OWNER, rail.HOW_FALLBACK)
+
+
+def test_the_ci_actor_is_not_read_back_as_a_recorded_pusher(rail, rail_cards) -> None:
+    """``ci`` is the rail naming ITSELF as the filer, never a pusher."""
+    # Arrange
+    card = {"agent": rail_cards.VERDICT_ACTOR}
+    # Act
+    _who, how = rail.resolve_recipient(card=card, repo=REPO, agents=[_agent(OWNER)])
+    # Assert
+    assert how == rail.HOW_FALLBACK
+
+
+def test_a_real_pusher_on_the_card_is_still_a_record(rail) -> None:
+    """The sentinel check must reject sentinels, not identities."""
+    # Arrange
+    card = {"agent": PUSHER}
+    # Act
+    who, how = rail.resolve_recipient(card=card, repo=REPO, agents=[_agent(OWNER)])
+    # Assert
+    assert (who, how) == (PUSHER, rail.HOW_RECORDED)
+
+
+# ---------------------------------------------------------------------------
+# WIRING: record_verdict must ASK, not keep a second copy of the old rule
+# ---------------------------------------------------------------------------
+def test_the_verdict_half_asks_for_the_attribution(verdict_half) -> None:
+    # Arrange
+    source = verdict_half
+    # Act
+    asks = "attribution(recipient=recipient, how=how, repo=repo)" in source
+    # Assert
+    assert asks
+
+
+def test_the_verdict_half_records_the_owner_not_the_recipient(card_write) -> None:
+    """THE line that was wrong: ``agent=recipient, assignee=recipient``.
+
+    Writing the RECIPIENT into the CARD is the defect in one expression — it
+    is what turned a routing choice into a recorded fact on 118 cards.
+    """
+    # Arrange
+    source = card_write
+    # Act
+    launders = "agent=recipient" in source or "assignee=recipient" in source
+    # Assert
+    assert not launders
+
+
+def test_the_verdict_half_writes_the_resolved_owner(card_write) -> None:
+    # Arrange
+    source = card_write
+    # Act
+    writes_owner = "agent=owner" in source and "assignee=owner" in source
+    # Assert
+    assert writes_owner
+
+
+def test_the_fallback_recipient_is_subscribed_rather_than_assigned(
+    verdict_half,
+) -> None:
+    """"Tell me, but this is not my job" — the right weight for a guess.
+
+    Without this the honest card would also be a SILENT one: nobody owns it,
+    so nobody is told. Subscribing keeps delivery while refusing the false
+    claim of authorship.
+    """
+    # Arrange
+    source = verdict_half
+    # Act
+    subscribes = "set_subscriber(task_id=card_id, who=recipient" in source
+    # Assert
+    assert subscribes
+
+
+def test_the_verdict_is_still_delivered_when_the_pusher_is_unknown(
+    verdict_half,
+) -> None:
+    """Honesty must not cost delivery.
+
+    An unrouted verdict beats a misrouted one, but a DROPPED verdict beats
+    neither — and 97.5% of pushes take this path, so refusing to deliver
+    here would silence the rail rather than correct it.
+    """
+    # Arrange
+    source = verdict_half
+    # Act
+    still_notifies = "notify_agent(token, agent=recipient" in source
+    # Assert
+    assert still_notifies
+
+
+def test_the_run_log_names_the_owner_and_the_recipient(verdict_half) -> None:
+    """A log printing only one of the two is how this went unnoticed."""
+    # Arrange
+    source = verdict_half
+    # Act
+    prints_both = "card owner={owner}" in source and "recipient {recipient}" in source
+    # Assert
+    assert prints_both
+
+
+# ---------------------------------------------------------------------------
+# the three states are distinguishable, which is the whole point
+# ---------------------------------------------------------------------------
+def test_the_three_provenance_values_are_distinct(rail) -> None:
+    """Collapsing them into one field IS the bug being fixed."""
+    # Arrange
+    values = (rail.HOW_RECORDED, rail.HOW_FALLBACK, rail.HOW_NONE)
+    # Act
+    distinct = set(values)
+    # Assert
+    assert len(distinct) == 3
+
+
+def test_only_the_recorded_provenance_yields_an_attribution(rail, rail_cards) -> None:
+    """Exactly ONE of the three may be written down as authorship."""
+    # Arrange
+    everything = (rail.HOW_RECORDED, rail.HOW_FALLBACK, rail.HOW_NONE)
+    # Act
+    attributed = [
+        how
+        for how in everything
+        if rail.attribution(recipient=PUSHER, how=how, repo=REPO)[0] == PUSHER
+    ]
+    # Assert
+    assert attributed == [rail.HOW_RECORDED]
+
+
+def test_the_unclaimed_owner_is_not_a_name_an_agent_could_have(rail_cards) -> None:
+    """It must be unmistakable, not merely unlikely."""
+    # Arrange
+    sentinel = rail_cards.UNCLAIMED_OWNER
+    # Act
+    looks_like_a_marker = sentinel.startswith("ci-") and "unclaimed" in sentinel
+    # Assert
+    assert looks_like_a_marker
+
+
+def test_the_unclaimed_owner_is_not_the_filer(rail_cards) -> None:
+    """Who FILED it (``ci``) and who OWNS it are different questions."""
+    # Arrange
+    sentinel, filer = rail_cards.UNCLAIMED_OWNER, rail_cards.VERDICT_ACTOR
+    # Act
+    distinct = sentinel != filer
+    # Assert
+    assert distinct
+
+
+# EOF


### PR DESCRIPTION
## The defect

The CI rail had two sources for "who should hear this verdict" and one field to write them in.

`pre-push` records a **measured** identity — the pushing process's own environment. When that record is missing, the verdict half **inferred** one by matching agent specs against the repository name. Both then went into `agent`/`assignee`, the fields that mean *this is who did it*.

That contradicts the rail's own written contract, in the same codebase — `ci_rail_cards.record_push`:

> `agent` is whoever actually PUSHED — resolved from the pushing process's own environment, never from the repo's owning agent.

**And it compounded.** `agent` written by run N is read back by run N+1 at the head of `resolve_recipient`, which then reports provenance `"card"` — *recorded by the pusher*. A branch with an open PR fires this workflow on both `push` and `pull_request`, so that second run is routine. One run's guess became the next run's evidence.

## Blast radius — measured, not estimated

214 cards carry an id starting `ci-`; 121 are rail-shaped (`ci-<repo>-<12 hex>`), the rest are hand-filed issue cards. Of those 121:

| | count | meaning |
|---|---|---|
| `created_by = "ci"` | **118 (97.5%)** | the verdict half created it → no pusher was ever on record → `agent` is an inference |
| `created_by = <a real agent>` | 3 (2.5%) | `pre-push` ran → `agent` is measured |

117 of the 118 name this repo's owning agent; 1 names `scitex-agent-container-04`. Date range 2026-08-12T09:00Z → 2026-08-15T07:06Z — the rail's entire life.

**The evidence survived, but by accident, and that is itself a finding.** The only discriminator is `created_by`, which is create-only and which the verdict half stamps `"ci"`. Nothing on the card *says* inferred. And it only works for the create path: had the push half recorded a pusher and the verdict half overwritten it with a different guess, nothing would remain to tell them apart.

**Why 97.5% and not a rare edge case:** `.githooks/pre-push` does invoke the rail, but only runs where `core.hooksPath` points at `.githooks`. `git config --get core.hooksPath` returns nothing in this repo, and it can never be set for a human push from a fresh clone or for anything GitHub-side. The fallback was the path, not the exception.

## The fix — three-valued, not a better guess

Provenance now decides what is **written**, not only what is logged:

| provenance | pusher | `agent`/`assignee` | delivery |
|---|---|---|---|
| `HOW_RECORDED` | **known** | the pusher | notified, no disclaimer |
| `HOW_FALLBACK` | **unknown** | `ci-unclaimed` | notified, added as **subscriber**, message says why it arrived |
| `HOW_NONE` | nobody | — | `_die`, unchanged |

**Why a sentinel and not a blank field.** `scitex_cards.add_task` refuses an owner-less card — *"assignee is required … an owner-less card is rejected (no silent fallback; see constitution)"*. So the choice was a real identity or a name that is visibly not one. `ci-unclaimed` is declared by no agent spec and resolves to no inbox, so a verdict filed against it is **visibly unrouted rather than confidently misrouted**, and `list_tasks(assignee=<a real agent>)` stops returning other people's pushes. The agent that was actually notified is recorded as a subscriber — told, but not made responsible.

`github.actor` was the other candidate and was rejected: it is a GitHub login, not a fleet agent id, so writing it into `agent` swaps one namespace confusion for another and still is not the pusher the contract names.

## The fallback is deliberately NOT deleted

118 of 121 cards took that path, and `record_verdict` treats an unresolved recipient as a hard failure. Deleting it would turn the verdict step **red on ~97% of pushes and destroy the verdict** instead of delivering it. An unrouted verdict beats a misrouted one; a dropped one beats neither. So it still routes and still delivers — it just no longer gets recorded as authorship.

`resolve_recipient` additionally refuses to read `ci-unclaimed` (or `ci`) back as a recorded pusher, which closes the laundering loop.

## Structure

Addressing moves to a new `.github/ci/ci_rail_recipient.py`. The rail is split by **failure domain** — `_cards` is the store, `_listen` the bus, `_message` the text, `_failure` the log — and "the verdict reached the wrong agent" was the only one of those with no home. `ci_card_rail.py` re-exports, so the git hook, the workflow and the existing suite are untouched. It also returns the orchestrator to under the 512-line limit.

## Proof

20 new tests in `tests/integration/test_ci_rail_recipient.py`, run against a checkout of the **pre-fix** tree:

```
19 failed, 1 passed
```

Including the direct one, failing on the defect itself rather than on a missing symbol:

```
test_the_verdict_half_records_the_owner_not_the_recipient
    launders = "agent=recipient" in source or "assignee=recipient" in source
>   assert not launders
E   assert not True
```

The single pre-fix **pass** is the delivery test — it must keep passing, because honesty must not cost delivery.

With the fix, both rail suites: **64 passed**.

## Not fixed here

`core.hooksPath` is unset in this repo, so `.githooks/pre-push` never runs and the measured path is unreachable for nearly every push. Arming it is what moves cards from the unknown column to the known one — a separate change with separate risk, and this fix must be correct without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
