### PR TITLE
fix(auth-heal): stop announcing "CANNOT report a clean fleet" while reporting one

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
@@ -198,15 +198,31 @@ def restart_login_expired(
             "  Each has a board card. A human needs to look — restarting is not "
             "fixing these (usually a real account problem)."
         )
-    if unseen:
+    # `unseen` is EVERY UNOBSERVED, but only some of them are this pass's own
+    # indeterminacy. `no-session` is a DETERMINATE reading handed to
+    # fleet-reconcile, and :meth:`PassOutcome.exit_code` already excludes it.
+    # Rendering both under one banner is how the summary came to contradict the
+    # verdict printed beside it: measured 2026-08-16, a pass exited 0 while
+    # announcing "this pass therefore CANNOT report a clean fleet" about 100
+    # sessionless agents. The verdict was fixed; the narration was not.
+    indeterminate = outcome.indeterminate()
+    no_session = tuple(r for r in unseen if r.reason == "no-session")
+    if indeterminate:
         console.print(
-            f"\n[magenta]{len(unseen)} agent(s) were NOT observed:[/magenta] "
-            f"{', '.join(r.name for r in unseen)}\n"
+            f"\n[magenta]{len(indeterminate)} agent(s) were NOT observed:[/magenta] "
+            f"{', '.join(r.name for r in indeterminate)}\n"
             "  Nothing was learned about these — they are neither healthy nor "
             "wedged, and this pass therefore CANNOT report a clean fleet.\n"
             "  Look at them by hand:\n"
             "    sac agents auth-status\n"
             "    sac agents list"
+        )
+    if no_session:
+        console.print(
+            f"\n[dim]{len(no_session)} registered agent(s) have no live session[/dim] "
+            "— fleet-reconcile's half of the fleet, not this pass's. A missing "
+            "session is a determinate reading, so it does NOT prevent a clean "
+            "report here."
         )
     if outcome.of(Verdict.BUDGET_UNKNOWN):
         console.print(

--- a/tests/scitex_agent_container/_authheal/test__pass_exit_code_indeterminacy.py
+++ b/tests/scitex_agent_container/_authheal/test__pass_exit_code_indeterminacy.py
@@ -143,3 +143,51 @@ def test_the_sessionless_count_survives_a_clean_exit() -> None:
     counted = outcome.counts()
     # Assert
     assert counted[Verdict.UNOBSERVED.value] == 92
+
+
+# --- the RENDERED populations ------------------------------------------
+# exit_code() and the printed summary must be driven by the SAME split, or the
+# command contradicts itself. Measured 2026-08-16 on this host: a pass exited 0
+# while printing "this pass therefore CANNOT report a clean fleet" about 100
+# sessionless agents. The verdict had been fixed months earlier; the narration
+# still counted EVERY UNOBSERVED. These pin the two populations the CLI renders
+# separately, so the alarming banner can never again describe a clean pass.
+
+
+def test_sessionless_reports_are_not_this_passs_indeterminacy() -> None:
+    """The banner population must be empty when nothing was truly unreadable."""
+    # Arrange
+    outcome = PassOutcome(reports=tuple(_sessionless(f"a{i}") for i in range(100)))
+    # Act
+    indeterminate = outcome.indeterminate()
+    # Assert
+    assert indeterminate == ()
+
+
+def test_an_unreadable_pane_is_this_passs_indeterminacy() -> None:
+    """A live-but-unreadable pane is the real blind spot and must be named."""
+    # Arrange
+    outcome = PassOutcome(reports=(_sessionless("idle"), _unreadable("live")))
+    # Act
+    names = tuple(r.name for r in outcome.indeterminate())
+    # Assert
+    assert names == ("live",)
+
+
+def test_the_two_rendered_populations_partition_every_unobserved() -> None:
+    """Exhaustive AND disjoint: no report may vanish, none may be printed twice.
+
+    Comparing the concatenation to the whole pins both at once — an overlap
+    makes it longer, a gap makes it shorter.
+    """
+    # Arrange
+    outcome = PassOutcome(
+        reports=(_sessionless("idle1"), _unreadable("live1"), _sessionless("idle2"))
+    )
+    unseen = outcome.of(Verdict.UNOBSERVED)
+    # Act
+    rendered = outcome.indeterminate() + tuple(
+        r for r in unseen if r.reason == "no-session"
+    )
+    # Assert
+    assert sorted(r.name for r in rendered) == sorted(r.name for r in unseen)


### PR DESCRIPTION
## The contradiction

`exit_code()` was fixed months ago (`99ef531f`) to exclude `no-session` from this pass's indeterminacy — a missing session is a **determinate** reading handed to fleet-reconcile, not a blind spot. The rendering never followed.

Measured on this host today, verbatim:

```
UNOBSERVED=100
  Nothing was learned about these — they are neither healthy nor wedged,
  and this pass therefore CANNOT report a clean fleet.
EXIT=0
```

It had just reported a clean fleet.

This is the **inverse** of the original bug on this same command, where the verdict was right and systemd's *label* (`status=2/INVALIDARGUMENT`) was wrong. Either way a reader stops at the prose and concludes the supervisor is blind when it isn't — and that reading is what kept this card open for 129 hours after the code was already correct.

## The change

Split the rendering to match the split `exit_code()` already makes:

| population | rendered as |
|---|---|
| `indeterminate()` — a **live** session whose pane would not capture | the alarming banner; still says a clean report is impossible, because it is |
| the `no-session` remainder | fleet-reconcile's half, explicitly stating it does **not** prevent a clean report here |

## Verification

End-to-end on the host, against the same 100-agent reality that produced the contradiction:

```
EXIT=0
grep -c 'CANNOT report a clean fleet'  ->  0
100 registered agent(s) have no live session — fleet-reconcile's half of the
fleet, not this pass's. A missing session is a determinate reading, so it does
NOT prevent a clean report here.
```

Three tests added to the existing indeterminacy suite — the file where the verdict half is already pinned, so both halves now live together.

The third test compares the concatenation of the two rendered populations against the whole `UNOBSERVED` set, pinning **exhaustive and disjoint in one assertion**: an overlap makes it longer, a gap makes it shorter. So no report can vanish from both banners or be printed under both.

```
12 passed
 8 failed, 4 passed   # with indeterminate() reverted to counting every UNOBSERVED
```

All three new tests fail under that sabotage.

## Not in scope

The card's FINDING 4 — a quota-exhausted agent is invisible to **both** supervisors, being neither session-gone nor auth-dead — is untouched and remains the substantive open gap. This PR only stops the command from misdescribing what it did observe.
