### PR TITLE
fix(statusline): budget 76, measured from the fleet's panes rather than assumed

### DIFF
--- a/src/scitex_agent_container/statusline.py
+++ b/src/scitex_agent_container/statusline.py
@@ -146,11 +146,34 @@ def _active_account() -> str:
 #: every NUMBER — while keeping the identity, which is the one part a human
 #: already knows. The fix is to fit, not to reorder.
 #:
-#: 80 and not less: at 78 this agent's own line lost its MODEL, because the
-#: full line measures exactly 80. Trimming the budget below the standard
-#: terminal width buys nothing (nothing is 79 columns wide) and costs a field
-#: on every turn, so the floor IS the budget.
-STATUSLINE_MAX_WIDTH = 80
+#: 76, AND THIS NUMBER IS MEASURED RATHER THAN CHOSEN. The first version of
+#: this fix used 80 on the reasoning that 80 is the standard terminal width.
+#: That was an assumption, and an adversarial pass measured the host's actual
+#: tmux panes and refuted it:
+#:
+#:     89 cols  dotfiles, handyman-01..04, scitex-agent-container,
+#:              scitex-dev, scitex-hub
+#:     80 cols  handyman-03/05/06/07/08, scitex-cards, scitex-hpc
+#:
+#: TWO populations, not one. Claude Code indents the line 2 columns and then
+#: truncates, and the measured content budget is pane_width - 3 (one sample at
+#: -4). So an 80-char line is fine on an 89-column pane — the operator's — and
+#: STILL TRUNCATES on the seven agents sitting at 80. Conservative rule
+#: pane_width - 4 gives 76.
+#:
+#: And the population is not stable: host tmux runs `window-size latest` with
+#: `default-size 80x24`, and sac never pins a size (`_runners/_tmux/tmux.py`
+#: builds `new-session -d -s <name>` with no -x/-y). A pane is 89 only while
+#: the operator's client is attached, and can become 80 UNDER A RUNNING AGENT.
+#: So the budget must target the minimum, not the pane we happen to see.
+#:
+#: DO NOT try to measure the width at runtime — every probe available here
+#: lies. The payload carries no width field; COLUMNS/LINES are unset; `stty
+#: size` fails with ENOTTY; and `tput cols` returns 80 from the terminfo
+#: DEFAULT (`screen-256color` has cols#80), which is right by coincidence on
+#: an 80-column pane and silently wrong on an 89-column one, with the two
+#: cases indistinguishable from the return value.
+STATUSLINE_MAX_WIDTH = 76
 
 #: Marker for a clamp WE performed. A deliberate, visible ellipsis beats the
 #: terminal's invisible one: the reader can tell the difference between "this

--- a/tests/scitex_agent_container/test_statusline_fits_and_shows_7d.py
+++ b/tests/scitex_agent_container/test_statusline_fits_and_shows_7d.py
@@ -69,22 +69,34 @@ def named_agent(env_save_restore):
 # ---------------------------------------------------------------------------
 
 
-def test_the_budget_is_no_wider_than_a_standard_terminal():
+def test_the_budget_fits_the_narrowest_pane_in_the_fleet():
     """Asserted against a LITERAL, because every other width test is not.
 
     The rest of this file compares ``len(line) <= STATUSLINE_MAX_WIDTH``, which
     is the property we want but is also parameterised by the very constant
     under test — set the constant to 10000 and all of them stay green while the
-    operator's pane truncates exactly as before. This is the one assertion that
-    can fail in that scenario, so widening the budget to make a line "fit" has
-    to come through here and be argued for.
+    panes truncate exactly as before. This is the one assertion that can fail in
+    that scenario, so widening the budget to make a line "fit" has to come
+    through here and be argued for.
+
+    76 IS MEASURED, NOT CHOSEN, and the first version of this file got it wrong.
+    It asserted ``<= 80`` on the reasoning that 80 is the standard terminal
+    width. An adversarial pass measured the host's real tmux panes and found TWO
+    populations — 89 columns (the operator's, and 5 others) and 80 columns
+    (seven agents). Claude Code indents 2 columns and truncates, with a measured
+    content budget of pane_width - 3 (one sample at -4). So the 80 I shipped was
+    fine on the pane I could see and still truncated on seven I could not.
+
+    The literal here is therefore the NARROWEST pane's budget, not a convention:
+    80 - 4. And it must stay the narrowest, because host tmux runs
+    `window-size latest`, so a pane can shrink to 80 under a running agent.
     """
     # Arrange
-    standard_terminal = 80
+    narrowest_pane_budget = 76
     # Act
     budget = STATUSLINE_MAX_WIDTH
     # Assert
-    assert budget <= standard_terminal
+    assert budget <= narrowest_pane_budget
 
 
 def test_the_live_payload_renders_within_the_width_budget(named_agent):
@@ -97,20 +109,57 @@ def test_the_live_payload_renders_within_the_width_budget(named_agent):
     assert len(line) <= STATUSLINE_MAX_WIDTH
 
 
-def test_the_live_payload_keeps_every_field_including_the_model(named_agent):
-    """Fitting must not be achieved by quietly dropping fields.
+def test_an_ordinary_agent_keeps_every_field_including_the_model(env_save_restore):
+    """Fitting must not be achieved by quietly dropping fields for EVERYONE.
 
-    The operator asked for 全部見えるように — everything visible. A budget tight
-    enough to force the sacrifice path on the ORDINARY case would satisfy the
-    width assertion above while failing the actual request; at 78 this line lost
-    its model. This pins the common case as whole.
+    The operator asked for 全部見えるように. A budget so tight that the sacrifice
+    path fires on every agent would satisfy the width assertion while failing
+    the request.
+
+    "Ordinary" is doing real work in that name. At the measured 76-column budget
+    the whole line fits for a typical agent name, and does NOT fit for the
+    longest ones — `scitex-agent-container` (22 chars) is already over, and the
+    fleet's longest is 32. That is the sacrifice order behaving correctly under
+    a real constraint, not a regression, and the companion tests below pin the
+    losing side. Naming this test for the ordinary case rather than for "the
+    live payload" is the honest description of what it can promise.
     """
     # Arrange
-    data = dict(_LIVE)
+    env_save_restore.set("SAC_AGENT", "scitex-dev")
     # Act
-    line = _render(data)
+    line = _render(dict(_LIVE))
     # Assert
     assert "Opus 5 1M" in line
+
+
+def test_the_fleets_longest_agent_name_still_fits(env_save_restore):
+    """The real worst case, measured across 135 distinct fleet agent names.
+
+    `clew-cohort-a-scitex-capsule-001` is 32 characters and ties two siblings
+    for longest; with `@scitex-compute-04` the identity segment alone is 50,
+    which is most of the budget before a single number is reached.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "clew-cohort-a-scitex-capsule-001")
+    # Act
+    line = _render(dict(_LIVE))
+    # Assert
+    assert len(line) <= STATUSLINE_MAX_WIDTH
+
+
+def test_the_fleets_longest_agent_name_keeps_its_numbers(env_save_restore):
+    """Fitting is not enough — the data must be what survives the squeeze.
+
+    An identity that consumes most of the budget is exactly the case where a
+    naive implementation would spend the line on the name and truncate the
+    quota, which is the defect this whole change exists to remove.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "clew-cohort-a-scitex-capsule-001")
+    # Act
+    line = _render(dict(_LIVE))
+    # Assert
+    assert "7d:21%" in line
 
 
 def test_an_absurdly_long_agent_name_still_fits(env_save_restore):


### PR DESCRIPTION
## What #1097 got wrong

#1097 shipped `STATUSLINE_MAX_WIDTH = 80` on the reasoning that 80 is the standard terminal width. That was an assumption dressed as a constant. An adversarial pass measured the host's real tmux panes:

| width | agents |
|---|---|
| **89 cols** | dotfiles, handyman-01..04, scitex-agent-container, scitex-dev, scitex-hub |
| **80 cols** | handyman-03/05/06/07/08, scitex-cards, scitex-hpc |

Claude Code indents 2 columns and truncates; measured content budget is `pane_width - 3` (one sample at `-4`). So the 80-char line #1097 produces is fine on an 89-column pane — **the operator's, the one whose truncation prompted the fix** — and still truncates on the seven agents at 80.

I fixed the pane I could see.

Conservative rule `pane_width - 4` → **76**.

## The population is not stable either

Host tmux runs `window-size latest` with `default-size 80x24`, and sac never pins a size (`_runners/_tmux/tmux.py` builds `new-session -d -s <name>`, no `-x`/`-y`). A pane is 89 only while a client is attached and can become 80 **under a running agent**. The budget must target the minimum.

## Verified against the fleet's real worst case

135 distinct agent names; longest is 32 and ties two siblings.

```
68  scitex-dev@compute-04 | Opus 5 1M | ctx:66% 5h:28% 7d:25% | wyusuuke
68  scitex-agent-container@compute-04 | ctx:66% 5h:28% 7d:25% | wyusuuke
76  clew-cohort-a-scitex-capsule-001@compute… | ctx:66% … | wyusuuke
```

Ordinary name keeps every field; a 22-char name sacrifices the model; the fleet's longest clamps the identity **visibly** and still carries every number and the account.

## Do not probe the width at runtime

Every probe available here lies, and one lies dangerously: `tput cols` returns **80 from the terminfo default** (`screen-256color` declares `cols#80`) — correct by coincidence on an 80-column pane, silently wrong on an 89-column one, and the two are indistinguishable from the return value. The payload has no width field, `COLUMNS`/`LINES` are unset, `stty size` fails with ENOTTY. Recorded in the constant's docstring.

## Tests

The literal guard now pins the **narrowest pane's** budget (76) rather than a convention (80). Two new cases cover the fleet's longest name: that it fits, and that its **numbers** survive the squeeze. `test_the_live_payload_keeps_every_field` is renamed to `test_an_ordinary_agent_...` because that is what it can honestly promise — at 76 the longest names do sacrifice the model, and the companion tests pin that losing side rather than leaving it implied.

```
42 passed
All checks passed   ruff --select F401,F811
```