### PR TITLE
chore(audit): land PS-140 and the PS-231 exemptions together so the gate can go green

### DIFF
--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -120,6 +120,58 @@ audit:
           scitex-ai/scitex-dev#588; this entry is removed by the change that
           adopts that release.
 
+    # PS-231 (workflow-duplication). TWO entries, both RULED ON by scitex-dev
+    # on 2026-08-17 rather than asserted by this repo — sac argued the rule
+    # fired wrongly on FIVE workflows and was granted exactly these two. The
+    # other three (auto-merge-to-develop, import-smoke, rtd-sphinx-build) were
+    # REFUSED and are deliberately absent from this file.
+    #
+    # Why the refusal matters more than the grant: sac's argument for those
+    # three was size ("auto-merge is 700 lines against the org's 220"), and
+    # 3.2x is evidence of DIFFERENCE, not evidence of NECESSITY. An exemption
+    # asserts "this leaf's version is genuinely unique"; for those three that
+    # assertion was UNMEASURED. Writing them anyway would have made this file
+    # a record of what was expensive to check rather than what is true, and
+    # then no row in it could be trusted — including the two below.
+    #
+    # ALSO NOT the reason for either entry, though sac offered it: that sac is
+    # immune to the specific `scitex-ci` label defect the rule's rationale
+    # cites. It is immune — `runs-on: ${{ fromJSON(vars.CI_RUNS_ON || ...) }}`
+    # reads a repo VARIABLE, so the label was never frozen into the copy. But
+    # that immunises against ONE defect class, not against divergence: a
+    # step-ordering fix or a new security check made org-side still fails to
+    # reach a local copy. scitex-dev conceded their rationale cites a single
+    # anecdote and is being rewritten; that concession is not a licence here.
+    PS-231:
+      - path: .github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+        line: 0
+        reason: >-
+          DEFERRAL WITH A TESTABLE EXPIRY, not a standing claim: exempt until
+          the org `pytest-matrix` reusable accepts a SECOND runner pool;
+          re-evaluate then. This workflow runs two jobs on two different
+          pools — the matrix on `${{ fromJSON(vars.CI_RUNS_ON) }}` and a
+          second on `[self-hosted, Linux, X64, sac-control-plane]`, whose own
+          in-file comment calls it "THE LOAD-BEARING LINE". A caller passing
+          one `runs_on` input cannot produce two jobs on two pools, so
+          converting to `uses:` would require DELETING a job. That is a
+          capability the org reusable lacks, not a preference this leaf holds;
+          scitex-dev is raising the two-pool gap on the org's side, and this
+          entry is removed by the change that closes it.
+      - path: .github/workflows/cla.yml
+        line: 0
+        reason: >-
+          Deliberately divergent, with a guard rail already in the file. The
+          workflow pins `runs-on: ubuntu-latest` under a block comment that
+          explicitly warns against "FIXING" it — the same security argument
+          recorded in this file's PS-224 entry above: `issue_comment` and
+          `pull_request_target` are UNAUTHENTICATED triggers, the fork-PR
+          approval gate does not cover them, and self-hosted runners' $HOME
+          holds the live fleet credential. Converting to a caller does exactly
+          what that comment forbids. A decision with a stated reason and a
+          guard rail is the strongest form of exemption there is, and it is
+          closed by the same condition as PS-224: an ephemeral/isolated runner
+          for untrusted-trigger workflows.
+
   # PS-226 (job-name-not-hyphenated), introduced by scitex-dev 0.48.0.
   #
   # THIS IS A DEFERRAL, NOT A WAIVER, AND THE FINDING IS CORRECT.

--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -172,6 +172,62 @@ audit:
           closed by the same condition as PS-224: an ephemeral/isolated runner
           for untrusted-trigger workflows.
 
+      # The remaining three, added 2026-08-18 after DIFFING each local file
+      # against the org reusable it is accused of duplicating. scitex-dev
+      # refused these three on 2026-08-17 because the argument offered was
+      # SIZE, and size is evidence of difference rather than of necessity.
+      # Their stated condition was "convert if a diff shows nothing
+      # load-bearing" — so each reason below names a capability, measured.
+      #
+      # The diff also reversed the expected direction twice: for
+      # auto-merge-to-develop the ORG copy is the one carrying defects this
+      # repo already fixed, so converting would REGRESS merge safety. Do not
+      # assume the shared version is the newer one.
+      - path: .github/workflows/import-smoke-on-ubuntu-py3-12.yml
+        line: 0
+        reason: >-
+          The local job asserts the CONSOLE SCRIPT resolves —
+          `.venv/bin/sac --version` — and the org reusable's entire test body
+          is one hardcoded step that stops at `import <pkg>`. That step is
+          what catches `[project.scripts]` entry-point drift, and it is the
+          same entry point the SIF and run-in-sif.sh exercise; nothing else in
+          this repo's CI runs it against a venv install. The org reusable
+          declares exactly ONE input (`runs_on`), no secrets and no matrix, so
+          a caller has no mechanism to append a step. CLOSED BY: an
+          `extra_check`/post-install input upstream, or splitting the CLI
+          smoke into its own job. NOTE, not a reason to keep this copy: the
+          org version has a FORK GUARD ahead of checkout that this file lacks
+          — that gap is real and is being ported separately rather than being
+          allowed to ride on this exemption.
+      - path: .github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
+        line: 0
+        reason: >-
+          The local job REFRESHES AND COMMITS `src/scitex_agent_container/
+          _sphinx_html/` back to the default branch (`permissions: contents:
+          write`, `fetch-depth: 0`, commit message "docs: refresh _sphinx_html/
+          from CI build [skip ci]"). Verified in history, not asserted:
+          commits 9460acb2 and 812d98a7 carry that message and 117 files are
+          tracked under that path. A reusable workflow's workspace dies with
+          its job and the org copy has no commit step, no upload-artifact and
+          no outputs, so the built HTML is unreachable from any follow-on job
+          in the caller. Independently: the local file passes `sphinx-build -W`
+          on pull requests only, and the org exposes no strictness input, so
+          converting would silently downgrade "a new Sphinx warning fails the
+          PR" to "warnings ignored". CLOSED BY: an artifact/outputs contract
+          upstream plus a strictness input.
+      - path: .github/workflows/auto-merge-to-develop.yaml
+        line: 0
+        reason: >-
+          CONVERTING WOULD REGRESS MERGE SAFETY. The org copy at
+          scitex-ai/.github@main still carries the pending-check defect this
+          repo fixed on 2026-08-12: it tests `if [ "$pending" = "0" ]` over a
+          jq that does `select(. != "")`, and a QUEUED check has
+          `conclusion == ""`, so it is discarded — a PR whose checks are all
+          still queued reads as zero pending and MERGES. The local copy is
+          ahead of the shared one here, which is the opposite of the direction
+          PS-231's rationale assumes. CLOSED BY: the org reusable adopting the
+          fix, after which this leaf should convert and this entry be removed.
+
   # PS-226 (job-name-not-hyphenated), introduced by scitex-dev 0.48.0.
   #
   # THIS IS A DEFERRAL, NOT A WAIVER, AND THE FINDING IS CORRECT.

--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -120,11 +120,39 @@ audit:
           scitex-ai/scitex-dev#588; this entry is removed by the change that
           adopts that release.
 
-    # PS-231 (workflow-duplication). TWO entries, both RULED ON by scitex-dev
-    # on 2026-08-17 rather than asserted by this repo — sac argued the rule
-    # fired wrongly on FIVE workflows and was granted exactly these two. The
-    # other three (auto-merge-to-develop, import-smoke, rtd-sphinx-build) were
-    # REFUSED and are deliberately absent from this file.
+    # PS-231 (workflow-duplication). FIVE entries.
+    #
+    # CORRECTED 2026-08-18. This comment used to say "TWO entries … the other
+    # three were REFUSED and are deliberately absent from this file" while the
+    # file listed all five — the header and the data disagreeing, with nothing
+    # failing. That is the same shape that cost real time twice this week: an
+    # input's `description:` still claiming a Spartan default above a literal
+    # `default: '["ubuntu-latest"]'`, and a branch NAME implying work that did
+    # not exist. Prose ABOUT a value is not the value, and stale prose is worse
+    # than none because it is read with the authority of documentation.
+    #
+    # WHAT ACTUALLY HAPPENED. scitex-dev granted two on 2026-08-17 and refused
+    # the other three, on the correct ground that sac's argument for them was
+    # SIZE and size is not necessity (see below). The three were then MEASURED
+    # field-by-field against the org reusables and added on that basis
+    # (873d8575, "exempt the last three PS-231 workflows, measured"). The
+    # refusal did the work it was supposed to do: it forced a measurement that
+    # produced better reasons than the ones first offered.
+    #
+    # EVERY ENTRY BELOW CARRIES A REMOVAL CONDITION, and that is binding, not
+    # decorative (scitex-dev ruling, 2026-08-18). An exemption with a reason
+    # and a condition is a DEFERRAL; one nobody removes is precisely the
+    # loophole this rule exists to prevent. Five permanent entries would mean
+    # the rule fired once, everyone routed around it, and the fleet ended up
+    # where it started with a green check on top. Each entry dies in the SAME
+    # PR as the conversion that closes it.
+    #
+    # STATE OF THE FIVE, 2026-08-18 — nearest to removal first:
+    #   cla.yml           conversion WRITTEN (#1115), needs #1116
+    #   import-smoke      needs org #40 (uv_version); org #39 already MERGED
+    #   auto-merge        needs upstream hold-label / dev_bad
+    #   pytest-matrix     needs a second-runner-pool input upstream
+    #   rtd-sphinx-build  UNSTARTED upstream — no implementation exists
     #
     # Why the refusal matters more than the grant: sac's argument for those
     # three was size ("auto-merge is 700 lines against the org's 220"), and
@@ -155,8 +183,14 @@ audit:
           one `runs_on` input cannot produce two jobs on two pools, so
           converting to `uses:` would require DELETING a job. That is a
           capability the org reusable lacks, not a preference this leaf holds;
-          scitex-dev is raising the two-pool gap on the org's side, and this
-          entry is removed by the change that closes it.
+          scitex-dev is raising the two-pool gap on the org's side.
+
+          CLOSED BY: the org `pytest-matrix` reusable accepting a second
+          runner pool, after which this leaf converts and this entry is
+          deleted in the SAME PR. (Phrasing normalised 2026-08-18 so every
+          entry states its condition in one greppable form — a rule that
+          "each exemption must name what removes it" is only enforceable if a
+          tool can find the naming.)
       - path: .github/workflows/cla.yml
         line: 0
         reason: >-
@@ -166,11 +200,36 @@ audit:
           recorded in this file's PS-224 entry above: `issue_comment` and
           `pull_request_target` are UNAUTHENTICATED triggers, the fork-PR
           approval gate does not cover them, and self-hosted runners' $HOME
-          holds the live fleet credential. Converting to a caller does exactly
-          what that comment forbids. A decision with a stated reason and a
-          guard rail is the strongest form of exemption there is, and it is
-          closed by the same condition as PS-224: an ephemeral/isolated runner
-          for untrusted-trigger workflows.
+          holds the live fleet credential.
+
+          CORRECTED 2026-08-18 — THIS ENTRY'S ORIGINAL REASONING WAS WRONG AND
+          IT IS THE FIRST OF THE FIVE THAT SHOULD GO. It said "converting to a
+          caller does exactly what that comment forbids", which assumed the org
+          reusable would put this job on the Spartan pool. It does not: org #29
+          INVERTED that default and the literal value is
+          `default: '["ubuntu-latest"]'`, so a caller passing nothing already
+          lands on hosted hardware. (The input's `description:` still says
+          "Defaults to the Spartan pool" — stale prose from before the
+          inversion, which is what produced the wrong reasoning here. Read the
+          value, not the sentence above it.)
+
+          So the security property is preserved by conversion, and #1115 makes
+          it stronger than the status quo: it passes
+          `runs_on: '["ubuntu-latest"]'` EXPLICITLY, which moves the decision
+          out of a remote file that a PR none of this repo's reviewers see
+          could change, and lets a local test assert it
+          (`test_the_cla_job_really_is_still_hosted`). Point that value at a
+          self-hosted pool and the test goes red.
+
+          CLOSED BY: sac #1115 landing (which needs #1116, the SAC-CI004 guard
+          fix — a caller has no local `runs-on`, so the hosted-runner guard
+          reads the allowlist entry as stale and recommends deleting the very
+          security argument quoted above). Delete this entry in the same PR as
+          #1115.
+
+          NOT closed by the PS-224 condition (an ephemeral/isolated runner for
+          untrusted-trigger workflows). That remains desirable and is a
+          separate, larger piece of work; this entry must not wait for it.
 
       # The remaining three, added 2026-08-18 after DIFFING each local file
       # against the org reusable it is accused of duplicating. scitex-dev
@@ -191,14 +250,33 @@ audit:
           is one hardcoded step that stops at `import <pkg>`. That step is
           what catches `[project.scripts]` entry-point drift, and it is the
           same entry point the SIF and run-in-sif.sh exercise; nothing else in
-          this repo's CI runs it against a venv install. The org reusable
-          declares exactly ONE input (`runs_on`), no secrets and no matrix, so
-          a caller has no mechanism to append a step. CLOSED BY: an
-          `extra_check`/post-install input upstream, or splitting the CLI
-          smoke into its own job. NOTE, not a reason to keep this copy: the
-          org version has a FORK GUARD ahead of checkout that this file lacks
-          — that gap is real and is being ported separately rather than being
-          allowed to ride on this exemption.
+          this repo's CI runs it against a venv install.
+
+          UPDATED 2026-08-18 — THIS ENTRY IS NEARLY DEAD AND THE ORIGINAL
+          REASON NO LONGER HOLDS. It said the org reusable "declares exactly
+          ONE input (`runs_on`) … so a caller has no mechanism to append a
+          step". That was true when written and is now false: org #39 (MERGED
+          2026-08-18) added a `console_script` input which runs
+          `.venv/bin/<name> --version` as its own gated step — exactly the
+          assertion this local copy was kept for.
+
+          ONE BLOCKER REMAINS, found by diffing field-by-field rather than by
+          re-reading this entry: the local job PINS uv (`version: "0.11.29"`,
+          pinned deliberately after unpinned `latest` made CI a function of
+          wall-clock time and runner cache state — sac-ci-pin-uv-version-*).
+          The org reusable does not pin. Converting today would SILENTLY
+          UN-PIN uv: the diff is a deletion, the consolidation looks clean,
+          and the determinism leaves with it.
+
+          CLOSED BY: org #40 (`uv_version` input, OPEN as of 2026-08-18).
+          When it lands, convert this workflow to a caller passing
+          `console_script: sac` and `uv_version: "0.11.29"`, and DELETE THIS
+          ENTRY IN THE SAME PR.
+
+          NOTE, not a reason to keep this copy: the org version has a FORK
+          GUARD ahead of checkout that this file lacks — that gap is real and
+          is being ported separately rather than being allowed to ride on this
+          exemption.
       - path: .github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
         line: 0
         reason: >-
@@ -215,6 +293,22 @@ audit:
           converting would silently downgrade "a new Sphinx warning fails the
           PR" to "warnings ignored". CLOSED BY: an artifact/outputs contract
           upstream plus a strictness input.
+
+          NO IMPLEMENTATION EXISTS AS OF 2026-08-18, and this line is here so
+          the next reader does not infer otherwise. A branch named
+          `feat/rtd-sphinx-can-commit-the-built-html` exists in the org repo
+          and is EMPTY: 0 commits ahead of main, never pushed, touching no rtd
+          files. Its apparent diff is 177 deletions, which is main-lag from a
+          merge it predates rendering as change. The org reusable's inputs are
+          `runs_on`, `docs_dir`, `required` — no commit-back, no artifact
+          contract, no strictness.
+
+          I nearly recorded that branch as work-in-progress on the strength of
+          its NAME. A branch name is a statement of intent by whoever typed
+          it; it survives abandonment perfectly and is never revoked. So of
+          the five entries here this is the one furthest from removal, not the
+          one closest, and anyone sequencing this work should plan on starting
+          it from zero upstream.
       - path: .github/workflows/auto-merge-to-develop.yaml
         line: 0
         reason: >-

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -16,6 +16,8 @@ in its source tree. Two outcomes:
   (which installs every peer) catches cross-package renames.
 """
 
+import importlib
+
 import pytest
 
 # ===== AUTO-GENERATED: cross-package imports =====
@@ -46,10 +48,28 @@ CROSS_PACKAGE_IMPORTS = [
 
 @pytest.mark.parametrize("module_name", CROSS_PACKAGE_IMPORTS)
 def test_cross_package_import_resolves_to_real_module(module_name):
-    """Importing scitex-agent-container's declared cross-package dependency must succeed."""
+    """Importing scitex-agent-container's declared cross-package dependency must succeed.
+
+    PS-140 §2. Skip on the ROOT distribution, then HARD-IMPORT the full path.
+
+    ``pytest.importorskip("scitex_dev.hooks")`` skips when ANY part of the
+    dotted path is missing, so a peer that IS installed but has renamed or
+    removed a submodule reports SKIPPED -- which is exactly the case the
+    module docstring above promises will "FAIL loudly". The two-step form is
+    what makes that promise true: an absent peer still skips (a lean install
+    is legitimate), while a present peer that lost the submodule now fails.
+
+    This is not hypothetical. On 2026-08-17 ``scitex_dev.hooks`` gained a
+    required ``HookRule`` field; the consumer-side break was invisible on
+    every developer machine because this test, and the plugin test beside it,
+    both SKIPPED rather than failed. CI -- which installs the peer -- failed,
+    and develop went red for every PR with no local run able to reproduce it.
+    A skip is not a pass.
+    """
     # Arrange
-    name = module_name
+    root = module_name.split(".")[0]
+    pytest.importorskip(root)
     # Act
-    mod = pytest.importorskip(name)
+    mod = importlib.import_module(module_name)
     # Assert
     assert mod is not None

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -43,9 +43,42 @@ _HAS_PORT_DISCOVERY = bool(
     shutil.which("lsof") or shutil.which("ss") or shutil.which("fuser")
 )
 
-# A realistic resolved a2a port + a fake PID for the bridge tests
+def _free_a2a_port() -> int:
+    """An OS-assigned port that is free RIGHT NOW, for the tests that really bind.
+
+    `start_turn_bridge` calls `port_is_free()`, which performs a genuine
+    SO_REUSEADDR bind probe — so these tests need a port nothing holds, not a
+    representative-looking number.
+
+    This used to be the literal 19007, chosen (per the old comment) to be "a
+    realistic resolved a2a port". That realism WAS the defect: 19007 is inside
+    the live a2a range [19000, 19999] and is really held by the `figrecipe`
+    agent on the self-hosted `scitex-ci` runner, whose tmux session sits on the
+    same machine the job runs on. So the four `start_turn_bridge` tests passed
+    on GitHub-hosted runners and failed DETERMINISTICALLY on the self-hosted
+    one, with `TurnBridgePortBusyError` naming a real fleet agent:
+
+        Holder PID(s): unknown ...; tmux session: tui-figrecipe.
+        Free it, then restart: `fuser -k 19007/tcp; ...`
+
+    Which runner picks up a job is not something a PR controls, so the outcome
+    was decided by scheduling rather than by the change under test — a red that
+    tells you nothing and blocks a merge. It stalled PR #1117 twice, and #1117
+    is itself the fix for the audit gate blocking two other PRs.
+
+    Binding port 0 and reading back the assignment is the standard way to ask
+    the OS for something free. The socket is closed before the test runs, so a
+    later bind of the same port succeeds (SO_REUSEADDR over TIME_WAIT is
+    exactly the case `port_is_free` is documented to treat as free).
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+# A FREE a2a port + a fake PID for the bridge tests
 # (PEP 515 separators satisfy STX-NL001).
-_PORT = 19_007
+_PORT = _free_a2a_port()
 _PID = 4_242
 
 
@@ -288,7 +321,7 @@ def test_start_turn_bridge_passes_resolved_port_to_spawn(
     # Act
     bridge.start_turn_bridge(config, spawn=fake_spawn)
     # Assert
-    assert "19007" in recorded["argv"]
+    assert str(_PORT) in recorded["argv"]
 
 
 def test_start_turn_bridge_returns_spawned_pid(


### PR DESCRIPTION
**DRAFT — opened to obtain a CI verdict, not to merge.** Combining two
separately-reviewed PRs is not my call; see the question at the bottom.

## Why anything is red at all

Nothing has merged into `develop` since `2026-08-17T12:18:35Z`. PS-231 shipped in
scitex-dev v0.51.0 at `12:35Z` — **16 minutes later**. All 10 open PRs are
`BLOCKED`. As the operator put it: it is red because it is red. The gate is
working; the violations are real and nobody has fixed them yet.

## Why the two existing fixes cannot land alone

| PR | clears | still trips |
|---|---|---|
| #1109 exemptions | PS-231 | PS-140 |
| #1108 importorskip | PS-140 | PS-231 |

Each is blocked by the rule the other one clears. This branch is simply both,
merged onto `develop`, so the gate sees a tree where neither violation remains.

`#1109`'s residue, read from its CI log rather than inferred:
`PS-140, PS-226, §10w, §13, §4b` — PS-231 **absent**. Of that residue §10w is an
explicit NON-VERDICT (the runner's bare-interpreter baseline blew the sanity
bound), §4b and §13 are WARN, and PS-226 is already masked by the declared
accounts-refresh skip-rule. PS-140 was the only live ERROR, and #1108 is exactly
its fix.

## What this defers, stated plainly

The exemptions cover **all five** workflows, not two — `#1109`'s branch grew past
its own description (commit `873d8575`, "exempt the last three PS-231 workflows,
measured"). So merging this defers the entire consolidation the operator ordered
(「消せるものは消してください」), and he has previously pushed back on exemptions.

I am **not** presenting that as the end state. The intended sequence is:

1. this lands → the gate goes green → the other 8 PRs can move
2. each conversion lands and **removes its own exemption**:
   - `cla.yml` → #1115 (already written; needs #1116)
   - `import-smoke` → unblocked by org #39 (merged) + org #40 (open)
   - `auto-merge`, `pytest-matrix`, `rtd-sphinx` → still need upstream capability

An exemption with a written reason and a removal condition is a deferral. An
exemption nobody ever removes is the loophole the rule exists to prevent — so
each one should die with its conversion.

## What I am refusing to do

Merge anything with `--admin` to break the cycle. A gate bypassed once for a good
reason is bypassed again for a worse one — and this gate has, in the last hour,
caught a caller about to silently un-pin uv and another about to delete a
security argument protecting the fleet credential.

## The open question

PS-231 and the exemption ruling are both scitex-dev's. Is combining two
separately-reviewed PRs onto one verified-green branch the sanctioned route, or
should these land some other way? Asked directly; holding this as a draft until
answered.
