### PR TITLE
fix(broker): an accepted-but-in-flight spawn is UNKNOWN, not a failure

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
+++ b/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
@@ -298,11 +298,21 @@ def maybe_broker_in_sif_spawn(
       planned LOCAL workspace argv / files, never the host's — so we
       leave it alone.
     * In a SIF — POSTs the spawn RPC to host listen via
-      :func:`broker_start_to_host`. On host-accepted + ``returncode==0``
-      returns ``True`` (caller MUST return True and skip the local
-      runtime). On host-accepted + ``returncode!=0``, raises
-      :class:`RuntimeError` with the host's response embedded. On any
-      transport / 4xx / 5xx failure, the underlying
+      :func:`broker_start_to_host`, then reads the host's answer as the
+      THREE-valued signal it is:
+
+      - ``returncode == 0`` — started. Returns ``True`` (caller MUST
+        return True and skip the local runtime).
+      - ``returncode`` ABSENT with ``status == "accepted"`` — HTTP 202:
+        accepted and still in flight at the server's declared deadline.
+        The outcome is UNKNOWN, which is **not** a failure. Returns
+        ``True`` (still brokered, so the caller must still skip the local
+        runtime — returning ``False`` here would start a SECOND agent)
+        and logs the ``poll`` route that will know the outcome.
+      - ``returncode != 0`` — genuinely failed. Raises
+        :class:`RuntimeError` with the host's response embedded.
+
+      On any transport / 4xx / 5xx failure, the underlying
       :class:`InSifBrokerError` propagates unchanged.
 
     Fail-loud invariants:
@@ -370,7 +380,53 @@ def maybe_broker_in_sif_spawn(
         assume_yes=assume_yes,
         force=force,
     )
-    rc = result.get("returncode") if isinstance(result, dict) else None
+    if not isinstance(result, dict):
+        raise RuntimeError(
+            f"sac-from-sac broker: host listen returned a non-object "
+            f"response for the spawn of {name!r}: {result!r}"
+        )
+
+    # THREE-VALUED, and the middle value is the entire point of this block.
+    # The host answers a brokered spawn in one of three ways, and only ONE
+    # of them is a failure:
+    #
+    #   returncode == 0     the host ran `sac agents start` and it succeeded
+    #   returncode ABSENT   HTTP 202 — accepted, still in flight at the
+    #                       server's declared deadline. The outcome is
+    #                       genuinely UNKNOWN, which is not the same as bad.
+    #   returncode != 0     the host ran it and it genuinely failed
+    #
+    # This used to read `rc = result.get("returncode") ...; if rc != 0: raise`,
+    # which collapsed the middle case into the failure pole — the bug shape
+    # §2 calls "the most common bug we ship". Measured 2026-08-15: starting a
+    # stopped `scitex-dev` raised RuntimeError and reported exit 1 while the
+    # agent came up perfectly and was answering on its a2a port seconds later.
+    # The raised message even carried the host's own sentence, verbatim:
+    # "This is NOT a failure: the spawn is running."
+    #
+    # It is DANGEROUS rather than merely wrong. The obvious response to
+    # "start failed" is to start it again — and `_spawn_client` warns, on the
+    # very 202 branch that hands us this body, that the response "must NOT be
+    # retried: a retry on a MUTATING route is exactly what starts a SECOND
+    # agent". Raising here is what manufactures that retry.
+    #
+    # In-flight returns True, never False: True means "brokered, caller MUST
+    # skip the local runtime". Returning False would send the caller down the
+    # local start path against an agent that is already launching — the exact
+    # double-spawn this guards against.
+    rc = result.get("returncode")
+    if rc is None and str(result.get("status", "")).lower() == "accepted":
+        logger.info(
+            "in-sif broker: spawn of %r was ACCEPTED and is still in flight "
+            "at the host's %ss deadline (phase=%s). This is not a failure and "
+            "must not be retried — poll %s for the outcome; a genuine failure "
+            "carries a startup_failed marker.",
+            name,
+            result.get("deadline_s"),
+            result.get("phase"),
+            result.get("poll"),
+        )
+        return True
     if rc != 0:
         raise RuntimeError(
             f"sac-from-sac broker: host listen accepted the spawn of "

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -426,6 +426,79 @@ def test_maybe_broker_in_sif_forwards_foreground_to_body(sif_env, listen_env) ->
 
 
 # ---------------------------------------------------------------------------
+# HTTP 202 accepted-but-in-flight is UNKNOWN, not failure
+#
+# Measured 2026-08-15: starting a stopped `scitex-dev` raised RuntimeError and
+# reported exit 1 while the agent came up fine and answered on its a2a port
+# seconds later. The old code read `if rc != 0: raise`, and a 202 body carries
+# no `returncode` at all — so `None != 0` sent the UNKNOWN case down the
+# failure branch. These three pin all three arms of the signal.
+# ---------------------------------------------------------------------------
+
+_ACCEPTED_202 = (
+    b'{"name":"child","status":"accepted","phase":"launch","deadline_s":30.0,'
+    b'"poll":"/agents/child/status",'
+    b'"detail":"still in flight at the 30s server deadline. This is NOT a '
+    b'failure: the spawn is running."}'
+)
+
+
+def test_in_flight_spawn_does_not_raise(sif_env, listen_env) -> None:
+    # Arrange
+    from scitex_agent_container._lifecycle._in_sif_broker import (
+        maybe_broker_in_sif_spawn,
+    )
+
+    sif_env("/path/to/parent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, _ = _opener_returning(_ACCEPTED_202, status=202)
+    # Act — must not raise; the host said the spawn is still running.
+    result = maybe_broker_in_sif_spawn("child", dry_run=False, opener=opener)
+    # Assert
+    assert result is True
+
+
+def test_in_flight_spawn_returns_true_so_caller_skips_local_start(
+    sif_env, listen_env
+) -> None:
+    # Arrange — False would send the caller down the LOCAL start path against
+    # an agent that is already launching, i.e. start a SECOND one. That is the
+    # damage `_spawn_client` warns about on this exact 202 branch.
+    from scitex_agent_container._lifecycle._in_sif_broker import (
+        maybe_broker_in_sif_spawn,
+    )
+
+    sif_env("/path/to/parent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, _ = _opener_returning(_ACCEPTED_202, status=202)
+    # Act
+    brokered = maybe_broker_in_sif_spawn("child", dry_run=False, opener=opener)
+    # Assert
+    assert brokered is True, "in-flight must count as brokered, never as 'do it locally'"
+
+
+def test_a_genuine_nonzero_returncode_still_raises(sif_env, listen_env) -> None:
+    # Arrange — the failure arm must survive the fix; this is the control that
+    # proves the new branch did not simply swallow every bad outcome.
+    from scitex_agent_container._lifecycle._in_sif_broker import (
+        maybe_broker_in_sif_spawn,
+    )
+
+    sif_env("/path/to/parent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, _ = _opener_returning(b'{"name":"child","returncode":3}')
+
+    def _act():
+        return maybe_broker_in_sif_spawn("child", dry_run=False, opener=opener)
+
+    # Act
+    raised = pytest.raises(RuntimeError, match="returncode=3")
+    # Assert
+    with raised:
+        _act()
+
+
+# ---------------------------------------------------------------------------
 # agent_start integration — in-SIF detection redirects to broker
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`maybe_broker_in_sif_spawn` read the host's answer as:

```python
rc = result.get("returncode") if isinstance(result, dict) else None
if rc != 0:
    raise RuntimeError(...)
```

An **HTTP 202 body carries no `returncode` at all**. So the accepted-and-still-launching case arrived as `None`, compared unequal to `0`, and went down the failure branch.

## Measured

2026-08-15 21:11Z. Starting a stopped `scitex-dev` returned `exit_code=1` with a `RuntimeError` — while the agent **came up perfectly** and was answering on a2a port 19013 seconds later. The exception text contained the host's own sentence, verbatim:

> `"This is NOT a failure: the spawn is running. Poll GET /agents/scitex-dev/status for the outcome"`

Before the call the agent had no port claim (`registry_status: stopped`, `a2a_port: null`), so the claim was new: the start worked and the caller was told it failed.

## Why this one is dangerous, not just wrong

The obvious response to "start failed" is to start it again. `_spawn_client` warns on the very 202 branch that hands us this body:

> `# And it must NOT be retried: a retry on a MUTATING route is exactly what starts a SECOND agent, which is the damage the old timeout-as-error-channel caused.`

The transport layer preserves "unknown" faithfully; this chokepoint then flattened it into an error channel — manufacturing the retry that comment exists to prevent.

## The change

Three-valued, per the constitution's §2 rule that every signal is true / false / **unknown**:

| host answer | meaning | behaviour |
|---|---|---|
| `returncode == 0` | started | return `True` |
| `returncode` absent + `status == "accepted"` | in flight, outcome **unknown** | log the `poll` route, return `True` |
| `returncode != 0` | genuinely failed | raise (unchanged) |

In-flight returns `True` and **never `False`** — `True` means "brokered, caller skips the local runtime". `False` would send the caller down the local start path against an agent that is already launching, i.e. cause the exact double-spawn this guards against.

## Verification

Three tests pin all three arms. Confirmed as a genuine before/after by running the new tests against the **old** source in a separate worktree:

```
OLD source + new tests:  2 failed, 1 passed
  test_in_flight_spawn_does_not_raise                           FAILED (the real RuntimeError)
  test_in_flight_spawn_returns_true_so_caller_skips_local_start FAILED
  test_a_genuine_nonzero_returncode_still_raises                PASSED  ← failure arm never broke

NEW source + new tests:  3 passed
```

The third test is the control: it proves the fix did not simply swallow every bad outcome.

Worth noting for anyone writing a similar control here: `pyproject.toml` sets `pythonpath = [".", "src"]`, which silently overrides a `PYTHONPATH=` you set on the command line. My first attempt at this control passed against what I *thought* was the old code and proved nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
