### PR TITLE
feat(accounts): one row per account, not one per host x account

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
@@ -73,6 +73,7 @@ def account_list(
     hosts: tuple[str, ...],
     no_fanout: bool,
     host_timeout: float,
+    by_host: bool,
 ) -> None:
     """List stored accounts across the fleet, and show this host's active one.
 
@@ -230,6 +231,7 @@ def account_list(
             no_fanout=no_fanout,
             host_timeout=host_timeout,
             openai_accounts=openai_accounts,
+            by_host=by_host,
         )
         rows = build_stored_rows(accounts, passive=True)
         _print_usage_bars(rows)

--- a/src/scitex_agent_container/cli_pkg/_account_list_collapse.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_collapse.py
@@ -1,0 +1,206 @@
+"""One row per ACCOUNT for ``sac accounts list``, not one per host×account.
+
+Operator directive 2026-08-17: 「アカウントは明らかに 4 つしかないですよね？
+なのにホスト毎に出てしまって醜いです。」 — there are plainly only four
+accounts, so printing them once per host is ugly.
+
+WHAT WAS WRONG WITH THE OLD TABLE. It rendered the cross product: four
+accounts times every host that answered, so a healthy five-host fleet
+produced twenty rows carrying four accounts' worth of information. Worse,
+the width that cross product needed came out of the Host column, which rich
+abbreviated to ``scitex-comp…`` — making compute-01/02/03/04 render
+identically, so the table did not merely repeat itself, it looked like it
+was repeating rows it was not. Measured 2026-08-17: sixteen rows, sixteen
+DISTINCT (host, account) pairs, zero duplicates in the data.
+
+WHAT COLLAPSES AND WHAT MUST NOT. The distinction is which side of the wire
+each fact lives on:
+
+* Identity and usage are properties of the ANTHROPIC ACCOUNT. Every host
+  reading them is reading the same upstream fact through its own cache, so
+  showing them once is not a summary — it is the fact stated once instead
+  of five times, and the freshest cache is the best available reading of it.
+* Credential freshness is a property of the FILE ON ONE MACHINE. Credentials
+  are per-host files and are not on the sync rail, so the same account is
+  routinely VALID on one machine and EXPIRED on another (measured
+  2026-08-14, when a restart refused with "no healthy stored account" while
+  the identical accounts were hours-fresh elsewhere).
+
+So this module collapses the first kind and REFUSES to collapse the second:
+when hosts agree, the status cell states the agreed value; when they differ,
+it names the hosts that differ rather than picking a representative. A
+collapse that hid an expired credential behind three valid ones would turn
+the ugly-but-honest table into a compact lie, and the exploded view exists
+(``--by-host``) for when the per-host detail is the question.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from rich.table import Table
+
+from ._account_list_format import format_as_of_short, format_snapshot_age
+from ._account_list_render import AccountRow, _fmt_status
+
+__all__ = ["AccountGroup", "collapse_by_account", "render_accounts_table"]
+
+
+@dataclass
+class AccountGroup:
+    """Every host's reading of ONE account, kept separable.
+
+    The per-host rows are retained rather than reduced on construction so
+    the renderer can decide, per column, whether the hosts agreed — a
+    pre-reduced group could not tell "all four say VALID" apart from "one
+    said VALID and the rest were dropped".
+    """
+
+    provider: str
+    name: str
+    rows: list[AccountRow] = field(default_factory=list)
+
+    @property
+    def hosts(self) -> list[str]:
+        return [r.host for r in self.rows if r.host]
+
+
+def collapse_by_account(rows: list[AccountRow]) -> list[AccountGroup]:
+    """Group rows by (provider, account), preserving first-seen order."""
+    groups: dict[tuple[str, str], AccountGroup] = {}
+    for row in rows:
+        key = (row.provider, row.name)
+        if key not in groups:
+            groups[key] = AccountGroup(provider=row.provider, name=row.name)
+        groups[key].rows.append(row)
+    return list(groups.values())
+
+
+def _fmt_hosts_cell(group: AccountGroup, all_hosts: list[str]) -> str:
+    """Say how many hosts hold this account, and NAME the ones that do not.
+
+    A bare count would answer "how many" while hiding "which", and the host
+    MISSING a credential is the actionable one — that is the host whose next
+    agent start refuses with "no healthy stored account".
+    """
+    present = [h for h in all_hosts if h in set(group.hosts)]
+    if not all_hosts:
+        return "-"
+    missing = [h for h in all_hosts if h not in set(group.hosts)]
+    if not missing:
+        return f"all {len(present)}"
+    return f"{len(present)}/{len(all_hosts)} (not on {', '.join(missing)})"
+
+
+def _fmt_status_cell(group: AccountGroup) -> str:
+    """The agreed credential status, or the disagreement spelled out.
+
+    Never reduces divergence to a representative value: an EXPIRED
+    credential hidden behind three VALID ones is the one thing this column
+    exists to surface.
+    """
+    states = {r.freshness_state for r in group.rows}
+    if len(states) == 1:
+        return _fmt_status(group.rows[0].freshness_state, group.rows[0].freshness_hours)
+    majority = max(states, key=lambda s: sum(r.freshness_state == s for r in group.rows))
+    odd = [r for r in group.rows if r.freshness_state != majority]
+    detail = ", ".join(f"{r.freshness_state} on {r.host or '?'}" for r in odd)
+    return f"{majority} x{len(group.rows) - len(odd)}; {detail}"
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    # stx-allow: fallback (reason: an unparseable cache timestamp must not
+    # abort the whole table; it simply cannot win the freshest-snapshot pick)
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _freshest_snapshot(group: AccountGroup) -> str | None:
+    """The newest usage snapshot any host holds for this account.
+
+    Usage lives on Anthropic's side; a host only caches it. So the newest
+    cache is the best available reading of one shared fact, not a sample
+    chosen from several competing ones.
+    """
+    dated = [(dt, r.snapshot_as_of) for r in group.rows if (dt := _parse_iso(r.snapshot_as_of))]
+    if not dated:
+        return None
+    return max(dated, key=lambda pair: pair[0])[1]
+
+
+def _fmt_identity_cell(group: AccountGroup) -> str:
+    """Identity is an account-level fact, so it is stated once.
+
+    A mismatch or duplicate reported by ANY host wins over the verified
+    readings, because a credential that authenticates as the wrong account
+    on one machine is a wrong credential, not a minority opinion.
+    """
+    for row in group.rows:
+        if row.duplicate_of:
+            return f"DUPLICATE of {row.duplicate_of}"
+    for row in group.rows:
+        if row.identity_state == "mismatch":
+            return f"MISMATCH -> {row.verified_email or 'another account'}"
+    verified = [r for r in group.rows if r.identity_state == "verified"]
+    if not verified:
+        return "unverified"
+    email = verified[0].verified_email
+    if not email:
+        return "ok"
+    # Account IDs are email-derived slugs, so a verified identity that matches
+    # its slug restates the Account column one punctuation change apart
+    # (`scitex-01-scitex-ai` / `scitex-01@scitex.ai`). Say `ok` instead and
+    # spend the width on the case that carries a fact: an email that does NOT
+    # match the label it is filed under.
+    from .._account.creds_sync import slugify_email
+
+    return "ok" if slugify_email(email) == group.name else email
+
+
+def render_accounts_table(
+    rows: list[AccountRow],
+    *,
+    now: datetime | None = None,
+) -> Table:
+    """Build the collapsed table: ``Provider | Account | Identity | Status |
+    Usage as of | Hosts``.
+
+    ``now`` is an injection seam so snapshot-age cells are deterministic in
+    tests without patching the clock.
+    """
+    groups = collapse_by_account(rows)
+    all_hosts: list[str] = []
+    for row in rows:
+        if row.host and row.host not in all_hosts:
+            all_hosts.append(row.host)
+
+    table = Table(title="Stored accounts", title_justify="left", show_lines=False)
+    table.add_column("Provider")
+    table.add_column("Account", style="bold")
+    table.add_column("Identity")
+    table.add_column("Status")
+    table.add_column("Usage as of")
+    if all_hosts:
+        table.add_column("Hosts", style="cyan")
+    for group in groups:
+        as_of = _freshest_snapshot(group)
+        cells = [
+            group.provider,
+            group.name,
+            _fmt_identity_cell(group),
+            _fmt_status_cell(group),
+            (
+                f"{format_as_of_short(as_of)} ({format_snapshot_age(as_of, now=now)})"
+                if as_of
+                else "-"
+            ),
+        ]
+        if all_hosts:
+            cells.append(_fmt_hosts_cell(group, all_hosts))
+        table.add_row(*cells)
+    return table

--- a/src/scitex_agent_container/cli_pkg/_account_list_fleet.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_fleet.py
@@ -90,6 +90,18 @@ def fleet_account_options(func):
         ),
     )(func)
     func = click.option(
+        "--by-host",
+        "by_host",
+        is_flag=True,
+        default=False,
+        help=(
+            "Fleet view: one row per host AND account instead of one row per "
+            "account. The collapsed default states each account once and names "
+            "any host that disagrees; use this when the per-host detail — which "
+            "machine holds which credential file — is itself the question."
+        ),
+    )(func)
+    func = click.option(
         "--host",
         "hosts",
         multiple=True,
@@ -204,6 +216,7 @@ def run_fleet_account_list(
     host_timeout: float | None = None,
     local_extras: dict | None = None,
     openai_accounts: list[dict] | None = None,
+    by_host: bool = False,
 ) -> None:
     """Collect every reachable host's accounts, print the header, then the rows.
 
@@ -281,4 +294,9 @@ def run_fleet_account_list(
                 f"fleet has none.[/yellow]"
             )
         return
-    console.print(render_stored_table(rows))
+    if by_host:
+        console.print(render_stored_table(rows))
+    else:
+        from ._account_list_collapse import render_accounts_table
+
+        console.print(render_accounts_table(rows))

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_collapse.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_collapse.py
@@ -1,0 +1,254 @@
+"""Tests for the one-row-per-account collapse of ``sac accounts list``.
+
+No-mocks pattern: every test hand-rolls real ``AccountRow`` values and reads
+the rendered table back as a string through ``rich``'s recording console, so
+what is asserted is the text an operator sees, not an intermediate the
+renderer might stop using.
+
+The load-bearing case is DIVERGENCE. Collapsing is only safe for facts that
+belong to the Anthropic account; credential freshness belongs to one file on
+one machine, and a collapse that let three VALID hosts hide one EXPIRED one
+would be a compact lie. Several tests below exist purely to hold that line.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+
+from scitex_agent_container.cli_pkg._account_list_collapse import (
+    _freshest_snapshot,
+    collapse_by_account,
+    render_accounts_table,
+)
+from scitex_agent_container.cli_pkg._account_list_render import AccountRow
+
+
+def _row(name: str, host: str, **over) -> AccountRow:
+    """One healthy fleet row, with any field overridable per test."""
+    base = dict(
+        name=name,
+        host=host,
+        freshness_state="VALID",
+        freshness_hours=6.0,
+        used_pct_5h=None,
+        used_pct_7d=None,
+        snapshot_as_of=None,
+        identity_state="verified",
+        verified_email=name.replace("-scitex-ai", "@scitex.ai"),
+    )
+    base.update(over)
+    return AccountRow(**base)
+
+
+def _render(rows: list[AccountRow]) -> str:
+    console = Console(record=True, width=200)
+    console.print(render_accounts_table(rows))
+    return console.export_text()
+
+
+@pytest.fixture
+def four_accounts_on_four_hosts() -> list[AccountRow]:
+    """The shape the operator actually sees: 4 accounts x 4 hosts = 16 rows."""
+    names = [
+        "scitex-01-scitex-ai",
+        "wyusuuke-gmail-com",
+        "ywata1989-gmail-com",
+        "ywatanabe-scitex-ai",
+    ]
+    hosts = ["h1", "h2", "h3", "h4"]
+    return [_row(n, h) for h in hosts for n in names]
+
+
+def test_sixteen_host_rows_collapse_to_four_account_groups(
+    four_accounts_on_four_hosts: list[AccountRow],
+) -> None:
+    # Arrange — 16 rows carrying 4 distinct accounts.
+    rows = four_accounts_on_four_hosts
+    # Act
+    groups = collapse_by_account(rows)
+    # Assert
+    assert len(groups) == 4
+
+
+def test_collapse_preserves_first_seen_account_order() -> None:
+    # Arrange
+    rows = [_row("b-account", "h1"), _row("a-account", "h1"), _row("b-account", "h2")]
+    # Act
+    groups = collapse_by_account(rows)
+    # Assert
+    assert [g.name for g in groups] == ["b-account", "a-account"]
+
+
+def test_group_keeps_every_hosts_reading_separable() -> None:
+    """Reduce on render, not on construction — see the module docstring."""
+    # Arrange
+    rows = [_row("acct", "h1"), _row("acct", "h2"), _row("acct", "h3")]
+    # Act
+    groups = collapse_by_account(rows)
+    # Assert
+    assert groups[0].hosts == ["h1", "h2", "h3"]
+
+
+def test_rendered_table_prints_each_account_once(
+    four_accounts_on_four_hosts: list[AccountRow],
+) -> None:
+    # Arrange
+    rows = four_accounts_on_four_hosts
+    # Act
+    text = _render(rows)
+    # Assert
+    assert text.count("wyusuuke-gmail-com") == 1
+
+
+def test_hosts_cell_says_all_when_every_host_holds_the_account(
+    four_accounts_on_four_hosts: list[AccountRow],
+) -> None:
+    # Arrange
+    rows = four_accounts_on_four_hosts
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "all 4" in text
+
+
+def test_hosts_cell_names_the_host_missing_the_credential() -> None:
+    """The host WITHOUT the credential is the actionable one.
+
+    That is the machine whose next agent start refuses with "no healthy
+    stored account", so a bare count would hide the only fact worth acting
+    on.
+    """
+    # Arrange — present on h1/h2, absent from h3 (which holds another account).
+    rows = [_row("acct", "h1"), _row("acct", "h2"), _row("other", "h3")]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "not on h3" in text
+
+
+def test_status_states_the_agreed_ttl_when_hosts_agree() -> None:
+    """Asserts the whole cell, not the substring ``VALID``.
+
+    ``"VALID" in text`` also passes on the divergence rendering
+    (``VALID x2; EXPIRED on h3``), so it could not tell the agree path from
+    the disagree path — the one distinction this function makes.
+    """
+    # Arrange
+    rows = [_row("acct", "h1"), _row("acct", "h2")]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "VALID +6h00m " in text
+
+
+def test_status_names_the_host_whose_credential_expired() -> None:
+    """A divergent credential must survive the collapse by name."""
+    # Arrange — two hosts VALID, one EXPIRED.
+    rows = [
+        _row("acct", "h1"),
+        _row("acct", "h2"),
+        _row("acct", "h3", freshness_state="EXPIRED", freshness_hours=-1.0),
+    ]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "EXPIRED on h3" in text
+
+
+def test_status_does_not_report_a_clean_ttl_when_hosts_disagree() -> None:
+    """The majority reading must not stand in for the whole group."""
+    # Arrange
+    rows = [
+        _row("acct", "h1"),
+        _row("acct", "h2"),
+        _row("acct", "h3", freshness_state="EXPIRED", freshness_hours=-1.0),
+    ]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "VALID x2" in text
+
+
+def test_identity_says_ok_when_the_verified_email_matches_the_slug() -> None:
+    """Do not restate the Account column one punctuation change apart."""
+    # Arrange
+    rows = [_row("scitex-01-scitex-ai", "h1", verified_email="scitex-01@scitex.ai")]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "scitex-01@scitex.ai" not in text
+
+
+def test_identity_prints_the_email_when_it_does_not_match_the_slug() -> None:
+    """A credential filed under the wrong label is what this column is for."""
+    # Arrange
+    rows = [_row("scitex-01-scitex-ai", "h1", verified_email="someone@else.com")]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "someone@else.com" in text
+
+
+def test_identity_mismatch_on_one_host_wins_over_verified_on_others() -> None:
+    """A wrong credential is a wrong credential, not a minority opinion."""
+    # Arrange
+    rows = [
+        _row("acct", "h1"),
+        _row("acct", "h2", identity_state="mismatch", verified_email="wrong@x.com"),
+    ]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "MISMATCH" in text
+
+
+def test_identity_duplicate_is_reported_over_every_other_state() -> None:
+    # Arrange
+    rows = [_row("acct", "h1"), _row("acct", "h2", duplicate_of="earlier-acct")]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "DUPLICATE of earlier-acct" in text
+
+
+def test_identity_is_unverified_when_no_host_checked() -> None:
+    # Arrange
+    rows = [_row("acct", "h1", identity_state="unverified", verified_email=None)]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "unverified" in text
+
+
+def test_usage_cell_takes_the_freshest_snapshot_across_hosts() -> None:
+    """Usage is an Anthropic-side fact; a host only caches it."""
+    # Arrange — h2 holds the newer cache.
+    rows = [
+        _row("acct", "h1", snapshot_as_of="2026-08-01T00:00:00+00:00"),
+        _row("acct", "h2", snapshot_as_of="2026-08-17T00:00:00+00:00"),
+    ]
+    # Act
+    groups = collapse_by_account(rows)
+    # Assert
+    assert _freshest_snapshot(groups[0]) == "2026-08-17T00:00:00+00:00"
+
+
+def test_no_snapshot_on_any_host_yields_no_freshest_snapshot() -> None:
+    """A bare ``"-" in text`` would match the table's own rule characters."""
+    # Arrange
+    rows = [_row("acct", "h1"), _row("acct", "h2")]
+    # Act
+    groups = collapse_by_account(rows)
+    # Assert
+    assert _freshest_snapshot(groups[0]) is None
+
+
+def test_hosts_column_is_absent_on_the_single_host_path() -> None:
+    """No Host anywhere means no fleet, so a Hosts column would say nothing."""
+    # Arrange
+    rows = [_row("acct", "")]
+    # Act
+    text = _render(rows)
+    # Assert
+    assert "Hosts" not in text


### PR DESCRIPTION
feat(accounts): one row per account, not one per host x account

Operator ruling 2026-08-17: 「アカウントは明らかに 4 つしかないですよね？
なのにホスト毎に出てしまって醜いです。」 — there are plainly only four
accounts, so printing them once per host is ugly.

MEASURED BEFORE: 5 hosts x 4 accounts = 20 rows carrying four accounts'
worth of information. AFTER: 4 rows. `--by-host` keeps the exploded view
for when "which machine holds which credential file" is the question.

WHAT I GOT WRONG FIRST, since it is the more useful half of this. I read
the operator's screenshot as a truncation artifact: the Host column had
been abbreviated to `scitex-comp…`, so compute-01/02/03/04 rendered
identically and the table LOOKED like it repeated rows. That reading was
true and irrelevant. `accounts list --json` held 16 rows with 16 DISTINCT
(host, account) pairs — no duplicates at all — and the operator was not
complaining about duplicates. He was saying the cross product should not
be the unit of display. Widening the Host column would have made the
cross product legible instead of removing it.

WHAT COLLAPSES AND WHAT MUST NOT — decided by which side of the wire each
fact lives on, not by what fits:

  * Identity and usage belong to the ANTHROPIC ACCOUNT. Every host reads
    the same upstream fact through its own cache, so stating it once is
    the fact stated once, and the freshest cache is the best reading of
    it. Identity also stops restating the Account column one punctuation
    change apart (`scitex-01-scitex-ai` / `scitex-01@scitex.ai`): it says
    `ok`, and prints the email only when it does NOT match the label the
    credential is filed under — the case the column exists for
    (INCIDENT 2026-08-12, one Anthropic account in two directories).

  * Credential freshness belongs to ONE FILE ON ONE MACHINE. Credentials
    are per-host and off the sync rail, so the same account is routinely
    VALID here and EXPIRED there (measured 2026-08-14, when a restart
    refused with "no healthy stored account" while the identical accounts
    were hours-fresh elsewhere). Divergence is therefore never reduced to
    a representative value: it renders `VALID x2; EXPIRED on <host>`.
    A collapse that hid one expired credential behind three valid ones
    would trade an ugly honest table for a compact lie.

The Hosts cell names the hosts MISSING an account rather than only
counting the ones that have it — the host without the credential is the
one whose next agent start refuses.

17 new tests. Sabotage-checked: making the status cell report the first
host as if it spoke for the group turns exactly the two divergence tests
red, and restoring returns 17/17. 98 pass across the three account-table
test files, so the existing fleet and render suites are unaffected.

NOT INCLUDED: a controller marker. sac has no controller concept — no
config field, no role, nothing. The only thing it could honestly mark
today is "the host that answered from its local registry", which changes
with wherever the command runs; labelling that `controller` would read
correctly on compute-04 and be false everywhere else. Awaiting the
operator's call on a declared refresh-owner field.
