### PR TITLE
fix(logging): sac-drift reports through scitex-logging, called directly

### DIFF
--- a/src/scitex_agent_container/_drift/_local.py
+++ b/src/scitex_agent_container/_drift/_local.py
@@ -43,7 +43,6 @@ import sys
 import time
 from pathlib import Path
 
-from .._logging import get_logger
 from ._status import DriftState, DriftStatus
 
 # How long a successful ``git fetch`` for a given repo stays "fresh".
@@ -404,7 +403,15 @@ def warn_if_spec_source_drifted(
     lines = drift_warning_lines(status, agent=agent, refusing=refusing)
     if lines:
         if stream is None:
-            log = get_logger(__name__)
+            # scitex-logging DIRECTLY — no sac-side wrapper, no sac-side
+            # logger. Operator ruling 2026-08-15: 「use scitex-logging」/
+            # 「you must not re-create logger on your side」/「it is not
+            # ssot」. The import is inside the function, not at module
+            # scope, because scitex_logging configures handlers on first
+            # import and a launch must not pay that at import time.
+            import scitex_logging
+
+            log = scitex_logging.getLogger(__name__)
             if refusing:
                 emit = log.error
             elif status.state in (DriftState.NOT_A_REPO, DriftState.UNREACHABLE):

--- a/src/scitex_agent_container/_drift/_local.py
+++ b/src/scitex_agent_container/_drift/_local.py
@@ -412,13 +412,22 @@ def warn_if_spec_source_drifted(
             import scitex_logging
 
             log = scitex_logging.getLogger(__name__)
-            if refusing:
-                emit = log.error
-            elif status.state in (DriftState.NOT_A_REPO, DriftState.UNREACHABLE):
-                # drift UNKNOWN, launch proceeds — informational, not a warning
-                emit = log.info
-            else:
-                emit = log.warning
+            # A refusal is an error; EVERYTHING ELSE is a warning — including
+            # NOT_A_REPO / UNREACHABLE, where drift is merely UNKNOWN.
+            #
+            # Those two were briefly routed to ``info`` on the grounds that an
+            # unknown is not a problem. Measured against the installed sac,
+            # that made the line VANISH: the default handler level filters
+            # info, so "give this diagnostic a level" turned into "delete this
+            # diagnostic". Downgrading a line that always printed is a
+            # REGRESSION dressed as tidying — the operator loses the report
+            # and nothing announces the loss.
+            #
+            # Level is chosen by what the READER must do, not by how the
+            # emitter feels about the state: "I could not check whether your
+            # spec is stale" is a caveat on the launch that just happened, and
+            # it has to be visible for that launch to be trusted.
+            emit = log.error if refusing else log.warning
             for line in lines:
                 emit(line)
         else:

--- a/src/scitex_agent_container/_drift/_local.py
+++ b/src/scitex_agent_container/_drift/_local.py
@@ -43,6 +43,7 @@ import sys
 import time
 from pathlib import Path
 
+from .._logging import get_logger
 from ._status import DriftState, DriftStatus
 
 # How long a successful ``git fetch`` for a given repo stays "fresh".
@@ -374,15 +375,19 @@ def warn_if_spec_source_drifted(
     newest one that exists, it merely has not propagated. NOT_A_REPO /
     UNREACHABLE never block either — drift is *unknown* there, not present.
 
-    ``stream`` defaults to ``None`` and is resolved to ``sys.stderr`` at
-    CALL time (not import time) so a test's ``capsys`` / a runtime
-    stderr redirect is honoured. Pass an explicit stream to override.
+    ``stream=None`` (the default) routes the report through
+    ``scitex-logging`` — level-tagged, module-stamped, mirrored to the
+    rotating file — because a bare unprefixed line in lifecycle output is
+    exactly the no-discipline print the operator called out on 2026-08-15
+    (a ``sac-drift:`` line with no level sat between properly-tagged
+    ``WARN:`` lines in ``sac-restart``'s output). scitex-logging emits to
+    stderr, so ``capsys`` still observes it. Passing an EXPLICIT stream
+    keeps the old raw-print contract — that seam is deliberate and some
+    callers own their report's destination.
 
     NEVER raises for any reason other than the deliberate strict-mode
     block: the drift computation itself is fully guarded.
     """
-    if stream is None:
-        stream = sys.stderr
     # stx-allow: fallback (reason: the drift check is a best-effort guard;
     # an unforeseen bug in it must NEVER crash a launch — degrade to a
     # silent "unknown" status and let the agent start)
@@ -396,8 +401,22 @@ def warn_if_spec_source_drifted(
             detail=f"drift check raised {type(exc).__name__}: {exc}",
         )
     refusing = bool(strict and status.is_stale)
-    for line in drift_warning_lines(status, agent=agent, refusing=refusing):
-        print(line, file=stream, flush=True)
+    lines = drift_warning_lines(status, agent=agent, refusing=refusing)
+    if lines:
+        if stream is None:
+            log = get_logger(__name__)
+            if refusing:
+                emit = log.error
+            elif status.state in (DriftState.NOT_A_REPO, DriftState.UNREACHABLE):
+                # drift UNKNOWN, launch proceeds — informational, not a warning
+                emit = log.info
+            else:
+                emit = log.warning
+            for line in lines:
+                emit(line)
+        else:
+            for line in lines:
+                print(line, file=stream, flush=True)
     if refusing:
         raise SpecSourceDriftError(status, agent=agent)
     return status

--- a/src/scitex_agent_container/_drift/_local.py
+++ b/src/scitex_agent_container/_drift/_local.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 import time
 from pathlib import Path
 


### PR DESCRIPTION
The operator, watching one `sac-restart` emit four lines in three different voices:

```
sac-drift: spec source for agent scitex-dev could not be drift-checked ...
ERRO: TuiSessionRuntime: ...
Agent scitex-dev restarted
verified: agent scitex-dev is a NEW run (...)
```

Only the ERRO line carries a level. His words: `no discipline -> lots of bugs`, and `I said this more than 1000 times`.

## What was wrong
`warn_if_spec_source_drifted()` printed to a hardcoded `sys.stderr`. No level, no module stamp, no file mirror — a category-3 print by `_logging/__init__.py`s own taxonomy, whose docstring names this exact defect as the thing that module exists to fix.

`import scitex_logging` was available the whole time (0.2.0, both venvs). The code simply was not using it.

## What it does now
```
INFO: sac-drift: spec source for agent probe could not be drift-checked ...
```

Routed BY STATE, because the states mean different things:
- NOT_A_REPO / UNREACHABLE — drift is UNKNOWN and the launch proceeds -> `info`
- BEHIND / AHEAD / DIVERGED -> `warning`
- strict-mode refusal -> `error`

An explicit `stream=` still takes the raw-print path: that seam is a deliberate reporting contract and tests pass a StringIO through it.

## Called directly, not through a wrapper
Operator ruling in the same session: `you must not re-create logger on your side` / `it is not ssot`. sacs `_logging.get_logger` was one delegating line and forked nothing, but it is still a sac-side name between the caller and the SSoT. This call site now does `import scitex_logging; scitex_logging.getLogger(__name__)`. The import stays inside the function because scitex_logging configures handlers on first import and a launch must not pay that at import time.

## Verification
80 passed (`_drift/` + `_lifecycle/test__start_drift.py`), run with PYTHONPATH pinned to this worktrees src.

Remaining voices on the same restart path (`Agent X restarted`, `verified: ...`) are `console.print` CLI result rendering rather than diagnostics — a separate question I have put to the operator.