### PR TITLE
feat(statusline): sac renders its own status line, and it names the host, workdir and account

### DIFF
--- a/src/scitex_agent_container/statusline.py
+++ b/src/scitex_agent_container/statusline.py
@@ -53,6 +53,84 @@ def _persist(raw: bytes, agent: str) -> None:
         pass
 
 
+def _hostname() -> str:
+    """Which machine this agent is really on.
+
+    The fleet runs one agent name on several hosts over its life, and a
+    duplicate on two hosts is a real incident (measured 2026-08-17: two
+    `scitex-hub` sessions on compute-03 and compute-04 shared one bot token
+    and split the operator's messages between them). The pane is where a
+    human notices that first, so the host belongs in it.
+    """
+    # stx-allow: fallback (reason: a statusline must never raise; an
+    # unresolvable hostname degrades to empty, not to a crash)
+    try:
+        import socket
+
+        return socket.gethostname()
+    except Exception:
+        return ""
+
+
+def _workdir(data: dict) -> str:
+    """The directory this session is working in, from the payload or cwd."""
+    # stx-allow: fallback (reason: display-only; any failure degrades to empty)
+    try:
+        ws = data.get("workspace") or {}
+        cwd = ws.get("current_dir") or ws.get("cwd") or data.get("cwd")
+        if not cwd:
+            cwd = os.getcwd()
+        return Path(str(cwd)).name or str(cwd)
+    except Exception:
+        return ""
+
+
+def _active_account() -> str:
+    """Which stored account the LIVE credential is, by content match.
+
+    Deliberately local and O(number of accounts): the live
+    ``~/.claude/.credentials.json`` is compared byte-for-byte against each
+    stored snapshot. No network call — a statusline renders on every turn
+    and must not depend on an API being reachable.
+
+    NOTE this reports the account whose SNAPSHOT matches, i.e. it inherits
+    the store's directory naming. The authoritative answer to "whose token
+    is this" is ``/api/oauth/profile`` (see ``_account/account_identity``);
+    that costs a round trip and belongs in ``accounts list``, not here.
+
+    IN A CONTAINER ``$HOME`` IS ``/home/agent`` AND THE ACCOUNTS STORE IS NOT
+    BOUND THERE — only the operator's home is. Measured 2026-08-17 while adding
+    this: the first version looked solely under ``Path.home()`` and rendered
+    ``acct:?`` for every agent, i.e. it was blank in precisely the place the
+    field exists to serve. So both roots are searched, container home first.
+    """
+    # stx-allow: fallback (reason: display-only; unreadable store degrades to
+    # empty rather than breaking the pane)
+    try:
+        live = Path.home() / ".claude" / ".credentials.json"
+        if not live.is_file():
+            return ""
+        want = live.read_bytes()
+        if not want:
+            return ""
+        roots = [
+            Path.home() / ".scitex" / "agent-container" / "accounts",
+            Path("/home/ywatanabe/.scitex/agent-container/accounts"),
+        ]
+        seen: set = set()
+        for root in roots:
+            resolved = str(root)
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            for cand in sorted(root.glob("*/.credentials.json")):
+                if cand.read_bytes() == want:
+                    return cand.parent.name
+        return "?"
+    except Exception:
+        return ""
+
+
 def _fallback_display(raw: bytes) -> None:
     # stx-allow: fallback (reason: statusLine display must never raise; corrupt
     # or unexpected payload shape silently outputs nothing rather than aborting)
@@ -60,14 +138,33 @@ def _fallback_display(raw: bytes) -> None:
         data = json.loads(raw)
         ctx_pct = (data.get("context_window") or {}).get("used_percentage", 0)
         model = (data.get("model") or {}).get("display_name", "")
-        parts = [f"ctx:{ctx_pct:.0f}%"]
+        parts: list[str] = []
+
+        host = _hostname()
+        agent = _agent_name()
+        if agent and agent != "unknown":
+            parts.append(f"{agent}@{host}" if host else agent)
+        elif host:
+            parts.append(host)
+
+        wd = _workdir(data)
+        if wd:
+            parts.append(wd)
+
         if model:
-            parts.insert(0, model)
+            parts.append(model)
+        parts.append(f"ctx:{ctx_pct:.0f}%")
+
         rl = data.get("rate_limits") or {}
         fh = rl.get("five_hour") or {}
         fh_pct = fh.get("used_percentage")
         if fh_pct is not None:
             parts.append(f"5h:{fh_pct:.0f}%")
+
+        acct = _active_account()
+        if acct:
+            parts.append(f"acct:{acct}")
+
         print(" | ".join(parts), flush=True)
     except Exception:
         pass
@@ -90,14 +187,32 @@ def main(stdin=None, runner=None) -> None:
     agent = _agent_name()
     _persist(raw, agent)
 
-    # Delegate display to claude-hud if available.
-    # stx-allow: fallback (reason: claude-hud is an optional user-scope plugin;
-    # FileNotFoundError means it is not installed — fall through to minimal echo)
-    try:
-        result = runner(["claude-hud"], input=raw)
-        sys.exit(result.returncode)
-    except FileNotFoundError:
-        pass
+    # sac RENDERS ITS OWN STATUS LINE. Operator ruling 2026-08-17:
+    # 「claude-hud は使わないで、scitex-agent-container 側で用意してもらえると
+    #   嬉しいです。自分たちでコントロールできるので。」
+    # (SUMMARY, translation mine: don't use claude-hud — provide it from sac,
+    # because then it is ours to control.)
+    #
+    # Previously this delegated to `claude-hud` whenever that binary happened
+    # to be on PATH, and only rendered sac's own line when it was absent. That
+    # made the pane's contents depend on what was installed rather than on what
+    # sac decided: the same agent showed different information on two hosts,
+    # and the fields sac wants to guarantee (host, workdir, account) could not
+    # be guaranteed at all. Measured the same day: claude-hud was installed on
+    # NEITHER compute-03 nor compute-04, so every agent was already rendering
+    # this function — the delegation was latent variance, not a live feature.
+    #
+    # Opt back in explicitly with SAC_STATUSLINE_DELEGATE=claude-hud if someone
+    # ever wants it; the default is ours.
+    delegate = os.environ.get("SAC_STATUSLINE_DELEGATE", "").strip()
+    if delegate:
+        # stx-allow: fallback (reason: an explicitly requested delegate that is
+        # not installed must degrade to sac's own line, never to a blank pane)
+        try:
+            result = runner([delegate], input=raw)
+            sys.exit(result.returncode)
+        except FileNotFoundError:
+            pass
 
     _fallback_display(raw)
 

--- a/tests/scitex_agent_container/test_statusline.py
+++ b/tests/scitex_agent_container/test_statusline.py
@@ -237,9 +237,54 @@ def _run_main_capturing_systemexit(stdin_bytes, runner_fn):
         return exc
 
 
+class _Exit7:
+    returncode = 7
+
+
+def _record_calls(sink: list):
+    """A runner that logs every invocation and would exit 7 if used."""
+
+    def _runner(argv, input=None):
+        sink.append(argv)
+        return _Exit7()
+
+    return _runner
+
+
+def test_main_invokes_no_delegate_when_none_is_named(state_dir, env_save_restore):
+    """Operator ruling 2026-08-17: the pane is sac's to control.
+
+    Delegation used to fire whenever ``claude-hud`` happened to be on PATH, so
+    the same agent rendered different information on two hosts depending on
+    what was installed. Now it fires only when explicitly asked.
+    """
+    # Arrange — no SAC_STATUSLINE_DELEGATE set.
+    env_save_restore.set("CLAUDE_AGENT_ID", "agent-no-delegate")
+    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "")
+    payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
+    called: list = []
+    # Act
+    _run_main_capturing_systemexit(payload, _record_calls(called))
+    # Assert
+    assert called == []
+
+
+def test_main_renders_locally_when_no_delegate_is_named(state_dir, env_save_restore):
+    """No delegate means fall through to sac's renderer, not exit with its code."""
+    # Arrange
+    env_save_restore.set("CLAUDE_AGENT_ID", "agent-no-delegate-2")
+    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "")
+    payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
+    # Act
+    exc = _run_main_capturing_systemexit(payload, _record_calls([]))
+    # Assert
+    assert exc is None
+
+
 def test_main_propagates_claude_hud_exit_code(state_dir, env_save_restore):
     # Arrange
     env_save_restore.set("CLAUDE_AGENT_ID", "agent-hud")
+    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "claude-hud")
     payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
 
     class _Result:
@@ -254,6 +299,7 @@ def test_main_propagates_claude_hud_exit_code(state_dir, env_save_restore):
 def test_main_forwards_payload_to_claude_hud_stdin(state_dir, env_save_restore):
     # Arrange
     env_save_restore.set("CLAUDE_AGENT_ID", "agent-hud2")
+    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "claude-hud")
     payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
     captured: dict = {}
 
@@ -360,6 +406,7 @@ def test_main_default_runner_uses_subprocess_run(
 ):
     # Arrange real claude-hud shim on PATH so default runner finds it.
     env_save_restore.set("CLAUDE_AGENT_ID", "agent-default-runner")
+    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "claude-hud")
     subprocess_shim.install("claude-hud", exit=0)
     payload = json.dumps({"context_window": {"used_percentage": 12}}).encode()
     # Act invoke without runner so subprocess.run default fires.


### PR DESCRIPTION
Operator ruling 2026-08-17: 「claude-hud は使わないで、scitex-agent-container 側で用意してもらえると嬉しいです。自分たちでコントロールできるので。」

## 1. Delegation is now opt-in

`main()` shelled out to `claude-hud` whenever that binary happened to be on PATH, rendering sac's own line only when it was absent. So the pane's contents depended on **what was installed**, not on what sac decided — and the fields sac wants to guarantee could not be guaranteed at all.

Measured the same day: claude-hud is installed on **neither compute-03 nor compute-04**, so every agent was already rendering sac's function. The delegation was latent variance, not a live feature.

Opt back in with `SAC_STATUSLINE_DELEGATE=claude-hud`.

## 2. The line now answers "which agent, where, on what"

```
scitex-agent-container@scitex-compute-04 | scitex-hub | Opus 5 (1M context) | ctx:11% | 5h:9% | acct:scitex-01-scitex-ai
```

| field | why it earned its place, this week |
|---|---|
| `host` | two `scitex-hub` sessions ran on compute-03 and compute-04 at once, sharing one bot token and splitting the operator's messages between them |
| `acct` | the operator asked "is wyusuuke actually being selected?" and nothing in a running agent could answer it — every check had to be made from outside the container |
| `workdir` | an agent on the wrong repo looks identical to one on the right repo until it commits |

## A bug this change caught in itself

The first `_active_account()` looked only under `Path.home()`. Inside a container that is `/home/agent`, where the accounts store is **not** bound — only the operator's home is — so it rendered `acct:?` for every agent: blank in precisely the place the field exists to serve. Both roots are searched now.

That surfaced on the first render, which is the argument for rendering once before shipping rather than reasoning about it.

## Design

Local, no network. The account is identified by byte-comparing the live credential against each stored snapshot — a statusline renders every turn and must not depend on an API being reachable. The authoritative "whose token is this" stays `/api/oauth/profile` in `accounts list`.

## Verification

25 tests pass. **Sabotage-checked**: forcing delegation back on turns exactly the two new tests red; restoring returns 25/25.