### PR TITLE
fix(dispatch)!: the spec handoff proved nothing — a peer exited 0 and wrote the spec one directory away

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -9,8 +9,9 @@ which asks the pure resolver in ``_common.classify_dispatch_host`` to map
 the concrete ``spec.host`` to local / remote / unknown. A ``remote``
 classification calls :func:`_dispatch_remote_start` to:
 
-  * drift-check via ``rsync --dry-run --itemize-changes``,
-  * rsync the spec dir to the peer,
+  * drift-check by comparing content digests with the peer,
+  * ship the spec dir and VERIFY it landed (see :mod:`._spec_handoff`,
+    which documents why an rsync exit code is not evidence of delivery),
   * invoke ``sac agents start <name> --no-redispatch --json`` over ssh
     (env_preamble-aware via :func:`build_ssh_argv`), and
   * write a lead-side ``state.db.instances`` row so cross-host
@@ -32,7 +33,14 @@ import click
 
 from ...config import AgentConfig
 from ._common import _local_host_names
-from ._dispatch_paths import local_spec_dir, remote_spec_target
+from ._dispatch_paths import local_spec_dir, remote_spec_dir
+from ._spec_handoff import (
+    local_manifest,
+    plan_handoff,
+    push_spec_dir,
+    read_remote_manifest,
+    ssh_runner,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection
@@ -54,19 +62,6 @@ def _spawned_by() -> str:
     return getenv("NAME") or "cli"
 
 
-def _is_first_launch_line(line: str) -> bool:
-    """Return True when an rsync ``--itemize-changes`` row is a pure-new
-    entry (head contains only ``+`` markers, no ``*`` deletion flag).
-
-    Itemized format: ``YXcstpoguax <name>`` — the leading 11-char head
-    is everything before the first space. First-launch markers are
-    ``>f+++++++++`` / ``cd+++++++++``; drift uses letters like
-    ``c.st....``; deletes use ``*deleting``.
-    """
-    head = line.split(" ", 1)[0]
-    return "+++++++++" in head and "*" not in head
-
-
 def _dispatch_remote_start(
     name: str,
     peer: str,
@@ -76,9 +71,9 @@ def _dispatch_remote_start(
 ) -> int:
     """Dispatch ``sac agents start <name>`` to a remote ``peer``.
 
-    Step 4 implementation: locate the local spec dir, drift-check via
-    ``rsync --dry-run --itemize-changes`` (content-checksum mode),
-    rsync the spec when the drift gate allows it, then invoke
+    Step 4 implementation: locate the local spec dir, drift-check by
+    comparing per-file digests with the peer, ship the spec when the
+    drift gate allows it and verify it actually landed, then invoke
     ``sac agents start <name> --no-redispatch --json`` on the peer
     over ssh (env_preamble-aware via :func:`build_ssh_argv`), parse
     the resulting JSON, and write a lead-side ``state.db.instances``
@@ -91,16 +86,17 @@ def _dispatch_remote_start(
             ``ssh:`` field in ``~/.scitex/agent-container/config.yaml``
             is the source of this alias.
         dry_run: When True, print the planned change count and return
-            0 without performing the actual rsync.
-        force: When True, override the drift gate and rsync anyway.
+            0 without shipping anything.
+        force: When True, override the drift gate and ship anyway.
 
     Raises:
         FileNotFoundError: When the local spec dir for ``name`` does
             not exist under ``~/.scitex/agent-container/agents/``.
-        RuntimeError: When ``rsync --dry-run`` fails, when drift is
-            detected without ``--force``, when the real rsync fails,
-            when the remote ``sac agents start`` returns non-zero,
-            or when its stdout is not valid JSON.
+        RuntimeError: When the peer's manifest cannot be read, when
+            drift is detected without ``--force``, when the transfer
+            fails OR SILENTLY MIS-DELIVERS (post-transfer digests do
+            not match), when the remote ``sac agents start`` returns
+            non-zero, or when its stdout is not valid JSON.
     """
     # 1. Locate the local spec dir ($SCITEX_DIR-aware — see _dispatch_paths).
     src_dir = local_spec_dir(name)
@@ -110,119 +106,59 @@ def _dispatch_remote_start(
             f"Create the spec locally before dispatching to {peer!r}."
         )
 
-    # 2. rsync --dry-run --itemize-changes (content-checksum mode).
-    # The destination root comes from the host REGISTRY (the SSOT port), not
-    # from the remote's ``~/.scitex`` — see :mod:`._dispatch_paths` for the
-    # measured Spartan incident that makes this mandatory.
+    # 2. Compare content digests with the peer. The destination root comes
+    # from the host REGISTRY (the SSOT port), not from the remote's
+    # ``~/.scitex`` — see :mod:`._dispatch_paths` for the measured Spartan
+    # incident that makes this mandatory.
     from ..._state.host_config import load as _load_host_config_for_root
 
-    remote_target = remote_spec_target(name, peer, _load_host_config_for_root().peers)
-    exclude_args = [
-        "--exclude=runtime/",
-        "--exclude=__pycache__/",
-        "--exclude=.pytest_cache/",
-        "--exclude=_sphinx_html/",
-    ]
-    # Drive rsync's ssh transport with the same TOFU policy we use for
-    # bare ssh (build_ssh_argv): accept-new lets the first-touch peer
-    # be added to known_hosts, but rejects any later key change. Without
-    # ``-e``, rsync would invoke ssh with whatever the user's defaults
-    # are, which on a fresh peer surfaces as a silent rc-1 from rsync.
-    rsync_ssh_opt = "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
-    rsync_dry_argv = [
-        "rsync",
-        "-acvn",  # archive + checksum + verbose + dry-run
-        "-e",
-        rsync_ssh_opt,
-        "--itemize-changes",
-        "--delete",
-        *exclude_args,
-        f"{src_dir!s}/",
-        remote_target,
-    ]
-    rsync_dry = subprocess.run(
-        rsync_dry_argv,
-        capture_output=True,
-        text=True,
-        check=False,
+    peers_for_root = _load_host_config_for_root().peers
+    remote_dir = remote_spec_dir(name, peer, peers_for_root)
+    peer_shell = ssh_runner(peer, peers_for_root)
+    plan = plan_handoff(
+        local_manifest(src_dir),
+        read_remote_manifest(remote_dir, peer_shell),
     )
-    if rsync_dry.returncode != 0:
-        raise RuntimeError(
-            f"rsync --dry-run failed against {peer!r} (rc={rsync_dry.returncode}):\n"
-            f"argv: {' '.join(shlex.quote(a) for a in rsync_dry_argv)}\n"
-            f"stderr:\n{rsync_dry.stderr}"
-        )
 
-    # 3. Parse itemized output. Itemized rows have an 11-char "YXcstpoguax"
-    # head (position 0 is one of "<>ch*."; position 1 is one of "fdLD");
-    # first-launch rows are all-plus; drift rows use letters; deletes start
-    # with "*deleting".  rsync also emits informational lines that are NOT
-    # itemize records — "sending incremental file list" (header), "created
-    # directory <path>" (top-level dir creation notice), "sent N bytes ..."
-    # (footer), "total size is ..." (footer).  We must keep only true
-    # itemize records.
-    _ITEMIZE_OP_CHARS = set("<>ch*.")
-    itemized = []
-    for line in rsync_dry.stdout.splitlines():
-        if not line or line.startswith((" ", "sending", "sent", "total", "created")):
-            continue
-        # A true itemize record starts with one of <>ch*. — informational
-        # lines (e.g. "Number of files: ...") will not match.
-        if len(line) < 11 or line[0] not in _ITEMIZE_OP_CHARS:
-            continue
-        itemized.append(line)
-    changes = itemized
-    first_launch = bool(changes) and all(_is_first_launch_line(c) for c in changes)
-    drift = bool(changes) and not first_launch
-
-    # 4. Drift gate — error unless --force was passed.
-    if drift and not force:
+    # 3. Drift gate — error unless --force was passed. Only a file the peer
+    # holds with DIFFERENT content is drift; peer-only files are reported at
+    # step 5 and kept (see :mod:`._spec_handoff` on dropping ``--delete``).
+    if plan.drift and not force:
         raise RuntimeError(
-            f"Spec drift between lead and {peer!r} for agent {name!r}:\n"
-            + "\n".join(f"  {c}" for c in changes)
+            f"Spec drift between lead and {peer!r} for agent {name!r} — the "
+            f"peer's copy of these files differs from the lead's:\n"
+            + "\n".join(f"  {rel}" for rel in plan.changed)
             + "\n\nResolve manually then re-run, "
             + "or pass --force to overwrite peer-side from lead. "
             + "See ~/proj/scitex-lead/GITIGNORED/WORKING/remote-agent-pipeline.md."
         )
 
-    # 5. Dry-run mode: report the plan and return without rsyncing.
+    # 4. Dry-run mode: report the plan and return without shipping anything.
     if dry_run:
-        if not changes:
+        if not plan.new and not plan.changed:
             status = "no drift"
-        elif first_launch:
+        elif plan.first_launch:
             status = "first launch"
-        else:
+        elif plan.changed:
             status = "drift overridden by --force"
+        else:
+            status = "new files only"
         click.echo(
-            f"[dispatch] dry-run for {name!r} -> {peer!r}: "
-            f"{status}; {len(changes)} file change(s) planned."
+            f"[dispatch] dry-run for {name!r} -> {peer!r} at {remote_dir}: "
+            f"{status}; {plan.summary()}."
         )
         return 0
 
-    # 6. Actual rsync (no --dry-run). Same TOFU ssh transport as the
-    # dry-run above so the real handoff also accepts a first-touch
-    # peer key.
-    rsync_real_argv = [
-        "rsync",
-        "-acv",
-        "-e",
-        rsync_ssh_opt,
-        "--delete",
-        *exclude_args,
-        f"{src_dir!s}/",
-        remote_target,
-    ]
-    rsync_real = subprocess.run(
-        rsync_real_argv,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if rsync_real.returncode != 0:
-        raise RuntimeError(
-            f"rsync failed against {peer!r} (rc={rsync_real.returncode}):\n"
-            f"argv: {' '.join(shlex.quote(a) for a in rsync_real_argv)}\n"
-            f"stderr:\n{rsync_real.stderr}"
+    # 5. Deliver — and PROVE delivery by re-reading the peer's own digests.
+    # An exit code is not evidence: a vendor-patched transport can exit 0
+    # having written the spec somewhere nobody reads, after which the remote
+    # `sac agents start` below would boot the agent from the STALE spec and
+    # this dispatch would report success. push_spec_dir raises instead.
+    push_spec_dir(src_dir, remote_dir, peer_shell, peer=peer)
+    if plan.extra:
+        click.echo(
+            f"[dispatch] {len(plan.extra)} peer-only file(s) on {peer!r} kept "
+            f"(the handoff never deletes): {', '.join(plan.extra)}"
         )
 
     # 7. Step 4: invoke remote-side `sac agents start --no-redispatch --json`

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch_paths.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch_paths.py
@@ -17,8 +17,8 @@ fleet's real root is the operator's home, so a home-anchored lookup reads
 an EMPTY shadow tree and reports a spec "not found" for an agent that
 plainly exists.
 
-The far side (:func:`remote_spec_target`)
------------------------------------------
+The far side (:func:`remote_spec_dir`)
+--------------------------------------
 Resolved through the ECOSYSTEM HOST REGISTRY (``scitex_dev.hosts`` — the
 SSOT port), never by following the remote's ``~/.scitex``. Measured on
 Spartan 2026-07-14::
@@ -26,13 +26,12 @@ Spartan 2026-07-14::
     registry says   spartan.scitex_root = /data/gpfs/projects/punim0264/ywatanabe/.scitex
     reality         ~/.scitex -> /data/gpfs/.../paper-scitex-clew/.scitex   (symlink)
 
-A HOME-relative rsync destination therefore wrote the fleet's Spartan state
-inside an unrelated paper project. ``resolve_peer_scitex_root`` returns an
-absolute registry root (inherited through the ``via:`` chain for ``spartan-*``
-compute nodes) or ``None`` — and ``None`` preserves the historical
-home-relative destination exactly, so ``~``-rooted peers (mba / nas) are
-byte-identical. ``~`` is never expanded on THIS machine: for a remote host
-it denotes the PEER's home, and expanding it locally yields the lead's.
+A HOME-relative destination therefore wrote the fleet's Spartan state inside
+an unrelated paper project. ``resolve_peer_scitex_root`` returns an absolute
+registry root (inherited through the ``via:`` chain for ``spartan-*`` compute
+nodes) or ``None``, in which case the path is left for the PEER's shell to
+expand. Nothing home-anchored is ever expanded on THIS machine: for a remote
+host it denotes the PEER's home, and expanding it locally yields the lead's.
 """
 
 from __future__ import annotations
@@ -45,7 +44,7 @@ if TYPE_CHECKING:
 
     from ..._state.host_config import PeerSpec
 
-__all__ = ["local_spec_dir", "remote_spec_target"]
+__all__ = ["local_spec_dir", "remote_spec_dir"]
 
 
 def local_spec_dir(name: str) -> Path:
@@ -55,18 +54,31 @@ def local_spec_dir(name: str) -> Path:
     return _local_state.user_path("agent-container", "agents", name)
 
 
-def remote_spec_target(name: str, peer: str, peers: "Mapping[str, PeerSpec]") -> str:
-    """rsync destination for ``name``'s spec on ``peer`` (registry-resolved).
+def remote_spec_dir(name: str, peer: str, peers: "Mapping[str, PeerSpec]") -> str:
+    """Where ``name``'s spec must land on ``peer`` (registry-resolved).
 
-    Returns an rsync target string (``<peer>:<path>/``). Falls back to the
-    historical home-relative ``.scitex/...`` path when the registry has no
-    absolute root for the peer — never a locally-expanded guess.
+    Returns a PATH, not an rsync target: a registry-pinned absolute root when
+    the peer has one, else the literal ``$HOME/.scitex/...``, which the PEER's
+    shell expands (:mod:`._spec_handoff` runs it inside ``sh -c``).
+
+    ``$HOME`` rather than the historical bare-relative ``.scitex/...``: a
+    relative path resolves against the remote CWD, and that is not always the
+    home directory. Measured 2026-08-15 — a non-interactive
+    ``ssh scitex-nas-03 pwd`` answers ``/home/ywatanabe/proj/scitex-hub``, so
+    the old destination aimed the spec (and, back when the handoff still
+    passed ``--delete``, a mirroring delete) at an unrelated repository.
+
+    ``~`` would also have worked here, but only because a shell expands it;
+    ``$HOME`` says so explicitly and cannot be mistaken for a path the LEAD
+    should expand. Expanding either one locally is always wrong — for a
+    remote host they denote the PEER's home, and the lead's is a different
+    tree (see the Spartan incident in this module's header).
     """
     from ..._state._host_ssh import resolve_peer_scitex_root
 
     root = resolve_peer_scitex_root(peer, dict(peers))
-    prefix = f"{root}/agent-container" if root else ".scitex/agent-container"
-    return f"{peer}:{prefix}/agents/{name}/"
+    prefix = f"{root}/agent-container" if root else "$HOME/.scitex/agent-container"
+    return f"{prefix}/agents/{name}"
 
 
 # EOF

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_spec_handoff.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_spec_handoff.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Verified spec handoff — put the lead's spec dir on a peer, and PROVE it.
+
+Why this replaced ``rsync``
+---------------------------
+Dispatch used to deliver the spec with ``rsync -acv --delete`` over ssh and
+treat ``rc == 0`` as delivery. Measured on ``scitex-nas-03`` (UGREEN DXP480T,
+2026-08-15) that inference is false. Its ``/usr/bin/rsync`` is a vendor-patched
+**setuid-root** 3.4.1 that routes even plain ``--server`` ssh transfers through
+the rsync *daemon* module code, and the module table in ``/etc/rsyncd.conf``
+maps module ``home`` to ``/home/ywatanabe``. The receiver strips the leading
+``/home`` from the destination and then resolves the remainder INSIDE that
+module root, so every path lands one level deep::
+
+    dest /home/ywatanabe/__p__/   -> written to /home/ywatanabe/ywatanabe/__p__/
+    dest ~/__p__/                 -> written to /home/ywatanabe/ywatanabe/__p__/   (same)
+    dest ~/                       -> "created directory ywatanabe"
+
+All three exited **0**, printed a normal file list, and reported bytes sent.
+Nothing arrived at the requested path. A destination whose parent does not
+exist under that doubled prefix fails the other way — ``mkdir ... (in home)
+failed: No such file or directory (2)``, rc 11 — even when the requested
+directory plainly exists. And ``--dry-run`` does not predict either outcome:
+the same destination that fails a real write with rc 11 plans cleanly with
+rc 0, because the dry run never calls ``mkdir``.
+
+So on that peer the old code had two ways to be wrong and no way to notice:
+a loud rc-12/rc-11 that reads like a permissions problem, or a silent rc-0
+that puts the spec somewhere nobody reads — after which the remote
+``sac agents start`` boots the agent from the STALE spec still sitting at the
+real path, and the dispatch reports success. Repairing the destination string
+cannot fix this: there is no path that both names the true directory and
+survives the doubling, and a peer that mis-delivers silently must not be
+trusted on the strength of an exit code anyway.
+
+The replacement therefore does not ask a transport to be trustworthy. It
+ships a tar stream through the ordinary login shell — the same shell
+:func:`build_ssh_argv` already uses for the remote ``sac agents start``, which
+works fine on every peer including this one — and then **re-reads the peer's
+own digests and compares them to the lead's**. Delivery is a measurement, not
+an exit code.
+
+Three deliberate differences from the old rsync behaviour
+--------------------------------------------------------
+1. **Nothing is deleted.** ``rsync --delete`` would have removed every peer-side
+   file the lead does not have. On ``scitex-nas-03`` that set includes
+   ``start-telegram-sidecar.sh`` and the sidecar logs, which exist only there.
+   Deleting operator-placed files as a side effect of starting an agent is the
+   unrequested deletion #1048 just promoted to a first-class gate, so peer-only
+   files are REPORTED and kept.
+2. **The destination is resolved by the peer's shell** (``"$HOME/.scitex/..."``)
+   rather than sent as a home-relative path. A bare relative destination
+   resolves against the remote CWD, and on ``scitex-nas-03`` a non-interactive
+   ``ssh … pwd`` is ``/home/ywatanabe/proj/scitex-hub``, not ``$HOME`` — which,
+   with the old ``--delete``, aimed a mirroring delete at an unrelated repo.
+   A registry-pinned ABSOLUTE root still wins; see :mod:`._dispatch_paths` for
+   the Spartan incident that makes the registry authoritative.
+3. **Drift is decided by content digests**, not by parsing ``--itemize-changes``.
+
+Symlinks are shipped by tar but not verified: both manifests count regular
+files only (``find -type f`` on the peer, ``is_file() and not is_symlink()``
+here), so the two sides always describe the same set.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from ..._state.host_config import PeerSpec
+
+    #: Runs a POSIX-``sh`` script somewhere and returns its raw result. The
+    #: one seam between this module and the network: :func:`ssh_runner`
+    #: supplies the real one, and a test supplies a peer that behaves
+    #: differently (one that re-roots writes, say) WITHOUT patching anything
+    #: inside this module.
+    PeerShell = Callable[[str, "bytes | None"], "subprocess.CompletedProcess[bytes]"]
+
+__all__ = [
+    "EXCLUDED_NAMES",
+    "HandoffPlan",
+    "local_manifest",
+    "manifest_script",
+    "parse_manifest",
+    "plan_handoff",
+    "push_spec_dir",
+    "read_remote_manifest",
+    "ssh_runner",
+]
+
+#: Directory names never shipped and never compared — peer-side runtime
+#: state and build caches. Matched at ANY depth, which is what rsync's
+#: ``--exclude=runtime/`` did too.
+EXCLUDED_NAMES: tuple[str, ...] = (
+    "runtime",
+    "__pycache__",
+    ".pytest_cache",
+    "_sphinx_html",
+)
+
+
+@dataclass(frozen=True)
+class HandoffPlan:
+    """What delivering the lead's spec dir to a peer would change.
+
+    ``new`` are relpaths the peer does not have, ``changed`` are relpaths it
+    has with different content, and ``extra`` are the peer's own files the
+    lead does not have (kept, never deleted).
+    """
+
+    new: tuple[str, ...]
+    changed: tuple[str, ...]
+    extra: tuple[str, ...]
+
+    @property
+    def first_launch(self) -> bool:
+        """True when the peer has none of the lead's files yet."""
+        return bool(self.new) and not self.changed
+
+    @property
+    def drift(self) -> bool:
+        """True when the peer holds a DIFFERENT version of a shared file.
+
+        Only ``changed`` counts. ``extra`` used to count as drift because
+        rsync reported the deletions it planned; nothing is deleted now, so
+        a peer-only file is news, not a conflict.
+        """
+        return bool(self.changed)
+
+    def summary(self) -> str:
+        """One-line human summary used by ``--dry-run`` and error text."""
+        return (
+            f"{len(self.new)} new, {len(self.changed)} changed, "
+            f"{len(self.extra)} peer-only"
+        )
+
+
+def _digest(path: Path) -> str:
+    """md5 of a file's bytes — an integrity check, not a security claim.
+
+    Chosen because ``md5sum`` is the one checksum tool present on every peer
+    in this fleet, including the NAS busybox-ish userlands; the comparison is
+    only ever lead-vs-peer for files the lead just wrote.
+    """
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 16), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def local_manifest(src_dir: Path) -> dict[str, str]:
+    """``{relpath: md5}`` for every regular file the lead would ship."""
+    manifest: dict[str, str] = {}
+    for path in sorted(src_dir.rglob("*")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        rel = path.relative_to(src_dir)
+        if any(part in EXCLUDED_NAMES for part in rel.parts):
+            continue
+        manifest[rel.as_posix()] = _digest(path)
+    return manifest
+
+
+def manifest_script(remote_dir: str) -> str:
+    """POSIX ``sh`` printing ``<md5>  ./<relpath>`` for the peer's spec dir.
+
+    An ABSENT directory is not an error — it is a first launch, so the script
+    exits 0 with no output. A missing ``md5sum`` IS an error: without it we
+    cannot verify delivery, and proceeding unverified is the exact failure
+    this module exists to remove.
+    """
+    prunes = " ".join(f"-name {shlex.quote(n)} -prune -o" for n in EXCLUDED_NAMES)
+    return (
+        f'd="{remote_dir}"; [ -d "$d" ] || exit 0; cd "$d" || exit 1; '
+        "command -v md5sum >/dev/null 2>&1 || "
+        '{ echo "sac: md5sum not found on peer" >&2; exit 3; }; '
+        f"find . {prunes} -type f -exec md5sum {{}} +"
+    )
+
+
+def parse_manifest(stdout: str) -> dict[str, str]:
+    """Parse ``md5sum`` output into ``{relpath: md5}``.
+
+    ``md5sum`` prints ``<hash>  <path>`` (two spaces, or one plus a binary
+    marker). Paths arrive as ``./sub/file`` because the script ``cd``s into
+    the spec dir first; the ``./`` is stripped so both sides use the same
+    keys as :func:`local_manifest`.
+    """
+    manifest: dict[str, str] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        digest, _, rest = line.partition(" ")
+        rel = rest.strip().lstrip("*").strip()
+        if not digest or not rel:
+            continue
+        if rel.startswith("./"):
+            rel = rel[2:]
+        manifest[rel] = digest
+    return manifest
+
+
+def plan_handoff(
+    local: Mapping[str, str], remote: Mapping[str, str]
+) -> HandoffPlan:
+    """Diff two manifests into a :class:`HandoffPlan`."""
+    new = tuple(sorted(rel for rel in local if rel not in remote))
+    changed = tuple(
+        sorted(rel for rel, dig in local.items() if rel in remote and remote[rel] != dig)
+    )
+    extra = tuple(sorted(rel for rel in remote if rel not in local))
+    return HandoffPlan(new=new, changed=changed, extra=extra)
+
+
+def ssh_runner(peer: str, peers: Mapping[str, PeerSpec]) -> PeerShell:
+    """A :data:`PeerShell` that runs scripts on ``peer`` over ssh.
+
+    The script is collapsed into ONE pre-quoted argv element because ssh
+    word-joins everything after the host and hands the result to the remote
+    shell — the same reason :func:`build_ssh_argv` pre-quotes its
+    ``env_preamble`` wrapper. That remote shell is also what expands the
+    ``$HOME`` in a registry-unpinned destination.
+    """
+    from ..._state.host_config import build_ssh_argv
+
+    def run(
+        script: str, stdin: bytes | None = None
+    ) -> subprocess.CompletedProcess[bytes]:
+        argv = build_ssh_argv(peer, [f"sh -c {shlex.quote(script)}"], dict(peers))
+        return subprocess.run(argv, input=stdin, capture_output=True, check=False)
+
+    return run
+
+
+def read_remote_manifest(remote_dir: str, shell: PeerShell) -> dict[str, str]:
+    """``{relpath: md5}`` as the PEER reports it. Empty when absent."""
+    result = shell(manifest_script(remote_dir))
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Could not read the spec manifest at {remote_dir} "
+            f"(rc={result.returncode}).\n"
+            f"stderr:\n{result.stderr.decode('utf-8', 'replace')}"
+        )
+    return parse_manifest(result.stdout.decode("utf-8", "replace"))
+
+
+def push_spec_dir(
+    src_dir: Path,
+    remote_dir: str,
+    shell: PeerShell,
+    *,
+    peer: str = "peer",
+) -> dict[str, str]:
+    """Ship ``src_dir`` to ``peer:remote_dir`` and PROVE every file landed.
+
+    Returns the peer's post-transfer manifest. Raises ``RuntimeError`` when
+    the local ``tar`` fails, when the remote extraction fails, or — the point
+    of the whole module — when the peer's own digests do not match the lead's
+    after a transfer that claimed success.
+    """
+    excludes = [f"--exclude={name}" for name in EXCLUDED_NAMES]
+    tar = subprocess.run(
+        ["tar", "-C", str(src_dir), "-czf", "-", *excludes, "."],
+        capture_output=True,
+        check=False,
+    )
+    if tar.returncode != 0:
+        raise RuntimeError(
+            f"Could not pack the spec dir {src_dir!s} (tar rc={tar.returncode}):\n"
+            f"{tar.stderr.decode('utf-8', 'replace')}"
+        )
+
+    extract = shell(
+        f'd="{remote_dir}"; mkdir -p "$d" && tar -C "$d" -xzf -',
+        tar.stdout,
+    )
+    if extract.returncode != 0:
+        raise RuntimeError(
+            f"Spec handoff to {peer!r} failed while extracting into "
+            f"{remote_dir} (rc={extract.returncode}):\n"
+            f"{extract.stderr.decode('utf-8', 'replace')}"
+        )
+
+    expected = local_manifest(src_dir)
+    landed = read_remote_manifest(remote_dir, shell)
+    missing = sorted(rel for rel in expected if rel not in landed)
+    wrong = sorted(
+        rel for rel, dig in expected.items() if rel in landed and landed[rel] != dig
+    )
+    if missing or wrong:
+        raise RuntimeError(
+            f"Spec handoff to {peer!r} reported success but the peer does NOT "
+            f"have what was sent — the agent would boot from a stale spec.\n"
+            f"  target:  {remote_dir}\n"
+            f"  missing: {', '.join(missing) or 'none'}\n"
+            f"  differing: {', '.join(wrong) or 'none'}\n"
+            "The transfer exited 0, so this is the peer writing somewhere "
+            "other than the requested path (a vendor-patched rsync/tar that "
+            "re-roots paths does exactly this). Verify with:\n"
+            f"  ssh {peer} 'ls -la {remote_dir}'"
+        )
+    return landed
+
+
+# EOF

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
@@ -1,17 +1,21 @@
 """Tests for cli_pkg.lifecycle._dispatch._dispatch_remote_start (step 4).
 
 See ``~/proj/scitex-lead/GITIGNORED/WORKING/remote-agent-pipeline.md``.
-Covers the drift-check / rsync surface (step 3b) AND the remote
+Covers the drift-check / spec-handoff surface (step 3b) AND the remote
 ``sac agents start`` invocation + JSON parse + lead-side instances
 row write (step 4).
 
-No-mocks: real ``subprocess.run`` against PATH-prepended fake
-``rsync`` and ``ssh`` binaries. Conforms to STX-TQ002 (AAA markers),
-STX-TQ003 (descriptive names), STX-TQ007 (one assert per test).
+No-mocks: real ``subprocess.run`` against a PATH-prepended fake ``ssh``
+binary that answers as the peer would in each phase of the handoff.
+Every leg is now an ssh call — the spec no longer travels by rsync, whose
+exit code was not evidence of delivery (see ``_spec_handoff``). Conforms
+to STX-TQ002 (AAA markers), STX-TQ003 (descriptive names), STX-TQ007
+(one assert per test).
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
@@ -36,53 +40,56 @@ from scitex_agent_container.config._types import HostsSpec
 # ---------------------------------------------------------------------------
 
 
-def _install_rsync_shim(
-    bin_dir: Path,
-    *,
-    dry_stdout: str = "",
-    dry_stderr: str = "",
-    dry_exit: int = 0,
-    real_stdout: str = "",
-    real_stderr: str = "",
-    real_exit: int = 0,
-) -> Path:
-    """rsync shim that branches on ``-acvn`` (dry-run) vs ``-acv``."""
-    log = bin_dir / "rsync.argv.jsonl"
-    script = bin_dir / "rsync"
-    body = (
-        f"#!{sys.executable}\n"
-        "import json, sys\n"
-        f"with open({json.dumps(str(log))}, 'a') as fh:\n"
-        "    fh.write(json.dumps(sys.argv[1:]) + '\\n')\n"
-        "is_dry = any(\n"
-        "    a.startswith('-') and not a.startswith('--') and 'n' in a\n"
-        "    for a in sys.argv[1:]\n"
-        ")\n"
-        f"d_out, d_err, d_rc = {json.dumps(dry_stdout)}, {json.dumps(dry_stderr)}, {int(dry_exit)}\n"
-        f"r_out, r_err, r_rc = {json.dumps(real_stdout)}, {json.dumps(real_stderr)}, {int(real_exit)}\n"
-        "out, err, rc = (d_out, d_err, d_rc) if is_dry else (r_out, r_err, r_rc)\n"
-        "sys.stdout.write(out); sys.stderr.write(err); sys.exit(rc)\n"
-    )
-    script.write_text(body)
-    script.chmod(0o755)
-    return script
-
-
 def _install_ssh_shim(
     bin_dir: Path,
     *,
+    peer_manifest: str = "",
+    manifest_exit: int = 0,
+    manifest_stderr: str = "",
+    landed_manifest: str | None = None,
+    extract_exit: int = 0,
+    extract_stderr: str = "",
     stdout: str = "{}",
     stderr: str = "",
     exit: int = 0,
 ) -> Path:
-    """ssh shim that records its argv (JSON list) and emits configured rc/stdout."""
+    """A fake peer, reached the way the real one is — over ``ssh``.
+
+    Every leg of a dispatch is now an ssh call, so the shim answers as the
+    peer would in each PHASE, recognised from the script it was handed:
+
+      * ``md5sum``  — report the spec dir's digests. The FIRST such call is
+        the pre-handoff read (``peer_manifest``); every later one is the
+        post-transfer verification (``landed_manifest``, defaulting to
+        ``peer_manifest`` so a peer that received nothing keeps saying so).
+        Splitting the two is what lets a test model a transport that exits 0
+        and delivers nowhere.
+      * ``tar -C``  — receive the spec (``extract_exit``).
+      * anything else — the ``sac agents start --json`` handoff (``stdout``).
+    """
     log = bin_dir / "ssh.argv.jsonl"
+    seen = bin_dir / "ssh.manifest.count"
     script = bin_dir / "ssh"
+    landed = peer_manifest if landed_manifest is None else landed_manifest
     body = (
         f"#!{sys.executable}\n"
-        "import json, sys\n"
-        f"with open({json.dumps(str(log))}, 'a') as fh:\n"
-        "    fh.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        "import json, os, sys\n"
+        f"log, seen = {json.dumps(str(log))}, {json.dumps(str(seen))}\n"
+        "argv = sys.argv[1:]\n"
+        "with open(log, 'a') as fh:\n"
+        "    fh.write(json.dumps(argv) + '\\n')\n"
+        "joined = ' '.join(argv)\n"
+        f"before, after = {json.dumps(peer_manifest)}, {json.dumps(landed)}\n"
+        "if 'md5sum' in joined:\n"
+        "    n = int(open(seen).read()) if os.path.exists(seen) else 0\n"
+        "    open(seen, 'w').write(str(n + 1))\n"
+        "    sys.stdout.write(before if n == 0 else after)\n"
+        f"    sys.stderr.write({json.dumps(manifest_stderr)})\n"
+        f"    sys.exit({int(manifest_exit)})\n"
+        "if 'tar -C' in joined:\n"
+        "    sys.stdin.buffer.read()\n"
+        f"    sys.stderr.write({json.dumps(extract_stderr)})\n"
+        f"    sys.exit({int(extract_exit)})\n"
         f"sys.stdout.write({json.dumps(stdout)})\n"
         f"sys.stderr.write({json.dumps(stderr)})\n"
         f"sys.exit({int(exit)})\n"
@@ -92,17 +99,6 @@ def _install_ssh_shim(
     return script
 
 
-def _is_dry_run_argv(argv: list[str]) -> bool:
-    return any(a.startswith("-") and not a.startswith("--") and "n" in a for a in argv)
-
-
-def _rsync_invocations(bin_dir: Path) -> list[list[str]]:
-    log = bin_dir / "rsync.argv.jsonl"
-    if not log.exists():
-        return []
-    return [json.loads(ln) for ln in log.read_text().splitlines() if ln.strip()]
-
-
 def _ssh_invocations(bin_dir: Path) -> list[list[str]]:
     log = bin_dir / "ssh.argv.jsonl"
     if not log.exists():
@@ -110,12 +106,8 @@ def _ssh_invocations(bin_dir: Path) -> list[list[str]]:
     return [json.loads(ln) for ln in log.read_text().splitlines() if ln.strip()]
 
 
-def _rsync_dry_count(bin_dir: Path) -> int:
-    return sum(1 for argv in _rsync_invocations(bin_dir) if _is_dry_run_argv(argv))
-
-
-def _rsync_real_count(bin_dir: Path) -> int:
-    return sum(1 for argv in _rsync_invocations(bin_dir) if not _is_dry_run_argv(argv))
+def _phase_count(bin_dir: Path, marker: str) -> int:
+    return sum(1 for argv in _ssh_invocations(bin_dir) if marker in " ".join(argv))
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +129,18 @@ def spec_dir(fake_home: Path) -> Path:
     d.mkdir(parents=True)
     (d / "spec.yaml").write_text("name: alpha\n")
     return d
+
+
+@pytest.fixture
+def registered_peer(fake_home: Path, env_save_restore) -> Path:
+    """Register ``peer-host`` in a real config.yaml.
+
+    Needed by EVERY dispatch test now: each leg of the handoff — the
+    manifest read, the transfer, the verification — is rendered by
+    ``build_ssh_argv``, which resolves the peer from this config. Under the
+    old rsync transport only the final ``sac agents start`` leg did.
+    """
+    return _write_peer_config(fake_home, env_save_restore)
 
 
 @pytest.fixture
@@ -218,29 +222,23 @@ class _Scenario:
         return str(self.raised) if self.raised is not None else ""
 
     @property
-    def dry_count(self) -> int:
-        return _rsync_dry_count(self.bin_dir)
-
-    @property
-    def real_count(self) -> int:
-        return _rsync_real_count(self.bin_dir)
+    def shipped_count(self) -> int:
+        """How many times the spec was actually handed to the peer."""
+        return _phase_count(self.bin_dir, "tar -C")
 
 
 def _act_dispatch(
     shim_bin: Path,
     capsys,
     *,
-    rsync_kwargs: dict[str, Any] | None = None,
     ssh_kwargs: dict[str, Any] | None = None,
     name: str = "alpha",
     peer: str = "peer-host",
     dry_run: bool = False,
     force: bool = False,
 ) -> _Scenario:
-    """Install shim(s) and invoke ``_dispatch_remote_start`` once."""
-    _install_rsync_shim(shim_bin, **(rsync_kwargs or {}))
-    if ssh_kwargs is not None:
-        _install_ssh_shim(shim_bin, **ssh_kwargs)
+    """Install the fake peer and invoke ``_dispatch_remote_start`` once."""
+    _install_ssh_shim(shim_bin, **(ssh_kwargs or {}))
     scen = _Scenario(bin_dir=shim_bin)
     try:
         scen.returned = _dispatch_remote_start(name, peer, dry_run=dry_run, force=force)
@@ -252,13 +250,32 @@ def _act_dispatch(
     return scen
 
 
-_FIRST_LAUNCH_OUTPUT = ">f+++++++++ spec.yaml\ncd+++++++++ overlays/\n"
-_DRIFT_OUTPUT = ">f.st...... spec.yaml\n>f+++++++++ NEWFILE.txt\n"
+#: The spec file the ``spec_dir`` fixture writes, and its real md5 — the
+#: digest a peer that received it correctly must report back.
+_ALPHA_BODY = "name: alpha\n"
+_ALPHA_MD5 = hashlib.md5(_ALPHA_BODY.encode(), usedforsecurity=False).hexdigest()
+
+#: A peer holding exactly what the lead has (post-transfer, or no drift).
+_DELIVERED = f"{_ALPHA_MD5}  ./spec.yaml\n"
+#: A peer holding a DIFFERENT spec.yaml — the drift gate's trigger.
+_PEER_DRIFTED = f"{'0' * 32}  ./spec.yaml\n"
+
 _OK_JSON = '{"a2a_port": 47213, "started_at": "2026-05-16T00:00:00Z"}'
 
-# Reusable step-4 shim kwargs (clean rsync + ok ssh).
-_RK_OK = dict(dry_stdout=_FIRST_LAUNCH_OUTPUT, dry_exit=0, real_exit=0)
-_SK_OK = dict(stdout=_OK_JSON, exit=0)
+def _peer_that_delivers(**start_kwargs) -> dict[str, Any]:
+    """A peer whose handoff genuinely succeeds, varying only its start reply.
+
+    Every step-4 test needs the spec to actually arrive before the remote
+    ``sac agents start`` is reached at all — the handoff now refuses to
+    continue past a mis-delivery — so the delivered digests are pinned here
+    and each test overrides only the ``--json`` reply it cares about.
+    """
+    return dict(peer_manifest="", landed_manifest=_DELIVERED, **start_kwargs)
+
+
+#: Reusable step-4 peer: empty before the handoff, correct after it, and a
+#: well-formed ``sac agents start --json`` reply.
+_SK_OK = _peer_that_delivers(stdout=_OK_JSON, exit=0)
 
 
 # ---------------------------------------------------------------------------
@@ -267,101 +284,143 @@ _SK_OK = dict(stdout=_OK_JSON, exit=0)
 
 
 class TestDispatchDriftBlocksWithoutForce:
-    def test_drift_without_force_raises_runtime_error(self, spec_dir, shim_bin, capsys):
-        # Arrange
-        rk = dict(dry_stdout=_DRIFT_OUTPUT, dry_exit=0)
+    def test_drift_without_force_raises_runtime_error(self, spec_dir, shim_bin, registered_peer, capsys):
+        # Arrange — the peer holds a DIFFERENT spec.yaml.
+        sk = dict(peer_manifest=_PEER_DRIFTED)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
         assert isinstance(scen.raised, RuntimeError)
 
-    def test_drift_message_mentions_spec_drift(self, spec_dir, shim_bin, capsys):
+    def test_drift_message_mentions_spec_drift(self, spec_dir, shim_bin, registered_peer, capsys):
         # Arrange
-        rk = dict(dry_stdout=_DRIFT_OUTPUT, dry_exit=0)
+        sk = dict(peer_manifest=_PEER_DRIFTED)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
         assert "Spec drift" in scen.message
 
-    def test_drift_does_not_invoke_real_rsync(self, spec_dir, shim_bin, capsys):
+    def test_drift_message_names_the_differing_file(self, spec_dir, shim_bin, registered_peer, capsys):
         # Arrange
-        rk = dict(dry_stdout=_DRIFT_OUTPUT, dry_exit=0)
+        sk = dict(peer_manifest=_PEER_DRIFTED)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
-        assert scen.real_count == 0
+        assert "spec.yaml" in scen.message
 
-
-class TestDispatchDryRunMode:
-    def test_dry_run_mode_does_not_raise(self, spec_dir, shim_bin, capsys):
+    def test_drift_ships_nothing(self, spec_dir, shim_bin, registered_peer, capsys):
         # Arrange
-        rk = dict(dry_stdout=">f+++++++++ spec.yaml\n", dry_exit=0)
+        sk = dict(peer_manifest=_PEER_DRIFTED)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk, dry_run=True)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
+        # Assert
+        assert scen.shipped_count == 0
+
+    def test_a_peer_only_file_alone_does_not_block_a_start(
+        self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
+    ):
+        """The handoff no longer deletes, so a file only the peer has is news
+        rather than a conflict — losing scitex-nas-03's sidecar launcher to a
+        mirroring delete is what that rule prevents."""
+        # Arrange
+        _write_peer_config(fake_home, env_save_restore)
+        peer_only = _DELIVERED + f"{'1' * 32}  ./start-telegram-sidecar.sh\n"
+        sk = dict(peer_manifest=peer_only, landed_manifest=peer_only, stdout=_OK_JSON)
+        # Act
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
         assert scen.raised is None
 
-    def test_dry_run_mode_returns_zero_exit(self, spec_dir, shim_bin, capsys):
+
+class TestDispatchDryRunMode:
+    def test_dry_run_mode_does_not_raise(self, spec_dir, shim_bin, registered_peer, capsys):
         # Arrange
-        rk = dict(dry_stdout=">f+++++++++ spec.yaml\n", dry_exit=0)
+        sk = dict(peer_manifest="")
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk, dry_run=True)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk, dry_run=True)
+        # Assert
+        assert scen.raised is None
+
+    def test_dry_run_mode_returns_zero_exit(self, spec_dir, shim_bin, registered_peer, capsys):
+        # Arrange
+        sk = dict(peer_manifest="")
+        # Act
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk, dry_run=True)
         # Assert
         assert scen.returned == 0
 
-    def test_dry_run_mode_prints_dispatch_marker(self, spec_dir, shim_bin, capsys):
+    def test_dry_run_mode_prints_dispatch_marker(self, spec_dir, shim_bin, registered_peer, capsys):
         # Arrange
-        rk = dict(dry_stdout=">f+++++++++ spec.yaml\n", dry_exit=0)
+        sk = dict(peer_manifest="")
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk, dry_run=True)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk, dry_run=True)
         # Assert
         assert "[dispatch] dry-run" in scen.captured_stdout
 
-    def test_dry_run_mode_skips_real_rsync(self, spec_dir, shim_bin, capsys):
+    def test_dry_run_mode_ships_nothing(self, spec_dir, shim_bin, registered_peer, capsys):
         # Arrange
-        rk = dict(dry_stdout=">f+++++++++ spec.yaml\n", dry_exit=0)
+        sk = dict(peer_manifest="")
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk, dry_run=True)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk, dry_run=True)
         # Assert
-        assert scen.real_count == 0
+        assert scen.shipped_count == 0
 
 
-class TestDispatchRsyncFailures:
-    def test_dry_run_failure_raises_runtime_error(self, spec_dir, shim_bin, capsys):
+class TestDispatchHandoffFailures:
+    def test_unreadable_peer_manifest_raises_runtime_error(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange
-        rk = dict(dry_stderr="ssh: host unreachable\n", dry_exit=255)
+        sk = dict(manifest_stderr="ssh: host unreachable\n", manifest_exit=255)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
         assert isinstance(scen.raised, RuntimeError)
 
-    def test_dry_run_failure_message_identifies_phase(self, spec_dir, shim_bin, capsys):
+    def test_unreadable_peer_manifest_message_identifies_phase(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange
-        rk = dict(dry_stderr="ssh: host unreachable\n", dry_exit=255)
+        sk = dict(manifest_stderr="ssh: host unreachable\n", manifest_exit=255)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
-        assert "rsync --dry-run failed" in scen.message
+        assert "Could not read the spec manifest" in scen.message
 
-    def test_real_rsync_failure_message_mentions_rsync_failed(
-        self, spec_dir, shim_bin, capsys
+    def test_a_failed_transfer_message_identifies_the_extract_phase(
+        self, spec_dir, shim_bin, registered_peer, capsys
     ):
-        # Arrange — clean dry-run, fail on real rsync.
-        rk = dict(dry_exit=0, real_stderr="broken pipe\n", real_exit=12)
+        # Arrange — the peer is readable, then refuses the write.
+        sk = dict(peer_manifest="", extract_stderr="broken pipe\n", extract_exit=12)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
-        assert "rsync failed" in scen.message
+        assert "failed while extracting" in scen.message
 
-    def test_real_rsync_failure_excludes_dry_run_phase(
-        self, spec_dir, shim_bin, capsys
+    def test_a_transfer_that_exits_zero_but_delivers_nothing_raises(
+        self, spec_dir, shim_bin, registered_peer, capsys
     ):
-        # Arrange — disambiguate from dry-run failure.
-        rk = dict(dry_exit=0, real_stderr="broken pipe\n", real_exit=12)
+        """THE regression. scitex-nas-03's patched rsync exited 0 and wrote the
+        spec one directory away; the old code then booted the agent from the
+        stale spec and called the dispatch a success."""
+        # Arrange — extraction "succeeds", peer still reports an empty dir.
+        sk = dict(peer_manifest="", landed_manifest="", extract_exit=0)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=rk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
-        assert "rsync --dry-run failed" not in scen.message
+        assert "stale spec" in scen.message
+
+    def test_a_silent_mis_delivery_never_reaches_the_remote_start(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
+        """The consequence that made this urgent: a mis-delivered spec must
+        not be followed by a start that reads whatever is at that path."""
+        # Arrange
+        sk = dict(peer_manifest="", landed_manifest="", extract_exit=0)
+        # Act
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
+        # Assert
+        assert _phase_count(shim_bin, "sac agents start") == 0
 
 
 class TestDispatchMissingSpecDir:
@@ -393,7 +452,7 @@ class TestDispatchSshSuccessPath:
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert — query state.db via the project API so schema is init'd.
         from scitex_agent_container._state.state_db import list_active_instances
 
@@ -406,7 +465,7 @@ class TestDispatchSshSuccessPath:
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         assert scen.returned == 0
 
@@ -416,7 +475,7 @@ class TestDispatchSshSuccessPath:
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         assert "started on 'peer-host'" in scen.captured_stdout
 
@@ -426,7 +485,7 @@ class TestDispatchSshSuccessPath:
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         assert "a2a_port=47213" in scen.captured_stdout
 
@@ -438,7 +497,7 @@ class TestDispatchSshSuccessPath:
         # peer (sac-agent-spawn design, Rule B/F).
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         from scitex_agent_container._state.state_db import list_active_instances
 
@@ -453,7 +512,7 @@ class TestDispatchSshSuccessPath:
         # crux of the remote-port gap fix).
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         from scitex_agent_container._state.state_db import list_active_instances
 
@@ -468,7 +527,7 @@ class TestDispatchSshSuccessPath:
         env_save_restore.set("SAC_NAME", "")
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         from scitex_agent_container._state.state_db import list_active_instances
 
@@ -483,12 +542,12 @@ class TestDispatchSshSuccessPath:
         # rather than substituting a default. Covers the cross-host
         # null-propagation seam.
         _write_peer_config(fake_home, env_save_restore)
-        sk_null = dict(
+        sk_null = _peer_that_delivers(
             stdout='{"a2a_port": null, "started_at": "2026-05-17T00:00:00Z"}',
             exit=0,
         )
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=sk_null)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=sk_null)
         # Assert
         from scitex_agent_container._state.state_db import list_active_instances
 
@@ -502,9 +561,9 @@ class TestDispatchSshFailurePaths:
     ):
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
-        sk = dict(stdout="", stderr="connection refused\n", exit=255)
+        sk = _peer_that_delivers(stdout="", stderr="connection refused\n", exit=255)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=sk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
         assert isinstance(scen.raised, RuntimeError)
 
@@ -513,9 +572,9 @@ class TestDispatchSshFailurePaths:
     ):
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
-        sk = dict(stderr="connection refused\n", exit=255)
+        sk = _peer_that_delivers(stderr="connection refused\n", exit=255)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=sk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
         assert "Remote `sac agents start alpha` failed" in scen.message
 
@@ -524,9 +583,9 @@ class TestDispatchSshFailurePaths:
     ):
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
-        sk = dict(stdout="OK\n", exit=0)
+        sk = _peer_that_delivers(stdout="OK\n", exit=0)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=sk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
         assert isinstance(scen.raised, RuntimeError)
 
@@ -535,9 +594,9 @@ class TestDispatchSshFailurePaths:
     ):
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
-        sk = dict(stdout="OK\n", exit=0)
+        sk = _peer_that_delivers(stdout="OK\n", exit=0)
         # Act
-        scen = _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=sk)
+        scen = _act_dispatch(shim_bin, capsys, ssh_kwargs=sk)
         # Assert
         assert "non-JSON stdout" in scen.message
 
@@ -557,7 +616,7 @@ class TestDispatchSshArgv:
         # Arrange — peer-side MUST NOT re-trigger the dispatch branch.
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         assert "--no-redispatch" in " ".join(_ssh_invocations(shim_bin)[-1])
 
@@ -567,7 +626,7 @@ class TestDispatchSshArgv:
         # Arrange — peer must emit machine-parseable output.
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         assert "--json" in " ".join(_ssh_invocations(shim_bin)[-1])
 
@@ -578,7 +637,7 @@ class TestDispatchSshArgv:
         # `bash -c '<preamble> && <cmd>'`.
         _write_peer_config(fake_home, env_save_restore, env_preamble=_LMOD_PREAMBLE)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         assert "module load Apptainer/1.3.3 && sac agents start" in " ".join(
             _ssh_invocations(shim_bin)[-1]
@@ -590,17 +649,19 @@ class TestDispatchSshArgv:
         # Arrange — bash -c wrapper is the explicit env_preamble shape.
         _write_peer_config(fake_home, env_save_restore, env_preamble=_LMOD_PREAMBLE)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
         assert any("bash -c" in tok for tok in _ssh_invocations(shim_bin)[-1])
 
 
 # ---------------------------------------------------------------------------
-# Bug 3 — TOFU policy: dispatch must add ``-o
-# StrictHostKeyChecking=accept-new`` to BOTH the ssh handoff AND rsync's
-# transport, so a first-touch peer (the most common dispatch failure
-# mode on a freshly-configured cluster) does not silently rc-1 with no
-# operator-actionable error.
+# Bug 3 — TOFU policy: EVERY leg of a dispatch must carry ``-o
+# StrictHostKeyChecking=accept-new``, so a first-touch peer (the most
+# common dispatch failure mode on a freshly-configured cluster) does not
+# silently rc-1 with no operator-actionable error. The spec handoff used
+# to hand rsync its own ``-e ssh …`` string, which had to repeat the
+# policy; it now goes through build_ssh_argv like everything else, so
+# there is exactly one place the policy can be got wrong.
 # ---------------------------------------------------------------------------
 
 
@@ -611,33 +672,36 @@ class TestDispatchStrictHostKeyChecking:
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert — the rendered ssh argv carries the TOFU policy.
         assert "StrictHostKeyChecking=accept-new" in " ".join(
             _ssh_invocations(shim_bin)[-1]
         )
 
-    def test_dispatch_dry_rsync_argv_uses_accept_new_transport(
+    def test_every_dispatch_leg_carries_the_tofu_policy(
         self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
     ):
-        # Arrange — clean first-launch dry-run, ok ssh.
+        # Arrange — manifest read, transfer, verification and remote start.
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
-        # Assert — rsync's -e transport carries the accept-new flag.
-        dry = next(a for a in _rsync_invocations(shim_bin) if _is_dry_run_argv(a))
-        assert any("StrictHostKeyChecking=accept-new" in tok for tok in dry)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
+        # Assert
+        assert all(
+            "StrictHostKeyChecking=accept-new" in " ".join(argv)
+            for argv in _ssh_invocations(shim_bin)
+        )
 
-    def test_dispatch_real_rsync_argv_uses_accept_new_transport(
+    def test_the_spec_transfer_is_one_of_those_legs(
         self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
     ):
+        """Guards the claim above from passing vacuously — if the transfer
+        stopped going over ssh, `all(...)` would still be True."""
         # Arrange
         _write_peer_config(fake_home, env_save_restore)
         # Act
-        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        _act_dispatch(shim_bin, capsys, ssh_kwargs=_SK_OK)
         # Assert
-        real = next(a for a in _rsync_invocations(shim_bin) if not _is_dry_run_argv(a))
-        assert any("StrictHostKeyChecking=accept-new" in tok for tok in real)
+        assert _phase_count(shim_bin, "tar -C") == 1
 
 
 # ---------------------------------------------------------------------------
@@ -884,12 +948,11 @@ class TestTryDispatchClassification:
     def test_known_peer_dispatches_remote_with_expected_ssh_argv(
         self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
     ):
-        # Arrange — host is a known peer distinct from the caller; PATH-shim
-        # rsync (clean first-launch) + ssh (ok JSON) stand in for the network.
+        # Arrange — host is a known peer distinct from the caller; the PATH-shim
+        # ssh stands in for the network across every phase of the handoff.
         # _dispatch_remote_start re-loads peers from the on-disk config for
         # build_ssh_argv, so register peer-host there too (real config.yaml).
         _write_peer_config(fake_home, env_save_restore, peer="peer-host")
-        _install_rsync_shim(shim_bin, **_RK_OK)
         _install_ssh_shim(shim_bin, **_SK_OK)
         cfg = _cfg_host("alpha", "peer-host")
         peers = {"peer-host": PeerSpec(name="peer-host", ssh="peer-host")}
@@ -902,9 +965,11 @@ class TestTryDispatchClassification:
             force=False,
             local_names={"ywata-note-win"},
         )
-        # Assert — dispatched, and the ssh argv runs the peer-side start verb.
+        # Assert — dispatched, and the LAST ssh argv runs the peer-side start
+        # verb (the earlier calls are the manifest read, the transfer and the
+        # post-transfer verification).
         ssh_calls = _ssh_invocations(shim_bin)
-        assert out is True and ssh_calls[0][-6:] == [
+        assert out is True and ssh_calls[-1][-6:] == [
             "sac",
             "agents",
             "start",

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__spec_handoff.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__spec_handoff.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The spec handoff must PROVE delivery, not infer it from an exit code.
+
+Pinned here because the defect that motivated the module is invisible to
+every other kind of check: on ``scitex-nas-03`` the transfer exits 0, prints
+a normal file list, and writes the spec one directory level away from the
+requested path (measured 2026-08-15). The remote ``sac agents start`` then
+boots the agent from the stale spec still sitting at the real path, and the
+dispatch reports success.
+
+Nothing here is patched. The peers below are real POSIX shells running the
+production scripts against real directories; :class:`ReroutingPeer` is a real
+shell too, wired the way the NAS is wired — writes land somewhere other than
+the path that was asked for. That is the whole seam the module exposes.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg.lifecycle._spec_handoff import (
+    EXCLUDED_NAMES,
+    local_manifest,
+    manifest_script,
+    parse_manifest,
+    plan_handoff,
+    push_spec_dir,
+    read_remote_manifest,
+)
+
+#: The destination the production code hands to the peer. A real dispatch
+#: sends ``$HOME/.scitex/...``; the peer's shell expands it. These tests send
+#: ``$SPEC_DIR`` and let the peer below define it — same mechanism, so the
+#: shell-expansion half of the contract is exercised rather than assumed.
+REMOTE_DIR = "$SPEC_DIR"
+
+
+class HonestPeer:
+    """A peer whose shell writes exactly where it is told."""
+
+    def __init__(self, spec_dir: Path) -> None:
+        self.spec_dir = spec_dir
+
+    def _env(self, root: Path) -> dict[str, str]:
+        return {**os.environ, "SPEC_DIR": str(root)}
+
+    def __call__(self, script: str, stdin: bytes | None = None):
+        return subprocess.run(
+            ["sh", "-c", script],
+            input=stdin if stdin is not None else b"",
+            capture_output=True,
+            check=False,
+            env=self._env(self.spec_dir),
+        )
+
+
+class ReroutingPeer(HonestPeer):
+    """A peer whose TRANSPORT re-roots writes, exactly like scitex-nas-03.
+
+    Its extraction succeeds — rc 0, no diagnostics — into ``writes_to``,
+    while anything that reads the spec dir still reads the path that was
+    requested. That is the shape that made a stale spec look like a fresh
+    deployment.
+    """
+
+    def __init__(self, spec_dir: Path, writes_to: Path) -> None:
+        super().__init__(spec_dir)
+        self.writes_to = writes_to
+
+    def __call__(self, script: str, stdin: bytes | None = None):
+        root = self.writes_to if "tar -C" in script else self.spec_dir
+        return subprocess.run(
+            ["sh", "-c", script],
+            input=stdin if stdin is not None else b"",
+            capture_output=True,
+            check=False,
+            env=self._env(root),
+        )
+
+
+class UnreachablePeer:
+    """A peer whose shell fails — the loud half of the contract."""
+
+    def __call__(self, script: str, stdin: bytes | None = None):
+        return subprocess.CompletedProcess(
+            args=[], returncode=11, stdout=b"", stderr=b"mkdir failed: No such file"
+        )
+
+
+@pytest.fixture
+def rerouted_delivery_error(tmp_path, spec_src):
+    """The message raised when a peer re-roots the write, captured once.
+
+    Lifted into a fixture so each claim about that message is its own test
+    with a single assertion.
+    """
+    peer = ReroutingPeer(tmp_path / "peer" / "asked-for", tmp_path / "peer" / "actual")
+    try:
+        push_spec_dir(spec_src, REMOTE_DIR, peer, peer="scitex-nas-03")
+    except RuntimeError as exc:
+        return str(exc)
+    raise AssertionError("a re-rooted delivery must not be reported as success")
+
+
+@pytest.fixture
+def spec_src(tmp_path):
+    """A lead-side spec dir with a nested file and excluded runtime state."""
+    root = tmp_path / "lead" / "scitex-hub"
+    (root / "to_home").mkdir(parents=True)
+    (root / "runtime").mkdir(parents=True)
+    (root / "spec.yaml").write_text("host: scitex-nas-03\n")
+    (root / "to_home" / "CLAUDE.md").write_text("house rules\n")
+    (root / "runtime" / "state.db").write_text("peer-side state\n")
+    return root
+
+
+# --------------------------------------------------------------------------
+# local_manifest — the lead's half
+# --------------------------------------------------------------------------
+
+
+def test_the_manifest_lists_every_shipped_file(spec_src):
+    # Arrange
+    expected = ["spec.yaml", "to_home/CLAUDE.md"]
+    # Act
+    manifest = local_manifest(spec_src)
+    # Assert
+    assert sorted(manifest) == expected
+
+
+def test_the_manifest_agrees_with_md5sum_byte_for_byte(spec_src):
+    # Arrange
+    proc = subprocess.run(
+        ["md5sum", str(spec_src / "spec.yaml")],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Act
+    digest = local_manifest(spec_src)["spec.yaml"]
+    # Assert
+    assert digest == proc.stdout.split()[0]
+
+
+@pytest.mark.parametrize("excluded", EXCLUDED_NAMES)
+def test_runtime_state_and_caches_are_never_shipped(tmp_path, excluded):
+    # Arrange
+    root = tmp_path / "scitex-hub"
+    (root / excluded).mkdir(parents=True)
+    (root / "spec.yaml").write_text("a")
+    (root / excluded / "junk").write_text("b")
+    # Act
+    manifest = local_manifest(root)
+    # Assert
+    assert sorted(manifest) == ["spec.yaml"]
+
+
+def test_an_excluded_directory_is_pruned_at_any_depth(tmp_path):
+    # Arrange
+    root = tmp_path / "scitex-hub"
+    (root / "to_home" / "__pycache__").mkdir(parents=True)
+    (root / "spec.yaml").write_text("a")
+    (root / "to_home" / "__pycache__" / "x.pyc").write_text("b")
+    # Act
+    manifest = local_manifest(root)
+    # Assert
+    assert sorted(manifest) == ["spec.yaml"]
+
+
+def test_a_symlink_is_absent_from_the_manifest(spec_src):
+    """``find -type f`` on the peer skips symlinks, so this side must too, or
+    every spec dir holding one would verify as mis-delivered."""
+    # Arrange
+    (spec_src / "link.yaml").symlink_to(spec_src / "spec.yaml")
+    # Act
+    manifest = local_manifest(spec_src)
+    # Assert
+    assert "link.yaml" not in manifest
+
+
+# --------------------------------------------------------------------------
+# manifest_script / parse_manifest — the peer's half
+# --------------------------------------------------------------------------
+
+
+def test_md5sum_output_parses_into_relative_paths():
+    # Arrange
+    stdout = "d41d8cd98f00b204e9800998ecf8427e  ./to_home/CLAUDE.md\n"
+    # Act
+    parsed = parse_manifest(stdout)
+    # Assert
+    assert parsed == {"to_home/CLAUDE.md": "d41d8cd98f00b204e9800998ecf8427e"}
+
+
+def test_the_peers_manifest_matches_the_leads_for_the_same_tree(spec_src):
+    """The two halves must agree on keys AND digests, or verification would
+    fail on a delivery that was in fact perfect."""
+    # Arrange
+    peer = HonestPeer(spec_src)
+    # Act
+    reported = read_remote_manifest(REMOTE_DIR, peer)
+    # Assert
+    assert reported == local_manifest(spec_src)
+
+
+def test_an_absent_spec_dir_reads_as_an_empty_manifest(tmp_path):
+    """A peer that has never seen this agent is a first launch, not a fault."""
+    # Arrange
+    peer = HonestPeer(tmp_path / "never-created")
+    # Act
+    reported = read_remote_manifest(REMOTE_DIR, peer)
+    # Assert
+    assert reported == {}
+
+
+def test_a_peer_that_cannot_be_read_is_an_error():
+    # Arrange
+    peer = UnreachablePeer()
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="Could not read the spec manifest"):
+        read_remote_manifest(REMOTE_DIR, peer)
+
+
+def test_the_manifest_script_prunes_excluded_directories(spec_src):
+    # Arrange
+    script = manifest_script(str(spec_src))
+    # Act
+    proc = subprocess.run(
+        ["sh", "-c", script], capture_output=True, text=True, check=True
+    )
+    # Assert
+    assert "runtime/state.db" not in parse_manifest(proc.stdout)
+
+
+# --------------------------------------------------------------------------
+# plan_handoff
+# --------------------------------------------------------------------------
+
+
+def test_an_empty_peer_is_a_first_launch():
+    # Arrange
+    local = {"spec.yaml": "aa"}
+    # Act
+    plan = plan_handoff(local, {})
+    # Assert
+    assert plan.first_launch is True
+
+
+def test_an_empty_peer_lists_every_file_as_new():
+    # Arrange
+    local = {"spec.yaml": "aa"}
+    # Act
+    plan = plan_handoff(local, {})
+    # Assert
+    assert plan.new == ("spec.yaml",)
+
+
+def test_a_differing_shared_file_is_drift():
+    # Arrange
+    local = {"spec.yaml": "aa"}
+    # Act
+    plan = plan_handoff(local, {"spec.yaml": "bb"})
+    # Assert
+    assert plan.drift is True
+
+
+def test_a_differing_shared_file_is_not_a_first_launch():
+    # Arrange
+    local = {"spec.yaml": "aa"}
+    # Act
+    plan = plan_handoff(local, {"spec.yaml": "bb"})
+    # Assert
+    assert plan.first_launch is False
+
+
+def test_an_identical_peer_plans_no_change():
+    # Arrange
+    local = {"spec.yaml": "aa"}
+    # Act
+    plan = plan_handoff(local, {"spec.yaml": "aa"})
+    # Assert
+    assert (plan.new, plan.changed, plan.extra) == ((), (), ())
+
+
+def test_a_peer_only_file_is_reported_as_extra():
+    # Arrange
+    local = {"spec.yaml": "aa"}
+    # Act
+    plan = plan_handoff(local, {"spec.yaml": "aa", "start-sidecar.sh": "cc"})
+    # Assert
+    assert plan.extra == ("start-sidecar.sh",)
+
+
+def test_a_peer_only_file_is_not_drift():
+    """It used to be, because rsync announced the deletion it planned. The
+    handoff no longer deletes, so a file only the peer has must not block a
+    start — losing scitex-nas-03's start-telegram-sidecar.sh to a mirroring
+    delete is the outcome that rule exists to prevent."""
+    # Arrange
+    local = {"spec.yaml": "aa"}
+    # Act
+    plan = plan_handoff(local, {"spec.yaml": "aa", "start-sidecar.sh": "cc"})
+    # Assert
+    assert plan.drift is False
+
+
+# --------------------------------------------------------------------------
+# push_spec_dir — the verification contract
+# --------------------------------------------------------------------------
+
+
+def test_a_delivery_puts_the_spec_where_it_was_asked_for(tmp_path, spec_src):
+    # Arrange
+    peer = HonestPeer(tmp_path / "peer" / "scitex-hub")
+    # Act
+    push_spec_dir(spec_src, REMOTE_DIR, peer)
+    # Assert
+    assert (peer.spec_dir / "spec.yaml").read_text() == "host: scitex-nas-03\n"
+
+
+def test_a_delivery_carries_nested_files(tmp_path, spec_src):
+    # Arrange
+    peer = HonestPeer(tmp_path / "peer" / "scitex-hub")
+    # Act
+    push_spec_dir(spec_src, REMOTE_DIR, peer)
+    # Assert
+    assert (peer.spec_dir / "to_home" / "CLAUDE.md").exists()
+
+
+def test_a_delivery_never_ships_peer_side_runtime_state(tmp_path, spec_src):
+    # Arrange
+    peer = HonestPeer(tmp_path / "peer" / "scitex-hub")
+    # Act
+    push_spec_dir(spec_src, REMOTE_DIR, peer)
+    # Assert
+    assert not (peer.spec_dir / "runtime").exists()
+
+
+def test_a_verified_delivery_returns_the_peers_own_manifest(tmp_path, spec_src):
+    # Arrange
+    peer = HonestPeer(tmp_path / "peer" / "scitex-hub")
+    # Act
+    landed = push_spec_dir(spec_src, REMOTE_DIR, peer)
+    # Assert
+    assert landed == local_manifest(spec_src)
+
+
+def test_a_transfer_that_exits_zero_but_lands_elsewhere_is_an_error(
+    tmp_path, spec_src
+):
+    """THE regression test. scitex-nas-03's patched rsync exited 0, listed the
+    files, and wrote them one level away; the old code then started the agent
+    from the stale spec and called the dispatch a success."""
+    # Arrange
+    peer = ReroutingPeer(tmp_path / "peer" / "asked-for", tmp_path / "peer" / "actual")
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="does NOT"):
+        push_spec_dir(spec_src, REMOTE_DIR, peer, peer="scitex-nas-03")
+
+
+def test_the_mis_delivery_error_names_the_files_that_never_arrived(
+    rerouted_delivery_error,
+):
+    # Arrange
+    expected = "spec.yaml"
+    # Act
+    message = rerouted_delivery_error
+    # Assert
+    assert expected in message
+
+
+def test_the_mis_delivery_error_warns_about_the_stale_spec(
+    rerouted_delivery_error,
+):
+    """The consequence is what makes this urgent: the next step boots the
+    agent from whatever spec is actually at that path."""
+    # Arrange
+    expected = "stale spec"
+    # Act
+    message = rerouted_delivery_error
+    # Assert
+    assert expected in message
+
+
+def test_the_mis_delivery_error_names_the_peer(rerouted_delivery_error):
+    # Arrange
+    expected = "scitex-nas-03"
+    # Act
+    message = rerouted_delivery_error
+    # Assert
+    assert expected in message
+
+
+def test_a_failing_extraction_is_reported_with_the_peers_stderr(spec_src):
+    # Arrange
+    peer = UnreachablePeer()
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="mkdir failed"):
+        push_spec_dir(spec_src, REMOTE_DIR, peer)
+
+
+# EOF


### PR DESCRIPTION
## The bug

Cross-host `sac agents start` delivered the spec with `rsync -acv --delete` over
ssh and treated **rc 0 as delivery**. On `scitex-nas-03` that inference is false.

Its `/usr/bin/rsync` is a vendor-patched **setuid-root** 3.4.1 that routes even
plain `--server` ssh transfers through the rsync *daemon* module code, and
`/etc/rsyncd.conf` maps module `home` to `/home/ywatanabe`. The receiver strips
the leading `/home` from the destination and resolves the remainder *inside*
that module root, so every write lands one level deep.

Measured 2026-08-15, from the host, real (non-dry-run) writes:

| destination sent | where it actually landed | rc |
|---|---|---|
| `/home/ywatanabe/__p2__/` | `/home/ywatanabe/ywatanabe/__p2__/` | **0** |
| `~/__p1__/` | `/home/ywatanabe/ywatanabe/__p1__/` | **0** |
| `~/` | `created directory ywatanabe` → `/home/ywatanabe/ywatanabe/` | **0** |

All three exited 0, printed a normal file list and reported bytes sent.
Nothing arrived at the requested path — confirmed by then finding
`probe.txt`, `__sac_p1__/` and `__sac_p2__/` under
`/home/ywatanabe/ywatanabe/` (since removed).

When the parent does not exist under that doubled prefix it fails the other
way instead — `mkdir "ywatanabe/.scitex/agent-container/agents/…" (in home)
failed: No such file or directory (2)`, rc 11 — **even when the requested
directory plainly exists**. That is the rc-12/rc-11 that has been blocking
`scitex-hub`, and it reads like a permissions problem while being nothing of
the kind.

And `--dry-run` predicts neither outcome: the same destination that fails a
real write with rc 11 **plans cleanly with rc 0**, because the dry run never
calls `mkdir`. A dry-run-only investigation concludes the path is fine.

So the old code had two ways to be wrong and no way to notice. Loudly — the
rc-12 everyone has been staring at. Silently, and far worse — an rc-0 that
puts the spec where nobody reads it, after which the remote `sac agents start`
boots the agent from the **stale spec still sitting at the real path** and the
dispatch reports success.

## Why not just fix the destination string

That was the obvious candidate and it does not work. `~/…` and
`/home/ywatanabe/…` fail identically on a real write; there is no path that
both names the true directory and survives the doubling. More fundamentally, a
peer that mis-delivers silently must not be trusted on the strength of an exit
code, whatever string you hand it.

## The change

The handoff no longer asks a transport to be trustworthy. It ships a tar
stream through the **ordinary login shell** — the same shell `build_ssh_argv`
already uses for the remote `sac agents start`, which works on every peer
including this one — and then **re-reads the peer's own digests and compares
them to the lead's**. Delivery is a measurement, not an exit code.

New `cli_pkg/lifecycle/_spec_handoff.py` holds it; `_dispatch.py` gets shorter
(502 → 438 lines). Three deliberate behaviour changes, all documented in the
module header:

1. **Nothing is deleted.** `--delete` would have removed every peer-side file
   the lead lacks. On `scitex-nas-03` that set is
   `start-telegram-sidecar.sh` + the sidecar logs, which exist only there.
   Deleting operator-placed files as a side effect of starting an agent is the
   unrequested deletion #1048 just promoted to a first-class gate. Peer-only
   files are now reported and kept, and no longer count as drift.
2. **The destination is resolved by the peer's shell** (`"$HOME/.scitex/…"`)
   instead of being sent home-relative. A relative destination resolves
   against the remote CWD, and a non-interactive `ssh scitex-nas-03 pwd`
   answers `/home/ywatanabe/proj/scitex-hub` — so the old form aimed the spec,
   and its mirroring delete, at an unrelated repository. A registry-pinned
   **absolute** root still wins (the Spartan incident in `_dispatch_paths`).
3. **Drift is decided by content digests**, not by parsing `--itemize-changes`.

## Tests

The one seam to the network is a `PeerShell` callable, so nothing is patched:
the tests are real POSIX shells running the production scripts against real
directories, and `test__dispatch.py`'s fake `ssh` binary now answers per
handoff phase.

The test that matters is `test_a_transfer_that_exits_zero_but_lands_elsewhere_is_an_error`
— a `ReroutingPeer` wired the way the NAS is wired: extraction succeeds with
rc 0 into a different directory, and a listing of the requested path still
shows nothing. Its sibling
`test_a_silent_mis_delivery_never_reaches_the_remote_start` pins the
consequence: a mis-delivered spec must not be followed by a start.

## Scope

This is defect **(B)** on card
`sac-nas03-cannot-start-under-its-own-fleet-name-20260814` (spec delivery).
Defect (A) — nas-03 identity — is #1056 and is disjoint: no file overlaps.
The stale `nas`/`nas1`/`nas2` host-registry rows are a **third**, independent
defect that belongs to scitex-dev's seed-once `create_default_hosts_yaml`;
I measured the rsync destination under both a stale and a freshly-seeded
registry and it is byte-identical, so repairing the registry would not have
moved this one.
