### PR TITLE
chore(release): promote develop to main as 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-08-17
+
+Six commits, and the theme is the same defect in five different places: **a
+check that runs, computes the correct answer, and has no consumer.** A broken
+check gets contradicted eventually; these were right, and the information died
+in the field.
+
+### Fixed
+
+- **A STALE quota snapshot now triggers a re-measure instead of being trusted
+  (#1095).** Measured on scitex-hub, compute-03: its quota cache was present,
+  well-formed, and 23 HOURS OLD. The boot gate asked only "does a cache exist",
+  so the picker read the pinned account's previous-day percentages — 7d=15% —
+  as evidence the pin was fine. The account was at 7d=100%, capped until Aug 22.
+  hub answered "You've hit your weekly limit" on every turn while the restart
+  reported success. Refreshing that one cache revived it: the picker then chose
+  a 7d=8% account by itself. The selector was never wrong; it was fed a day-old
+  number and had no way to know.
+
+  PRESENCE and AGE now answer different questions and stay separate. Presence
+  means this host runs a quota system, so the gate is ARMED — always. Age means
+  the numbers may no longer be true, so the cache is re-measured before the
+  pick. The first attempt at this fix routed staleness into the ABSENT-cache
+  path, which DEGRADES when its refresh fails — that would have started booting
+  agents on a present-but-blind cache instead of refusing them, re-opening the
+  2026-07-20 incident while fixing hub's. Two existing tests caught it.
+
+- **The status line FITS, and shows the 7d quota (#1097, #1098).** Measured by
+  rendering a live payload through the production renderer: 131 characters,
+  truncated by the pane at ~86, mid `Opus 5 (1M conte…`. Truncation eats from
+  the RIGHT, so it discarded ctx, 5h and the account — every NUMBER — while
+  keeping the identity, which is the one part a human already knows.
+
+  Two redundancies were paying for it: the agent name appeared twice (once as
+  the name, once as the workdir basename, because sac repos are named after
+  their agent), and the model carried the payload's prose parenthetical.
+
+  `7d` is the substantive half. hub's incident was a 7d=100% account while 5h
+  read LOW; the pane displayed the reassuring number and hid the fatal one, and
+  `seven_day.used_percentage` was in the payload the whole time.
+
+  The width budget is 76 and it is MEASURED, not chosen. #1097 shipped 80 on
+  the reasoning that 80 is the standard terminal width; measuring the host's
+  real tmux panes found TWO populations — 89 columns and 80 — so an 80-char
+  line was fine on the pane whose truncation prompted the fix and still
+  truncated on seven agents. Host tmux runs `window-size latest`, so a pane can
+  shrink to 80 under a running agent; the budget targets the minimum. Do not
+  probe the width at runtime: `tput cols` returns 80 from the terminfo DEFAULT
+  with no tty, which is right by coincidence at 80 columns and silently wrong
+  at 89.
+
+- **`sac host sync --check` no longer reports a finding as ill health (#1093).**
+  `--exit-zero` for the timer: a check that finds drift has done its job, and
+  an exit code that conflates "I found something" with "I failed" turns the
+  unit red for working correctly.
+
+### Changed
+
+- **`accounts list` refreshes the quota snapshot before rendering it (#1094).**
+  Operator, asked twice: 「sac accounts list should automatically refresh the
+  snapshot beforehand … it is just time consuming for me to type it by
+  myself」. A stale snapshot here is worse than none — measured the same day,
+  same account, two hosts: one read 7d=15% while the account was capped at
+  100%. This is the command an operator reaches for to decide which account to
+  use. `--no-refresh-quota` opts out. The refresh is USAGE-ONLY and never
+  touches a credential.
+
+- **A failed dispatch now NAMES the `host:` line that chose the peer (#1096).**
+  2026-08-09: fleet specs carried `host: ywata-note-win`; the lifecycle verbs
+  dispatched there and twelve agents died with `Permission denied (publickey)`
+  — a message naming the AGENT and never the field that picked the destination.
+
+  Not a refusal and not a probe. `_host_chain.resolve_host_chain` deliberately
+  exempts a bare STRING pin from the reachability oracle: for a LIST the verdict
+  CHOOSES among alternatives, but a pin has no alternatives, so probing could
+  only REFUSE — and the module's invariant is "never a licence to reject a host
+  the operator asked for". The pin is still obeyed and the peer's error
+  propagates unchanged; only the silence is removed.
+
 ## [0.26.0] - 2026-08-17
 
 Promotes 50 commits of accumulated `develop` work to `main`. Cut because

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.26.0"
+version = "0.26.1"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -267,12 +267,21 @@ def provide_jobs() -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-host-sync-check",
             schedule="0 * * * *",  # hourly (cron form; timer cadence below)
-            command="sac host sync --check --all --alarm",
+            command="sac host sync --check --all --alarm --exit-zero",
             description=(
                 "Read-only drift check of every peer's sac checkout vs the "
                 "centre; records each verdict in sac's own event log so the "
                 "shout is DURABLE. Mutates nothing on any peer — never runs "
-                "the fast-forward remedy (Stage 1)."
+                "the fast-forward remedy (Stage 1). "
+                "--exit-zero because FINDING drift is not this unit being "
+                "unhealthy. MEASURED 2026-08-17: without it, drift exits 1 "
+                "and undetermined exits 2, systemd recorded the unit "
+                "`failed`, compute-04 went `degraded`, and the dotfiles sync "
+                "installer read `is-system-running: degraded` as 'systemd "
+                "absent' and silently refused to install its timer — so that "
+                "host stopped receiving dotfiles sync altogether. The verdict "
+                "still reaches its real readers: the printed report, the JSON "
+                "`exit_code`, and the --alarm event-log record."
             ),
             kind="timer",
             # First check 10min after boot/login (peers reachable, listen

--- a/src/scitex_agent_container/_lifecycle/_quota_evidence.py
+++ b/src/scitex_agent_container/_lifecycle/_quota_evidence.py
@@ -102,12 +102,45 @@ def pick_with_quota_evidence(
     """
     from .._account.quota_cache import quota_cache_present
 
+    # PRESENCE decides whether this host runs a quota system at all, and that
+    # is the only question the never-block invariant turns on. AGE decides
+    # whether the numbers may still be true, and its only remedy is a refresh.
+    # Keeping those two separate is the whole correction here: staleness must
+    # never DISARM the gate, because "the cache is old" and "this host has no
+    # cache" call for opposite treatment.
+    #
+    # MEASURED 2026-08-17, scitex-hub on scitex-compute-03. Its quota cache was
+    # present, well-formed, and 23 HOURS OLD. Nothing in this decision looked
+    # at age, so the armed path trusted it and the picker read the pinned
+    # account's stale percentages — 7d=15% from the previous day — as evidence
+    # that the pin was fine. The account was actually at 7d=100%, capped until
+    # Aug 22. hub kept the pin and answered "You've hit your weekly limit" on
+    # every turn while the restart reported success. Refreshing that one cache
+    # was what revived it: the picker then chose a 7d=8% account by itself. The
+    # selector was never wrong; it was fed a day-old number and had no way to
+    # know.
+    #
+    # The first attempt at this fix routed a stale cache into
+    # `_build_evidence_once` — the ABSENT-cache path — which looks equivalent
+    # and is not: that path DEGRADES when its refresh fails. So a cache that
+    # was present-but-blind and older than the window would have started
+    # booting agents instead of refusing them, re-opening the 2026-07-20
+    # incident (scitex-cards launched onto a 7d=100% account read as
+    # "5h=? 7d=?") in the act of fixing hub's. Two tests said so.
     if quota_cache_present(quota_cache_path):
+        refreshed = False
+        if not _has_fresh_quota_evidence(quota_cache_path):
+            refreshed = _refresh_stale_evidence(
+                agent_name=agent_name,
+                quota_cache_path=quota_cache_path,
+                store_dir=store_dir,
+            )
         return _pick_armed(
             pick,
             agent_name=agent_name,
             quota_cache_path=quota_cache_path,
             store_dir=store_dir,
+            already_refreshed=refreshed,
         )
 
     blocker = _build_evidence_once(
@@ -134,12 +167,51 @@ def pick_with_quota_evidence(
     return picked
 
 
+def _refresh_stale_evidence(
+    *,
+    agent_name: str,
+    quota_cache_path: Path | str | None,
+    store_dir: Path | None,
+) -> bool:
+    """Re-measure a cache too OLD to decide a boot on. True if a refresh ran.
+
+    Best-effort by construction, and unlike :func:`_build_evidence_once` a
+    failure here changes NOTHING about the gate: the host demonstrably has a
+    quota cache, so the never-block invariant — which exists for hosts running
+    no quota system at all — does not apply to it. A stale cache that cannot be
+    refreshed is simply picked against with the gate ARMED, and the pick then
+    refuses or proceeds on its own merits.
+
+    The old cache is deliberately left in place when the refresh fails. It is
+    the only evidence this host has, and deleting it (as the absent-cache path
+    does for the empty file IT created) would silently convert a fail-loud host
+    into a degrading one.
+    """
+    logger.info(
+        "quota cache is too old to decide %r's boot — re-measuring before picking",
+        agent_name,
+    )
+    try:
+        _refresh(quota_cache_path=quota_cache_path, store_dir=store_dir)
+    except Exception as exc:  # stx-allow: fallback (reason: the staleness re-measure is BEST-EFFORT. A populator that raises must leave the boot exactly where it stood — picking against the old cache with the gate ARMED — never crash a start that would otherwise have succeeded.)
+        logger.warning(
+            "could not refresh %r's stale quota cache (%s: %s) — picking with the "
+            "gate armed against the cache as it stands",
+            agent_name,
+            exc.__class__.__name__,
+            exc,
+        )
+        return False
+    return True
+
+
 def _pick_armed(
     pick: Callable[[bool], str],
     *,
     agent_name: str,
     quota_cache_path: Path | str | None,
     store_dir: Path | None,
+    already_refreshed: bool = False,
 ) -> str:
     """Pick with the gate ARMED, self-repairing a blind cache once.
 
@@ -160,6 +232,12 @@ def _pick_armed(
     try:
         return pick(True)
     except BlindQuotaCacheError as blind:
+        if already_refreshed:
+            # A staleness re-measure just ran, seconds ago, against this same
+            # store. Running the populator again would measure exactly what it
+            # measured then, so the refusal is already the post-refresh one
+            # this path exists to produce.
+            raise
         logger.info(
             "quota cache blind for %r — refreshing it once before refusing",
             agent_name,
@@ -293,3 +371,53 @@ def _refresh(
 
 def _as_int(value: Any) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+# How old a quota snapshot may be and still count as EVIDENCE for a boot
+# decision. Deliberately generous relative to the 5-minute writer cadence
+# (`_account.claude_usage._CACHE_TTL_SECONDS`) — this is not "is the cache
+# warm", it is "could this number still be true". An hour of drift cannot turn
+# a healthy account into a capped one under any realistic burn rate; a day
+# demonstrably can, and did.
+QUOTA_EVIDENCE_MAX_AGE_S = 3600.0
+
+
+def _has_fresh_quota_evidence(
+    quota_cache_path: Path | str | None,
+    *,
+    max_age_s: float = QUOTA_EVIDENCE_MAX_AGE_S,
+    now: float | None = None,
+) -> bool:
+    """Is there a quota snapshot RECENT ENOUGH to decide a boot on?
+
+    Three outcomes collapse to two here on purpose, and the collapse is the
+    safe direction: absent, unreadable, undated and stale all return False,
+    which routes the caller into "go and build the evidence" rather than into
+    a silent launch. Only a present, parseable, dated and recent cache is
+    evidence.
+
+    ``now`` and ``max_age_s`` are injection seams so the tests can age a cache
+    deterministically instead of sleeping or patching the clock.
+    """
+    import json
+    import time
+
+    # `_resolve_cache_path` is the reader's OWN resolver (override -> env ->
+    # container bind -> host default). Re-implementing that cascade here is how
+    # a freshness check ends up dating a different file than the picker reads.
+    from .._account.quota_cache import _resolve_cache_path, quota_cache_present
+
+    if not quota_cache_present(quota_cache_path):
+        return False
+
+    # stx-allow: fallback (reason: an unreadable or undated cache is TREATED AS
+    # STALE, which is the conservative branch — it triggers a refresh rather
+    # than allowing a boot on evidence we cannot date)
+    try:
+        payload = json.loads(Path(_resolve_cache_path(quota_cache_path)).read_text())
+        written_at = float(payload["written_at"])
+    except Exception:
+        return False
+
+    current = time.time() if now is None else now
+    return (current - written_at) <= max_age_s

--- a/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
@@ -66,6 +66,18 @@ from ._account_list_fleet import fleet_account_options, run_fleet_account_list
         "column always shows the snapshot age so a stale number is obvious."
     ),
 )
+@click.option(
+    "--no-refresh-quota",
+    "refresh_quota",
+    flag_value=False,
+    default=True,
+    help=(
+        "Skip the automatic quota-snapshot refresh this command performs "
+        "before rendering, and read whatever is cached. Faster and fully "
+        "offline; the bars may then be stale, and the renderer says so. "
+        "The refresh refetches USAGE ONLY — it never touches a credential."
+    ),
+)
 def account_list(
     as_json: bool,
     refresh: bool,
@@ -74,6 +86,7 @@ def account_list(
     no_fanout: bool,
     host_timeout: float,
     by_host: bool,
+    refresh_quota: bool,
 ) -> None:
     """List stored accounts across the fleet, and show this host's active one.
 
@@ -135,6 +148,43 @@ def account_list(
     from ._account_openai import format_openai_account_block
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
+
+    # REFRESH THE QUOTA SNAPSHOT BEFORE READING IT.
+    #
+    # Operator ruling 2026-08-17, second time of asking: "sac accounts list
+    # should automatically refresh the snapshot beforehand ... it is just
+    # time consuming for me to type it by myself." The first answer was a
+    # 5-minute timer (PR #1085), which fixes the host that RUNS the timer and
+    # leaves every other host rendering yesterday's numbers.
+    #
+    # WHY A STALE SNAPSHOT IS WORSE THAN NO SNAPSHOT HERE. Measured the same
+    # day, same account, two hosts:
+    #
+    #     ywata-note-win cache (1d old)   scitex-01-scitex-ai  7d = 15%
+    #     scitex-compute-03, refreshed    scitex-01-scitex-ai  7d = 100%
+    #
+    # The stale reading says the account has headroom while it is in fact
+    # capped until Aug 22 — the number is not merely old, it is INVERTED, and
+    # this is the command an operator reaches for to decide which account to
+    # use. The renderer already detects the condition and prints "! snapshot
+    # older than the refresh window"; narrating a fixable staleness instead of
+    # fixing it is what this change ends.
+    #
+    # SAFE BY CONSTRUCTION: this refetches USAGE ONLY. It does not touch a
+    # credential. A credential refresh rotates a single-use token and would
+    # revoke every other host still holding it — which is why the fleet path
+    # is passive and stays passive. `--no-refresh-quota` opts out for a fast,
+    # deliberately-offline read.
+    if refresh_quota:
+        # stx-allow: fallback (reason: a usage refetch is best-effort — no
+        # network, a 429, or an unreadable store must degrade to the cached
+        # view, never delete the operator's credential inventory mid-incident)
+        try:
+            from .._account.quota_cache_refresh import refresh_quota_cache
+
+            refresh_quota_cache()
+        except Exception:
+            pass
 
     accounts = list_accounts()
     # An UNREADABLE OpenAI store must not delete the Claude view. This command is

--- a/src/scitex_agent_container/cli_pkg/_host_sync.py
+++ b/src/scitex_agent_container/cli_pkg/_host_sync.py
@@ -140,6 +140,19 @@ def _print_result(result: SyncResult) -> None:
         "Mutates no peer."
     ),
 )
+@click.option(
+    "--exit-zero",
+    "exit_zero",
+    is_flag=True,
+    default=False,
+    help=(
+        "Always exit 0. The verdict is unchanged and still printed, still in "
+        "the JSON `exit_code`, and still recorded by --alarm — only the "
+        "PROCESS status is neutralised. For unattended runners (systemd "
+        "timers) where a non-zero status means 'this job is unhealthy', not "
+        "'this job found something'."
+    ),
+)
 @click.pass_context
 def host_sync(
     ctx: click.Context,
@@ -152,6 +165,7 @@ def host_sync(
     timeout: int,
     as_json: bool,
     alarm: bool,
+    exit_zero: bool,
 ) -> None:
     """Reconcile a peer's sac checkout to the centre's code. One-way.
 
@@ -228,6 +242,26 @@ def host_sync(
             )
 
     code = exit_code_for([r.outcome for r in results])
+    # The VERDICT and the PROCESS STATUS are two different facts, and only one
+    # of them belongs to systemd. `code` stays the verdict everywhere it is
+    # read as one — printed below, and carried in the JSON `exit_code` — while
+    # `status` is what this process exits with.
+    #
+    # MEASURED 2026-08-17: this verb runs hourly as
+    # scitex-agent-container-host-sync-check.service. Finding drift exits 1
+    # and "could not determine" exits 2, so systemd recorded the unit as
+    # `failed` for doing its job correctly, which put compute-04 into
+    # `degraded`. The dotfiles sync installer then tested
+    # `systemctl --user is-system-running`, read `degraded` as "systemd is
+    # absent", and PERMANENTLY and SILENTLY refused to install its timer — so
+    # that host stopped receiving dotfiles sync entirely. A finding became a
+    # health signal became a missing service, across two packages, with every
+    # step reporting success.
+    #
+    # Hence --exit-zero rather than SuccessExitStatus=1 2 on the unit: that
+    # would also swallow a genuine crash, which is the shape that left a
+    # stale-lock monitor's detection rendering as success and nobody told.
+    status = 0 if exit_zero else code
 
     # Make the shout DURABLE: record each verdict in sac's own event log.
     # This runs in BOTH output modes — the record is independent of whatever
@@ -248,7 +282,7 @@ def host_sync(
                 "failed": list(alarm_outcome.failed),
             }
         click.echo(json.dumps(payload, indent=2))
-        raise SystemExit(code)
+        raise SystemExit(status)
 
     mode = "check (read-only)" if check_only else "sync"
     console.print(f"[bold]sac host {mode}[/bold]  centre -> {len(results)} peer(s)\n")
@@ -271,7 +305,7 @@ def host_sync(
         )
     if alarm_outcome is not None:
         console.print(f"[dim]{alarm_outcome.summary_line()}[/dim]")
-    raise SystemExit(code)
+    raise SystemExit(status)
 
 
 def register(host_group) -> None:

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -329,13 +329,67 @@ def try_dispatch(
     )
     if dispatch_peer is None:
         return False
-    (dispatcher or _dispatch_remote_start)(
-        name=config.name,
-        peer=dispatch_peer,
-        dry_run=dry_run,
-        force=force,
-    )
+    try:
+        (dispatcher or _dispatch_remote_start)(
+            name=config.name,
+            peer=dispatch_peer,
+            dry_run=dry_run,
+            force=force,
+        )
+    except Exception:
+        # The failure is re-raised UNCHANGED — this only adds the sentence the
+        # operator needs to attribute it. See :func:`_explain_pinned_hop_failure`.
+        _explain_pinned_hop_failure(
+            config.name, config.hosts_spec.host, dispatch_peer
+        )
+        raise
     return True
+
+
+def _explain_pinned_hop_failure(
+    name: str,
+    spec_host: str | list[str] | None,
+    peer: str,
+) -> None:
+    """Name ``spec.host`` when a dispatch driven by it fails.
+
+    MEASURED 2026-08-09: specs across the fleet carried ``host: ywata-note-win``
+    after the laptop was retired. The lifecycle verbs dispatched there and TWELVE
+    agents died with ``Permission denied (publickey)`` — a message that names the
+    AGENT and never the field that chose the destination. Attributing it took
+    days, because nothing in the output connected "this agent will not start" to
+    "a line in its spec points at a machine that is gone".
+
+    Why this is a message and not a probe: ``_host_chain.resolve_host_chain``
+    deliberately never probes a STRING ``host:`` — only a LIST is probed, where
+    the verdict CHOOSES among alternatives. A pin has no alternatives, so a probe
+    there could only REFUSE, and refusing an explicit pin on a prober's say-so is
+    a worse failure than the one being fixed ("never a licence to reject a host
+    the operator asked for"). Probing pre-emptively would also add an ssh
+    round-trip to every remote start, to say something the imminent hop is about
+    to establish for free.
+
+    So the pin is still obeyed and the error still propagates untouched. What
+    changes is that the operator is no longer left to guess WHY this peer.
+    """
+    if not isinstance(spec_host, str) or not spec_host:
+        # A LIST was already walked and probed candidate-by-candidate, and its
+        # own error accounts for every entry; an empty pin never routes remote.
+        return
+    from .._helpers._console import system_msg
+
+    system_msg(
+        f"{name}: this hop was chosen by `host: {spec_host}` in the agent's "
+        f"spec — sac dispatched to peer {peer!r} because of that line, and the "
+        "hop failed (the error below is the peer's, unmodified). A plain "
+        "`host:` pin is never reachability-probed, so a pin at a machine that "
+        "is retired, asleep, or no longer accepting this key fails HERE, with "
+        "a message that names the agent rather than the spec. If "
+        f"{spec_host} is not where this agent should run, correct or remove "
+        "`host:` — an absent `host:` means 'start on whichever machine runs "
+        "the command'.",
+        style="warn",
+    )
 
 
 def lookup_remote_peer(name: str) -> tuple[str, dict] | None:

--- a/src/scitex_agent_container/statusline.py
+++ b/src/scitex_agent_container/statusline.py
@@ -131,41 +131,168 @@ def _active_account() -> str:
         return ""
 
 
+#: Hard width budget for the rendered line.
+#:
+#: The payload carries NO terminal width — measured 2026-08-17 against a live
+#: capture: it has session, model, workspace, cost, context_window and
+#: rate_limits, and nothing describing the pane. So this is a FLOOR we choose,
+#: not a width we read: 80 columns is the classic minimum, and the line must
+#: still fit after the TUI's own left decoration.
+#:
+#: Why a budget at all (operator, 2026-08-17): 「途中でトランケーションされて
+#: しまってんですよ。なので情報が見えなくなってる…全部見えるように」. The line
+#: was 131 chars and his pane cut it at ~86, mid-model-name. Terminal
+#: truncation eats from the RIGHT, so it discarded ctx / 5h / account —
+#: every NUMBER — while keeping the identity, which is the one part a human
+#: already knows. The fix is to fit, not to reorder.
+#:
+#: 80 and not less: at 78 this agent's own line lost its MODEL, because the
+#: full line measures exactly 80. Trimming the budget below the standard
+#: terminal width buys nothing (nothing is 79 columns wide) and costs a field
+#: on every turn, so the floor IS the budget.
+STATUSLINE_MAX_WIDTH = 80
+
+#: Marker for a clamp WE performed. A deliberate, visible ellipsis beats the
+#: terminal's invisible one: the reader can tell the difference between "this
+#: is the whole value" and "sac shortened this".
+_CLAMP = "…"
+
+
+def _short_host(host: str) -> str:
+    """Drop the fleet-wide ``scitex-`` prefix every host name carries.
+
+    ``scitex-compute-04`` -> ``compute-04``. Purely redundant: the prefix is
+    on every host, so it distinguishes nothing while costing 7 columns on the
+    one line where columns are scarce. What remains is still unique across the
+    peer table (compute-01..04, nas-01..03, mba, spartan, ywata-note-win), so
+    :func:`_hostname`'s stated purpose — noticing the same agent name alive on
+    two machines — survives intact.
+    """
+    return host[len("scitex-") :] if host.startswith("scitex-") else host
+
+
+def _short_model(model: str) -> str:
+    """``Opus 5 (1M context)`` -> ``Opus 5 1M``; leave un-parenthesised names alone.
+
+    The parenthetical is the payload's prose, not information: the only part
+    that varies between models an operator might be surprised by is the size
+    token itself. A name with no parenthetical (``claude-opus-4-7``) is passed
+    through byte-for-byte.
+    """
+    head, sep, tail = model.partition("(")
+    if not sep:
+        return model
+    head = head.strip()
+    size = tail.split()[0].rstrip(")") if tail.split() else ""
+    return f"{head} {size}".strip() if size else head
+
+
+def _short_account(acct: str) -> str:
+    """First dash-segment, which is the fleet's EXISTING key for an account.
+
+    ``wyusuuke-gmail-com`` -> ``wyusuuke``. Not an invention: the quota cache
+    already indexes accounts by exactly this segment under the name ``short``,
+    and the stored accounts are distinct in it (scitex, ywatanabe, wyusuuke,
+    ywata1989). So the pane and the quota cache name accounts the same way.
+    """
+    return acct.split("-", 1)[0] if "-" in acct else acct
+
+
+def _render(data: dict) -> str:
+    """Build the status line, guaranteed to fit :data:`STATUSLINE_MAX_WIDTH`.
+
+    Field order and the sacrifice order are the whole design:
+
+    * IDENTITY (``agent@host``) — who and where.
+    * MODEL — compacted.
+    * NUMBERS (``ctx`` / ``5h`` / ``7d``) — grouped into ONE segment separated
+      by spaces rather than ``|``, which buys back four columns.
+    * ACCOUNT — which credential is live.
+
+    ``7d`` IS NEW AND IS THE POINT. Measured 2026-08-17: scitex-hub ran pinned
+    to an account at 7d=100%, capped for days, and answered "You've hit your
+    weekly limit" on every turn — while 5h read LOW and every other signal
+    (SUCC, live tmux, rendered TUI) said healthy. The pane was displaying the
+    reassuring number and hiding the fatal one, and ``seven_day`` was in the
+    payload the whole time.
+
+    WORKDIR IS DROPPED WHEN IT REPEATS THE AGENT NAME. sac repos are named
+    after their agent, so the old line spent 24 columns printing
+    ``scitex-agent-container`` a second time.
+
+    When the line still does not fit, it is shortened in a stated order —
+    model first (least volatile, and recoverable from ``sac agents list``),
+    then the identity is clamped with a visible marker. The NUMBERS and the
+    ACCOUNT are never dropped: they are why the line exists.
+    """
+    ctx_pct = (data.get("context_window") or {}).get("used_percentage", 0)
+
+    host = _short_host(_hostname())
+    agent = _agent_name()
+    if agent and agent != "unknown":
+        identity = f"{agent}@{host}" if host else agent
+    else:
+        identity = host
+
+    model = _short_model((data.get("model") or {}).get("display_name", ""))
+
+    nums = [f"ctx:{ctx_pct:.0f}%"]
+    rl = data.get("rate_limits") or {}
+    fh_pct = (rl.get("five_hour") or {}).get("used_percentage")
+    if fh_pct is not None:
+        nums.append(f"5h:{fh_pct:.0f}%")
+    sd_pct = (rl.get("seven_day") or {}).get("used_percentage")
+    if sd_pct is not None:
+        nums.append(f"7d:{sd_pct:.0f}%")
+
+    tail: list[str] = [" ".join(nums)]
+    acct = _short_account(_active_account())
+    if acct:
+        tail.append(acct)
+
+    wd = _workdir(data)
+    if wd == agent:
+        # sac repos are named after their agent, so the old line spent 24
+        # columns printing the same string twice.
+        wd = ""
+
+    def _head(with_wd: bool, with_model: bool) -> list[str]:
+        out = [identity] if identity else []
+        if with_wd and wd:
+            out.append(wd)
+        if with_model and model:
+            out.append(model)
+        return out
+
+    # Sacrifice order, widest-first and stated rather than emergent:
+    #   1. WORKDIR — the weakest field. Normally the repo name, which is
+    #      derivable from the agent; it only differs at all inside a worktree.
+    #   2. MODEL — recoverable from `sac agents list`, and it changes rarely.
+    #   3. IDENTITY — clamped, never dropped, and clamped VISIBLY.
+    # The numbers and the account are never sacrificed: they are why the line
+    # exists, and they are precisely what the terminal was eating before.
+    for with_wd, with_model in ((True, True), (False, True), (False, False)):
+        head = _head(with_wd, with_model)
+        line = " | ".join(head + tail)
+        if len(line) <= STATUSLINE_MAX_WIDTH:
+            return line
+    if not head:
+        return line
+
+    # 2. Clamp the identity, visibly. The numbers keep their columns.
+    fixed = len(" | ".join(head[1:] + tail)) + len(" | ")
+    room = STATUSLINE_MAX_WIDTH - fixed
+    if room < len(_CLAMP) + 1:
+        return " | ".join(head[1:] + tail)
+    head[0] = head[0][: room - len(_CLAMP)] + _CLAMP
+    return " | ".join(head + tail)
+
+
 def _display(raw: bytes) -> None:
     # stx-allow: fallback (reason: statusLine display must never raise; corrupt
     # or unexpected payload shape silently outputs nothing rather than aborting)
     try:
-        data = json.loads(raw)
-        ctx_pct = (data.get("context_window") or {}).get("used_percentage", 0)
-        model = (data.get("model") or {}).get("display_name", "")
-        parts: list[str] = []
-
-        host = _hostname()
-        agent = _agent_name()
-        if agent and agent != "unknown":
-            parts.append(f"{agent}@{host}" if host else agent)
-        elif host:
-            parts.append(host)
-
-        wd = _workdir(data)
-        if wd:
-            parts.append(wd)
-
-        if model:
-            parts.append(model)
-        parts.append(f"ctx:{ctx_pct:.0f}%")
-
-        rl = data.get("rate_limits") or {}
-        fh = rl.get("five_hour") or {}
-        fh_pct = fh.get("used_percentage")
-        if fh_pct is not None:
-            parts.append(f"5h:{fh_pct:.0f}%")
-
-        acct = _active_account()
-        if acct:
-            parts.append(f"acct:{acct}")
-
-        print(" | ".join(parts), flush=True)
+        print(_render(json.loads(raw)), flush=True)
     except Exception:
         pass
 

--- a/src/scitex_agent_container/statusline.py
+++ b/src/scitex_agent_container/statusline.py
@@ -146,11 +146,34 @@ def _active_account() -> str:
 #: every NUMBER — while keeping the identity, which is the one part a human
 #: already knows. The fix is to fit, not to reorder.
 #:
-#: 80 and not less: at 78 this agent's own line lost its MODEL, because the
-#: full line measures exactly 80. Trimming the budget below the standard
-#: terminal width buys nothing (nothing is 79 columns wide) and costs a field
-#: on every turn, so the floor IS the budget.
-STATUSLINE_MAX_WIDTH = 80
+#: 76, AND THIS NUMBER IS MEASURED RATHER THAN CHOSEN. The first version of
+#: this fix used 80 on the reasoning that 80 is the standard terminal width.
+#: That was an assumption, and an adversarial pass measured the host's actual
+#: tmux panes and refuted it:
+#:
+#:     89 cols  dotfiles, handyman-01..04, scitex-agent-container,
+#:              scitex-dev, scitex-hub
+#:     80 cols  handyman-03/05/06/07/08, scitex-cards, scitex-hpc
+#:
+#: TWO populations, not one. Claude Code indents the line 2 columns and then
+#: truncates, and the measured content budget is pane_width - 3 (one sample at
+#: -4). So an 80-char line is fine on an 89-column pane — the operator's — and
+#: STILL TRUNCATES on the seven agents sitting at 80. Conservative rule
+#: pane_width - 4 gives 76.
+#:
+#: And the population is not stable: host tmux runs `window-size latest` with
+#: `default-size 80x24`, and sac never pins a size (`_runners/_tmux/tmux.py`
+#: builds `new-session -d -s <name>` with no -x/-y). A pane is 89 only while
+#: the operator's client is attached, and can become 80 UNDER A RUNNING AGENT.
+#: So the budget must target the minimum, not the pane we happen to see.
+#:
+#: DO NOT try to measure the width at runtime — every probe available here
+#: lies. The payload carries no width field; COLUMNS/LINES are unset; `stty
+#: size` fails with ENOTTY; and `tput cols` returns 80 from the terminfo
+#: DEFAULT (`screen-256color` has cols#80), which is right by coincidence on
+#: an 80-column pane and silently wrong on an 89-column one, with the two
+#: cases indistinguishable from the return value.
+STATUSLINE_MAX_WIDTH = 76
 
 #: Marker for a clamp WE performed. A deliberate, visible ellipsis beats the
 #: terminal's invisible one: the reader can tell the difference between "this

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -341,10 +341,22 @@ def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
     # Arrange — belt-and-braces: the exact mutating form `sac host sync
     # <peer>` (no --check) must never be what this timer runs. The command
     # is the read-only detector, full stop.
+    #
+    # `--exit-zero` was added 2026-08-17 and does NOT weaken that intent: it
+    # touches only this process's exit status, never a peer. It is here
+    # because the tri-state verdict (1 = drift found, 2 = undetermined) was
+    # being read by systemd as unit failure, which put the host into
+    # `degraded`, which made the dotfiles sync installer conclude systemd
+    # was absent and silently stop installing its timer.
+    #
+    # Kept as EXACT EQUALITY on purpose. This assertion is the reason that
+    # change could not land unnoticed — a substring check would have let it
+    # through silently, and the next edit to this command deserves the same
+    # scrutiny. Update the literal deliberately; do not relax the operator.
     # Act
     job = _job("scitex-agent-container-host-sync-check")
     # Assert — the command is precisely the read-only check+alarm form.
-    assert job.command == "sac host sync --check --all --alarm"
+    assert job.command == "sac host sync --check --all --alarm --exit-zero"
 
 
 def test_host_sync_check_cadence_is_hourly() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__quota_evidence_freshness.py
+++ b/tests/scitex_agent_container/_lifecycle/test__quota_evidence_freshness.py
@@ -1,0 +1,325 @@
+"""A STALE quota snapshot is not evidence — it routes into a refresh.
+
+MEASURED 2026-08-17, scitex-hub on scitex-compute-03. Its quota cache was
+present, well-formed, and 23 hours old. The boot decision asked only "does a
+cache exist", so the armed path trusted it and the picker read the pinned
+account's previous-day percentages — 7d=15% — as evidence the pin was fine.
+The account was at 7d=100%, capped until Aug 22. hub answered "You've hit
+your weekly limit" on every turn while the restart reported success.
+Refreshing that one cache revived it: the picker then chose a 7d=8% account
+by itself. The selector was never wrong; it was fed a day-old number and had
+no way to know.
+
+This is the SECOND time that failure shape reached production — the module's
+own docstring records scitex-02 on 2026-08-06, an agent booting onto a
+d7=100% account while startup reported success. That fix armed the gate when
+the cache was ABSENT. A STALE cache walks straight past an absence check,
+which is why it recurred.
+
+No mocks: each test writes a REAL cache file with a REAL `written_at` epoch
+and reads it back through the production resolver. Age is supplied via the
+``now`` seam rather than by sleeping.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._creds import BlindQuotaCacheError
+from scitex_agent_container._lifecycle._quota_evidence import (
+    QUOTA_EVIDENCE_MAX_AGE_S,
+    _has_fresh_quota_evidence,
+)
+from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
+from scitex_agent_container.config import AgentConfig
+
+_NOW = 1_786_000_000.0
+
+# hub's pair. Distinct first dash-segments, because that segment is the quota
+# cache's per-account match key (``short``).
+_EXHAUSTED = "wyusuuke-gmail-com"
+_HEALTHY = "ywatanabe-scitex-ai"
+
+# Older than QUOTA_EVIDENCE_MAX_AGE_S by a wide margin, and the incident's own
+# age. Written relative to the real clock because these boots go through the
+# production reader, which has no ``now`` seam.
+_A_DAY_OLD = 23 * 3600
+
+
+def _write_cache(tmp_path, *, written_at, accounts=None):
+    path = tmp_path / "quota-cache.json"
+    path.write_text(
+        json.dumps(
+            {
+                "written_at": written_at,
+                "accounts": accounts
+                if accounts is not None
+                else {"acct": {"short": "a", "h5": 0.0, "d7": 15.0, "ttl_h": 6.0}},
+            }
+        )
+    )
+    return path
+
+
+def test_a_cache_written_now_is_evidence(tmp_path):
+    """Positive control: the check can return True at all."""
+    # Arrange
+    path = _write_cache(tmp_path, written_at=_NOW)
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is True
+
+
+def test_a_day_old_cache_is_not_evidence(tmp_path):
+    """hub's exact condition: present, well-formed, 23 hours old."""
+    # Arrange
+    path = _write_cache(tmp_path, written_at=_NOW - 23 * 3600)
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_a_cache_just_inside_the_window_is_evidence(tmp_path):
+    """Boundary, from the literal side — not computed from the constant.
+
+    Deriving the boundary from QUOTA_EVIDENCE_MAX_AGE_S on both sides would
+    keep passing if the constant were set to a year.
+    """
+    # Arrange
+    path = _write_cache(tmp_path, written_at=_NOW - 3599)
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is True
+
+
+def test_a_cache_just_outside_the_window_is_not_evidence(tmp_path):
+    # Arrange
+    path = _write_cache(tmp_path, written_at=_NOW - 3601)
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_an_absent_cache_is_not_evidence(tmp_path):
+    # Arrange
+    missing = tmp_path / "nope" / "quota-cache.json"
+    # Act
+    fresh = _has_fresh_quota_evidence(missing, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_an_undated_cache_is_not_evidence(tmp_path):
+    """No `written_at` means the age is unknowable, and unknown is not OK."""
+    # Arrange
+    path = tmp_path / "quota-cache.json"
+    path.write_text(json.dumps({"accounts": {"acct": {"h5": 0.0, "d7": 15.0}}}))
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+def test_an_unparseable_cache_is_not_evidence(tmp_path):
+    """A corrupt cache must fail toward refreshing, never toward launching."""
+    # Arrange
+    path = tmp_path / "quota-cache.json"
+    path.write_text("{not json")
+    # Act
+    fresh = _has_fresh_quota_evidence(path, now=_NOW)
+    # Assert
+    assert fresh is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a stale cache is REFRESHED, and the gate stays ARMED either way.
+#
+# PA-306: no mocks. The refresh is kept offline WITHOUT patching it —
+# ``_account.claude_usage.fetch_usage_for_credentials`` consults its production
+# per-account cache (``<account_dir>/usage.json``, 5-min TTL) before any token
+# read or network call, so seeding that real file is enough to make the
+# populator succeed, and a snapshot with no ``accessToken`` is enough to make
+# it fail.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _install_cache(tmp_path: Path, accounts: dict) -> Iterator[Path]:
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    cache = tmp_path / "runtime" / "quota-cache.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"written_at": time.time() - _A_DAY_OLD, "accounts": accounts})
+    )
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(cache)
+    try:
+        yield cache
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
+def _entry(short: str, *, h5: float, d7: float) -> dict:
+    return {
+        "short": short,
+        "h5": h5,
+        "d7": d7,
+        "ttl_h": 6.0,
+        "reset_at_5h": None,
+        "reset_at_7d": None,
+    }
+
+
+@pytest.fixture
+def _stale_inverted_cache(tmp_path: Path) -> Iterator[Path]:
+    """A day-old cache whose numbers are the REVERSE of the current truth.
+
+    Inverted rather than merely optimistic on purpose: a stale file that
+    happened to agree with reality could not distinguish a build that
+    re-measures from one that trusts it.
+    """
+    yield from _install_cache(
+        tmp_path,
+        {
+            _EXHAUSTED: _entry("wyusuuke", h5=2.0, d7=5.0),
+            _HEALTHY: _entry("ywatanabe", h5=40.0, d7=100.0),
+        },
+    )
+
+
+@pytest.fixture
+def _stale_blind_cache(tmp_path: Path) -> Iterator[Path]:
+    """A day-old cache that exists and holds NOTHING."""
+    yield from _install_cache(tmp_path, {})
+
+
+def _default_store(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _write_snapshot(store: Path, slug: str, *, with_token: bool = True) -> Path:
+    path = store / slug / ".credentials.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    oauth: dict[str, object] = {"expiresAt": int((time.time() + 7_200.0) * 1_000)}
+    if with_token:
+        oauth["accessToken"] = "not-a-real-token"
+    path.write_text(json.dumps({"claudeAiOauth": oauth}))
+    return path
+
+
+def _seed_usage_cache(creds: Path, *, pct_5h: float, pct_7d: float) -> None:
+    """Seed the REAL per-account usage cache the populator's fetcher reads."""
+    (creds.parent / "usage.json").write_text(
+        json.dumps(
+            {
+                "used_pct_5h": pct_5h,
+                "used_pct_7d": pct_7d,
+                "reset_at_5h": None,
+                "reset_at_7d": None,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "error": None,
+            }
+        )
+    )
+
+
+def _pool_config(name: str, paths: list[Path]) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    cfg.claude.credentials_files = [str(p) for p in paths]
+    return cfg
+
+
+def test_a_stale_cache_is_re_measured_and_its_wrong_numbers_are_not_used(
+    _isolate_home, _stale_inverted_cache
+):
+    """hub's incident end-to-end: the stale numbers point the WRONG WAY.
+
+    The cache on disk says the capped account is at d7=5% and the healthy one
+    at d7=100% — an inversion, because that is what a day-old snapshot of a
+    burning account looks like. The truth lives in each account's real
+    ``usage.json``, which the populator reads.
+
+    A build that trusts the stale file therefore picks the CAPPED account, and
+    one that re-measures picks the healthy one. Asserting on the identity of
+    the picked account rather than on "a refresh happened" means this cannot
+    pass by observing the mechanism while the decision stays wrong.
+    """
+    # Arrange
+    store = _default_store(_isolate_home)
+    p_hot = _write_snapshot(store, _EXHAUSTED)
+    p_cool = _write_snapshot(store, _HEALTHY)
+    _seed_usage_cache(p_hot, pct_5h=12.0, pct_7d=100.0)
+    _seed_usage_cache(p_cool, pct_5h=3.0, pct_7d=5.0)
+    cfg = _pool_config("figrecipe", [p_hot, p_cool])
+
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+    # Assert
+    assert cfg.claude.credentials_file == str(p_cool)
+
+
+def test_a_stale_cache_does_not_disarm_the_fail_loud_gate(
+    _isolate_home, _stale_blind_cache
+):
+    """The regression CI caught: staleness must never soften the refusal.
+
+    A present-but-blind cache older than the window is still a host that RUNS
+    a quota system, so the never-block invariant — which exists for hosts that
+    run none — does not apply to it. Routing staleness into the absent-cache
+    path made this boot DEGRADE and proceed, re-opening the 2026-07-20
+    incident (scitex-cards launched onto a 7d=100% account read as "5h=? 7d=?")
+    while fixing hub's.
+    """
+    # Arrange: a cache that is present, stale, and holds nothing — and no
+    # credential the populator could use to clear the blindness.
+    store = _default_store(_isolate_home)
+    p_a = _write_snapshot(store, _EXHAUSTED, with_token=False)
+    p_b = _write_snapshot(store, _HEALTHY, with_token=False)
+    cfg = _pool_config("figrecipe", [p_a, p_b])
+
+    # Act
+    # Assert
+    with pytest.raises(BlindQuotaCacheError):
+        _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+
+def test_the_window_is_not_generous_enough_to_hide_a_days_drift():
+    """The constant must be well under the drift that caused the incident.
+
+    hub's cache was 23h old. A window anywhere near that would have accepted
+    it. Asserted against a literal so widening the constant to paper over a
+    flaky refresher fails here rather than silently restoring the bug.
+    """
+    # Arrange
+    a_day = 24 * 3600
+    # Act
+    window = QUOTA_EVIDENCE_MAX_AGE_S
+    # Assert
+    assert window <= a_day / 4

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch_pinned_hop_failure.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch_pinned_hop_failure.py
@@ -1,0 +1,160 @@
+"""A dispatch chosen by ``host:`` must NAME that line when the hop fails.
+
+MEASURED 2026-08-09: fleet specs still carried ``host: ywata-note-win`` after
+the laptop was retired. The lifecycle verbs dispatched there and TWELVE agents
+died with ``Permission denied (publickey)`` — a message naming the AGENT and
+never the field that picked the destination. Attribution took days, because
+nothing connected "this agent will not start" to "a line in its spec points at
+a machine that is gone".
+
+What is locked here
+-------------------
+1. The peer's error propagates UNCHANGED. The pin is still obeyed; this is a
+   message, not a veto. A plain ``host:`` string is deliberately never
+   reachability-probed (``_host_chain.resolve_host_chain`` — probing a pin
+   could only REFUSE, since a pin has no alternatives to choose between), so
+   the failure still arrives from the hop itself.
+2. The warning NAMES ``host:`` and its value, so the operator can attribute
+   the failure to the spec rather than to the agent.
+3. A LIST pin gets NO such warning — it was walked candidate-by-candidate and
+   its own error already accounts for every entry.
+4. A dispatch that SUCCEEDS says nothing. A warning that also fires on healthy
+   dispatches is one nobody reads.
+
+PA-306: no mocks. ``dispatcher`` is the production injection seam
+``try_dispatch`` already exposes for exactly this, and the failure is a real
+exception raised by a real callable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+
+import pytest
+
+from scitex_agent_container._state.host_config import PeerSpec
+from scitex_agent_container.cli_pkg.lifecycle._dispatch import try_dispatch
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import HostsSpec
+
+# The retired laptop from the incident, and a machine that is not it.
+_RETIRED = "ywata-note-win"
+_HERE = "scitex-compute-04"
+
+# What the failing hop actually said in 2026-08-09. Asserted verbatim so a
+# change that "helpfully" rewraps or replaces the peer's own error fails here.
+_PEER_ERROR = "Permission denied (publickey)"
+
+# ``pytest.raises(match=...)`` is a REGEX search, and the incident's own error
+# text contains "(publickey)" — an empty capture group that matches everywhere,
+# so an unescaped pattern passes against ANY RuntimeError.
+_PEER_ERROR_RE = re.escape(_PEER_ERROR)
+
+# The FIELD together with its VALUE. The peer name alone already appears in
+# ordinary dispatch output, so matching only that would pass against a build
+# that explains nothing.
+_ATTRIBUTION = f"host: {_RETIRED}"
+
+
+def _cfg(host) -> AgentConfig:
+    cfg = AgentConfig(name="figrecipe")
+    cfg.hosts_spec = HostsSpec(host=host, hosts=[])
+    return cfg
+
+
+def _peers(*names) -> dict:
+    return {n: PeerSpec(name=n, ssh=n) for n in names}
+
+
+def _raises_like_the_incident(**_kwargs) -> int:
+    raise RuntimeError(_PEER_ERROR)
+
+
+def _succeeds(**_kwargs) -> int:
+    return 0
+
+
+def _dispatch(host, dispatcher):
+    return try_dispatch(
+        _cfg(host),
+        _HERE,
+        _peers(_RETIRED),
+        dry_run=False,
+        force=False,
+        dispatcher=dispatcher,
+    )
+
+
+# STDERR, not stdout: `system_msg` writes diagnostics to stderr (and to the
+# scitex-logging record). Asserting on `.out` reads an empty string and every
+# "warning is absent" test below would pass against a build that warns
+# correctly — the negative tests would be vacuous rather than merely wrong.
+
+
+@pytest.fixture
+def string_pin_output(capsys) -> str:
+    """Stderr of a STRING-pinned dispatch whose hop failed."""
+    with contextlib.suppress(RuntimeError):
+        _dispatch(_RETIRED, _raises_like_the_incident)
+    return capsys.readouterr().err
+
+
+@pytest.fixture
+def list_pin_output(capsys) -> str:
+    """Output of a LIST-pinned dispatch whose hop failed."""
+    with contextlib.suppress(RuntimeError):
+        _dispatch([_RETIRED], _raises_like_the_incident)
+    return capsys.readouterr().err
+
+
+@pytest.fixture
+def successful_dispatch_output(capsys) -> str:
+    """Output of a STRING-pinned dispatch that SUCCEEDED."""
+    _dispatch(_RETIRED, _succeeds)
+    return capsys.readouterr().err
+
+
+def test_the_peers_error_propagates_unchanged():
+    """The pin is obeyed and the failure is not swallowed or reworded."""
+    # Arrange
+    dispatcher = _raises_like_the_incident
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=_PEER_ERROR_RE):
+        _dispatch(_RETIRED, dispatcher)
+
+
+def test_the_warning_names_the_spec_line_that_chose_the_peer(string_pin_output):
+    """The whole point: `host: ywata-note-win` must appear in the output."""
+    # Arrange
+    text = string_pin_output
+    # Act
+    attributed = _ATTRIBUTION in text
+    # Assert
+    assert attributed is True
+
+
+def test_a_list_pin_is_not_given_the_single_pin_explanation(list_pin_output):
+    """A chain already accounts for every candidate in its own error.
+
+    Two explanations for one failure is worse than one: the chain walk reports
+    which entries were probed and rejected, and a pin-shaped sentence pasted
+    underneath would describe a decision that was not made this way.
+    """
+    # Arrange
+    text = list_pin_output
+    # Act
+    attributed = _ATTRIBUTION in text
+    # Assert
+    assert attributed is False
+
+
+def test_a_dispatch_that_succeeds_explains_nothing(successful_dispatch_output):
+    """A warning that fires on healthy dispatches is one nobody reads."""
+    # Arrange
+    text = successful_dispatch_output
+    # Act
+    attributed = _ATTRIBUTION in text
+    # Assert
+    assert attributed is False

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_cmd_refreshes_quota.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_cmd_refreshes_quota.py
@@ -1,0 +1,90 @@
+"""``sac accounts list`` refreshes the quota snapshot before rendering it.
+
+Operator ruling 2026-08-17, asked twice: "sac accounts list should
+automatically refresh the snapshot beforehand ... it is just time consuming
+for me to type it by myself." The first answer was a 5-minute systemd timer
+(PR #1085), which refreshes the host that RUNS the timer and leaves every
+other host rendering yesterday's numbers.
+
+WHY A STALE SNAPSHOT IS WORSE THAN NO SNAPSHOT. Measured the same day, same
+account, two hosts:
+
+    ywata-note-win cache (1d old)    scitex-01-scitex-ai   7d = 15%
+    scitex-compute-03, refreshed     scitex-01-scitex-ai   7d = 100%
+
+The stale reading says the account has headroom while it is capped until
+Aug 22. This is the command an operator reaches for to decide which account
+to use, so an inverted number here is not cosmetic. It also had a live
+consequence the same night: compute-03's cache was 23h old with every
+percentage None, the account picker's rule is "keep the pinned account
+unless its quota is KNOWN-bad", None is not known-bad, and scitex-hub was
+therefore kept on a 7d-100% account and could not take a single turn.
+
+The refresh is USAGE-ONLY and never touches a credential — a credential
+refresh rotates a single-use token and would revoke every other host
+holding it.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._account_list_cmd import account_list
+
+
+def _help() -> str:
+    return CliRunner().invoke(account_list, ["--help"]).output
+
+
+def test_the_opt_out_flag_is_documented():
+    """An operator who needs a fast offline read must be able to find it."""
+    # Arrange
+    text = _help()
+    # Act
+    present = "--no-refresh-quota" in text
+    # Assert
+    assert present is True
+
+
+def test_refresh_quota_defaults_to_on():
+    """The whole point: no flag typed, snapshot still fresh.
+
+    Asserted on the parameter's real default rather than on prose, so
+    flipping the default silently cannot leave this green.
+    """
+    # Arrange
+    params = {p.name: p for p in account_list.params}
+    # Act
+    default = params["refresh_quota"].default
+    # Assert
+    assert default is True
+
+
+def test_the_opt_out_flag_turns_it_off():
+    """`--no-refresh-quota` must actually reach False, not merely parse."""
+    # Arrange
+    params = {p.name: p for p in account_list.params}
+    # Act
+    flag_value = params["refresh_quota"].flag_value
+    # Assert
+    assert flag_value is False
+
+
+def test_help_states_that_no_credential_is_touched():
+    """The safety property must be findable at the point of use.
+
+    A reader deciding whether this command is safe during an incident should
+    not have to read the source to learn it refetches usage only.
+
+    Whitespace is COLLAPSED before matching. Click rewraps option help to the
+    terminal width, so "USAGE ONLY" is split across a line break and a naive
+    substring check fails against text that plainly contains the phrase —
+    the first version of this test did exactly that. Asserting on rendered
+    help means asserting on a layout you do not control.
+    """
+    # Arrange
+    text = " ".join(_help().lower().split())
+    # Act
+    says_usage_only = "usage only" in text
+    # Assert
+    assert says_usage_only is True

--- a/tests/scitex_agent_container/cli_pkg/test__host_sync_exit_zero.py
+++ b/tests/scitex_agent_container/cli_pkg/test__host_sync_exit_zero.py
@@ -1,0 +1,142 @@
+"""``--exit-zero`` separates the VERDICT from the PROCESS STATUS.
+
+Why this flag exists, measured 2026-08-17: `sac host sync --check --all
+--alarm` runs hourly as scitex-agent-container-host-sync-check.service.
+Finding drift exits 1 and "could not determine" exits 2, so systemd recorded
+the unit as `failed` for doing its job correctly. That put compute-04 into
+`degraded`; the dotfiles sync installer then tested
+`systemctl --user is-system-running`, read `degraded` as "systemd is
+absent", and PERMANENTLY and SILENTLY refused to install its timer — so that
+host stopped receiving dotfiles sync entirely. A finding became a health
+signal became a missing service, across two packages, every step reporting
+success.
+
+THE FIXTURE USES A PEER THAT CANNOT BE REACHED, ON PURPOSE. An empty peer
+list is rejected by the verb ("no syncable peers"), and a reachable peer
+would make the verdict 0 — either way the tests could not tell "the status
+was neutralised" apart from "there was nothing to neutralise". An
+unreachable peer yields UNDETERMINED, a genuinely non-zero verdict, which
+is the only case the flag changes. That is the positive control.
+
+No mocks: a real Click invocation against a real config file, asserting the
+process status and the JSON a caller actually receives.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._host_sync import host_sync
+
+# `.invalid` is reserved by RFC 2606 and can never resolve, so ssh fails
+# immediately rather than waiting on a network timeout.
+_UNREACHABLE = "host:\n  aliases: {}\npeers:\n  nowhere:\n    ssh: nowhere.invalid\n"
+
+
+@pytest.fixture
+def unreachable_peer_config(tmp_path, env_save_restore):
+    """One peer that cannot be reached -> UNDETERMINED -> non-zero verdict.
+
+    The env var is ``SCITEX_AGENT_CONTAINER_CONFIG``, read from
+    ``_state/host_config.py:85`` rather than guessed. Getting this name
+    wrong does not fail a test — it silently loads the OPERATOR'S REAL
+    config and ssh-es every peer in the fleet.
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_UNREACHABLE)
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return cfg
+
+
+def _run(args):
+    return CliRunner().invoke(host_sync, args, catch_exceptions=False)
+
+
+_BASE = ["--check", "--all", "--json", "--timeout", "1"]
+
+
+def test_without_the_flag_an_unreachable_peer_exits_non_zero(unreachable_peer_config):
+    """The positive control: this case really does exit non-zero by default.
+
+    Without this, every assertion below could pass on a verb that never
+    returns non-zero at all.
+    """
+    # Arrange
+    args = list(_BASE)
+    # Act
+    result = _run(args)
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_with_the_flag_the_process_exits_zero(unreachable_peer_config):
+    """The whole point: systemd must not read a finding as ill health."""
+    # Arrange
+    args = [*_BASE, "--exit-zero"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_with_the_flag_the_verdict_is_still_non_zero_in_json(unreachable_peer_config):
+    """The half that stops this becoming a gate that cannot fail.
+
+    Status neutral, verdict intact. A fix that suppressed both would pass
+    the test above and fail this one.
+    """
+    # Arrange
+    args = [*_BASE, "--exit-zero"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert json.loads(result.output)["exit_code"] != 0
+
+
+def test_the_flag_does_not_change_the_verdict_value(unreachable_peer_config):
+    """The reported verdict is identical with and without the flag."""
+    # Arrange
+    plain = _run(list(_BASE))
+    # Act
+    zeroed = _run([*_BASE, "--exit-zero"])
+    # Assert
+    assert json.loads(zeroed.output)["exit_code"] == json.loads(plain.output)["exit_code"]
+
+
+def test_default_still_routes_verdict_to_status(unreachable_peer_config):
+    """The contract for interactive and script callers is UNCHANGED."""
+    # Arrange
+    result = _run(list(_BASE))
+    # Act
+    verdict = json.loads(result.output)["exit_code"]
+    # Assert
+    assert result.exit_code == verdict
+
+
+def test_help_documents_exit_zero():
+    """A job depends on this flag; an undocumented flag is a trap."""
+    # Arrange
+    args = ["--help"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert "--exit-zero" in result.output
+
+
+def test_the_job_command_passes_exit_zero():
+    """The flag is worthless if the JobSpec does not use it.
+
+    Asserted against the real registered JobSpec, so editing the job's
+    command cannot leave this green while the timer keeps exiting non-zero.
+    """
+    # Arrange
+    from scitex_agent_container._jobs._jobs_plugin import provide_jobs
+
+    jobs = {j.name: j for j in provide_jobs()}
+    # Act
+    command = jobs["scitex-agent-container-host-sync-check"].command
+    # Assert
+    assert "--exit-zero" in command

--- a/tests/scitex_agent_container/test_statusline_fits_and_shows_7d.py
+++ b/tests/scitex_agent_container/test_statusline_fits_and_shows_7d.py
@@ -1,0 +1,329 @@
+"""The status line must FIT, and it must show the quota that actually kills agents.
+
+OPERATOR, 2026-08-17: 「途中でトランケーションされてしまってんですよ。なので情報が
+見えなくなってるのでこれなおせますかね。全部見えるように」 — it gets truncated
+partway, so information is invisible; fix it so EVERYTHING is visible.
+
+MEASURED the same day, rendering his live payload through the production
+renderer: the line was 131 characters and his pane cut it at ~86, mid
+``Opus 5 (1M conte…``. Terminal truncation eats from the RIGHT, so what was
+discarded was ctx / 5h / account — every NUMBER — while the identity survived,
+which is the one part a human already knows. Two redundancies were paying for
+that: ``scitex-agent-container`` appeared TWICE (agent name, then workdir
+basename, because sac repos are named after their agent), and the model carried
+the payload's prose parenthetical verbatim.
+
+AND 7d IS ADDED, which is the substantive half. scitex-hub ran pinned to an
+account at 7d=100%, capped for days, answering "You've hit your weekly limit"
+on every turn — while 5h read LOW and every other signal (SUCC, live tmux,
+rendered TUI) said healthy. The pane displayed the reassuring number and hid
+the fatal one. ``rate_limits.seven_day.used_percentage`` was in the payload the
+whole time.
+
+WHY THE WIDTH ASSERTIONS TEST AN INVARIANT, NOT A STRING: ``_render`` reads the
+real hostname and the real account store, so an exact expected line would be a
+test of THIS machine. ``len(line) <= STATUSLINE_MAX_WIDTH`` is the property the
+operator actually asked for and it holds on every host.
+
+PA-306: no mocks. Identity comes from the real env seam (``SAC_AGENT``), and
+the payloads are real payload SHAPES captured from a live capture.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import scitex_agent_container.statusline as sl_mod
+from scitex_agent_container.statusline import (
+    STATUSLINE_MAX_WIDTH,
+    _render,
+    _short_account,
+    _short_host,
+    _short_model,
+)
+
+# The exact shape of a live payload, captured 2026-08-17 from
+# ~/.scitex/agent-container/statusline/scitex-agent-container.json.
+_LIVE = {
+    "model": {"id": "claude-opus-5[1m]", "display_name": "Opus 5 (1M context)"},
+    "workspace": {"current_dir": "/home/ywatanabe/proj/scitex-agent-container"},
+    "context_window": {"used_percentage": 47},
+    "rate_limits": {
+        "five_hour": {"used_percentage": 6},
+        "seven_day": {"used_percentage": 21},
+    },
+}
+
+
+@pytest.fixture
+def named_agent(env_save_restore):
+    """Pin the identity so the line is not at the mercy of ambient env."""
+    env_save_restore.set("SAC_AGENT", "scitex-agent-container")
+    return "scitex-agent-container"
+
+
+# ---------------------------------------------------------------------------
+# The operator's request: it must fit.
+# ---------------------------------------------------------------------------
+
+
+def test_the_budget_is_no_wider_than_a_standard_terminal():
+    """Asserted against a LITERAL, because every other width test is not.
+
+    The rest of this file compares ``len(line) <= STATUSLINE_MAX_WIDTH``, which
+    is the property we want but is also parameterised by the very constant
+    under test — set the constant to 10000 and all of them stay green while the
+    operator's pane truncates exactly as before. This is the one assertion that
+    can fail in that scenario, so widening the budget to make a line "fit" has
+    to come through here and be argued for.
+    """
+    # Arrange
+    standard_terminal = 80
+    # Act
+    budget = STATUSLINE_MAX_WIDTH
+    # Assert
+    assert budget <= standard_terminal
+
+
+def test_the_live_payload_renders_within_the_width_budget(named_agent):
+    """The 131-character line that prompted the request must now fit."""
+    # Arrange
+    data = dict(_LIVE)
+    # Act
+    line = _render(data)
+    # Assert
+    assert len(line) <= STATUSLINE_MAX_WIDTH
+
+
+def test_the_live_payload_keeps_every_field_including_the_model(named_agent):
+    """Fitting must not be achieved by quietly dropping fields.
+
+    The operator asked for 全部見えるように — everything visible. A budget tight
+    enough to force the sacrifice path on the ORDINARY case would satisfy the
+    width assertion above while failing the actual request; at 78 this line lost
+    its model. This pins the common case as whole.
+    """
+    # Arrange
+    data = dict(_LIVE)
+    # Act
+    line = _render(data)
+    # Assert
+    assert "Opus 5 1M" in line
+
+
+def test_an_absurdly_long_agent_name_still_fits(env_save_restore):
+    """The budget is a guarantee, not a hope — clamping is ours, not the terminal's."""
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "a" * 200)
+    # Act
+    line = _render(dict(_LIVE))
+    # Assert
+    assert len(line) <= STATUSLINE_MAX_WIDTH
+
+
+def test_the_numbers_survive_when_the_identity_is_clamped(env_save_restore):
+    """Identity is what gets sacrificed under pressure — never the data.
+
+    The whole defect was that truncation discarded the volatile numbers and
+    kept the guessable name. A clamp that repeated that would be no fix.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "a" * 200)
+    # Act
+    line = _render(dict(_LIVE))
+    # Assert
+    assert "7d:21%" in line
+
+
+def test_three_digit_percentages_still_fit(env_save_restore):
+    """A capped account reads 100 — the widest the numbers ever get."""
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "scitex-agent-container")
+    data = dict(_LIVE)
+    data["context_window"] = {"used_percentage": 100}
+    data["rate_limits"] = {
+        "five_hour": {"used_percentage": 100},
+        "seven_day": {"used_percentage": 100},
+    }
+    # Act
+    line = _render(data)
+    # Assert
+    assert len(line) <= STATUSLINE_MAX_WIDTH
+
+
+# ---------------------------------------------------------------------------
+# 7d — the field the incident was about.
+# ---------------------------------------------------------------------------
+
+
+def test_the_seven_day_quota_is_rendered(named_agent):
+    """hub was at 7d=100% while 5h read low. The pane must show it."""
+    # Arrange
+    data = dict(_LIVE)
+    # Act
+    line = _render(data)
+    # Assert
+    assert "7d:21%" in line
+
+
+def test_seven_day_is_omitted_when_the_payload_lacks_it(named_agent):
+    """Absent is a third value: render nothing rather than a fabricated 0%."""
+    # Arrange
+    data = dict(_LIVE)
+    data["rate_limits"] = {"five_hour": {"used_percentage": 6}}
+    # Act
+    line = _render(data)
+    # Assert
+    assert "7d" not in line
+
+
+def test_a_payload_with_no_rate_limits_still_renders_context(named_agent):
+    """Degrade cleanly: a missing section must not cost the whole line."""
+    # Arrange
+    data = {"model": {"display_name": "M"}, "context_window": {"used_percentage": 3}}
+    # Act
+    line = _render(data)
+    # Assert
+    assert "ctx:3%" in line
+
+
+# ---------------------------------------------------------------------------
+# The redundancies that were paying for the truncation.
+# ---------------------------------------------------------------------------
+
+
+def test_the_workdir_is_dropped_when_it_repeats_the_agent_name(named_agent):
+    """sac repos are named after their agent — printing both costs 24 columns."""
+    # Arrange
+    data = dict(_LIVE)  # workspace basename == the agent name
+    # Act
+    occurrences = _render(data).count("scitex-agent-container")
+    # Assert
+    assert occurrences == 1
+
+
+def test_a_workdir_that_differs_from_the_agent_is_kept_when_there_is_room(
+    env_save_restore,
+):
+    """Dropping it UNCONDITIONALLY would hide a genuinely different location.
+
+    Asserted against a minimal payload on purpose, and this is a real limit
+    rather than a weakened test: under a FULL payload the same case does not
+    fit 78 columns (it measures 84), so the workdir is sacrificed first by
+    design — see the sacrifice order in ``_render``. The distinction this test
+    locks is "dropped only under budget pressure" versus "never rendered at
+    all", and only the second would be a bug. The companion test below pins
+    the pressure case so both halves are stated.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "some-agent")
+    data = {
+        "model": {"display_name": "M"},
+        "context_window": {"used_percentage": 5},
+        "workspace": {"current_dir": "/home/ywatanabe/proj/scitex-scholar"},
+    }
+    # Act
+    line = _render(data)
+    # Assert
+    assert "scitex-scholar" in line
+
+
+def test_under_pressure_the_workdir_goes_before_the_numbers(env_save_restore):
+    """The sacrifice order, asserted from the losing side.
+
+    A full payload plus a differing workdir exceeds the budget. What must
+    survive is the data — the exact thing the terminal was discarding before.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "some-agent")
+    data = dict(_LIVE)
+    data["workspace"] = {"current_dir": "/home/ywatanabe/proj/scitex-scholar"}
+    # Act
+    line = _render(data)
+    # Assert
+    assert "7d:21%" in line
+
+
+# ---------------------------------------------------------------------------
+# The shorteners — each must stay unambiguous within the fleet.
+# ---------------------------------------------------------------------------
+
+
+def test_the_shared_scitex_host_prefix_is_dropped():
+    """Every host carries it, so it distinguishes nothing and costs 7 columns."""
+    # Arrange
+    host = "scitex-compute-04"
+    # Act
+    short = _short_host(host)
+    # Assert
+    assert short == "compute-04"
+
+
+def test_a_host_without_the_shared_prefix_is_untouched():
+    """ywata-note-win and mba must not be mangled by a prefix rule."""
+    # Arrange
+    host = "ywata-note-win"
+    # Act
+    short = _short_host(host)
+    # Assert
+    assert short == "ywata-note-win"
+
+
+def test_the_model_parenthetical_is_compacted_but_the_size_is_kept():
+    """`(1M context)` is prose; `1M` is the part that could surprise someone."""
+    # Arrange
+    model = "Opus 5 (1M context)"
+    # Act
+    short = _short_model(model)
+    # Assert
+    assert short == "Opus 5 1M"
+
+
+def test_a_model_name_without_a_parenthetical_passes_through_verbatim():
+    """Locks the existing contract — `claude-opus-4-7` must not be rewritten."""
+    # Arrange
+    model = "claude-opus-4-7"
+    # Act
+    short = _short_model(model)
+    # Assert
+    assert short == "claude-opus-4-7"
+
+
+def test_the_account_is_shortened_to_the_fleets_own_key():
+    """Not an invention: the quota cache already indexes accounts by this segment.
+
+    It calls it `short`, and the four stored accounts are distinct in it
+    (scitex, ywatanabe, wyusuuke, ywata1989), so the pane and the quota cache
+    name an account the same way.
+    """
+    # Arrange
+    account = "wyusuuke-gmail-com"
+    # Act
+    short = _short_account(account)
+    # Assert
+    assert short == "wyusuuke"
+
+
+# ---------------------------------------------------------------------------
+# Never raise — the pane must survive a payload we did not anticipate.
+# ---------------------------------------------------------------------------
+
+
+def test_display_stays_silent_on_garbage_rather_than_raising(capsys):
+    # Arrange
+    payload = b"{not json"
+    # Act
+    sl_mod._display(payload)
+    # Assert
+    assert capsys.readouterr().out == ""
+
+
+def test_display_prints_the_rendered_line_for_a_real_payload(named_agent, capsys):
+    # Arrange
+    payload = json.dumps(_LIVE).encode()
+    # Act
+    sl_mod._display(payload)
+    # Assert
+    assert "ctx:47%" in capsys.readouterr().out

--- a/tests/scitex_agent_container/test_statusline_fits_and_shows_7d.py
+++ b/tests/scitex_agent_container/test_statusline_fits_and_shows_7d.py
@@ -69,22 +69,34 @@ def named_agent(env_save_restore):
 # ---------------------------------------------------------------------------
 
 
-def test_the_budget_is_no_wider_than_a_standard_terminal():
+def test_the_budget_fits_the_narrowest_pane_in_the_fleet():
     """Asserted against a LITERAL, because every other width test is not.
 
     The rest of this file compares ``len(line) <= STATUSLINE_MAX_WIDTH``, which
     is the property we want but is also parameterised by the very constant
     under test — set the constant to 10000 and all of them stay green while the
-    operator's pane truncates exactly as before. This is the one assertion that
-    can fail in that scenario, so widening the budget to make a line "fit" has
-    to come through here and be argued for.
+    panes truncate exactly as before. This is the one assertion that can fail in
+    that scenario, so widening the budget to make a line "fit" has to come
+    through here and be argued for.
+
+    76 IS MEASURED, NOT CHOSEN, and the first version of this file got it wrong.
+    It asserted ``<= 80`` on the reasoning that 80 is the standard terminal
+    width. An adversarial pass measured the host's real tmux panes and found TWO
+    populations — 89 columns (the operator's, and 5 others) and 80 columns
+    (seven agents). Claude Code indents 2 columns and truncates, with a measured
+    content budget of pane_width - 3 (one sample at -4). So the 80 I shipped was
+    fine on the pane I could see and still truncated on seven I could not.
+
+    The literal here is therefore the NARROWEST pane's budget, not a convention:
+    80 - 4. And it must stay the narrowest, because host tmux runs
+    `window-size latest`, so a pane can shrink to 80 under a running agent.
     """
     # Arrange
-    standard_terminal = 80
+    narrowest_pane_budget = 76
     # Act
     budget = STATUSLINE_MAX_WIDTH
     # Assert
-    assert budget <= standard_terminal
+    assert budget <= narrowest_pane_budget
 
 
 def test_the_live_payload_renders_within_the_width_budget(named_agent):
@@ -97,20 +109,57 @@ def test_the_live_payload_renders_within_the_width_budget(named_agent):
     assert len(line) <= STATUSLINE_MAX_WIDTH
 
 
-def test_the_live_payload_keeps_every_field_including_the_model(named_agent):
-    """Fitting must not be achieved by quietly dropping fields.
+def test_an_ordinary_agent_keeps_every_field_including_the_model(env_save_restore):
+    """Fitting must not be achieved by quietly dropping fields for EVERYONE.
 
-    The operator asked for 全部見えるように — everything visible. A budget tight
-    enough to force the sacrifice path on the ORDINARY case would satisfy the
-    width assertion above while failing the actual request; at 78 this line lost
-    its model. This pins the common case as whole.
+    The operator asked for 全部見えるように. A budget so tight that the sacrifice
+    path fires on every agent would satisfy the width assertion while failing
+    the request.
+
+    "Ordinary" is doing real work in that name. At the measured 76-column budget
+    the whole line fits for a typical agent name, and does NOT fit for the
+    longest ones — `scitex-agent-container` (22 chars) is already over, and the
+    fleet's longest is 32. That is the sacrifice order behaving correctly under
+    a real constraint, not a regression, and the companion tests below pin the
+    losing side. Naming this test for the ordinary case rather than for "the
+    live payload" is the honest description of what it can promise.
     """
     # Arrange
-    data = dict(_LIVE)
+    env_save_restore.set("SAC_AGENT", "scitex-dev")
     # Act
-    line = _render(data)
+    line = _render(dict(_LIVE))
     # Assert
     assert "Opus 5 1M" in line
+
+
+def test_the_fleets_longest_agent_name_still_fits(env_save_restore):
+    """The real worst case, measured across 135 distinct fleet agent names.
+
+    `clew-cohort-a-scitex-capsule-001` is 32 characters and ties two siblings
+    for longest; with `@scitex-compute-04` the identity segment alone is 50,
+    which is most of the budget before a single number is reached.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "clew-cohort-a-scitex-capsule-001")
+    # Act
+    line = _render(dict(_LIVE))
+    # Assert
+    assert len(line) <= STATUSLINE_MAX_WIDTH
+
+
+def test_the_fleets_longest_agent_name_keeps_its_numbers(env_save_restore):
+    """Fitting is not enough — the data must be what survives the squeeze.
+
+    An identity that consumes most of the budget is exactly the case where a
+    naive implementation would spend the line on the name and truncate the
+    quota, which is the defect this whole change exists to remove.
+    """
+    # Arrange
+    env_save_restore.set("SAC_AGENT", "clew-cohort-a-scitex-capsule-001")
+    # Act
+    line = _render(dict(_LIVE))
+    # Assert
+    assert "7d:21%" in line
 
 
 def test_an_absurdly_long_agent_name_still_fits(env_save_restore):


### PR DESCRIPTION
Version promotion for **0.26.1**. develop is `f3ee3a1d`, main is `8a0ea80f`.

```
develop ahead of main:  8
main ahead of develop:  0
```

main is **0 commits ahead**, so this is a clean fast-forward — no tree adoption needed, unlike 0.26.0 (where squash-promotion had destroyed the merge base and produced 34 phantom add/add conflicts).

## Contents

| PR | |
|---|---|
| #1095 | a STALE quota snapshot triggers a re-measure, not blind trust |
| #1097 | the status line FITS, and shows the 7d quota |
| #1098 | budget 76, measured from the fleet's panes rather than assumed |
| #1096 | a failed dispatch NAMES the `host:` line that chose the peer |
| #1094 | `accounts list` refreshes the snapshot before rendering it |
| #1093 | `host sync --check` stops reporting a finding as ill health |

Full rationale in CHANGELOG `[0.26.1]`.

Cut under the standing authorization (`constitution.md:176`). `v0.26.1` is tagged at the merge commit once this lands, which triggers `pypi-publish-and-github-release-on-tag.yml`.

**Note on what publishing does and does not do:** nothing on the fleet installs sac from PyPI. On compute-04 the package agents import is a read-only bind from the host's main checkout, so delivery there was a `git pull` — already done and verified end-to-end. compute-02/03 have no checkout at that path and their mechanism is unmeasured, tracked in `sac-delivery-topology-is-not-uniform-across-hosts-20260817`.