### PR TITLE
feat(jobs): refresh the account quota cache on a schedule, so placement decisions stop using day-old numbers

### DIFF
--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -265,6 +265,59 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=300,
         ),
         JobSpec(
+            name="scitex-agent-container-accounts-quota-cache",
+            schedule="*/5 * * * *",  # every 5min (cron form; timer below)
+            command="sac accounts refresh-quota-cache",
+            description=(
+                "Keeps the per-account usage cache FRESH. Nothing else did: "
+                "sac.accounts-refresh rotates TOKENS and accounts-keepalive "
+                "COPIES tokens, so before this job every quota number the "
+                "fleet showed was as old as the last time a human happened to "
+                "run the verb by hand. Reads usage only — it neither mints nor "
+                "rotates, so it cannot revoke a credential a running agent "
+                "holds (the hazard that makes `accounts refresh` dangerous to "
+                "schedule aggressively). "
+                "MEASURED COST OF NOT HAVING IT, 2026-08-17: `sac accounts "
+                "list` rendered every bar with `! snapshot older than the "
+                "refresh window` and `(stale 1d)` — it detected its own "
+                "staleness and did not fix it. On that day-old snapshot "
+                "scitex-01 read 7d=23% and wyusuuke read 7d=100%; the truth "
+                "after a manual refresh was scitex-01 94% and wyusuuke 0% — "
+                "INVERTED. An agent was repointed at the nearly-exhausted "
+                "account on the strength of it, and the operator's own "
+                "diagnosis was that an account reaches 94% precisely because "
+                "no one is refreshing the numbers that would have shown it "
+                "climbing. A cache that reports its own staleness without "
+                "repairing it is a record, not a gate."
+            ),
+            kind="timer",
+            # 5min, at the operator's instruction — he proposed 1min and
+            # offered 5min "if that is overdoing it". Taking the 5.
+            #
+            # The cadence is chosen against the 5h window, which is the fast
+            # one: a busy account can cross from comfortable to exhausted
+            # inside a single hour, so an hourly cadence would still permit a
+            # placement decision on numbers that predate the exhaustion. The
+            # 7d window moves far too slowly to drive this.
+            #
+            # WHY NOT 1min. Staleness at 5min is already far inside any
+            # decision window — no account crosses a threshold that matters in
+            # five minutes, so 1min buys freshness nobody can act on while
+            # costing 5x the calls (4 accounts x 1440 = 5760/day against a
+            # third-party usage endpoint whose rate limits we do not control
+            # and have not measured). If a case ever appears where a 5min-old
+            # number caused a wrong decision, that is the evidence to go to
+            # 1min — and it would be evidence, not a guess.
+            on_boot_sec="2min",
+            on_unit_active_sec="5min",
+            # One usage read per stored account (4 today), each a single
+            # HTTPS call. 120s covers all of them with a slow network and
+            # never hangs. A pass killed here leaves the previous cache in
+            # place — stale, which is the status quo this job improves on,
+            # never wrong.
+            timeout_sec=120,
+        ),
+        JobSpec(
             name="scitex-agent-container-host-sync-check",
             schedule="0 * * * *",  # hourly (cron form; timer cadence below)
             command="sac host sync --check --all --alarm",

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -134,6 +134,11 @@ RENAMES: tuple[Rename, ...] = (
         kind="timer",
     ),
     Rename(
+        old="sac.accounts-quota-cache",
+        new="scitex-agent-container-accounts-quota-cache",
+        kind="timer",
+    ),
+    Rename(
         old="sac.fleet-reconcile",
         new="scitex-agent-container-fleet-reconcile",
         kind="timer",

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -71,6 +71,10 @@ def test_provider_returns_every_expected_job() -> None:
     assert names == {
         "sac.accounts-refresh",
         "scitex-agent-container-accounts-keepalive",
+        # The usage-cache refresher. Nothing else reads usage: accounts-refresh
+        # rotates tokens and accounts-keepalive copies them, so before this job
+        # every quota number the fleet showed was as old as the last manual run.
+        "scitex-agent-container-accounts-quota-cache",
         "scitex-agent-container-host-sync-check",
         "scitex-agent-container-worktree-gc",
         "scitex-agent-container-spartan-sif-bake",


### PR DESCRIPTION
Nothing kept the account usage cache fresh. `sac.accounts-refresh` rotates **tokens** and `accounts-keepalive` **copies** tokens; neither reads usage. So every quota number the fleet displayed was as old as the last time a human happened to run `sac accounts refresh-quota-cache` by hand.

## Measured, 2026-08-17

`sac accounts list` rendered every bar with `! snapshot older than the refresh window` and `(stale 1d)`. It detected its own staleness and did not repair it. On that day-old snapshot:

| account | stale reading | truth after a manual refresh |
|---|---|---|
| scitex-01-scitex-ai | 7d **23%** | 7d **94%** |
| wyusuuke-gmail-com | 7d **100%** | 7d **0%** |

Inverted. An agent was repointed onto the nearly-exhausted account on the strength of the stale reading.

The operator's diagnosis is the sharper one: an account reaches 94% *precisely because* nothing refreshes the numbers that would have shown it climbing there.

This is the constitution's §2 shape — **a cache that reports its own staleness without repairing it is a record, not a gate.** Named reader: anyone choosing an account, human or agent.

## Why this verb is safe to schedule

`refresh-quota-cache` reads usage only. It neither mints nor rotates, so it cannot revoke a single-use credential that running agents still hold — the hazard that makes `accounts refresh` dangerous to run aggressively.

## Cadence

5 min, at the operator's instruction (he proposed 1 min and offered 5 "if that is overdoing it").

Chosen against the **5h** window, which is the fast one: a busy account can cross from comfortable to exhausted inside an hour, so hourly would still permit a placement decision on numbers that predate the exhaustion. The 7d window moves far too slowly to drive this.

Not 1 min: staleness at 5 min is already inside any decision window, so 1 min buys freshness nobody can act on while costing 5x the calls (4 accounts x 1440 = 5760/day) against a third-party endpoint whose rate limits we do not control and have not measured. If a 5-min-old number ever causes a wrong decision, *that* is the evidence to go to 1 min.

A pass killed at the 120s timeout leaves the previous cache in place — stale, which is the status quo this job improves on, never wrong.

## Verification

`provide_jobs()` constructs 10 jobs including `scitex-agent-container-accounts-quota-cache | 5min`.
