### PR TITLE
fix(ssh): quote ONCE, in the builder, for both branches (regression + latent defect)

### DIFF
--- a/src/scitex_agent_container/_state/_host_ssh.py
+++ b/src/scitex_agent_container/_state/_host_ssh.py
@@ -234,10 +234,40 @@ def build_ssh_argv(
         # the contract every caller was already written against. Making the
         # two agree is the fix; quoting here and not there is what made a
         # peer's behaviour depend on whether it happened to carry a preamble.
-        inner = f"{preamble} && {' '.join(command)}"
+        inner = f"{preamble} && {shlex.join(list(command))}"
         argv.append(f"bash -c {shlex.quote(inner)}")
     else:
-        argv += list(command)
+        # ONE shlex-joined element, NOT raw tokens — measured 2026-08-17 with a
+        # live caller, twice.
+        #
+        # ``command`` MEANS THE SAME THING IN BOTH BRANCHES: a real argv list
+        # whose quoting this function owns. It did not always, and the two
+        # attempts it took to get here are worth recording because each failed
+        # in the other's direction.
+        #
+        #   1. preamble shlex.join + here raw tokens (the original)
+        #      A caller wanting one remote token had to pre-quote it for THIS
+        #      branch, and the preamble branch then quoted it a second time:
+        #      the remote bash looked for a FILE named ``sh -c '...'``, rc=127
+        #      on every preamble peer. That took scitex-hub down.
+        #
+        #   2. preamble space-join + here raw tokens (the first fix)
+        #      Consistent, and consistently WRONG. It exported this branch's
+        #      long-standing inability to carry a quoted argument onto the
+        #      preamble peers, breaking a live creds probe that passes
+        #      ``["python3", "-c", "<one-liner>"]``. Measured A/B on
+        #      scitex-compute-03: parent rc=0, that fix rc=2 syntax error.
+        #
+        # THE DECIDING MEASUREMENT was the BARE peer in that same A/B: nas-03
+        # failed on BOTH renderings. This branch never handled a
+        # whitespace-bearing argument at all — nothing had exercised it, so the
+        # defect sat here silently while looking like a preamble-only problem.
+        #
+        # ssh word-joins everything after the host and hands it to the remote
+        # shell, so emitting ONE shlex-joined element puts exactly the intended
+        # command line on the wire. Callers pass real argv lists and stop
+        # pre-quoting; both branches quote once, here.
+        argv.append(shlex.join(list(command)))
     return argv
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_spec_handoff.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_spec_handoff.py
@@ -225,18 +225,28 @@ def plan_handoff(
 def ssh_runner(peer: str, peers: Mapping[str, PeerSpec]) -> PeerShell:
     """A :data:`PeerShell` that runs scripts on ``peer`` over ssh.
 
-    The script is collapsed into ONE pre-quoted argv element because ssh
-    word-joins everything after the host and hands the result to the remote
-    shell — the same reason :func:`build_ssh_argv` pre-quotes its
-    ``env_preamble`` wrapper. That remote shell is also what expands the
-    ``$HOME`` in a registry-unpinned destination.
+    A REAL ARGV LIST — ``["sh", "-c", script]`` — because
+    :func:`build_ssh_argv` owns the quoting for both of its branches. The
+    remote shell is what expands the ``$HOME`` in a registry-unpinned
+    destination.
+
+    THIS USED TO PRE-QUOTE THE SCRIPT INTO ONE ELEMENT, and that was the
+    2026-08-17 outage. The no-preamble branch appended raw tokens for ssh to
+    word-join, so a caller wanting one remote token had to quote it itself —
+    but the env_preamble branch ``shlex.join``ed the same argument, quoting it
+    a SECOND time. The remote bash then looked for a file named
+    ``sh -c '...'`` and returned 127 on every preamble peer, which is what made
+    scitex-hub unstartable by any path.
+
+    Both branches now quote once, in the builder, so pre-quoting here would
+    re-create the doubling from the other side.
     """
     from ..._state.host_config import build_ssh_argv
 
     def run(
         script: str, stdin: bytes | None = None
     ) -> subprocess.CompletedProcess[bytes]:
-        argv = build_ssh_argv(peer, [f"sh -c {shlex.quote(script)}"], dict(peers))
+        argv = build_ssh_argv(peer, ["sh", "-c", script], dict(peers))
         return subprocess.run(argv, input=stdin, capture_output=True, check=False)
 
     return run

--- a/tests/scitex_agent_container/_state/test__host_ssh.py
+++ b/tests/scitex_agent_container/_state/test__host_ssh.py
@@ -1,4 +1,4 @@
-"""A peer's ``env_preamble`` must not change how its command is quoted.
+"""``command`` means a real argv list, quoted exactly ONCE by the builder.
 
 MEASURED 2026-08-17, reported by scitex-cards with a control. Every peer
 carrying an ``env_preamble`` returned rc=127 for any dispatched command::
@@ -14,21 +14,38 @@ compute-03, and both ``agent_start`` from a container and ``agent_spawn``
 through the host broker funnel here. It also blocked a scitex-cards client
 rollout, because the two affected hosts could not be reached to do it.
 
-THE MECHANISM — two individually-correct quotings that compose wrongly. ssh
-word-joins everything after the host and hands the result to the remote shell,
-so a caller wanting ONE remote token must pre-quote it; ``_spec_handoff``
-correctly does, passing a single element ``sh -c '...'``. The preamble branch
-then ran ``shlex.join`` over that already-quoted element, quoting it a second
-time, so the remote bash saw one word and looked for a FILE by that name.
+THE MECHANISM — the two branches DISAGREED about what ``command`` means. ssh
+word-joins everything after the host and hands the result to the remote shell.
+The preamble branch treated ``command`` as a real argv list (``shlex.join``);
+the bare branch treated it as tokens the caller had already quoted. No caller
+could satisfy both. ``_spec_handoff`` pre-quoted for the bare branch, passing
+one element ``sh -c '...'``, and the preamble branch then quoted it a SECOND
+time — so the remote bash saw a single word and looked for a FILE by that name.
 Each layer's docstring explained why IT quoted. Neither knew the other did.
 
-WHAT THESE TESTS PIN, and why it is a 2x2 rather than the one broken case:
-the bug was an ASYMMETRY between the two branches, so a fix verified only on
-the preamble side could silently re-break the bare side that works today.
-Both command shapes in real use are covered against both peer kinds:
+THE FIRST FIX made the preamble branch space-join to match the bare branch.
+Consistent, and consistently WRONG: it exported the bare branch's long-standing
+inability to carry a whitespace-bearing argument onto the preamble peers,
+breaking a live caller that passes ``["python3", "-c", "<one-liner>"]`` (A/B on
+real hosts: compute-03 parent rc=0, that fix rc=2 syntax error). THE DECIDING
+MEASUREMENT was the BARE peer in that same A/B — nas-03 failed on BOTH
+renderings. That branch had never carried a quoted argument at all, so the
+defect sat there silently while looking like a preamble-only problem.
 
-    pre-quoted single element   the ``_spec_handoff`` shape
-    real argv list              the ``priority_cmds`` shape
+THE FIX IS QUOTE-ONCE-IN-THE-BUILDER. ``command`` now means ONE thing on both
+sides: a real argv list whose quoting ``build_ssh_argv`` owns, emitted as a
+single ``shlex``-joined element so ssh's word-join puts exactly the intended
+command line on the wire. Callers pass real argv lists and stop pre-quoting.
+
+WHAT THESE TESTS PIN, and why it is a 2x2 rather than the one broken case: the
+bug was an ASYMMETRY between the two branches, so a fix verified only on the
+preamble side can silently re-break the bare side — and the first fix proved
+the reverse direction is just as easy. Both command shapes in real use are
+covered against both peer kinds:
+
+    argv with a whitespace-bearing argument   the ``_spec_handoff`` and
+                                              creds-probe shape
+    argv of plain words                       the ``priority_cmds`` shape
 
 PA-306: no mocks. A real config file through the production
 ``$SCITEX_AGENT_CONTAINER_CONFIG`` seam and the real argv builder. Nothing is
@@ -49,10 +66,12 @@ _PREAMBLE_PEER = "withpreamble"
 _BARE_PEER = "nopreamble"
 _PREAMBLE = 'export PATH="$HOME/.env-sac/bin:$PATH"'
 
-#: The `_spec_handoff` shape: ONE element the caller already quoted.
-_PREQUOTED = "sh -c 'echo REACHED'"
+#: The `_spec_handoff` shape: a real argv list whose LAST element is a whole
+#: script — spaces and all. This is the element the builder must quote, and
+#: must quote exactly once.
+_SCRIPT_ARGV = ["sh", "-c", "echo REACHED"]
 
-#: The `priority_cmds` shape: a real argv list.
+#: The `priority_cmds` shape: a real argv list of plain words.
 _ARGV_LIST = ["echo", "REACHED"]
 
 
@@ -76,40 +95,53 @@ peers:
 def _remote_command(argv: list[str]) -> str:
     """What the REMOTE shell ends up parsing, for either branch.
 
-    The preamble branch collapses into a single ``bash -c <quoted>`` element;
-    the bare branch leaves tokens that ssh will space-join. Recovering the
-    remote command line for both is what lets one assertion span the asymmetry
-    that caused the bug.
+    Both branches collapse into a single trailing element — the preamble
+    branch a ``bash -c <quoted>`` wrapper, the bare branch the shlex-joined
+    command itself — precisely so ssh's post-host word-join cannot disturb
+    the quoting. Recovering the remote command line for both is what lets one
+    assertion span the asymmetry that caused the bug.
     """
     if argv[-1].startswith("bash -c "):
         return shlex.split(argv[-1])[2]
-    # Bare branch: ssh joins every token after `--` with spaces.
-    return " ".join(argv[argv.index("--") + 1 :])
+    return argv[-1]
 
 
 # ---------------------------------------------------------------------------
-# The regression: a pre-quoted element survives BOTH peer kinds intact.
+# The regression: the caller's argv round-trips through BOTH peer kinds.
 # ---------------------------------------------------------------------------
 
 
-def test_a_prequoted_command_is_not_requoted_for_a_preamble_peer(peers):
-    """The bug. Double-quoting made the remote bash look for a file."""
+def test_a_script_argument_is_quoted_exactly_once_for_a_preamble_peer(peers):
+    """The outage. Double-quoting made the remote bash look for a file.
+
+    Asserted as a ROUND-TRIP — re-parse the remote command line and get the
+    caller's argv back — because that is the property the two failed attempts
+    each broke in a different direction: quoting twice fuses the argv into one
+    word, quoting zero times splits the script argument into several. Only
+    quoting exactly once reproduces `["sh", "-c", "echo REACHED"]` remotely.
+    """
     # Arrange
-    command = [_PREQUOTED]
+    command = list(_SCRIPT_ARGV)
     # Act
     remote = _remote_command(build_ssh_argv(_PREAMBLE_PEER, command, peers))
     # Assert
-    assert remote.endswith(_PREQUOTED)
+    assert shlex.split(remote)[-len(_SCRIPT_ARGV) :] == _SCRIPT_ARGV
 
 
-def test_a_prequoted_command_is_not_requoted_for_a_bare_peer(peers):
-    """The side that worked, pinned so a one-sided fix cannot break it."""
+def test_a_script_argument_is_quoted_exactly_once_for_a_bare_peer(peers):
+    """The branch the deciding measurement condemned, now pinned.
+
+    This side LOOKED healthy through the outage because nothing ever handed it
+    a whitespace-bearing argument; nas-03 then failed the live A/B on both
+    candidate renderings. Same round-trip property as the preamble case — that
+    the two branches now agree on it is the whole fix.
+    """
     # Arrange
-    command = [_PREQUOTED]
+    command = list(_SCRIPT_ARGV)
     # Act
     remote = _remote_command(build_ssh_argv(_BARE_PEER, command, peers))
     # Assert
-    assert remote.endswith(_PREQUOTED)
+    assert shlex.split(remote)[-len(_SCRIPT_ARGV) :] == _SCRIPT_ARGV
 
 
 def test_a_real_argv_list_survives_a_preamble_peer(peers):
@@ -145,7 +177,7 @@ def test_the_preamble_still_runs_before_the_command(peers):
     contains-check and still fail every dispatch.
     """
     # Arrange
-    command = [_PREQUOTED]
+    command = list(_SCRIPT_ARGV)
     # Act
     remote = _remote_command(build_ssh_argv(_PREAMBLE_PEER, command, peers))
     # Assert
@@ -153,9 +185,9 @@ def test_the_preamble_still_runs_before_the_command(peers):
 
 
 def test_a_bare_peer_gets_no_preamble_wrapper(peers):
-    """A peer without env_preamble must keep its byte-identical argv shape."""
+    """A peer without env_preamble must not acquire a `bash -c` wrapper."""
     # Arrange
-    command = [_PREQUOTED]
+    command = list(_SCRIPT_ARGV)
     # Act
     argv = build_ssh_argv(_BARE_PEER, command, peers)
     # Assert

--- a/tests/scitex_agent_container/_state/test__peer_resolve.py
+++ b/tests/scitex_agent_container/_state/test__peer_resolve.py
@@ -26,6 +26,7 @@ supported CLI, so callers hand-rolled ssh instead.
 from __future__ import annotations
 
 import os
+import shlex
 import textwrap
 from collections.abc import Iterator
 from pathlib import Path
@@ -69,6 +70,25 @@ _HOSTS_YAML = textwrap.dedent(
 )
 
 _SPARTAN_PREAMBLE = ("module load Apptainer/1.3.3",)
+
+
+def _remote_command(argv: list[str]) -> str:
+    """The command line ssh actually puts on the REMOTE shell.
+
+    ssh word-joins everything after the host, so ``build_ssh_argv``
+    collapses the command into ONE trailing argv element that it quotes
+    itself — a bare ``shlex.join`` for a plain peer, or a
+    ``bash -c '<preamble> && <cmd>'`` wrapper for a peer carrying an
+    ``env_preamble``. Reading the tail back through this helper keeps the
+    assertions pinned to what the remote runs, which is the thing these
+    tests have always cared about, rather than to the local tokenisation
+    (which changed on 2026-08-17 when both branches were made to quote
+    exactly once).
+    """
+    tail = argv[-1]
+    if tail.startswith("bash -c "):
+        return shlex.split(tail)[2]
+    return tail
 
 
 def _set_scitex_dir(value: str) -> Iterator[None]:
@@ -134,13 +154,25 @@ def test_registry_peer_carries_the_declared_ssh_alias(registry: Path) -> None:
 
 
 def test_registry_peer_renders_a_real_ssh_argv(registry: Path) -> None:
-    """The resolved peer must be usable by the unmodified ssh renderer."""
+    """The resolved peer must be usable by the unmodified ssh renderer.
+
+    A peer that exists ONLY in the host registry — no config.yaml entry
+    at all, which is the outage this file was written for — must dispatch
+    the caller's command to the remote intact. ``mba``'s registry row
+    declares a home-relative ``~/.scitex`` root, so no ``SCITEX_DIR=``
+    pin is prepended and the remote line is the command verbatim.
+
+    Assertion shape changed 2026-08-17: the renderer now emits ONE
+    shlex-joined trailing element instead of N raw tokens, so the tail is
+    read back with :func:`_remote_command`. The property is untouched —
+    only the tail's local shape moved.
+    """
     # Arrange
     merged = peers_with_registry({})
     # Act
     argv = build_ssh_argv("mba", ["sac", "host", "list", "--json"], merged)
     # Assert
-    assert argv[argv.index("--") + 1 :] == ["sac", "host", "list", "--json"]
+    assert _remote_command(argv) == "sac host list --json"
 
 
 def test_registry_peer_ssh_argv_targets_the_alias(registry: Path) -> None:

--- a/tests/scitex_agent_container/_state/test_host_config.py
+++ b/tests/scitex_agent_container/_state/test_host_config.py
@@ -487,6 +487,16 @@ def test_host_exec_passes_ssh_target_to_ssh(cfg_path: Path, subprocess_shim):
 
 
 def test_host_exec_appends_command_after_double_dash(cfg_path: Path, subprocess_shim):
+    """The ssh options end at ``--`` and the user's command is what follows.
+
+    Assertion SHAPE changed (was ``argv[-3:] == ["--", "echo", "hello"]``)
+    because ``build_ssh_argv`` now emits the command as ONE shlex-joined
+    element rather than N raw tokens — ssh word-joins everything after the
+    host anyway, and quoting it once here is what makes a whitespace-bearing
+    argument survive. The PROPERTY is unchanged and still the point: the
+    ``--`` separator is present, the dispatched command sits immediately
+    after it, and nothing is appended past the command.
+    """
     # Arrange
     cfg_path.write_text("peers:\n  mba: { ssh: ywatanabe@mba.local }\n")
     subprocess_shim.install("ssh", exit=0)
@@ -496,7 +506,7 @@ def test_host_exec_appends_command_after_double_dash(cfg_path: Path, subprocess_
     CliRunner().invoke(host_exec, ["mba", "--", "echo", "hello"])
     # Assert
     argv = subprocess_shim.argv_for("ssh")
-    assert argv[-3:] == ["--", "echo", "hello"]
+    assert argv[-2:] == ["--", "echo hello"]
 
 
 def test_host_probe_reports_reachable_with_remote_canonical(
@@ -634,6 +644,17 @@ def test_dispatch_remote_unknown_peer_returns_2(cfg_path: Path):
 def test_dispatch_remote_invokes_ssh_with_remote_sac_command(
     cfg_path: Path, subprocess_shim
 ):
+    """``--on <peer> agent list`` runs ``sac agent list`` on the remote.
+
+    Assertion SHAPE changed (was ``["sac", "agent", "list"]``) because
+    ``build_ssh_argv`` now renders the command as ONE shlex-joined element
+    instead of N raw tokens. The PROPERTY is unchanged: everything after the
+    ``--`` separator is the remote command line, and dispatch re-prefixes the
+    local subcommand with ``sac`` so the peer runs the CLI rather than a bare
+    ``agent list``. Compared against the literal wire string on purpose — a
+    test that recomputed it with ``shlex.join`` would be parameterised by the
+    code under test and could not fail.
+    """
     # Arrange
     cfg_path.write_text("peers:\n  mba: { ssh: ywatanabe@mba.local }\n")
     subprocess_shim.install("ssh", exit=7)
@@ -644,7 +665,7 @@ def test_dispatch_remote_invokes_ssh_with_remote_sac_command(
     # Assert
     argv = subprocess_shim.argv_for("ssh")
     sep = argv.index("--")
-    assert argv[sep + 1 :] == ["sac", "agent", "list"]
+    assert argv[sep + 1 :] == ["sac agent list"]
 
 
 def test_dispatch_remote_propagates_ssh_exit_code(cfg_path: Path, subprocess_shim):

--- a/tests/scitex_agent_container/_state/test_host_config_env_preamble.py
+++ b/tests/scitex_agent_container/_state/test_host_config_env_preamble.py
@@ -11,14 +11,19 @@ Covers:
 - ``load`` parses the YAML scalar (``|`` literal block) form, the list
   form, and tolerates absence.
 - ``build_ssh_argv`` wraps the dispatched command in ``bash -c
-  '<preamble> && <cmd>'`` when the peer carries a preamble, and is
-  byte-identical to the pre-preamble shape when it doesn't.
+  '<preamble> && <cmd>'`` when the peer carries a preamble, and emits
+  the command unwrapped when it doesn't.
+- Both branches quote the command EXACTLY ONCE (2026-08-17): each
+  renders the whole remote command line into ONE trailing argv
+  element, so a whitespace-bearing argument survives as a single token
+  whichever branch a peer happens to take.
 - Backwards compat: a multi-hop peer without a preamble still emits
-  ``-J <chain>`` and the raw command tail.
+  ``-J <chain>`` and dispatches the command with no ``bash -c`` wrapper.
 """
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 import pytest
@@ -28,6 +33,28 @@ from scitex_agent_container._state.host_config import (
     build_ssh_argv,
     load,
 )
+
+
+def _remote_command(argv: list[str]) -> str:
+    """The command line the REMOTE shell receives, from either branch.
+
+    ssh word-joins everything after the host and hands the result to the
+    remote user's shell, so ``build_ssh_argv`` puts the entire remote
+    command line into ONE trailing argv element: ``shlex.join(command)``
+    on the bare branch, and ``bash -c '<preamble> && <cmd>'`` on the
+    preamble branch.
+
+    Tests that care about WHAT RUNS REMOTELY assert on this string rather
+    than on token positions in the argv. The token count is an artifact of
+    the local rendering — it has already changed twice while the remote
+    command line stayed the thing that had to be right. Assertions about
+    ssh OPTIONS, the ``-J`` chain or the host target still read the argv
+    directly; those parts are unaffected.
+    """
+    tail = argv[-1]
+    if tail.startswith("bash -c "):
+        return shlex.split(tail)[2]
+    return tail
 
 
 @pytest.fixture
@@ -189,20 +216,25 @@ peers:
 # ---------------------------------------------------------------------------
 
 
-def test_build_ssh_argv_without_preamble_is_unchanged():
-    # Arrange — single-hop, no preamble: argv tail must be `[--, cmd...]`
-    # exactly as before this feature landed.
+def test_build_ssh_argv_without_preamble_dispatches_the_command_unwrapped():
+    """A peer with no preamble gets no ``bash -c`` wrapper interposed.
+
+    RESHAPED 2026-08-17 (was ``..._is_unchanged``, pinning the five raw
+    tail tokens ``[host, --, sac, agent, list]``). The quote-once fix
+    collapses the command into ONE trailing element, so the literal token
+    count is gone — but the property that test existed for is not: a peer
+    without a preamble is still dispatched to ITS ssh target, after the
+    ``--`` separator, with the command going straight to the remote login
+    shell and nothing wrapped around it. That is what is asserted now, and
+    it still fails loudly if the preamble branch ever leaks into a peer
+    that carries no preamble.
+    """
+    # Arrange
     peers = {"mba": PeerSpec(name="mba", ssh="ywatanabe@mba.local")}
     # Act
     argv = build_ssh_argv("mba", ["sac", "agent", "list"], peers)
-    # Assert — last 4 tokens are the ssh target + raw command tail.
-    assert argv[-5:] == [
-        "ywatanabe@mba.local",
-        "--",
-        "sac",
-        "agent",
-        "list",
-    ]
+    # Assert — ssh target, separator, then the bare remote command line.
+    assert argv[-3:] == ["ywatanabe@mba.local", "--", "sac agent list"]
 
 
 @pytest.fixture
@@ -258,42 +290,33 @@ def test_build_ssh_argv_inner_string_appends_user_command_after_preamble(
     assert final.endswith("which apptainer'")
 
 
-def test_build_ssh_argv_joins_the_command_the_same_way_both_branches_do():
-    """The preamble branch must treat ``command`` exactly as the bare one does.
+def test_build_ssh_argv_preamble_peer_keeps_whitespace_argument_as_one_token():
+    """A whitespace-bearing argument survives as ONE token on a preamble peer.
 
-    CHANGED 2026-08-17, and the previous assertion here was the reason a P1
-    outage existed. It pinned the preamble branch to ``shlex.join``, i.e. to
-    ``command`` being a REAL ARGV LIST — while the bare branch appends raw
-    tokens for ssh to word-join, i.e. ``command`` being ALREADY SHELL-QUOTED.
+    REWRITTEN 2026-08-17, twice-measured, and the earlier versions of this
+    test were each part of an outage rather than a guard against one.
 
-    Two incompatible meanings for one parameter, selected by a branch the
-    caller cannot see. NO CALLER COULD SATISFY BOTH: ``_spec_handoff``
-    pre-quoted its script to make the bare branch work, the preamble branch
-    quoted that a second time, and the remote bash looked for a FILE named
-    ``sh -c '...'`` — rc=127 on every preamble peer, which is what made
-    scitex-hub unstartable by any path (measured on compute-02 and -03, with
-    the bare peer nas-03 returning 0 as the control).
+    v1 pinned the preamble branch to ``shlex.join`` while the bare branch
+    appended raw already-quoted tokens. Two incompatible meanings for one
+    parameter, selected by a branch the caller cannot see: ``_spec_handoff``
+    pre-quoted its script to satisfy the bare branch, the preamble branch
+    quoted it a SECOND time, and the remote bash looked for a FILE named
+    ``sh -c '...'`` — rc=127 on every preamble peer, which took scitex-hub
+    down and unstartable by any path.
 
-    So the contract is now stateable in one sentence, and it is the bare
-    branch's: ``command`` is a token list that will be SPACE-JOINED, and a
-    caller wanting one remote token pre-quotes it. Every caller in the repo
-    already satisfies that.
+    v2 (mine) made the preamble branch SPACE-JOIN to match the bare one and
+    asserted here that ``echo 'hello world'`` reflows into two remote
+    arguments. Consistent, and consistently wrong: it exported the bare
+    branch's inability to carry a quoted argument onto the preamble peers
+    and broke a live caller passing ``["python3", "-c", "<one-liner>"]``
+    (A/B on scitex-compute-03: parent rc=0, that fix rc=2 syntax error).
 
-    THE COST, stated rather than hidden: an argument containing whitespace
-    reflows into two on a preamble peer, where it previously survived. That is
-    not a new hazard — it is what the bare branch has always done to the same
-    input — but it IS a behaviour change for preamble peers, and the property
-    this test used to guarantee is genuinely gone.
-
-    Preserving quoting on BOTH branches is strictly better and is the
-    follow-up: make the bare branch emit one ``shlex.join``ed element too.
-    That is not bundled here because it changes the rendered argv SHAPE and
-    breaks 13 tests that deliberately pin it (including
-    ``test_build_ssh_argv_without_preamble_is_unchanged`` and
-    ``test_home_rooted_peer_argv_is_byte_identical``, which exist to prove
-    registry pinning leaves an unpinned peer's argv untouched). Rewriting a
-    documented byte-identity invariant deserves its own review, not a hurried
-    edit while an agent is down.
+    THE DECIDING MEASUREMENT was the bare peer nas-03 in that same A/B: it
+    failed on BOTH renderings. The bare branch had never once carried a
+    whitespace-bearing argument — nothing exercised it, so a contract defect
+    read as a preamble-only problem. ``command`` now means one thing in both
+    branches (a real argv list whose quoting ``build_ssh_argv`` owns), and
+    THIS is the property that makes the contract worth having.
     """
     # Arrange
     peers = {
@@ -305,8 +328,31 @@ def test_build_ssh_argv_joins_the_command_the_same_way_both_branches_do():
     }
     # Act
     argv = build_ssh_argv("spartan-bm152", ["echo", "hello world"], peers)
-    # Assert
-    assert argv[-1] == "bash -c 'module load Apptainer/1.3.3 && echo hello world'"
+    # Assert — re-parse the remote command line the way the remote shell
+    # will; it must yield back the argv we handed in, not a reflowed one.
+    assert shlex.split(_remote_command(argv))[-2:] == ["echo", "hello world"]
+
+
+def test_build_ssh_argv_bare_peer_keeps_whitespace_argument_as_one_token():
+    """The same guarantee on a peer with no preamble — the branch that lacked it.
+
+    Companion to the preamble case above, and the one the fix actually
+    ADDED behaviour to. nas-03 (a bare peer) was the control in the
+    2026-08-17 A/B and failed on both candidate renderings, because this
+    branch used to append raw tokens for ssh to word-join: ``hello world``
+    arrived as two remote arguments. Nothing in the fleet had exercised
+    it, so the defect sat here silently.
+
+    Pinning it on BOTH peer kinds is deliberate — a peer's dispatch must
+    not depend on whether it happens to carry an ``env_preamble``.
+    """
+    # Arrange
+    peers = {"nas-03": PeerSpec(name="nas-03", ssh="nas-03")}
+    # Act
+    argv = build_ssh_argv("nas-03", ["echo", "hello world"], peers)
+    # Assert — re-parse the remote command line the way the remote shell
+    # will; it must yield back the argv we handed in, not a reflowed one.
+    assert shlex.split(_remote_command(argv))[-2:] == ["echo", "hello world"]
 
 
 @pytest.fixture
@@ -368,8 +414,8 @@ def empty_preamble_argv() -> list[str]:
     """Render the ssh argv for a peer with an explicit empty preamble.
 
     Shared by the pair of single-assert tests below that pin (a) no
-    bash wrapper is inserted, and (b) the command tail is byte-identical
-    to the pre-preamble argv shape.
+    bash wrapper is inserted, and (b) the command reaches the remote
+    directly, right after the ``--`` separator.
     """
     peers = {"mba": PeerSpec(name="mba", ssh="mba", env_preamble=())}
     return build_ssh_argv("mba", ["echo", "hi"], peers)
@@ -386,15 +432,25 @@ def test_build_ssh_argv_empty_preamble_does_not_insert_bash_wrapper(
     assert not has_bash
 
 
-def test_build_ssh_argv_empty_preamble_preserves_raw_command_tail(
+def test_build_ssh_argv_empty_preamble_sends_command_after_the_separator(
     empty_preamble_argv: list[str],
 ):
+    """An EMPTY preamble takes the bare branch, command intact after ``--``.
+
+    RESHAPED 2026-08-17 (was ``..._preserves_raw_command_tail``, pinning
+    ``["--", "echo", "hi"]``). The quote-once fix renders the command as one
+    joined element, so "raw tokens" is no longer the shape — but the property
+    is untouched and is the one this test was written for: an ``env_preamble``
+    that is present-but-empty must be treated as ABSENT, i.e. the command
+    goes straight to the remote shell after the separator with no wrapper
+    layer between. The sibling test above pins the no-``bash`` half.
+    """
     # Arrange: fixture builds the argv for a peer with an empty preamble.
     argv = empty_preamble_argv
-    # Act: read the last three tokens (separator + raw command).
-    tail = argv[-3:]
+    # Act: read the last two tokens (separator + remote command line).
+    tail = argv[-2:]
     # Assert
-    assert tail == ["--", "echo", "hi"]
+    assert tail == ["--", "echo hi"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_state/test_host_registry.py
+++ b/tests/scitex_agent_container/_state/test_host_registry.py
@@ -142,11 +142,20 @@ def _remote_command_line(argv: list[str]) -> str:
     thing every assertion below was ever a proxy for. Peers carrying an
     ``env_preamble`` wrap it in ``bash -c '<preamble> && <cmd>'``; unwrap
     that so both dispatch paths are compared on the same footing.
+
+    JOIN EVERYTHING PAST THE ``--``, not just the first element. ssh
+    word-joins the WHOLE tail, so reading only ``argv[i + 1]`` would be
+    blind to any extra trailing token — and extra trailing tokens DO
+    reach the remote shell. Caught by mutation testing: a build_ssh_argv
+    that emits the joined element AND THEN appends the raw tokens (so the
+    remote runs the command twice) left every assertion in this file
+    green while the helper read one element, and fails four of them once
+    the whole tail is joined.
     """
-    element = argv[argv.index("--") + 1]
-    if element.startswith("bash -c "):
-        return shlex.split(element)[2]
-    return element
+    line = " ".join(argv[argv.index("--") + 1 :])
+    if line.startswith("bash -c "):
+        return shlex.split(line)[2]
+    return line
 
 
 def test_registry_rows_are_read_through_the_ssot(registry: Path) -> None:

--- a/tests/scitex_agent_container/_state/test_host_registry.py
+++ b/tests/scitex_agent_container/_state/test_host_registry.py
@@ -22,6 +22,7 @@ EXPLICITLY, and never expands ``~`` on the local machine.
 from __future__ import annotations
 
 import os
+import shlex
 import textwrap
 from collections.abc import Iterator
 from pathlib import Path
@@ -125,9 +126,27 @@ def _peers() -> dict[str, PeerSpec]:
     }
 
 
-def _remote_cmd(argv: list[str]) -> list[str]:
-    """The command portion of an ssh argv (everything past the ``--``)."""
-    return argv[argv.index("--") + 1 :]
+def _remote_command_line(argv: list[str]) -> str:
+    """The command line ssh actually puts on the wire, from either branch.
+
+    This used to slice the raw tokens past the ``--``. Since 2026-08-17
+    ``build_ssh_argv`` owns the quoting and emits the whole remote command
+    as ONE ``shlex.join``-ed element in BOTH branches (previously the
+    preamble branch shlex-joined while the bare branch appended raw
+    tokens, so no caller could satisfy both — that disagreement double-
+    quoted ``sh -c '…'`` into rc=127 on every preamble peer).
+
+    Asserting on the joined string is not a concession to the new shape:
+    ssh word-joins everything after the host and hands the result to the
+    remote user's shell, so this string IS what the remote parses — the
+    thing every assertion below was ever a proxy for. Peers carrying an
+    ``env_preamble`` wrap it in ``bash -c '<preamble> && <cmd>'``; unwrap
+    that so both dispatch paths are compared on the same footing.
+    """
+    element = argv[argv.index("--") + 1]
+    if element.startswith("bash -c "):
+        return shlex.split(element)[2]
+    return element
 
 
 def test_registry_rows_are_read_through_the_ssot(registry: Path) -> None:
@@ -199,18 +218,20 @@ def test_compute_node_inherits_root_via_chain(registry: Path) -> None:
 
 
 def test_sac_invocation_is_registry_pinned(registry: Path) -> None:
+    """A registry-known peer's sac run reaches the remote shell pinned.
+
+    The pin is a SHELL ASSIGNMENT PREFIX, so what matters is that the
+    remote shell parses ``SCITEX_DIR=<root>`` immediately before ``sac``
+    — assert the whole remote command line, not the local token slice
+    (the argv now carries it as one joined element).
+    """
     # Arrange
     peers = _peers()
+    expected = f"SCITEX_DIR={SPARTAN_ROOT} sac agents start a"
     # Act
     argv = build_ssh_argv("spartan", ["sac", "agents", "start", "a"], peers)
     # Assert
-    assert _remote_cmd(argv) == [
-        f"SCITEX_DIR={SPARTAN_ROOT}",
-        "sac",
-        "agents",
-        "start",
-        "a",
-    ]
+    assert _remote_command_line(argv) == expected
 
 
 def test_pin_survives_the_lmod_preamble_wrapper(registry: Path) -> None:
@@ -229,33 +250,53 @@ def test_pin_survives_the_lmod_preamble_wrapper(registry: Path) -> None:
 
 
 def test_home_rooted_peer_argv_is_byte_identical(registry: Path) -> None:
-    """No regression for mba / nas: their registry root IS ``~/.scitex``."""
+    """No regression for mba / nas: their registry root IS ``~/.scitex``.
+
+    Home-relative means the registry has no absolute answer, and sac must
+    not invent one — the peer keeps the dispatch it had before the pin
+    existed. Assertion shape changed 2026-08-17 (one joined element in
+    place of N tokens); the property is unchanged and still the point:
+    registry pinning does not alter an UNPINNED peer's remote command
+    line.
+    """
     # Arrange
     peers = _peers()
     # Act
     argv = build_ssh_argv("mba", ["sac", "agents", "start", "a"], peers)
     # Assert
-    assert _remote_cmd(argv) == ["sac", "agents", "start", "a"]
+    assert _remote_command_line(argv) == "sac agents start a"
 
 
 def test_non_sac_command_is_never_touched(registry: Path) -> None:
-    """``sac host exec <peer> -- <arbitrary>`` must pass through unchanged."""
+    """``sac host exec <peer> -- <arbitrary>`` must pass through unchanged.
+
+    Spartan IS registry-pinned, so this proves the pin is gated on the
+    command being a sac run and not on the peer. Asserted on the remote
+    command line (one joined element since 2026-08-17): the arbitrary
+    command reaches the remote shell with no ``SCITEX_DIR=`` prefix.
+    """
     # Arrange
     peers = _peers()
     # Act
     argv = build_ssh_argv("spartan", ["hostname", "-s"], peers)
     # Assert
-    assert _remote_cmd(argv) == ["hostname", "-s"]
+    assert _remote_command_line(argv) == "hostname -s"
 
 
 def test_absolute_path_to_sac_is_still_detected(registry: Path) -> None:
-    """Spartan invokes ``/home/ywatanabe/.env-3.11/bin/sac`` — still a sac run."""
+    """Spartan invokes ``/home/ywatanabe/.env-3.11/bin/sac`` — still a sac run.
+
+    Detection, not exact rendering, is what this pins: the assertion asks
+    only that the remote command line OPENS with the pin (it used to ask
+    the same of the first raw token, before the command became one joined
+    element on 2026-08-17).
+    """
     # Arrange
     peers = _peers()
     # Act
     argv = build_ssh_argv("spartan", ["/home/x/.env-3.11/bin/sac", "agents"], peers)
     # Assert
-    assert _remote_cmd(argv)[0] == f"SCITEX_DIR={SPARTAN_ROOT}"
+    assert _remote_command_line(argv).startswith(f"SCITEX_DIR={SPARTAN_ROOT} ")
 
 
 def test_peer_absent_from_registry_is_never_pinned(
@@ -267,13 +308,18 @@ def test_peer_absent_from_registry_is_never_pinned(
     it has no better answer than it had before, so the remote keeps
     expanding its own ``~/.scitex``. Guessing here is precisely the class
     of bug this whole change exists to kill.
+
+    Same peer and same command as the pinned test above, differing only
+    in the registry fixture, so the un-pinned remote command line is the
+    contrast that carries the meaning. (Assertion shape changed
+    2026-08-17: one joined element, same property.)
     """
     # Arrange
     peers = _peers()
     # Act
     argv = build_ssh_argv("spartan", ["sac", "agents", "start", "a"], peers)
     # Assert
-    assert _remote_cmd(argv) == ["sac", "agents", "start", "a"]
+    assert _remote_command_line(argv) == "sac agents start a"
 
 
 # EOF

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -108,6 +109,25 @@ def _ssh_invocations(bin_dir: Path) -> list[list[str]]:
 
 def _phase_count(bin_dir: Path, marker: str) -> int:
     return sum(1 for argv in _ssh_invocations(bin_dir) if marker in " ".join(argv))
+
+
+def _remote_argv(argv: list[str]) -> list[str]:
+    """Tokens of the command line the PEER runs, recovered from an ssh argv.
+
+    ssh word-joins everything after the host and hands the result to the
+    remote shell, so ``build_ssh_argv`` owns the quoting and emits the whole
+    remote command as ONE shlex-joined trailing element (a peer carrying an
+    ``env_preamble`` gets that wrapped in ``bash -c '<preamble> && <cmd>'``).
+    The command's tokens are therefore no longer separate members of the
+    local ssh argv, and an ``x in argv`` membership test — which was always
+    a proxy for "x is on the remote command line" — can no longer see them.
+    This recovers the real remote command line so assertions keep talking
+    about what the peer actually executes.
+    """
+    tail = argv[-1]
+    if tail.startswith("bash -c "):
+        return shlex.split(shlex.split(tail)[2])
+    return shlex.split(tail)
 
 
 # ---------------------------------------------------------------------------
@@ -965,11 +985,17 @@ class TestTryDispatchClassification:
             force=False,
             local_names={"ywata-note-win"},
         )
-        # Assert — dispatched, and the LAST ssh argv runs the peer-side start
-        # verb (the earlier calls are the manifest read, the transfer and the
-        # post-transfer verification).
+        # Assert — dispatched, and the LAST ssh call makes the PEER run the
+        # peer-side start verb (the earlier calls are the manifest read, the
+        # transfer and the post-transfer verification). Asserted against the
+        # recovered remote command line rather than the raw ssh argv: the
+        # command now travels as one shlex-joined element, so the tail-slice
+        # of the argv is ssh options, not the verb. Same property — the peer
+        # runs ``sac agents start alpha`` with ``--no-redispatch`` (no
+        # dispatch loop back) and ``--json`` (parseable envelope) — and the
+        # tail slice still tolerates a registry ``SCITEX_DIR=`` pin in front.
         ssh_calls = _ssh_invocations(shim_bin)
-        assert out is True and ssh_calls[-1][-6:] == [
+        assert out is True and _remote_argv(ssh_calls[-1])[-6:] == [
             "sac",
             "agents",
             "start",

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
@@ -24,6 +24,7 @@ Same-shape invariants over a single arrange/act collapse into
 from __future__ import annotations
 
 import os
+import shlex
 from contextlib import contextmanager
 from typing import Any, Callable, Iterator
 
@@ -402,6 +403,25 @@ def _ssh_invocations(bin_dir):
     return [_json.loads(ln) for ln in log.read_text().splitlines() if ln.strip()]
 
 
+def _remote_argv(argv):
+    """Tokens of the command line the PEER runs, recovered from an ssh argv.
+
+    ssh word-joins everything after the host and hands the result to the
+    remote shell, so ``build_ssh_argv`` owns the quoting and emits the whole
+    remote command as ONE shlex-joined trailing element (a peer carrying an
+    ``env_preamble`` gets that wrapped in ``bash -c '<preamble> && <cmd>'``).
+    The command's tokens are therefore no longer separate members of the
+    local ssh argv, and an ``x in argv`` membership test — which was always
+    a proxy for "x is on the remote command line" — can no longer see them.
+    This recovers the real remote command line so assertions keep talking
+    about what the peer actually executes.
+    """
+    tail = argv[-1]
+    if tail.startswith("bash -c "):
+        return shlex.split(shlex.split(tail)[2])
+    return shlex.split(tail)
+
+
 def test_cross_host_restart_dispatches_via_ssh(remote_row_for_zeta, ssh_shim):
     # Arrange
     runner = CliRunner()
@@ -438,9 +458,13 @@ def test_cross_host_restart_ssh_argv_includes_json_flag(remote_row_for_zeta, ssh
     runner = CliRunner()
     # Act
     runner.invoke(restart, ["zeta", "-y"])
-    argv = _ssh_invocations(ssh_shim)[-1]
-    # Assert
-    assert "--json" in argv
+    remote = _remote_argv(_ssh_invocations(ssh_shim)[-1])
+    # Assert — the lead parses the peer's envelope to update its own row, so
+    # ``--json`` must reach the REMOTE command line. Membership was asserted
+    # on the raw ssh argv while the command still travelled as separate argv
+    # members; build_ssh_argv now joins it into one element, so the same
+    # property is asserted against the recovered remote command line.
+    assert "--json" in remote
 
 
 def test_cross_host_restart_does_not_call_local_agent_restart(

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
@@ -7,6 +7,7 @@ module namespace via a small ``_swap`` context manager.
 from __future__ import annotations
 
 import os
+import shlex
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, Iterator
@@ -461,6 +462,25 @@ def _ssh_invocations(bin_dir):
     return [_json.loads(ln) for ln in log.read_text().splitlines() if ln.strip()]
 
 
+def _remote_argv(argv):
+    """Tokens of the command line the PEER runs, recovered from an ssh argv.
+
+    ssh word-joins everything after the host and hands the result to the
+    remote shell, so ``build_ssh_argv`` owns the quoting and emits the whole
+    remote command as ONE shlex-joined trailing element (a peer carrying an
+    ``env_preamble`` gets that wrapped in ``bash -c '<preamble> && <cmd>'``).
+    The command's tokens are therefore no longer separate members of the
+    local ssh argv, and an ``x in argv`` membership test — which was always
+    a proxy for "x is on the remote command line" — can no longer see them.
+    This recovers the real remote command line so assertions keep talking
+    about what the peer actually executes.
+    """
+    tail = argv[-1]
+    if tail.startswith("bash -c "):
+        return shlex.split(shlex.split(tail)[2])
+    return shlex.split(tail)
+
+
 def test_cross_host_stop_dispatches_via_ssh(remote_row_for_zeta, ssh_shim):
     # Arrange
     runner = CliRunner()
@@ -495,9 +515,13 @@ def test_cross_host_stop_ssh_argv_includes_json_flag(remote_row_for_zeta, ssh_sh
     runner = CliRunner()
     # Act
     runner.invoke(stop, ["zeta"])
-    argv = _ssh_invocations(ssh_shim)[-1]
-    # Assert
-    assert "--json" in argv
+    remote = _remote_argv(_ssh_invocations(ssh_shim)[-1])
+    # Assert — the lead parses the peer's envelope to close its own row, so
+    # ``--json`` must reach the REMOTE command line. Membership was asserted
+    # on the raw ssh argv while the command still travelled as separate argv
+    # members; build_ssh_argv now joins it into one element, so the same
+    # property is asserted against the recovered remote command line.
+    assert "--json" in remote
 
 
 def test_cross_host_stop_updates_lead_side_row(remote_row_for_zeta, ssh_shim):


### PR DESCRIPTION
Fixes a regression I shipped in `be467096` **and** a latent defect that predates it. Reported by scitex-cards within minutes of that merge, on a live caller.

## The regression

`_send_preflight`'s creds probe dispatches `["python3", "-c", "<one-liner>"]`. On a preamble peer the space-join I introduced handed that to bash unquoted:

```
bash: -c: line 1: syntax error near unexpected token `('
```

A/B on the real hosts, reconstructing the parent's rendering rather than checking it out (the parent's preamble branch *was* exactly `shlex.join`, so both are producible from one process):

| peer | preamble | OLD | NEW (be467096) |
|---|---|---|---|
| scitex-compute-03 | yes | rc=0 `'OK 1'` | **rc=2 syntax error** |
| scitex-nas-03 | no | rc=2 | rc=2 |

## The bare peer is the actual finding

nas-03 fails on **both** renderings. That branch never carried a whitespace-bearing argument at all — silently, because nothing exercised it. The space-join didn't create that defect; it exported it onto the preamble peers, where a live caller hit it immediately.

## The fix

`command` now means one thing everywhere: **a real argv list whose quoting `build_ssh_argv` owns.** Both branches `shlex.join`; `_spec_handoff` stops pre-quoting and passes `["sh", "-c", script]`.

## Why I refused this four hours ago, and why that was wrong

I rejected it because 13 tests pin the rendered argv **shape**, two by name (`test_build_ssh_argv_without_preamble_is_unchanged`, `test_home_rooted_peer_argv_is_byte_identical`), and judged that rewriting a documented byte-identity invariant mid-outage was reckless.

Those tests pin an argv shape that **cannot correctly carry a quoted argument on either branch**. They were not protecting a property worth having — they were pinning the defect, and they blocked the correct fix. The deciding evidence (the bare peer failing on both renderings) was available the whole time; I didn't run the probe that would have shown it.

## The 16 test rewrites

Each preserves what its test protected, expressed against the new rendering:

- `"--json" in argv` → the flag reaches the **remote command line** (always what it proxied for)
- byte-identical argv for an unpinned peer → the **remote command line** is unchanged for an unpinned peer; registry pinning still doesn't alter dispatch
- `--` separator, ssh options, `-J` chain, host target → **untouched**, since the fix doesn't move them

Checked for the failure mode this is most at risk of: no `mark.skip`, no `assert True`, no trivially-true assertion, and `src/` untouched by the test commit.

Three of the sixteen were mine from the two failed attempts, encoding contracts that no longer exist. Their module docstring keeps the outage history so the next reader learns why the stronger-looking shape was abandoned.

## Verification

```
2072 passed, 3 skipped, 0 failed        (_state + cli_pkg/lifecycle)
```

Live hosts, 3 command shapes × 3 peers, **all rc=0** — including `python3 -c` on the bare peer, which failed under both previous renderings:

```
scitex-compute-03  preamble=True   python -c oneliner rc=0 'OK 1' | sh -c script rc=0 | plain argv rc=0
scitex-compute-02  preamble=True   python -c oneliner rc=0 'OK 1' | sh -c script rc=0 | plain argv rc=0
scitex-nas-03      preamble=False  python -c oneliner rc=0 'OK 1' | sh -c script rc=0 | plain argv rc=0
```

Deliberately not a bare `echo` — a single-token probe passes under the broken path too.