### PR TITLE
chore(release): v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-08-16
+
 ### Fixed
 
 - **Nothing ever applied the declared JobSpecs to a host; provisioning now


### PR DESCRIPTION
Promotes the accumulated `[Unreleased]` entries to `[0.25.0]` so the release can finally be cut.

**Why this was stuck.** `pyproject` has declared `0.25.0` since 2026-08-05, but no `v0.25.0` tag was ever created and the CHANGELOG had no released `[0.25.0]` section. **229 commits over 11 days** have all shipped under that one frozen, never-released label. PyPI still serves 0.24.25.

That is not a cosmetic problem — it is how three hosts ended up running a wheel reporting the same `0.25.0` as develop while missing a fix that had already merged (#1045). Only the build hash distinguished them, and nothing compares build hashes.

**Why nobody noticed.** `autobump-release-sweep` has been running every 15 minutes the whole time and reporting **success**. With pyproject at `V`, no tag `vV`, and no `[V]` section, it takes the `INCONSISTENT — refusing to guess` branch, emits an `::error::` annotation, and `exit 0`. The run history is green by construction, so the heartbeat that was supposed to make a stall visible hid it instead.

**This change** adds the `## [0.25.0] - 2026-08-16` header and leaves an empty `## [Unreleased]` above it — the exact shape `autobump verify` requires:

```
autobump verify --version 0.25.0  ->  OK: pyproject + CHANGELOG are consistent   (rc 0)
autobump verify --version 0.99.0  ->  rc 3     <- positive control: it can fail
```

No version arithmetic: `0.25.0` is what pyproject already declared, so this tags the tree that has been calling itself 0.25.0 all along rather than inventing a new number. Diff is one header line.