### PR TITLE
feat(drift): warn when a spec's inert sibling copy is newer

### DIFF
--- a/src/scitex_agent_container/_drift/_local.py
+++ b/src/scitex_agent_container/_drift/_local.py
@@ -42,6 +42,7 @@ import subprocess
 import time
 from pathlib import Path
 
+from ._sibling import warn_if_newer_sibling
 from ._status import DriftState, DriftStatus
 
 # How long a successful ``git fetch`` for a given repo stays "fresh".
@@ -432,6 +433,17 @@ def warn_if_spec_source_drifted(
         else:
             for line in lines:
                 print(line, file=stream, flush=True)
+    # Sibling-copy staleness — a DIFFERENT mechanism from git drift, and
+    # deliberately INDEPENDENT of it: it must fire even when the spec
+    # source is NOT_A_REPO (the deliberately-not-a-repo live layout is the
+    # exact incident case), and it NEVER refuses. It is advisory and
+    # degrades to silence on any internal error.
+    try:
+        warn_if_newer_sibling(spec_path, agent=agent, stream=stream)
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: the sibling check is advisory and already fully guarded inside _sibling; this second guard keeps "a warning must never crash a launch" true even if that guarantee regressed)
+        pass
     if refusing:
         raise SpecSourceDriftError(status, agent=agent)
     return status

--- a/src/scitex_agent_container/_drift/_sibling.py
+++ b/src/scitex_agent_container/_drift/_sibling.py
@@ -1,0 +1,287 @@
+"""Sibling-copy staleness warning (sac-drift family).
+
+2026-08-15 incident: the operator edited ``~/.dotfiles/src/.scitex/.../
+spec.yaml`` — the dotfiles SOURCE copy — and restarted the agent; nothing
+changed, because sac loads ``~/.scitex/.../spec.yaml`` (the runtime copy,
+written four hours earlier). Nothing anywhere said the file he edited was
+inert. Four hours were spent discovering that by hand.
+
+The live spec tree is DELIBERATELY not a git repo (the deploy flow
+classifies ``.scitex`` as runtime state), so the git-drift check in
+:mod:`._local` cannot see this at all — and must not be "fixed" into a
+refusal, which would stop every agent from starting. The useful check is
+different, and it is always applicable:
+
+    a DIFFERENT copy of this spec exists at <path>, it is NEWER than the
+    one I load, and I do not read it.
+
+That is one ``stat`` per candidate, it fires exactly in the case that cost
+four hours, and it is a WARNING naming both paths and both mtimes — never
+a refusal, since a stale sibling copy is normal and harmless most of the
+time.
+
+Sibling discovery has two composed mechanisms; NEITHER hardcodes a host
+layout (the check must keep applying when the layout changes):
+
+* **zero-config** — the spec's intra-``.scitex`` tail (everything after
+  the LAST ``.scitex`` path component of the loaded path; the canonical
+  ``agent-container/agents/<agent>/spec.yaml`` location when the path has
+  no ``.scitex`` anchor) re-rooted at the canonical scitex scopes:
+  ``scitex_config.local_state.user_root()`` (``$SCITEX_DIR`` /
+  ``~/.scitex``) and the project-scope ``.scitex`` root.
+* **configured** — :data:`SIBLING_ROOTS_ENV` (``SAC_SPEC_SIBLING_ROOTS``):
+  a colon-separated list of directories, each naming a ``.scitex`` tree
+  itself or its PARENT (the source-tree root, e.g. ``~/.dotfiles/src``).
+  Both depths are probed, so the operator points at wherever the source
+  tree actually lives without knowing which form the check expects.
+
+ADVISORY CONTRACT: this module never raises and never refuses a launch.
+It degrades to a silent no-op on any error — a warning that crashes a
+launch is a launch-killer wearing a warning's clothes.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+# Operator-configurable list of ``.scitex`` tree roots (or their parents).
+# See the module docstring; entries are os.pathsep-separated.
+SIBLING_ROOTS_ENV = "SAC_SPEC_SIBLING_ROOTS"
+
+# This package's local-state pkg-short — the scope its specs live under.
+_PKG_SHORT = "agent-container"
+
+
+def spec_rel_tail(spec_path: str | Path, *, agent: str | None = None) -> Path | None:
+    """The spec's path INSIDE its ``.scitex`` tree, or ``None``.
+
+    Derived from the spec's own path — no hardcoded host layout: the
+    innermost ``.scitex`` component is the tree root, and everything after
+    it is the tail that re-roots identically under any other ``.scitex``
+    tree. When the path carries no ``.scitex`` anchor at all, fall back to
+    the canonical ``agent-container/agents/<agent>/spec.yaml`` location
+    (requires ``agent``); without either an anchor or an agent there is
+    nothing to compare and the check is a silent no-op.
+    """
+    parts = Path(spec_path).parts
+    for idx in range(len(parts) - 1, -1, -1):
+        if parts[idx] == ".scitex":
+            if idx + 1 >= len(parts):
+                return None  # the path ends AT the tree root — not a spec
+            return Path(*parts[idx + 1:])
+    if agent:
+        return Path(_PKG_SHORT) / "agents" / agent / "spec.yaml"
+    return None
+
+
+def _canonical_bases() -> list[Path]:
+    """The ``.scitex`` trees this host can read, with zero configuration.
+
+    The two canonical scopes from ``scitex_config.local_state``:
+    ``user_root()`` (``$SCITEX_DIR`` / ``~/.scitex``) and the project
+    scope's ``.scitex`` root (``<git-repo>/.scitex`` when the cwd is in a
+    repo that has one). Both are known-to-be-``.scitex``-dir roots, so a
+    candidate is simply ``base / tail``.
+    """
+    bases: list[Path] = []
+    # Import lazily so a missing scitex_config (optional dep elsewhere)
+    # never breaks this advisory — the check just loses its canonical
+    # scopes and degrades to configured-roots-only (or silent).
+    try:
+        from scitex_config._ecosystem import local_state
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: advisory check — a missing optional dep means fewer probes, never a launch failure)
+        return bases
+    try:
+        bases.append(local_state.user_root())
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: a broken resolver must not crash a launch — skip this probe)
+        pass
+    try:
+        project_scope = local_state.find_project_scope(_PKG_SHORT)
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: the project-scope probe is best-effort — skip it on any resolver error)
+        project_scope = None
+    if project_scope is not None:
+        bases.append(project_scope.parent)  # <repo>/.scitex
+    return bases
+
+
+def _configured_roots() -> list[Path]:
+    """Operator-declared sibling roots from :data:`SIBLING_ROOTS_ENV`.
+
+    Each entry may name a ``.scitex`` tree itself or its parent; the
+    prober expands both depths. ``expanduser`` is applied so the operator
+    can write ``~/.dotfiles/src``.
+    """
+    raw = os.environ.get(SIBLING_ROOTS_ENV, "")
+    roots: list[Path] = []
+    for entry in raw.split(os.pathsep):
+        entry = entry.strip()
+        if entry:
+            roots.append(Path(entry).expanduser())
+    return roots
+
+
+def candidate_sibling_paths(
+    spec_path: str | Path,
+    *,
+    agent: str | None = None,
+    extra_roots: Sequence[str | Path] = (),
+) -> list[Path]:
+    """Every path at which another copy of this spec could live.
+
+    The spec's own intra-``.scitex`` tail re-rooted at: the canonical
+    scitex scopes (``base / tail``) plus each configured/extra root at
+    BOTH depths (``root / tail`` and ``root / .scitex / tail``). The
+    loaded spec's own resolved path is excluded, as are probes resolving
+    to the same file twice — a file is not a sibling of itself, and a
+    symlinked copy must not be warned about its own target.
+    """
+    tail = spec_rel_tail(spec_path, agent=agent)
+    if tail is None:
+        return []
+    loaded = Path(spec_path).resolve()
+    probes: list[Path] = []
+    for base in _canonical_bases():
+        probes.append(base / tail)
+    for root in [*extra_roots, *_configured_roots()]:
+        root = Path(root).expanduser()
+        probes.append(root / tail)
+        probes.append(root / ".scitex" / tail)
+    seen: set[Path] = set()
+    candidates: list[Path] = []
+    for probe in probes:
+        try:
+            resolved = probe.resolve()
+        except OSError:  # stx-allow: fallback (reason: an unresolvable probe path is skipped — advisory check, never a launch failure)
+            continue
+        if resolved in seen or resolved == loaded:
+            continue
+        seen.add(resolved)
+        candidates.append(probe)
+    return candidates
+
+
+def find_newer_siblings(
+    spec_path: str | Path,
+    *,
+    agent: str | None = None,
+    extra_roots: Sequence[str | Path] = (),
+) -> list[tuple[Path, float]]:
+    """Sibling copies STRICTLY newer than the loaded spec.
+
+    Returns ``(sibling_path, sibling_mtime)`` pairs. Strictly-newer is
+    deliberate: an equal or older sibling is not a signal — it is the
+    normal state. The comparison is on the mtime the copy actually
+    carries (symlinks resolve to their target, whose mtime is what any
+    reader through that path would see). A missing spec or a candidate
+    that cannot be stat'ed is skipped; this function never raises.
+    """
+    try:
+        loaded_mtime = Path(spec_path).stat().st_mtime
+    except OSError:
+        return []  # no loadable spec => nothing to compare against
+    results: list[tuple[Path, float]] = []
+    for sibling in candidate_sibling_paths(
+        spec_path, agent=agent, extra_roots=extra_roots
+    ):
+        try:
+            stat = sibling.stat()
+        except OSError:
+            continue  # candidate absent on this host
+        if stat.st_mtime > loaded_mtime:
+            results.append((sibling, stat.st_mtime))
+    return results
+
+
+def _fmt_mtime(mtime: float) -> str:
+    """Human-readable local timestamp for the warning's mtime columns."""
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(mtime))
+
+
+def sibling_warning_lines(
+    spec_path: str | Path,
+    *,
+    siblings: Sequence[tuple[Path, float]],
+    agent: str | None = None,
+) -> list[str]:
+    """The warning text: BOTH paths and BOTH mtimes, naming the outcome.
+
+    A stale sibling is a WARNING, never a refusal — most of the time an
+    inert sibling copy is normal and harmless. The line exists so that the
+    one time it is the copy the operator DID just edit, nobody spends four
+    hours finding out that by hand.
+    """
+    who = f" for agent '{agent}'" if agent else ""
+    lines = [
+        f"sac-drift WARNING{who}: a DIFFERENT copy of this spec is NEWER "
+        f"than the one I load, and I do not read it:",
+    ]
+    try:
+        loaded_mtime = _fmt_mtime(Path(spec_path).stat().st_mtime)
+    except OSError:
+        loaded_mtime = "unknown"
+    lines.append(f"  loaded:  {spec_path}   (mtime {loaded_mtime})")
+    for sibling, sibling_mtime in siblings:
+        lines.append(f"  sibling: {sibling}   (mtime {_fmt_mtime(sibling_mtime)})")
+    lines.append(
+        "  if you edited the sibling copy, that edit is NOT in effect — "
+        "sac loads the 'loaded' path above."
+    )
+    return lines
+
+
+def warn_if_newer_sibling(
+    spec_path: str | Path,
+    *,
+    agent: str | None = None,
+    stream=None,
+) -> int:
+    """Emit the sibling-staleness warning if (and only if) one is due.
+
+    The launch-funnel entry point (called from
+    ``warn_if_spec_source_drifted``): reads :data:`SIBLING_ROOTS_ENV`
+    itself, emits through scitex-logging when ``stream is None`` (same
+    lazy-import idiom as ``_local.py`` — a launch must not pay handler
+    setup at import time) or the explicit ``stream``, and returns the
+    number of newer siblings found (0 = silent).
+
+    ADVISORY ONLY: never raises and never refuses a launch — any internal
+    failure degrades to silence.
+    """
+    try:
+        siblings = find_newer_siblings(spec_path, agent=agent)
+        if not siblings:
+            return 0
+        lines = sibling_warning_lines(spec_path, siblings=siblings, agent=agent)
+        if stream is None:
+            import scitex_logging
+
+            log = scitex_logging.getLogger(__name__)
+            for line in lines:
+                log.warning(line)
+        else:
+            for line in lines:
+                print(line, file=stream, flush=True)
+        return len(siblings)
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: advisory check — ANY internal failure degrades to silence; a warning must never crash a launch)
+        return 0
+
+
+__all__ = [
+    "SIBLING_ROOTS_ENV",
+    "candidate_sibling_paths",
+    "find_newer_siblings",
+    "sibling_warning_lines",
+    "spec_rel_tail",
+    "warn_if_newer_sibling",
+]

--- a/tests/scitex_agent_container/_drift/test__sibling.py
+++ b/tests/scitex_agent_container/_drift/test__sibling.py
@@ -1,0 +1,506 @@
+"""Tests for the sibling-copy staleness warning (_drift/_sibling.py).
+
+The 2026-08-15 incident: the operator edited the dotfiles SOURCE copy of a
+spec while sac launched the runtime copy, and nothing anywhere said the
+edit was inert — four hours lost. These tests cover the WARNING that
+exists so that four hours never happens again: a DIFFERENT copy of the
+spec exists, it is NEWER than the one loaded, and the loaded one is what
+actually runs.
+
+PA-306: no mocks. Real files, real symlinks, real mtimes (``os.utime``
+with fixed epochs), real git-less "live" trees for the incident case.
+SCITEX_DIR is redirected to tmp_path so the canonical user-scope probe
+never sees the operator's real ~/.scitex.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._drift import DriftState, warn_if_spec_source_drifted
+from scitex_agent_container._drift._sibling import (
+    SIBLING_ROOTS_ENV,
+    candidate_sibling_paths,
+    find_newer_siblings,
+    sibling_warning_lines,
+    spec_rel_tail,
+    warn_if_newer_sibling,
+)
+
+# Fixed epochs so the mtime columns of the warning are assertable: the
+# "loaded" spec is one hour OLDER than the "sibling" copy.
+_OLD = 1_700_000_000.0
+_NEW = 1_700_003_600.0
+
+_TAIL = Path("agent-container") / "agents" / "foo" / "spec.yaml"
+
+
+def _make_spec(base: Path, agent: str = "foo") -> Path:
+    """A spec.yaml at <base>/.scitex/agent-container/agents/<agent>/."""
+    spec = base / ".scitex" / "agent-container" / "agents" / agent / "spec.yaml"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("apiVersion: scitex-agent-container/v3\nkind: Agent\n")
+    return spec
+
+
+def _touch(path: Path, epoch: float) -> None:
+    """Pin a file's mtime to an exact epoch (both access and modify)."""
+    os.utime(path, (epoch, epoch))
+
+
+def _fmt(epoch: float) -> str:
+    """The warning's mtime format, for asserting known epochs verbatim."""
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(epoch))
+
+
+def _join(lines: list[str]) -> str:
+    return "\n".join(lines)
+
+
+@pytest.fixture
+def isolated_scitex_dir(tmp_path: Path, env_save_restore):
+    """Redirect SCITEX_DIR to tmp_path so user_root() sees an empty tree."""
+    home = tmp_path / "scitex-home"
+    home.mkdir()
+    env_save_restore.set("SCITEX_DIR", str(home))
+    return home
+
+
+# ---------------------------------------------------------------------------
+# spec_rel_tail — the intra-.scitex tail, derived from the path itself
+# ---------------------------------------------------------------------------
+
+
+def test_spec_rel_tail_uses_innermost_scitex_anchor():
+    # Arrange
+    spec = "/home/op/.scitex/agent-container/agents/foo/spec.yaml"
+    # Act
+    tail = spec_rel_tail(spec, agent="ignored")
+    # Assert
+    assert tail == _TAIL
+
+
+def test_spec_rel_tail_falls_back_to_canonical_when_unanchored():
+    # Arrange
+    spec = "/home/op/elsewhere/foo/spec.yaml"
+    # Act
+    tail = spec_rel_tail(spec, agent="foo")
+    # Assert
+    assert tail == _TAIL
+
+
+def test_spec_rel_tail_unanchored_without_agent_is_none():
+    # Arrange
+    spec = "/home/op/elsewhere/spec.yaml"
+    # Act
+    tail = spec_rel_tail(spec)
+    # Assert
+    assert tail is None
+
+
+def test_spec_rel_tail_of_tree_root_is_none():
+    # Arrange
+    spec = "/home/op/.scitex"
+    # Act
+    tail = spec_rel_tail(spec)
+    # Assert
+    assert tail is None
+
+
+# ---------------------------------------------------------------------------
+# candidate_sibling_paths — derivation, no hardcoded host layout
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_paths_probe_configured_tree_root(
+    tmp_path: Path, isolated_scitex_dir
+):
+    # Arrange — the configured root names the .scitex tree ITSELF.
+    loaded = _make_spec(tmp_path / "A")
+    tree_b = tmp_path / "B" / ".scitex"
+    # Act
+    candidates = candidate_sibling_paths(loaded, agent="foo", extra_roots=[tree_b])
+    # Assert — the sibling sits at <tree>/<tail>
+    assert tree_b / _TAIL in candidates
+
+
+def test_candidate_paths_probe_configured_parent_root(
+    tmp_path: Path, isolated_scitex_dir
+):
+    # Arrange — the configured root names the PARENT of the .scitex tree
+    # (the source-tree root, e.g. ~/.dotfiles/src): both depths probed.
+    loaded = _make_spec(tmp_path / "A")
+    parent_b = tmp_path / "B"
+    # Act
+    candidates = candidate_sibling_paths(loaded, agent="foo", extra_roots=[parent_b])
+    # Assert — the .scitex-depth probe is among the candidates
+    assert parent_b / ".scitex" / _TAIL in candidates
+
+
+def test_candidate_paths_exclude_the_loaded_spec_itself(
+    tmp_path: Path, isolated_scitex_dir
+):
+    # Arrange — the loaded spec's OWN tree is configured as a root.
+    loaded = _make_spec(tmp_path / "A")
+    # Act
+    candidates = candidate_sibling_paths(
+        loaded, agent="foo", extra_roots=[tmp_path / "A"]
+    )
+    # Assert — a file is not a sibling of itself
+    assert loaded.resolve() not in {c.resolve() for c in candidates}
+
+
+# ---------------------------------------------------------------------------
+# find_newer_siblings — strictly-newer, stat-cheap, never raises
+# ---------------------------------------------------------------------------
+
+
+def test_find_newer_flags_strictly_newer_sibling(
+    tmp_path: Path, isolated_scitex_dir
+):
+    # Arrange — loaded (tree A) is older; the sibling (tree B, parent form)
+    # is one hour newer.
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _OLD)
+    _touch(sibling, _NEW)
+    # Act
+    found = find_newer_siblings(loaded, agent="foo", extra_roots=[tmp_path / "B"])
+    # Assert
+    assert found == [(sibling, _NEW)]
+
+
+def test_find_newer_silent_when_sibling_older(tmp_path: Path, isolated_scitex_dir):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _NEW)
+    _touch(sibling, _OLD)
+    # Act
+    found = find_newer_siblings(loaded, agent="foo", extra_roots=[tmp_path / "B"])
+    # Assert
+    assert found == []
+
+
+def test_find_newer_silent_when_mtimes_equal(tmp_path: Path, isolated_scitex_dir):
+    # Arrange — strictly-newer is the rule; equal is the normal state.
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _NEW)
+    _touch(sibling, _NEW)
+    # Act
+    found = find_newer_siblings(loaded, agent="foo", extra_roots=[tmp_path / "B"])
+    # Assert
+    assert found == []
+
+
+def test_find_newer_missing_spec_returns_empty(tmp_path: Path, isolated_scitex_dir):
+    # Arrange — nothing at the loaded path; a sibling root is configured.
+    loaded = tmp_path / "A" / ".scitex" / _TAIL
+    # Act
+    found = find_newer_siblings(loaded, agent="foo", extra_roots=[tmp_path / "B"])
+    # Assert
+    assert found == []
+
+
+def test_loaded_tree_as_root_does_not_flag_self(
+    tmp_path: Path, isolated_scitex_dir
+):
+    # Arrange — only the loaded spec exists, and its own tree is configured
+    # as a root: the self-copy must be excluded, never flagged.
+    loaded = _make_spec(tmp_path / "A")
+    _touch(loaded, _NEW)
+    # Act
+    found = find_newer_siblings(loaded, agent="foo", extra_roots=[tmp_path / "A"])
+    # Assert
+    assert found == []
+
+
+def test_symlink_sibling_carries_target_mtime(
+    tmp_path: Path, isolated_scitex_dir
+):
+    # Arrange — the sibling PATH is a symlink to a real, newer file: any
+    # reader through that path sees the target's mtime, so that is the
+    # mtime the warning must report.
+    loaded = _make_spec(tmp_path / "A")
+    _touch(loaded, _OLD)
+    target = tmp_path / "real" / "spec-target.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text("apiVersion: scitex-agent-container/v3\n")
+    _touch(target, _NEW)
+    sibling = tmp_path / "B" / ".scitex" / _TAIL
+    sibling.parent.mkdir(parents=True)
+    sibling.symlink_to(target)
+    # Act
+    found = find_newer_siblings(loaded, agent="foo", extra_roots=[tmp_path / "B"])
+    # Assert
+    assert found == [(sibling, _NEW)]
+
+
+def test_duplicate_probes_of_one_file_are_deduplicated(
+    tmp_path: Path, isolated_scitex_dir
+):
+    # Arrange — the same sibling file is probed at both configured depths
+    # (parent B and tree B/.scitex).
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _OLD)
+    _touch(sibling, _NEW)
+    # Act
+    found = find_newer_siblings(
+        loaded, agent="foo", extra_roots=[tmp_path / "B", tmp_path / "B" / ".scitex"]
+    )
+    # Assert
+    assert len(found) == 1
+
+
+# ---------------------------------------------------------------------------
+# sibling_warning_lines — BOTH paths and BOTH mtimes, naming the outcome
+# ---------------------------------------------------------------------------
+
+
+def test_warning_lines_banner_names_the_agent(tmp_path: Path):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = tmp_path / "B" / ".scitex" / _TAIL
+    # Act
+    lines = sibling_warning_lines(loaded, siblings=[(sibling, _NEW)], agent="foo")
+    # Assert
+    assert "sac-drift WARNING for agent 'foo'" in _join(lines)
+
+
+def test_warning_lines_name_the_loaded_path(tmp_path: Path):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = tmp_path / "B" / ".scitex" / _TAIL
+    # Act
+    lines = sibling_warning_lines(loaded, siblings=[(sibling, _NEW)], agent="foo")
+    # Assert
+    assert str(loaded) in _join(lines)
+
+
+def test_warning_lines_name_the_sibling_path(tmp_path: Path):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = tmp_path / "B" / ".scitex" / _TAIL
+    # Act
+    lines = sibling_warning_lines(loaded, siblings=[(sibling, _NEW)], agent="foo")
+    # Assert
+    assert str(sibling) in _join(lines)
+
+
+def test_warning_lines_carry_the_sibling_mtime(tmp_path: Path):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = tmp_path / "B" / ".scitex" / _TAIL
+    # Act
+    lines = sibling_warning_lines(loaded, siblings=[(sibling, _NEW)], agent="foo")
+    # Assert
+    assert f"mtime {_fmt(_NEW)}" in _join(lines)
+
+
+def test_warning_lines_carry_the_loaded_mtime(tmp_path: Path):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = tmp_path / "B" / ".scitex" / _TAIL
+    _touch(loaded, _OLD)
+    # Act
+    lines = sibling_warning_lines(loaded, siblings=[(sibling, _NEW)], agent="foo")
+    # Assert
+    assert f"mtime {_fmt(_OLD)}" in _join(lines)
+
+
+def test_warning_lines_state_the_consequence(tmp_path: Path):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = tmp_path / "B" / ".scitex" / _TAIL
+    # Act
+    lines = sibling_warning_lines(loaded, siblings=[(sibling, _NEW)], agent="foo")
+    # Assert
+    assert "NOT in effect" in _join(lines)
+
+
+# ---------------------------------------------------------------------------
+# warn_if_newer_sibling — the launch-funnel entry point (advisory only)
+# ---------------------------------------------------------------------------
+
+
+def test_warn_emits_banner_to_explicit_stream(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore
+):
+    # Arrange — the operator points SAC_SPEC_SIBLING_ROOTS at the
+    # source-tree parent; the sibling is newer than the loaded spec.
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _OLD)
+    _touch(sibling, _NEW)
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    stream = io.StringIO()
+    # Act
+    warn_if_newer_sibling(loaded, agent="foo", stream=stream)
+    # Assert
+    assert "sac-drift WARNING" in stream.getvalue()
+
+
+def test_warn_returns_newer_sibling_count(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore
+):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _OLD)
+    _touch(sibling, _NEW)
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    # Act
+    count = warn_if_newer_sibling(loaded, agent="foo")
+    # Assert
+    assert count == 1
+
+
+def test_warn_silent_without_newer_sibling(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore
+):
+    # Arrange — the sibling is OLDER: the normal state, no signal.
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _NEW)
+    _touch(sibling, _OLD)
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    stream = io.StringIO()
+    # Act
+    warn_if_newer_sibling(loaded, agent="foo", stream=stream)
+    # Assert
+    assert stream.getvalue() == ""
+
+
+def test_warn_returns_zero_without_newer_sibling(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore
+):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _NEW)
+    _touch(sibling, _OLD)
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    # Act
+    count = warn_if_newer_sibling(loaded, agent="foo")
+    # Assert
+    assert count == 0
+
+
+def test_warn_missing_spec_is_silent(tmp_path: Path, isolated_scitex_dir, env_save_restore):
+    # Arrange — the loaded spec is absent; a sibling exists, but there is
+    # nothing to compare against.
+    _make_spec(tmp_path / "B")
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    loaded = tmp_path / "A" / ".scitex" / _TAIL
+    # Act
+    count = warn_if_newer_sibling(loaded, agent="foo")
+    # Assert
+    assert count == 0
+
+
+def test_warn_ignores_unresolvable_roots(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore
+):
+    # Arrange — the env names a ghost root, a blank entry, and a root with
+    # no spec: nothing to warn about, and nothing may raise.
+    loaded = _make_spec(tmp_path / "A")
+    env_save_restore.set(
+        SIBLING_ROOTS_ENV,
+        f"{tmp_path / 'ghost'}:{tmp_path / 'blank-adjacent'}:{tmp_path / 'B'}",
+    )
+    # Act
+    count = warn_if_newer_sibling(loaded, agent="foo")
+    # Assert
+    assert count == 0
+
+
+def test_unanchored_path_without_agent_is_a_noop(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore
+):
+    # Arrange — the loaded path has no .scitex anchor and no agent to
+    # derive the canonical tail from: nothing to compare, silent no-op.
+    spec = tmp_path / "loose" / "spec.yaml"
+    spec.parent.mkdir(parents=True)
+    spec.write_text("apiVersion: scitex-agent-container/v3\n")
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    # Act
+    count = warn_if_newer_sibling(spec)
+    # Assert
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# The launch funnel — warn_if_spec_source_drifted must carry the warning
+# ---------------------------------------------------------------------------
+
+
+def test_strict_funnel_warns_on_newer_sibling(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore, capsys
+):
+    # Arrange — the 2026-08-15 incident shape: a NOT_A_REPO live spec
+    # (the deliberate runtime layout) with a NEWER source-tree sibling.
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _OLD)
+    _touch(sibling, _NEW)
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    # Act
+    warn_if_spec_source_drifted(loaded, agent="foo", strict=True, do_fetch=False)
+    # Assert
+    assert "sac-drift WARNING for agent 'foo'" in capsys.readouterr().err
+
+
+def test_strict_funnel_names_the_inert_sibling(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore, capsys
+):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _OLD)
+    _touch(sibling, _NEW)
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    # Act
+    warn_if_spec_source_drifted(loaded, agent="foo", strict=True, do_fetch=False)
+    # Assert
+    assert str(sibling) in capsys.readouterr().err
+
+
+def test_strict_funnel_sibling_warning_stays_a_warning(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore, capsys
+):
+    # Arrange
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _OLD)
+    _touch(sibling, _NEW)
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    # Act — must RETURN (not raise) even under strict; the sibling is a
+    # warning, never a refusal.
+    status = warn_if_spec_source_drifted(loaded, agent="foo", strict=True, do_fetch=False)
+    # Assert
+    assert status.state is DriftState.NOT_A_REPO
+
+
+def test_strict_funnel_silent_on_older_sibling(
+    tmp_path: Path, isolated_scitex_dir, env_save_restore, capsys
+):
+    # Arrange — the sibling is OLDER: the normal state, no sibling signal.
+    loaded = _make_spec(tmp_path / "A")
+    sibling = _make_spec(tmp_path / "B")
+    _touch(loaded, _NEW)
+    _touch(sibling, _OLD)
+    env_save_restore.set(SIBLING_ROOTS_ENV, str(tmp_path / "B"))
+    # Act
+    warn_if_spec_source_drifted(loaded, agent="foo", strict=True, do_fetch=False)
+    # Assert
+    assert "sac-drift WARNING" not in capsys.readouterr().err


### PR DESCRIPTION
## What and why

2026-08-15 incident: the operator edited the dotfiles SOURCE copy of a
spec (`~/.dotfiles/src/.scitex/.../spec.yaml`) and sac launched the
RUNTIME copy (`~/.scitex/.../spec.yaml`). The live spec tree is
deliberately not a git repo, so the git-drift check in `_local` cannot
see this — and must not be turned into a refusal, which would stop
every agent from starting. Four hours were lost before the inert edit
was found by hand.

This adds the check that IS always applicable, in `_drift/_sibling.py`:

> a DIFFERENT copy of this spec exists, it is NEWER than the one I
> load, and I do not read it.

- Advisory only — one `stat` per candidate, never raises, never refuses
  a launch; any internal failure degrades to a silent no-op.
- The warning names BOTH paths and BOTH mtimes and states the
  consequence ("that edit is NOT in effect").
- A stale sibling stays a WARNING — never a refusal — even under
  `strict`, so the NOT_A_REPO incident state still boots.

## Sibling discovery (no hardcoded host layout)

- Zero-config: the spec's own intra-`.scitex` tail (everything after
  the LAST `.scitex` path component) re-rooted at the canonical scopes:
  `scitex_config.local_state.user_root()` and the project-scope
  `.scitex` root.
- Configured: `SAC_SPEC_SIBLING_ROOTS` (colon-separated); each entry
  may name a `.scitex` tree itself or its PARENT (the source-tree
  root, e.g. `~/.dotfiles/src`) — both depths are probed, so the
  operator points at wherever the source tree lives without knowing
  which form the check expects.

## Wiring

`warn_if_spec_source_drifted` calls `warn_if_newer_sibling` after the
git-drift emission and before the refusal decision. Double-guarded:
the module is fully internally guarded (advisory contract), and the
call site carries its own `try` so "a warning must never crash a
launch" holds even if that guarantee regressed.

## Tests

31 new tests in `tests/scitex_agent_container/_drift/test__sibling.py`
(PA-306, no mocks — real files, real symlinks, real `os.utime`),
covering the tail derivation, the candidate probe set, the
strictly-newer mtime rule, symlink mtimes, the warning text, the
advisory no-raise contract, and the strict-funnel integration
(a newer sibling warns but does NOT refuse). Local regression suite +
mirror guard:

    53 passed in 1.72s

Card: fleet-config-lives-only-on-compute04-untracked-20260815