### PR TITLE
fix(ci-poll): bound one verdict post well inside the tick that starts it

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
@@ -39,6 +39,25 @@ logger = logging.getLogger(__name__)
 # scale. Override via ``SAC_GITHUB_CI_POLL_INTERVAL_S`` at the wiring site.
 DEFAULT_CI_POLL_INTERVAL_S = 300.0
 
+#: Per-target budget for delivering ONE verdict.
+#:
+#: ``post_turn`` defaults to ``timeout_s=600.0``, which is longer than the
+#: tick bound below (``max(poll_interval_s, 30.0)``, i.e. 300s by default) —
+#: so a single unresponsive peer could outlive the tick that started it. And
+#: ``run_blocking_or`` ABANDONS a timed-out call rather than cancelling it,
+#: so the abandoned post keeps running while the loop sleeps and starts the
+#: next tick: two ticks alive at once, both able to post.
+#:
+#: Never observed in production, and it structurally cannot be: the
+#: delivered-set is keyed on ``(repo, pr, head_sha, conclusion)``, so a
+#: duplicate delivery from an overlapping tick is deduped away and leaves no
+#: row to find. An absent symptom here is not evidence of absence.
+#:
+#: A verdict notification is a short POST to a peer on the same fleet. It
+#: does not need a ten-minute budget, and bounding it well under the tick
+#: keeps the inversion impossible rather than merely unobserved.
+VERDICT_POST_TIMEOUT_S = 30.0
+
 
 def _default_ready_check() -> bool:
     from ._github_ci import gh_ready
@@ -96,7 +115,17 @@ async def github_ci_poll_loop(
     if conclusion_for is None:
         from ._github_ci import pr_ci_conclusion as conclusion_for
     if deliver is None:
-        from ._ci_deliver import deliver_verdict as deliver
+        from functools import partial
+
+        from .._network.peer import post_turn
+        from ._ci_deliver import deliver_verdict as _deliver_verdict
+
+        _bounded_post = partial(post_turn, timeout_s=VERDICT_POST_TIMEOUT_S)
+
+        def deliver(*args, **kwargs):
+            # Bind the bounded transport unless a caller supplied its own.
+            kwargs.setdefault("post", _bounded_post)
+            return _deliver_verdict(*args, **kwargs)
 
     def _tick_body() -> None:
         # Each of repos_source / list_prs / conclusion_for / deliver may
@@ -138,4 +167,8 @@ async def github_ci_poll_loop(
         raise
 
 
-__all__ = ["DEFAULT_CI_POLL_INTERVAL_S", "github_ci_poll_loop"]
+__all__ = [
+    "DEFAULT_CI_POLL_INTERVAL_S",
+    "VERDICT_POST_TIMEOUT_S",
+    "github_ci_poll_loop",
+]

--- a/tests/scitex_agent_container/_lifecycle/test__github_ci_poll_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__github_ci_poll_loop.py
@@ -133,3 +133,41 @@ async def test_loop_honours_cancellation_cleanly():
     # Assert — the finally must re-raise CancelledError, not swallow it.
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+# --- the post budget must fit inside the tick that starts it -----------
+# post_turn defaults to timeout_s=600.0 while the tick is bounded at
+# max(poll_interval_s, 30.0) = 300s, and run_blocking_or ABANDONS rather
+# than cancels — so one unresponsive peer could leave two ticks alive at
+# once. The dedup key hides the duplicate, so this cannot be caught by
+# looking for symptoms; it has to be pinned as an invariant.
+
+
+def test_verdict_post_budget_fits_inside_the_default_tick_bound():
+    # Arrange
+    from scitex_agent_container._lifecycle._github_ci_poll_loop import (
+        DEFAULT_CI_POLL_INTERVAL_S,
+        VERDICT_POST_TIMEOUT_S,
+    )
+
+    # Act
+    tick_bound = max(DEFAULT_CI_POLL_INTERVAL_S, 30.0)
+    # Assert
+    assert VERDICT_POST_TIMEOUT_S < tick_bound
+
+
+def test_verdict_post_budget_is_shorter_than_the_transport_default():
+    # Arrange — the whole defect is that the transport's own default
+    # (600s) is longer than the tick that wraps it.
+    import inspect
+
+    from scitex_agent_container._lifecycle._github_ci_poll_loop import (
+        VERDICT_POST_TIMEOUT_S,
+    )
+    from scitex_agent_container._network.peer import post_turn
+
+    transport_default = inspect.signature(post_turn).parameters["timeout_s"].default
+    # Act
+    bounded = VERDICT_POST_TIMEOUT_S
+    # Assert
+    assert bounded < transport_default


### PR DESCRIPTION
## The inversion

`post_turn` defaults to `timeout_s=600.0`. The poll tick is bounded at `max(poll_interval_s, 30.0)` — **300s** by default.

So one unresponsive peer could outlive the tick that started it. And `run_blocking_or` **abandons** a timed-out call rather than cancelling it: the abandoned post keeps running while the loop sleeps and starts the next tick, leaving two ticks alive at once, both able to post.

## Why there is no symptom to point at

This has never been observed, and it **structurally cannot be**. The delivered-set is keyed on `(repo, pr, head_sha, conclusion)`, so a duplicate delivery from an overlapping tick is deduped away and leaves no row behind.

An absent symptom is not evidence of absence when the table cannot represent the symptom. That is why this is pinned as an **invariant** rather than as a behavioural test — there is no behaviour to assert on.

## The change

`VERDICT_POST_TIMEOUT_S = 30.0`, bound into the poller's transport. A verdict notification is a short POST to a peer on the same fleet; it does not need a ten-minute budget. Bounding it makes the inversion impossible rather than merely unobserved.

Bound via `kwargs.setdefault("post", ...)`, so an injected `post` seam still wins and every existing test keeps its own transport.

## Verification

```
7 passed
```

Two invariants, both sabotage-verified — restoring the 600s budget fails **exactly** those two:

- the budget is under the tick bound
- the budget is under the transport's own default, read from `post_turn`'s **signature** rather than hardcoded, so the test notices if that default ever moves

## Context

Fourth and last of the CI-ring defects found while diagnosing why the ring delivered fourteen "fix-and-push" messages in a day to a PR nobody was pushing to. The other three are #1080 (consecutive-failure cap; naming the stuck check) and #1081 (report the repo name GitHub returns, not a constructed guess).
