### PR TITLE
feat(accounts): let keepalive declare a peer intermittent, so a closed laptop is not a red alarm

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_keepalive.py
+++ b/src/scitex_agent_container/cli_pkg/_account_keepalive.py
@@ -157,6 +157,20 @@ def register_keepalive_command(group: click.Group) -> None:
         ),
     )
     @click.option(
+        "--optional-peer",
+        "optional_peers",
+        multiple=True,
+        metavar="PEER",
+        help=(
+            "Declare a peer as INTERMITTENT: it is still pushed to, and any "
+            "failure is still printed, but its failure does not fail the run. "
+            "For laptops and anything else that is legitimately off. Must "
+            "also appear in --to. Repeatable. Nothing is implicit here — a "
+            "peer is optional only because the command line says so, so the "
+            "unit file states exactly which hosts may be absent."
+        ),
+    )
+    @click.option(
         "--json",
         "as_json",
         is_flag=True,
@@ -171,6 +185,7 @@ def register_keepalive_command(group: click.Group) -> None:
         remote_path: str | None,
         force: bool,
         sweep: bool,
+        optional_peers: tuple[str, ...],
         as_json: bool,
     ) -> None:
         """Copy this host's CURRENT access token to peers, access-only.
@@ -230,10 +245,23 @@ def register_keepalive_command(group: click.Group) -> None:
                 err=True,
             )
 
+        # An optional peer must be one we are actually pushing to. Silently
+        # accepting a name that is not in --to would let a typo disarm
+        # nothing while looking like it disarmed something.
+        optional = set(optional_peers)
+        unknown_optional = sorted(optional - set(peers))
+        if unknown_optional:
+            raise click.UsageError(
+                "--optional-peer names host(s) absent from --to: "
+                f"{', '.join(unknown_optional)}. An optional peer must also "
+                "be a target, or the declaration applies to nothing."
+            )
+
         floor = MIN_VALIDITY_S if min_validity is None else min_validity
         records: list[dict[str, Any]] = []
         verified_peers: list[str] = []
         failed = False
+        tolerated: list[str] = []
 
         for account_label in accounts:
             for peer in peers:
@@ -256,17 +284,23 @@ def register_keepalive_command(group: click.Group) -> None:
                     KeepaliveError,
                     SnapshotPushError,
                 ) as exc:  # stx-allow: fallback (reason: see inline comment)
-                    failed = True
+                    is_optional = peer in optional
+                    if is_optional:
+                        tolerated.append(f"{peer}/{account_label}")
+                    else:
+                        failed = True
                     records.append(
                         {
                             "account": account_label,
                             "peer": peer,
                             "ok": False,
                             "error": str(exc),
+                            "optional": is_optional,
                         }
                     )
+                    label = "FAILED (optional peer)" if is_optional else "FAILED"
                     click.echo(
-                        f"  {peer:20s}  {account_label}: FAILED — {exc}", err=True
+                        f"  {peer:20s}  {account_label}: {label} — {exc}", err=True
                     )
                     continue
 
@@ -304,6 +338,18 @@ def register_keepalive_command(group: click.Group) -> None:
             records.append({"peer": peer, "ok": True, "sweep_output": output})
             for line in str(output).splitlines():
                 click.echo(f"    {line}", err=True)
+
+        # A tolerated failure must never be a silent one. The whole point of
+        # declaring a peer optional is to keep the RED meaningful for the
+        # always-on hosts; that only works if the run still says out loud
+        # what it forgave, and how many.
+        if tolerated:
+            click.echo(
+                f"  TOLERATED: {len(tolerated)} failure(s) on declared "
+                f"optional peer(s) — {', '.join(tolerated)}. Exit stays 0 for "
+                "these; they were declared intermittent with --optional-peer.",
+                err=True,
+            )
 
         if as_json:
             click.echo(  # stx-allow: STX-IO006

--- a/tests/scitex_agent_container/cli_pkg/test__account_keepalive_optional_peer.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_keepalive_optional_peer.py
@@ -1,0 +1,155 @@
+"""A laptop being off must not make the credential alarm red.
+
+WHY THIS EXISTS (2026-08-16):
+
+`scitex-agent-container-accounts-keepalive` is the DISTRIBUTION half of the
+single-refresher model — the only thing keeping access-only hosts alive. It
+had been sitting in `failed` state, and the measured reason was one line:
+
+    ywata-note-win  ...: FAILED — ssh: connect to host 192.168.11.101
+                                  port 22: No route to host
+
+Every other peer in that same run reported `already current ... (verified
+HTTP 200)`. The credentials were entirely healthy; the operator's LAPTOP was
+closed.
+
+The unit exits non-zero if ANY peer fails, so a portable machine being off
+pins the fleet's credential alarm red permanently. That is worse than having
+no alarm: a signal that is always red is one nobody reads, and this is the
+signal that says agents are about to start 401ing.
+
+THE FIX IS A DECLARATION, NOT A DETECTOR. It would be easy to sniff the error
+text for "No route to host" and treat network failures as soft. That is
+exactly the implicit surprise logic the operator has ruled against — you
+could not tell from the unit file which hosts may be absent. Instead the
+caller NAMES the intermittent peers, so `systemctl cat` shows you:
+
+    ... --to ywata-note-win --optional-peer ywata-note-win
+
+and the tolerance is visible at the call site.
+
+Tolerated failures are still pushed, still printed, still recorded with
+`"optional": true` in --json, and still summarised on the TOLERATED line. The
+run forgives them; it never hides them.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def keepalive_cli():
+    """The account group with the keepalive command registered."""
+    import click
+
+    from scitex_agent_container.cli_pkg._account_keepalive import (
+        register_keepalive_command,
+    )
+
+    @click.group()
+    def group():
+        pass
+
+    register_keepalive_command(group)
+    return group
+
+
+@pytest.fixture
+def undeclared_target_result(keepalive_cli):
+    """Invoke with an --optional-peer that is NOT among the --to targets."""
+    return CliRunner().invoke(
+        keepalive_cli,
+        [
+            "keepalive",
+            "--account", "alpha-example-com",
+            "--to", "compute-04",
+            "--optional-peer", "a-host-not-in-to",
+        ],
+    )
+
+
+@pytest.fixture
+def declared_target_result(keepalive_cli):
+    """Invoke with an --optional-peer that IS among the --to targets."""
+    return CliRunner().invoke(
+        keepalive_cli,
+        [
+            "keepalive",
+            "--account", "alpha-example-com",
+            "--to", "ywata-note-win",
+            "--optional-peer", "ywata-note-win",
+        ],
+    )
+
+
+@pytest.fixture
+def help_result(keepalive_cli):
+    """`keepalive --help`, which is what a reader of the unit file consults."""
+    return CliRunner().invoke(keepalive_cli, ["keepalive", "--help"])
+
+
+def test_optional_peer_absent_from_to_is_refused(undeclared_target_result):
+    """A declaration that applies to nothing is a typo, not a tolerance."""
+    # Arrange: see fixture
+    result = undeclared_target_result
+
+    # Act
+    exit_code = result.exit_code
+
+    # Assert
+    assert exit_code != 0
+
+
+def test_the_refusal_names_the_offending_host(undeclared_target_result):
+    """Naming it is what makes the typo fixable without rerunning."""
+    # Arrange: see fixture
+    result = undeclared_target_result
+
+    # Act
+    output = result.output
+
+    # Assert
+    assert "a-host-not-in-to" in output
+
+
+def test_a_declared_optional_peer_passes_the_guard(declared_target_result):
+    """The mirror case.
+
+    Without this, a guard that rejected EVERY optional peer would satisfy the
+    refusal tests above while making the flag unusable — green by refusing,
+    which is the cannot-succeed twin of a gate that cannot fail.
+    """
+    # Arrange: see fixture
+    result = declared_target_result
+
+    # Act: the guard's own message is the discriminator. The command may still
+    # fail later for environmental reasons (no such stored account on this
+    # machine), so exit 0 is the wrong thing to assert.
+    output = result.output
+
+    # Assert
+    assert "absent from --to" not in output
+
+
+def test_help_advertises_the_flag(help_result):
+    """The unit file is the record, so the flag must be discoverable."""
+    # Arrange: see fixture
+    result = help_result
+
+    # Act
+    output = result.output
+
+    # Assert
+    assert "--optional-peer" in output
+
+
+def test_help_explains_what_optional_means(help_result):
+    """A flag named without its meaning invites use on an always-on host."""
+    # Arrange: see fixture
+    result = help_result
+
+    # Act
+    output = result.output
+
+    # Assert
+    assert "INTERMITTENT" in output


### PR DESCRIPTION
## The alarm that could not go green

`scitex-agent-container-accounts-keepalive` is the **distribution half** of the single-refresher model — the only thing keeping access-only hosts alive. It was sitting in `failed`. Measured cause, one line out of the entire run:

```
ywata-note-win  ...: FAILED — ssh: connect to host 192.168.11.101 port 22: No route to host
```

Every other peer in that same run reported `already current ... (verified HTTP 200)`. Credentials were healthy on every always-on host. The operator's **laptop was closed**.

The unit exits non-zero if *any* peer fails, so a portable machine being off pins the fleet's credential alarm red permanently. That is worse than having no alarm — a signal that is always red is one nobody reads, and this is the signal that says agents are about to start 401ing.

## A declaration, not a detector

The tempting fix is to sniff the error text for `No route to host` and treat network failures as soft. Rejected, for two reasons:

1. It is implicit surprise logic — you could not tell from the unit file which hosts may be absent.
2. It would equally forgive a genuinely unreachable **server**, which is the case the alarm exists for.

Instead the caller names them, so `systemctl cat` shows the tolerance at the call site:

```
sac accounts keepalive --all --to ywata-note-win --optional-peer ywata-note-win
```

Anything not named still fails the run.

## Guards on the flag itself

- An `--optional-peer` absent from `--to` is a `UsageError` — a declaration that applies to nothing looks like it disarmed something.
- Tolerated failures are still pushed, still printed (marked `FAILED (optional peer)`), still recorded with `"optional": true` in `--json`, and summarised on a `TOLERATED` line naming each one.
- The run forgives them; it never hides them.

## Not included on purpose

The unit's own `--optional-peer ywata-note-win` is **not** added here. The flag must exist in the installed sac before the unit can pass it, or every tick becomes a `UsageError`. Follow-up once this is live.

## Measured, in both directions

Proven under plain `python`, **not** pytest — pytest inserts its rootdir ahead of `PYTHONPATH`, and an earlier control of mine passed against code that did not contain the change:

| tree | refuses undeclared | help documents | exit |
|---|---|---|---|
| worktree src (fix present) | True | True | 0 |
| main src (fix absent) | False | False | 1 |

The resolved module path is printed on each run, so the reader can see which code answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
