### PR TITLE
feat(dispatch): name `host:` when the hop it chose fails

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -329,13 +329,67 @@ def try_dispatch(
     )
     if dispatch_peer is None:
         return False
-    (dispatcher or _dispatch_remote_start)(
-        name=config.name,
-        peer=dispatch_peer,
-        dry_run=dry_run,
-        force=force,
-    )
+    try:
+        (dispatcher or _dispatch_remote_start)(
+            name=config.name,
+            peer=dispatch_peer,
+            dry_run=dry_run,
+            force=force,
+        )
+    except Exception:
+        # The failure is re-raised UNCHANGED — this only adds the sentence the
+        # operator needs to attribute it. See :func:`_explain_pinned_hop_failure`.
+        _explain_pinned_hop_failure(
+            config.name, config.hosts_spec.host, dispatch_peer
+        )
+        raise
     return True
+
+
+def _explain_pinned_hop_failure(
+    name: str,
+    spec_host: str | list[str] | None,
+    peer: str,
+) -> None:
+    """Name ``spec.host`` when a dispatch driven by it fails.
+
+    MEASURED 2026-08-09: specs across the fleet carried ``host: ywata-note-win``
+    after the laptop was retired. The lifecycle verbs dispatched there and TWELVE
+    agents died with ``Permission denied (publickey)`` — a message that names the
+    AGENT and never the field that chose the destination. Attributing it took
+    days, because nothing in the output connected "this agent will not start" to
+    "a line in its spec points at a machine that is gone".
+
+    Why this is a message and not a probe: ``_host_chain.resolve_host_chain``
+    deliberately never probes a STRING ``host:`` — only a LIST is probed, where
+    the verdict CHOOSES among alternatives. A pin has no alternatives, so a probe
+    there could only REFUSE, and refusing an explicit pin on a prober's say-so is
+    a worse failure than the one being fixed ("never a licence to reject a host
+    the operator asked for"). Probing pre-emptively would also add an ssh
+    round-trip to every remote start, to say something the imminent hop is about
+    to establish for free.
+
+    So the pin is still obeyed and the error still propagates untouched. What
+    changes is that the operator is no longer left to guess WHY this peer.
+    """
+    if not isinstance(spec_host, str) or not spec_host:
+        # A LIST was already walked and probed candidate-by-candidate, and its
+        # own error accounts for every entry; an empty pin never routes remote.
+        return
+    from .._helpers._console import system_msg
+
+    system_msg(
+        f"{name}: this hop was chosen by `host: {spec_host}` in the agent's "
+        f"spec — sac dispatched to peer {peer!r} because of that line, and the "
+        "hop failed (the error below is the peer's, unmodified). A plain "
+        "`host:` pin is never reachability-probed, so a pin at a machine that "
+        "is retired, asleep, or no longer accepting this key fails HERE, with "
+        "a message that names the agent rather than the spec. If "
+        f"{spec_host} is not where this agent should run, correct or remove "
+        "`host:` — an absent `host:` means 'start on whichever machine runs "
+        "the command'.",
+        style="warn",
+    )
 
 
 def lookup_remote_peer(name: str) -> tuple[str, dict] | None:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch_pinned_hop_failure.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch_pinned_hop_failure.py
@@ -1,0 +1,160 @@
+"""A dispatch chosen by ``host:`` must NAME that line when the hop fails.
+
+MEASURED 2026-08-09: fleet specs still carried ``host: ywata-note-win`` after
+the laptop was retired. The lifecycle verbs dispatched there and TWELVE agents
+died with ``Permission denied (publickey)`` — a message naming the AGENT and
+never the field that picked the destination. Attribution took days, because
+nothing connected "this agent will not start" to "a line in its spec points at
+a machine that is gone".
+
+What is locked here
+-------------------
+1. The peer's error propagates UNCHANGED. The pin is still obeyed; this is a
+   message, not a veto. A plain ``host:`` string is deliberately never
+   reachability-probed (``_host_chain.resolve_host_chain`` — probing a pin
+   could only REFUSE, since a pin has no alternatives to choose between), so
+   the failure still arrives from the hop itself.
+2. The warning NAMES ``host:`` and its value, so the operator can attribute
+   the failure to the spec rather than to the agent.
+3. A LIST pin gets NO such warning — it was walked candidate-by-candidate and
+   its own error already accounts for every entry.
+4. A dispatch that SUCCEEDS says nothing. A warning that also fires on healthy
+   dispatches is one nobody reads.
+
+PA-306: no mocks. ``dispatcher`` is the production injection seam
+``try_dispatch`` already exposes for exactly this, and the failure is a real
+exception raised by a real callable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+
+import pytest
+
+from scitex_agent_container._state.host_config import PeerSpec
+from scitex_agent_container.cli_pkg.lifecycle._dispatch import try_dispatch
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import HostsSpec
+
+# The retired laptop from the incident, and a machine that is not it.
+_RETIRED = "ywata-note-win"
+_HERE = "scitex-compute-04"
+
+# What the failing hop actually said in 2026-08-09. Asserted verbatim so a
+# change that "helpfully" rewraps or replaces the peer's own error fails here.
+_PEER_ERROR = "Permission denied (publickey)"
+
+# ``pytest.raises(match=...)`` is a REGEX search, and the incident's own error
+# text contains "(publickey)" — an empty capture group that matches everywhere,
+# so an unescaped pattern passes against ANY RuntimeError.
+_PEER_ERROR_RE = re.escape(_PEER_ERROR)
+
+# The FIELD together with its VALUE. The peer name alone already appears in
+# ordinary dispatch output, so matching only that would pass against a build
+# that explains nothing.
+_ATTRIBUTION = f"host: {_RETIRED}"
+
+
+def _cfg(host) -> AgentConfig:
+    cfg = AgentConfig(name="figrecipe")
+    cfg.hosts_spec = HostsSpec(host=host, hosts=[])
+    return cfg
+
+
+def _peers(*names) -> dict:
+    return {n: PeerSpec(name=n, ssh=n) for n in names}
+
+
+def _raises_like_the_incident(**_kwargs) -> int:
+    raise RuntimeError(_PEER_ERROR)
+
+
+def _succeeds(**_kwargs) -> int:
+    return 0
+
+
+def _dispatch(host, dispatcher):
+    return try_dispatch(
+        _cfg(host),
+        _HERE,
+        _peers(_RETIRED),
+        dry_run=False,
+        force=False,
+        dispatcher=dispatcher,
+    )
+
+
+# STDERR, not stdout: `system_msg` writes diagnostics to stderr (and to the
+# scitex-logging record). Asserting on `.out` reads an empty string and every
+# "warning is absent" test below would pass against a build that warns
+# correctly — the negative tests would be vacuous rather than merely wrong.
+
+
+@pytest.fixture
+def string_pin_output(capsys) -> str:
+    """Stderr of a STRING-pinned dispatch whose hop failed."""
+    with contextlib.suppress(RuntimeError):
+        _dispatch(_RETIRED, _raises_like_the_incident)
+    return capsys.readouterr().err
+
+
+@pytest.fixture
+def list_pin_output(capsys) -> str:
+    """Output of a LIST-pinned dispatch whose hop failed."""
+    with contextlib.suppress(RuntimeError):
+        _dispatch([_RETIRED], _raises_like_the_incident)
+    return capsys.readouterr().err
+
+
+@pytest.fixture
+def successful_dispatch_output(capsys) -> str:
+    """Output of a STRING-pinned dispatch that SUCCEEDED."""
+    _dispatch(_RETIRED, _succeeds)
+    return capsys.readouterr().err
+
+
+def test_the_peers_error_propagates_unchanged():
+    """The pin is obeyed and the failure is not swallowed or reworded."""
+    # Arrange
+    dispatcher = _raises_like_the_incident
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=_PEER_ERROR_RE):
+        _dispatch(_RETIRED, dispatcher)
+
+
+def test_the_warning_names_the_spec_line_that_chose_the_peer(string_pin_output):
+    """The whole point: `host: ywata-note-win` must appear in the output."""
+    # Arrange
+    text = string_pin_output
+    # Act
+    attributed = _ATTRIBUTION in text
+    # Assert
+    assert attributed is True
+
+
+def test_a_list_pin_is_not_given_the_single_pin_explanation(list_pin_output):
+    """A chain already accounts for every candidate in its own error.
+
+    Two explanations for one failure is worse than one: the chain walk reports
+    which entries were probed and rejected, and a pin-shaped sentence pasted
+    underneath would describe a decision that was not made this way.
+    """
+    # Arrange
+    text = list_pin_output
+    # Act
+    attributed = _ATTRIBUTION in text
+    # Assert
+    assert attributed is False
+
+
+def test_a_dispatch_that_succeeds_explains_nothing(successful_dispatch_output):
+    """A warning that fires on healthy dispatches is one nobody reads."""
+    # Arrange
+    text = successful_dispatch_output
+    # Act
+    attributed = _ATTRIBUTION in text
+    # Assert
+    assert attributed is False


### PR DESCRIPTION
## The incident

**2026-08-09**: fleet specs still carried `host: ywata-note-win` after the laptop was retired. The lifecycle verbs dispatched there and **twelve agents** died with `Permission denied (publickey)` — a message that names the *agent* and never the field that picked the destination. Attribution took days, because nothing in the output connected "this agent will not start" to "a line in its spec points at a machine that is gone".

## What this is not

**Not a refusal, and not a probe.**

`_host_chain.resolve_host_chain` deliberately never probes a STRING `host:` — only a LIST is probed, because there a verdict *chooses among alternatives*. A pin has no alternatives, so a probe there could only **refuse**, and the module states the invariant plainly: never *"a licence to reject a host the operator asked for"*.

Probing pre-emptively would also add an ssh round-trip to every remote start, to learn something the imminent hop establishes for free.

So the pin is still obeyed, the hop still runs, and **the peer's error propagates unchanged**. What changes is that a sentence above it says which spec line chose this peer — and that an absent `host:` means "start on whichever machine runs the command".

A LIST pin is deliberately excluded: it was walked candidate-by-candidate and its own error already accounts for every entry. Two explanations for one failure is worse than one.

## Two test bugs found while writing this

Both would have left a green suite asserting nothing:

| Bug | Why it mattered |
|---|---|
| `pytest.raises(match=...)` is a **regex** search, and the incident's error text contains `(publickey)` | An empty capture group matches everywhere, so the unescaped pattern passed against *any* `RuntimeError` |
| `system_msg` writes to **stderr** | Asserting on `capsys.readouterr().out` read an empty string, making all three "the warning is absent" tests vacuously true against a build that warns correctly |

## Verification

```
746 passed, 4 skipped        full lifecycle suite + audit
0 unmasked audit errors      (the 1 masked PS-226 also fails on develop —
                              the supervised OAuth-refresher unit migration)
ruff --select F401,F811      All checks passed
```

## Context

Answers the `host:`-field question dotfiles raised on 2026-08-14. The other half — removing the stale pins from 49 dormant package specs — is theirs, and is unblocked by four measurements taken tonight:

1. `host:` is optional in the schema (`host: str | list[str] = ""`)
2. state records the actual host (per-`(agent, host)` registry rows)
3. an absent `host:` routes **local**, and is never silently defaulted to a hostname (`_host_chain.py:220-221`)
4. spec writes do not reconcile registry rows — every instance-row writer is lifecycle- or GC-driven
