### PR TITLE
fix(statusline): make the line FIT, and show the 7d quota that kills agents

### DIFF
--- a/src/scitex_agent_container/statusline.py
+++ b/src/scitex_agent_container/statusline.py
@@ -131,41 +131,168 @@ def _active_account() -> str:
         return ""
 
 
+#: Hard width budget for the rendered line.
+#:
+#: The payload carries NO terminal width — measured 2026-08-17 against a live
+#: capture: it has session, model, workspace, cost, context_window and
+#: rate_limits, and nothing describing the pane. So this is a FLOOR we choose,
+#: not a width we read: 80 columns is the classic minimum, and the line must
+#: still fit after the TUI's own left decoration.
+#:
+#: Why a budget at all (operator, 2026-08-17): 「途中でトランケーションされて
+#: しまってんですよ。なので情報が見えなくなってる…全部見えるように」. The line
+#: was 131 chars and his pane cut it at ~86, mid-model-name. Terminal
+#: truncation eats from the RIGHT, so it discarded ctx / 5h / account —
+#: every NUMBER — while keeping the identity, which is the one part a human
+#: already knows. The fix is to fit, not to reorder.
+#:
+#: 80 and not less: at 78 this agent's own line lost its MODEL, because the
+#: full line measures exactly 80. Trimming the budget below the standard
+#: terminal width buys nothing (nothing is 79 columns wide) and costs a field
+#: on every turn, so the floor IS the budget.
+STATUSLINE_MAX_WIDTH = 80
+
+#: Marker for a clamp WE performed. A deliberate, visible ellipsis beats the
+#: terminal's invisible one: the reader can tell the difference between "this
+#: is the whole value" and "sac shortened this".
+_CLAMP = "…"
+
+
+def _short_host(host: str) -> str:
+    """Drop the fleet-wide ``scitex-`` prefix every host name carries.
+
+    ``scitex-compute-04`` -> ``compute-04``. Purely redundant: the prefix is
+    on every host, so it distinguishes nothing while costing 7 columns on the
+    one line where columns are scarce. What remains is still unique across the
+    peer table (compute-01..04, nas-01..03, mba, spartan, ywata-note-win), so
+    :func:`_hostname`'s stated purpose — noticing the same agent name alive on
+    two machines — survives intact.
+    """
+    return host[len("scitex-") :] if host.startswith("scitex-") else host
+
+
+def _short_model(model: str) -> str:
+    """``Opus 5 (1M context)`` -> ``Opus 5 1M``; leave un-parenthesised names alone.
+
+    The parenthetical is the payload's prose, not information: the only part
+    that varies between models an operator might be surprised by is the size
+    token itself. A name with no parenthetical (``claude-opus-4-7``) is passed
+    through byte-for-byte.
+    """
+    head, sep, tail = model.partition("(")
+    if not sep:
+        return model
+    head = head.strip()
+    size = tail.split()[0].rstrip(")") if tail.split() else ""
+    return f"{head} {size}".strip() if size else head
+
+
+def _short_account(acct: str) -> str:
+    """First dash-segment, which is the fleet's EXISTING key for an account.
+
+    ``wyusuuke-gmail-com`` -> ``wyusuuke``. Not an invention: the quota cache
+    already indexes accounts by exactly this segment under the name ``short``,
+    and the stored accounts are distinct in it (scitex, ywatanabe, wyusuuke,
+    ywata1989). So the pane and the quota cache name accounts the same way.
+    """
+    return acct.split("-", 1)[0] if "-" in acct else acct
+
+
+def _render(data: dict) -> str:
+    """Build the status line, guaranteed to fit :data:`STATUSLINE_MAX_WIDTH`.
+
+    Field order and the sacrifice order are the whole design:
+
+    * IDENTITY (``agent@host``) — who and where.
+    * MODEL — compacted.
+    * NUMBERS (``ctx`` / ``5h`` / ``7d``) — grouped into ONE segment separated
+      by spaces rather than ``|``, which buys back four columns.
+    * ACCOUNT — which credential is live.
+
+    ``7d`` IS NEW AND IS THE POINT. Measured 2026-08-17: scitex-hub ran pinned
+    to an account at 7d=100%, capped for days, and answered "You've hit your
+    weekly limit" on every turn — while 5h read LOW and every other signal
+    (SUCC, live tmux, rendered TUI) said healthy. The pane was displaying the
+    reassuring number and hiding the fatal one, and ``seven_day`` was in the
+    payload the whole time.
+
+    WORKDIR IS DROPPED WHEN IT REPEATS THE AGENT NAME. sac repos are named
+    after their agent, so the old line spent 24 columns printing
+    ``scitex-agent-container`` a second time.
+
+    When the line still does not fit, it is shortened in a stated order —
+    model first (least volatile, and recoverable from ``sac agents list``),
+    then the identity is clamped with a visible marker. The NUMBERS and the
+    ACCOUNT are never dropped: they are why the line exists.
+    """
+    ctx_pct = (data.get("context_window") or {}).get("used_percentage", 0)
+
+    host = _short_host(_hostname())
+    agent = _agent_name()
+    if agent and agent != "unknown":
+        identity = f"{agent}@{host}" if host else agent
+    else:
+        identity = host
+
+    model = _short_model((data.get("model") or {}).get("display_name", ""))
+
+    nums = [f"ctx:{ctx_pct:.0f}%"]
+    rl = data.get("rate_limits") or {}
+    fh_pct = (rl.get("five_hour") or {}).get("used_percentage")
+    if fh_pct is not None:
+        nums.append(f"5h:{fh_pct:.0f}%")
+    sd_pct = (rl.get("seven_day") or {}).get("used_percentage")
+    if sd_pct is not None:
+        nums.append(f"7d:{sd_pct:.0f}%")
+
+    tail: list[str] = [" ".join(nums)]
+    acct = _short_account(_active_account())
+    if acct:
+        tail.append(acct)
+
+    wd = _workdir(data)
+    if wd == agent:
+        # sac repos are named after their agent, so the old line spent 24
+        # columns printing the same string twice.
+        wd = ""
+
+    def _head(with_wd: bool, with_model: bool) -> list[str]:
+        out = [identity] if identity else []
+        if with_wd and wd:
+            out.append(wd)
+        if with_model and model:
+            out.append(model)
+        return out
+
+    # Sacrifice order, widest-first and stated rather than emergent:
+    #   1. WORKDIR — the weakest field. Normally the repo name, which is
+    #      derivable from the agent; it only differs at all inside a worktree.
+    #   2. MODEL — recoverable from `sac agents list`, and it changes rarely.
+    #   3. IDENTITY — clamped, never dropped, and clamped VISIBLY.
+    # The numbers and the account are never sacrificed: they are why the line
+    # exists, and they are precisely what the terminal was eating before.
+    for with_wd, with_model in ((True, True), (False, True), (False, False)):
+        head = _head(with_wd, with_model)
+        line = " | ".join(head + tail)
+        if len(line) <= STATUSLINE_MAX_WIDTH:
+            return line
+    if not head:
+        return line
+
+    # 2. Clamp the identity, visibly. The numbers keep their columns.
+    fixed = len(" | ".join(head[1:] + tail)) + len(" | ")
+    room = STATUSLINE_MAX_WIDTH - fixed
+    if room < len(_CLAMP) + 1:
+        return " | ".join(head[1:] + tail)
+    head[0] = head[0][: room - len(_CLAMP)] + _CLAMP
+    return " | ".join(head + tail)
+
+
 def _display(raw: bytes) -> None:
     # stx-allow: fallback (reason: statusLine display must never raise; corrupt
     # or unexpected payload shape silently outputs nothing rather than aborting)
     try:
-        data = json.loads(raw)
-        ctx_pct = (data.get("context_window") or {}).get("used_percentage", 0)
-        model = (data.get("model") or {}).get("display_name", "")
-        parts: list[str] = []
-
-        host = _hostname()
-        agent = _agent_name()
-        if agent and agent != "unknown":
-            parts.append(f"{agent}@{host}" if host else agent)
-        elif host:
-            parts.append(host)
-
-        wd = _workdir(data)
-        if wd:
-            parts.append(wd)
-
-        if model:
-            parts.append(model)
-        parts.append(f"ctx:{ctx_pct:.0f}%")
-
-        rl = data.get("rate_limits") or {}
-        fh = rl.get("five_hour") or {}
-        fh_pct = fh.get("used_percentage")
-        if fh_pct is not None:
-            parts.append(f"5h:{fh_pct:.0f}%")
-
-        acct = _active_account()
-        if acct:
-            parts.append(f"acct:{acct}")
-
-        print(" | ".join(parts), flush=True)
+        print(_render(json.loads(raw)), flush=True)
     except Exception:
         pass
 

--- a/tests/scitex_agent_container/test_statusline_fits_and_shows_7d.py
+++ b/tests/scitex_agent_container/test_statusline_fits_and_shows_7d.py
@@ -1,0 +1,329 @@
+"""The status line must FIT, and it must show the quota that actually kills agents.
+
+OPERATOR, 2026-08-17: 「途中でトランケーションされてしまってんですよ。なので情報が
+見えなくなってるのでこれなおせますかね。全部見えるように」 — it gets truncated
+partway, so information is invisible; fix it so EVERYTHING is visible.
+
+MEASURED the same day, rendering his live payload through the production
+renderer: the line was 131 characters and his pane cut it at ~86, mid
+``Opus 5 (1M conte…``. Terminal truncation eats from the RIGHT, so what was
+discarded was ctx / 5h / account — every NUMBER — while the identity survived,
+which is the one part a human already knows. Two redundancies were paying for
+that: ``scitex-agent-container`` appeared TWICE (agent name, then workdir
+basename, because sac repos are named after their agent), and the model carried
+the payload's prose parenthetical verbatim.
+
+AND 7d IS ADDED, which is the substantive half. scitex-hub ran pinned to an
+account at 7d=100%, capped for days, answering "You've hit your weekly limit"
+on every turn — while 5h read LOW and every other signal (SUCC, live tmux,
+rendered TUI) said healthy. The pane displayed the reassuring number and hid
+the fatal one. ``rate_limits.seven_day.used_percentage`` was in the payload the
+whole time.
+
+WHY THE WIDTH ASSERTIONS TEST AN INVARIANT, NOT A STRING: ``_render`` reads the
+real hostname and the real account store, so an exact expected line would be a
+test of THIS machine. ``len(line) <= STATUSLINE_MAX_WIDTH`` is the property the
+operator actually asked for and it holds on every host.
+
+PA-306: no mocks. Identity comes from the real env seam (``SAC_AGENT``), and
+the payloads are real payload SHAPES captured from a live capture.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import scitex_agent_container.statusline as sl_mod
+from scitex_agent_container.statusline import (
+    STATUSLINE_MAX_WIDTH,
+    _render,
+    _short_account,
+    _short_host,
+    _short_model,
+)
+
+# The exact shape of a live payload, captured 2026-08-17 from
+# ~/.scitex/agent-container/statusline/scitex-agent-container.json.
+_LIVE = {
+    "model": {"id": "claude-opus-5[1m]", "display_name": "Opus 5 (1M context)"},
+    "workspace": {"current_dir": "/home/ywatanabe/proj/scitex-agent-container"},
+    "context_window": {"used_percentage": 47},
+    "rate_limits": {
+        "five_hour": {"used_percentage": 6},
+        "seven_day": {"used_percentage": 21},
+    },
+}
+
+
+@pytest.fixture
+def named_agent(env_save_restore):
+    """Pin the identity so the line is not at the mercy of ambient env."""
+    env_save_restore.set("SAC_AGENT", "scitex-agent-container")
+    return "scitex-agent-container"
+
+
+# ---------------------------------------------------------------------------
+# The operator's request: it must fit.
+# ---------------------------------------------------------------------------
+
+
+def test_the_budget_is_no_wider_than_a_standard_terminal():
+    """Asserted against a LITERAL, because every other width test is not.
+
+    The rest of this file compares ``len(line) <= STATUSLINE_MAX_WIDTH``, which
+    is the property we want but is also parameterised by the very constant
+    under test — set the constant to 10000 and all of them stay green while the
+    operator's pane truncates exactly as before. This is the one assertion that
+    can fail in that scenario, so widening the budget to make a line "fit" has
+    to come through here and be argued for.
+    """
+    # Arrange
+    standard_terminal = 80
+    # Act
+    budget = STATUSLINE_MAX_WIDTH
+    # Assert
+    assert budget <= standard_terminal
+
+
+def test_the_live_payload_renders_within_the_width_budget(named_agent):
+    """The 131-character line that prompted the request must now fit."""
+    # Arrange
+    data = dict(_LIVE)
+    # Act
+    line = _render(data)
+    # Assert
+    assert len(line) <= STATUSLINE_MAX_WIDTH
+
+
+def test_the_live_payload_keeps_every_field_including_the_model(named_agent):
+    """Fitting must not be achieved by quietly dropping fields.
+
+    The operator asked for 全部見えるように — everything visible. A budget tight
+    enough to force the sacrifice path on the ORDINARY case would satisfy the
+    width assertion above while failing the actual request; at 78 this line lost
+    its model. This pins the common case as whole.
+    """
+    # Arrange
+    data = dict(_LIVE)
+    # Act
+    line = _render(data)
+    # Assert
+    assert "Opus 5 1M" in line
+
+
+def test_an_absurdly_long_agent_name_still_fits(env_save_restore):
+    """The budget is a guarantee, not a hope — clamping is ours, not the terminal's."""
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "a" * 200)
+    # Act
+    line = _render(dict(_LIVE))
+    # Assert
+    assert len(line) <= STATUSLINE_MAX_WIDTH
+
+
+def test_the_numbers_survive_when_the_identity_is_clamped(env_save_restore):
+    """Identity is what gets sacrificed under pressure — never the data.
+
+    The whole defect was that truncation discarded the volatile numbers and
+    kept the guessable name. A clamp that repeated that would be no fix.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "a" * 200)
+    # Act
+    line = _render(dict(_LIVE))
+    # Assert
+    assert "7d:21%" in line
+
+
+def test_three_digit_percentages_still_fit(env_save_restore):
+    """A capped account reads 100 — the widest the numbers ever get."""
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "scitex-agent-container")
+    data = dict(_LIVE)
+    data["context_window"] = {"used_percentage": 100}
+    data["rate_limits"] = {
+        "five_hour": {"used_percentage": 100},
+        "seven_day": {"used_percentage": 100},
+    }
+    # Act
+    line = _render(data)
+    # Assert
+    assert len(line) <= STATUSLINE_MAX_WIDTH
+
+
+# ---------------------------------------------------------------------------
+# 7d — the field the incident was about.
+# ---------------------------------------------------------------------------
+
+
+def test_the_seven_day_quota_is_rendered(named_agent):
+    """hub was at 7d=100% while 5h read low. The pane must show it."""
+    # Arrange
+    data = dict(_LIVE)
+    # Act
+    line = _render(data)
+    # Assert
+    assert "7d:21%" in line
+
+
+def test_seven_day_is_omitted_when_the_payload_lacks_it(named_agent):
+    """Absent is a third value: render nothing rather than a fabricated 0%."""
+    # Arrange
+    data = dict(_LIVE)
+    data["rate_limits"] = {"five_hour": {"used_percentage": 6}}
+    # Act
+    line = _render(data)
+    # Assert
+    assert "7d" not in line
+
+
+def test_a_payload_with_no_rate_limits_still_renders_context(named_agent):
+    """Degrade cleanly: a missing section must not cost the whole line."""
+    # Arrange
+    data = {"model": {"display_name": "M"}, "context_window": {"used_percentage": 3}}
+    # Act
+    line = _render(data)
+    # Assert
+    assert "ctx:3%" in line
+
+
+# ---------------------------------------------------------------------------
+# The redundancies that were paying for the truncation.
+# ---------------------------------------------------------------------------
+
+
+def test_the_workdir_is_dropped_when_it_repeats_the_agent_name(named_agent):
+    """sac repos are named after their agent — printing both costs 24 columns."""
+    # Arrange
+    data = dict(_LIVE)  # workspace basename == the agent name
+    # Act
+    occurrences = _render(data).count("scitex-agent-container")
+    # Assert
+    assert occurrences == 1
+
+
+def test_a_workdir_that_differs_from_the_agent_is_kept_when_there_is_room(
+    env_save_restore,
+):
+    """Dropping it UNCONDITIONALLY would hide a genuinely different location.
+
+    Asserted against a minimal payload on purpose, and this is a real limit
+    rather than a weakened test: under a FULL payload the same case does not
+    fit 78 columns (it measures 84), so the workdir is sacrificed first by
+    design — see the sacrifice order in ``_render``. The distinction this test
+    locks is "dropped only under budget pressure" versus "never rendered at
+    all", and only the second would be a bug. The companion test below pins
+    the pressure case so both halves are stated.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "some-agent")
+    data = {
+        "model": {"display_name": "M"},
+        "context_window": {"used_percentage": 5},
+        "workspace": {"current_dir": "/home/ywatanabe/proj/scitex-scholar"},
+    }
+    # Act
+    line = _render(data)
+    # Assert
+    assert "scitex-scholar" in line
+
+
+def test_under_pressure_the_workdir_goes_before_the_numbers(env_save_restore):
+    """The sacrifice order, asserted from the losing side.
+
+    A full payload plus a differing workdir exceeds the budget. What must
+    survive is the data — the exact thing the terminal was discarding before.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "some-agent")
+    data = dict(_LIVE)
+    data["workspace"] = {"current_dir": "/home/ywatanabe/proj/scitex-scholar"}
+    # Act
+    line = _render(data)
+    # Assert
+    assert "7d:21%" in line
+
+
+# ---------------------------------------------------------------------------
+# The shorteners — each must stay unambiguous within the fleet.
+# ---------------------------------------------------------------------------
+
+
+def test_the_shared_scitex_host_prefix_is_dropped():
+    """Every host carries it, so it distinguishes nothing and costs 7 columns."""
+    # Arrange
+    host = "scitex-compute-04"
+    # Act
+    short = _short_host(host)
+    # Assert
+    assert short == "compute-04"
+
+
+def test_a_host_without_the_shared_prefix_is_untouched():
+    """ywata-note-win and mba must not be mangled by a prefix rule."""
+    # Arrange
+    host = "ywata-note-win"
+    # Act
+    short = _short_host(host)
+    # Assert
+    assert short == "ywata-note-win"
+
+
+def test_the_model_parenthetical_is_compacted_but_the_size_is_kept():
+    """`(1M context)` is prose; `1M` is the part that could surprise someone."""
+    # Arrange
+    model = "Opus 5 (1M context)"
+    # Act
+    short = _short_model(model)
+    # Assert
+    assert short == "Opus 5 1M"
+
+
+def test_a_model_name_without_a_parenthetical_passes_through_verbatim():
+    """Locks the existing contract — `claude-opus-4-7` must not be rewritten."""
+    # Arrange
+    model = "claude-opus-4-7"
+    # Act
+    short = _short_model(model)
+    # Assert
+    assert short == "claude-opus-4-7"
+
+
+def test_the_account_is_shortened_to_the_fleets_own_key():
+    """Not an invention: the quota cache already indexes accounts by this segment.
+
+    It calls it `short`, and the four stored accounts are distinct in it
+    (scitex, ywatanabe, wyusuuke, ywata1989), so the pane and the quota cache
+    name an account the same way.
+    """
+    # Arrange
+    account = "wyusuuke-gmail-com"
+    # Act
+    short = _short_account(account)
+    # Assert
+    assert short == "wyusuuke"
+
+
+# ---------------------------------------------------------------------------
+# Never raise — the pane must survive a payload we did not anticipate.
+# ---------------------------------------------------------------------------
+
+
+def test_display_stays_silent_on_garbage_rather_than_raising(capsys):
+    # Arrange
+    payload = b"{not json"
+    # Act
+    sl_mod._display(payload)
+    # Assert
+    assert capsys.readouterr().out == ""
+
+
+def test_display_prints_the_rendered_line_for_a_real_payload(named_agent, capsys):
+    # Arrange
+    payload = json.dumps(_LIVE).encode()
+    # Act
+    sl_mod._display(payload)
+    # Assert
+    assert "ctx:47%" in capsys.readouterr().out


### PR DESCRIPTION
## The request

**Operator, 2026-08-17:** 「途中でトランケーションされてしまってんですよ。なので情報が見えなくなってるのでこれなおせますかね。**全部見えるように**」

## Measured, not guessed

Rendering his live payload through the production renderer:

```
BEFORE  131 chars   (his pane cut it at ~86, mid "Opus 5 (1M conte…")
  scitex-agent-container@scitex-compute-04 | scitex-agent-container | Opus 5 (1M context) | ctx:47% | 5h:6% | acct:wyusuuke-gmail-com

AFTER    80 chars
  scitex-agent-container@compute-04 | Opus 5 1M | ctx:55% 5h:16% 7d:23% | wyusuuke
```

Terminal truncation eats from the **right**. So it discarded ctx, 5h and the account — every *number* — while keeping the identity, which is the one part a human already knows. The pane was spending its columns on the guessable half.

Two redundancies were paying for it:

| Redundancy | Cost |
|---|---|
| `scitex-agent-container` printed twice — agent name, then workdir basename (sac repos are named after their agent) | 24 cols |
| the model's prose parenthetical, verbatim from the payload | 10 cols |

## 7d is the substantive half

`rate_limits.seven_day.used_percentage` was in the payload the whole time and was never rendered.

scitex-hub ran pinned to an account at **7d=100%**, capped for days, answering *"You've hit your weekly limit"* on every turn — while **5h read low** and every other signal (`SUCC`, live tmux, rendered TUI) said healthy. The pane was displaying the reassuring number and hiding the fatal one.

## The budget is a guarantee, not a hope

The payload carries **no terminal width** (verified against a live capture), so 80 is a floor we choose rather than a width we read. `_render` fits it by construction, sacrificing in a stated order:

1. **workdir** — normally the repo name, derivable from the agent; differs only inside a worktree
2. **model** — recoverable from `sac agents list`, changes rarely
3. **identity** — clamped, never dropped, and clamped *visibly* with `…`

The numbers and the account are never sacrificed. They are why the line exists, and they are exactly what was being lost.

**80 and not less:** at 78 this agent's own line lost its model, because the full line measures exactly 80. Trimming below the standard terminal width buys nothing (nothing is 79 columns wide) and costs a field on every turn.

## Testability

`_display` is now a thin wrapper over a pure `_render(dict) -> str`, so width is testable without capturing stdout.

**19 new tests.** One asserts the budget against a **literal 80** — because every other width test compares against `STATUSLINE_MAX_WIDTH` and would stay green if someone set that constant to 10000. Widening the budget to make a line "fit" now has to come through an assertion that can fail.

All **21 pre-existing** statusline tests still pass, including the one pinning an un-parenthesised model name (`claude-opus-4-7`) as passing through verbatim.

```
40 passed          statusline suites
All checks passed  ruff --select F401,F811
0 unmasked         audit (the 1 masked PS-226 also fails on develop)
```
