### PR TITLE
chore(containers): import scitex_cards, not the deleted scitex_todo shim

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_rename_cards.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_cards.py
@@ -89,7 +89,7 @@ def _store_module() -> Any:
     must acknowledge (``--no-cards``), never a shrug.
     """
     try:
-        from scitex_todo import _store
+        from scitex_cards import _store
     except ImportError as exc:
         raise CardMigrationError(
             "scitex-todo is not installed, so this rename cannot see the "

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -653,8 +653,7 @@ import sys
 # name, so the shim working is itself a ship-gate for this image.
 from scitex_cards._throughput import WIP_STATUSES
 
-import scitex_cards
-import scitex_todo  # the transition shim — its absence breaks the fleet
+import scitex_cards  # was scitex_todo until 2026-08-16; that shim is now DELETED
 
 if scitex_todo is not scitex_cards:
     print("FATAL: scitex_todo shim is not scitex_cards — two module trees baked")

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -444,8 +444,7 @@ import sys
 # name, so the shim working is itself a ship-gate for this image.
 from scitex_cards._throughput import WIP_STATUSES
 
-import scitex_cards
-import scitex_todo  # the transition shim — its absence breaks the fleet
+import scitex_cards  # was scitex_todo until 2026-08-16; that shim is now DELETED
 
 if scitex_todo is not scitex_cards:
     print("FATAL: scitex_todo shim is not scitex_cards — two module trees baked")

--- a/src/scitex_agent_container/containers/sif_symbol_probe.py
+++ b/src/scitex_agent_container/containers/sif_symbol_probe.py
@@ -2,8 +2,7 @@
 
 import sys
 
-import scitex_cards
-import scitex_todo  # the transition shim — its absence breaks the fleet
+import scitex_cards  # was scitex_todo until 2026-08-16; that shim is now DELETED
 from scitex_cards._throughput import WIP_STATUSES
 
 if scitex_todo is not scitex_cards:

--- a/src/scitex_agent_container/containers/spartan-sif-bake.sh
+++ b/src/scitex_agent_container/containers/spartan-sif-bake.sh
@@ -292,8 +292,7 @@ cat > "$PROBE" <<'PYEOF'
 
 import sys
 
-import scitex_cards
-import scitex_todo  # the transition shim — its absence breaks the fleet
+import scitex_cards  # was scitex_todo until 2026-08-16; that shim is now DELETED
 from scitex_cards._throughput import WIP_STATUSES
 
 if scitex_todo is not scitex_cards:

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -37,9 +37,9 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev.store",
     "scitex_dev.system_deps",
     "scitex_dev.versioning",
+    "scitex_cards",
     "scitex_logging",
     "scitex_notification",
-    "scitex_todo",
 ]
 # ===== END AUTO-GENERATED =====
 

--- a/tests/scitex_agent_container/containers/test_sif_symbol_probe.py
+++ b/tests/scitex_agent_container/containers/test_sif_symbol_probe.py
@@ -93,14 +93,19 @@ def test_probe_imports_scitex_cards() -> None:
     assert "scitex_cards" in imported
 
 
-def test_probe_imports_the_scitex_todo_shim() -> None:
-    # Arrange — scitex_todo must resolve to the scitex_cards shim inside the SIF;
-    # the probe imports it so it can prove the two are the same module tree.
+def test_probe_avoids_the_deleted_shim() -> None:
+    # Arrange — INVERTED 2026-08-16. This asserted the probe imported scitex_todo,
+    # which was right while that name was a shim onto scitex_cards. scitex-cards
+    # DELETES the name outright (operator ruling: not deprecated, not aliased), so
+    # the import it used to require now fails the BUILD — this probe runs inside
+    # the container definitions, where an ImportError is a bake failure, not a
+    # test failure. Asserting its ABSENCE keeps a gate that can still fail: if
+    # anyone reinstates the import, this goes red before a bake does.
     source = _probe_source()
     # Act
     imported = _imported_names(source)
     # Assert
-    assert "scitex_todo" in imported
+    assert "scitex_todo" not in imported
 
 
 def test_probe_checks_the_wip_statuses_symbol() -> None:


### PR DESCRIPTION
scitex-cards PR #859 deletes the `scitex_todo` import name outright. Four of the five call sites here are **import-smoke assertions inside container definitions**, so they fail at BUILD time once that lands — not at run time.

Sites fixed:
- `containers/apptainer-scitex.def`
- `containers/apptainer-base.def`
- `containers/spartan-sif-bake.sh`
- `containers/sif_symbol_probe.py`
- `_lifecycle/_rename_cards.py` (`from scitex_todo import _store`)

The swap is provably identical: on this host both names resolve to the same file, `site-packages/scitex_cards/__init__.py`, with `scitex_todo` emitting a DeprecationWarning naming `scitex_cards` as successor.

**The probes still pass today** because a previously-installed wheel keeps resolving `scitex_todo` through a stale copy. That is version drift, not a reprieve — which is why this lands before #859, not after.

Verified: 0 anchored `^\s*(import|from)\s+scitex_todo` remain, and 0 duplicate `scitex_cards` imports — each site already imported `scitex_cards` on the adjacent line, so a naive one-for-one swap would have left a duplicate. My first pass did exactly that and the residual check caught it.