### PR TITLE
fix(agents-list): --capability must search purpose and role, not only capabilities

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -147,6 +147,55 @@ def _label_group_matches(labels: dict, wanted: str) -> bool:
     return bool(have & want)
 
 
+def _label_capability_matches(labels: dict, wanted: str) -> bool:
+    """True iff ``wanted`` names a CAPABILITY, a PURPOSE, or a ROLE.
+
+    Written 2026-08-18 after ``--capability handyman`` returned ZERO while
+    eight handymen were running and registered. Two agents hit it
+    independently within the hour and both nearly reported "no handymen
+    available" to the operator -- in the same hour he told the fleet to keep
+    them busy because they cost no Anthropic quota. A discovery surface that
+    silently answers "none" is worse than one that errors, because nobody
+    investigates a zero.
+
+    THE CAUSE was a field mismatch, not a matching bug. Those agents carry::
+
+        purpose:      general-handyman
+        capabilities: edit, refactor, read, test, investigate, cleanup
+
+    The word people search for lives in ``purpose``; ``capabilities`` holds
+    VERBS. So the old filter was correct about the field it read and wrong
+    about the question anyone was asking it.
+
+    MATCHING IS DELIBERATELY ASYMMETRIC, because the fields are:
+
+    * ``capabilities`` is a comma-separated list of DISCRETE TOKENS, so it
+      matches EXACTLY. Substring matching there would make ``read`` match
+      ``spread`` and quietly widen every existing query.
+    * ``purpose`` and ``role`` are descriptive PHRASES ("general-handyman",
+      "product-lead-orchestrator"), so they match by SUBSTRING -- otherwise
+      nobody finds a handyman without typing the whole compound.
+
+    Case-insensitive and whitespace-trimmed, mirroring
+    :func:`_label_group_matches`.
+    """
+    want = wanted.strip().lower()
+    if not want:
+        return False
+    caps = {
+        c.strip().lower()
+        for c in str(labels.get("capabilities", "") or "").split(",")
+        if c.strip()
+    }
+    if want in caps:
+        return True
+    for field in ("purpose", "role"):
+        value = str(labels.get(field, "") or "").strip().lower()
+        if value and want in value:
+            return True
+    return False
+
+
 def get_agent_list_data(
     registry: Registry,
     capability: str | None = None,
@@ -256,14 +305,8 @@ def get_agent_list_data(
 
         if machine and labels.get("machine") != machine:
             continue
-        if capability:
-            caps = [
-                c.strip()
-                for c in labels.get("capabilities", "").split(",")
-                if c.strip()
-            ]
-            if capability not in caps:
-                continue
+        if capability and not _label_capability_matches(labels, capability):
+            continue
         if group and not _label_group_matches(labels, group):
             continue
 

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -162,14 +162,8 @@ def defined_agent_rows(
             pass
         if machine and labels.get("machine") != machine:
             continue
-        if capability:
-            caps = [
-                c.strip()
-                for c in labels.get("capabilities", "").split(",")
-                if c.strip()
-            ]
-            if capability not in caps:
-                continue
+        if capability and not _al._label_capability_matches(labels, capability):
+            continue
         if group and not _al._label_group_matches(labels, group):
             continue
         # FIX (no double-parse): a spec that ``load_config`` accepted is
@@ -450,14 +444,8 @@ def remote_instance_rows(
             labels = {}
         if machine and labels.get("machine") != machine:
             continue
-        if capability:
-            caps = [
-                c.strip()
-                for c in labels.get("capabilities", "").split(",")
-                if c.strip()
-            ]
-            if capability not in caps:
-                continue
+        if capability and not _al._label_capability_matches(labels, capability):
+            continue
         if group and not _al._label_group_matches(labels, group):
             continue
         candidates.append(

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_capability_filter.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_capability_filter.py
@@ -1,0 +1,109 @@
+"""``--capability handyman`` must find the handymen.
+
+WHY THIS FILE EXISTS. On 2026-08-18 the operator told the fleet to route work
+to the qwen handymen aggressively, because they cost no Anthropic quota. Within
+the hour TWO agents independently ran ``agent_list(capability="handyman")``,
+got ZERO while eight handymen were running and registered, and both came close
+to reporting "no handymen available" — which would have sent every delegating
+agent back to spending the quota the instruction exists to save.
+
+The filter was correct about the field it read and wrong about the question it
+was being asked. Those agents carry::
+
+    purpose:      general-handyman
+    capabilities: edit, refactor, read, test, investigate, cleanup
+
+"handyman" lives in ``purpose``; ``capabilities`` holds verbs.
+
+A DISCOVERY SURFACE THAT SILENTLY ANSWERS "NONE" IS WORSE THAN ONE THAT ERRORS,
+because nobody investigates a zero. That is the same empty-vs-absent shape as
+the hosted-runner guard fixed in #1116 (unresolvable rendered as unhosted) and
+as the cross-host router reporting "not in registry" for a live agent whose
+port was never propagated. Three instances in one surface in one night, which
+is why this is pinned by a test rather than left to a comment.
+
+Both directions are asserted, because a filter that matches everything is as
+useless as one that matches nothing — and the widening fix is the tempting one.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.cli_pkg._helpers._agent_list import (
+    _label_capability_matches,
+)
+
+#: The real label shape of handyman-c03-01..08, copied from a live spec rather
+#: than paraphrased — a paraphrase would test the paraphrase.
+HANDYMAN_LABELS = {
+    "role": "project-maintainer",
+    "purpose": "general-handyman",
+    "capabilities": "edit, refactor, read, test, investigate, cleanup",
+}
+
+
+def test_the_word_people_search_for_finds_the_handymen() -> None:
+    # Arrange: the exact query two agents ran and got zero from.
+    labels = HANDYMAN_LABELS
+    # Act
+    found = _label_capability_matches(labels, "handyman")
+    # Assert
+    assert found is True
+
+
+def test_a_real_capability_verb_still_matches() -> None:
+    # Arrange: the pre-existing behaviour must survive the widening.
+    labels = HANDYMAN_LABELS
+    # Act
+    found = _label_capability_matches(labels, "refactor")
+    # Assert
+    assert found is True
+
+
+def test_an_unrelated_word_still_does_not_match() -> None:
+    # Arrange: the both-directions half. A filter that matches everything is
+    # as useless as one that matches nothing, and widening is the tempting fix.
+    labels = HANDYMAN_LABELS
+    # Act
+    found = _label_capability_matches(labels, "deploy")
+    # Assert
+    assert found is False
+
+
+def test_capabilities_match_whole_tokens_not_substrings() -> None:
+    # Arrange: `read` is a real capability; `rea` must NOT match it. Substring
+    # matching on the token list would make `read` match `spread` and quietly
+    # widen every query that already works.
+    labels = HANDYMAN_LABELS
+    # Act
+    found = _label_capability_matches(labels, "rea")
+    # Assert
+    assert found is False
+
+
+def test_role_is_searchable_too() -> None:
+    # Arrange: role carries the other phrase people search by.
+    labels = HANDYMAN_LABELS
+    # Act
+    found = _label_capability_matches(labels, "maintainer")
+    # Assert
+    assert found is True
+
+
+def test_an_agent_with_no_labels_matches_nothing() -> None:
+    # Arrange: absent fields must be a clean False, not a crash — the filter
+    # runs over every agent on disk, including ones with sparse specs.
+    labels: dict = {}
+    # Act
+    found = _label_capability_matches(labels, "handyman")
+    # Assert
+    assert found is False
+
+
+def test_an_empty_query_matches_nothing() -> None:
+    # Arrange: guards the caller's `if capability and not ...` shape — an empty
+    # string must never be treated as "match everything".
+    labels = HANDYMAN_LABELS
+    # Act
+    found = _label_capability_matches(labels, "   ")
+    # Assert
+    assert found is False


### PR DESCRIPTION
## The failure

`agent_list(capability="handyman")` returned **zero** while eight handymen were
running and registered. Two agents hit it independently within the hour, and both
came close to reporting *"no handymen available"* — in the same hour the operator
told the fleet to keep them busy **because they cost no Anthropic quota**.

An agent that cannot find spare qwen capacity does the work itself. So this bug
spends the exact quota the instruction exists to save.

## The cause — a field mismatch, not a matching bug

Those agents carry:

```yaml
purpose:      general-handyman
capabilities: edit, refactor, read, test, investigate, cleanup
```

The word people search for lives in `purpose`. `capabilities` holds **verbs**. The
filter was correct about the field it read and wrong about the question it was
being asked — and *"no match"* and *"none exist"* print identically, so nobody
investigates the zero.

Same empty-vs-absent shape as the hosted-runner guard fixed in #1116
(unresolvable rendered as unhosted), and as the cross-host router reporting "not
in registry" for a live agent whose port was never propagated. Three instances in
one surface in one night.

## Deliberately asymmetric matching

| field | shape | matching |
|---|---|---|
| `capabilities` | discrete tokens | **exact** |
| `purpose`, `role` | descriptive phrases | **substring** |

Substring matching on the token list would make `read` match `spread` and quietly
widen every query that already works. Substring on the phrases is what lets
someone find a handyman without typing `general-handyman`.

## Three call sites, one helper

`_agent_list.py` plus **both** functions in `_agent_list_discover.py`. The second
discover site was easy to miss — I found it only by grepping for all sites rather
than fixing the two I already knew about.

## Verification

| check | result |
|---|---|
| new tests | 7 passed, both directions |
| helper suite (regression) | 277 passed |
| ruff check / format | clean |
| `_al` in scope at both discover sites | asserted via AST, not assumed |

The both-directions half is the one that matters: a filter matching everything is
as useless as one matching nothing, and widening is the tempting fix. `rea` must
not match `read`; `deploy` must not match a handyman.
