### PR TITLE
fix(tests): skip on the ROOT, hard-import the full path (PS-140)

### DIFF
--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -16,6 +16,8 @@ in its source tree. Two outcomes:
   (which installs every peer) catches cross-package renames.
 """
 
+import importlib
+
 import pytest
 
 # ===== AUTO-GENERATED: cross-package imports =====
@@ -46,10 +48,28 @@ CROSS_PACKAGE_IMPORTS = [
 
 @pytest.mark.parametrize("module_name", CROSS_PACKAGE_IMPORTS)
 def test_cross_package_import_resolves_to_real_module(module_name):
-    """Importing scitex-agent-container's declared cross-package dependency must succeed."""
+    """Importing scitex-agent-container's declared cross-package dependency must succeed.
+
+    PS-140 §2. Skip on the ROOT distribution, then HARD-IMPORT the full path.
+
+    ``pytest.importorskip("scitex_dev.hooks")`` skips when ANY part of the
+    dotted path is missing, so a peer that IS installed but has renamed or
+    removed a submodule reports SKIPPED -- which is exactly the case the
+    module docstring above promises will "FAIL loudly". The two-step form is
+    what makes that promise true: an absent peer still skips (a lean install
+    is legitimate), while a present peer that lost the submodule now fails.
+
+    This is not hypothetical. On 2026-08-17 ``scitex_dev.hooks`` gained a
+    required ``HookRule`` field; the consumer-side break was invisible on
+    every developer machine because this test, and the plugin test beside it,
+    both SKIPPED rather than failed. CI -- which installs the peer -- failed,
+    and develop went red for every PR with no local run able to reproduce it.
+    A skip is not a pass.
+    """
     # Arrange
-    name = module_name
+    root = module_name.split(".")[0]
+    pytest.importorskip(root)
     # Act
-    mod = pytest.importorskip(name)
+    mod = importlib.import_module(module_name)
     # Assert
     assert mod is not None


### PR DESCRIPTION
fix(tests): skip on the ROOT, hard-import the full path (PS-140)

`pytest.importorskip("scitex_dev.hooks")` skips when ANY part of the dotted
path is missing. So a peer that IS installed but has renamed or removed a
submodule reported SKIPPED -- precisely the case this file's own docstring
promises will "FAIL loudly".

The two-step form makes that promise true:

    root = module_name.split(".")[0]
    pytest.importorskip(root)               # absent PEER still skips
    mod = importlib.import_module(module_name)   # present peer, missing
                                                 # submodule now FAILS

An absent peer still skips, because a lean install where an optional extra
is genuinely not present must not fail. A present peer that lost the
submodule now fails, which is the whole reason this gate exists.

THIS IS NOT HYPOTHETICAL -- IT IS WHY TODAY'S BREAK WAS INVISIBLE.

On 2026-08-17 `scitex_dev.hooks` gained a required `HookRule` field. Local
venvs could not import `scitex_dev.hooks` at all, so this test skipped, and
the three plugin tests beside it skipped for the same reason. Every
developer machine reported GREEN. CI, which installs the peer, ran them and
failed -- and develop went red for every PR in the repo with no local run
able to reproduce it. The test that exists to catch cross-package renames
was structurally incapable of catching one.

A skip is not a pass. A suite reporting `3 skipped` where CI reports
`3 failed` is reporting on a different population, and the difference is
invisible precisely because the skip prints the reassuring word.

Verified in three arms, because a green run cannot demonstrate this fix --
the point is that a previously-SKIPPING case must now FAIL:

    A. peer installed, submodule absent   FAILED   (was SKIP)
       ModuleNotFoundError: No module named 'scitex_dev.hooks'
    B. submodule present                  1 passed
    C. whole file, submodule present      16 passed, 4 skipped
       (the 4 skips are genuinely-absent peers -- correct)

Card: sac-develop-is-red-hookrule-provider-and-audit-20260817
