### PR TITLE
fix(restart-login-expired): stop reprinting the no-session population that the count line already reports

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
@@ -51,6 +51,31 @@ def _print_report(report) -> None:
     console.print(f"    [dim]{report.detail}[/dim]", soft_wrap=True)
 
 
+def already_summarised_by_count(report) -> bool:
+    """True when this report's per-agent detail adds nothing to the count line.
+
+    A ``no-session`` UNOBSERVED is a DETERMINATE reading handed to
+    fleet-reconcile, and the pass already prints it once, by count:
+
+        "105 registered agent(s) have no live session — fleet-reconcile's half
+         of the fleet, not this pass's."
+
+    Printing each of those agents as well repeats one sentence ~105 times per
+    pass, every 5 minutes. Measured on compute-04 2026-08-18: 93,778 UNOBSERVED
+    lines in a 32 MB timer log (~105 per pass x ~893 passes ~= 74 hours), while
+    the summary above appeared once per pass and said everything the 105 did.
+
+    An INDETERMINATE UNOBSERVED is never suppressed. Those mean "nothing was
+    learned about this agent", they are why a pass cannot report a clean fleet,
+    and losing them would turn a loud gap into a silent one — the opposite of
+    the fix. The distinction is the point, not an optimisation.
+
+    ``.reason`` is only read once the verdict is UNOBSERVED (``and`` short
+    circuits), which is the same access the no_session tuple below already makes.
+    """
+    return report.verdict is Verdict.UNOBSERVED and report.reason == "no-session"
+
+
 @click.command(name="restart-login-expired")
 @click.option(
     "--apply",
@@ -172,7 +197,12 @@ def restart_login_expired(
         f"{len(outcome.reports) - len(unseen)} corroborated login-expired "
         f"agent(s), {len(unseen)} NOT observed\n"
     )
+    # See :func:`already_summarised_by_count` — the no-session population is printed
+    # once, by count, below; repeating it per-agent is what put 93,778 lines in a
+    # 32 MB timer log. Indeterminate UNOBSERVED reports still print individually.
     for report in outcome.reports:
+        if already_summarised_by_count(report):
+            continue
         _print_report(report)
 
     counts = outcome.counts()

--- a/tests/scitex_agent_container/cli_pkg/test__agents_restart_login_expired.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_restart_login_expired.py
@@ -14,6 +14,10 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
+from scitex_agent_container._reconcile._rule import Verdict
+from scitex_agent_container.cli_pkg._agents_restart_login_expired import (
+    already_summarised_by_count,
+)
 from scitex_agent_container.cli_pkg.agent_group import agent_group
 
 
@@ -70,3 +74,57 @@ def test_apply_and_check_error_explains_why():
     result = runner.invoke(agent_group, ["restart-login-expired", "--apply", "--check"])
     # Assert
     assert "contradictory" in result.output
+
+
+# ---------------------------------------------------------------------------
+# already_summarised_by_count — which reports the per-agent listing may skip.
+#
+# The suppression exists because a pass printed ~105 no-session agents EVERY
+# five minutes on top of the count line that already said the same thing:
+# 93,778 such lines in a 32 MB timer log, measured on compute-04 2026-08-18.
+#
+# The risk of a suppression is always that it hides the thing you needed, so
+# the INDETERMINATE case is pinned separately and deliberately: those reports
+# mean "nothing was learned", and silencing them would convert a loud gap into
+# a quiet one.
+
+
+class _FakeReport:
+    """Minimal stand-in carrying only the fields the predicate reads.
+
+    Not a mock: no behaviour is faked, no call is recorded. It is a value with
+    two attributes, which is exactly what the predicate consumes.
+    """
+
+    def __init__(self, verdict, reason: str) -> None:
+        self.verdict = verdict
+        self.reason = reason
+
+
+def test_no_session_unobserved_is_summarised_by_count():
+    # Arrange — the determinate population, already reported once as a total.
+    report = _FakeReport(Verdict.UNOBSERVED, "no-session")
+    # Act
+    skipped = already_summarised_by_count(report)
+    # Assert
+    assert skipped is True
+
+
+def test_indeterminate_unobserved_is_still_printed_per_agent():
+    # Arrange — "nothing was learned about this agent" must stay individually
+    # visible; it is why a pass cannot report a clean fleet.
+    report = _FakeReport(Verdict.UNOBSERVED, "pane-unreadable")
+    # Act
+    skipped = already_summarised_by_count(report)
+    # Assert
+    assert skipped is False
+
+
+def test_a_restarted_agent_is_never_suppressed():
+    # Arrange — a non-UNOBSERVED verdict must be unaffected even if some other
+    # code path ever gives it a no-session reason.
+    report = _FakeReport(Verdict.RESTARTED, "no-session")
+    # Act
+    skipped = already_summarised_by_count(report)
+    # Assert
+    assert skipped is False


### PR DESCRIPTION
## The problem

`sac agents restart-login-expired` prints every report individually — including each agent with **no live session** — and then prints the correct one-line summary of exactly those agents twenty lines below.

Measured on compute-04, 2026-08-18:

| | |
|---|---|
| timer log | **32 MB** (33,445,942 bytes) |
| `UNOBSERVED` lines | **93,778** (~105 per pass × ~893 passes ≈ 74 hours) |
| `UNOBSERVED=` | 105 |

while the same pass already printed, once and correctly:

> 105 registered agent(s) have no live session — fleet-reconcile's half of the fleet, not this pass's. A missing session is a determinate reading, so it does NOT prevent a clean report here.

So the summary this relies on **already exists**. What was missing was suppressing the per-agent repetition beneath it. The timer fires every 5 minutes, so the growth is unbounded.

## What is deliberately NOT suppressed

An **indeterminate** `UNOBSERVED` still prints per-agent. Those mean *"nothing was learned about this agent"*, they are why a pass cannot report a clean fleet, and hiding them would convert a loud gap into a silent one — the opposite of the fix.

A suppression's characteristic failure is hiding the thing you needed, so that case is pinned by its own test rather than left to the reader's goodwill.

## Shape

The decision is extracted into `already_summarised_by_count()`, so the loop reads as intent and the behaviour is testable without constructing a whole `PassOutcome`. `.reason` is only read once the verdict is `UNOBSERVED` (`and` short-circuits) — the same access the existing `no_session` tuple already makes.

## Tests — three, each failing without this change

| case | expected |
|---|---|
| no-session `UNOBSERVED` | suppressed |
| **indeterminate `UNOBSERVED`** | **still printed** (guards over-suppression) |
| `RESTARTED` + no-session reason | never suppressed (verdict checked, not just reason) |

Local: 9 passed in that file, and `tests/develop/test_audit.py` 2 passed on this branch after syncing with the merged develop.

## Context

Found while working card `sac-auth-restarter-is-local-only-and-reports-99-unobserved-every-5min-20260817`. That card's larger subject — the restarter being host-local and structurally unable to see agents on other hosts — is **not** addressed here and remains open. This PR only stops the log growth that made the honest per-agent refusal unreadable.
