### PR TITLE
fix(host-sync): a finding is not ill health — add --exit-zero for the timer

### DIFF
--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -267,12 +267,21 @@ def provide_jobs() -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-host-sync-check",
             schedule="0 * * * *",  # hourly (cron form; timer cadence below)
-            command="sac host sync --check --all --alarm",
+            command="sac host sync --check --all --alarm --exit-zero",
             description=(
                 "Read-only drift check of every peer's sac checkout vs the "
                 "centre; records each verdict in sac's own event log so the "
                 "shout is DURABLE. Mutates nothing on any peer — never runs "
-                "the fast-forward remedy (Stage 1)."
+                "the fast-forward remedy (Stage 1). "
+                "--exit-zero because FINDING drift is not this unit being "
+                "unhealthy. MEASURED 2026-08-17: without it, drift exits 1 "
+                "and undetermined exits 2, systemd recorded the unit "
+                "`failed`, compute-04 went `degraded`, and the dotfiles sync "
+                "installer read `is-system-running: degraded` as 'systemd "
+                "absent' and silently refused to install its timer — so that "
+                "host stopped receiving dotfiles sync altogether. The verdict "
+                "still reaches its real readers: the printed report, the JSON "
+                "`exit_code`, and the --alarm event-log record."
             ),
             kind="timer",
             # First check 10min after boot/login (peers reachable, listen

--- a/src/scitex_agent_container/cli_pkg/_host_sync.py
+++ b/src/scitex_agent_container/cli_pkg/_host_sync.py
@@ -140,6 +140,19 @@ def _print_result(result: SyncResult) -> None:
         "Mutates no peer."
     ),
 )
+@click.option(
+    "--exit-zero",
+    "exit_zero",
+    is_flag=True,
+    default=False,
+    help=(
+        "Always exit 0. The verdict is unchanged and still printed, still in "
+        "the JSON `exit_code`, and still recorded by --alarm — only the "
+        "PROCESS status is neutralised. For unattended runners (systemd "
+        "timers) where a non-zero status means 'this job is unhealthy', not "
+        "'this job found something'."
+    ),
+)
 @click.pass_context
 def host_sync(
     ctx: click.Context,
@@ -152,6 +165,7 @@ def host_sync(
     timeout: int,
     as_json: bool,
     alarm: bool,
+    exit_zero: bool,
 ) -> None:
     """Reconcile a peer's sac checkout to the centre's code. One-way.
 
@@ -228,6 +242,26 @@ def host_sync(
             )
 
     code = exit_code_for([r.outcome for r in results])
+    # The VERDICT and the PROCESS STATUS are two different facts, and only one
+    # of them belongs to systemd. `code` stays the verdict everywhere it is
+    # read as one — printed below, and carried in the JSON `exit_code` — while
+    # `status` is what this process exits with.
+    #
+    # MEASURED 2026-08-17: this verb runs hourly as
+    # scitex-agent-container-host-sync-check.service. Finding drift exits 1
+    # and "could not determine" exits 2, so systemd recorded the unit as
+    # `failed` for doing its job correctly, which put compute-04 into
+    # `degraded`. The dotfiles sync installer then tested
+    # `systemctl --user is-system-running`, read `degraded` as "systemd is
+    # absent", and PERMANENTLY and SILENTLY refused to install its timer — so
+    # that host stopped receiving dotfiles sync entirely. A finding became a
+    # health signal became a missing service, across two packages, with every
+    # step reporting success.
+    #
+    # Hence --exit-zero rather than SuccessExitStatus=1 2 on the unit: that
+    # would also swallow a genuine crash, which is the shape that left a
+    # stale-lock monitor's detection rendering as success and nobody told.
+    status = 0 if exit_zero else code
 
     # Make the shout DURABLE: record each verdict in sac's own event log.
     # This runs in BOTH output modes — the record is independent of whatever
@@ -248,7 +282,7 @@ def host_sync(
                 "failed": list(alarm_outcome.failed),
             }
         click.echo(json.dumps(payload, indent=2))
-        raise SystemExit(code)
+        raise SystemExit(status)
 
     mode = "check (read-only)" if check_only else "sync"
     console.print(f"[bold]sac host {mode}[/bold]  centre -> {len(results)} peer(s)\n")
@@ -271,7 +305,7 @@ def host_sync(
         )
     if alarm_outcome is not None:
         console.print(f"[dim]{alarm_outcome.summary_line()}[/dim]")
-    raise SystemExit(code)
+    raise SystemExit(status)
 
 
 def register(host_group) -> None:

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -341,10 +341,22 @@ def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
     # Arrange — belt-and-braces: the exact mutating form `sac host sync
     # <peer>` (no --check) must never be what this timer runs. The command
     # is the read-only detector, full stop.
+    #
+    # `--exit-zero` was added 2026-08-17 and does NOT weaken that intent: it
+    # touches only this process's exit status, never a peer. It is here
+    # because the tri-state verdict (1 = drift found, 2 = undetermined) was
+    # being read by systemd as unit failure, which put the host into
+    # `degraded`, which made the dotfiles sync installer conclude systemd
+    # was absent and silently stop installing its timer.
+    #
+    # Kept as EXACT EQUALITY on purpose. This assertion is the reason that
+    # change could not land unnoticed — a substring check would have let it
+    # through silently, and the next edit to this command deserves the same
+    # scrutiny. Update the literal deliberately; do not relax the operator.
     # Act
     job = _job("scitex-agent-container-host-sync-check")
     # Assert — the command is precisely the read-only check+alarm form.
-    assert job.command == "sac host sync --check --all --alarm"
+    assert job.command == "sac host sync --check --all --alarm --exit-zero"
 
 
 def test_host_sync_check_cadence_is_hourly() -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__host_sync_exit_zero.py
+++ b/tests/scitex_agent_container/cli_pkg/test__host_sync_exit_zero.py
@@ -1,0 +1,142 @@
+"""``--exit-zero`` separates the VERDICT from the PROCESS STATUS.
+
+Why this flag exists, measured 2026-08-17: `sac host sync --check --all
+--alarm` runs hourly as scitex-agent-container-host-sync-check.service.
+Finding drift exits 1 and "could not determine" exits 2, so systemd recorded
+the unit as `failed` for doing its job correctly. That put compute-04 into
+`degraded`; the dotfiles sync installer then tested
+`systemctl --user is-system-running`, read `degraded` as "systemd is
+absent", and PERMANENTLY and SILENTLY refused to install its timer — so that
+host stopped receiving dotfiles sync entirely. A finding became a health
+signal became a missing service, across two packages, every step reporting
+success.
+
+THE FIXTURE USES A PEER THAT CANNOT BE REACHED, ON PURPOSE. An empty peer
+list is rejected by the verb ("no syncable peers"), and a reachable peer
+would make the verdict 0 — either way the tests could not tell "the status
+was neutralised" apart from "there was nothing to neutralise". An
+unreachable peer yields UNDETERMINED, a genuinely non-zero verdict, which
+is the only case the flag changes. That is the positive control.
+
+No mocks: a real Click invocation against a real config file, asserting the
+process status and the JSON a caller actually receives.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._host_sync import host_sync
+
+# `.invalid` is reserved by RFC 2606 and can never resolve, so ssh fails
+# immediately rather than waiting on a network timeout.
+_UNREACHABLE = "host:\n  aliases: {}\npeers:\n  nowhere:\n    ssh: nowhere.invalid\n"
+
+
+@pytest.fixture
+def unreachable_peer_config(tmp_path, env_save_restore):
+    """One peer that cannot be reached -> UNDETERMINED -> non-zero verdict.
+
+    The env var is ``SCITEX_AGENT_CONTAINER_CONFIG``, read from
+    ``_state/host_config.py:85`` rather than guessed. Getting this name
+    wrong does not fail a test — it silently loads the OPERATOR'S REAL
+    config and ssh-es every peer in the fleet.
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_UNREACHABLE)
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return cfg
+
+
+def _run(args):
+    return CliRunner().invoke(host_sync, args, catch_exceptions=False)
+
+
+_BASE = ["--check", "--all", "--json", "--timeout", "1"]
+
+
+def test_without_the_flag_an_unreachable_peer_exits_non_zero(unreachable_peer_config):
+    """The positive control: this case really does exit non-zero by default.
+
+    Without this, every assertion below could pass on a verb that never
+    returns non-zero at all.
+    """
+    # Arrange
+    args = list(_BASE)
+    # Act
+    result = _run(args)
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_with_the_flag_the_process_exits_zero(unreachable_peer_config):
+    """The whole point: systemd must not read a finding as ill health."""
+    # Arrange
+    args = [*_BASE, "--exit-zero"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_with_the_flag_the_verdict_is_still_non_zero_in_json(unreachable_peer_config):
+    """The half that stops this becoming a gate that cannot fail.
+
+    Status neutral, verdict intact. A fix that suppressed both would pass
+    the test above and fail this one.
+    """
+    # Arrange
+    args = [*_BASE, "--exit-zero"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert json.loads(result.output)["exit_code"] != 0
+
+
+def test_the_flag_does_not_change_the_verdict_value(unreachable_peer_config):
+    """The reported verdict is identical with and without the flag."""
+    # Arrange
+    plain = _run(list(_BASE))
+    # Act
+    zeroed = _run([*_BASE, "--exit-zero"])
+    # Assert
+    assert json.loads(zeroed.output)["exit_code"] == json.loads(plain.output)["exit_code"]
+
+
+def test_default_still_routes_verdict_to_status(unreachable_peer_config):
+    """The contract for interactive and script callers is UNCHANGED."""
+    # Arrange
+    result = _run(list(_BASE))
+    # Act
+    verdict = json.loads(result.output)["exit_code"]
+    # Assert
+    assert result.exit_code == verdict
+
+
+def test_help_documents_exit_zero():
+    """A job depends on this flag; an undocumented flag is a trap."""
+    # Arrange
+    args = ["--help"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert "--exit-zero" in result.output
+
+
+def test_the_job_command_passes_exit_zero():
+    """The flag is worthless if the JobSpec does not use it.
+
+    Asserted against the real registered JobSpec, so editing the job's
+    command cannot leave this green while the timer keeps exiting non-zero.
+    """
+    # Arrange
+    from scitex_agent_container._jobs._jobs_plugin import provide_jobs
+
+    jobs = {j.name: j for j in provide_jobs()}
+    # Act
+    command = jobs["scitex-agent-container-host-sync-check"].command
+    # Assert
+    assert "--exit-zero" in command


### PR DESCRIPTION
fix(host-sync): a finding is not ill health — add --exit-zero for the timer

MEASURED 2026-08-17, and it crossed a package boundary.

`sac host sync --check --all --alarm` runs hourly as
scitex-agent-container-host-sync-check.service. Its exit codes are a
tri-state verdict:

    CURRENT/SYNCED       0
    DRIFTED/REFUSED      1
    UNDETERMINED/FAILED  2

So the unit exits non-zero whenever it FINDS something — which is the job
working, not the job failing. systemd cannot know that, and records the
unit `failed`. Then:

    unit failed
      -> `systemctl --user is-system-running` returns `degraded`
      -> the dotfiles sync installer tests exactly that and reads
         `degraded` as "systemd is absent"
      -> it refuses to install its timer, PERMANENTLY and SILENTLY
      -> the host stops receiving dotfiles sync, including unit
         re-assertion

compute-04 was in that state. Survey at the time:

    scitex-compute-01   running    failed: none
    scitex-compute-02   running    failed: none
    scitex-compute-03   DEGRADED   hub-vanished-tracked-files.service
    scitex-compute-04   DEGRADED   dotfiles-drift-check.service,
                                   scitex-agent-container-host-sync-check.service

Neither side could see it alone: dotfiles saw "systemd absent" with no
reason to inspect our units; we saw a wrong badge with no reason to inspect
their installer. Found only because the two agents compared notes.

THE FIX SEPARATES TWO FACTS THAT WERE SHARING ONE CHANNEL. `--exit-zero`
neutralises the PROCESS STATUS only. The verdict is unchanged and still
reaches every reader that treats it as one: the printed report, the JSON
`exit_code`, and the --alarm event-log record. The default contract for
interactive and script callers is untouched — only the unattended runner
opts out.

WHY NOT `SuccessExitStatus=1 2` ON THE UNIT, which is the one-line
alternative: it would also swallow a genuine crash. That is the shape that
left scitex-hpc's stale-lock monitor rendering a detection as success with
nobody told. Narrowing what the process REPORTS is safe; teaching systemd
to ignore failures is not.

TESTS — 7, and the first one is the control. An unreachable peer
(`nowhere.invalid`, RFC 2606, fails instantly) yields UNDETERMINED, a
genuinely non-zero verdict. Without that control the suite would assert
against a verdict of 0 and could not tell "the status was neutralised" from
"there was nothing to neutralise". Two tests then pin BOTH halves: process
exits 0, and the JSON verdict is still non-zero. A fix that suppressed both
would pass one and fail the other. The last test reads the real registered
JobSpec, so editing the job's command cannot leave this green while the
timer keeps exiting non-zero.

ONE THING THE TESTS THEMSELVES ALMOST GOT WRONG: the config env var is
`SCITEX_AGENT_CONTAINER_CONFIG`. My first fixture used a plausible
`..._HOST_CONFIG`, which does not fail — it silently loads the operator's
REAL config and ssh-es every peer in the fleet. The tests hung; that is how
I found it. Name read from `_state/host_config.py:85`, not guessed.
