### PR TITLE
fix(trunk): combine the HookRule provider arg and the PS-140 import test so the trunk can go green

### DIFF
--- a/src/scitex_agent_container/_claude_hooks_plugin.py
+++ b/src/scitex_agent_container/_claude_hooks_plugin.py
@@ -82,6 +82,7 @@ def provide_hooks() -> "tuple[HookRule, ...]":
             event="pre-tool-use",
             severity="deny",
             matches=("Bash",),
+            provider=_PROVIDER,
             script=DENY_RAW_APPTAINER_BUILD,
         ),
     )

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -16,6 +16,8 @@ in its source tree. Two outcomes:
   (which installs every peer) catches cross-package renames.
 """
 
+import importlib
+
 import pytest
 
 # ===== AUTO-GENERATED: cross-package imports =====
@@ -46,10 +48,28 @@ CROSS_PACKAGE_IMPORTS = [
 
 @pytest.mark.parametrize("module_name", CROSS_PACKAGE_IMPORTS)
 def test_cross_package_import_resolves_to_real_module(module_name):
-    """Importing scitex-agent-container's declared cross-package dependency must succeed."""
+    """Importing scitex-agent-container's declared cross-package dependency must succeed.
+
+    PS-140 §2. Skip on the ROOT distribution, then HARD-IMPORT the full path.
+
+    ``pytest.importorskip("scitex_dev.hooks")`` skips when ANY part of the
+    dotted path is missing, so a peer that IS installed but has renamed or
+    removed a submodule reports SKIPPED -- which is exactly the case the
+    module docstring above promises will "FAIL loudly". The two-step form is
+    what makes that promise true: an absent peer still skips (a lean install
+    is legitimate), while a present peer that lost the submodule now fails.
+
+    This is not hypothetical. On 2026-08-17 ``scitex_dev.hooks`` gained a
+    required ``HookRule`` field; the consumer-side break was invisible on
+    every developer machine because this test, and the plugin test beside it,
+    both SKIPPED rather than failed. CI -- which installs the peer -- failed,
+    and develop went red for every PR with no local run able to reproduce it.
+    A skip is not a pass.
+    """
     # Arrange
-    name = module_name
+    root = module_name.split(".")[0]
+    pytest.importorskip(root)
     # Act
-    mod = pytest.importorskip(name)
+    mod = importlib.import_module(module_name)
     # Assert
     assert mod is not None


### PR DESCRIPTION
Combines PR #1107 (HookRule provider arg) and PR #1108 (PS-140 importorskip on the ROOT) onto one branch.

WHY A COMBINED BRANCH. Both fixes are correct and neither can prove itself alone: every open PR is red for the OTHER one's absence, so five branches sit BLOCKED while each individually fixes one of the two causes. Nothing lands, and scitex-dev is holding fleet self-pull behind #1111 which is blocked by the same wall.

THE RED IS UPSTREAM AND PRE-EXISTING, not caused by any of these branches. `main` shows the identical four failures in a run from 17:27Z — hours before these branches existed — so a scitex-dev release after 12:18Z broke every branch built since. That is measured, not inferred.

WHAT THIS FIXES
- 3x `TypeError: HookRule.__init__() missing 1 required positional argument: 'provider'` (from #1107, one line)
- `PS-140 cross-package-imports-test-missing` (from #1108: skip on the ROOT, hard-import the FULL path)

WHAT IT DOES NOT FIX, and why I expect green anyway. The CI assertion lists five findings, but read the findings rather than the count — the test itself says so. Of the five: PS-226 is MASKED by a declared skip-rule (deferred unit migration, single-use OAuth token); §4b and §13 are WARN; and §10w is not a verdict at all — it reads "COULD NOT MEASURE RELIABLY ... No verdict is claimed in either direction: this is neither a pass nor a failure", a rule correctly refusing to judge on a slow runner. PS-140 is the only genuine unmasked error, and it is fixed here.

I COULD NOT VERIFY THIS LOCALLY AND WILL NOT PRETEND OTHERWISE. Running the three HookRule tests here gives 6 passed / 3 skipped, and the three skipped are EXACTLY the three that fail in CI — `scitex_dev.hooks contract not installed yet; provider ships inert`. That local run could not have failed for any input. CI has the contract installed, which is why it sees the TypeError, so CI is the only competent instrument for this change.

PREDICTION, stated before the run so it can be wrong: the 3 TypeErrors disappear and `test_audit_all_clean` passes. If audit stays red, the residue is §4b/§13/§10w being counted as violations, and that is a reporting question for scitex-dev rather than more code from me.