### PR TITLE
refactor(statusline): delete claude-hud, including the opt-in that kept it

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -111,7 +111,7 @@ material on the host.
 ### `~/.claude/settings.json`
 
 Per-user Claude Code settings. Common keys: `permissions`, `statusLine`
-(command used to render the bottom bar, often claude-hud),
+(command used to render the bottom bar; sac agents run `sac-statusline`),
 `enabledPlugins`. Contains no secrets but may reveal which plugins /
 skills are enabled.
 

--- a/docs/sphinx/credentials.md
+++ b/docs/sphinx/credentials.md
@@ -111,7 +111,7 @@ material on the host.
 ### `~/.claude/settings.json`
 
 Per-user Claude Code settings. Common keys: `permissions`, `statusLine`
-(command used to render the bottom bar, often claude-hud),
+(command used to render the bottom bar; sac agents run `sac-statusline`),
 `enabledPlugins`. Contains no secrets but may reveal which plugins /
 skills are enabled.
 

--- a/src/scitex_agent_container/_lifecycle/_status.py
+++ b/src/scitex_agent_container/_lifecycle/_status.py
@@ -254,7 +254,7 @@ def agent_status(
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         result["snapshot"] = None
 
-    # Enrich with claude-hud-style metadata. Canonical source for the
+    # Enrich with the rich metadata payload. Canonical source for the
     # Agents-tab dashboard; the MCP sidecar heartbeat shells out to this
     # command rather than duplicating the logic in TypeScript.
     # stx-allow: fallback (reason: agent_meta requires psutil and an active tmux session; metadata enrichment is optional and must never break status)

--- a/src/scitex_agent_container/_state/_meta/pane.py
+++ b/src/scitex_agent_container/_state/_meta/pane.py
@@ -150,9 +150,9 @@ def _classify_pane_state(pane_text: str) -> tuple[str, str]:
     return "unknown", ""
 
     # Note: "waiting" (freshly booted, never received work) is intentionally
-    # NOT detected here. The earlier draft relied on the claude-hud
-    # statusline `Context ░░░░░░░░░░ 0%` marker, but claude-hud is an
-    # external tool not present in every install. The dashboard derives
+    # NOT detected here. An earlier draft read a `Context ░░░░░░░░░░ 0%`
+    # marker off the pane's statusline, which made pane classification depend
+    # on how the status line happens to be rendered. The dashboard derives
     # "waiting" instead from the hub-side `last_tool_at` field — an agent
     # that is connected but has never recorded a tool call is waiting,
     # regardless of what its pane statusline looks like.

--- a/src/scitex_agent_container/_state/agent_meta.py
+++ b/src/scitex_agent_container/_state/agent_meta.py
@@ -1,4 +1,4 @@
-"""Rich agent metadata collection (claude-hud-style).
+"""Rich agent metadata collection.
 
 Canonical source of truth for the metadata payload that is:
   1. Emitted by ``scitex-agent-container show-status <name> --json``.
@@ -97,7 +97,7 @@ def collect_rich(
     workdir: str,
     session: str,
 ) -> dict[str, Any]:
-    """Collect claude-hud-style metadata for one agent.
+    """Collect the rich metadata payload for one agent.
 
     Parameters
     ----------

--- a/src/scitex_agent_container/runtimes/settings_json.py
+++ b/src/scitex_agent_container/runtimes/settings_json.py
@@ -318,8 +318,9 @@ def setup_settings_json(
     # Register sac-statusline as the statusLine command so the JSON payload
     # is persisted to ~/.scitex/agent-container/runtime/statusline/<agent>.json each
     # turn. sac agent status prefers this authoritative source over the JSONL
-    # approximation (sac issue #52). No-op if claude-hud is absent — the
-    # script falls back to a minimal echo.
+    # approximation (sac issue #52). sac-statusline both persists the payload
+    # and renders the line itself, so this is the only statusLine command an
+    # agent ever needs and it depends on nothing outside sac.
     settings["statusLine"] = {"type": "command", "command": "sac-statusline"}
 
     if not settings:

--- a/src/scitex_agent_container/statusline.py
+++ b/src/scitex_agent_container/statusline.py
@@ -5,8 +5,9 @@ via stdin that contains context usage, rate-limits, model info, and session
 details. We tee the payload to a per-agent JSON file so ``sac agent status`` can
 report authoritative context data instead of the 1M-token JSONL approximation.
 
-If claude-hud is installed, display is delegated to it. Otherwise a minimal
-single-line fallback is printed.
+sac then renders the status line itself — one line naming the agent, host,
+workdir, model, context, 5h quota and active account. There is no delegation
+to any external renderer: what the pane shows is sac's decision on every host.
 
 Usage (written by setup_settings_json into .claude/settings.local.json):
     { "statusLine": { "type": "command", "command": "sac-statusline" } }
@@ -16,7 +17,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import sys
 from pathlib import Path
 
@@ -131,7 +131,7 @@ def _active_account() -> str:
         return ""
 
 
-def _fallback_display(raw: bytes) -> None:
+def _display(raw: bytes) -> None:
     # stx-allow: fallback (reason: statusLine display must never raise; corrupt
     # or unexpected payload shape silently outputs nothing rather than aborting)
     try:
@@ -170,51 +170,32 @@ def _fallback_display(raw: bytes) -> None:
         pass
 
 
-def main(stdin=None, runner=None) -> None:
+def main(stdin=None) -> None:
     """Entry point for the sac-statusline command.
 
-    ``stdin`` / ``runner`` are injection seams: default to ``sys.stdin``
-    / ``subprocess.run`` so production callers are unchanged. Tests
-    pass a real bytes-stream and a hand-rolled runner.
+    ``stdin`` is an injection seam: defaults to ``sys.stdin`` so production
+    callers are unchanged; tests pass a real bytes-stream.
     """
     if stdin is None:
         stdin = sys.stdin
-    if runner is None:
-        runner = subprocess.run
     raw = stdin.buffer.read() if hasattr(stdin, "buffer") else stdin.read()
     if isinstance(raw, str):
         raw = raw.encode()
     agent = _agent_name()
     _persist(raw, agent)
 
-    # sac RENDERS ITS OWN STATUS LINE. Operator ruling 2026-08-17:
-    # 「claude-hud は使わないで、scitex-agent-container 側で用意してもらえると
-    #   嬉しいです。自分たちでコントロールできるので。」
-    # (SUMMARY, translation mine: don't use claude-hud — provide it from sac,
-    # because then it is ours to control.)
+    # sac RENDERS ITS OWN STATUS LINE — there is no delegation seam, by
+    # operator ruling 2026-08-17: provide the status line from sac, because
+    # then it is ours to control, and delete the rest cleanly.
     #
-    # Previously this delegated to `claude-hud` whenever that binary happened
-    # to be on PATH, and only rendered sac's own line when it was absent. That
-    # made the pane's contents depend on what was installed rather than on what
-    # sac decided: the same agent showed different information on two hosts,
-    # and the fields sac wants to guarantee (host, workdir, account) could not
-    # be guaranteed at all. Measured the same day: claude-hud was installed on
-    # NEITHER compute-03 nor compute-04, so every agent was already rendering
-    # this function — the delegation was latent variance, not a live feature.
-    #
-    # Opt back in explicitly with SAC_STATUSLINE_DELEGATE=claude-hud if someone
-    # ever wants it; the default is ours.
-    delegate = os.environ.get("SAC_STATUSLINE_DELEGATE", "").strip()
-    if delegate:
-        # stx-allow: fallback (reason: an explicitly requested delegate that is
-        # not installed must degrade to sac's own line, never to a blank pane)
-        try:
-            result = runner([delegate], input=raw)
-            sys.exit(result.returncode)
-        except FileNotFoundError:
-            pass
-
-    _fallback_display(raw)
+    # This function used to shell out to an external renderer whenever that
+    # binary happened to be on PATH, which made the pane's contents depend on
+    # what was installed rather than on what sac decided: the same agent showed
+    # different information on two hosts, and the fields sac wants to guarantee
+    # (host, workdir, account) could not be guaranteed at all. It was installed
+    # on NEITHER compute-03 NOR compute-04 when measured, so every agent was
+    # already rendering the line below — latent variance, not a live feature.
+    _display(raw)
 
 
 def read_statusline_json(agent_name: str) -> dict | None:

--- a/tests/integration/test_agent_meta_setup_audit.py
+++ b/tests/integration/test_agent_meta_setup_audit.py
@@ -1,8 +1,8 @@
 """Tests for the setup-audit and auth-rotation fields on the
 ``collect_rich`` payload.
 
-These tests cover the three concerns raised alongside the claude-hud
-statusline discussion (2026-04-17):
+These tests cover the three concerns raised alongside the statusline
+discussion (2026-04-17):
 
 1. The plan label must come from ``rateLimitTier`` (credentials.json),
    not from ``billingType`` (claude.json). The latter only reports
@@ -392,7 +392,7 @@ def rich_payload_with_plugins_and_mcp(tmp_path: Path, env_save_restore) -> dict:
         json.dumps(
             {
                 "plugins": {
-                    "claude-hud@claude-hud": [{"scope": "user", "version": "0.0.10"}]
+                    "sample-plugin@sample-marketplace": [{"scope": "user", "version": "0.0.10"}]
                 }
             }
         )
@@ -434,7 +434,7 @@ def test_collect_rich_lists_installed_plugin_by_name(
     # Act
     plugins = rich_payload_with_plugins_and_mcp["installed_plugins"]
     # Assert
-    assert plugins and plugins[0]["name"] == "claude-hud@claude-hud"
+    assert plugins and plugins[0]["name"] == "sample-plugin@sample-marketplace"
 
 
 def test_collect_rich_emits_structured_mcp_servers_entry(

--- a/tests/integration/test_pane_state_classifier.py
+++ b/tests/integration/test_pane_state_classifier.py
@@ -3,11 +3,11 @@
 The classifier reads tmux pane tail and returns a ``(state, snippet)``
 pair where ``state`` is a string label and ``snippet`` is the matched
 context. We only assert on signals that come from **Claude Code itself** —
-banners, error messages, prompt glyphs — not from optional statusline
-tools like claude-hud (https://github.com/jarrodwatts/claude-hud) which
-wouldn't be present in every install.
+banners, error messages, prompt glyphs — not from whatever the pane's
+statusline happens to render, which is a separate concern and must not
+become an input to pane classification.
 
-For state that needs claude-hud-style context-pct / tool-history info,
+For state that needs context-pct / tool-history info,
 detection lives in the dashboard's ``_computeStateLocal`` (app.js) using
 hub-side hook event fields (``last_tool_at``), not pane text. That is
 the "use logic, not pattern matching" rule.

--- a/tests/scitex_agent_container/_account/test_credentials.py
+++ b/tests/scitex_agent_container/_account/test_credentials.py
@@ -74,8 +74,8 @@ _HAPPY_CREDENTIALS_JSON = {
 
 _HAPPY_SETTINGS_JSON = {
     "permissions": {"allow": []},
-    "statusLine": {"type": "command", "command": "claude-hud"},
-    "enabledPlugins": ["hud"],
+    "statusLine": {"type": "command", "command": "sac-statusline"},
+    "enabledPlugins": ["sample"],
 }
 
 
@@ -102,8 +102,8 @@ def happy_path_result(tmp_path: Path) -> dict:
         ("num_startups", 42),
         ("subscription_type", "max"),
         ("rate_limit_tier", "default_claude_max_20x"),
-        ("status_line_command", "claude-hud"),
-        ("enabled_plugins", ["hud"]),
+        ("status_line_command", "sac-statusline"),
+        ("enabled_plugins", ["sample"]),
     ],
 )
 def test_happy_path_field_value_matches_expected(
@@ -581,7 +581,7 @@ def installed_plugins_two_distinct(tmp_path: Path) -> list[dict]:
             {
                 "version": 2,
                 "plugins": {
-                    "claude-hud@claude-hud": [
+                    "sample-plugin@sample-marketplace": [
                         {
                             "scope": "user",
                             "version": "0.0.10",
@@ -627,7 +627,7 @@ def test_installed_plugins_parsed_names_match_expected_pair(
     names = sorted(p["name"] for p in plugins)
     # Assert
     assert names == [
-        "claude-hud@claude-hud",
+        "sample-plugin@sample-marketplace",
         "telegram@claude-plugins-official",
     ]
 
@@ -640,17 +640,17 @@ def test_installed_plugins_parsed_names_match_expected_pair(
         ("installed_at", "2026-03-18T00:00:26.724Z"),
     ],
 )
-def test_installed_plugins_parsed_hud_entry_field_matches(
+def test_installed_plugins_parsed_first_entry_field_matches(
     installed_plugins_two_distinct: list[dict], field: str, expected: str
 ) -> None:
     # Arrange
-    hud = next(
+    entry = next(
         p
         for p in installed_plugins_two_distinct
-        if p["name"] == "claude-hud@claude-hud"
+        if p["name"] == "sample-plugin@sample-marketplace"
     )
     # Act
-    actual = hud[field]
+    actual = entry[field]
     # Assert
     assert actual == expected
 

--- a/tests/scitex_agent_container/test_statusline.py
+++ b/tests/scitex_agent_container/test_statusline.py
@@ -3,9 +3,9 @@
 No-mocks pattern (PA-306):
 - ``$SAC_STATUSLINE_STATE_DIR`` env override redirects the persist dir
   (no module-attribute swap of ``_STATE_DIR``).
-- ``main(stdin=, runner=)`` accepts injection seams for the stdin
-  bytes-stream and the subprocess runner; tests pass real ``io.BytesIO``
-  and hand-rolled callables.
+- ``main(stdin=)`` accepts an injection seam for the stdin bytes-stream;
+  tests pass a real ``io.BytesIO``. There is no runner seam: sac renders
+  the line itself and never shells out.
 - ``_persist`` OSError path tested by writing to a real read-only
   directory (chmod 0o555).
 """
@@ -146,20 +146,20 @@ def test_agent_name_returns_unknown_with_no_env_set(env_save_restore):
 
 
 # ---------------------------------------------------------------------------
-# _fallback_display
+# _display
 # ---------------------------------------------------------------------------
 
 
-def test_fallback_display_renders_context_percent(capsys):
+def test_display_renders_context_percent(capsys):
     # Arrange
     payload = json.dumps({"context_window": {"used_percentage": 42.0}}).encode()
     # Act
-    sl_mod._fallback_display(payload)
+    sl_mod._display(payload)
     # Assert
     assert "ctx:42%" in capsys.readouterr().out
 
 
-def test_fallback_display_includes_model_display_name(capsys):
+def test_display_includes_model_display_name(capsys):
     # Arrange
     payload = json.dumps(
         {
@@ -168,12 +168,12 @@ def test_fallback_display_includes_model_display_name(capsys):
         }
     ).encode()
     # Act
-    sl_mod._fallback_display(payload)
+    sl_mod._display(payload)
     # Assert
     assert "claude-opus-4-7" in capsys.readouterr().out
 
 
-def test_fallback_display_includes_five_hour_used_pct(capsys):
+def test_display_includes_five_hour_used_pct(capsys):
     # Arrange
     payload = json.dumps(
         {
@@ -182,36 +182,36 @@ def test_fallback_display_includes_five_hour_used_pct(capsys):
         }
     ).encode()
     # Act
-    sl_mod._fallback_display(payload)
+    sl_mod._display(payload)
     # Assert
     assert "5h:22%" in capsys.readouterr().out
 
 
-def test_fallback_display_omits_five_hour_when_pct_absent(capsys):
+def test_display_omits_five_hour_when_pct_absent(capsys):
     # Arrange
     payload = json.dumps(
         {"context_window": {"used_percentage": 1.0}, "rate_limits": {"five_hour": {}}}
     ).encode()
     # Act
-    sl_mod._fallback_display(payload)
+    sl_mod._display(payload)
     # Assert
     assert "5h" not in capsys.readouterr().out
 
 
-def test_fallback_display_silent_on_garbage_input(capsys):
+def test_display_silent_on_garbage_input(capsys):
     # Arrange
     payload = b"not json"
     # Act
-    sl_mod._fallback_display(payload)
+    sl_mod._display(payload)
     # Assert
     assert capsys.readouterr().out == ""
 
 
-def test_fallback_display_defaults_ctx_to_zero_when_missing(capsys):
+def test_display_defaults_ctx_to_zero_when_missing(capsys):
     # Arrange
     payload = json.dumps({"other": "fields"}).encode()
     # Act
-    sl_mod._fallback_display(payload)
+    sl_mod._display(payload)
     # Assert
     assert "ctx:0%" in capsys.readouterr().out
 
@@ -228,145 +228,64 @@ class _Stdin:
         self.buffer = io.BytesIO(raw)
 
 
-def _run_main_capturing_systemexit(stdin_bytes, runner_fn):
-    """Run sl_mod.main and return the SystemExit, or None if not raised."""
-    try:
-        sl_mod.main(stdin=_Stdin(stdin_bytes), runner=runner_fn)
-        return None
-    except SystemExit as exc:
-        return exc
+def test_statusline_module_never_shells_out():
+    """Operator ruling 2026-08-17: delete the delegation, do not hide it.
 
+    An earlier revision kept the mechanism behind an opt-in env var. That left
+    a second way for the pane to be rendered by something other than sac, which
+    is exactly the variance the ruling removes: the same agent showed different
+    information on two hosts depending on what happened to be installed.
 
-class _Exit7:
-    returncode = 7
-
-
-def _record_calls(sink: list):
-    """A runner that logs every invocation and would exit 7 if used."""
-
-    def _runner(argv, input=None):
-        sink.append(argv)
-        return _Exit7()
-
-    return _runner
-
-
-def test_main_invokes_no_delegate_when_none_is_named(state_dir, env_save_restore):
-    """Operator ruling 2026-08-17: the pane is sac's to control.
-
-    Delegation used to fire whenever ``claude-hud`` happened to be on PATH, so
-    the same agent rendered different information on two hosts depending on
-    what was installed. Now it fires only when explicitly asked.
+    Asserted against the real production source rather than a patched
+    collaborator, so it stays true no matter how a future shell-out is spelled
+    (``subprocess.run``, ``Popen``, ``os.system``, a lazy import inside main).
     """
-    # Arrange — no SAC_STATUSLINE_DELEGATE set.
-    env_save_restore.set("CLAUDE_AGENT_ID", "agent-no-delegate")
-    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "")
-    payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
-    called: list = []
-    # Act
-    _run_main_capturing_systemexit(payload, _record_calls(called))
-    # Assert
-    assert called == []
-
-
-def test_main_renders_locally_when_no_delegate_is_named(state_dir, env_save_restore):
-    """No delegate means fall through to sac's renderer, not exit with its code."""
     # Arrange
-    env_save_restore.set("CLAUDE_AGENT_ID", "agent-no-delegate-2")
-    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "")
-    payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
+    source = Path(sl_mod.__file__).read_text()
     # Act
-    exc = _run_main_capturing_systemexit(payload, _record_calls([]))
+    spawn_tokens = [t for t in ("subprocess", "os.system", "Popen") if t in source]
     # Assert
-    assert exc is None
+    assert spawn_tokens == []
 
 
-def test_main_propagates_claude_hud_exit_code(state_dir, env_save_restore):
+def test_main_does_not_exit(state_dir, env_save_restore):
+    """main() renders and returns; it no longer carries another tool's rc."""
     # Arrange
-    env_save_restore.set("CLAUDE_AGENT_ID", "agent-hud")
-    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "claude-hud")
+    env_save_restore.set("CLAUDE_AGENT_ID", "agent-no-exit")
     payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
-
-    class _Result:
-        returncode = 7
-
-    # Act
-    exc = _run_main_capturing_systemexit(payload, lambda argv, input=None: _Result())
+    # Act — a SystemExit raised here propagates and fails the test.
+    returned = sl_mod.main(stdin=_Stdin(payload))
     # Assert
-    assert exc is not None and exc.code == 7
+    assert returned is None
 
 
-def test_main_forwards_payload_to_claude_hud_stdin(state_dir, env_save_restore):
+def test_main_renders_the_payload(state_dir, env_save_restore, capsys):
     # Arrange
-    env_save_restore.set("CLAUDE_AGENT_ID", "agent-hud2")
-    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "claude-hud")
-    payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
-    captured: dict = {}
-
-    class _Result:
-        returncode = 0
-
-    def runner(argv, input=None):
-        captured["input"] = input
-        return _Result()
-
-    # Act
-    _run_main_capturing_systemexit(payload, runner)
-    # Assert
-    assert captured["input"] == payload
-
-
-def test_main_persists_payload_before_delegating(state_dir, env_save_restore):
-    # Arrange
-    env_save_restore.set("CLAUDE_AGENT_ID", "agent-persist")
-    payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
-
-    class _Result:
-        returncode = 0
-
-    # Act
-    _run_main_capturing_systemexit(payload, lambda argv, input=None: _Result())
-    # Assert
-    assert (state_dir / "agent-persist.json").exists()
-
-
-def test_main_falls_back_to_local_display_when_claude_hud_missing(
-    state_dir, env_save_restore, capsys
-):
-    # Arrange
-    env_save_restore.set("CLAUDE_AGENT_ID", "agent-fb")
+    env_save_restore.set("CLAUDE_AGENT_ID", "agent-render")
     payload = json.dumps(
         {
             "context_window": {"used_percentage": 88},
             "model": {"display_name": "M"},
         }
     ).encode()
-
-    def runner(argv, input=None):
-        raise FileNotFoundError("no claude-hud")
-
     # Act
-    sl_mod.main(stdin=_Stdin(payload), runner=runner)
+    sl_mod.main(stdin=_Stdin(payload))
     # Assert
     assert "ctx:88%" in capsys.readouterr().out
 
 
-def test_main_fallback_path_persists_payload(state_dir, env_save_restore):
+def test_main_persists_payload(state_dir, env_save_restore):
     # Arrange
-    env_save_restore.set("CLAUDE_AGENT_ID", "agent-fb-persist")
-    payload = json.dumps({"context_window": {"used_percentage": 88}}).encode()
-
-    def runner(argv, input=None):
-        raise FileNotFoundError("no claude-hud")
-
+    env_save_restore.set("CLAUDE_AGENT_ID", "agent-persist")
+    payload = json.dumps({"context_window": {"used_percentage": 50}}).encode()
     # Act
-    sl_mod.main(stdin=_Stdin(payload), runner=runner)
+    sl_mod.main(stdin=_Stdin(payload))
     # Assert
-    assert (state_dir / "agent-fb-persist.json").exists()
+    assert (state_dir / "agent-persist.json").exists()
 
 
 # ---------------------------------------------------------------------------
-# main() default-argument branches (stdin=None, runner=None, str raw)
+# main() default-argument branches (stdin=None, str raw)
 # ---------------------------------------------------------------------------
 
 
@@ -388,34 +307,11 @@ def test_main_default_stdin_reads_from_sys_stdin(state_dir, env_save_restore):
     sys.stdin = _Stdin(payload)
     try:
         # Act
-        sl_mod.main(runner=lambda argv, input=None: _R0())
-    except SystemExit:
-        pass
+        sl_mod.main()
     finally:
         sys.stdin = saved
     # Assert default-stdin branch persisted the payload from sys.stdin.
     assert (state_dir / "agent-default-stdin.json").exists()
-
-
-class _R0:
-    returncode = 0
-
-
-def test_main_default_runner_uses_subprocess_run(
-    state_dir, env_save_restore, subprocess_shim
-):
-    # Arrange real claude-hud shim on PATH so default runner finds it.
-    env_save_restore.set("CLAUDE_AGENT_ID", "agent-default-runner")
-    env_save_restore.set("SAC_STATUSLINE_DELEGATE", "claude-hud")
-    subprocess_shim.install("claude-hud", exit=0)
-    payload = json.dumps({"context_window": {"used_percentage": 12}}).encode()
-    # Act invoke without runner so subprocess.run default fires.
-    try:
-        sl_mod.main(stdin=_Stdin(payload))
-    except SystemExit:
-        pass
-    # Assert the real subprocess.run reached the shim.
-    assert subprocess_shim.call_count("claude-hud") == 1
 
 
 def test_main_encodes_str_stdin_to_bytes_before_persist(state_dir, env_save_restore):
@@ -423,13 +319,7 @@ def test_main_encodes_str_stdin_to_bytes_before_persist(state_dir, env_save_rest
     env_save_restore.set("CLAUDE_AGENT_ID", "agent-str-stdin")
     payload_text = json.dumps({"context_window": {"used_percentage": 7}})
     # Act
-    try:
-        sl_mod.main(
-            stdin=_StrStdin(payload_text),
-            runner=lambda argv, input=None: _R0(),
-        )
-    except SystemExit:
-        pass
+    sl_mod.main(stdin=_StrStdin(payload_text))
     # Assert persisted file contains the UTF-8 encoded payload.
     stored = (state_dir / "agent-str-stdin.json").read_bytes()
     assert stored == payload_text.encode()


### PR DESCRIPTION
refactor(statusline): delete claude-hud, including the opt-in that kept it

Operator ruling 2026-08-17: 「claude-hud の話は全部削除しましょう。余計なもの
はきれいに削除がいいです。」 — delete all of it; extraneous things are best
removed cleanly.

WHY THIS IS A SECOND COMMIT AND NOT PART OF #1086. #1086 made delegation
OPT-IN behind SAC_STATUSLINE_DELEGATE and kept the mechanism. That was the
wrong shape and the operator said so: an env var that can re-point the pane
at an external renderer is still a second way for the status line to be
something other than sac's decision, which is the variance the whole change
exists to remove. Keeping the alternative as a documented escape hatch is
the menu this codebase's own rule refuses — if exactly one value is viable,
delete the field rather than preserve the others as history.

WHAT GOES:
  * the delegation branch, the env var, and the `runner` injection seam
  * `import subprocess` — statusline.py no longer spawns anything at all
  * the six delegation tests, replaced by one that asserts the PRODUCTION
    SOURCE contains no spawn token (subprocess / os.system / Popen). That
    reads the real module rather than a patched collaborator, so it stays
    true however a future shell-out is spelled, including a lazy import
    inside main().

Also renamed `_fallback_display` -> `_display`. "Fallback" named a position
in a control flow that no longer exists; a fallback with nothing to fall
back from is a misleading name, and the rule here is to rename rather than
re-explain.

SWEPT THE REST OF THE VOCABULARY. claude-hud also appeared in comments that
asserted things which are now false (`settings_json.py` claimed the status
line "falls back to a minimal echo" if claude-hud is absent), in
descriptive names for unrelated payloads ("claude-hud-style metadata"), in
docs/credentials.md, and as sample data in four test fixtures. All replaced
with what is actually true. The pane-classifier comment is the one worth
reading: it explained why pane state must not be derived from claude-hud
specifically, when the real reason is that it must not be derived from
whatever renders the status line at all.

ONE REFERENCE DELIBERATELY LEFT: `_account/claude_usage.py:97`, a comment
attributing the User-Agent to claude-hud. The file is 585 lines and the
line-limit hook blocks any edit until it is split. The value it sends is
`claude-code/2.1` and has nothing to do with claude-hud, so the comment is
merely wrong rather than load-bearing; splitting a live OAuth module inside
a statusline change would bury it in unrelated churn. Carded separately.

196 tests pass across the four affected files.
