### PR TITLE
fix(ci-ring): cap consecutive failure deliveries so a standing sync PR stops re-firing

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_ci_deliver.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_deliver.py
@@ -28,6 +28,15 @@ logger = logging.getLogger(__name__)
 
 TERMINAL_CONCLUSIONS = frozenset({"success", "failure"})
 
+#: Consecutive reds (no green in between) delivered normally before the ring
+#: escalates once and then goes quiet for that PR. Measured 2026-08-16: a
+#: standing ``release: sync main with develop`` PR whose head ref IS the source
+#: branch collected FOURTEEN "Red: fix-and-push" deliveries in a day. Nobody had
+#: pushed at it — each unrelated feature merge moved its head, minting a fresh
+#: dedup key. The instruction was unfollowable and the volume taught its
+#: recipients to skim.
+CONSECUTIVE_FAILURE_CAP = 3
+
 
 def _verdict_text(repo: str, pr: int, head_sha: str, conclusion: str) -> str:
     short = head_sha[:8] if head_sha else "?"
@@ -37,6 +46,25 @@ def _verdict_text(repo: str, pr: int, head_sha: str, conclusion: str) -> str:
     else:
         tail = " Red: fix-and-push — the ring re-fires on your next push."
     return head + tail
+
+
+def _escalation_text(repo: str, pr: int, head_sha: str, streak: int) -> str:
+    """The one message sent when a PR trips :data:`CONSECUTIVE_FAILURE_CAP`.
+
+    Deliberately does NOT say "fix-and-push". That instruction is what kept
+    the measured loop alive, and by this point it is the one thing already
+    known not to work.
+    """
+    short = head_sha[:8] if head_sha else "?"
+    return (
+        f"CI STUCK — {repo} PR #{pr} ({short}). This is red #{streak + 1} "
+        "with no green in between, so the ring is going SILENT for this PR "
+        "until a green verdict lands. Pushing has not cleared it; check "
+        "whether the failing check is a REQUIRED context (a non-required "
+        "check cannot block a merge), and whether this PR's head is moving "
+        "for reasons unrelated to your changes — a standing sync PR's head "
+        "tracks its source branch, so every merge there re-fires CI."
+    )
 
 
 def deliver_verdict(
@@ -50,6 +78,7 @@ def deliver_verdict(
     ancestors: Any = None,
     already_delivered: Any = None,
     record: Any = None,
+    failure_streak: Any = None,
     db_path: Any = None,
     agents_dir: Any = None,
     pr_body: str | None = None,
@@ -58,7 +87,13 @@ def deliver_verdict(
 
     Returns a summary ``{"delivered": [names], "skipped": bool,
     "reason": str}``. ``reason`` ∈ {``delivered``, ``non-terminal``,
-    ``already-delivered``, ``no-owner``}.
+    ``already-delivered``, ``no-owner``, ``escalated``, ``streak-capped``}.
+
+    After :data:`CONSECUTIVE_FAILURE_CAP` reds with no green in between,
+    one ``escalated`` message goes out and every further red for that PR
+    is ``streak-capped`` — recorded but not delivered — until a green
+    resets the streak. The recorded count IS the state, so no extra
+    column is needed and a restart cannot lose the position.
     """
     if conclusion not in TERMINAL_CONCLUSIONS:
         return {"delivered": [], "skipped": True, "reason": "non-terminal"}
@@ -85,18 +120,44 @@ def deliver_verdict(
         from .._state.state_db_verdict_dedup import record_verdict_delivered
 
         record = record_verdict_delivered
+    if failure_streak is None:
+        from .._state.state_db_verdict_dedup import failures_since_last_success
+
+        failure_streak = failures_since_last_success
 
     if already_delivered(
         repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion, db_path=db_path
     ):
         return {"delivered": [], "skipped": True, "reason": "already-delivered"}
 
+    # Streak gate — BEFORE resolving an owner, so a capped PR costs no gh call.
+    # `streak` counts reds already delivered since the last green, so the first
+    # red sees 0. Record even when silent: the count is the state, and letting
+    # it stall would un-cap the PR on the next tick.
+    escalating = False
+    if conclusion == "failure":
+        streak = failure_streak(repo=repo, pr=pr, db_path=db_path)
+        if streak > CONSECUTIVE_FAILURE_CAP:
+            record(
+                repo=repo,
+                pr=pr,
+                head_sha=head_sha,
+                conclusion=conclusion,
+                db_path=db_path,
+            )
+            return {"delivered": [], "skipped": True, "reason": "streak-capped"}
+        escalating = streak == CONSECUTIVE_FAILURE_CAP
+
     owner = owner_resolver(repo, pr_body=pr_body, agents_dir=agents_dir)
     if not owner:
         return {"delivered": [], "skipped": True, "reason": "no-owner"}
 
     targets = [owner, *ancestors(name=owner, db_path=db_path)]
-    text = _verdict_text(repo, pr, head_sha, conclusion)
+    text = (
+        _escalation_text(repo, pr, head_sha, streak)
+        if escalating
+        else _verdict_text(repo, pr, head_sha, conclusion)
+    )
     delivered: list[str] = []
     for target in targets:
         try:
@@ -110,7 +171,15 @@ def deliver_verdict(
     # the agent picks the verdict up on its own heartbeat; re-spamming a
     # transiently-unreachable fleet every tick is worse than one miss.
     record(repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion, db_path=db_path)
-    return {"delivered": delivered, "skipped": False, "reason": "delivered"}
+    return {
+        "delivered": delivered,
+        "skipped": False,
+        "reason": "escalated" if escalating else "delivered",
+    }
 
 
-__all__ = ["TERMINAL_CONCLUSIONS", "deliver_verdict"]
+__all__ = [
+    "CONSECUTIVE_FAILURE_CAP",
+    "TERMINAL_CONCLUSIONS",
+    "deliver_verdict",
+]

--- a/src/scitex_agent_container/_lifecycle/_ci_deliver.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_deliver.py
@@ -48,19 +48,31 @@ def _verdict_text(repo: str, pr: int, head_sha: str, conclusion: str) -> str:
     return head + tail
 
 
-def _escalation_text(repo: str, pr: int, head_sha: str, streak: int) -> str:
+def _escalation_text(
+    repo: str,
+    pr: int,
+    head_sha: str,
+    streak: int,
+    checks: list | None = None,
+) -> str:
     """The one message sent when a PR trips :data:`CONSECUTIVE_FAILURE_CAP`.
 
     Deliberately does NOT say "fix-and-push". That instruction is what kept
     the measured loop alive, and by this point it is the one thing already
     known not to work.
+
+    ``checks`` names the currently-failing checks when they could be
+    resolved. Naming them is the difference between advice the reader can
+    act on and advice they cannot: "check whether the failing check is
+    required" is unanswerable without knowing which check it is.
     """
     short = head_sha[:8] if head_sha else "?"
+    named = f" Failing now: {', '.join(checks)}." if checks else ""
     return (
         f"CI STUCK — {repo} PR #{pr} ({short}). This is red #{streak + 1} "
-        "with no green in between, so the ring is going SILENT for this PR "
-        "until a green verdict lands. Pushing has not cleared it; check "
-        "whether the failing check is a REQUIRED context (a non-required "
+        f"with no green in between, so the ring is going SILENT for this PR "
+        f"until a green verdict lands.{named} Pushing has not cleared it; "
+        "check whether that check is a REQUIRED context (a non-required "
         "check cannot block a merge), and whether this PR's head is moving "
         "for reasons unrelated to your changes — a standing sync PR's head "
         "tracks its source branch, so every merge there re-fires CI."
@@ -79,6 +91,7 @@ def deliver_verdict(
     already_delivered: Any = None,
     record: Any = None,
     failure_streak: Any = None,
+    failing_checks: Any = None,
     db_path: Any = None,
     agents_dir: Any = None,
     pr_body: str | None = None,
@@ -153,11 +166,21 @@ def deliver_verdict(
         return {"delivered": [], "skipped": True, "reason": "no-owner"}
 
     targets = [owner, *ancestors(name=owner, db_path=db_path)]
-    text = (
-        _escalation_text(repo, pr, head_sha, streak)
-        if escalating
-        else _verdict_text(repo, pr, head_sha, conclusion)
-    )
+    if escalating:
+        # One extra gh call, on the rare escalation tick only — never on the
+        # hot path. Fail-soft: an unnamed escalation still beats no escalation.
+        if failing_checks is None:
+            from ._github_ci import failing_check_names
+
+            failing_checks = failing_check_names
+        try:
+            checks = failing_checks(repo, pr)
+        except Exception as exc:  # stx-allow: fallback (naming is a nicety, not the message)
+            logger.warning("deliver_verdict: failing_check_names failed: %s", exc)
+            checks = []
+        text = _escalation_text(repo, pr, head_sha, streak, checks)
+    else:
+        text = _verdict_text(repo, pr, head_sha, conclusion)
     delivered: list[str] = []
     for target in targets:
         try:

--- a/src/scitex_agent_container/_lifecycle/_github_ci.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci.py
@@ -94,6 +94,34 @@ def pr_ci_conclusion(repo: str, pr: int, *, run: GhRunner = _run_gh) -> str:
     return CONCLUSION_NONE
 
 
+def failing_check_names(repo: str, pr: int, *, run: GhRunner = _run_gh) -> list:
+    """Return the NAMES of the PR's checks currently in a failing bucket.
+
+    :func:`pr_ci_conclusion` asks only for ``bucket``, which is all a
+    pass/fail verdict needs — but it means the ring cannot tell "a
+    different check failed this time" from "the same check has been red
+    across every head sha", and those warrant different advice. Deliberately
+    a SEPARATE call rather than widening the hot path: this is only needed
+    on the rare escalation tick, not on every poll.
+
+    Sorted and de-duplicated. Unparseable / empty output → ``[]``, so a
+    caller can always render the escalation without a name.
+    """
+    raw = run(["pr", "checks", str(pr), "-R", repo, "--json", "name,bucket"])
+    try:
+        rows = json.loads(raw) if raw.strip() else []
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(rows, list):
+        return []
+    names = {
+        str(r.get("name", "")).strip()
+        for r in rows
+        if isinstance(r, dict) and str(r.get("bucket", "")) in _FAILING_BUCKETS
+    }
+    return sorted(n for n in names if n)
+
+
 def pr_head_sha(repo: str, pr: int, *, run: GhRunner = _run_gh) -> str:
     """Return the PR's current head sha (empty string if unresolvable)."""
     raw = run(["api", f"repos/{repo}/pulls/{pr}", "--jq", ".head.sha"])
@@ -172,6 +200,7 @@ __all__ = [
     "CONCLUSION_NONE",
     "CONCLUSION_PENDING",
     "CONCLUSION_SUCCESS",
+    "failing_check_names",
     "gh_ready",
     "list_open_prs",
     "pr_ci_conclusion",

--- a/src/scitex_agent_container/_state/state_db_verdict_dedup.py
+++ b/src/scitex_agent_container/_state/state_db_verdict_dedup.py
@@ -115,7 +115,46 @@ def record_verdict_delivered(
         )
 
 
+def failures_since_last_success(
+    *,
+    repo: str,
+    pr: int,
+    db_path: Path | None = None,
+) -> int:
+    """Count failure verdicts delivered for this PR since its last green.
+
+    The dedup key includes ``head_sha``, so a PR whose head keeps moving
+    re-fires forever — every push is a fresh key. That is correct for a
+    branch someone is pushing fixes to, and wrong for a standing sync PR
+    whose head tracks its source branch: there, each unrelated merge
+    moves the head and earns another "fix-and-push" the recipient cannot
+    act on. This count is the streak the caller caps on.
+
+    Counts only rows *newer* than the most recent ``success`` for the
+    same ``(repo, pr)``, so a red→green→red sequence starts over rather
+    than staying capped forever. With no success on record the floor is
+    ``0.0``, which every real ``delivered_at`` exceeds.
+
+    Returns 0 on a fresh db (the table is ensured first).
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        row = conn.execute(
+            "SELECT count(*) FROM verdict_delivered "
+            "WHERE repo=? AND pr=? AND conclusion='failure' "
+            "  AND delivered_at > COALESCE(("
+            "        SELECT max(delivered_at) FROM verdict_delivered "
+            "        WHERE repo=? AND pr=? AND conclusion='success'"
+            "      ), 0.0)",
+            (repo, int(pr), repo, int(pr)),
+        ).fetchone()
+    return int(row[0]) if row else 0
+
+
 __all__ = [
+    "failures_since_last_success",
     "init_verdict_dedup_schema",
     "record_verdict_delivered",
     "verdict_already_delivered",

--- a/tests/scitex_agent_container/_lifecycle/test__ci_deliver.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_deliver.py
@@ -18,13 +18,16 @@ from scitex_agent_container._lifecycle._ci_deliver import (
 )
 
 
-def _seams(*, owner="proj-x", ancestors=("lead",), already=False, streak=0):
+def _seams(
+    *, owner="proj-x", ancestors=("lead",), already=False, streak=0, checks=()
+):
     """Build a kwargs dict of DI seams + a capture list for posts.
 
-    ``streak`` seams :func:`failures_since_last_success`. It MUST be
-    injected: without it the failure path binds the production reader and
-    the suite starts touching the real ``state.db`` (STX-NM — seams, not
-    mocks; zero state.db dependency).
+    ``streak`` seams :func:`failures_since_last_success` and ``checks``
+    seams :func:`failing_check_names`. Both MUST be injected: without them
+    the failure path binds the production readers and the suite starts
+    touching the real ``state.db`` and shelling out to ``gh`` (STX-NM —
+    seams, not mocks).
     """
     posts: list[str] = []
     recorded: list[tuple] = []
@@ -34,6 +37,7 @@ def _seams(*, owner="proj-x", ancestors=("lead",), already=False, streak=0):
         ancestors=lambda *, name, db_path=None: list(ancestors),
         already_delivered=lambda **kw: already,
         failure_streak=lambda **kw: streak,
+        failing_checks=lambda repo, pr: list(checks),
         record=lambda **kw: recorded.append(
             (kw["repo"], kw["pr"], kw["head_sha"], kw["conclusion"])
         ),
@@ -222,3 +226,42 @@ def test_green_is_never_capped_however_long_the_red_streak():
     deliver_verdict("o/r", 1, "sha", "success", **seams)
     # Assert
     assert posts == ["proj-x", "lead"]
+
+
+def test_escalation_names_the_failing_check():
+    # Arrange — "check whether the failing check is required" is
+    # unanswerable unless the message says WHICH check.
+    captured: list[str] = []
+    seams, _, _ = _seams(streak=3, checks=("CodeQL",))
+    seams["post"] = lambda name, text: captured.append(text)
+    # Act
+    deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert "CodeQL" in captured[0]
+
+
+def test_escalation_still_sends_when_the_check_names_are_unavailable():
+    # Arrange — naming is a nicety; an unnamed escalation must still go out
+    # rather than the resolution failure swallowing the whole message.
+    captured: list[str] = []
+    seams, _, _ = _seams(streak=3, checks=())
+    seams["post"] = lambda name, text: captured.append(text)
+    seams["failing_checks"] = lambda repo, pr: (_ for _ in ()).throw(RuntimeError("gh down"))
+    # Act
+    deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert captured[0].startswith("CI STUCK")
+
+
+def test_normal_red_never_costs_a_check_name_lookup():
+    # Arrange — the extra gh call belongs on the rare escalation tick only,
+    # never on the hot path. A lookup that raises proves it is not reached.
+    def exploding_lookup(repo, pr):
+        raise AssertionError("failing_check_names ran on a non-escalating red")
+
+    seams, _, _ = _seams(streak=0)
+    seams["failing_checks"] = exploding_lookup
+    # Act
+    result = deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert result["reason"] == "delivered"

--- a/tests/scitex_agent_container/_lifecycle/test__ci_deliver.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_deliver.py
@@ -12,11 +12,20 @@ Conventions: one assertion per test (STX-TQ007); AAA markers.
 
 from __future__ import annotations
 
-from scitex_agent_container._lifecycle._ci_deliver import deliver_verdict
+from scitex_agent_container._lifecycle._ci_deliver import (
+    CONSECUTIVE_FAILURE_CAP,
+    deliver_verdict,
+)
 
 
-def _seams(*, owner="proj-x", ancestors=("lead",), already=False):
-    """Build a kwargs dict of DI seams + a capture list for posts."""
+def _seams(*, owner="proj-x", ancestors=("lead",), already=False, streak=0):
+    """Build a kwargs dict of DI seams + a capture list for posts.
+
+    ``streak`` seams :func:`failures_since_last_success`. It MUST be
+    injected: without it the failure path binds the production reader and
+    the suite starts touching the real ``state.db`` (STX-NM — seams, not
+    mocks; zero state.db dependency).
+    """
     posts: list[str] = []
     recorded: list[tuple] = []
     seams = dict(
@@ -24,6 +33,7 @@ def _seams(*, owner="proj-x", ancestors=("lead",), already=False):
         owner_resolver=lambda repo, **kw: owner,
         ancestors=lambda *, name, db_path=None: list(ancestors),
         already_delivered=lambda **kw: already,
+        failure_streak=lambda **kw: streak,
         record=lambda **kw: recorded.append(
             (kw["repo"], kw["pr"], kw["head_sha"], kw["conclusion"])
         ),
@@ -106,9 +116,109 @@ def test_delivered_message_names_repo_pr_and_conclusion():
         owner_resolver=lambda repo, **kw: "proj-x",
         ancestors=lambda *, name, db_path=None: [],
         already_delivered=lambda **kw: False,
+        failure_streak=lambda **kw: 0,
         record=lambda **kw: None,
     )
     # Act
     deliver_verdict("ywatanabe1989/scitex-dev", 42, "deadbeef", "failure", **seams)
     # Assert
     assert "scitex-dev" in captured[0] and "42" in captured[0]
+
+
+# --- consecutive-failure cap -------------------------------------------
+# Measured 2026-08-16: a standing sync PR whose head ref IS its source
+# branch collected fourteen "Red: fix-and-push" deliveries in a day, one
+# per unrelated feature merge. Nobody had pushed at it.
+#
+# The streaks below are LITERALS (2 / 3 / 4), never `CONSECUTIVE_FAILURE_CAP
+# ± 1`. Writing them in terms of the constant makes the suite VACUOUS: both
+# sides of the `streak == CAP` comparison move together, so changing the cap
+# to any value leaves every test green while asserting nothing. Verified by
+# sabotage — with `CAP = 10**9` the constant-relative version passed 14/14.
+# `test_cap_value_is_pinned` is the single place a cap change must be
+# declared deliberately.
+
+
+def test_cap_value_is_pinned():
+    # Arrange — the literals below encode this number; changing the cap
+    # without updating them would silently re-vacuum the suite.
+    expected = 3
+    # Act
+    actual = CONSECUTIVE_FAILURE_CAP
+    # Assert
+    assert actual == expected
+
+
+def test_red_below_the_cap_still_delivers_normally():
+    # Arrange — two reds on record, one short of the cap.
+    seams, posts, _ = _seams(streak=2)
+    # Act
+    result = deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert result["reason"] == "delivered"
+
+
+def test_red_at_the_cap_escalates():
+    # Arrange — the third red is the single escalation tick.
+    seams, posts, _ = _seams(streak=3)
+    # Act
+    result = deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert result["reason"] == "escalated"
+
+
+def test_escalation_does_not_tell_the_recipient_to_push():
+    # Arrange — "fix-and-push" is the instruction that kept the loop alive.
+    captured: list[str] = []
+    seams, _, _ = _seams(streak=3)
+    seams["post"] = lambda name, text: captured.append(text)
+    # Act
+    deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert "fix-and-push" not in captured[0]
+
+
+def test_red_past_the_cap_is_silent():
+    # Arrange — one past the escalation tick.
+    seams, posts, _ = _seams(streak=4)
+    # Act
+    deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert posts == []
+
+
+def test_capped_red_is_recorded_but_not_posted():
+    # Arrange — if a silenced red were not recorded the count would stall
+    # and the very next tick would un-cap the PR. Asserting the RECORD
+    # alone does not discriminate: the normal delivery path records too,
+    # so that version stays green with the cap disabled. The pair does
+    # discriminate, and stays one assertion (STX-TQ007).
+    seams, posts, recorded = _seams(streak=4)
+    # Act
+    deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert (recorded, posts) == ([("o/r", 1, "sha", "failure")], [])
+
+
+def test_capped_red_never_resolves_an_owner():
+    # Arrange — the gate runs before owner resolution, so a silenced PR
+    # costs no gh call. A resolver that raises proves it is never reached.
+    def exploding_resolver(repo, **kw):
+        raise AssertionError("owner resolution ran for a capped PR")
+
+    seams, _, _ = _seams(streak=4)
+    seams["owner_resolver"] = exploding_resolver
+    # Act
+    result = deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert result["reason"] == "streak-capped"
+
+
+def test_green_is_never_capped_however_long_the_red_streak():
+    # Arrange — the cap must not suppress the recovery signal, which is
+    # the one message that lets the streak reset.
+    seams, posts, _ = _seams(streak=99)
+    # Act
+    deliver_verdict("o/r", 1, "sha", "success", **seams)
+    # Assert
+    assert posts == ["proj-x", "lead"]

--- a/tests/scitex_agent_container/_lifecycle/test__github_ci.py
+++ b/tests/scitex_agent_container/_lifecycle/test__github_ci.py
@@ -117,3 +117,63 @@ def test_gh_ready_false_when_probe_reports_unauthenticated():
     ready = gh_ready(probe=probe)
     # Assert
     assert ready is False
+
+
+# --- failing_check_names (names the stuck check for the escalation) -----
+
+
+def test_failing_check_names_returns_only_failing_buckets():
+    # Arrange
+    from scitex_agent_container._lifecycle._github_ci import failing_check_names
+
+    payload = (
+        '[{"name":"CodeQL","bucket":"fail"},'
+        ' {"name":"pytest","bucket":"pass"},'
+        ' {"name":"lint","bucket":"cancel"}]'
+    )
+    # Act
+    names = failing_check_names("o/r", 1, run=lambda args: payload)
+    # Assert
+    assert names == ["CodeQL", "lint"]
+
+
+def test_failing_check_names_requests_the_name_field():
+    # Arrange — `--json bucket` alone discards the name, so the ring cannot
+    # tell "same check every time" from "a new one".
+    from scitex_agent_container._lifecycle._github_ci import failing_check_names
+
+    seen: list[list] = []
+
+    def spy(args):
+        seen.append(args)
+        return "[]"
+
+    # Act
+    failing_check_names("o/r", 1, run=spy)
+    # Assert
+    assert "name,bucket" in seen[0]
+
+
+def test_failing_check_names_is_empty_on_unparseable_output():
+    # Arrange — a caller must always be able to render the escalation.
+    from scitex_agent_container._lifecycle._github_ci import failing_check_names
+
+    # Act
+    names = failing_check_names("o/r", 1, run=lambda args: "not json")
+    # Assert
+    assert names == []
+
+
+def test_failing_check_names_dedupes_and_sorts():
+    # Arrange — a matrix leg can appear more than once.
+    from scitex_agent_container._lifecycle._github_ci import failing_check_names
+
+    payload = (
+        '[{"name":"zeta","bucket":"fail"},'
+        ' {"name":"alpha","bucket":"fail"},'
+        ' {"name":"alpha","bucket":"fail"}]'
+    )
+    # Act
+    names = failing_check_names("o/r", 1, run=lambda args: payload)
+    # Assert
+    assert names == ["alpha", "zeta"]

--- a/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
+++ b/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
@@ -169,3 +169,109 @@ def test_record_is_idempotent(db_path: Path):
     record_verdict_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
     # Assert
     assert verdict_already_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
+
+
+# ---------------------------------------------------------------------------
+# Failure streak — the consecutive-failure cap's counter
+#
+# `delivered_at` is passed explicitly throughout: the streak is defined by
+# comparison against the last green's timestamp, and two records written in
+# the same float tick would make the ordering ambiguous. Production ticks are
+# minutes apart, so this is a test-determinism concern, not a live one.
+# ---------------------------------------------------------------------------
+
+
+def test_failure_streak_counts_reds_for_this_pr(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        failures_since_last_success,
+        record_verdict_delivered,
+    )
+
+    for i, sha in enumerate(("a", "b", "c")):
+        record_verdict_delivered(
+            repo="o/r", pr=1, head_sha=sha, conclusion="failure", delivered_at=100.0 + i
+        )
+    # Act
+    streak = failures_since_last_success(repo="o/r", pr=1)
+    # Assert
+    assert streak == 3
+
+
+def test_failure_streak_resets_after_a_green(db_path: Path):
+    # Arrange — two reds, a green, then one more red.
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        failures_since_last_success,
+        record_verdict_delivered,
+    )
+
+    record_verdict_delivered(
+        repo="o/r", pr=1, head_sha="a", conclusion="failure", delivered_at=100.0
+    )
+    record_verdict_delivered(
+        repo="o/r", pr=1, head_sha="b", conclusion="failure", delivered_at=101.0
+    )
+    record_verdict_delivered(
+        repo="o/r", pr=1, head_sha="g", conclusion="success", delivered_at=102.0
+    )
+    record_verdict_delivered(
+        repo="o/r", pr=1, head_sha="d", conclusion="failure", delivered_at=103.0
+    )
+    # Act
+    streak = failures_since_last_success(repo="o/r", pr=1)
+    # Assert
+    assert streak == 1
+
+
+def test_failure_streak_ignores_another_prs_reds(db_path: Path):
+    # Arrange — a noisy neighbour must not cap this PR.
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        failures_since_last_success,
+        record_verdict_delivered,
+    )
+
+    for i, sha in enumerate(("a", "b", "c", "d", "e")):
+        record_verdict_delivered(
+            repo="o/r",
+            pr=999,
+            head_sha=sha,
+            conclusion="failure",
+            delivered_at=100.0 + i,
+        )
+    # Act
+    streak = failures_since_last_success(repo="o/r", pr=1)
+    # Assert
+    assert streak == 0
+
+
+def test_failure_streak_ignores_another_repos_reds(db_path: Path):
+    # Arrange — same PR number in a different repo is a different PR.
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        failures_since_last_success,
+        record_verdict_delivered,
+    )
+
+    for i, sha in enumerate(("a", "b", "c", "d")):
+        record_verdict_delivered(
+            repo="other/repo",
+            pr=1,
+            head_sha=sha,
+            conclusion="failure",
+            delivered_at=100.0 + i,
+        )
+    # Act
+    streak = failures_since_last_success(repo="o/r", pr=1)
+    # Assert
+    assert streak == 0
+
+
+def test_failure_streak_is_zero_on_a_fresh_db(db_path: Path):
+    # Arrange — never written; the table must be ensured lazily, not raise.
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        failures_since_last_success,
+    )
+
+    # Act
+    streak = failures_since_last_success(repo="o/r", pr=1)
+    # Assert
+    assert streak == 0


### PR DESCRIPTION
## What

The CI verdict ring dedups on `(repo, pr, head_sha, conclusion)`, so every new head SHA mints a fresh key and re-delivers. That is correct for a branch someone is pushing fixes to, and wrong for a **standing sync PR whose head ref IS its source branch** — each unrelated merge there moves the head and earns another `Red: fix-and-push — the ring re-fires on your next push`.

## Why now

Measured 2026-08-16 against a live `release: sync main with develop` PR:

- **14 failure deliveries in a day**, 3.5× the next-highest PR in the fleet
- on a check that was **not a required context**, that no push could change
- **nobody had pushed at it** — its head ref is `develop`, so eleven ordinary feature merges moved it

The instruction was unfollowable and the volume taught its recipients to skim. I then read my own monitor's output as evidence about another team's behaviour and posted a wrong public diagnosis on their PR, which I have since corrected. The ring produced that error, not the other repo.

## The change

A consecutive-failure cap (`CONSECUTIVE_FAILURE_CAP = 3`):

| streak | behaviour |
|---|---|
| 0–2 | normal delivery |
| 3 | **one** escalation, which deliberately does *not* say "fix-and-push" |
| 4+ | recorded, not delivered — silent until a green resets the streak |

- `failures_since_last_success()` counts rows newer than the PR's last `success`, so **the recorded count IS the state** — no schema change, and a restart cannot lose position.
- The gate runs **before owner resolution**, so a capped PR costs no `gh` call.
- **Green is never capped** — it is the one signal that lets the streak reset.
- The escalation names what to check instead: is the failing check a *required* context, and is the head moving for unrelated reasons?

## Verification

```
27 passed          # with the cap
 6 failed, 9 passed # with CONSECUTIVE_FAILURE_CAP = 10**9 (sabotage)
```

**The first version of these tests was vacuous** and I nearly shipped it. They were written as `streak=CONSECUTIVE_FAILURE_CAP ± 1`, so raising the cap to `10**9` moved *both sides* of the `streak == CAP` comparison and left them **14/14 green while asserting nothing**. Rewritten with literal streaks (2/3/4) plus a single `test_cap_value_is_pinned`, so a cap change must be declared deliberately in one place.

A second test was also non-discriminating — asserting the silenced red was *recorded* passes under sabotage too, because the normal delivery path records as well. It now asserts the pair `(recorded, posts) == ([...], [])`, still one assertion.

`failures_since_last_success` is seamed into the existing DI kwargs, and `_seams()` injects it, so the suite keeps its zero-`state.db` property.

## Pre-existing failure, not from this branch

`tests/develop/test_audit.py::test_audit_all_clean` fails locally on **`PS-226 §1 job-name-not-hyphenated`** in `src/scitex_agent_container/_jobs/_jobs_plugin.py:16`. Control: the **unmodified develop checkout fails identically**, same rule, same file. Not introduced here.

Worth flagging separately: that same commit (`42c71961`) is **green in CI**, with the **same scitex-dev 0.50.0** on both sides — so local and CI disagree on an identical commit and identical tool version. The local run reports `audit-api: distribution metadata for 'scitex-agent-container' not found (continuing with source-only checks)`, which is an environmental difference but **unverified as the cause**. Tracked separately; not a blocker for this PR.

## Follow-ups (carded, not in this PR)

- `_github_ci.py:80` requests only `--json bucket`, discarding the check **name** — so the ring cannot classify "same check red across N distinct SHAs".
- `_ci_owner.py:101` **fabricates** the repo owner from a hardcoded default rather than reading `nameWithOwner` back from GitHub. This is the sole source of a stale pre-transfer org name in every notification, and it is shadowable.
- `_github_ci_poll_loop.py:127` bounds the tick (300s) shorter than the transport it wraps (600s default).
