### PR TITLE
fix(ci-owner): report the repo name GitHub returns, not a constructed guess

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_ci_owner.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_owner.py
@@ -87,18 +87,70 @@ def resolve_owner(
     return None
 
 
-def tracked_repos(*, agents_dir: Path | None = None, org: str | None = None) -> list:
+#: Process-lifetime cache of constructed name → canonical ``owner/repo``.
+#: A transfer or rename is rare and the poller restarts often, so a
+#: per-process cache is enough; it keeps the poll tick from spending one
+#: ``gh`` call per repo per tick.
+_CANONICAL_CACHE: dict = {}
+
+
+def _canonical_name_with_owner(repo: str) -> str:
+    """Return GitHub's canonical ``owner/name`` for ``repo``.
+
+    A constructed ``<org>/<project>`` string is a GUESS about who owns the
+    repo today. GitHub redirects path-addressed REST GETs after a transfer,
+    so the guess keeps working and nothing ever reports that it is stale —
+    while every notification quotes an owner that may no longer exist.
+    Measured 2026-08-16: the ring named a repo by a pre-transfer owner for
+    long enough to cost a whole investigation into whether two repos
+    existed. Search endpoints do NOT follow the redirect, so the stale name
+    also silently returns zero results there.
+
+    Fail-soft: any failure returns ``repo`` unchanged, which is exactly the
+    previous behaviour, so a gh outage degrades to a guess rather than to
+    an empty poll list.
+    """
+    cached = _CANONICAL_CACHE.get(repo)
+    if cached is not None:
+        return cached
+    try:
+        from ._github_ci import _run_gh
+
+        raw = _run_gh(
+            ["repo", "view", repo, "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
+        )
+    except Exception:  # stx-allow: fallback (gh missing → keep the constructed name)
+        raw = ""
+    resolved = (raw or "").strip()
+    out = resolved if "/" in resolved else repo
+    _CANONICAL_CACHE[repo] = out
+    return out
+
+
+def tracked_repos(
+    *,
+    agents_dir: Path | None = None,
+    org: str | None = None,
+    canonicalize=None,
+) -> list:
     """Return the ``owner/repo`` strings the CI poller should watch.
 
     Derived from sac's own agent specs (the repos that have an owning
     agent): each spec's ``metadata.labels.project`` becomes
-    ``<org>/<project>``. ``org`` defaults to ``$SAC_CI_POLL_ORG`` then
-    ``ywatanabe1989`` (the SciTeX GitHub org). Sorted + de-duped; a
-    project with no agent contributes nothing, so the poller only ever
-    watches repos sac can actually deliver a verdict for.
+    ``<org>/<project>``, which is then resolved to the name GitHub
+    actually reports. ``org`` seeds that lookup and defaults to
+    ``$SAC_CI_POLL_ORG``; the constructed string is a starting guess, not
+    the answer. Sorted + de-duped AFTER resolution, so two projects that
+    resolve to one repo collapse. A project with no agent contributes
+    nothing, so the poller only ever watches repos sac can deliver a
+    verdict for.
+
+    ``canonicalize`` is an injection seam; production callers leave it
+    ``None``.
     """
     agents_dir = agents_dir if agents_dir is not None else _default_agents_dir()
     resolved_org = org or os.environ.get("SAC_CI_POLL_ORG", "ywatanabe1989")
+    canonicalize = canonicalize or _canonical_name_with_owner
     if not agents_dir.is_dir():
         return []
     import yaml
@@ -112,7 +164,7 @@ def tracked_repos(*, agents_dir: Path | None = None, org: str | None = None) -> 
             continue
         if isinstance(project, str) and project.strip():
             projects.add(project.strip())
-    return [f"{resolved_org}/{p}" for p in sorted(projects)]
+    return sorted({canonicalize(f"{resolved_org}/{p}") for p in projects})
 
 
 __all__ = [

--- a/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
@@ -95,13 +95,16 @@ def test_unknown_repo_resolves_to_none(tmp_path: Path):
 
 
 def test_tracked_repos_derives_owner_repo_from_spec_labels(tmp_path: Path):
-    # Arrange
+    # Arrange — canonicalize seamed to identity: this test is about the
+    # construction from spec labels, not about the GitHub lookup.
     agents = tmp_path / "agents"
     _write_spec(agents, "proj-scitex-dev", "scitex-dev")
     # Act
-    repos = tracked_repos(agents_dir=agents, org="ywatanabe1989")
+    repos = tracked_repos(
+        agents_dir=agents, org="an-org", canonicalize=lambda repo: repo
+    )
     # Assert
-    assert repos == ["ywatanabe1989/scitex-dev"]
+    assert repos == ["an-org/scitex-dev"]
 
 
 def test_tracked_repos_empty_when_no_specs(tmp_path: Path):
@@ -109,6 +112,94 @@ def test_tracked_repos_empty_when_no_specs(tmp_path: Path):
     agents = tmp_path / "agents"
     agents.mkdir()
     # Act
-    repos = tracked_repos(agents_dir=agents, org="ywatanabe1989")
+    repos = tracked_repos(
+        agents_dir=agents, org="an-org", canonicalize=lambda repo: repo
+    )
     # Assert
     assert repos == []
+
+
+# --- canonical owner/name resolution -----------------------------------
+# The constructed `<org>/<project>` is a GUESS about who owns the repo
+# today. GitHub redirects path-addressed REST GETs after a transfer, so a
+# stale guess keeps working and never reports itself — while every
+# notification quotes an owner that may no longer exist, and search
+# endpoints silently return nothing for it.
+
+
+def test_tracked_repos_reports_the_name_github_returns_not_the_guess():
+    # Arrange — the constructed guess and the canonical answer differ,
+    # which is exactly the transfer case that caused this.
+    from scitex_agent_container._lifecycle._ci_owner import tracked_repos as tr
+    from pathlib import Path as _P
+    import tempfile, textwrap
+
+    with tempfile.TemporaryDirectory() as td:
+        agents = _P(td) / "agents"
+        _write_spec(agents, "proj-hub", "scitex-hub")
+        # Act
+        repos = tr(
+            agents_dir=agents,
+            org="old-owner",
+            canonicalize=lambda repo: "new-org/scitex-hub",
+        )
+    # Assert
+    assert repos == ["new-org/scitex-hub"]
+
+
+def test_tracked_repos_collapses_two_projects_that_resolve_to_one_repo(
+    tmp_path: Path,
+):
+    # Arrange — de-dup must happen AFTER resolution, or a renamed repo is
+    # polled twice under two names.
+    agents = tmp_path / "agents"
+    _write_spec(agents, "proj-a", "old-name")
+    _write_spec(agents, "proj-b", "new-name")
+    # Act
+    repos = tracked_repos(
+        agents_dir=agents, org="an-org", canonicalize=lambda repo: "an-org/new-name"
+    )
+    # Assert
+    assert repos == ["an-org/new-name"]
+
+
+def test_canonical_lookup_falls_back_to_the_guess_when_gh_gives_nothing():
+    # Arrange — a gh outage must degrade to the previous behaviour (a
+    # guess), never to an empty poll list that silently watches nothing.
+    from scitex_agent_container._lifecycle import _ci_owner as mod
+
+    mod._CANONICAL_CACHE.clear()
+    saved = mod._run_gh if hasattr(mod, "_run_gh") else None
+    import scitex_agent_container._lifecycle._github_ci as ghmod
+
+    real = ghmod._run_gh
+    ghmod._run_gh = lambda args: ""
+    try:
+        # Act
+        out = mod._canonical_name_with_owner("an-org/a-repo")
+    finally:
+        ghmod._run_gh = real
+        mod._CANONICAL_CACHE.clear()
+    # Assert
+    assert out == "an-org/a-repo"
+
+
+def test_canonical_lookup_is_cached_so_a_tick_costs_one_call_per_repo():
+    # Arrange — without a cache the poll loop spends one gh call per repo
+    # per tick, forever.
+    from scitex_agent_container._lifecycle import _ci_owner as mod
+    import scitex_agent_container._lifecycle._github_ci as ghmod
+
+    mod._CANONICAL_CACHE.clear()
+    calls: list = []
+    real = ghmod._run_gh
+    ghmod._run_gh = lambda args: calls.append(args) or "an-org/canonical"
+    try:
+        # Act
+        mod._canonical_name_with_owner("an-org/a-repo")
+        mod._canonical_name_with_owner("an-org/a-repo")
+    finally:
+        ghmod._run_gh = real
+        mod._CANONICAL_CACHE.clear()
+    # Assert
+    assert len(calls) == 1

--- a/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
@@ -127,22 +127,19 @@ def test_tracked_repos_empty_when_no_specs(tmp_path: Path):
 # endpoints silently return nothing for it.
 
 
-def test_tracked_repos_reports_the_name_github_returns_not_the_guess():
+def test_tracked_repos_reports_the_name_github_returns_not_the_guess(
+    tmp_path: Path,
+):
     # Arrange — the constructed guess and the canonical answer differ,
     # which is exactly the transfer case that caused this.
-    from scitex_agent_container._lifecycle._ci_owner import tracked_repos as tr
-    from pathlib import Path as _P
-    import tempfile, textwrap
-
-    with tempfile.TemporaryDirectory() as td:
-        agents = _P(td) / "agents"
-        _write_spec(agents, "proj-hub", "scitex-hub")
-        # Act
-        repos = tr(
-            agents_dir=agents,
-            org="old-owner",
-            canonicalize=lambda repo: "new-org/scitex-hub",
-        )
+    agents = tmp_path / "agents"
+    _write_spec(agents, "proj-hub", "scitex-hub")
+    # Act
+    repos = tracked_repos(
+        agents_dir=agents,
+        org="old-owner",
+        canonicalize=lambda repo: "new-org/scitex-hub",
+    )
     # Assert
     assert repos == ["new-org/scitex-hub"]
 


### PR DESCRIPTION
## What

`tracked_repos()` built each watched repo as `f"{org}/{project}"`, where `org` defaults to a hardcoded literal. That string is a **guess** about who owns the repo today, and nothing ever checks it.

## Why it survives undetected

GitHub **redirects path-addressed REST GETs** after a transfer. `gh api repos/<stale-owner>/<repo>` keeps working and returns the right data — so the poller polls correctly while every notification it emits quotes an owner that may no longer exist.

Measured 2026-08-16: the ring named a repo by a pre-transfer owner consistently enough that I spent an entire investigation branch establishing whether two separate repos existed. It was one repo (`id 1010976100`) and a stale label.

The redirect is **not** universal, which makes the stale name worse than cosmetic:

| call | canonical name | stale name |
|---|---|---|
| REST `GET /repos/...` | data | **301 → data** (redirect followed) |
| REST `search/issues` | 594 results | **`Validation Failed`** |
| GraphQL `search(...)` | 594 | **HTTP 200, `issueCount: 0`, no errors** |
| `gh search code --repo ...` | 151 bytes of hits | **rc=0, 0 bytes stdout, 0 bytes stderr** |

The last two are success values that are also the didn't-check value.

## The change

Resolve each constructed name through `gh repo view --json nameWithOwner` and report what GitHub says.

- **Fail-soft:** any failure returns the constructed name unchanged — exactly the previous behaviour — so a gh outage degrades to a guess rather than to an empty poll list that silently watches nothing.
- **De-dup after resolution**, so two specs whose projects resolve to one repo collapse instead of being polled twice under two names.
- **Cached for the process lifetime.** A transfer is rare and the poller restarts often, so this costs one `gh` call per repo per *process*, not per tick.
- `canonicalize` is an injection seam; the two pre-existing tests now inject identity, declaring that they test the construction rather than the lookup.

## Verification

```
11 passed
```

Sabotage-verified twice, each against the unit it targets — not one blanket run:

| sabotage | result |
|---|---|
| drop the canonicalisation (return the guess) | **2 failed** — exactly the 2 canonicalisation tests |
| drop the cache | **1 failed** — exactly the 1 cache test |

The two `_canonical_name_with_owner` unit tests correctly survive sabotage 1, and the two `tracked_repos` tests correctly survive sabotage 2, because they pin different units. I checked that rather than assuming every test should flip.

## Not in scope

`resolve_owner()` matches on the repo **basename** only, so the stale org never broke verdict *routing* — it corrupted the displayed name and the query string. No change needed there.
