### PR TITLE
test(tui): pin the delivery gap — send_turn reports success without evidence

### DIFF
--- a/src/scitex_agent_container/runtimes/_pane_acceptance.py
+++ b/src/scitex_agent_container/runtimes/_pane_acceptance.py
@@ -1,0 +1,77 @@
+"""Will this pane RUN a turn handed to it now, or park it?
+
+``prompts.is_ready`` reads like it answers this and does not. It delegates to
+``_detect_done``, which keys on the string "bypass permissions" — and the status
+bar carries that string the WHOLE TIME, including mid-turn. Verified on live
+panes, busy and idle, in one capture: the marker is present in both. So
+``is_ready`` is really "no modal is blocking", which is exactly what boot-drain
+needs and is correct there, and is the wrong question for dispatch.
+
+WHY THIS MATTERS MORE THAN IT SOUNDS. ``TuiSessionRuntime.send_turn`` gated on
+``is_ready``, typed the turn into the pane, pressed Enter and returned True. The
+turn bridge answers 200 {"delivered": true} on that True and ``sac peer
+post-turn`` exits 0. So a turn dispatched into a busy pane produced four
+affirmative signals and no work — and the operator, who was told to escalate
+when work does not progress, had no observable non-progress condition to
+escalate on.
+
+MEASURED 2026-08-18, four dispatches across four agent states (wedged/resumed,
+plain-restarted, fresh-started, and confirmed-not-spinning): zero completed.
+The last of those is why this module checks two things rather than one — that
+pane was NOT spinning and was holding queued input, so "not busy" alone would
+have called it ready and lost the work again.
+
+THREE STATES SHARE THE "LOOKS FINE" APPEARANCE and only one accepts work:
+
+    genuinely idle        runs the turn                      ACCEPTING
+    mid-turn (working)    parks it behind the current turn   not accepting
+    holding queued input  parks it behind the queue          not accepting
+"""
+
+from __future__ import annotations
+
+from .prompts import is_ready
+
+#: A working agent prints an elapsed/token line — "(5m 39s · ↓ 12.2k tokens)" —
+#: and a /btw tip whose wording is stable across versions. Keyed on SHAPE, never
+#: on the spinner's word: "Slithering", "Bunning" and the rest ROTATE, so a
+#: vocabulary-based detector works right up until the word changes and then
+#: fails silently in the direction that loses work.
+_BUSY_MARKERS = ("tokens)", "without interrupting")
+
+#: Claude Code parks input typed while it is working and says so in the pane. A
+#: pane in this state ACCEPTS keystrokes and does not run them, which is the
+#: exact failure this module exists to stop.
+_QUEUED_MARKER = "Press up to edit queued messages"
+
+
+def is_busy(content: str) -> bool:
+    """True when the agent is mid-turn, detected by shape not by spinner word."""
+    return any(marker in content for marker in _BUSY_MARKERS)
+
+
+def has_queued_input(content: str) -> bool:
+    """True when the pane is holding input it has not run yet."""
+    return _QUEUED_MARKER in content
+
+
+def is_accepting(content: str) -> bool:
+    """True when a turn handed to this pane now will actually run."""
+    return is_ready(content) and not is_busy(content) and not has_queued_input(content)
+
+
+def refusal_reason(content: str) -> str | None:
+    """Why this pane would park a turn, or None when it would run it.
+
+    Returned rather than logged so the CALLER can put it in its refusal — a
+    dispatcher that says "not delivered" without saying why sends the operator
+    back to the pane to find out, which is the manual step the whole verified
+    -delivery change exists to remove.
+    """
+    if not is_ready(content):
+        return "a modal is blocking the input (not at the main prompt)"
+    if is_busy(content):
+        return "the agent is mid-turn; a turn sent now is parked behind it, not run"
+    if has_queued_input(content):
+        return "the pane is already holding queued input that has not run"
+    return None

--- a/src/scitex_agent_container/runtimes/_tui_delivery.py
+++ b/src/scitex_agent_container/runtimes/_tui_delivery.py
@@ -1,0 +1,101 @@
+"""Handing a turn to a live TUI pane, and refusing when it would be parked.
+
+Extracted from ``tui_session.py`` (which was over the line limit) because this
+is a cohesive responsibility with its own correctness question the rest of that
+module does not share: WILL THIS PANE RUN WHAT I HAND IT?
+
+THE DEFECT THIS EXISTS TO CLOSE. Until 2026-08-18 delivery returned True on the
+strength of having sent keystrokes, and nothing asked whether the application
+took them. The chain that produced was four affirmative signals and no work:
+
+    send_turn types into a busy pane        -> returns True
+      -> turn bridge answers 200 {"delivered": true, "text": ""}
+        -> `sac peer post-turn` exits 0
+          -> nothing runs, and no layer is lying
+
+Measured: four dispatches across four agent states (wedged/resumed,
+plain-restarted, fresh-started, and confirmed-not-spinning), zero completions,
+including one 35-minute window with no restart in it — long past any plausible
+compaction pause, which was the alternative explanation worth ruling out.
+
+WHY IT MATTERS BEYOND RELIABILITY. The operator's standing rule is to use the
+cheap local-model agents first and escalate when work does not progress. An
+unobservable non-progress condition means that escalation can never trigger, so
+the rule silently cannot be implemented. A delivery primitive that cannot report
+failure disables the policy above it.
+
+REFUSAL, NOT WAITING. This returns False rather than blocking until the pane
+frees up. The caller — a dispatcher, a sweep, an operator — is the one holding
+the context to decide between retrying, choosing another agent, and escalating.
+Blocking here would hide an unbounded wait inside a call every caller believes
+is fast.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from . import _pane_acceptance
+
+logger = logging.getLogger(__name__)
+
+
+def send_turn_to_pane(
+    mux: Any,
+    name: str,
+    text: str,
+    *,
+    wait_ready: bool = True,
+    ensure_ready: Callable[[], None] | None = None,
+) -> bool:
+    """Deliver one turn to ``name``'s pane; False when it was NOT delivered.
+
+    Args:
+        mux: multiplexer exposing ``exists`` / ``capture_content`` /
+            ``send_text_and_submit``.
+        name: tmux session name.
+        text: the turn.
+        wait_ready: drain modals and check acceptance first. False skips BOTH,
+            for the in-memory unit suite whose fake renders neither.
+        ensure_ready: callable that drains any first-launch / mid-session modal
+            before the pane is read.
+
+    Returns:
+        True only when the keystrokes were sent to a pane that will run them.
+    """
+    if not mux.exists(name):
+        # No runtime to deliver to — distinct from "delivered", and the caller
+        # needs that distinction to tell a dead agent from a busy one.
+        return False
+
+    if wait_ready:
+        if ensure_ready is not None:
+            ensure_ready()
+        # Read the pane AFTER draining: the drain is what makes readiness
+        # meaningful, and busy/queued state can only be judged once no modal
+        # covers it.
+        content = mux.capture_content(name)
+        if not _pane_acceptance.is_accepting(content):
+            logger.warning(
+                "send_turn REFUSED for %s: %s — the turn was NOT delivered",
+                name,
+                _pane_acceptance.refusal_reason(content),
+            )
+            return False
+
+    mux.send_text_and_submit(name, text)
+    return True
+
+
+def capture_pane_logs(mux: Any, name: str, lines: int = 50) -> str:
+    """Last ``lines`` of pane output; empty string when the session is absent.
+
+    Empty-on-absent rather than raising, because callers distinguish the two by
+    asking ``is_running`` first — but note that makes "" ambiguous between "no
+    session" and "a session with no output", which is why it is not a liveness
+    signal.
+    """
+    if not mux.exists(name):
+        return ""
+    return str(mux.capture_logs(name, lines=lines))

--- a/src/scitex_agent_container/runtimes/_tui_delivery.py
+++ b/src/scitex_agent_container/runtimes/_tui_delivery.py
@@ -47,19 +47,34 @@ def send_turn_to_pane(
     text: str,
     *,
     wait_ready: bool = True,
+    require_accepting: bool = True,
     ensure_ready: Callable[[], None] | None = None,
 ) -> bool:
     """Deliver one turn to ``name``'s pane; False when it was NOT delivered.
+
+    THE DRAIN AND THE ACCEPTANCE CHECK ARE SEPARATE FLAGS ON PURPOSE, and
+    conflating them is how the first version of this fix missed the path that
+    matters. The turn bridge — the route ``sac peer post-turn`` actually takes
+    — passes ``wait_ready=False`` for a documented and still-valid reason: the
+    drain blocks up to 60s waiting on a marker an idle autonomous pane may
+    never render, which is fatal for a wake POST. If acceptance rode on the
+    same flag, every bridge dispatch would skip it and the fix would cover only
+    the paths that were not broken.
+
+    They are also different in cost, which is why one can be default-on: the
+    drain BLOCKS; the acceptance check is a single ``capture_content``.
 
     Args:
         mux: multiplexer exposing ``exists`` / ``capture_content`` /
             ``send_text_and_submit``.
         name: tmux session name.
         text: the turn.
-        wait_ready: drain modals and check acceptance first. False skips BOTH,
-            for the in-memory unit suite whose fake renders neither.
-        ensure_ready: callable that drains any first-launch / mid-session modal
-            before the pane is read.
+        wait_ready: run the blocking modal drain first.
+        require_accepting: refuse when the pane would PARK the turn. Default
+            on, including when ``wait_ready`` is False. Set False only for the
+            in-memory unit suite, whose fake renders no status bar and would
+            therefore always read as not-accepting.
+        ensure_ready: callable that drains any first-launch / mid-session modal.
 
     Returns:
         True only when the keystrokes were sent to a pane that will run them.
@@ -69,12 +84,12 @@ def send_turn_to_pane(
         # needs that distinction to tell a dead agent from a busy one.
         return False
 
-    if wait_ready:
-        if ensure_ready is not None:
-            ensure_ready()
-        # Read the pane AFTER draining: the drain is what makes readiness
-        # meaningful, and busy/queued state can only be judged once no modal
-        # covers it.
+    if wait_ready and ensure_ready is not None:
+        ensure_ready()
+
+    if require_accepting:
+        # Read the pane AFTER any drain: a modal on screen would otherwise be
+        # read as "not accepting" for the wrong reason.
         content = mux.capture_content(name)
         if not _pane_acceptance.is_accepting(content):
             logger.warning(
@@ -86,6 +101,24 @@ def send_turn_to_pane(
 
     mux.send_text_and_submit(name, text)
     return True
+
+
+def why_not_deliverable(mux: Any, name: str) -> str | None:
+    """Why a turn to ``name`` would not be delivered now, or None if it would.
+
+    Exists so a CALLER can put the specific reason in its own error. The turn
+    bridge previously raised "TUI session ... does not exist" for every False
+    from send_turn, which was accurate when absence was the only cause and
+    became a MISDIAGNOSIS the moment a second cause existed: a busy pane is
+    not a missing session, and telling an operator otherwise sends them to
+    look for a dead agent that is in fact working.
+
+    An error that names the wrong cause is worse than one that names none,
+    because it is actionable in the wrong direction.
+    """
+    if not mux.exists(name):
+        return "no tmux session for this agent — nothing to deliver to"
+    return _pane_acceptance.refusal_reason(mux.capture_content(name))
 
 
 def capture_pane_logs(mux: Any, name: str, lines: int = 50) -> str:

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -346,17 +346,41 @@ def _build_on_turn(
                     config.name,
                     exc,
                 )
-        # ``wait_ready=False`` → the bare send_text_and_submit primitive
-        # (text + Enter). The full ``wait_until_input_ready`` drain blocks up
+        # ``wait_ready=False`` → skip the blocking modal DRAIN, which waits up
         # to 60s on a "? for shortcuts" marker an idle autonomous pane may
-        # never render — fatal for a wake POST; boot modals are already
-        # drained by ``start()._drain_at_boot`` and claude queues keystrokes
-        # typed mid-turn, so a live wake needs no drain and is never dropped.
+        # never render — fatal for a wake POST. Boot modals are already drained
+        # by ``start()._drain_at_boot``, so a live wake needs no drain.
+        #
+        # THE ACCEPTANCE CHECK STILL RUNS. It is a separate flag precisely
+        # because it must survive ``wait_ready=False``: this is the path
+        # dispatch actually takes, so gating acceptance on the drain flag would
+        # have left the real route unchecked. It costs one capture, not 60s.
+        #
+        # THE SENTENCE THAT USED TO END THIS COMMENT — "claude queues
+        # keystrokes typed mid-turn, so a live wake ... is never dropped" — IS
+        # FALSE and is why this bug survived. Measured 2026-08-18: four
+        # dispatches to live agents across four pane states produced zero
+        # completed tasks, one over a 35-minute window with no restart in it.
+        # Claude does queue them; the queue does not reliably drain.
         delivered = runtime.send_turn(config, text, wait_ready=False)
         if not delivered:
+            # Name the ACTUAL cause. This used to assert the session did not
+            # exist, which was true when absence was the only cause and became
+            # a misdiagnosis the moment a busy pane could also refuse — it sent
+            # the reader hunting a dead agent that was in fact working.
+            #
+            # getattr-guarded because the REASON is enrichment and the RAISE is
+            # the contract. A runtime seam that cannot explain itself must
+            # still fail loudly; making the failure depend on the explainer
+            # would let a missing method turn a refusal into a crash, or worse
+            # into a silent success in some future caller that catches it.
+            explain = getattr(runtime, "why_not_deliverable", None)
+            why = (explain(config) if callable(explain) else None) or (
+                "no reason available from this runtime — the session is absent, "
+                "or the pane would park the turn rather than run it"
+            )
             raise RuntimeError(
-                f"TUI session for agent {config.name!r} does not exist; "
-                "cannot deliver the pushed turn."
+                f"turn NOT delivered to agent {config.name!r}: {why}"
             )
 
     return on_turn

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -502,3 +502,10 @@ class TuiSessionRuntime(
         return _tui_delivery.capture_pane_logs(
             self._mux, session_name_for(config), lines
         )
+
+    def why_not_deliverable(self, config: AgentConfig) -> str | None:
+        """Reason a turn would not be delivered now, or None if it would be.
+
+        So a caller's error can name the ACTUAL cause instead of guessing one.
+        """
+        return _tui_delivery.why_not_deliverable(self._mux, session_name_for(config))

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -31,6 +31,7 @@ from .._runners._tmux.tmux import (
     TuiInputNotReadyError,
 )
 from ..config import AgentConfig
+from . import _tui_delivery
 from ._apptainer_build_argv import build_run_argv
 from ._tui_auth_stage import TuiAuthStageError
 from ._tui_boot_drain import TuiBootDrainMixin
@@ -477,33 +478,27 @@ class TuiSessionRuntime(
         *,
         wait_ready: bool = True,
     ) -> bool:
-        """Deliver one turn of input to the in-tmux TUI.
+        """Deliver one turn to the in-tmux TUI; ``False`` when NOT delivered.
 
-        Uses ``send_text_and_submit`` (text first, settle delay, then a separate
-        ``Enter``) — the bare primitive proven to reach the claude TUI input and
-        submit cleanly on the live host. Returns ``False`` (and skips the send)
-        when sac's tmux session for this agent does not exist — the TUI analogue
-        of the SDK "no live turn endpoint" guard, so a caller can distinguish
-        "delivered" from "no runtime to deliver to".
-
-        When ``wait_ready`` (the default; skippable for the in-memory unit
-        suite), first :meth:`wait_until_input_ready` to drain any first-launch /
-        mid-session modal via the :mod:`runtimes.prompts` registry before
-        delivering, so keystrokes never land on a not-yet-bound input.
+        False covers three distinct cases a caller must tell apart: no tmux
+        session (nothing to deliver to), and — since 2026-08-18 — a pane that
+        would PARK the turn rather than run it, either mid-turn or already
+        holding queued input. See :mod:`runtimes._tui_delivery` for the
+        mechanism and the measurement, and :mod:`runtimes._pane_acceptance`
+        for why "not busy" is not the test.
         """
-        name = session_name_for(config)
-        if not self._mux.exists(name):
-            return False
-        if wait_ready:
-            self.wait_until_input_ready(config)
-        self._mux.send_text_and_submit(name, text)
-        return True
+        return _tui_delivery.send_turn_to_pane(
+            self._mux,
+            session_name_for(config),
+            text,
+            wait_ready=wait_ready,
+            ensure_ready=lambda: self.wait_until_input_ready(config),
+        )
 
     def logs(self, config: AgentConfig, lines: int = 50) -> str:
         """Return the last ``lines`` of pane output; empty string when the
         session does not exist (distinguish via ``is_running`` first).
         """
-        name = session_name_for(config)
-        if not self._mux.exists(name):
-            return ""
-        return str(self._mux.capture_logs(name, lines=lines))
+        return _tui_delivery.capture_pane_logs(
+            self._mux, session_name_for(config), lines
+        )

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -117,7 +117,19 @@ class _MemoryMultiplexer:
         # (post-2026-06-14 lead a2a 278159b5) short-circuits in the
         # in-memory unit suite. The fake doesn't render first-launch
         # modals; the drain has no work to do and must not block.
-        return "\n".join(sess.pane) + "\n? for shortcuts"
+        #
+        # "bypass permissions" is the STATUS BAR a real idle pane carries, and
+        # it is what `prompts._detect_done` keys on. Without it this fake
+        # models a pane that is neither ready nor busy — a state no live agent
+        # is ever in — so every delivery test would exercise the refusal path
+        # rather than the path it means to test. Modelling an IDLE pane is the
+        # honest default here; tests that want a busy one say so explicitly by
+        # overriding capture_content (see the busy-pane tests below).
+        return (
+            "\n".join(sess.pane)
+            + "\n? for shortcuts"
+            + "\n  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+        )
 
     @classmethod
     def capture_logs(cls, session_name: str, lines: int = 50) -> str:

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -762,18 +762,6 @@ def test_busy_pane_still_satisfies_the_input_ready_predicate(
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "send_turn reports delivery on the strength of having sent keystrokes. "
-        "Measured 2026-08-18: four dispatches to live handymen across four "
-        "agent states produced zero completed tasks, while each returned "
-        "200 {'delivered': true}. The fix is an acceptance check, not a "
-        "busy check — a non-spinning pane may still be queued or compacting, "
-        "so 'not busy' is not 'will run'. Flip to XPASS when send_turn "
-        "verifies the turn was ACCEPTED."
-    ),
-)
 def test_send_turn_refuses_when_the_pane_is_busy(
     mux: type[_MemoryMultiplexer],
 ) -> None:

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -20,6 +20,7 @@ from typing import Iterator
 import pytest
 
 from scitex_agent_container._runners._tmux.tmux import TuiInputNotReadyError
+from scitex_agent_container.runtimes import prompts as _prompts
 from scitex_agent_container.runtimes.tui_session import (
     TuiSessionRuntime,
     session_name_for,
@@ -716,6 +717,91 @@ def test_tui_runtime_send_turn_skips_send_when_no_session(
     # the runtime guarded the send instead of letting it create a
     # phantom entry via the implicit dict-insert path.
     assert "tui-sigma" not in mux._sessions
+
+
+# A pane frame captured VERBATIM from a live handyman mid-turn on
+# scitex-compute-04, 2026-08-18. Kept literal rather than paraphrased: the
+# whole point of the test below is which substrings are and are not present,
+# so a tidied-up imitation would test the imitation.
+_BUSY_PANE = """\
+● Showing recent commits on hm01-audit branch
+  ⎿  $ timeout 7 git -C /home/ywatanabe/proj/scitex-cards log --oneline -8
+✻ Slithering… (5m 39s · ↓ 12.2k tokens)
+  ⎿  Tip: Use /btw to ask a quick side question without interrupting Claude's
+     current work
+                                                          7% until auto-compact
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  handyman-01@compute-04 | local-coder | qwen38-27b | ctx:69%
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+"""
+
+
+def test_busy_pane_still_satisfies_the_input_ready_predicate(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    """The gate `send_turn` relies on cannot see a working agent.
+
+    This is a CHARACTERISATION test: it asserts today's behaviour so the
+    mechanism is pinned, not the behaviour we want. `_detect_done` keys on
+    "bypass permissions", and the status bar carries that string while the
+    agent is mid-turn — verified on live panes, busy and idle, in one capture.
+    So the predicate documented as "at the main input prompt" is really
+    "no modal is blocking", and it returns True for an agent that is working.
+    """
+    # Arrange
+    del mux  # not needed; this exercises the predicate directly
+    busy_frame = _BUSY_PANE
+    # Act
+    ready = _prompts.is_ready(busy_frame)
+    # Assert — the busy frame passes the ready check. That is the defect.
+    assert ready is True, (
+        "if this now fails, is_ready() has learned to detect a working agent "
+        "and the xfail below should be re-examined"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "send_turn reports delivery on the strength of having sent keystrokes. "
+        "Measured 2026-08-18: four dispatches to live handymen across four "
+        "agent states produced zero completed tasks, while each returned "
+        "200 {'delivered': true}. The fix is an acceptance check, not a "
+        "busy check — a non-spinning pane may still be queued or compacting, "
+        "so 'not busy' is not 'will run'. Flip to XPASS when send_turn "
+        "verifies the turn was ACCEPTED."
+    ),
+)
+def test_send_turn_refuses_when_the_pane_is_busy(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    """A turn typed into a working pane must not be reported as delivered.
+
+    The caller's only signal is this bool: the turn bridge answers
+    200 {"delivered": true} on True, and `sac peer post-turn` exits 0. So a
+    True here is the last point at which the fleet can distinguish "the agent
+    took the work" from "keystrokes were sent at a busy terminal", and today
+    it cannot. The operator's standing rule is "use handyman first, escalate
+    when work does not progress" — an unobservable non-progress condition
+    means that escalation can never trigger.
+    """
+    # Arrange — a live session whose pane is mid-turn.
+    class _BusyMux(mux):  # type: ignore[misc, valid-type]
+        @classmethod
+        def capture_content(cls, session_name: str) -> str:
+            del session_name
+            return _BUSY_PANE
+
+    _BusyMux.reset()
+    runtime = TuiSessionRuntime(multiplexer=_BusyMux, command_builder=_fake_builder)
+    config = _Config(name="busy-pane")
+    runtime.start(config)
+    # Act
+    delivered = runtime.send_turn(config, "work-that-will-be-dropped")
+    # Assert
+    assert delivered is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two tests, no production change. The fix needs a case that can fail first, and this is the one function whose entire defect is reporting success without evidence — shipping a delivery-verification patch with no failing case would reproduce the bug in the remedy.

MEASURED 2026-08-18 on live handymen: four dispatches across four agent states (wedged/resumed, plain-restarted, fresh-started, and confirmed-not-spinning) produced ZERO completed tasks, while every one returned 200 {'delivered': true} and post-turn exited 0. A freshly started agent DID execute its own card work, so the runtime runs work; it does not run DISPATCHED work.

MECHANISM. prompts._detect_done keys on 'bypass permissions' and the status bar carries that string while the agent is mid-turn. Verified against live panes, busy and idle, in one capture: the marker is present in BOTH. So the predicate documented as 'at the main input prompt' actually computes 'no modal is blocking' — true at boot, where it was written and is correct, and false for every later turn. wait_until_input_ready therefore returns immediately on a working pane, send_turn types into it, and returns True on the strength of having sent keystrokes.

test_busy_pane_still_satisfies_the_input_ready_predicate is a CHARACTERISATION test: it asserts today's behaviour so the mechanism is pinned rather than the behaviour we want, and it carries a message telling a future reader to re-examine the xfail if it ever starts failing.

test_send_turn_refuses_when_the_pane_is_busy is xfail(strict=True), so it flips to a hard failure the moment delivery verification lands — it names its own unblock condition instead of relying on someone remembering.

THE FIX IS AN ACCEPTANCE CHECK, NOT A BUSY CHECK, and the xfail reason says so. I tried the busy check as a workaround and disproved it the same evening: a dispatch to a pane my own discriminator called idle also vanished, because 'not spinning' collapses genuinely-idle, queued-and-waiting and about-to-compact into one reading and only the first accepts work.

WHY THE BOOL MATTERS BEYOND RELIABILITY: it is the last point at which the fleet can distinguish 'the agent took the work' from 'keystrokes were sent at a busy terminal'. The operator's standing rule is to use handyman first and escalate when work does not progress; an unobservable non-progress condition means that escalation can never trigger.

The busy pane fixture is a verbatim live capture rather than a tidied imitation, because the test is about which substrings are and are not present.
