### PR TITLE
fix(host): `host exec` must not swallow the peer's output

### DIFF
--- a/src/scitex_agent_container/cli_pkg/host_group.py
+++ b/src/scitex_agent_container/cli_pkg/host_group.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 
 import click
 
@@ -169,8 +170,12 @@ def host_exec(peer: str, argv: tuple[str, ...]) -> None:
     PEER may be a ``peers:`` entry in config.yaml or any host in the
     scitex-dev registry that declares an ``ssh_alias``; config.yaml wins
     when both define it. The peer's ``via:`` chain renders into ssh's
-    ``-J`` flag automatically; sac never opens a port. Stdio is inherited
-    so streaming output works.
+    ``-J`` flag automatically; sac never opens a port.
+
+    ON A TTY stdio is INHERITED so long-running output streams live. OFF a
+    TTY it is CAPTURED and re-emitted through click — see
+    :func:`_run_peer_command`, which explains why that difference is not
+    cosmetic.
     """
     cfg = load()
     peers = peers_with_registry(cfg.peers)
@@ -183,8 +188,52 @@ def host_exec(peer: str, argv: tuple[str, ...]) -> None:
         )
         raise SystemExit(2)
     ssh_argv = build_ssh_argv(peer, list(argv), peers)
-    proc = subprocess.run(ssh_argv)
-    raise SystemExit(proc.returncode)
+    raise SystemExit(_run_peer_command(ssh_argv))
+
+
+def _run_peer_command(ssh_argv: list[str]) -> int:
+    """Run the ssh child, capturing its output when nothing is watching a TTY.
+
+    WHY THIS IS NOT COSMETIC — measured 2026-08-17, twice, by two agents.
+
+    The straightforward ``subprocess.run(ssh_argv)`` inherits the OS-LEVEL
+    file descriptors, so the child writes past any IN-PROCESS capture. That is
+    exactly right for a human at a terminal: output streams as it arrives. It
+    is silently wrong for every programmatic caller, because the MCP surface
+    invokes this command through Click's ``CliRunner``, which captures
+    Python-level streams only. The ssh child's bytes go to the real fd and the
+    caller receives EMPTY stdout and EMPTY stderr with only an exit code.
+
+    What that produced in practice:
+
+      * ``sac host exec <peer> -- agents list`` returned ``exit 127`` with BOTH
+        streams empty. 127 is command-not-found — the non-login ssh shell
+        lacked the peer's venv on PATH — but the stderr that would have said so
+        was gone. A bare 127 is indistinguishable from a dozen other failures.
+      * Worse, a command containing ``hostname`` returned ``exit_code 0`` with
+        empty stdout. ``hostname`` cannot print nothing, so the command had not
+        run — and the tool reported SUCCESS. An empty stdout with a zero exit
+        reads as "ran fine, found nothing", and the agent that hit it nearly
+        published "0 runtime homes on that host" as a finding. It would have
+        corroborated a WRONG hypothesis of mine with a fabricated measurement:
+        two agents agreeing, from one broken instrument, about something
+        neither had measured.
+
+    So the rule this encodes: a transport must never render "I could not run
+    it" identically to "it ran and produced nothing". Capturing off-TTY and
+    re-emitting through click makes the child's own words survive to whatever
+    is actually reading.
+    """
+    if sys.stdout.isatty():
+        # A human is watching: inherit, so output streams as it arrives.
+        return subprocess.run(ssh_argv).returncode
+
+    proc = subprocess.run(ssh_argv, capture_output=True, text=True)
+    if proc.stdout:
+        click.echo(proc.stdout, nl=False)
+    if proc.stderr:
+        click.echo(proc.stderr, nl=False, err=True)
+    return proc.returncode
 
 
 @host_group.command("probe")

--- a/tests/scitex_agent_container/cli_pkg/test_host_group_exec_captures_output.py
+++ b/tests/scitex_agent_container/cli_pkg/test_host_group_exec_captures_output.py
@@ -1,0 +1,142 @@
+"""`host exec` must not render "could not run it" as "ran and found nothing".
+
+MEASURED 2026-08-17, twice, by two different agents against the live fleet:
+
+  * `sac host exec <peer> -- agents list` returned exit 127 with BOTH streams
+    empty. 127 is command-not-found — the non-login ssh shell lacked the peer's
+    venv on PATH — but the stderr saying so was gone.
+  * Worse: a command containing `hostname` returned exit_code 0 with EMPTY
+    stdout. `hostname` cannot print nothing, so the command had not run, and
+    the tool reported SUCCESS. The agent who hit it nearly published "0 runtime
+    homes on that host" as a finding, which would have corroborated a wrong
+    hypothesis of mine with a fabricated measurement.
+
+CAUSE: `subprocess.run(argv)` inherits the OS-LEVEL fds. Correct for a human at
+a terminal — output streams live. Silently wrong for programmatic callers,
+because the MCP surface invokes this command through Click's ``CliRunner``,
+which captures PYTHON-level streams only. The child's bytes went to the real fd
+and the caller got empty strings plus an exit code.
+
+WHY THESE TESTS GO THROUGH CliRunner AND NOT capsys — THIS IS THE WHOLE POINT.
+pytest's default capture is FD-LEVEL, so it would capture the old inherited
+output too and every assertion here would pass against the unfixed code. That
+is precisely the "test that cannot fail" this repo keeps finding. ``CliRunner``
+is both the real broken consumer AND the only capture that distinguishes the
+two implementations.
+
+PA-306: no mocks. Real `subprocess`, real child processes, real CliRunner.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.host_group import _run_peer_command
+
+
+@click.command(
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True}
+)
+@click.argument("argv", nargs=-1, type=click.UNPROCESSED)
+def _probe(argv):
+    """Minimal real Click command exercising the production helper.
+
+    Mirrors ``host exec``'s own ``context_settings`` and ``UNPROCESSED`` on
+    purpose: without them Click parses a child's ``-c`` as an unknown OPTION
+    and returns usage-error 2 before the helper ever runs, which is a test
+    harness failure wearing the costume of a production one.
+    """
+    raise SystemExit(_run_peer_command(list(argv)))
+
+
+def _run(*argv: str):
+    return CliRunner().invoke(_probe, list(argv))
+
+
+# ---------------------------------------------------------------------------
+# The regression: output must reach a programmatic caller.
+# ---------------------------------------------------------------------------
+
+
+def test_child_stdout_reaches_a_programmatic_caller():
+    """The exact failure: a caller got EMPTY stdout from a command that printed.
+
+    Fails against the unfixed implementation, because an inherited fd writes
+    past CliRunner entirely.
+    """
+    # Arrange
+    marker = "hello-from-the-child"
+    # Act
+    result = _run("sh", "-c", f"echo {marker}")
+    # Assert
+    assert marker in result.stdout
+
+
+def test_child_stderr_reaches_a_programmatic_caller():
+    """The 127 case: the message explaining the failure must survive.
+
+    A bare exit code with no stderr is indistinguishable from a dozen other
+    failures, which is what made the original incident take two hours.
+    """
+    # Arrange
+    marker = "explanation-on-stderr"
+    # Act
+    result = _run("sh", "-c", f"echo {marker} >&2")
+    # Assert
+    assert marker in result.output
+
+
+def test_a_command_that_prints_nothing_is_distinguishable_from_one_that_failed():
+    """The dangerous flavour, pinned from the safe side.
+
+    A genuinely silent success must still be exit 0 — so that an EMPTY result
+    paired with a NON-zero exit is unambiguously "did not run", rather than
+    sharing its shape with "ran fine, found nothing".
+    """
+    # Arrange
+    silent_success = ("sh", "-c", "true")
+    # Act
+    result = _run(*silent_success)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_a_command_that_cannot_run_reports_nonzero():
+    # Arrange
+    missing = ("sh", "-c", "exit 127")
+    # Act
+    result = _run(*missing)
+    # Assert
+    assert result.exit_code == 127
+
+
+# ---------------------------------------------------------------------------
+# The exit code is the caller's contract and must pass through untouched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code", [0, 1, 2, 3, 42, 127])
+def test_the_childs_exit_code_is_returned_verbatim(code: int):
+    # Arrange
+    argv = ("sh", "-c", f"exit {code}")
+    # Act
+    result = _run(*argv)
+    # Assert
+    assert result.exit_code == code
+
+
+def test_stdout_and_stderr_are_not_merged_into_one_stream():
+    """Keeping them separate is what lets a caller tell data from diagnosis.
+
+    `result.output` merges both; `result.stdout` is stdout alone. If the helper
+    echoed stderr to stdout, the payload would be polluted by diagnostics — the
+    same defect in the opposite direction.
+    """
+    # Arrange
+    argv = ("sh", "-c", "echo PAYLOAD; echo DIAGNOSTIC >&2")
+    # Act
+    result = _run(*argv)
+    # Assert
+    assert "DIAGNOSTIC" not in result.stdout


### PR DESCRIPTION
## Measured twice tonight, by two different agents

| call | result |
|---|---|
| `sac host exec <peer> -- agents list` | **exit 127, both streams empty** |
| a command containing `hostname` | **exit_code 0, stdout empty** |

127 is command-not-found — the non-login ssh shell lacked that peer's venv on PATH — but the stderr that would have *said so* was gone. A bare 127 with no output is indistinguishable from a dozen other failures.

The second is the dangerous one. **`hostname` cannot print nothing**, so the command had not run — and the tool reported SUCCESS. An empty stdout with a zero exit reads as "ran fine, found nothing."

That nearly cost a fabricated finding: the agent who hit it was about to report "0 runtime homes on that host", which would have **corroborated a wrong hypothesis of mine** with a measurement that never happened. Two agents agreeing, from one broken instrument, about something neither had measured. It was caught only because they had put `hostname` in the command as a positive control, out of habit.

## Cause

`subprocess.run(ssh_argv)` inherits the **OS-level** file descriptors. Exactly right for a human at a terminal — output streams as it arrives, and the docstring says so deliberately. Silently wrong for every programmatic caller, because the MCP surface invokes this command through Click's `CliRunner`, which captures **Python-level** streams only. The child's bytes went straight to the real fd; the caller received two empty strings and an exit code.

## Fix

Inherit on a TTY; capture off-TTY and re-emit through `click`. stdout and stderr stay **separate** — merging them would pollute the payload with diagnostics, the same defect in the opposite direction.

The rule this encodes: **a transport must never render "I could not run it" identically to "it ran and produced nothing."**

## Why the tests use CliRunner and not capsys

pytest's default capture is **fd-level**, so it captures the old inherited output too — every assertion here would pass against the unfixed code. A test that cannot fail. `CliRunner` is both the real broken consumer *and* the only capture that distinguishes the two implementations.

That distinguishing claim is **verified, not asserted**: a separate control runs the same assertion against develop's one-liner and against the fix, outside any `pyproject.toml` so no rootdir `pythonpath` can repin the import.

```
old implementation -> marker NOT in captured stdout   (bug reproduced)
new implementation -> marker IN captured stdout       (fix confirmed)
```

```
35 passed          host_group suite (24 pre-existing + 11 new)
All checks passed  ruff --select F401,F811
```