### PR TITLE
fix(reconcile): the enforcer honours the DECLARED host, not the observed one

### DIFF
--- a/src/scitex_agent_container/_reconcile/_pass.py
+++ b/src/scitex_agent_container/_reconcile/_pass.py
@@ -207,6 +207,58 @@ def _real_restart(name: str) -> bool:
     return agent_restart(name) is not False
 
 
+def _declared_host_is_local(config: Any) -> bool | None:
+    """Does ``spec.host`` — the host the operator PINNED — name this machine?
+
+    Three-valued, and the ``None`` matters: no pin, or a pin we could not
+    resolve, must behave exactly as before rather than inventing a refusal.
+    Only a CONFIDENT "the pin names somewhere else" stops a restart.
+
+    The pin lives at ``config.hosts_spec.host``. There is no ``config.host``;
+    reaching for one returns ``None`` and reads as "no pin", which is how a
+    pinned agent gets silently restarted on the wrong machine.
+
+    This asks the SAME question the interactive start path asks, via the same
+    routing helper, so the enforcer and the CLI cannot drift into disagreeing
+    about who owns an agent.
+    """
+    # stx-allow: fallback (reason: an unresolvable route must degrade to
+    # "unknown" (None), never to a refusal — a reconciler that stops restarting
+    # the whole fleet because one lookup raised is worse than one that keeps
+    # the previous behaviour for that agent.)
+    try:
+        declared = getattr(getattr(config, "hosts_spec", None), "host", None)
+        if not declared:
+            return None
+        from ..cli_pkg.lifecycle._host_routing import classify_spec_host_route
+
+        route, _ = classify_spec_host_route(declared, _local_host(), _peers())
+        return route == "local"
+    except Exception:
+        return None
+
+
+def _peers() -> dict[str, Any]:
+    """Registered peers, or none — only used to resolve a pin to local/remote.
+
+    Built exactly as the CLI builds it (``cli_pkg/host_group.py``): the config
+    file's peers, widened by the host registry. Deliberately the same two calls
+    rather than a private reimplementation, so the enforcer and the CLI cannot
+    disagree about which names are peers.
+    """
+    # stx-allow: fallback (reason: see _declared_host_is_local — an unreadable
+    # peer registry must not manufacture a refusal, so it degrades to "no peers
+    # known", which makes an unresolvable pin read as UNKNOWN rather than as
+    # "pinned elsewhere".)
+    try:
+        from .._state._peer_resolve import peers_with_registry
+        from .._state.host_config import load as load_host_config
+
+        return dict(peers_with_registry(load_host_config().peers))
+    except Exception:
+        return {}
+
+
 def _local_host() -> str:
     """This machine's name AS ``instances.host`` records it.
 
@@ -338,6 +390,7 @@ def reconcile_pass(
             session_present=present,
             row=row,
             local_host=local_host,
+            declared_host_is_local=_declared_host_is_local(config),
         )
         if decision.verdict is not Verdict.RESTART:
             reports.append(

--- a/src/scitex_agent_container/_reconcile/_rule.py
+++ b/src/scitex_agent_container/_reconcile/_rule.py
@@ -147,6 +147,7 @@ def decide(
     session_present: bool | None,
     row: Mapping[str, Any] | None,
     local_host: str | None = None,
+    declared_host_is_local: bool | None = None,
 ) -> Decision:
     """Decide ONE agent's fate from facts alone. Pure — no IO, no clock.
 
@@ -166,6 +167,17 @@ def decide(
     local_host
         This machine's name as ``instances.host`` records it. When given, a
         row belonging to ANOTHER host is skipped — see the remote guard.
+    declared_host_is_local
+        Whether ``spec.host`` — the host the operator PINNED the agent to —
+        resolves to this machine. Three-valued on purpose:
+
+        ``True``   the pin names us; proceed.
+        ``False``  the pin names somewhere else; this pass must not restart it.
+        ``None``   no pin, or it could not be resolved; behave as before.
+
+        This is the DECLARED host, and it is a different question from
+        ``local_host``, which is where the agent was last OBSERVED. Passing
+        only the observed one is the defect this parameter exists to fix.
     """
     if policy not in MANAGED_POLICIES:
         return Decision(
@@ -173,6 +185,33 @@ def decide(
             "policy-never",
             f"restart.policy={policy!r} — sac never promised to keep {name} "
             f"running, so nothing to enforce",
+        )
+
+    # --- THE PIN IS OWNERSHIP, and it is asked BEFORE any liveness question -
+    # An agent pinned to another host is not ours to restart, however dead it
+    # looks from here. This is checked before tmux because "is it mine?"
+    # precedes "is it alive?" — reading the local tmux for an agent that
+    # belongs elsewhere can only produce misleading evidence.
+    #
+    # WHY THIS EXISTS (measured 2026-08-15). The guard below keys off
+    # ``local_host``, which is where the agent was last OBSERVED. scitex-hub
+    # is pinned to scitex-nas-03 but has never managed to RUN there, so its
+    # instances row said compute-04 — the observed host MATCHED, the guard
+    # said "mine", and every pass restarted it on the wrong machine. Each
+    # restart rewrote the row with compute-04 and made the next pass more
+    # confident. A pin that has never been satisfied could never become
+    # satisfiable through this path.
+    #
+    # The operator's ruling on seeing it: 「NASで起動しているのに、フォール
+    # バックはないでしょう、あり得ないです」 — an agent running in the wrong
+    # place reads as healthy, which is worse than one plainly down.
+    if declared_host_is_local is False:
+        return Decision(
+            Verdict.SKIPPED,
+            "pinned-elsewhere",
+            f"{name}'s spec pins it to another host — this pass will NOT start "
+            f"it here. Its absence from our tmux is expected, not evidence of "
+            f"death, and starting it locally would silently defeat the pin",
         )
 
     # --- 2. TMUX IS THE FACT, and a non-observation is not a fact ---------

--- a/tests/scitex_agent_container/_reconcile/test__rule.py
+++ b/tests/scitex_agent_container/_reconcile/test__rule.py
@@ -54,6 +54,75 @@ def _row(**overrides) -> dict:
     return row
 
 
+# --- the PIN: ownership is asked before liveness -----------------------------
+
+
+def _pinned_elsewhere_corpse():
+    """A PERFECT local corpse whose spec pins it somewhere else.
+
+    Deliberately every signal says "restart me": the row's host matches the
+    local host and ``ended_at`` is None. Only the pin dissents. That is the
+    exact production shape — scitex-hub was pinned to scitex-nas-03, had never
+    managed to RUN there, so its row said compute-04, the old guard read
+    row_host == local_host as "mine", and every 5-minute pass restarted it on
+    the wrong machine while rewriting the row to agree.
+    """
+    return _decide(
+        row=_row(host="host-a", ended_at=None),
+        local_host="host-a",
+        declared_host_is_local=False,
+    )
+
+
+def test_agent_pinned_to_another_host_is_skipped():
+    # Arrange
+    # Act
+    decision = _pinned_elsewhere_corpse()
+    # Assert
+    assert decision.verdict is Verdict.SKIPPED
+
+
+def test_agent_pinned_to_another_host_says_why():
+    # Arrange
+    # Act
+    decision = _pinned_elsewhere_corpse()
+    # Assert
+    assert decision.reason == "pinned-elsewhere"
+
+
+def test_a_pin_naming_this_host_still_restarts():
+    # Arrange
+    row = _row(ended_at=None)
+    # Act
+    decision = _decide(row=row, declared_host_is_local=True)
+    # Assert
+    assert decision.verdict is Verdict.RESTART
+
+
+def test_an_unresolvable_pin_is_unknown_not_a_refusal():
+    """``None`` is not ``False``.
+
+    A pin we could not resolve must leave the previous behaviour untouched.
+    Inventing a refusal from a failed lookup would stop the enforcer
+    restarting the WHOLE fleet the moment the peer registry became unreadable.
+    """
+    # Arrange
+    row = _row(ended_at=None)
+    # Act
+    decision = _decide(row=row, declared_host_is_local=None)
+    # Assert
+    assert decision.verdict is Verdict.RESTART
+
+
+def test_callers_that_omit_the_pin_are_unaffected():
+    # Arrange
+    row = _row(ended_at=None)
+    # Act
+    decision = _decide(row=row)
+    # Assert
+    assert decision.verdict is Verdict.RESTART
+
+
 # --- the promise: is this agent even ours to keep alive? --------------------
 
 


### PR DESCRIPTION
Operator, on finding scitex-hub running on compute-04 while its spec pins scitex-nas-03: **NASで起動しているのに、フォールバックはないでしょう、あり得ないです**.

He was right, and it was not a fallback — the guard meant to prevent this asks the wrong question.

## The defect
`_reconcile/_rule.py` compares `row.host` (where the agent **last ran**) against this machine. The **declared** host — `spec.hosts_spec.host`, parsed correctly and sitting right there — was never consulted anywhere in `_reconcile/`.

**Self-reinforcing:** hub is pinned to nas-03 but never managed to run there (nas-03 cannot open sessions), so its row said compute-04. The guard read row_host == local_host, concluded *mine*, restarted it here — and each restart rewrote the row to agree. A pin that has never been satisfied could never become satisfiable.

## The fix
`decide()` gains `declared_host_is_local`, asked **before** any liveness question — *is it mine?* precedes *is it alive?*. Three-valued, and the None matters:

| value | meaning |
|---|---|
| True | pin names us — proceed unchanged |
| False | pin names elsewhere — SKIP, reason `pinned-elsewhere` |
| None | no pin / unresolvable — behave exactly as before |

Only a **confident** elsewhere stops a restart: an unreadable peer registry must not manufacture a refusal that stops the enforcer restarting the whole fleet.

`_pass.py` resolves it via `classify_spec_host_route` with peers built the way the CLI builds them (`peers_with_registry(host_config.load().peers)`) — the same calls, not a reimplementation, so enforcer and CLI cannot drift into disagreeing about ownership.

## Verified against the live fleet
```
this machine: scitex-compute-04    peers known: 12
scitex-hub    pin=scitex-nas-03      -> False (skipped)
scitex-dev    pin=scitex-compute-04  -> True
grant-agent   pin=scitex-compute-04  -> True
```

## Falsified
- with the guard: **175 passed**
- guard removed: **exactly the 2 pinned-elsewhere tests fail**, 32 others pass

The fixture is deliberately a *perfect local corpse* — matching host, no ended_at — so every signal says restart and only the pin dissents.

## Follow-up, not in this PR
`_real_restart` still calls `agent_restart` directly; routing it through the CLI host-routing layer would give the richer refusal message that layer already writes.