### PR TITLE
fix(accounts): an empty SHADOW store must not read as an empty fleet

### DIFF
--- a/src/scitex_agent_container/_state/account_store_state.py
+++ b/src/scitex_agent_container/_state/account_store_state.py
@@ -1,0 +1,213 @@
+"""Whether an EMPTY account listing means "no accounts" or "could not look".
+
+``list_accounts()`` is documented to never raise and to return ``[]`` when the
+store directory does not exist or is unreadable. That is a deliberate,
+long-standing contract and this module does not change it — but it collapses
+two facts into one value, and the collapse is the bug:
+
+    []  because this host genuinely has no accounts yet
+    []  because we looked somewhere the store is not
+
+MEASURED 2026-08-17, inside the scitex-agent-container agent on compute-04.
+``sac accounts list --no-fanout`` printed
+
+    No accounts stored or active. Use: scitex-agent-container account save <name>
+
+while the identical command run as the operator listed FOUR healthy accounts.
+The container's ``$HOME`` is ``/home/agent``; the store lives under
+``/home/ywatanabe/.scitex/agent-container/accounts`` and only the operator's
+home is bound, so ``Path.home()/.scitex/...`` resolved a path that does not
+exist. The credential inventory then advised creating an account that already
+existed four times over.
+
+In the FLEET view the same collapse is worse than a wrong message: the local
+host silently vanishes from the table. My reading showed 16 rows across four
+hosts; the operator's showed 20 across five. The missing host was the one the
+command was running on. Nothing in the output marked the difference, and I
+came within one sentence of reporting the controller's credentials as gone.
+
+So this module answers the question the list cannot: WAS THE STORE READ? It
+is three-valued on purpose (§2 of the constitution — "Every signal is
+three-valued: true, false, and unknown. Collapsing unknown into either pole
+is the most common bug we ship"), and ``account_count`` is ``None`` in every
+state except ``readable``, so an unattributable count is not merely undrawn
+but unrepresentable.
+
+Named after :func:`~.._account_usage_state.classify_usage`, which already
+does this for usage percentages — same shape, same reason, adjacent problem.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["StoreState", "classify_store", "READABLE", "ABSENT", "UNREADABLE"]
+
+READABLE = "readable"
+ABSENT = "absent"
+UNREADABLE = "unreadable"
+
+_STATES = (READABLE, ABSENT, UNREADABLE)
+
+
+@dataclass(frozen=True)
+class StoreState:
+    """sac's STANDING to say how many accounts a host has.
+
+    Attributes
+    ----------
+    path
+        The directory that was actually consulted. Reported even when the
+        read failed, because "which path did you look at" is the first
+        question a wrong answer raises — and on a container the answer is
+        usually the whole explanation.
+    state
+        ``readable`` / ``absent`` / ``unreadable``.
+    account_count
+        Number of accounts found, or ``None`` when ``state`` is not
+        ``readable``. A count that nobody could take must not be
+        expressible as a number.
+    """
+
+    path: Path
+    state: str
+    account_count: int | None
+
+    def __post_init__(self) -> None:
+        if self.state not in _STATES:
+            raise ValueError(f"state must be one of {_STATES}, got {self.state!r}")
+        if self.state == READABLE and self.account_count is None:
+            raise ValueError("a readable store must report a count")
+        if self.state != READABLE and self.account_count is not None:
+            raise ValueError(
+                f"a {self.state} store cannot report a count "
+                f"(got {self.account_count}) — that is the collapse this "
+                f"class exists to prevent"
+            )
+
+    @property
+    def empty_is_trustworthy(self) -> bool:
+        """True iff an empty listing may be reported as "this host has none"."""
+        return self.state == READABLE
+
+
+def classify_store(store_dir: Path | None = None, home: Path | None = None) -> StoreState:
+    """Report whether the account store could be read, and how many it holds.
+
+    Resolves the SAME path :func:`.._state.account_store.list_accounts` uses,
+    so the two can never disagree about where they looked.
+    """
+    from .account_store import _store_path
+
+    resolved = _store_path(store_dir, home or Path.home())
+    if not resolved.exists():
+        return StoreState(path=resolved, state=ABSENT, account_count=None)
+    if not resolved.is_dir():
+        return StoreState(path=resolved, state=UNREADABLE, account_count=None)
+    # stx-allow: fallback (reason: an unreadable dir is a REPORTED state here,
+    # not a swallowed error — the return value says so and carries no count)
+    try:
+        entries = [p for p in resolved.iterdir() if p.is_dir()]
+    except OSError:
+        return StoreState(path=resolved, state=UNREADABLE, account_count=None)
+
+    from .account_store import list_accounts
+
+    return StoreState(
+        path=resolved,
+        state=READABLE,
+        account_count=len(list_accounts(store_dir=store_dir, home=home)),
+    )
+
+
+def populated_stores_elsewhere(
+    exclude: Path, homes_root: Path | None = None
+) -> list[Path]:
+    """Other account stores on this machine that DO hold accounts.
+
+    THE CASE THIS EXISTS FOR, and it is not the one the three states above
+    describe. Measured 2026-08-17 inside an agent container: the resolved
+    store was ``/home/agent/.scitex/agent-container/accounts`` — it EXISTED,
+    it was readable, and it held zero accounts. So it is not absent and not
+    unreadable; it is an empty SHADOW, and a shadow answers "how many
+    accounts does this host have" with a confident, well-formed, wrong zero
+    while four healthy accounts sit in the operator's home on the same
+    machine.
+
+    No classification of the resolved path can catch that, because nothing
+    about the resolved path is malformed. The only way to know the zero is
+    misleading is to look somewhere else and find the accounts — which is
+    what this does.
+
+    Deliberately generic: it scans the home directories that exist on this
+    machine rather than naming one. A hardcoded ``/home/ywatanabe`` would
+    work here and be wrong on every other host, which is the same
+    vantage-point error in a new place.
+
+    ``homes_root`` defaults to ``/home`` and exists so this is TESTABLE.
+    Without it the function reads the real machine, and its own unit test
+    could not construct a "genuinely empty, no shadow" case on a host that
+    has accounts — which is exactly how the first version failed: the test
+    asserting the friendly message got the shadow message instead, because
+    on this machine the tmp_path store really WAS a shadow. A hidden
+    dependency on the live filesystem is not a detail; it is the difference
+    between a test that pins behaviour and one that reports the host.
+    """
+    from .account_store import _DEFAULT_STORE_SUBDIR
+
+    root = homes_root if homes_root is not None else Path("/home")
+    found: list[Path] = []
+    # stx-allow: fallback (reason: a machine without /home is not an error to
+    # report here — it simply has no neighbour stores to offer)
+    try:
+        homes = sorted(p for p in root.iterdir() if p.is_dir())
+    except OSError:
+        return found
+    for home in homes:
+        candidate = home / _DEFAULT_STORE_SUBDIR
+        if candidate == exclude or not candidate.is_dir():
+            continue
+        # stx-allow: fallback (reason: an unreadable neighbour home is not
+        # this function's problem to report; it simply cannot contribute)
+        try:
+            if any(p.is_dir() for p in candidate.iterdir()):
+                found.append(candidate)
+        except OSError:
+            continue
+    return found
+
+
+def no_accounts_message(state: StoreState, homes_root: Path | None = None) -> str:
+    """The line to print when a listing came back empty.
+
+    Two different sentences for two different facts, which is the whole
+    point: telling an operator to create an account, when the truth is that
+    sac looked in the wrong place, sends them to fix something that is not
+    broken.
+    """
+    if state.state == ABSENT:
+        return (
+            f"Account store NOT FOUND at {state.path} — this is NOT the same as "
+            f"having no accounts, and nothing here should be read as a count. "
+            f"Inside a container the store is usually on the host and not bound; "
+            f"check $HOME (this process sees {Path.home()})."
+        )
+    if state.state == UNREADABLE:
+        return (
+            f"Account store at {state.path} is UNREADABLE (exists, could not be "
+            f"listed) — no count can be taken. Check permissions."
+        )
+    elsewhere = populated_stores_elsewhere(exclude=state.path, homes_root=homes_root)
+    if elsewhere:
+        others = ", ".join(str(p) for p in elsewhere)
+        return (
+            f"No accounts in {state.path} — but accounts DO exist elsewhere on "
+            f"this machine: {others}. This store is an empty shadow, not an "
+            f"empty fleet; $HOME here is {Path.home()}. Do NOT create a new "
+            f"account to fix this — point at the populated store instead."
+        )
+    return (
+        "No accounts stored or active. Use: "
+        "scitex-agent-container account save <name>"
+    )

--- a/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
@@ -240,10 +240,15 @@ def account_list(
     rows = build_stored_rows(accounts, refresh=refresh, passive=passive)
     all_rows = rows + build_openai_rows(openai_accounts)
     if not all_rows:
-        click.echo(
-            "No accounts stored or active. Use: "
-            "scitex-agent-container account save <name>"
-        )
+        # WHICH empty is this? An unread store and an empty one produce the
+        # identical `[]` from list_accounts, and only one of them means "this
+        # host has no accounts". Advising `account save` on the other sends
+        # the operator to create something that already exists — measured
+        # 2026-08-17 from inside a container, where the store lives on the
+        # host and $HOME does not reach it.
+        from .._state.account_store_state import classify_store, no_accounts_message
+
+        click.echo(no_accounts_message(classify_store()))
         return
     console.print(
         "[dim]--refresh is LOCAL-ONLY: it refetches usage, and a refetch can "

--- a/src/scitex_agent_container/cli_pkg/_account_list_fleet.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_fleet.py
@@ -282,10 +282,16 @@ def run_fleet_account_list(
         # the same blank table is an UNOBSERVED fleet, and telling him to go
         # create an account would be advice derived from a reading nobody took.
         if listing.responded == listing.total:
-            click.echo(
-                "No accounts stored or active. Use: "
-                "scitex-agent-container account save <name>"
+            # Every host answered, so the fleet's emptiness is observed —
+            # EXCEPT for the local host, whose answer came from a store this
+            # process may not be able to reach at all (container $HOME).
+            # Say which of those two this is rather than advising a fix.
+            from .._state.account_store_state import (
+                classify_store,
+                no_accounts_message,
             )
+
+            click.echo(no_accounts_message(classify_store()))
         else:
             missing = ", ".join(r.host for r in listing.unanswered)
             console.print(

--- a/tests/scitex_agent_container/_state/test_account_store_state.py
+++ b/tests/scitex_agent_container/_state/test_account_store_state.py
@@ -1,0 +1,239 @@
+"""Tests for the three-valued account-store classification.
+
+No mocks: every case builds a REAL directory on tmp_path (or points at a
+path that genuinely does not exist) and reads it back, because the whole
+defect being fixed is a wrong answer about the filesystem — a stubbed
+filesystem could not have caught it and cannot guard it.
+
+The load-bearing tests are the two that assert an ABSENT store is NOT
+reported as an empty one. That collapse is what told an agent the fleet
+controller had zero accounts while four were healthy on the host.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state.account_store_state import (
+    ABSENT,
+    READABLE,
+    UNREADABLE,
+    StoreState,
+    classify_store,
+    no_accounts_message,
+)
+
+
+def _make_store(root: Path, *account_names: str) -> Path:
+    store = root / ".scitex" / "agent-container" / "accounts"
+    store.mkdir(parents=True)
+    for name in account_names:
+        acct = store / name
+        acct.mkdir()
+        (acct / "account.json").write_text('{"name": "%s"}' % name)
+    return store
+
+
+def test_a_missing_store_is_absent_not_empty(tmp_path: Path) -> None:
+    """The defect this module exists to prevent."""
+    # Arrange — a home with no store in it at all.
+    home = tmp_path / "nowhere"
+    home.mkdir()
+    # Act
+    state = classify_store(home=home)
+    # Assert
+    assert state.state == ABSENT
+
+
+def test_a_missing_store_reports_no_count(tmp_path: Path) -> None:
+    """A count nobody could take must not be expressible as a number."""
+    # Arrange
+    home = tmp_path / "nowhere2"
+    home.mkdir()
+    # Act
+    state = classify_store(home=home)
+    # Assert
+    assert state.account_count is None
+
+
+def test_an_empty_store_is_readable_with_zero(tmp_path: Path) -> None:
+    """The OTHER empty — genuinely no accounts — still reports zero."""
+    # Arrange
+    _make_store(tmp_path)
+    # Act
+    state = classify_store(home=tmp_path)
+    # Assert
+    assert state.state == READABLE
+
+
+def test_an_empty_store_counts_zero(tmp_path: Path) -> None:
+    # Arrange
+    _make_store(tmp_path)
+    # Act
+    state = classify_store(home=tmp_path)
+    # Assert
+    assert state.account_count == 0
+
+
+def test_a_populated_store_counts_its_accounts(tmp_path: Path) -> None:
+    # Arrange
+    _make_store(tmp_path, "alice-example-com", "bob-example-com")
+    # Act
+    state = classify_store(home=tmp_path)
+    # Assert
+    assert state.account_count == 2
+
+
+def test_a_store_path_that_is_a_file_is_unreadable(tmp_path: Path) -> None:
+    # Arrange — the path exists but is not a directory.
+    store = tmp_path / ".scitex" / "agent-container"
+    store.mkdir(parents=True)
+    (store / "accounts").write_text("not a directory")
+    # Act
+    state = classify_store(home=tmp_path)
+    # Assert
+    assert state.state == UNREADABLE
+
+
+def test_empty_is_trustworthy_only_when_readable(tmp_path: Path) -> None:
+    # Arrange
+    home = tmp_path / "gone"
+    home.mkdir()
+    # Act
+    state = classify_store(home=home)
+    # Assert
+    assert state.empty_is_trustworthy is False
+
+
+def test_the_resolved_path_is_reported_even_on_failure(tmp_path: Path) -> None:
+    """Which path did you look at — the first question a wrong answer raises."""
+    # Arrange
+    home = tmp_path / "missing"
+    home.mkdir()
+    # Act
+    state = classify_store(home=home)
+    # Assert
+    assert str(state.path).startswith(str(home))
+
+
+def test_absent_message_refuses_to_advise_creating_an_account(tmp_path: Path) -> None:
+    """Telling an operator to `account save` here is the actual harm."""
+    # Arrange
+    home = tmp_path / "unbound"
+    home.mkdir()
+    state = classify_store(home=home)
+    # Act
+    message = no_accounts_message(state)
+    # Assert
+    assert "account save" not in message
+
+
+def test_absent_message_names_the_path_it_looked_at(tmp_path: Path) -> None:
+    # Arrange
+    home = tmp_path / "unbound2"
+    home.mkdir()
+    state = classify_store(home=home)
+    # Act
+    message = no_accounts_message(state)
+    # Assert
+    assert str(state.path) in message
+
+
+def test_readable_empty_message_does_advise_creating_an_account(tmp_path: Path) -> None:
+    """The genuine empty keeps the helpful advice — that case was never wrong.
+
+    ``homes_root`` points at an EMPTY directory so this is a real "no store
+    anywhere else" machine. Without that the first version of this test read
+    the live host, found the operator's populated store, and got the shadow
+    message — a test that reported the machine instead of the behaviour.
+    """
+    # Arrange
+    _make_store(tmp_path)
+    state = classify_store(home=tmp_path)
+    empty_homes = tmp_path / "no-other-homes"
+    empty_homes.mkdir()
+    # Act
+    message = no_accounts_message(state, homes_root=empty_homes)
+    # Assert
+    assert "account save" in message
+
+
+def test_a_populated_neighbour_store_is_reported_as_a_shadow(tmp_path: Path) -> None:
+    """The defect measured 2026-08-17: empty here, four accounts next door."""
+    # Arrange — this home is empty; a neighbour home holds an account.
+    homes = tmp_path / "homes"
+    mine = homes / "agent"
+    mine.mkdir(parents=True)
+    _make_store(mine)
+    _make_store(homes / "operator", "scitex-01-scitex-ai")
+    state = classify_store(home=mine)
+    # Act
+    message = no_accounts_message(state, homes_root=homes)
+    # Assert
+    assert "empty shadow" in message
+
+
+def test_the_shadow_message_refuses_to_advise_creating_an_account(
+    tmp_path: Path,
+) -> None:
+    """Creating an account here would add a fifth to a store nobody reads."""
+    # Arrange
+    homes = tmp_path / "homes2"
+    mine = homes / "agent"
+    mine.mkdir(parents=True)
+    _make_store(mine)
+    _make_store(homes / "operator", "scitex-01-scitex-ai")
+    state = classify_store(home=mine)
+    # Act
+    message = no_accounts_message(state, homes_root=homes)
+    # Assert
+    assert "Do NOT create a new account" in message
+
+
+def test_the_shadow_message_names_the_populated_store(tmp_path: Path) -> None:
+    """Naming WHERE the accounts are is what makes this actionable."""
+    # Arrange
+    homes = tmp_path / "homes3"
+    mine = homes / "agent"
+    mine.mkdir(parents=True)
+    _make_store(mine)
+    real = _make_store(homes / "operator", "scitex-01-scitex-ai")
+    state = classify_store(home=mine)
+    # Act
+    message = no_accounts_message(state, homes_root=homes)
+    # Assert
+    assert str(real) in message
+
+
+def test_a_readable_state_must_carry_a_count() -> None:
+    """The validator fails where the value is built, not three layers down."""
+    # Arrange
+    build = lambda: StoreState(path=Path("/x"), state=READABLE, account_count=None)
+    # Act
+    raised = pytest.raises(ValueError)
+    # Assert
+    with raised:
+        build()
+
+
+def test_an_absent_state_must_not_carry_a_count() -> None:
+    """Constructing the collapse itself is an error."""
+    # Arrange
+    build = lambda: StoreState(path=Path("/x"), state=ABSENT, account_count=0)
+    # Act
+    raised = pytest.raises(ValueError)
+    # Assert
+    with raised:
+        build()
+
+
+def test_an_unknown_state_string_is_rejected() -> None:
+    # Arrange
+    build = lambda: StoreState(path=Path("/x"), state="probably-fine", account_count=None)
+    # Act
+    raised = pytest.raises(ValueError)
+    # Assert
+    with raised:
+        build()


### PR DESCRIPTION
fix(accounts): an empty SHADOW store must not read as an empty fleet

MEASURED 2026-08-17, inside the scitex-agent-container agent on compute-04.
`sac accounts list --no-fanout` printed

    No accounts stored or active. Use: scitex-agent-container account save <name>

while the identical command run as the operator listed FOUR healthy accounts
on the same machine. In the FLEET view the local host simply vanished from
the table — my read showed 16 rows across four hosts, the operator's showed
20 across five, and the missing host was the controller, the machine the
command was running on. Nothing in the output marked the difference. I came
one sentence from reporting the controller's credentials as gone.

WHAT I FIRST THOUGHT, AND WHY IT WAS WRONG — this is the useful half.
I diagnosed "the store path does not exist inside a container" and built a
three-valued StoreState (readable / absent / unreadable) to stop an
unreadable store rendering as an empty one. Then I ran the fixed CLI in the
container that exhibits the bug, and it printed the SAME misleading message.
Measuring instead of assuming:

    state: readable   path: /home/agent/.scitex/agent-container/accounts   count: 0

The store is not absent. It EXISTS, it is readable, and it is genuinely
empty — an empty SHADOW beside the real one. Nothing about the resolved path
is malformed, so no classification OF THAT PATH can ever catch it. The
classification was correct and did not address the defect.

The only way to know the zero is misleading is to look somewhere else and
find the accounts. So `populated_stores_elsewhere` scans the machine's other
homes and, when one holds accounts, the message names it and says explicitly
NOT to create an account — creating one would add a fifth to a store nobody
reads.

Deliberately generic: it scans /home rather than naming /home/ywatanabe. A
hardcode would work on this host and be the same vantage-point error
everywhere else.

`homes_root` is a parameter because the first version had no seam and its
own test caught that: `test_readable_empty_message_does_advise_creating_an_account`
FAILED, because on this machine the tmp_path store really was a shadow. The
test was reporting the host rather than the behaviour. A hidden dependency
on the live filesystem is not a detail.

StoreState is kept and is not redundant: absent and unreadable stores remain
real states that must not render as counts, and its validator refuses to
construct the collapse at all (a non-readable state carrying a count raises
where it is built, not three layers downstream).

list_accounts() is UNCHANGED — its "never raises, returns []" contract is
long-standing and widely relied on. This adds the missing question beside
it rather than breaking every caller.

36 tests pass. Verified end-to-end in the container that exhibits the bug:
the message now names the shadow, names the populated store, and refuses the
bad advice.
