### PR TITLE
fix(ci-guard): a caller job is UNRESOLVABLE, not unhosted (SAC-CI004)

### DIFF
--- a/src/scitex_agent_container/_hosted_runner_guard.py
+++ b/src/scitex_agent_container/_hosted_runner_guard.py
@@ -417,9 +417,34 @@ def check_repo(repo: Path) -> list[Violation]:
         exempt_jobs = _allowed_jobs(entry) if entry is not None else set()
 
         for job_id, job in _iter_jobs(doc):
-            # A `uses:` job calls a reusable workflow and declares no runner
-            # of its own — there is no runs-on decision to police here.
+            # A `uses:` job calls a reusable workflow and declares no runner of
+            # its own, so there is no LOCAL runs-on decision to police. But
+            # "no local decision" is not "not hosted": the runner is chosen by
+            # the callee's input default, in another repository this guard
+            # cannot read. The honest verdict is UNRESOLVABLE.
+            #
+            # THAT DISTINCTION IS LOAD-BEARING FOR THE ALLOWLIST. A bare
+            # `continue` contributes nothing to `used`, so _stale_violations
+            # then reports the entry as "no hosted job left in it — delete the
+            # entry" for a workflow it was never able to assess. Measured
+            # 2026-08-18 on cla.yml: converting it to a caller (PS-231) made
+            # the guard recommend deleting the one entry that documents WHY it
+            # must stay hosted — unauthenticated `issue_comment` /
+            # `pull_request_target` triggers running a third-party action,
+            # where the self-hosted $HOME holds the fleet's live credential.
+            # Following that advice would leave the next one-line
+            # `runs_on: '["self-hosted",...]'` with nothing in front of it.
+            #
+            # A guard must never recommend destroying a documented exception it
+            # could not evaluate. So an allowlisted caller KEEPS its entry
+            # alive; job scoping is still honoured, because "convert it to a
+            # caller" must not become a way to launder a new job into someone
+            # else's exception.
             if "runs-on" not in job and job.get("uses"):
+                if entry is not None and (
+                    exempt_jobs is None or job_id in exempt_jobs
+                ):
+                    used.add((path.name, job_id))
                 continue
 
             verdict = classify_runs_on(job)

--- a/tests/scitex_agent_container/test__hosted_runner_guard.py
+++ b/tests/scitex_agent_container/test__hosted_runner_guard.py
@@ -82,6 +82,19 @@ REUSABLE_CALLER = (
     "name: demo\non: [push]\njobs:\n  call:\n    uses: ./.github/workflows/other.yml\n"
 )
 
+# The shape PS-231 pushes a leaf into: the body is replaced by a call to the
+# org reusable, so the runner is decided by the CALLEE's input default — in
+# another repository, which this guard cannot read.
+ORG_CALLER = (
+    "name: cla\n"
+    "on: [issue_comment]\n"
+    "jobs:\n"
+    "  CLAssistant:\n"
+    "    uses: scitex-ai/.github/.github/workflows/cla.yml@main\n"
+    "    with:\n"
+    "      runs_on: '[\"ubuntu-latest\"]'\n"
+)
+
 LEGACY_NAMED = (
     "name: quality\n"
     "on: [push]\n"
@@ -284,6 +297,45 @@ def test_allowlist_entry_for_missing_workflow_is_flagged(tmp_path: Path) -> None
     codes = _codes(tmp_path)
     # Assert
     assert codes == [CODE_ALLOWLIST_STALE]
+
+
+def test_allowlisted_caller_is_not_reported_stale(tmp_path: Path) -> None:
+    # Arrange: cla.yml has become a CALLER (PS-231). Its runner is now decided
+    # by the callee's input default, in another repository this guard cannot
+    # read. Reporting the entry stale here would tell the reader to delete the
+    # SECURITY ARGUMENT for a workflow whose triggers are unauthenticated and
+    # which runs a third-party action — the one thing standing in front of a
+    # one-line change to a self-hosted pool. Unresolvable is not unhosted.
+    _write_repo(
+        tmp_path,
+        {"cla.yml": ORG_CALLER},
+        allowlist=_allowlist("cla.yml"),
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert CODE_ALLOWLIST_STALE not in codes
+
+
+def test_caller_outside_the_job_scope_leaves_the_entry_stale(
+    tmp_path: Path,
+) -> None:
+    # Arrange: the OTHER direction, and the one that keeps the fix honest. The
+    # entry is scoped to job `CLAssistant`, but the file's only caller is named
+    # `unrelated`. Nothing the entry covers is present, so the entry really IS
+    # stale and must still be reported. A fix that marked ANY caller as "in
+    # use" would silently keep every job-scoped entry alive for ever, which is
+    # the standing-loophole this rule exists to prevent.
+    caller_named_otherwise = ORG_CALLER.replace("CLAssistant:", "unrelated:")
+    _write_repo(
+        tmp_path,
+        {"cla.yml": caller_named_otherwise},
+        allowlist=_allowlist("cla.yml", jobs="CLAssistant"),
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert CODE_ALLOWLIST_STALE in codes
 
 
 def test_job_scoped_allowlist_does_not_cover_a_new_job(tmp_path: Path) -> None:


### PR DESCRIPTION
## The defect

The no-hosted-runners guard skipped `uses:` jobs entirely — a caller declares no
runner of its own, so there is no *local* `runs-on` decision to police. That much
is true. But **"no local decision" is not "not hosted"**: the runner is chosen by
the callee's input default, in another repository the guard cannot read.

A skipped job contributes nothing to `used`, so `_stale_violations` then reported
the workflow's allowlist entry as *"no hosted job left in it — delete the entry"*
for a workflow it was **never able to assess**.

## Why it matters more than a false positive

Measured on `cla.yml`. Converting it to the org caller (PS-231, which the
operator ordered) makes the guard recommend deleting the one entry that
documents why it must stay hosted:

> `issue_comment` + `pull_request_target` — both unauthenticated on a public repo
> and outside the fork-PR approval gate — running a **third-party action**, on a
> pool where `$HOME` is the operator's real home holding the **live fleet
> credential**. The entry ends: *"DO NOT 'FIX' THIS BY MIGRATING IT."*

Delete it and the next one-line `runs_on: '["self-hosted",...]'` has nothing
standing in front of it, with a fleet credential rather than a disposable VM as
the blast radius. So complying with PS-231 currently *invites* removing a
security control.

A guard must never recommend destroying a documented exception it could not
evaluate.

## The fix

An allowlisted caller now marks its entry as still in use. **Job scoping is still
honoured**, so "convert it to a caller" cannot launder a new job into someone
else's exception. Un-allowlisted callers are unchanged — scope is deliberately
narrow.

## Proven both directions

A guard you have only ever seen pass is a hope, so:

| check | result |
|---|---|
| new test — allowlisted caller | `SAC-CI004` absent (was present) |
| new test — caller outside the job scope | `SAC-CI004` **still** present |
| whole guard suite | 40 passed |
| fixed guard vs the PS-231 branch tree | exit 0 |
| **old** guard vs that same tree | exit 1 |

The last row is the one that matters: it proves the fix is what changed the
verdict, not something incidental about the tree.

## Provenance

Found while doing the PS-231 conversion in #1115, which stays open as the worked
example. scitex-dev owns PS-231 and initially took the guard fix, then corrected
themselves — the guard, its rule id, its allowlist and its tests all live here,
so the code change is ours. They are reviewing, and will amend PS-231's own text
to warn that converting to a caller does **not** mean a hosted-runner exception
became unnecessary.
