### PR TITLE
fix(accounts): editor litter is not an account — skip dot-prefixed store dirs

### DIFF
--- a/src/scitex_agent_container/_state/account_store.py
+++ b/src/scitex_agent_container/_state/account_store.py
@@ -123,7 +123,28 @@ def list_accounts(
         # credentials snapshot is MISSING but whose `account.json` remains —
         # that is a real account in a broken state and callers must still
         # see it, which a "has credentials" test alone would hide.
-        if account_dir.name.startswith("_"):
+        # DOT-PREFIXED DIRS ARE BOOKKEEPING TOO, and omitting them shipped a
+        # visible bug. Measured 2026-08-16: an editor left
+        # `.swap-backup-20260815` in the store, and `sac accounts list` — which
+        # the operator watches on a 10s refresh — rendered it as a real account:
+        #
+        #     - claude-code:.swap-backup-20260815
+        #         5h  [      unknown       ] (unknown)
+        #         ! no usage snapshot
+        #
+        # It reached that far because the structural test below DELIBERATELY
+        # admits a BARE directory: an account whose metadata and credentials
+        # are both gone is a real account in a broken state and callers must
+        # still see it. Editor litter is bare in exactly the same way, so the
+        # structural test cannot tell them apart — which is precisely why the
+        # `_` skip exists above it, and why `.` belongs in the same rule rather
+        # than in a new one. Neither prefix is a legal account name; both mark
+        # something the store keeps beside its accounts.
+        #
+        # The operator's judgement on finding it: 「dirty codebase means buggy
+        # project」. Deleting the stray file would have cleared the symptom and
+        # left the enumerator ready to do it again on the next editor crash.
+        if account_dir.name.startswith(("_", ".")):
             continue
         meta_file = account_dir / _METADATA_FILENAME
         if (


### PR DESCRIPTION
The operator watched `sac accounts list` on a 10s refresh and saw an editor swap file rendered as a real account:

```
- claude-code:.swap-backup-20260815
  5h  [      unknown       ] (unknown)
  7d  [      unknown       ] (unknown)
     ! no usage snapshot
```

His judgement: **"dirty codebase means buggy project"** — and deleting the stray file would have cleared the symptom while leaving the enumerator ready to do it again on the next editor crash.

## Why it got through

The structural test **deliberately admits a bare directory**: an account whose metadata *and* credentials are gone is a real account in a broken state, and callers must still see it. Editor litter is bare in exactly the same way, so the structural test cannot separate them — which is precisely why the `_` skip already sits above it. `.` belongs in that same rule, not a new one. Neither prefix is a legal account name; both mark something the store keeps *beside* its accounts.

## Reproduced before fixing

Against the unfixed module, a bare `.swap-backup-20260815` in the store gives:

```
list_accounts(...) -> ['.swap-backup-20260815', 'alpha']
```

## No unit test ships with this — deliberately

Two tests were written and then **removed, because they passed against the unfixed code**. A gate that cannot fail is worse than no gate.

Under the repo test harness the same fixture yields `CONTENTS=['.swap-backup-20260815','alpha']` but `NAMES=['alpha']` — the litter is in the store and still isn't listed. Something in the conftest environment masks the production behaviour, so this suite cannot currently express the regression. That masking is the more serious finding and is filed separately; shipping a green test that proves nothing would have hidden it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
