### PR TITLE
fix(tests): stop guarding on a module that no longer exists, so these can fail again

### DIFF
--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -14,11 +14,21 @@ Two escape routes exist and both are closed:
    time, so a fixture that only sets ``$HOME`` CANNOT redirect them — it
    would read and write the live fleet while looking isolated.
 
-2. **The board.** Every scitex-todo call takes an explicit ``store=``.
+2. **The board.** Every scitex-cards call takes an explicit ``store=``.
+   That explicit argument is the PRIMARY isolation and it is what these
+   tests actually rely on.
+
    Belt and braces, :func:`isolated_board` ALSO points
-   ``$SCITEX_TODO_TASKS_YAML_SHARED`` at the tmp store, so even a call
-   that forgot to pass ``store=`` lands in the tmp file rather than on the
-   real 1,400-card board.
+   ``$SCITEX_TODO_TASKS_YAML_SHARED`` at the tmp store, so a call that
+   forgot to pass ``store=`` would land in the tmp file rather than on the
+   real board. WARNING, 2026-08-16: that second net is now INERT —
+   scitex_cards does not read ``SCITEX_TODO_TASKS_YAML_SHARED`` (its axis
+   is ``SCITEX_CARDS_DB``), so a forgotten ``store=`` would no longer be
+   caught. The env var is left as-is rather than renamed on a guess:
+   pointing it at the right variable without checking what scitex_cards
+   actually resolves would restore the APPEARANCE of a safety net while a
+   forgotten ``store=`` reached the live board. Verify the resolution
+   first, then re-arm it.
 
 No mocks: the store is a real YAML file that real ``scitex_todo`` reads
 and writes, and the state.db is a real SQLite file with the real schema.
@@ -493,7 +503,12 @@ def add_card(
     ``scitex-todo`` rejects an owner-less card outright ("creator+assignee
     are mandatory ... no silent fallback"), so ``owner`` is required.
     """
-    from scitex_todo import _store
+    # scitex_cards, not scitex_todo: v0.41.0 deleted that module outright.
+    # This is a HARD import on purpose — the callers guard with
+    # importorskip("scitex_cards"), so reaching here means the package IS
+    # installed and a failure here is a real broken path, not an absent
+    # optional peer.
+    from scitex_cards import _store
 
     _store.add_task(
         store,

--- a/tests/scitex_agent_container/_lifecycle/test__rename_isolation.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_isolation.py
@@ -13,6 +13,7 @@ So: assert the isolation, do not assume it.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 import pytest
@@ -96,14 +97,20 @@ def test_isolated_board_redirects_scitex_todos_default_store(board: Path):
     ``store=None`` makes scitex-todo resolve its default store. If that
     still resolved to the live 1,400-card board, one missing keyword in the
     rename code would reassign real cards. The fixture points
-    ``$SCITEX_TODO_TASKS_YAML_SHARED`` at the tmp store, and scitex-todo
+    ``$SCITEX_TODO_TASKS_YAML_SHARED`` at the tmp store, and scitex-cards
     reads that env var at CALL time — so this holds.
 
     Skips when the optional peer is absent (sac's own CI); there is no
     default store to redirect then, and faking one would prove nothing.
     """
     # Arrange
-    _store = pytest.importorskip("scitex_todo._store")
+    # Skip only when the optional peer is genuinely ABSENT; if it is present
+    # but the submodule path has moved, FAIL. `importorskip` on the full
+    # dotted path cannot tell those apart — ModuleNotFoundError is an
+    # ImportError subclass, so a rename or deletion becomes a silent skip,
+    # which is what scitex_todo._store had already become here.
+    pytest.importorskip("scitex_cards")
+    _store = importlib.import_module("scitex_cards._store")
     # Act
     resolved = _store.resolve_tasks_path()
     # Assert

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
@@ -305,8 +305,15 @@ def test_rename_migrates_every_card(fleet: Layout, board: Path):
 
 
 def _seed(board: Path, count: int) -> list[str]:
-    """Seed real cards, skipping the test when the optional peer is absent."""
-    pytest.importorskip("scitex_todo")
+    """Seed real cards, skipping the test when the optional peer is absent.
+
+    Names scitex_cards, NOT scitex_todo. scitex-cards v0.41.0 DELETED the
+    scitex_todo module outright, and `importorskip` skips on
+    ModuleNotFoundError — an ImportError subclass — so guarding on a deleted
+    name turns this test into a permanent, silent SKIP. It would never fail
+    and never run: green by absence.
+    """
+    pytest.importorskip("scitex_cards")
     from ..._helpers.fleet_root import seed_cards
 
     return seed_cards(board, OLD, count)


### PR DESCRIPTION
## Two tests that could no longer fail

```python
test__rename.py:309            pytest.importorskip("scitex_todo")
test__rename_isolation.py:106  pytest.importorskip("scitex_todo._store")
```

scitex-cards **v0.41.0 deleted `scitex_todo` outright** at 05:29Z today — not deprecated, not aliased. `importorskip` skips on `ModuleNotFoundError`, which is an **`ImportError` subclass**, so the deletion did not break these tests. It made them **permanently vacuous**: they would never fail and never run, and the suite would keep reporting green.

Green by absence, arriving through the one door that looks like caution.

This is the concrete instance behind the PS-140 finding scitex-dev flagged sac for as UNDETERMINED. scitex-cards found it from the other side and has the same shape in their own cross-package import gate.

## The skip itself is legitimate — the name and the shape were not

Measured in sac's venv: `scitex_cards`, `scitex_cards._store` and `scitex_todo` **all** raise `ModuleNotFoundError`. sac genuinely does not install the card package, so "optional peer absent" is a real state these tests must tolerate. Keeping `importorskip` is right; guarding on a deleted name is not.

| case | guard |
|---|---|
| root package | `importorskip("scitex_cards")` |
| submodule | `importorskip("scitex_cards")` → absent peer, **skip** |
| | `importlib.import_module("scitex_cards._store")` → moved path, **fail** |

Guarding on the full dotted path cannot distinguish *"the optional package is not installed"* from *"the package is installed and the submodule was renamed"*. The two-step form can, and that distinction is the entire defect.

## Demonstrated in both directions

Against a stub package that **exists but has no `_store`** — precisely the renamed-submodule case these tests must catch:

```
OLD  pytest.importorskip("scitex_cards._store")        -> Skipped
NEW  importorskip(root) + import_module(submodule)     -> ModuleNotFoundError
```

The old form silently skipped the exact failure it existed to detect.

In this repo as it stands: **25 passed, 5 skipped** (the peer really is absent), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
