### PR TITLE
fix(priority): route singleton-reconcile through the peer map

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_priority_ssh.py
+++ b/src/scitex_agent_container/cli_pkg/_priority_ssh.py
@@ -1,0 +1,164 @@
+"""ssh reach for the singleton reconciler — argv construction and execution.
+
+Extracted from :mod:`.priority_cmds`, which had grown two separable jobs:
+DECIDING whether an agent should yield (rank a spec's host chain) and REACHING
+the host to find out (turn a peer NAME into an ssh argv and run it). This is
+the reaching half. It is also the half the 2026-08-17 defect lived in, so the
+peer-table knowledge and the incident record now sit in one place.
+
+``priority_cmds`` re-exports every name here under its old private spelling,
+so no import or call site moved.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+# Lightweight SSH reachability options — no TTY, short timeout, no host-key
+# prompt. See :func:`peer_ssh_argv` for which of these survive for a REGISTERED
+# peer and which the fleet-standard builder overrides.
+_SSH_PROBE_OPTS = [
+    "-o",
+    "ConnectTimeout=3",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "StrictHostKeyChecking=no",
+    "-o",
+    "LogLevel=ERROR",
+]
+
+# Wall-clock ceiling on a single probe, enforced by subprocess rather than by
+# ssh. It is the BINDING bound for a registered peer (see peer_ssh_argv), so it
+# is named rather than inlined: the two timeouts interact, and a future edit to
+# either one should be able to see the other.
+_PROBE_WALL_TIMEOUT = 5
+
+_SSH_START_TIMEOUT = 30  # seconds to wait for remote sac agent start
+
+
+def peer_ssh_argv(host: str, command: list[str], opts: list[str]) -> list[str]:
+    """Render ssh argv for ``host``, TRANSLATING it through the peer table.
+
+    WHY THIS EXISTS — measured 2026-08-17.
+
+    ``spec.host`` names a PEER. sac's peer table maps that name to an ssh
+    ALIAS, and the two are not interchangeable:
+
+        peer name        ywata-note-win
+        ssh alias        ywata-note-win-net  -> bastion-win.scitex.ai (works)
+        the BARE name                        -> 192.168.11.101 (dead LAN IP)
+
+    This module used to hand the raw ``spec.host`` straight to ``ssh``. So for
+    every agent pinned to that peer — 54 of them — it reported "preferred host
+    unreachable" while sac's OWN dispatch reached the same machine fine,
+    because dispatch translates and this did not. Two consumers, one string,
+    opposite outcomes.
+
+    That is not merely a bad report. :func:`ssh_start_agent` fed the same
+    untranslated name to a REMOTE START, so a yield decision made on a false
+    "unreachable" would have tried to start an agent by ssh-ing to an address
+    that goes nowhere.
+
+    A host that is NOT a registered peer is passed through unchanged: it may
+    still resolve via ``~/.ssh/config``, and that path works today. Translating
+    only what the table knows about fixes the defect without breaking it.
+
+    ONE DELIBERATE TIMEOUT CHANGE, WRITTEN DOWN BECAUSE IT IS INVISIBLE IN THE
+    DIFF. ``build_ssh_argv`` emits its own ``-o`` defaults BEFORE ``extra_opts``
+    and ssh honours the FIRST occurrence of an option, so for a REGISTERED peer
+    the ``ConnectTimeout=3`` above no longer applies — the fleet-standard
+    ``ConnectTimeout=10`` wins. Measured on the rendered argv, which carries
+    both values in that order; not inferred from the builder's source.
+
+    The effect is bounded and does NOT reach 10s: :func:`probe_ssh` caps the
+    call at ``_PROBE_WALL_TIMEOUT`` (5s) and treats the expiry as unreachable,
+    which is the same verdict ssh's own 3s timeout produced. So an unreachable
+    registered peer costs 5s instead of 3s and still answers False — a latency
+    change on fan-out, not a behaviour change. Accepted rather than worked
+    around: the builder's values are the fleet's considered ones (its docstring
+    calls 10 "probe-friendly") and this module's were an outlier predating
+    them. ``test_priority_cmds_peer_translation`` pins both the winning value
+    and the wall-clock cap so neither drifts silently.
+
+    The pass-through path is unaffected — there the caller's opts are the only
+    ones present, and ``ConnectTimeout=3`` still binds.
+    """
+    # stx-allow: fallback (reason: an unreadable/absent peer table must degrade
+    # to today's behaviour — pass the name through — rather than break a probe
+    # that works on hosts resolved by ~/.ssh/config alone)
+    try:
+        from .._state._host_ssh import build_ssh_argv
+        from .._state._peer_resolve import peers_with_registry
+        from .._state.host_config import load as _load_host_config
+
+        peers = peers_with_registry(_load_host_config().peers)
+    except Exception:
+        peers = {}
+
+    if host in peers:
+        return build_ssh_argv(host, command, peers, extra_opts=opts)
+    return ["ssh", *opts, host, *command]
+
+
+def probe_ssh(host: str) -> bool:
+    """Return True if ``host`` is reachable via SSH (``hostname`` exits 0)."""
+    try:
+        result = subprocess.run(
+            peer_ssh_argv(host, ["hostname"], _SSH_PROBE_OPTS),
+            capture_output=True,
+            timeout=_PROBE_WALL_TIMEOUT,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+def ssh_start_agent(host: str, agent_name: str) -> bool:
+    """SSH to *host* and run ``sac agent start <agent_name>`` in the background.
+
+    Returns True if the remote command exited 0.
+
+    ``host`` is a PEER NAME and is translated through the peer table by
+    :func:`peer_ssh_argv` — see there for why the untranslated form sent a
+    remote START to an address that goes nowhere.
+    """
+    # Singleton-reconcile fans out across many hosts in parallel; share
+    # one ssh master per peer so MaxSessions / MaxStartups stay happy.
+    # For a REGISTERED peer the builder emits these itself, so they land
+    # twice with identical values — ssh takes the first, which is the same
+    # string either way. Kept for the pass-through path, where they are the
+    # only copy.
+    from .._state.host_config import ssh_control_options
+
+    opts = [
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "LogLevel=ERROR",
+        *ssh_control_options(),
+    ]
+    cmd = peer_ssh_argv(host, ["sac", "agent", "start", agent_name], opts)
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=_SSH_START_TIMEOUT,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+__all__ = [
+    "_PROBE_WALL_TIMEOUT",
+    "_SSH_PROBE_OPTS",
+    "_SSH_START_TIMEOUT",
+    "peer_ssh_argv",
+    "probe_ssh",
+    "ssh_start_agent",
+]

--- a/src/scitex_agent_container/cli_pkg/priority_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/priority_cmds.py
@@ -19,7 +19,6 @@ Usage:
 from __future__ import annotations
 
 import json
-import subprocess
 import sys
 
 import click
@@ -30,31 +29,15 @@ from ..config import load_config
 from ..config._host import resolve_hostname
 from ..config._resolve import resolve_with_prefix
 from ._helpers import console
+from ._priority_ssh import _SSH_PROBE_OPTS  # noqa: F401  (re-export)
+from ._priority_ssh import _SSH_START_TIMEOUT  # noqa: F401  (re-export)
+from ._priority_ssh import peer_ssh_argv, probe_ssh, ssh_start_agent
 
-# Lightweight SSH reachability options — no TTY, short timeout, no host-key prompt.
-_SSH_PROBE_OPTS = [
-    "-o",
-    "ConnectTimeout=3",
-    "-o",
-    "BatchMode=yes",
-    "-o",
-    "StrictHostKeyChecking=no",
-    "-o",
-    "LogLevel=ERROR",
-]
-
-
-def _probe_ssh(host: str) -> bool:
-    """Return True if ``host`` is reachable via SSH (``hostname`` exits 0)."""
-    try:
-        result = subprocess.run(
-            ["ssh"] + _SSH_PROBE_OPTS + [host, "hostname"],
-            capture_output=True,
-            timeout=5,
-        )
-        return result.returncode == 0
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        return False
+# Old private spellings, kept so existing imports and call sites resolve
+# unchanged after the ssh half moved to ._priority_ssh.
+_peer_ssh_argv = peer_ssh_argv
+_probe_ssh = probe_ssh
+_ssh_start_agent = ssh_start_agent
 
 
 def _priority_report(
@@ -241,43 +224,6 @@ def priority_check(
 # singleton-reconcile: sweep all locally registered agents and yield any
 # that have a higher-priority reachable host.  (fleet issue #250)
 # ---------------------------------------------------------------------------
-
-_SSH_START_TIMEOUT = 30  # seconds to wait for remote sac agent start
-
-
-def _ssh_start_agent(host: str, agent_name: str) -> bool:
-    """SSH to *host* and run ``sac agent start <agent_name>`` in the background.
-
-    Returns True if the remote command exited 0.
-    """
-    # Singleton-reconcile fans out across many hosts in parallel; share
-    # one ssh master per peer so MaxSessions / MaxStartups stay happy.
-    from .._state.host_config import ssh_control_options
-
-    cmd = [
-        "ssh",
-        "-o",
-        "ConnectTimeout=10",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "LogLevel=ERROR",
-        *ssh_control_options(),
-        host,
-        f"sac agent start {agent_name}",
-    ]
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            timeout=_SSH_START_TIMEOUT,
-        )
-        return result.returncode == 0
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        return False
-
 
 @click.command("reconcile-singletons")
 @click.option(

--- a/tests/scitex_agent_container/cli_pkg/test_priority_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_priority_cmds.py
@@ -222,14 +222,35 @@ def test_ssh_start_agent_returns_false_when_remote_exits_nonzero(subprocess_shim
     assert result is False
 
 
-def test_ssh_start_agent_runs_sac_start_command_on_target_host(subprocess_shim):
+def test_ssh_start_agent_targets_the_named_host(subprocess_shim):
     # Arrange
     subprocess_shim.install("ssh", exit=0)
     # Act
     _ssh_start_agent("target-host", "my-agent")
     # Assert
-    argv = subprocess_shim.argv_for("ssh")
-    assert "target-host" in argv and "sac agent start my-agent" in argv
+    assert "target-host" in subprocess_shim.argv_for("ssh")
+
+
+def test_ssh_start_agent_runs_sac_start_command_on_target_host(subprocess_shim):
+    """The remote command line is `sac agent start <name>`.
+
+    ASSERTED ON THE JOINED COMMAND LINE, not on tokenisation. This used to
+    pass the command as ONE argv element (``f"sac agent start {name}"``) and
+    now passes four. Both reach the remote identically — ssh joins every token
+    after the host with spaces and hands the result to the login shell (see
+    ``build_ssh_argv``) — so tokenisation was never the property worth pinning.
+
+    The split form is REQUIRED, not cosmetic: ``_is_sac_invocation`` decides
+    whether to inject the registry's ``SCITEX_DIR=<root>`` pin by testing
+    ``basename(command[0]) == "sac"``. Against the joined string that basename
+    is the whole sentence, so the pin would silently never apply on this path.
+    """
+    # Arrange
+    subprocess_shim.install("ssh", exit=0)
+    # Act
+    _ssh_start_agent("target-host", "my-agent")
+    # Assert
+    assert "sac agent start my-agent" in " ".join(subprocess_shim.argv_for("ssh"))
 
 
 def test_ssh_start_agent_returns_false_when_ssh_binary_missing(

--- a/tests/scitex_agent_container/cli_pkg/test_priority_cmds_peer_translation.py
+++ b/tests/scitex_agent_container/cli_pkg/test_priority_cmds_peer_translation.py
@@ -1,0 +1,232 @@
+"""`priority_cmds` must translate a peer NAME into its ssh ALIAS.
+
+MEASURED 2026-08-17. `spec.host` names a PEER; sac's peer table maps that name
+to an ssh ALIAS, and for the fleet's laptop the two resolve to different
+machines:
+
+    peer name        ywata-note-win
+    ssh alias        ywata-note-win-net  -> bastion-win.scitex.ai   (reaches)
+    the BARE name                        -> 192.168.11.101          (dead)
+
+This module handed the raw `spec.host` straight to ssh. So for every agent
+pinned to that peer — 54 of them — it reported "preferred host unreachable"
+while sac's OWN dispatch reached the same machine fine, because dispatch
+translates and this did not. Two consumers, one string, opposite outcomes.
+
+Not merely a bad report: `_ssh_start_agent` fed the same untranslated name to a
+REMOTE START, so a yield decision taken on a false "unreachable" would have
+tried to start an agent at an address that goes nowhere.
+
+WHAT THESE TESTS ASSERT, and why it is the report rather than the mechanism:
+the ssh TARGET must be the alias and must NOT be the bare peer name. That is a
+property of the rendered argv, so it holds however the translation is
+implemented — a test keyed to "does it call build_ssh_argv" would pass a
+reimplementation that called it wrongly.
+
+PA-306: no mocks. A real config file through the production
+`$SCITEX_AGENT_CONTAINER_CONFIG` seam, and the real argv builder. Nothing is
+executed — argv rendering is the whole subject.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg._priority_ssh import (
+    _PROBE_WALL_TIMEOUT,
+    _SSH_PROBE_OPTS,
+)
+from scitex_agent_container.cli_pkg.priority_cmds import _peer_ssh_argv
+
+# The incident's own pair: a peer whose name is NOT its ssh alias.
+_PEER = "ywata-note-win"
+_ALIAS = "ywata-note-win-net"
+
+_OPTS = ["-o", "BatchMode=yes"]
+
+
+@pytest.fixture
+def peer_table(tmp_path: Path, env_save_restore) -> None:
+    """A real config file with one aliased peer and one jump-chained peer."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        f"""
+peers:
+  {_PEER}: {{ ssh: {_ALIAS} }}
+  mba: {{ ssh: ywatanabe@mba.local }}
+  behind-jump:
+    ssh: deep-host
+    via: [mba]
+"""
+    )
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+
+
+# ---------------------------------------------------------------------------
+# The regression.
+# ---------------------------------------------------------------------------
+
+
+def test_a_registered_peer_is_reached_by_its_ssh_alias(peer_table):
+    """The fix: the ssh target is the ALIAS the peer table declares."""
+    # Arrange
+    command = ["hostname"]
+    # Act
+    argv = _peer_ssh_argv(_PEER, command, _OPTS)
+    # Assert
+    assert _ALIAS in argv
+
+
+def test_the_bare_peer_name_is_never_the_ssh_target(peer_table):
+    """The bug, asserted from the losing side.
+
+    `ywata-note-win` as an ssh target resolves to a dead LAN address. Its
+    presence anywhere in the argv as a standalone token would mean the
+    translation did not happen.
+    """
+    # Arrange
+    command = ["hostname"]
+    # Act
+    argv = _peer_ssh_argv(_PEER, command, _OPTS)
+    # Assert
+    assert _PEER not in argv
+
+
+def test_the_command_survives_translation(peer_table):
+    """Translating the host must not drop what we came to run."""
+    # Arrange
+    command = ["sac", "agent", "start", "figrecipe"]
+    # Act
+    argv = _peer_ssh_argv(_PEER, command, _OPTS)
+    # Assert
+    assert "figrecipe" in argv
+
+
+def test_the_caller_supplied_ssh_options_survive_translation(peer_table):
+    """BatchMode/ConnectTimeout are why the probe cannot hang. Keep them."""
+    # Arrange
+    command = ["hostname"]
+    # Act
+    argv = _peer_ssh_argv(_PEER, command, _OPTS)
+    # Assert
+    assert "BatchMode=yes" in argv
+
+
+def test_a_jump_chained_peer_renders_a_proxy_jump(peer_table):
+    """Proves we went through the real builder, not a lookalike.
+
+    A hand-rolled `["ssh", alias, cmd]` would pass every assertion above and
+    still strand any peer that needs a bastion. `-J` only appears if the
+    production chain logic ran.
+    """
+    # Arrange
+    command = ["hostname"]
+    # Act
+    argv = _peer_ssh_argv("behind-jump", command, _OPTS)
+    # Assert
+    assert "-J" in argv
+
+
+# ---------------------------------------------------------------------------
+# The timeout the fix silently changed. Pinned so it cannot change again
+# without a test saying so.
+# ---------------------------------------------------------------------------
+
+
+def _first_connect_timeout(argv: list[str]) -> int:
+    """The ConnectTimeout ssh will actually honour — the FIRST one present.
+
+    Rendered argv can legitimately carry the option twice (the builder emits
+    its own defaults, then appends the caller's). ssh takes the first, so
+    reading "is ConnectTimeout=3 in argv" would answer the wrong question:
+    it is present AND ignored.
+    """
+    for token in argv:
+        if token.startswith("ConnectTimeout="):
+            return int(token.split("=", 1)[1])
+    raise AssertionError(f"no ConnectTimeout in argv: {argv}")
+
+
+def test_a_registered_peer_uses_the_fleet_standard_connect_timeout(peer_table):
+    """Routing through the builder means the builder's timeout wins.
+
+    This module's private ConnectTimeout=3 is still APPENDED, and is still
+    inert, because build_ssh_argv emits its defaults first. Asserting the
+    effective value rather than mere presence is the whole point.
+    """
+    # Arrange
+    command = ["hostname"]
+    # Act
+    argv = _peer_ssh_argv(_PEER, command, _SSH_PROBE_OPTS)
+    # Assert
+    assert _first_connect_timeout(argv) == 10
+
+
+def test_an_unregistered_host_keeps_the_short_probe_timeout(peer_table):
+    """The pass-through path is untouched — there our 3s is the only copy."""
+    # Arrange
+    stranger = "some-host-not-in-the-table"
+    # Act
+    argv = _peer_ssh_argv(stranger, ["hostname"], _SSH_PROBE_OPTS)
+    # Assert
+    assert _first_connect_timeout(argv) == 3
+
+
+def test_the_wall_clock_cap_fires_before_the_ssh_timeout(peer_table):
+    """Why the slower ssh timeout does not change the VERDICT, only latency.
+
+    `probe_ssh` bounds the call with subprocess `timeout=_PROBE_WALL_TIMEOUT`
+    and treats expiry as unreachable. As long as that cap is shorter than the
+    ssh ConnectTimeout, an unreachable registered peer still answers False —
+    it just costs the cap instead of 3s. If someone later raises the cap above
+    the ssh timeout, this inverts and the argument in the docstring stops
+    holding, so the relationship is asserted rather than described.
+    """
+    # Arrange
+    argv = _peer_ssh_argv(_PEER, ["hostname"], _SSH_PROBE_OPTS)
+    # Act
+    ssh_timeout = _first_connect_timeout(argv)
+    # Assert
+    assert _PROBE_WALL_TIMEOUT < ssh_timeout
+
+
+# ---------------------------------------------------------------------------
+# The non-regression: hosts the table does not know must keep working.
+# ---------------------------------------------------------------------------
+
+
+def test_an_unregistered_host_is_passed_through_unchanged(peer_table):
+    """It may still resolve via ~/.ssh/config, and that path works today.
+
+    Translating only what the table knows fixes the defect without breaking
+    the case it never covered.
+    """
+    # Arrange
+    stranger = "some-host-not-in-the-table"
+    # Act
+    argv = _peer_ssh_argv(stranger, ["hostname"], _OPTS)
+    # Assert
+    assert stranger in argv
+
+
+def test_an_unregistered_host_still_gets_its_command(peer_table):
+    # Arrange
+    stranger = "some-host-not-in-the-table"
+    # Act
+    argv = _peer_ssh_argv(stranger, ["hostname"], _OPTS)
+    # Assert
+    assert "hostname" in argv
+
+
+def test_an_absent_peer_table_degrades_to_pass_through(env_save_restore, tmp_path):
+    """An unreadable config must not break a probe that works without one."""
+    # Arrange
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_CONFIG", str(tmp_path / "does-not-exist.yaml")
+    )
+    # Act
+    argv = _peer_ssh_argv("anything", ["hostname"], _OPTS)
+    # Assert
+    assert "anything" in argv


### PR DESCRIPTION
## The defect

`spec.host` names a **peer**. sac's peer table maps that name to an ssh **alias**, and for the fleet's laptop the two resolve to different machines:

| | resolves to | |
|---|---|---|
| peer name `ywata-note-win` | — | (what this module used) |
| ssh alias `ywata-note-win-net` | `bastion-win.scitex.ai` | reaches |
| the bare name | `192.168.11.101` | dead LAN IP |

`priority_cmds` handed the raw `spec.host` straight to `ssh`. So for every agent pinned to that peer it reported **"preferred host unreachable"** while sac's own dispatch reached the same machine fine — dispatch translates, this did not. Two consumers, one string, opposite outcomes.

Not merely a bad report: `_ssh_start_agent` fed the same untranslated name to a **remote start**, so a yield decision taken on a false "unreachable" would have tried to start an agent at an address that goes nowhere.

## The fix

Both ssh paths now go through `build_ssh_argv`, which also buys ProxyJump chains for peers behind a bastion. Hosts the table does not know are passed through unchanged — they may still resolve via `~/.ssh/config`, and that path works today.

## Two behaviour changes, stated because neither shows up in the diff

**1. `ConnectTimeout` for a registered peer is now 10, not 3.** `build_ssh_argv` emits its defaults *before* `extra_opts` and ssh honours the first occurrence, so this module's private `3` is appended and inert. Measured on the rendered argv, not inferred from the builder's source.

The effect is bounded and never reaches 10: `probe_ssh` caps the call at 5s and treats expiry as unreachable — the same verdict ssh's own timeout produced. An unreachable registered peer costs 5s instead of 3s and still answers `False`. That's latency on fan-out, not a behaviour change.

Accepted rather than worked around: the builder's values are the fleet's considered ones (its docstring calls 10 "probe-friendly") and this module's were an outlier predating them.

**2. The remote command is now four argv tokens, not one joined string.** Both reach the remote identically — ssh joins post-host tokens with spaces — but the split form is **required** for the SSOT pin: `_is_sac_invocation` tests `basename(command[0]) == "sac"`, and against the joined string that basename is the whole sentence, so `SCITEX_DIR=<root>` would silently never be injected on this path.

## Tests

Assert the **rendered argv** — the report, not the mechanism. A test keyed to "does it call `build_ssh_argv`" would pass a reimplementation that called it wrongly; `-J` appearing for a jump-chained peer is what proves the production chain logic ran.

Timeouts are asserted on the **effective** value (first occurrence wins), since `ConnectTimeout=3` is present *and* ignored — asserting presence would have answered the wrong question. One test pins the cap-below-ssh-timeout relationship, so if someone later raises the cap the argument above stops holding loudly rather than silently.

PA-306: real config through the production `$SCITEX_AGENT_CONTAINER_CONFIG` seam, real argv builder, no mocks.

## Refactor

`priority_cmds.py` crossed the 512-line cap, so its two jobs are split: **deciding** whether to yield stays, **reaching** the host moves to `_priority_ssh.py` (407 + 164). Old private names are re-exported, so no call site or import moved.

## Verification

`95 passed` — `test_priority_cmds`, `test_priority_cmds_peer_translation`, `test_ssh_control_options` — verified running against the **worktree** tree, not the main checkout.

One pre-existing test needed retargeting: `test_ssh_start_agent_runs_sac_start_command_on_target_host` asserted the joined-string tokenisation. It now asserts the remote command line, which is the property that actually matters, and the docstring records why.

## Known gap, not fixed here

`peer_ssh_argv` reads the real host config when `$SCITEX_AGENT_CONTAINER_CONFIG` is unset, so `test_priority_cmds.py` now depends on machine state. It passes here **because** this host's peer table happens not to contain `target-host` / `any-host` / `h` — that's luck, not isolation, and could bite on a differently-configured CI runner. Worth a follow-up that pins an empty config for those tests.
