### PR TITLE
fix(migrate): --include-held never reached the planner, so the held cutover was unreachable

### DIFF
--- a/src/scitex_agent_container/_jobs/_migrate/_plan.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_plan.py
@@ -151,6 +151,7 @@ def plan_one(
     present: Iterable[str] = (),
     dropin_dirs: Iterable[str] = (),
     install_argv: Callable[[Rename], tuple[str, ...]] = default_install_argv,
+    include_held: bool = False,
 ) -> tuple[Step, ...]:
     """Build the ordered plan for ONE job.
 
@@ -159,13 +160,18 @@ def plan_one(
     the caller and passed in, so this stays pure and the plan is a
     function of observed state rather than of hope.
 
-    A held job plans nothing — see ``Rename.hold``.
+    A held job plans nothing UNLESS ``include_held`` is passed — see
+    ``Rename.hold``. The default stays refuse-by-default so a bulk run can
+    never sweep one up; the override exists because the hold text itself
+    names the supervised command that is meant to clear it, and a flag the
+    caller can set but the planner ignores is a declaration with no
+    mechanism behind it.
 
     A job whose old units are absent still gets ``install``, ``logging``
     and ``verify``: the rename may have half-completed on this host, and
     saying so is what ``verify`` is for.
     """
-    if rename.held:
+    if rename.held and not include_held:
         return ()
 
     on_host = frozenset(present)
@@ -272,8 +278,14 @@ def plan(
     present: Iterable[str] = (),
     dropin_dirs: Iterable[str] = (),
     install_argv: Callable[[Rename], tuple[str, ...]] = default_install_argv,
+    include_held: bool = False,
 ) -> tuple[Step, ...]:
-    """The full ordered plan across every non-held job in ``renames``."""
+    """The full ordered plan across ``renames``.
+
+    Held jobs contribute nothing unless ``include_held`` is set; the caller
+    that sets it is expected to have narrowed ``renames`` to the one job it
+    means (the CLI enforces ``--include-held`` requires ``--only``).
+    """
     on_host = frozenset(present)
     dirs = frozenset(dropin_dirs)
     steps: list[Step] = []
@@ -284,6 +296,7 @@ def plan(
                 present=on_host,
                 dropin_dirs=dirs,
                 install_argv=install_argv,
+                include_held=include_held,
             )
         )
     out = tuple(steps)

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
@@ -245,6 +245,7 @@ def register_migrate_command(dev_group: click.Group) -> None:
             present=present,
             dropin_dirs=dropins,
             install_argv=_install_argv_factory(),
+            include_held=include_held,
         )
 
         chosen = _migrate.selection(env=dict(__import__("os").environ), home=Path.home())

--- a/tests/scitex_agent_container/_jobs/_migrate/test__plan.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__plan.py
@@ -316,3 +316,40 @@ def test_a_step_renders_its_argv_for_the_dry_run() -> None:
     rendered = step.render()
     # Assert
     assert "systemctl stop x" in rendered
+
+
+def test_a_held_job_plans_the_cutover_when_include_held_is_set() -> None:
+    # Arrange — the hold text itself names the supervised command meant to
+    # clear it, so the override has to actually reach the planner.
+    held = [r for r in _renames.RENAMES if r.held][0]
+    # Act
+    steps = _plan.plan_one(
+        held, present=frozenset(held.old_units()), include_held=True
+    )
+    # Assert
+    assert steps != ()
+
+
+def test_include_held_does_not_bypass_stop_before_install() -> None:
+    # Arrange — the override must not buy its way past the ordering this
+    # module exists to guarantee: installing the new unit before displacing
+    # the old one leaves BOTH supervising the same command.
+    held = [r for r in _renames.RENAMES if r.held][0]
+    steps = _plan.plan_one(
+        held, present=frozenset(held.old_units()), include_held=True
+    )
+    actions = _actions(steps)
+    # Act
+    stopped_before_installed = actions.index("stop") < actions.index("install")
+    # Assert
+    assert stopped_before_installed
+
+
+def test_the_full_plan_honours_include_held_for_the_named_job() -> None:
+    # Arrange — the CLI narrows `renames` to one job before setting the
+    # flag, so plan() must thread it through rather than drop it.
+    held = [r for r in _renames.RENAMES if r.held][0]
+    # Act
+    steps = _plan.plan((held,), present=frozenset(held.old_units()), include_held=True)
+    # Assert
+    assert held.new in {s.target for s in steps if s.action == "install"}


### PR DESCRIPTION
`sac dev migrate-job-names --only accounts-refresh --include-held` printed **"Nothing to migrate"** while `sac.accounts-refresh.timer` was installed, enabled and **active** on compute-04.

## The bug

The flag cleared the CLI's gate and then hit a second, unconditional one:

```python
renames = _select(tuple(only), include_held)   # ✅ correctly INCLUDES the held rename
steps = _migrate.plan(renames, present=..., ...)   # ❌ include_held is not a parameter
    → plan_one(...)                                # `if rename.held: return ()`
```

Selection honoured the flag; planning discarded it. `--include-held` was a declared capability with no mechanism behind it — exactly the "declaration with no live counterpart" disease `_jobs_audit` exists to detect.

**The rendering made it worse.** The HELD notice prints only for held jobs *not* in `renames`:

```python
held = [r for r in _migrate.RENAMES if r.held and r not in renames]
```

So naming the job with `--only` also suppressed the one line that would have explained the empty plan. You ask for exactly one job and are told nothing at all about it — no plan, no hold reason, no error.

## Why it matters beyond the flag

This is why the **PS-226 deferral never resolved.** The audit skip-rule defers to a supervised migration; `Rename.hold` names the exact command to run; that command was a no-op. An exception whose escape hatch doesn't work is a permanent exception — and the operator's ruling today was precisely that audit exclusions must not become permanent.

## The fix

`include_held` is threaded `plan` → `plan_one`. The default is unchanged and still refuse-by-default, so a bulk run can never sweep up a held job; the CLI already enforces that `--include-held` requires `--only`.

## Tests — 3 added, no mocks (PA-306), real `Rename` rows from the real table

- held-plans-nothing by default: **unchanged** (pre-existing test still passes)
- with the flag, a plan appears
- **the override does not buy past `stop`-before-`install`** — the ordering this module exists to guarantee holds for the held job too

## Verification against real host state

Not just unit tests — run against the actual units on compute-04:

```
Plan (10 steps):
  stop           systemctl --user stop sac.accounts-refresh.service
  stop           systemctl --user stop sac.accounts-refresh.timer
  disable        systemctl --user disable sac.accounts-refresh.service
  disable        systemctl --user disable sac.accounts-refresh.timer
  displace       sac.accounts-refresh.service
  displace       sac.accounts-refresh.timer
  daemon-reload  systemctl --user daemon-reload
  install        scitex-dev ecosystem dev timer install --name scitex-agent-container-accounts-refresh --yes
  logging        scitex-agent-container-accounts-refresh.service.d/10-logging.conf
  verify         scitex-agent-container-accounts-refresh
```

`install` comes **after** `displace`, so the two refreshers can never coexist — which is the whole reason the job was held. 119 migrate tests pass.

The cutover itself is **not** performed by this PR; it remains operator-supervised per `Rename.hold`.
