### PR TITLE
fix(cli): nest `skills` under `dev`, keep the old spelling as a redirect (audit-cli §13)

### DIFF
--- a/src/scitex_agent_container/__init__.py
+++ b/src/scitex_agent_container/__init__.py
@@ -14,7 +14,7 @@ Public surface — CLI-tree-shaped noun submodules::
     sac.agent.start("head-nas")       # `sac agent start head-nas`
     sac.db.query(table="instances")   # `sac db query --table=instances`
     sac.host.list()                   # `sac host list`
-    sac.skills.get("02_quick-start")  # `sac skills get 02_quick-start`
+    sac.skills.get("02_quick-start")  # `sac dev skills get 02_quick-start`
 
 Each noun submodule (`agent`, `db`, `host`, `image`, `template`,
 `account`, `skills`, `mcp`) re-exports its verbs under bare names

--- a/src/scitex_agent_container/_mcp/_tools/_skills.py
+++ b/src/scitex_agent_container/_mcp/_tools/_skills.py
@@ -1,4 +1,4 @@
-"""``sac skills ...`` tools (F-CS15) — Python API + MCP wrappers.
+"""``sac dev skills ...`` tools (F-CS15) — Python API + MCP wrappers.
 
 Required pair per scitex MCP convention §5: every package exposes
 ``<pkg>_skills_list`` and ``<pkg>_skills_get`` so an agent can

--- a/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
@@ -119,7 +119,7 @@ sac image switch X
 | `sac doctor [--fleet]` | Diagnose agent-spec source drift (locally, or `--fleet` across peers). |
 | `sac subagent get-state` | Pure state data for every matching Claude Code Agent-tool subagent (Type 2). |
 | `sac mcp list-tools` | Local MCP introspection (no MCP server bundled — sac agents spawn their own via `to_home/.mcp.json`). |
-| `sac skills list / get` | Bundled agent-facing skills. |
+| `sac dev skills list / get` | Bundled agent-facing skills. |
 | `sac list-python-apis` | Enumerate the public Python API. |
 | `sac auto-accept` | Auto-accept TUI handler for legacy claude-code agents (the apptainer/SDK runner doesn't need it). |
 

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -85,7 +85,7 @@ COMMAND_CATEGORIES = [
         ],
     ),
     ("Remote testing", ["pytest"]),
-    ("Introspection", ["whoami", "mcp", "list-python-apis", "skills", "versions"]),
+    ("Introspection", ["whoami", "mcp", "list-python-apis", "versions"]),
     ("Developer", ["dev"]),
 ]
 
@@ -107,7 +107,10 @@ class _MainGroup(LazyGroup):
         "registry": f"{_PKG}.registry_group:registry_group",
         "event": f"{_PKG}.event_group:event_group",
         "image": f"{_PKG}.image_group:image_group",
-        "skills": f"{_PKG}.skills_group:skills_group",
+        # `skills` is NOT here — it moved under `dev` (audit-cli §13:
+        # self-maintenance commands nest under the `dev` group). The legacy
+        # top-level spelling lives in LAZY_RENAMED below, so `sac skills`
+        # keeps working and tells the caller where it went.
         # Git-worktree hygiene (repo-scoped, not agent-scoped): report +
         # reap PROVABLY-safe stale worktrees, alarm on a repo still over
         # its cap. The permanent countermeasure to worktree sprawl
@@ -278,6 +281,12 @@ class _MainGroup(LazyGroup):
     # a redirect to stderr and exits with code 2). Soft warnings let
     # stale scripts persist indefinitely; hard errors force the fix.
     LAZY_RENAMED = {
+        # Self-maintenance moved under `dev` (audit-cli §13; doctrine
+        # 20_dev-commands.md). Kept as a redirect rather than deleted:
+        # `sac skills` is in operators' muscle memory and in scripts, and a
+        # bare "no such command" would teach nothing. The redirect names the
+        # new path.
+        "skills": (f"{_PKG}.skills_group:skills_group", "sac dev skills"),
         # Lifecycle
         "start": (f"{_PKG}.lifecycle:start", "sac agents start"),
         "stop": (f"{_PKG}.lifecycle:stop", "sac agents stop"),

--- a/src/scitex_agent_container/cli_pkg/dev_group.py
+++ b/src/scitex_agent_container/cli_pkg/dev_group.py
@@ -169,6 +169,21 @@ def dev_group() -> None:
     """Developer / maintainer plumbing (CI secrets, scheduled jobs, etc.)."""
 
 
+# `sac dev skills` — self-maintenance, so it belongs under `dev` rather
+# than at the top level (audit-cli §13; doctrine 20_dev-commands.md,
+# operator directive). The top-level `sac skills` still works: it is
+# registered in `_main.py`'s LAZY_RENAMED, which redirects to this path
+# and tells the caller the new spelling.
+#
+# Imported at dev_group import time, not at CLI startup. `dev_group`
+# itself is a LAZY_COMMANDS entry, so this module is only loaded when
+# someone actually types `sac dev …` — the cold-start budget (§10) is
+# untouched. Attaching it in `_main.py` instead WOULD have cost every
+# invocation an eager import of skills_group.
+from .skills_group import skills_group
+
+dev_group.add_command(skills_group)
+
 # Federated scheduled-job subcommands (`sac dev {cron,systemd}`, derived
 # from `_dev_jobs.GROUP_KINDS`) delegate to scitex-dev's ecosystem
 # aggregator. Kept in their own module to hold this file under the

--- a/src/scitex_agent_container/cli_pkg/skills_group.py
+++ b/src/scitex_agent_container/cli_pkg/skills_group.py
@@ -1,4 +1,4 @@
-"""`sac skills` — list / get / install agent-facing skills bundled with this package.
+"""`sac dev skills` — list / get / install agent-facing skills bundled with this package.
 
 Self-contained. No scitex-dev runtime dep — walks the package's own
 `_skills/scitex-agent-container/` directory directly.
@@ -37,10 +37,10 @@ def skills_group() -> None:
 
     \b
     Examples:
-      $ sac skills list
-      $ sac skills get 01_installation
-      $ sac skills install                      # → ~/.scitex/dev/skills/scitex-agent-container/
-      $ sac skills install --claude-symlink     # also expose to ~/.claude/skills/scitex/
+      $ sac dev skills list
+      $ sac dev skills get 01_installation
+      $ sac dev skills install                      # → ~/.scitex/dev/skills/scitex-agent-container/
+      $ sac dev skills install --claude-symlink     # also expose to ~/.claude/skills/scitex/
     """
 
 
@@ -51,8 +51,8 @@ def skills_list(as_json: bool) -> None:
 
     \b
     Example:
-      $ sac skills list
-      $ sac skills list --json
+      $ sac dev skills list
+      $ sac dev skills list --json
     """
     root = _skills_root()
     files = _list_skill_files(root)
@@ -82,8 +82,8 @@ def skills_get(name: str, as_json: bool) -> None:
 
     \b
     Example:
-      $ sac skills get 01_installation
-      $ sac skills get 02_quick-start --json
+      $ sac dev skills get 01_installation
+      $ sac dev skills get 02_quick-start --json
     """
     root = _skills_root()
     target_stem = name[:-3] if name.endswith(".md") else name
@@ -149,9 +149,9 @@ def skills_install(
 
     \b
     Example:
-      $ sac skills install
-      $ sac skills install --claude-symlink
-      $ sac skills install --no-link --dest /tmp/sac-skills
+      $ sac dev skills install
+      $ sac dev skills install --claude-symlink
+      $ sac dev skills install --no-link --dest /tmp/sac-skills
     """
     del yes  # accepted for §2 compliance; install is non-interactive
     src = _skills_root().resolve()


### PR DESCRIPTION
## What

Moves `skills` under the existing `dev` group and keeps `sac skills`
working as a redirect. Closes audit-cli **§13** (self-maintenance
commands nest under `dev`; doctrine `20_dev-commands.md`).

## Uses sac's own idiom, not a new one

`LAZY_RENAMED` already redirects `start` / `stop` / `restart` /
`validate` / `check`. Importing scitex_dev's `deprecated_alias` would
have introduced a second mechanism for the same job and left the next
reader guessing which applies.

```
sac dev skills --help  -> renders
sac skills --help      -> "[RENAMED] Use `sac dev skills` instead."
```

## Attached in `dev_group.py`, not `_main.py`

`dev_group` is itself a `LAZY_COMMANDS` entry, so `skills_group` imports
only when someone types `sac dev …`. Attaching it in `_main.py` would
have cost **every** `sac` invocation an eager import — that is audit rule
**§10**, the cold-start budget, which this change must not spend.

## Docs updated in the same commit — the redirect exits 2

Searched for callers before shipping (an earlier positive control
returned nothing and invalidated its own search, so this was re-run with
a working one). No executable callers in dotfiles, but **eleven** doc
references inside sac, including the examples the command itself prints.
Left alone, this would have shipped documentation telling readers to run
a command that exits 2:

| file | what |
|---|---|
| `cli_pkg/skills_group.py` | module docstring + 10 examples |
| `_skills/…/04_cli-reference.md` | the command table |
| `__init__.py` | the Python-API docstring |
| `_mcp/_tools/_skills.py` | module docstring |

Generated sphinx HTML left alone — it regenerates.

## Verification

Ran the CLI and the suite rather than reading the diff:

```
3172 passed, 5 skipped, 16 deselected   (tests/…/cli_pkg)
```

including `test_skills_group.py`'s 41 tests.

## Scope

**Deliberately does not touch** `.scitex/dev/config.yaml` or
`tests/integration/test_cross_package_imports.py` — those are #1117's
(PS-140 + the PS-231 exemptions). This branch was split out of a earlier
one of mine that duplicated #1117; the duplicate is closed.
