### PR TITLE
fix(jobs): make every JobSpec command self-bounding so it survives cron

### DIFF
--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -335,7 +335,12 @@ def provide_jobs() -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-accounts-quota-cache",
             schedule="*/5 * * * *",  # every 5min (cron form; timer below)
-            command="sac accounts refresh-quota-cache",
+            # SELF-BOUNDING (120s). One usage read per stored account (4
+            # today), each a single HTTPS call; 120s covers all of them on a
+            # slow network and never hangs. A pass killed here leaves the
+            # PREVIOUS cache in place — stale, which is the status quo this
+            # job improves on, never wrong.
+            command="/usr/bin/timeout 120 sac accounts refresh-quota-cache",
             description=(
                 "Keeps the per-account usage cache FRESH. Nothing else did: "
                 "sac.accounts-refresh rotates TOKENS and accounts-keepalive "
@@ -378,12 +383,6 @@ def provide_jobs() -> "list[JobSpec]":
             # 1min — and it would be evidence, not a guess.
             on_boot_sec="2min",
             on_unit_active_sec="5min",
-            # One usage read per stored account (4 today), each a single
-            # HTTPS call. 120s covers all of them with a slow network and
-            # never hangs. A pass killed here leaves the previous cache in
-            # place — stale, which is the status quo this job improves on,
-            # never wrong.
-            timeout_sec=120,
         ),
         JobSpec(
             name="scitex-agent-container-host-sync-check",

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -156,6 +156,44 @@ def provide_jobs() -> "list[JobSpec]":
     ``--sync-active-login`` keeps the operator's live session valid across
     the single-use refresh_token rotation.
 
+    EVERY COMMAND IS SELF-BOUNDING; NONE DECLARES ``timeout_sec``
+    ------------------------------------------------------------
+    Each command starts with a literal ``/usr/bin/timeout <N> ``, because
+    that is the only place a bound can survive. Since the supervisor
+    redesign (operator policy 2026-06-14) ``scitex-dev ecosystem up``
+    lowers every ``kind="timer"`` JobSpec onto the managed CRONTAB block,
+    and a cron line is ``<schedule> <command> # marker`` and nothing else
+    — it has no field a timeout could ride in.
+
+    ``timeout_sec`` is DROPPED rather than kept alongside the prefix:
+    scitex-dev's guard (``_up_timer_lowering.lowering_losses``) keys on the
+    FIELD BEING SET, not on whether the command is really bounded, so a
+    spec carrying both still counts as a dropped guarantee and still
+    REFUSES the lowering — ``ecosystem up`` aborts for the whole ecosystem,
+    measured, not assumed. Nothing is lost by dropping it: the bound moved
+    into the command, where both rendering targets honour it. Previously it
+    was a systemd-only promise that evaporated on cron, which is how
+    ``fleet-reconcile`` piled up fourteen concurrent instances, the oldest
+    45 minutes old (2026-07-18).
+
+    Two spelling choices, both load-bearing. ``/usr/bin/timeout`` is
+    ABSOLUTE (GNU coreutils 9.4, verified on scitex-compute-04): cron's and
+    systemd's minimal PATHs both carry ``/usr/bin`` so a bare ``timeout``
+    would resolve too, but the absolute form keeps ``heal-agent-auth``'s
+    "depends on no PATH at all" property true. The INNER command stays
+    PATH-relative (``sac …``) because sac's install path VARIES BY HOST
+    (``~/.env-sac/bin/sac`` on scitex-compute-04, ``~/.env-3.11/bin/sac``
+    elsewhere), so pinning one absolute ``sac`` would break the others —
+    and the cron line has always run ``sac`` off cron's PATH anyway.
+
+    KNOWN CONSEQUENCE, stated rather than papered over: a wrapper prefix
+    means ``resolve_execstart`` (which absolutises only the FIRST token)
+    no longer absolutises the inner ``sac`` should these specs ever be
+    rendered as systemd units instead — the same hazard scitex-dev's own
+    lowering module documents. Not live today (``up`` writes cron, not
+    units); a future move back to a timer surface must pin the inner path
+    or declare ``venv`` at that time.
+
     """
     from scitex_dev.jobs import JobSpec
 
@@ -205,7 +243,13 @@ def provide_jobs() -> "list[JobSpec]":
             # that must keep existing.
             name="scitex-agent-container-accounts-refresh",
             schedule="0 */2 * * *",  # every 2h
-            command=("sac accounts refresh --all --include-active --sync-active-login"),
+            # SELF-BOUNDING (120s) — see the convention note above. The
+            # bound has to live in the command because this job lands on
+            # CRON, where `timeout_sec` cannot follow it.
+            command=(
+                "/usr/bin/timeout 120 "
+                "sac accounts refresh --all --include-active --sync-active-login"
+            ),
             description=(
                 "Headless OAuth access-token refresh for all stored Claude "
                 "accounts including the active one (sole-refresher model), "
@@ -224,12 +268,18 @@ def provide_jobs() -> "list[JobSpec]":
             kind="timer",
             on_boot_sec="15min",
             on_unit_active_sec="2h",
-            timeout_sec=120,
         ),
         JobSpec(
             name="scitex-agent-container-accounts-keepalive",
             schedule="*/15 * * * *",  # every 15min (cron form; timer below)
+            # SELF-BOUNDING (300s). Per peer: a handful of coreutils ssh ops
+            # plus ONE outbound HTTPS verification from the peer (15s cap
+            # inside the probe). 300s covers three peers including a slow one
+            # without ever hanging forever. A pass killed here leaves the
+            # peer's previous credential intact — nothing is published
+            # unverified.
             command=(
+                "/usr/bin/timeout 300 "
                 "sac accounts keepalive --all "
                 "--to ywata-note-win "
                 "--to scitex-compute-03 "
@@ -281,12 +331,6 @@ def provide_jobs() -> "list[JobSpec]":
             # peer is verified, not rewritten.
             on_boot_sec="10min",
             on_unit_active_sec="15min",
-            # Per peer: a handful of coreutils ssh ops plus ONE outbound
-            # HTTPS verification from the peer (15s cap inside the probe).
-            # 300s covers three peers including a slow one without ever
-            # hanging forever. A pass killed here leaves the peer's previous
-            # credential intact — nothing is published unverified.
-            timeout_sec=300,
         ),
         JobSpec(
             name="scitex-agent-container-accounts-quota-cache",
@@ -344,7 +388,15 @@ def provide_jobs() -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-host-sync-check",
             schedule="0 * * * *",  # hourly (cron form; timer cadence below)
-            command="sac host sync --check --all --alarm --exit-zero",
+            # SELF-BOUNDING (600s). Sequential per-ssh probe over every peer,
+            # each capped at the verb's 120s default (an unreachable peer
+            # waits its ssh connect-timeout). 600s comfortably covers a
+            # handful of peers including a slow/unreachable one without ever
+            # hanging forever.
+            command=(
+                "/usr/bin/timeout 600 "
+                "sac host sync --check --all --alarm --exit-zero"
+            ),
             description=(
                 "Read-only drift check of every peer's sac checkout vs the "
                 "centre; records each verdict in sac's own event log so the "
@@ -366,16 +418,18 @@ def provide_jobs() -> "list[JobSpec]":
             # 2h token refresh, so hourly is ample and gentle on ssh.
             on_boot_sec="10min",
             on_unit_active_sec="1h",
-            # Sequential per-ssh probe over every peer, each capped at the
-            # verb's 120s default (an unreachable peer waits its ssh
-            # connect-timeout). 600s comfortably covers a handful of peers
-            # including a slow/unreachable one without ever hanging forever.
-            timeout_sec=600,
         ),
         JobSpec(
             name="scitex-agent-container-worktree-gc",
             schedule="30 4 * * *",  # daily 04:30 (cron form; timer cadence below)
-            command="sac worktree gc --apply --all",
+            # SELF-BOUNDING (900s). A pass is a handful of local `git` calls
+            # per worktree plus one `gh pr list` per unmerged branch (the
+            # squash-merge leg). A repo deep in sprawl with a slow/
+            # rate-limited gh is the worst case; 900s covers the whole
+            # fleet's repos without ever hanging forever. Every gh failure
+            # already degrades to KEEP, so a timeout costs a skipped reap,
+            # never a wrong one.
+            command="/usr/bin/timeout 900 sac worktree gc --apply --all",
             description=(
                 "Daily git-worktree GC: removes only worktrees PROVEN safe "
                 "(clean AND merged AND older than 24h AND not in use — never "
@@ -391,18 +445,18 @@ def provide_jobs() -> "list[JobSpec]":
             # boot keeps it clear of the login/auth settling window.
             on_boot_sec="20min",
             on_unit_active_sec="1d",
-            # A pass is a handful of local `git` calls per worktree plus one
-            # `gh pr list` per unmerged branch (the squash-merge leg). A repo
-            # deep in sprawl with a slow/rate-limited gh is the worst case;
-            # 900s covers the whole fleet's repos without ever hanging
-            # forever. Every gh failure already degrades to KEEP, so a
-            # timeout costs a skipped reap, never a wrong one.
-            timeout_sec=900,
         ),
         JobSpec(
             name="scitex-agent-container-spartan-sif-bake",
             schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
-            command="sac image bake-remote --yes",
+            # SELF-BOUNDING (14400s = 4h), and the one where the bound
+            # matters most: at a */10 cadence an UNBOUNDED bake outlives its
+            # own tick by design, so a wedged run would pile up against every
+            # later one. Two full bakes (base ~15-25min + scitex ~10-20min)
+            # plus a multi-GB pull on a slow link fit comfortably; the
+            # per-leg ssh timeout inside the command is 7200s, so 4h bounds
+            # the whole chain without ever killing a legitimate run.
+            command="/usr/bin/timeout 14400 sac image bake-remote --yes",
             description=(
                 "10-minute SIF refresh with zero master CPU: bake sac-base + "
                 "sac-scitex on the standing Spartan CPU lease (srun "
@@ -437,16 +491,15 @@ def provide_jobs() -> "list[JobSpec]":
             # something changed, the rest of that window bouncing off the lock.
             on_boot_sec="30min",
             on_unit_active_sec="10min",
-            # Two full bakes (base ~15-25min + scitex ~10-20min) plus a
-            # multi-GB pull on a slow link fit comfortably; the per-leg
-            # ssh timeout inside the command is 7200s, so 4h bounds the
-            # whole chain without ever hanging forever.
-            timeout_sec=14_400,
         ),
         JobSpec(
             name="scitex-agent-container-freshness-refresh",
             schedule="7 * * * *",  # hourly (cron form; timer cadence below)
-            command="sac freshness refresh",
+            # SELF-BOUNDING (300s). Generous on purpose, matching the
+            # primitive's own 30s per-source timeouts: a busy host must not
+            # be mistaken for a broken one, and a manufactured UNKNOWN is
+            # exactly the failure mode. Nothing is waiting on this run.
+            command="/usr/bin/timeout 300 sac freshness refresh",
             description=(
                 "Publishes the version-currency verdict to the cache that "
                 "every `sac` invocation reads. Runs the real checks (PyPI, "
@@ -465,11 +518,6 @@ def provide_jobs() -> "list[JobSpec]":
             # pass makes real network calls.
             on_boot_sec="25min",
             on_unit_active_sec="1h",
-            # Generous on purpose, matching the primitive's own 30s per-source
-            # timeouts: a busy host must not be mistaken for a broken one, and
-            # a manufactured UNKNOWN is exactly the failure mode. Nothing is
-            # waiting on this run.
-            timeout_sec=300,
         ),
         # The two AGENT-LIVENESS enforcers live together in
         # :mod:`._specs_liveness` — each one's scope is defined by what the
@@ -479,14 +527,25 @@ def provide_jobs() -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-heal-agent-auth",
             schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
-            # ABSOLUTE by design, both tokens. `resolve_execstart` passes a
+            # ABSOLUTE by design, EVERY token. `resolve_execstart` passes a
             # command whose head starts with "/" through VERBATIM, so this is
             # the only form that depends on neither the ambient PATH nor which
             # interpreter ran `ecosystem up`. A systemd --user unit gets a
             # MINIMAL PATH, so the venv python must be named outright: the
             # script's own `#!/usr/bin/env python3` would resolve to the SYSTEM
             # python under systemd, not the 3.11 venv the fleet runs on.
+            #
+            # The `timeout` head is spelled ABSOLUTELY for the same reason —
+            # it keeps this command's "depends on no PATH at all" property
+            # intact, which a bare `timeout` would have quietly given up.
+            #
+            # SELF-BOUNDING (300s). A no-op tick takes ~2-8s, and the worst
+            # observed pass (a TUI restart at 15:30:04 settling by 15:32:08)
+            # ~2min. A pass killed here is SAFE — state is persisted per
+            # restart, so the next tick still honours the debounce for
+            # anything already bounced.
             command=(
+                "/usr/bin/timeout 300 "
                 "/home/ywatanabe/.env-3.11/bin/python "
                 "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
             ),
@@ -520,13 +579,6 @@ def provide_jobs() -> "list[JobSpec]":
             # every kind="timer", so a window missed while the host was asleep
             # fires on resume — the property a crontab line does NOT have and a
             # laptop fleet needs most.
-            #
-            # 300s matches the siblings and comfortably outlives a real pass:
-            # a no-op tick takes ~2-8s, and the worst observed pass (a TUI
-            # restart at 15:30:04 settling by 15:32:08) ~2min. A pass killed
-            # here is SAFE — state is persisted per restart, so the next tick
-            # still honours the debounce for anything already bounced.
-            timeout_sec=300,
         ),
     ]
 

--- a/src/scitex_agent_container/_jobs/_specs_liveness.py
+++ b/src/scitex_agent_container/_jobs/_specs_liveness.py
@@ -31,7 +31,18 @@ def liveness_jobs() -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-fleet-reconcile",
             schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
-            command="sac agents reconcile --apply",
+            # SELF-BOUNDING (300s) — the bound lives in the command because
+            # this job lands on CRON, where `timeout_sec` cannot follow it.
+            # A no-op pass takes ~seconds; this bounds the pathological one
+            # (`--limit` restarts, each a stop+settle+start). A pass killed at
+            # this timeout is SAFE: the restart history is persisted per
+            # restart, not at the end, so the next tick still honours the
+            # debounce for anything already bounced.
+            #
+            # This is the job whose UNBOUNDED cron line was measured piling
+            # up fourteen concurrent instances, the oldest 45 minutes old
+            # (2026-07-18) — the incident that motivated the guard.
+            command="/usr/bin/timeout 300 sac agents reconcile --apply",
             description=(
                 "The enforcer of 'should be running => is running'. Restarts "
                 "agents whose tmux session is GONE while their spec asks to be "
@@ -63,17 +74,18 @@ def liveness_jobs() -> "list[JobSpec]":
             # read each — cheap enough to run often.
             on_boot_sec="5min",
             on_unit_active_sec="5min",
-            # A no-op pass takes ~seconds; this bounds the pathological one
-            # (`--limit` restarts, each a stop+settle+start). A pass killed at
-            # this timeout is SAFE: the restart history is persisted per
-            # restart, not at the end, so the next tick still honours the
-            # debounce for anything already bounced.
-            timeout_sec=300,
         ),
         JobSpec(
             name="scitex-agent-container-restart-login-expired-agents",
             schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
-            command="sac agents restart-login-expired --apply",
+            # SELF-BOUNDING (300s), mirroring fleet-reconcile: bounds the
+            # pathological pass (`--limit` restarts, each a stop+settle+start)
+            # plus the ~4s capture interval. A pass killed here is SAFE —
+            # history is persisted per restart, so the next tick still honours
+            # the debounce for anything bounced.
+            command=(
+                "/usr/bin/timeout 300 sac agents restart-login-expired --apply"
+            ),
             description=(
                 "Restarts LIVE agents wedged behind a frozen 'Login expired' "
                 "banner (auth-dead but tmux-alive) — the half fleet-reconcile "
@@ -99,10 +111,5 @@ def liveness_jobs() -> "list[JobSpec]":
             # plus two pane captures ~4s apart.
             on_boot_sec="5min",
             on_unit_active_sec="5min",
-            # Mirrors fleet-reconcile: bounds the pathological pass (`--limit`
-            # restarts, each a stop+settle+start) plus the ~4s capture interval.
-            # A pass killed here is SAFE — history is persisted per restart, so
-            # the next tick still honours the debounce for anything bounced.
-            timeout_sec=300,
         ),
     ]

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -40,6 +40,8 @@ the provider import is lazy, so an old scitex-dev must not fail CI here.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 jobs_mod = pytest.importorskip(
@@ -116,6 +118,7 @@ def test_provider_job_command_includes_active_account() -> None:
     job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert job.command == (
+        "/usr/bin/timeout 120 "
         "sac accounts refresh --all --include-active --sync-active-login"
     )
 
@@ -207,6 +210,7 @@ def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert job.command == (
+        "/usr/bin/timeout 300 "
         "sac accounts keepalive --all "
         "--to ywata-note-win "
         "--to scitex-compute-03 "
@@ -222,10 +226,13 @@ def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() ->
     # turn a keepalive into a fleet-wide logout every 15 minutes, so pin the
     # verb itself rather than trusting the full-command assertion above to be
     # re-read whenever someone edits the peer list.
+    #
+    # Indexed PAST the self-bounding `/usr/bin/timeout <N>` prefix (tokens 0
+    # and 1), so this still pins the VERB rather than the wrapper.
     # Act
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
-    assert job.command.split()[:3] == ["sac", "accounts", "keepalive"]
+    assert job.command.split()[2:5] == ["sac", "accounts", "keepalive"]
 
 
 def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
@@ -256,10 +263,13 @@ def test_accounts_keepalive_timeout_outlives_a_three_peer_pass() -> None:
     # verification (15s cap inside the probe). 300s covers three peers
     # including a slow one. A pass killed here is SAFE — nothing is published
     # unverified, so the peer keeps its previous credential.
+    #
+    # The bound is asserted on the COMMAND, not on `timeout_sec`, because
+    # this job is deployed to cron and a cron line cannot carry that field.
     # Act
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
-    assert job.timeout_sec == 300
+    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
 def test_accounts_keepalive_constructs_as_a_real_jobspec() -> None:
@@ -360,7 +370,9 @@ def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
     # Act
     job = _job("scitex-agent-container-host-sync-check")
     # Assert — the command is precisely the read-only check+alarm form.
-    assert job.command == "sac host sync --check --all --alarm --exit-zero"
+    assert job.command == (
+        "/usr/bin/timeout 600 sac host sync --check --all --alarm --exit-zero"
+    )
 
 
 def test_host_sync_check_cadence_is_hourly() -> None:
@@ -398,7 +410,7 @@ def test_worktree_gc_command_is_the_apply_form() -> None:
     # Act
     job = _job("scitex-agent-container-worktree-gc")
     # Assert
-    assert job.command == "sac worktree gc --apply --all"
+    assert job.command == "/usr/bin/timeout 900 sac worktree gc --apply --all"
 
 
 def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
@@ -448,7 +460,7 @@ def test_fleet_reconcile_command_is_the_applying_form() -> None:
     # Act
     job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
-    assert job.command == "sac agents reconcile --apply"
+    assert job.command == "/usr/bin/timeout 300 sac agents reconcile --apply"
 
 
 def test_fleet_reconcile_cadence_is_five_minutes() -> None:
@@ -466,10 +478,16 @@ def test_fleet_reconcile_timeout_outlives_a_capped_pass() -> None:
     # stop+settle+start. A pass killed at this timeout is SAFE (the restart
     # history is persisted per restart, not at the end), but the timeout must
     # still comfortably exceed a normal pass or the enforcer never finishes.
+    #
+    # THIS is the job whose unbounded cron line was measured accumulating
+    # fourteen concurrent instances, the oldest 45 minutes old (2026-07-18).
+    # A `timeout_sec` assertion would have passed throughout that incident,
+    # because the field was set and the deployed cron line was still
+    # unbounded — so the bound is pinned where it actually runs.
     # Act
     job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
-    assert job.timeout_sec == 300
+    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
 def test_spartan_sif_bake_job_name_is_package_prefixed() -> None:
@@ -528,7 +546,7 @@ def test_spartan_sif_bake_command_is_the_confirmed_form() -> None:
     # Act
     job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
-    assert job.command == "sac image bake-remote --yes"
+    assert job.command == "/usr/bin/timeout 14400 sac image bake-remote --yes"
 
 
 def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
@@ -547,13 +565,19 @@ def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
 
 def test_spartan_sif_bake_timeout_outlives_two_bakes_and_a_pull() -> None:
     # Arrange — two full bakes (base + scitex) plus a multi-GB pull on a
-    # slow link must fit; the per-leg ssh timeout is 7200s, so the unit
-    # cap must exceed the worst legitimate chain or the timer kills its
+    # slow link must fit; the per-leg ssh timeout is 7200s, so the cap
+    # must exceed the worst legitimate chain or the timer kills its
     # own successful runs.
+    #
+    # This job needs a REAL bound more than any sibling: at a */10 cadence
+    # an unbounded bake outlives its own tick by construction, so a wedged
+    # run piles up against every later one. The bound therefore has to be
+    # in the command — cron, the surface this is deployed to, cannot carry
+    # `timeout_sec` at all.
     # Act
     job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
-    assert job.timeout_sec == 14_400
+    assert job.command.startswith("/usr/bin/timeout 14400 ")
 
 
 def test_restart_login_expired_command_is_the_applying_form() -> None:
@@ -563,7 +587,9 @@ def test_restart_login_expired_command_is_the_applying_form() -> None:
     # Act
     job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
-    assert job.command == "sac agents restart-login-expired --apply"
+    assert job.command == (
+        "/usr/bin/timeout 300 sac agents restart-login-expired --apply"
+    )
 
 
 def test_restart_login_expired_cadence_is_five_minutes() -> None:
@@ -646,20 +672,36 @@ def test_heal_agent_auth_interpreter_token_is_absolute() -> None:
     # Arrange — scitex-dev's `resolve_execstart` passes a head starting with "/"
     # through VERBATIM. An absolute head is therefore the only form that depends
     # on neither the ambient PATH nor which interpreter ran `ecosystem up`.
+    #
+    # The interpreter is token 2 now, after the `/usr/bin/timeout <N>` prefix.
     # Act
     job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.command.split()[0].startswith("/")
+    assert job.command.split()[2].startswith("/")
+
+
+def test_heal_agent_auth_command_head_is_still_absolute() -> None:
+    # Arrange — the self-bounding prefix must not cost this job its
+    # PATH-independence. `/usr/bin/timeout` is spelled absolutely precisely so
+    # the HEAD keeps starting with "/" and `resolve_execstart` keeps passing
+    # the whole command through verbatim. A bare `timeout` would have quietly
+    # made this the one command that needs an ambient PATH.
+    # Act
+    job = _job("scitex-agent-container-heal-agent-auth")
+    # Assert
+    assert job.command.split()[0] == "/usr/bin/timeout"
 
 
 def test_heal_agent_auth_script_token_is_absolute() -> None:
     # Arrange — a systemd --user unit gets a MINIMAL PATH and no meaningful cwd,
     # so the script argument must be absolute too; a relative path would exec
     # fine under cron's $HOME cwd and fail as status=127 under systemd.
+    #
+    # The script is token 3 now, after the `/usr/bin/timeout <N>` prefix.
     # Act
     job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.command.split()[1].startswith("/")
+    assert job.command.split()[3].startswith("/")
 
 
 def test_heal_agent_auth_runs_the_venv_python_not_the_system_one() -> None:
@@ -670,7 +712,9 @@ def test_heal_agent_auth_runs_the_venv_python_not_the_system_one() -> None:
     # Act
     job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.command.startswith("/home/ywatanabe/.env-3.11/bin/python ")
+    assert job.command.startswith(
+        "/usr/bin/timeout 300 /home/ywatanabe/.env-3.11/bin/python "
+    )
 
 
 def test_heal_agent_auth_targets_the_real_auth_heal_entrypoint() -> None:
@@ -691,10 +735,13 @@ def test_heal_agent_auth_timeout_outlives_a_restarting_pass() -> None:
     # Arrange — a no-op tick takes ~2-8s; the worst observed pass (a TUI restart
     # at 15:30:04 settling by 15:32:08) ~2min. A pass killed here is SAFE (state
     # is persisted per restart), but the timeout must still outlive a real one.
+    #
+    # Pinned on the COMMAND: this job is lowered onto cron, and a cron line
+    # has no field a `timeout_sec` could ride in.
     # Act
     job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.timeout_sec == 300
+    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
 def test_heal_agent_auth_constructs_as_a_real_jobspec() -> None:
@@ -718,3 +765,158 @@ def test_heal_agent_auth_and_restart_login_expired_are_both_declared() -> None:
     names = {job.name for job in provide_jobs()}
     # Assert
     assert {"scitex-agent-container-heal-agent-auth", "scitex-agent-container-restart-login-expired-agents"} <= names
+
+
+# ---------------------------------------------------------------------------
+# THE POPULATION INVARIANT — what lets these JobSpecs land on cron at all.
+#
+# The per-job pins above are pinned by name; these are pinned over EVERY job,
+# because the way this contract breaks is by OMISSION in a job added later,
+# which no name-based test would notice.
+#
+# The mechanism: `scitex-dev ecosystem up` lowers every kind="timer" JobSpec
+# onto the managed crontab block (operator policy 2026-06-14), and a cron line
+# is `<schedule> <command> # marker` and nothing else — there is no field a
+# `timeout_sec` could ride in. scitex-dev's guard therefore REFUSES to lower a
+# timer declaring one, and because `up` is all-or-nothing, ONE such job blocks
+# every provider on the host. Measured 2026-08-17 on scitex-compute-04: nine
+# sac jobs declared `timeout_sec`, `up` aborted, nothing could be armed.
+#
+# So the bound lives in the COMMAND, and the field that cannot travel is gone.
+# ---------------------------------------------------------------------------
+
+#: A self-bounding command: the coreutils binary, a whole-second bound, and a
+#: non-empty payload after it.
+_SELF_BOUNDING = re.compile(r"^/usr/bin/timeout (\d+) (\S.*)$")
+
+
+def test_every_command_is_self_bounding() -> None:
+    # Arrange — the bound must live in the COMMAND, the only part of a JobSpec
+    # a cron line carries. Asserted over every job rather than an enumerated
+    # set: a job added later without a bound is exactly the regression this
+    # pins, and a list would not catch it.
+    # Act
+    unbounded = [
+        job.name for job in provide_jobs() if not _SELF_BOUNDING.match(job.command)
+    ]
+    # Assert
+    assert unbounded == []
+
+
+def test_no_job_declares_timeout_sec() -> None:
+    # Arrange — NOT a style rule. scitex-dev's lowering guard fires on
+    # `timeout_sec is not None` and never inspects whether the command is
+    # actually bounded, so a job carrying BOTH a literal `timeout` and this
+    # field still refuses to lower and still aborts `ecosystem up` for the
+    # whole host. The field is therefore dropped, not kept alongside.
+    # Act
+    declaring = [job.name for job in provide_jobs() if job.timeout_sec is not None]
+    # Assert
+    assert declaring == []
+
+
+def test_no_command_is_double_bounded() -> None:
+    # Arrange — the payload after the prefix must not itself be a `timeout`
+    # invocation. Two nested bounds are not a stricter bound; they are a
+    # second number nobody maintains, and the inner one silently wins.
+    # Act
+    doubled = [
+        job.name
+        for job in provide_jobs()
+        if (m := _SELF_BOUNDING.match(job.command))
+        and m.group(2).split()[0].endswith("timeout")
+    ]
+    # Assert
+    assert doubled == []
+
+
+def test_declared_bound_is_a_positive_number_of_seconds() -> None:
+    # Arrange — `timeout 0 <cmd>` means "no timeout at all" in coreutils, so a
+    # zero would read as a bound while removing one. Guard the value, not just
+    # the shape.
+    # Act
+    bounds = {
+        job.name: int(m.group(1))
+        for job in provide_jobs()
+        if (m := _SELF_BOUNDING.match(job.command))
+    }
+    # Assert
+    assert all(seconds > 0 for seconds in bounds.values()), bounds
+
+
+def test_the_prefix_wraps_something_in_every_job() -> None:
+    # Arrange — a positive control on the regex above: prove it matches a real
+    # payload in EVERY job, not merely in some. Anchoring on the job count (an
+    # identity) rather than on `> 0` (a quantity) keeps this honest when the
+    # provider list changes.
+    # Act
+    payloads = [
+        m.group(2)
+        for job in provide_jobs()
+        if (m := _SELF_BOUNDING.match(job.command))
+    ]
+    # Assert
+    assert len(payloads) == len(provide_jobs())
+
+
+# ---------------------------------------------------------------------------
+# The operator-facing outcome, measured through scitex-dev's OWN guard rather
+# than restated in our words. Skips cleanly on a scitex-dev predating the
+# lowering module, so CI never reddens on a version lag.
+# ---------------------------------------------------------------------------
+
+
+def _lowering():
+    return pytest.importorskip(
+        "scitex_dev._cli.ecosystem._cmds._up_timer_lowering",
+        reason="installed scitex-dev predates the timer-lowering guard",
+    )
+
+
+def test_no_job_degrades_when_lowered_onto_cron() -> None:
+    # Arrange — `degraded_job_names` is the exact predicate `ecosystem up`
+    # reports under --allow-lossy-timer-lowering. Nine sac jobs were listed
+    # there on 2026-08-17; the target is none.
+    low = _lowering()
+    # Act
+    degraded = low.degraded_job_names(provide_jobs())
+    # Assert
+    assert degraded == []
+
+
+def test_strict_lowering_does_not_abort_the_ecosystem() -> None:
+    # Arrange — this is THE blocker being fixed. `ecosystem up` calls
+    # `collect_cron_jobs` WITHOUT allow_lossy first; one raising job aborts the
+    # run before anything is written, for every provider on the host.
+    low = _lowering()
+    jobs = provide_jobs()
+    # Act — must not raise TimerLoweringError.
+    _merged, _native, lowered = low.collect_cron_jobs(jobs, allow_lossy=False)
+    # Assert
+    assert lowered == len([job for job in jobs if job.kind == "timer"])
+
+
+def test_strict_lowering_installs_every_declared_job() -> None:
+    # Arrange — the companion to the abort check: proceeding is only the right
+    # outcome if nothing was quietly dropped on the way through.
+    low = _lowering()
+    jobs = provide_jobs()
+    # Act
+    merged, _native, _lowered = low.collect_cron_jobs(jobs, allow_lossy=False)
+    # Assert
+    assert len(merged) == len(jobs)
+
+
+def test_the_cron_line_that_lands_on_the_host_carries_the_bound() -> None:
+    # Arrange — the end-to-end check, and the one that would have caught the
+    # original defect: assert on the ARTIFACT (the crontab line) rather than on
+    # the declaration. A `timeout_sec` assertion passed throughout the
+    # 2026-07-18 incident while the deployed line was unbounded.
+    low = _lowering()
+    from scitex_dev.jobs import _cron_block as cron_block
+
+    merged, _native, _lowered = low.collect_cron_jobs(provide_jobs(), allow_lossy=False)
+    # Act
+    lines = [cron_block.build_cron_line(spec) for spec in merged]
+    # Assert
+    assert all(" /usr/bin/timeout " in line for line in lines), lines


### PR DESCRIPTION
## The blocker

`scitex-dev ecosystem up` **aborted** on scitex-compute-04 (2026-08-17) before writing
anything, because all nine of sac's JobSpecs declared `timeout_sec` and a cron line has
no way to carry it. `up` is all-or-nothing, so our nine jobs blocked **every** provider
on that host — scitex-dev's own five included — and nothing could be armed at all.

## The mechanism

Since the supervisor redesign (operator policy 2026-06-14) `ecosystem up` lowers every
`kind="timer"` JobSpec onto the managed **crontab** block, and a cron line is
`<schedule> <command> # marker` and nothing else. There is no field a timeout could ride
in, so scitex-dev's guard refuses the lowering rather than deploying a weaker artifact
under the same name.

The fix moves the bound out of the declaration and into the one field cron does carry:
every command now begins with a literal `/usr/bin/timeout <N> `, with `N` the value that
used to sit in `timeout_sec`. The bound is now honoured on **both** rendering targets
instead of being a systemd-only promise that evaporated on cron.

## `timeout_sec` is dropped, and that was measured rather than assumed

`_up_timer_lowering.lowering_losses` keys on **the field being set** and never inspects
whether the command is actually bounded. A spec carrying both a literal `timeout` and
`timeout_sec` therefore still counts as a dropped guarantee and still aborts the run —
so keeping it alongside would have fixed nothing. Nothing is lost by removing it: for a
`Type=oneshot` timer service systemd disables the start timeout by default anyway, and
the command now bounds itself.

## The nine commands

```
0 */2 * * *   /usr/bin/timeout 120   sac accounts refresh --all --include-active --sync-active-login
*/15 * * * *  /usr/bin/timeout 300   sac accounts keepalive --all --to ywata-note-win --to scitex-compute-03 --to scitex-compute-04
0 * * * *     /usr/bin/timeout 600   sac host sync --check --all --alarm --exit-zero
30 4 * * *    /usr/bin/timeout 900   sac worktree gc --apply --all
*/10 * * * *  /usr/bin/timeout 14400 sac image bake-remote --yes
7 * * * *     /usr/bin/timeout 300   sac freshness refresh
*/5 * * * *   /usr/bin/timeout 300   sac agents reconcile --apply
*/5 * * * *   /usr/bin/timeout 300   sac agents restart-login-expired --apply
*/10 * * * *  /usr/bin/timeout 300   /home/ywatanabe/.env-3.11/bin/python /home/ywatanabe/.scitex/agent-container/bin/auth-heal.py
```

None of the nine already began with `timeout`, and none is a pipeline or uses `&&`, so a
single prefix bounds the whole process in every case.

## Two spelling choices, both load-bearing

* **`/usr/bin/timeout` is absolute.** GNU coreutils 9.4, verified on scitex-compute-04
  itself. Cron's and systemd's minimal PATHs both include `/usr/bin`, so a bare `timeout`
  would resolve too — but the absolute form is what keeps `heal-agent-auth`'s "depends on
  no PATH at all" property true: its head must start with `/` for `resolve_execstart` to
  pass the command through verbatim.
* **The inner command stays PATH-relative (`sac …`).** sac's install path *varies by
  host* — `~/.env-sac/bin/sac` on scitex-compute-04 versus `~/.env-3.11/bin/sac`
  elsewhere (`docs/relocate.md`) — so pinning one absolute `sac` would break the other
  hosts. The cron line has always run `sac` off cron's PATH; that is unchanged.

## Measured, through scitex-dev's own guard

Control = the installed sac (still declaring `timeout_sec`); subject = this branch. Both
driven through the real `run_up` orchestrator in preview mode (no `--yes`).

| | degraded | `ecosystem up` |
|---|---|---|
| before | **9** | aborts on `sac.accounts-refresh`, installs nothing |
| after | **0** | proceeds, lowers all 13 discovered timers |

Preview mode confirmed writing nothing: `cron: --yes required to write the crontab block;
skipping`, and `cron_jobs_installed = 0`.

The remaining per-job notices are the `on_boot_sec` advisories, which scitex-dev
classifies as non-blocking preferences by design.

## Known consequence, recorded rather than papered over

A wrapper prefix means `resolve_execstart` (which absolutises only the **first** token)
no longer absolutises the inner `sac` **if** these specs are ever rendered as systemd
units instead — the same hazard scitex-dev's lowering module documents for wrapper
prefixes. Not live today, since `up` writes cron rather than units; a future move back to
a timer surface must pin the inner path or declare `venv` at that time. This is stated in
the provider docstring so the next reader is not surprised.

## Tests

`tests/scitex_agent_container/_jobs/` — **216 passed**.

The four `timeout_sec == N` pins now assert the bound on the command, where it actually
runs, and the `heal-agent-auth` token-position pins move past the prefix. A new section
pins the **population** invariant over every job rather than a listed set — every command
self-bounding, no job declaring `timeout_sec`, no double bound, a positive bound, and
zero degraded jobs measured through scitex-dev's own guard including the rendered crontab
line. A job added later without a bound now fails here instead of silently re-blocking
the host.

## CI red is repo-wide and pre-existing — this PR adds zero failures

CI reports 4 failed / 17079 passed. **`main` reports the same 4 failures**, in a run that
started at 17:27Z — hours before this branch existed:

```
FAILED tests/develop/test_audit.py::test_audit_all_clean
       - audit-all reported violations (exit=1): PS-140, PS-226, PS-231, §10w, §13, §4b
FAILED tests/scitex_agent_container/test__claude_hooks_plugin.py::test_provider_yields_the_raw_build_rule
FAILED tests/scitex_agent_container/test__claude_hooks_plugin.py::test_raw_build_rule_denies_on_bash_pre_tool_use
FAILED tests/scitex_agent_container/test__claude_hooks_plugin.py::test_every_rule_states_a_substantive_reason
       - TypeError: HookRule.__init__() missing 1 required positional argument: 'provider'
```

Identical set, identical rule codes. The cause is an upstream scitex-dev release landing
after 12:18Z (new audit rules PS-140/PS-231 plus a breaking `HookRule` signature); every
branch built since then is red, `main` included, and dedicated fix branches are already
open (`fix/hookrule-provider-arg`, `fix/ps140-importorskip-on-root`,
`fix/ps231-exemptions-pytest-matrix-and-cla`). None of it touches the jobs module.

The counts reconcile exactly against the green `develop` run at this PR's base commit
(`be467096`, 17069 passed / 88 skipped / 0 failed):

| | passed | skipped | failed | collected |
|---|---|---|---|---|
| develop @ be467096 | 17069 | 88 | 0 | 17157 |
| this PR | 17079 | 84 | 4 | 17167 |

Collected is **+10 — exactly the 10 tests added here, all passing**. The 4 failures come
out of the previously-passing set (the upstream break), and the 4 fewer skips are
previously-`importorskip`-ed tests that the newer scitex-dev now makes runnable. Nothing
in this diff moved them.
