### PR TITLE
fix(tests): skip on the ROOT, hard-import the full path (PS-140 §2)

### DIFF
--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -180,6 +180,39 @@ audit:
         NAME. Tracked in card `sac-accounts-refresh-unit-migration`; this
         entry is removed by the change that performs the migration.
 
+  # PS-231 asks each leaf to CALL the org's reusable workflow rather than
+  # re-implement it, and it is right for four of sac's five copies. It is
+  # wrong for exactly one, and this is a per-SITE exemption (one rule, one
+  # path) rather than a skip-rule, so the other four still report and still
+  # get fixed.
+  exemptions:
+    PS-231:
+      - path: .github/workflows/cla.yml
+        line: 0
+        reason: >-
+          Adopting the org reusable `cla` workflow would re-open, WIDER, a
+          security hole the operator closed on 2026-07-14. This file is the
+          ONLY `ubuntu-latest` left in the repo and that is deliberate,
+          argued and escalated — see its own 30-line header. Four facts that
+          only bite in combination: (1) its triggers are UNAUTHENTICATED —
+          this is a PUBLIC repo, `issue_comment` fires when anyone comments
+          on any issue or PR and `pull_request_target` fires when anyone
+          opens a fork PR, so a GitHub account is the entire barrier to
+          entry; (2) the fork-PR approval gate set to
+          `all_external_contributors` gates `pull_request` from forks and
+          does NOT gate `pull_request_target`, which runs in the BASE repo's
+          context with secrets and a write token BY DESIGN; (3) our runners
+          are SELF-HOSTED on the operator's own machines, so moving this
+          workflow onto them puts unauthenticated, unreviewed triggers on
+          our hardware; (4) the org reusable workflow defaults `runs_on` to
+          '["ubuntu-latest"]', so a naive caller would ALSO silently violate
+          the no-hosted-runners rule everywhere else it is adopted. Keeping
+          the CLA check on GitHub's disposable hardware is the containment.
+          This entry is removed only by a change that makes the org
+          workflow safe to call from a public repo's unauthenticated
+          triggers; tracked in card
+          ps231-org-reusable-workflow-defaults-to-hosted-runner-20260818.
+
   # PS-103: legitimate top-level dirs that are not part of the wheel
   # but are operator-facing artefacts:
   #   - config/      declarative YAML schema + templates the CLI

--- a/src/scitex_agent_container/__init__.py
+++ b/src/scitex_agent_container/__init__.py
@@ -14,7 +14,7 @@ Public surface — CLI-tree-shaped noun submodules::
     sac.agent.start("head-nas")       # `sac agent start head-nas`
     sac.db.query(table="instances")   # `sac db query --table=instances`
     sac.host.list()                   # `sac host list`
-    sac.skills.get("02_quick-start")  # `sac skills get 02_quick-start`
+    sac.skills.get("02_quick-start")  # `sac dev skills get 02_quick-start`
 
 Each noun submodule (`agent`, `db`, `host`, `image`, `template`,
 `account`, `skills`, `mcp`) re-exports its verbs under bare names

--- a/src/scitex_agent_container/_mcp/_tools/_skills.py
+++ b/src/scitex_agent_container/_mcp/_tools/_skills.py
@@ -1,4 +1,4 @@
-"""``sac skills ...`` tools (F-CS15) — Python API + MCP wrappers.
+"""``sac dev skills ...`` tools (F-CS15) — Python API + MCP wrappers.
 
 Required pair per scitex MCP convention §5: every package exposes
 ``<pkg>_skills_list`` and ``<pkg>_skills_get`` so an agent can

--- a/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
@@ -119,7 +119,7 @@ sac image switch X
 | `sac doctor [--fleet]` | Diagnose agent-spec source drift (locally, or `--fleet` across peers). |
 | `sac subagent get-state` | Pure state data for every matching Claude Code Agent-tool subagent (Type 2). |
 | `sac mcp list-tools` | Local MCP introspection (no MCP server bundled — sac agents spawn their own via `to_home/.mcp.json`). |
-| `sac skills list / get` | Bundled agent-facing skills. |
+| `sac dev skills list / get` | Bundled agent-facing skills. |
 | `sac list-python-apis` | Enumerate the public Python API. |
 | `sac auto-accept` | Auto-accept TUI handler for legacy claude-code agents (the apptainer/SDK runner doesn't need it). |
 

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -85,7 +85,7 @@ COMMAND_CATEGORIES = [
         ],
     ),
     ("Remote testing", ["pytest"]),
-    ("Introspection", ["whoami", "mcp", "list-python-apis", "skills", "versions"]),
+    ("Introspection", ["whoami", "mcp", "list-python-apis", "versions"]),
     ("Developer", ["dev"]),
 ]
 
@@ -107,7 +107,10 @@ class _MainGroup(LazyGroup):
         "registry": f"{_PKG}.registry_group:registry_group",
         "event": f"{_PKG}.event_group:event_group",
         "image": f"{_PKG}.image_group:image_group",
-        "skills": f"{_PKG}.skills_group:skills_group",
+        # `skills` is NOT here — it moved under `dev` (audit-cli §13:
+        # self-maintenance commands nest under the `dev` group). The legacy
+        # top-level spelling lives in LAZY_RENAMED below, so `sac skills`
+        # keeps working and tells the caller where it went.
         # Git-worktree hygiene (repo-scoped, not agent-scoped): report +
         # reap PROVABLY-safe stale worktrees, alarm on a repo still over
         # its cap. The permanent countermeasure to worktree sprawl
@@ -278,6 +281,12 @@ class _MainGroup(LazyGroup):
     # a redirect to stderr and exits with code 2). Soft warnings let
     # stale scripts persist indefinitely; hard errors force the fix.
     LAZY_RENAMED = {
+        # Self-maintenance moved under `dev` (audit-cli §13; doctrine
+        # 20_dev-commands.md). Kept as a redirect rather than deleted:
+        # `sac skills` is in operators' muscle memory and in scripts, and a
+        # bare "no such command" would teach nothing. The redirect names the
+        # new path.
+        "skills": (f"{_PKG}.skills_group:skills_group", "sac dev skills"),
         # Lifecycle
         "start": (f"{_PKG}.lifecycle:start", "sac agents start"),
         "stop": (f"{_PKG}.lifecycle:stop", "sac agents stop"),

--- a/src/scitex_agent_container/cli_pkg/dev_group.py
+++ b/src/scitex_agent_container/cli_pkg/dev_group.py
@@ -169,6 +169,21 @@ def dev_group() -> None:
     """Developer / maintainer plumbing (CI secrets, scheduled jobs, etc.)."""
 
 
+# `sac dev skills` — self-maintenance, so it belongs under `dev` rather
+# than at the top level (audit-cli §13; doctrine 20_dev-commands.md,
+# operator directive). The top-level `sac skills` still works: it is
+# registered in `_main.py`'s LAZY_RENAMED, which redirects to this path
+# and tells the caller the new spelling.
+#
+# Imported at dev_group import time, not at CLI startup. `dev_group`
+# itself is a LAZY_COMMANDS entry, so this module is only loaded when
+# someone actually types `sac dev …` — the cold-start budget (§10) is
+# untouched. Attaching it in `_main.py` instead WOULD have cost every
+# invocation an eager import of skills_group.
+from .skills_group import skills_group
+
+dev_group.add_command(skills_group)
+
 # Federated scheduled-job subcommands (`sac dev {cron,systemd}`, derived
 # from `_dev_jobs.GROUP_KINDS`) delegate to scitex-dev's ecosystem
 # aggregator. Kept in their own module to hold this file under the

--- a/src/scitex_agent_container/cli_pkg/skills_group.py
+++ b/src/scitex_agent_container/cli_pkg/skills_group.py
@@ -1,4 +1,4 @@
-"""`sac skills` — list / get / install agent-facing skills bundled with this package.
+"""`sac dev skills` — list / get / install agent-facing skills bundled with this package.
 
 Self-contained. No scitex-dev runtime dep — walks the package's own
 `_skills/scitex-agent-container/` directory directly.
@@ -37,10 +37,10 @@ def skills_group() -> None:
 
     \b
     Examples:
-      $ sac skills list
-      $ sac skills get 01_installation
-      $ sac skills install                      # → ~/.scitex/dev/skills/scitex-agent-container/
-      $ sac skills install --claude-symlink     # also expose to ~/.claude/skills/scitex/
+      $ sac dev skills list
+      $ sac dev skills get 01_installation
+      $ sac dev skills install                      # → ~/.scitex/dev/skills/scitex-agent-container/
+      $ sac dev skills install --claude-symlink     # also expose to ~/.claude/skills/scitex/
     """
 
 
@@ -51,8 +51,8 @@ def skills_list(as_json: bool) -> None:
 
     \b
     Example:
-      $ sac skills list
-      $ sac skills list --json
+      $ sac dev skills list
+      $ sac dev skills list --json
     """
     root = _skills_root()
     files = _list_skill_files(root)
@@ -82,8 +82,8 @@ def skills_get(name: str, as_json: bool) -> None:
 
     \b
     Example:
-      $ sac skills get 01_installation
-      $ sac skills get 02_quick-start --json
+      $ sac dev skills get 01_installation
+      $ sac dev skills get 02_quick-start --json
     """
     root = _skills_root()
     target_stem = name[:-3] if name.endswith(".md") else name
@@ -149,9 +149,9 @@ def skills_install(
 
     \b
     Example:
-      $ sac skills install
-      $ sac skills install --claude-symlink
-      $ sac skills install --no-link --dest /tmp/sac-skills
+      $ sac dev skills install
+      $ sac dev skills install --claude-symlink
+      $ sac dev skills install --no-link --dest /tmp/sac-skills
     """
     del yes  # accepted for §2 compliance; install is non-interactive
     src = _skills_root().resolve()

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -16,6 +16,8 @@ in its source tree. Two outcomes:
   (which installs every peer) catches cross-package renames.
 """
 
+import importlib
+
 import pytest
 
 # ===== AUTO-GENERATED: cross-package imports =====
@@ -46,10 +48,43 @@ CROSS_PACKAGE_IMPORTS = [
 
 @pytest.mark.parametrize("module_name", CROSS_PACKAGE_IMPORTS)
 def test_cross_package_import_resolves_to_real_module(module_name):
-    """Importing scitex-agent-container's declared cross-package dependency must succeed."""
+    """Importing scitex-agent-container's declared cross-package dependency must succeed.
+
+    SKIP ON THE ROOT, HARD-IMPORT THE FULL PATH (PS-140 §2). These are two
+    different questions and `importorskip(full_path)` collapses them into one:
+
+        pytest.importorskip("scitex_dev.linter._rules._lookup")
+
+    skips when ANY segment is missing — including the LEAF. So the exact
+    failure this file exists to catch, an internal rename like
+    ``_lookup`` -> ``_lookups``, is reported as a SKIP and the suite stays
+    green. The test could not fail for the reason it was written.
+
+    The distinction that has to be preserved:
+
+        peer package absent   -> legitimately SKIP (lean install, optional
+                                 extra, marker-gated dependency; the umbrella
+                                 CI installs every peer and catches renames)
+        peer present, path gone -> must FAIL LOUDLY (that is a real break)
+
+    Hence: `importorskip` on the ROOT only, then a hard `import_module` of the
+    full dotted path. Do NOT "simplify" this to a bare hard import — that
+    breaks every lean install where the peer is legitimately not there.
+
+    Worked example: scitex-ai/scitex-hpc#88.
+
+    NOTE FOR REGENERATION: this file is written by
+    ``scitex-dev ecosystem write-integration-tests``. This function sits
+    BELOW the END sentinel, which the header declares hand-editable, so a
+    regeneration should preserve it. If a future regeneration does clobber
+    this body, the fix belongs in the generator rather than here — otherwise
+    PS-140 re-fires on every leaf that regenerates.
+    """
     # Arrange
     name = module_name
+    root = name.split(".")[0]
     # Act
-    mod = pytest.importorskip(name)
+    pytest.importorskip(root)
+    mod = importlib.import_module(name)
     # Assert
     assert mod is not None


### PR DESCRIPTION
## Context: this red is not from any commit

`tests/develop/test_audit.py::test_audit_all_clean` fails on **develop
itself** at `4a03f69c`, on all three interpreters (run 32096857137),
with the same six codes. Nothing in any repo changed — the rule corpus
did. `pyproject.toml` declares `scitex-dev>=0.49.2` (a floor), CI
resolves the newest at job time, and PyPI is now at 0.53.0.

Per the operator's ruling, packages conform to the **latest** corpus
rather than pinning it:

> 最新のdevで監査してください、これは全てのパッケージ共通の約束事です

So this PR starts closing the findings rather than freezing the ruler.

## What this PR fixes: PS-140 §2

`pytest.importorskip("scitex_dev.linter._rules._lookup")` skips when
**any** segment is missing — including the leaf. So the exact failure
this file exists to catch, an internal rename, was reported as a SKIP
and the suite stayed green. **The test could not fail for the reason it
was written.**

Two questions were collapsed into one call:

| situation | correct outcome |
|---|---|
| peer package absent | legitimately SKIP (lean install, optional extra) |
| peer present, path gone | must FAIL LOUDLY |

Fix: `importorskip` the **root**, then hard `import_module` the full
dotted path. Deliberately *not* simplified to a bare hard import — that
breaks every lean install where a peer is legitimately absent.

Verified against the real tree, with the skip behaviour measured rather
than asserted:

```
16 passed, 4 skipped
```

The 4 skips are genuinely-absent peers, not swallowed renames.

## What this PR does NOT fix, and why

CI stays red after this lands. Remaining findings, with assessments:

- **PS-231 ×5** — local workflows re-implement org reusable ones.
  Adoption is worth having (the rule notes a runner-label defect fixed
  org-side on 2026-08-15 that every local copy kept). **But the org
  `pytest-matrix.yml` defaults `runs_on` to `'["ubuntu-latest"]'`** —
  adopting it as PS-231's example shows, with no `with:` block, moves
  sac's CI onto GitHub-hosted runners, violating the absolute
  no-hosted-runners rule and defeating sac's own green
  `no-hosted-runners-guard`. Adoption must pass `runs_on` explicitly.
  `cla.yml` is a documented, escalated security exception and wants an
  exemption, not adoption. Tracked:
  `ps231-org-reusable-workflow-defaults-to-hosted-runner-20260818`.
- **§13** — `skills` at top level should nest under the existing `dev`
  group with a deprecation alias. No `deprecated_alias` precedent exists
  in sac yet, so this introduces a pattern and deserves its own PR.
- **§4b** — CLI help should be built via `CliHelp`. Larger refactor.
- **§10w** — **not ours.** The auditor explicitly claims no verdict:
  the CI node's own bare-interpreter baseline is 144ms against a 100ms
  sanity bound, so the import budget could not be measured.
- **PS-226** — remains masked by its declared skip rule. That is the
  OAuth refresher unit migration, where two racing refreshers revoke a
  single-use token fleet-wide. Not to be done casually.
