### PR TITLE
feat(agents): mark the caller's own row in agents list with is_self

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_row.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_row.py
@@ -15,6 +15,8 @@ failed when the account precedence was moved out of ``_agent_list``.
 
 from __future__ import annotations
 
+import os
+
 __all__ = ["_MOVEMENT_DEFAULTS", "_movement_fields", "build_agent_row"]
 
 # The always-present movement trio in its empty shape — the tolerant fallback
@@ -114,4 +116,25 @@ def build_agent_row(
         row["probe_error"] = probe_error
     if labels:
         row["labels"] = labels
+    # THE CALLER'S OWN ROW — one boolean that hands every consumer a free
+    # control. This listing is vantage-point dependent: read from inside a
+    # container it reports SPEC DEFINITIONS, and on 2026-08-16 it returned
+    # running=0 for a fleet where eight handymen and three maintainers were
+    # provably working, newest heartbeat eleven days stale. scitex-hpc hit the
+    # same thing from a DIFFERENT container and found the decisive detail —
+    # their OWN row read ``status: defined`` while they were executing the
+    # command that produced it.
+    #
+    # So: if the row describing YOU disagrees with the fact that you are
+    # running, the listing cannot be trusted about anyone else. Marking the
+    # self row turns "you must remember this instrument is vantage-dependent"
+    # into something the OUTPUT ITSELF reveals, which is the only version of
+    # that rule that survives being forgotten.
+    #
+    # Identity comes from SCITEX_TODO_AGENT_ID, the same variable every agent
+    # already stamps its card writes with — deliberately NOT the hostname or
+    # the spec, because those answer a different question. When it is unset
+    # (a human at a shell), no row is marked and nothing changes.
+    if name and name == os.environ.get("SCITEX_TODO_AGENT_ID", ""):
+        row["is_self"] = True
     return row

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_row_is_self.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_row_is_self.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""``is_self`` on the caller's own agent-list row.
+
+WHY THIS GATE EXISTS. ``sac agents list`` is vantage-point dependent: read from
+inside a container it reports SPEC DEFINITIONS, and on 2026-08-16 it returned
+``running=0`` for a fleet where eight handymen and three maintainers were
+provably working. scitex-hpc hit the same thing from a different container and
+found the decisive detail — their OWN row read ``status: defined`` while they
+were executing the command that produced it.
+
+So the self row is a free control: if the listing is wrong about the one agent
+the caller can verify with certainty, its answer about every other row carries
+no information. These tests keep that marker present, absent where it would be a
+lie, and silent when there is no identity to compare against.
+
+The environment is mutated FOR REAL and restored on teardown rather than patched
+— the production code reads ``os.environ`` and so does the test, so a rename of
+the variable breaks this gate instead of sliding past a stubbed lookup.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from scitex_agent_container.cli_pkg._helpers._agent_list_row import build_agent_row
+
+_VAR = "SCITEX_TODO_AGENT_ID"
+_ME = "scitex-agent-container"
+
+_ROW_KWARGS = dict(
+    status_val="running",
+    screen_name="tui-x",
+    multiplexer="tmux",
+    started="2026-08-16T00:00:00Z",
+    host_label="scitex-compute-04",
+    host_display="scitex-compute-04",
+    spec_path="/spec.yaml",
+    a2a_port=19003,
+    account_label="acct",
+    deferred=True,
+    errors=None,
+    liveness_unknown=False,
+    labels=None,
+)
+
+
+@pytest.fixture
+def identified_as_me() -> Iterator[None]:
+    """Set the real agent-identity variable, restore whatever was there."""
+    previous = os.environ.get(_VAR)
+    os.environ[_VAR] = _ME
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(_VAR, None)
+        else:
+            os.environ[_VAR] = previous
+
+
+@pytest.fixture
+def identified_as_nobody() -> Iterator[None]:
+    """Remove the identity entirely — a human at a shell, not an agent."""
+    previous = os.environ.get(_VAR)
+    os.environ.pop(_VAR, None)
+    try:
+        yield
+    finally:
+        if previous is not None:
+            os.environ[_VAR] = previous
+
+
+def test_marks_the_caller(identified_as_me: None) -> None:
+    # Arrange — the caller identifies itself the same way it stamps card writes.
+    name = _ME
+    # Act
+    row = build_agent_row(name=name, **_ROW_KWARGS)
+    # Assert
+    assert row["is_self"] is True
+
+
+def test_omits_for_peers(identified_as_me: None) -> None:
+    # Arrange — a peer's row must NOT claim to be the caller, or the control is
+    # worse than useless: it would validate the listing against the wrong agent.
+    name = "handyman-01"
+    # Act
+    row = build_agent_row(name=name, **_ROW_KWARGS)
+    # Assert
+    assert "is_self" not in row
+
+
+def test_absent_without_identity(identified_as_nobody: None) -> None:
+    # Arrange — with no agent identity, marking any row would invent a control
+    # that does not exist.
+    name = _ME
+    # Act
+    row = build_agent_row(name=name, **_ROW_KWARGS)
+    # Assert
+    assert "is_self" not in row


### PR DESCRIPTION
One boolean that hands every consumer a free control.

**Why.** `sac agents list` is vantage-point dependent: read from inside a container it reports **spec definitions**. On 2026-08-16 it returned `running=0` for a fleet where eight handymen and three maintainers were provably working, newest heartbeat eleven days stale — I nearly reported the fleet as empty. scitex-hpc hit the same from a *different* container and found the decisive detail: their **own** row read `status: defined` while they were executing the command that produced it.

If the listing is wrong about the one agent the caller can verify with certainty, its answer about the other rows carries no information. Marking the self row turns "you must remember this instrument is vantage-dependent" into something the **output itself reveals**.

Proposed by scitex-hpc. Their option (a) — set `liveness_unknown` when the owning host is unreachable — follows separately.

Identity comes from `SCITEX_TODO_AGENT_ID`, the same variable every agent stamps its card writes with; deliberately not the hostname or the spec. Unset (a human at a shell) marks nothing. Attached only on the self row, matching the module's existing convention.

**Tests, and a control that actually discriminates.** Three cases: marked for the caller, absent for peers, absent without identity. No `monkeypatch` (banned ecosystem-wide, and the linter is right) — the fixtures mutate `os.environ` for real and restore on teardown, so renaming the variable breaks the gate rather than sliding past a stub.

My **first control was worthless and looked fine**: the runner inserts its rootdir ahead of `PYTHONPATH`, so both runs imported the worktree's code and both passed. Re-run under plain python, where the imported module path visibly differs:

```
worktree src -> is_self present -> assertion WOULD PASS   (exit 0)
main src     -> is_self ABSENT  -> assertion WOULD FAIL   (exit 1)
```
