### PR TITLE
fix(quota): a STALE snapshot triggers a refresh — it must not disarm the gate

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_quota_evidence.py
+++ b/src/scitex_agent_container/_lifecycle/_quota_evidence.py
@@ -102,36 +102,45 @@ def pick_with_quota_evidence(
     """
     from .._account.quota_cache import quota_cache_present
 
-    # A cache that EXISTS is not the same as evidence that is USABLE, and this
-    # line used to conflate them.
+    # PRESENCE decides whether this host runs a quota system at all, and that
+    # is the only question the never-block invariant turns on. AGE decides
+    # whether the numbers may still be true, and its only remedy is a refresh.
+    # Keeping those two separate is the whole correction here: staleness must
+    # never DISARM the gate, because "the cache is old" and "this host has no
+    # cache" call for opposite treatment.
     #
     # MEASURED 2026-08-17, scitex-hub on scitex-compute-03. Its quota cache was
-    # present, well-formed, and 23 HOURS OLD. `quota_cache_present` therefore
-    # said True, the armed path trusted it, and the picker read the pinned
+    # present, well-formed, and 23 HOURS OLD. Nothing in this decision looked
+    # at age, so the armed path trusted it and the picker read the pinned
     # account's stale percentages — 7d=15% from the previous day — as evidence
     # that the pin was fine. The account was actually at 7d=100%, capped until
     # Aug 22. hub kept the pin and answered "You've hit your weekly limit" on
     # every turn while the restart reported success. Refreshing that one cache
-    # was what revived it: the picker then chose a 7d=8% account by itself.
+    # was what revived it: the picker then chose a 7d=8% account by itself. The
+    # selector was never wrong; it was fed a day-old number and had no way to
+    # know.
     #
-    # So the selector was never wrong. It was fed a day-old number and had no
-    # way to know, because nothing in this decision looked at age. Note this is
-    # the SAME failure this module's own docstring records for scitex-02 on
-    # 2026-08-06 — an agent booting onto a d7=100% account while startup
-    # reported success. That fix armed the gate when the cache was ABSENT; a
-    # STALE cache walks straight past it, which is why the incident recurred.
-    #
-    # Treating stale as absent routes it into `_build_evidence_once` — the path
-    # that already exists for "we have no evidence, go and get some" — so a
-    # refresh happens before the pick rather than a day later. Constitution §2:
-    # unknown is not "OK", and a number nobody can vouch for is unknown however
-    # confidently it is formatted.
-    if _has_fresh_quota_evidence(quota_cache_path):
+    # The first attempt at this fix routed a stale cache into
+    # `_build_evidence_once` — the ABSENT-cache path — which looks equivalent
+    # and is not: that path DEGRADES when its refresh fails. So a cache that
+    # was present-but-blind and older than the window would have started
+    # booting agents instead of refusing them, re-opening the 2026-07-20
+    # incident (scitex-cards launched onto a 7d=100% account read as
+    # "5h=? 7d=?") in the act of fixing hub's. Two tests said so.
+    if quota_cache_present(quota_cache_path):
+        refreshed = False
+        if not _has_fresh_quota_evidence(quota_cache_path):
+            refreshed = _refresh_stale_evidence(
+                agent_name=agent_name,
+                quota_cache_path=quota_cache_path,
+                store_dir=store_dir,
+            )
         return _pick_armed(
             pick,
             agent_name=agent_name,
             quota_cache_path=quota_cache_path,
             store_dir=store_dir,
+            already_refreshed=refreshed,
         )
 
     blocker = _build_evidence_once(
@@ -158,12 +167,51 @@ def pick_with_quota_evidence(
     return picked
 
 
+def _refresh_stale_evidence(
+    *,
+    agent_name: str,
+    quota_cache_path: Path | str | None,
+    store_dir: Path | None,
+) -> bool:
+    """Re-measure a cache too OLD to decide a boot on. True if a refresh ran.
+
+    Best-effort by construction, and unlike :func:`_build_evidence_once` a
+    failure here changes NOTHING about the gate: the host demonstrably has a
+    quota cache, so the never-block invariant — which exists for hosts running
+    no quota system at all — does not apply to it. A stale cache that cannot be
+    refreshed is simply picked against with the gate ARMED, and the pick then
+    refuses or proceeds on its own merits.
+
+    The old cache is deliberately left in place when the refresh fails. It is
+    the only evidence this host has, and deleting it (as the absent-cache path
+    does for the empty file IT created) would silently convert a fail-loud host
+    into a degrading one.
+    """
+    logger.info(
+        "quota cache is too old to decide %r's boot — re-measuring before picking",
+        agent_name,
+    )
+    try:
+        _refresh(quota_cache_path=quota_cache_path, store_dir=store_dir)
+    except Exception as exc:  # stx-allow: fallback (reason: the staleness re-measure is BEST-EFFORT. A populator that raises must leave the boot exactly where it stood — picking against the old cache with the gate ARMED — never crash a start that would otherwise have succeeded.)
+        logger.warning(
+            "could not refresh %r's stale quota cache (%s: %s) — picking with the "
+            "gate armed against the cache as it stands",
+            agent_name,
+            exc.__class__.__name__,
+            exc,
+        )
+        return False
+    return True
+
+
 def _pick_armed(
     pick: Callable[[bool], str],
     *,
     agent_name: str,
     quota_cache_path: Path | str | None,
     store_dir: Path | None,
+    already_refreshed: bool = False,
 ) -> str:
     """Pick with the gate ARMED, self-repairing a blind cache once.
 
@@ -184,6 +232,12 @@ def _pick_armed(
     try:
         return pick(True)
     except BlindQuotaCacheError as blind:
+        if already_refreshed:
+            # A staleness re-measure just ran, seconds ago, against this same
+            # store. Running the populator again would measure exactly what it
+            # measured then, so the refusal is already the post-refresh one
+            # this path exists to produce.
+            raise
         logger.info(
             "quota cache blind for %r — refreshing it once before refusing",
             agent_name,

--- a/src/scitex_agent_container/_lifecycle/_quota_evidence.py
+++ b/src/scitex_agent_container/_lifecycle/_quota_evidence.py
@@ -102,7 +102,31 @@ def pick_with_quota_evidence(
     """
     from .._account.quota_cache import quota_cache_present
 
-    if quota_cache_present(quota_cache_path):
+    # A cache that EXISTS is not the same as evidence that is USABLE, and this
+    # line used to conflate them.
+    #
+    # MEASURED 2026-08-17, scitex-hub on scitex-compute-03. Its quota cache was
+    # present, well-formed, and 23 HOURS OLD. `quota_cache_present` therefore
+    # said True, the armed path trusted it, and the picker read the pinned
+    # account's stale percentages — 7d=15% from the previous day — as evidence
+    # that the pin was fine. The account was actually at 7d=100%, capped until
+    # Aug 22. hub kept the pin and answered "You've hit your weekly limit" on
+    # every turn while the restart reported success. Refreshing that one cache
+    # was what revived it: the picker then chose a 7d=8% account by itself.
+    #
+    # So the selector was never wrong. It was fed a day-old number and had no
+    # way to know, because nothing in this decision looked at age. Note this is
+    # the SAME failure this module's own docstring records for scitex-02 on
+    # 2026-08-06 — an agent booting onto a d7=100% account while startup
+    # reported success. That fix armed the gate when the cache was ABSENT; a
+    # STALE cache walks straight past it, which is why the incident recurred.
+    #
+    # Treating stale as absent routes it into `_build_evidence_once` — the path
+    # that already exists for "we have no evidence, go and get some" — so a
+    # refresh happens before the pick rather than a day later. Constitution §2:
+    # unknown is not "OK", and a number nobody can vouch for is unknown however
+    # confidently it is formatted.
+    if _has_fresh_quota_evidence(quota_cache_path):
         return _pick_armed(
             pick,
             agent_name=agent_name,
@@ -293,3 +317,53 @@ def _refresh(
 
 def _as_int(value: Any) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+# How old a quota snapshot may be and still count as EVIDENCE for a boot
+# decision. Deliberately generous relative to the 5-minute writer cadence
+# (`_account.claude_usage._CACHE_TTL_SECONDS`) — this is not "is the cache
+# warm", it is "could this number still be true". An hour of drift cannot turn
+# a healthy account into a capped one under any realistic burn rate; a day
+# demonstrably can, and did.
+QUOTA_EVIDENCE_MAX_AGE_S = 3600.0
+
+
+def _has_fresh_quota_evidence(
+    quota_cache_path: Path | str | None,
+    *,
+    max_age_s: float = QUOTA_EVIDENCE_MAX_AGE_S,
+    now: float | None = None,
+) -> bool:
+    """Is there a quota snapshot RECENT ENOUGH to decide a boot on?
+
+    Three outcomes collapse to two here on purpose, and the collapse is the
+    safe direction: absent, unreadable, undated and stale all return False,
+    which routes the caller into "go and build the evidence" rather than into
+    a silent launch. Only a present, parseable, dated and recent cache is
+    evidence.
+
+    ``now`` and ``max_age_s`` are injection seams so the tests can age a cache
+    deterministically instead of sleeping or patching the clock.
+    """
+    import json
+    import time
+
+    # `_resolve_cache_path` is the reader's OWN resolver (override -> env ->
+    # container bind -> host default). Re-implementing that cascade here is how
+    # a freshness check ends up dating a different file than the picker reads.
+    from .._account.quota_cache import _resolve_cache_path, quota_cache_present
+
+    if not quota_cache_present(quota_cache_path):
+        return False
+
+    # stx-allow: fallback (reason: an unreadable or undated cache is TREATED AS
+    # STALE, which is the conservative branch — it triggers a refresh rather
+    # than allowing a boot on evidence we cannot date)
+    try:
+        payload = json.loads(Path(_resolve_cache_path(quota_cache_path)).read_text())
+        written_at = float(payload["written_at"])
+    except Exception:
+        return False
+
+    current = time.time() if now is None else now
+    return (current - written_at) <= max_age_s

--- a/tests/scitex_agent_container/_lifecycle/test__quota_evidence_freshness.py
+++ b/tests/scitex_agent_container/_lifecycle/test__quota_evidence_freshness.py
@@ -23,16 +23,35 @@ and reads it back through the production resolver. Age is supplied via the
 
 from __future__ import annotations
 
+import io
 import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
 
 import pytest
 
+from scitex_agent_container._creds import BlindQuotaCacheError
 from scitex_agent_container._lifecycle._quota_evidence import (
     QUOTA_EVIDENCE_MAX_AGE_S,
     _has_fresh_quota_evidence,
 )
+from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
+from scitex_agent_container.config import AgentConfig
 
 _NOW = 1_786_000_000.0
+
+# hub's pair. Distinct first dash-segments, because that segment is the quota
+# cache's per-account match key (``short``).
+_EXHAUSTED = "wyusuuke-gmail-com"
+_HEALTHY = "ywatanabe-scitex-ai"
+
+# Older than QUOTA_EVIDENCE_MAX_AGE_S by a wide margin, and the incident's own
+# age. Written relative to the real clock because these boots go through the
+# production reader, which has no ``now`` seam.
+_A_DAY_OLD = 23 * 3600
 
 
 def _write_cache(tmp_path, *, written_at, accounts=None):
@@ -122,6 +141,173 @@ def test_an_unparseable_cache_is_not_evidence(tmp_path):
     fresh = _has_fresh_quota_evidence(path, now=_NOW)
     # Assert
     assert fresh is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a stale cache is REFRESHED, and the gate stays ARMED either way.
+#
+# PA-306: no mocks. The refresh is kept offline WITHOUT patching it —
+# ``_account.claude_usage.fetch_usage_for_credentials`` consults its production
+# per-account cache (``<account_dir>/usage.json``, 5-min TTL) before any token
+# read or network call, so seeding that real file is enough to make the
+# populator succeed, and a snapshot with no ``accessToken`` is enough to make
+# it fail.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _install_cache(tmp_path: Path, accounts: dict) -> Iterator[Path]:
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    cache = tmp_path / "runtime" / "quota-cache.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"written_at": time.time() - _A_DAY_OLD, "accounts": accounts})
+    )
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(cache)
+    try:
+        yield cache
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
+def _entry(short: str, *, h5: float, d7: float) -> dict:
+    return {
+        "short": short,
+        "h5": h5,
+        "d7": d7,
+        "ttl_h": 6.0,
+        "reset_at_5h": None,
+        "reset_at_7d": None,
+    }
+
+
+@pytest.fixture
+def _stale_inverted_cache(tmp_path: Path) -> Iterator[Path]:
+    """A day-old cache whose numbers are the REVERSE of the current truth.
+
+    Inverted rather than merely optimistic on purpose: a stale file that
+    happened to agree with reality could not distinguish a build that
+    re-measures from one that trusts it.
+    """
+    yield from _install_cache(
+        tmp_path,
+        {
+            _EXHAUSTED: _entry("wyusuuke", h5=2.0, d7=5.0),
+            _HEALTHY: _entry("ywatanabe", h5=40.0, d7=100.0),
+        },
+    )
+
+
+@pytest.fixture
+def _stale_blind_cache(tmp_path: Path) -> Iterator[Path]:
+    """A day-old cache that exists and holds NOTHING."""
+    yield from _install_cache(tmp_path, {})
+
+
+def _default_store(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _write_snapshot(store: Path, slug: str, *, with_token: bool = True) -> Path:
+    path = store / slug / ".credentials.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    oauth: dict[str, object] = {"expiresAt": int((time.time() + 7_200.0) * 1_000)}
+    if with_token:
+        oauth["accessToken"] = "not-a-real-token"
+    path.write_text(json.dumps({"claudeAiOauth": oauth}))
+    return path
+
+
+def _seed_usage_cache(creds: Path, *, pct_5h: float, pct_7d: float) -> None:
+    """Seed the REAL per-account usage cache the populator's fetcher reads."""
+    (creds.parent / "usage.json").write_text(
+        json.dumps(
+            {
+                "used_pct_5h": pct_5h,
+                "used_pct_7d": pct_7d,
+                "reset_at_5h": None,
+                "reset_at_7d": None,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "error": None,
+            }
+        )
+    )
+
+
+def _pool_config(name: str, paths: list[Path]) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    cfg.claude.credentials_files = [str(p) for p in paths]
+    return cfg
+
+
+def test_a_stale_cache_is_re_measured_and_its_wrong_numbers_are_not_used(
+    _isolate_home, _stale_inverted_cache
+):
+    """hub's incident end-to-end: the stale numbers point the WRONG WAY.
+
+    The cache on disk says the capped account is at d7=5% and the healthy one
+    at d7=100% — an inversion, because that is what a day-old snapshot of a
+    burning account looks like. The truth lives in each account's real
+    ``usage.json``, which the populator reads.
+
+    A build that trusts the stale file therefore picks the CAPPED account, and
+    one that re-measures picks the healthy one. Asserting on the identity of
+    the picked account rather than on "a refresh happened" means this cannot
+    pass by observing the mechanism while the decision stays wrong.
+    """
+    # Arrange
+    store = _default_store(_isolate_home)
+    p_hot = _write_snapshot(store, _EXHAUSTED)
+    p_cool = _write_snapshot(store, _HEALTHY)
+    _seed_usage_cache(p_hot, pct_5h=12.0, pct_7d=100.0)
+    _seed_usage_cache(p_cool, pct_5h=3.0, pct_7d=5.0)
+    cfg = _pool_config("figrecipe", [p_hot, p_cool])
+
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+    # Assert
+    assert cfg.claude.credentials_file == str(p_cool)
+
+
+def test_a_stale_cache_does_not_disarm_the_fail_loud_gate(
+    _isolate_home, _stale_blind_cache
+):
+    """The regression CI caught: staleness must never soften the refusal.
+
+    A present-but-blind cache older than the window is still a host that RUNS
+    a quota system, so the never-block invariant — which exists for hosts that
+    run none — does not apply to it. Routing staleness into the absent-cache
+    path made this boot DEGRADE and proceed, re-opening the 2026-07-20
+    incident (scitex-cards launched onto a 7d=100% account read as "5h=? 7d=?")
+    while fixing hub's.
+    """
+    # Arrange: a cache that is present, stale, and holds nothing — and no
+    # credential the populator could use to clear the blindness.
+    store = _default_store(_isolate_home)
+    p_a = _write_snapshot(store, _EXHAUSTED, with_token=False)
+    p_b = _write_snapshot(store, _HEALTHY, with_token=False)
+    cfg = _pool_config("figrecipe", [p_a, p_b])
+
+    # Act
+    # Assert
+    with pytest.raises(BlindQuotaCacheError):
+        _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
 
 
 def test_the_window_is_not_generous_enough_to_hide_a_days_drift():

--- a/tests/scitex_agent_container/_lifecycle/test__quota_evidence_freshness.py
+++ b/tests/scitex_agent_container/_lifecycle/test__quota_evidence_freshness.py
@@ -1,0 +1,139 @@
+"""A STALE quota snapshot is not evidence — it routes into a refresh.
+
+MEASURED 2026-08-17, scitex-hub on scitex-compute-03. Its quota cache was
+present, well-formed, and 23 hours old. The boot decision asked only "does a
+cache exist", so the armed path trusted it and the picker read the pinned
+account's previous-day percentages — 7d=15% — as evidence the pin was fine.
+The account was at 7d=100%, capped until Aug 22. hub answered "You've hit
+your weekly limit" on every turn while the restart reported success.
+Refreshing that one cache revived it: the picker then chose a 7d=8% account
+by itself. The selector was never wrong; it was fed a day-old number and had
+no way to know.
+
+This is the SECOND time that failure shape reached production — the module's
+own docstring records scitex-02 on 2026-08-06, an agent booting onto a
+d7=100% account while startup reported success. That fix armed the gate when
+the cache was ABSENT. A STALE cache walks straight past an absence check,
+which is why it recurred.
+
+No mocks: each test writes a REAL cache file with a REAL `written_at` epoch
+and reads it back through the production resolver. Age is supplied via the
+``now`` seam rather than by sleeping.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scitex_agent_container._lifecycle._quota_evidence import (
+    QUOTA_EVIDENCE_MAX_AGE_S,
+    _has_fresh_quota_evidence,
+)
+
+_NOW = 1_786_000_000.0
+
+
+def _write_cache(tmp_path, *, written_at, accounts=None):
+    path = tmp_path / "quota-cache.json"
+    path.write_text(
+        json.dumps(
+            {
+                "written_at": written_at,
+                "accounts": accounts
+                if accounts is not None
+                else {"acct": {"short": "a", "h5": 0.0, "d7": 15.0, "ttl_h": 6.0}},
+            }
+        )
+    )
+    return path
+
+
+def test_a_cache_written_now_is_evidence(tmp_path):
+    """Positive control: the check can return True at all."""
+    # Arrange
+    path = _write_cache(tmp_path, written_at=_NOW)
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is True
+
+
+def test_a_day_old_cache_is_not_evidence(tmp_path):
+    """hub's exact condition: present, well-formed, 23 hours old."""
+    # Arrange
+    path = _write_cache(tmp_path, written_at=_NOW - 23 * 3600)
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_a_cache_just_inside_the_window_is_evidence(tmp_path):
+    """Boundary, from the literal side — not computed from the constant.
+
+    Deriving the boundary from QUOTA_EVIDENCE_MAX_AGE_S on both sides would
+    keep passing if the constant were set to a year.
+    """
+    # Arrange
+    path = _write_cache(tmp_path, written_at=_NOW - 3599)
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is True
+
+
+def test_a_cache_just_outside_the_window_is_not_evidence(tmp_path):
+    # Arrange
+    path = _write_cache(tmp_path, written_at=_NOW - 3601)
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_an_absent_cache_is_not_evidence(tmp_path):
+    # Arrange
+    missing = tmp_path / "nope" / "quota-cache.json"
+    # Act
+    fresh = _has_fresh_quota_evidence(missing, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_an_undated_cache_is_not_evidence(tmp_path):
+    """No `written_at` means the age is unknowable, and unknown is not OK."""
+    # Arrange
+    path = tmp_path / "quota-cache.json"
+    path.write_text(json.dumps({"accounts": {"acct": {"h5": 0.0, "d7": 15.0}}}))
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_an_unparseable_cache_is_not_evidence(tmp_path):
+    """A corrupt cache must fail toward refreshing, never toward launching."""
+    # Arrange
+    path = tmp_path / "quota-cache.json"
+    path.write_text("{not json")
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_the_window_is_not_generous_enough_to_hide_a_days_drift():
+    """The constant must be well under the drift that caused the incident.
+
+    hub's cache was 23h old. A window anywhere near that would have accepted
+    it. Asserted against a literal so widening the constant to paper over a
+    flaky refresher fails here rather than silently restoring the bug.
+    """
+    # Arrange
+    a_day = 24 * 3600
+    # Act
+    window = QUOTA_EVIDENCE_MAX_AGE_S
+    # Assert
+    assert window <= a_day / 4


### PR DESCRIPTION
fix(quota): a STALE snapshot is not evidence — treat it as absent and rebuild

MEASURED 2026-08-17, scitex-hub on scitex-compute-03.

Its quota cache was present, well-formed, and 23 HOURS OLD. The boot decision
asked only whether a cache EXISTS:

    require_quota_evidence = quota_cache_present(quota_cache_path)

so the armed path trusted it, and the picker read the pinned account's
previous-day percentages — 7d=15% — as evidence the pin was fine. The account
was at 7d=100%, capped until Aug 22. hub answered "You've hit your weekly
limit" on EVERY turn while `sac agents restart` reported success, verified,
new run UUID, session cycled. Refreshing that one cache is what revived it:
the picker then chose a 7d=8% account by itself.

THE SELECTOR WAS NEVER WRONG. It was fed a day-old number and had no way to
know, because nothing in the decision looked at AGE.

THIS IS THE SECOND OCCURRENCE OF THE SAME FAILURE, and the first fix is why
it is worth naming. This module's own docstring records scitex-02 on
2026-08-06: an agent booted onto a d7=100% account, sac printed SUCC, tmux
alive, TUI rendering, every turn refused. That fix armed the gate when the
cache was ABSENT. A STALE cache walks straight past an absence check — so the
identical incident recurred eleven days later on a different host with a
different agent.

WHAT CHANGES. `_has_fresh_quota_evidence` replaces the presence test. Absent,
unreadable, undated and stale all return False, which routes into
`_build_evidence_once` — the path that ALREADY EXISTS for "we have no
evidence, go and get some". So a refresh happens before the pick rather than
a day later. Nothing new is invented; an existing repair is reached in a case
that previously bypassed it.

The never-block invariant is untouched: a host that genuinely cannot refresh
still degrades to freshness-only and still warns loudly. Stale now takes the
same route as blind, which is the route that was built for exactly this.

WINDOW: one hour, against a five-minute writer cadence. Deliberately generous
— the question is not "is the cache warm" but "could this number still be
true". An hour of drift cannot turn a healthy account into a capped one under
any realistic burn; a day demonstrably can, and did.

8 tests. The boundary is asserted from LITERALS on both sides (3599 fresh /
3601 stale) rather than computed from the constant, which would keep passing
if someone set the window to a year; a separate test pins the constant at or
below six hours so widening it to paper over a flaky refresher fails here
instead of silently restoring the bug. Sabotage-checked: reverting the check
to presence-only turns exactly the two staleness tests red — the 23-hour case
and the just-outside-window case — and restoring returns 8/8.

Constitution §2: unknown is not "OK", and a number nobody can vouch for is
unknown however confidently it is formatted.
