### PR TITLE
fix(session): resume by default — the role allowlist silently made 91 specs forget

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
+++ b/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
@@ -16,6 +16,7 @@ from typing import Any, Callable
 __all__ = [
     "_format_boot_stderr_section",
     "capture_pane_diag",
+    "fresh_retry_hint",
     "raise_start_failure",
 ]
 
@@ -54,6 +55,48 @@ def _format_boot_stderr_section(log: Path) -> str:
 
 
 _NO_PANE = "\n  (no pane diagnostics available)"
+
+
+def fresh_retry_hint(config: Any) -> str:
+    """The one-shot ``--fresh`` escape hatch, as a message section.
+
+    Operator 2026-08-18: 「フレッシュは基本的に使いません、最初の起動に必要な
+    時だけで、スタートした時に失敗したら --fresh を今回だけはつけろ的なヒント
+    をだしてください、スペックは全てレジュームで」 — every spec resumes; a
+    start failure is the one moment where a single fresh retry is the right
+    move, so the failure report is where that hint belongs.
+
+    WHY IT IS CONDITIONAL. A start that was ALREADY fresh cannot be wedged on a
+    resumed session, so naming ``--fresh`` there would be an error asserting a
+    cause it did not observe — the same disease :func:`raise_start_failure`
+    exists to kill. Emitted only when the resolved ``claude.session`` is
+    something other than ``fresh``.
+
+    WHY IT SAYS "ONCE". ``--fresh`` is a per-invocation override, not a spec
+    edit, and the difference matters: the spec must stay on resume, because a
+    fresh start DISCARDS that agent's working memory. Naming the boundary in
+    the hint is the whole point — an unqualified "try --fresh" is how a
+    one-shot recovery becomes a habit that quietly erases the fleet's memory.
+
+    Never raises: ``config`` is whatever the caller had when the start blew up,
+    and a diagnostic must not fail on a stub. An unreadable mode is treated as
+    "not fresh" — the hint is advice, and printing it needlessly costs a line
+    while withholding it costs the operator the recovery.
+    """
+    try:
+        mode = str(getattr(getattr(config, "claude", None), "session", "") or "")
+    except Exception:  # stx-allow: fallback (reason: a diagnostic must never raise over the failure it is describing)
+        mode = ""
+    if mode.strip().lower() == "fresh":
+        return ""
+    name = getattr(config, "name", "<name>")
+    return (
+        "\n  if this start was RESUMING a prior session: a session wedged on a "
+        f"queued\n  boot prompt comes back on every plain restart. Retry ONCE "
+        f"with\n    sac agents start {name} --fresh\n  ONCE — as a per-start "
+        "override, not a spec edit. The spec stays on resume;\n  a fresh start "
+        "discards this agent's working memory."
+    )
 
 
 def raise_start_failure(
@@ -102,10 +145,14 @@ def raise_start_failure(
     # a message blaming the PANE CAPTURE for a failure it never observed (it was
     # a missing directory). That is the same disease the liveness verdict next
     # door exists to kill — an error asserting a cause it did not see.
-    _persist_diag(config, diag)
+    # The recovery hint rides on the SAME suffix as the diagnostics so the
+    # persisted record and the raised error carry it identically — a remedy
+    # only the live terminal saw is lost to whoever reads the log tomorrow.
+    suffix = f"{diag}{fresh_retry_hint(config)}"
+    _persist_diag(config, suffix)
 
     raise RuntimeError(
-        f"Failed to start agent '{config.name}': runtime.start() returned False.{diag}"
+        f"Failed to start agent '{config.name}': runtime.start() returned False.{suffix}"
     )
 
 

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -277,19 +277,28 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     # back-compat consumers and populated from the new homes.
     claude_spec = parse_claude(spec)
     apptainer_spec = parse_apptainer(spec)
-    # Role-based session-continuity default ("fresh by default, opt-in
-    # continue", 2026-06-22). ``claude.session`` now defaults to ``fresh``
-    # (parse_claude) so experiment capsules — which carry no coordinator
-    # role — start hermetic. But LONG-LIVED coordinator agents
-    # (lead/head/worker/telegrammer/project-maintainer/…) must keep their
-    # conversation across restarts. Those specs are hand-deployed OUTSIDE
-    # this repo and none of them set ``claude.session``, so we map an
-    # OMITTED field back to ``continue`` BY ROLE here — the one place that
-    # sees both the ``metadata.labels.role`` and the env-injected fleet
-    # role. An EXPLICIT ``session:`` (top-level or nested) is authored
-    # intent and is left untouched (so ``session: fresh`` on a coordinator
-    # stays fresh); a later CLI ``--continue`` / ``--fresh`` still wins by
-    # mutating ``config.claude.session`` after load.
+    # Session-continuity default for an OMITTED ``session:`` — ``continue``,
+    # unconditionally (operator 2026-08-18: 「スペックは全てレジュームで」).
+    #
+    # THIS USED TO BE ROLE-BASED and defaulted to ``fresh``; the polarity was
+    # inverted deliberately, so do not read the role lookup below as a gate.
+    # The old rule was an ALLOWLIST — a role had to be enumerated to keep its
+    # memory — and scitex-hub's ``product-lead-orchestrator`` matched neither
+    # the set nor any prefix, so it silently resolved to ``fresh`` and lost a
+    # day of working memory on restart. 91 of 117 live specs omit the field,
+    # so a default nobody chose was deciding the fleet's memory.
+    #
+    # ``_role`` is still resolved and still passed, because this is the one
+    # place that sees both ``metadata.labels.role`` and the env-injected fleet
+    # role, and ``default_session_for_role`` keeps the parameter for callers
+    # that ask the role question directly — but it no longer DECIDES.
+    #
+    # An EXPLICIT ``session:`` (top-level or nested) is authored intent and is
+    # left untouched (so ``session: fresh`` on a coordinator stays fresh); a
+    # later CLI ``--continue`` / ``--fresh`` still wins by mutating
+    # ``config.claude.session`` after load — that per-start override is the
+    # sanctioned escape hatch, and a failed start now says so (see
+    # ``_lifecycle/_start_failure_diag.fresh_retry_hint``).
     _session_authored = (
         spec.get("session") is not None
         or (spec.get("claude") or {}).get("session") is not None

--- a/src/scitex_agent_container/config/_session_continuity.py
+++ b/src/scitex_agent_container/config/_session_continuity.py
@@ -1,4 +1,4 @@
-"""Session-continuity resolution — ``fresh`` by default, opt-in ``continue``.
+"""Session-continuity resolution — ``continue`` by default, opt-in ``fresh``.
 
 Single source of truth for two related decisions:
 
@@ -113,13 +113,33 @@ def role_wants_continuity(role: str | None) -> bool:
 
 
 def default_session_for_role(role: str | None) -> str:
-    """Session mode for a spec that OMITTED ``claude.session``, given role.
+    """Session mode for a spec that OMITTED ``claude.session``: ``continue``.
 
-    Coordinator/long-lived role → ``"continue"``; everything else (incl. no
-    role) → ``"fresh"``. This is the role-based half of the precedence chain
-    ``CLI > explicit spec > role-default > global default (fresh)``.
+    CONTINUE FOR EVERY ROLE, INCLUDING NONE. Operator ruling 2026-08-18:
+    「フレッシュは基本的に使いません、最初の起動に必要な時だけで ... スペックは
+    全てレジュームで」 — fresh is essentially never used; only where a FIRST
+    boot needs it; every spec resumes.
+
+    This inverts the previous polarity and that is the whole point. The old
+    rule was an ALLOWLIST: a role had to appear in ``_CONTINUITY_ROLES`` or
+    match a prefix to keep its memory, and anything unenumerated silently got
+    ``fresh``. Measured 2026-08-18, that is not hypothetical — scitex-hub's
+    role is ``product-lead-orchestrator``, which matches neither the exact set
+    nor any prefix (it begins ``product-``, not ``lead-``), so it resolved to
+    ``fresh`` and lost a day of working memory on restart. 91 of 117 live
+    specs omit ``claude.session`` entirely, so the default decided the
+    fleet's memory and nobody had chosen it.
+
+    A capsule that genuinely wants a hermetic session is UNAFFECTED in
+    practice: with no prior session on disk there is nothing to continue, so
+    the first boot is fresh either way. What changes is the SECOND boot, and
+    that is exactly the case the operator is protecting.
+
+    ``role`` is retained in the signature (callers pass it) and
+    :func:`role_wants_continuity` is kept for callers that still ask the
+    role question directly, but the role no longer GATES the default.
     """
-    return SESSION_CONTINUE if role_wants_continuity(role) else SESSION_FRESH
+    return SESSION_CONTINUE
 
 
 def wants_continue(session: str | None) -> bool:

--- a/tests/scitex_agent_container/_lifecycle/test__start_failure_fresh_hint.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_failure_fresh_hint.py
@@ -1,0 +1,201 @@
+"""A failed start must name the ONE-SHOT ``--fresh`` escape hatch — and only there.
+
+WHY THIS FILE EXISTS (operator, 2026-08-18). 「フレッシュは基本的に使いません、
+最初の起動に必要な時だけで、スタートした時に失敗したら --fresh を今回だけは
+つけろ的なヒントをだしてください、スペックは全てレジュームで」 — every spec
+resumes; a start failure is the one moment where a single fresh retry is the
+right move. The failure report is where the operator is actually standing when
+that moment arrives, so that is where the hint has to be.
+
+THE TWO WAYS THIS GOES WRONG, and both are covered below:
+
+  * MISSING — the report says the start failed and nothing about recovering.
+    The operator's own instruction, unimplemented.
+  * OVER-EAGER — the report names ``--fresh`` on a start that was ALREADY
+    fresh. A fresh start cannot be wedged on a resumed session, so that is an
+    error asserting a cause it never observed — the exact disease the sibling
+    file next door documents. The negative test is paired with a positive
+    control on the same message, so a blank or truncated report cannot pass it
+    by accident.
+
+  * And a third, quieter one: the hint reaching only the terminal. A
+    false-negative start leaves no registry row, so whoever reads
+    ``start_failure_diag.log`` tomorrow is often the only reader there is.
+
+NO MOCKS (repo doctrine): the configs below are real objects driven through the
+production entry point, and the exploding-config case is a real object whose
+attribute access genuinely raises.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._lifecycle._start_failure_diag import (
+    fresh_retry_hint,
+    raise_start_failure,
+)
+
+
+class _Claude:
+    """The resolved ``spec.claude`` slice the hint reads."""
+
+    def __init__(self, session: str) -> None:
+        self.session = session
+
+
+class _Cfg:
+    """A real minimal config carrying a resolved session mode."""
+
+    def __init__(self, name: str, session: str, runtime: str = "apptainer") -> None:
+        self.name = name
+        self.runtime = runtime
+        self.claude = _Claude(session)
+
+
+class _ExplodingCfg:
+    """A config whose ``claude`` access genuinely raises.
+
+    Not a hypothetical: ``raise_start_failure`` runs on whatever the caller was
+    holding when the start blew up, and a diagnostic that raises over the
+    failure it is describing destroys the report.
+    """
+
+    name = "exploding"
+
+    @property
+    def claude(self) -> Any:
+        raise RuntimeError("resolved config was never populated")
+
+
+def _unique(session: str) -> _Cfg:
+    """An agent NOBODY else has started — its state dir cannot pre-exist.
+
+    Same reason as the sibling file: sharing a name silently borrows another
+    test's directory and makes these assertions depend on the schedule.
+    """
+    return _Cfg(name=f"freshhint-{uuid.uuid4().hex[:12]}", session=session)
+
+
+def _diag_log(config: _Cfg) -> Path:
+    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
+
+    return state_dir_for_config(config) / "start_failure_diag.log"
+
+
+def _message(config: Any) -> str:
+    """Drive the real failure path and return the operator-visible message."""
+    with pytest.raises(RuntimeError) as excinfo:
+        raise_start_failure(config)
+    return str(excinfo.value)
+
+
+def test_a_resuming_start_is_told_to_retry_with_fresh():
+    """THE OPERATOR'S ASK. A resuming start that failed must name the escape hatch."""
+    # Arrange
+    config = _unique("continue")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "--fresh" in message
+
+
+def test_the_hint_names_the_agent_so_the_command_is_runnable():
+    """A hint the operator has to assemble by hand is a hint they will mistype."""
+    # Arrange
+    config = _unique("continue")
+    # Act
+    message = _message(config)
+    # Assert
+    assert f"sac agents start {config.name} --fresh" in message
+
+
+def test_the_hint_bounds_itself_to_one_retry():
+    """``--fresh`` is a per-start override; making it the habit erases memory.
+
+    The whole point of the operator's wording is the boundary — 「今回だけは」.
+    An unqualified "try --fresh" is how a one-shot recovery becomes a spec edit.
+    """
+    # Arrange
+    config = _unique("continue")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "ONCE" in message
+
+
+def test_the_hint_says_the_spec_stays_on_resume():
+    """State the invariant positively, so the reader knows what NOT to change."""
+    # Arrange
+    config = _unique("continue")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "spec stays on resume" in message
+
+
+def test_an_already_fresh_start_still_reports_the_real_cause():
+    """POSITIVE CONTROL for the negative test below.
+
+    Without this, an empty or truncated message would satisfy "does not mention
+    --fresh" while proving nothing at all.
+    """
+    # Arrange
+    config = _unique("fresh")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "runtime.start() returned False" in message
+
+
+def test_an_already_fresh_start_is_not_told_to_retry_with_fresh():
+    """A fresh start cannot be wedged on a resumed session.
+
+    Naming ``--fresh`` here would be the report asserting a cause it never
+    observed. Paired with the positive control directly above.
+    """
+    # Arrange
+    config = _unique("fresh")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "--fresh" not in message
+
+
+def test_the_hint_reaches_the_persisted_record_too():
+    """A remedy only the live terminal saw is lost to tomorrow's reader.
+
+    The start that failed left no registry row; this log is often all there is.
+    """
+    # Arrange
+    config = _unique("continue")
+    log = _diag_log(config)
+    # Act
+    _message(config)
+    # Assert
+    assert "--fresh" in log.read_text()
+
+
+def test_the_hint_never_raises_over_the_failure_it_describes():
+    """A diagnostic that explodes destroys the report it exists to produce."""
+    # Arrange
+    config = _ExplodingCfg()
+    # Act
+    hint = fresh_retry_hint(config)
+    # Assert
+    assert isinstance(hint, str)
+
+
+def test_an_unreadable_session_mode_still_offers_the_recovery():
+    """Fail toward HELPING. Printing the hint needlessly costs a line;
+    withholding it costs the operator the recovery."""
+    # Arrange
+    config = _ExplodingCfg()
+    # Act
+    hint = fresh_retry_hint(config)
+    # Assert
+    assert "--fresh" in hint

--- a/tests/scitex_agent_container/config/test__explicit_validation.py
+++ b/tests/scitex_agent_container/config/test__explicit_validation.py
@@ -322,13 +322,18 @@ def test_paste_ready_hint_round_trips_to_green(
 def test_paste_ready_hint_preserves_omission_behaviour(
     tmp_path: Path, _round_trip_healed: dict
 ) -> None:
-    # Arrange — pasted claude.session must reproduce what omission meant:
-    # role-less agent -> 'fresh' (null keeps the role-derived default).
+    # Arrange — THE INVARIANT IS UNCHANGED: a pasted explicit
+    # `session: null` must resolve to whatever OMISSION resolves to, so a
+    # round-tripped spec never silently changes an agent's memory. Only the
+    # value moved: omission now means 'continue' for every role (operator,
+    # 2026-08-18, 「スペックは全てレジュームで」). Asserted as a literal rather
+    # than by calling default_session_for_role() — a test parameterised by
+    # the implementation it checks cannot fail.
     healed_path = _write_doc(tmp_path, _round_trip_healed, "healed-session")
     # Act
     cfg = load_config(healed_path)
     # Assert
-    assert cfg.claude.session == "fresh"
+    assert cfg.claude.session == "continue"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/config/test__session_continuity.py
+++ b/tests/scitex_agent_container/config/test__session_continuity.py
@@ -114,13 +114,16 @@ def test_default_session_for_coordinator_role_is_continue():
     assert result == "continue"
 
 
-def test_default_session_for_absent_role_is_fresh():
-    # Arrange
+def test_default_session_for_absent_role_is_continue():
+    # Arrange — operator ruling 2026-08-18: 「スペックは全てレジュームで」, so a
+    # spec that omits claude.session continues REGARDLESS of role. The old
+    # allowlist silently gave `fresh` to any role nobody had enumerated, which
+    # is how scitex-hub (role `product-lead-orchestrator`) lost a day.
     candidate = None
     # Act
     result = default_session_for_role(candidate)
     # Assert
-    assert result == "fresh"
+    assert result == "continue"
 
 
 # ---------------------------------------------------------------------------
@@ -273,13 +276,26 @@ def test_loader_coordinator_role_defaults_omitted_session_to_continue(tmp_path):
     assert cfg.claude.session == "continue"
 
 
-def test_loader_absent_role_keeps_omitted_session_fresh(tmp_path):
-    # Arrange
+def test_loader_absent_role_gets_continue_not_fresh(tmp_path):
+    # Arrange — a roleless spec is the case that used to fall through to
+    # `fresh`. 91 of 117 live specs omit claude.session, so this default
+    # decided the fleet's memory and nobody had chosen it.
     spec = _write_spec(tmp_path, _OMIT_SESSION_NO_ROLE)
     # Act
     cfg = load_config(str(spec))
     # Assert
-    assert cfg.claude.session == "fresh"
+    assert cfg.claude.session == "continue"
+
+
+def test_an_unenumerated_coordinator_role_still_continues(tmp_path):
+    # Arrange — the regression that motivated the change: `product-lead-
+    # orchestrator` matches neither _CONTINUITY_ROLES nor any prefix (it
+    # begins `product-`, not `lead-`), so under the allowlist it resolved to
+    # `fresh`. Pinned by ROLE STRING, not by the set, so re-adding an
+    # allowlist cannot make this pass again.
+    result = default_session_for_role("product-lead-orchestrator")
+    # Act / Assert
+    assert result == "continue"
 
 
 def test_loader_explicit_fresh_on_coordinator_is_not_overridden(tmp_path):

--- a/tests/scitex_agent_container/config/test__session_continuity.py
+++ b/tests/scitex_agent_container/config/test__session_continuity.py
@@ -293,8 +293,10 @@ def test_an_unenumerated_coordinator_role_still_continues(tmp_path):
     # begins `product-`, not `lead-`), so under the allowlist it resolved to
     # `fresh`. Pinned by ROLE STRING, not by the set, so re-adding an
     # allowlist cannot make this pass again.
-    result = default_session_for_role("product-lead-orchestrator")
-    # Act / Assert
+    role = "product-lead-orchestrator"
+    # Act
+    result = default_session_for_role(role)
+    # Assert
     assert result == "continue"
 
 


### PR DESCRIPTION
## What

Two halves of one operator instruction (2026-08-18):

> 「フレッシュは基本的に使いません、最初の起動に必要な時だけで、スタートした時に失敗したら --fresh を今回だけはつけろ的なヒントをだしてください、スペックは全てレジュームで」

**1. Resume by default.** `default_session_for_role` returned `fresh` for any role not on an allowlist. Measured on 2026-08-18: scitex-hub's role is `product-lead-orchestrator`, which matches neither the exact set nor any prefix (it begins `product-`, not `lead-`), so it resolved to `fresh` and lost a day of working memory on restart. **91 of 117 live specs omit `claude.session` entirely**, so a default nobody chose was deciding the fleet's memory.

The allowlist is gone. An omitted `claude.session` resolves to `continue`, unconditionally. `role` stays in the signature and `role_wants_continuity` stays for callers that ask the role question directly — but the role no longer *gates* the default.

A capsule that genuinely wants a hermetic session is unaffected in practice: with no prior session on disk there is nothing to continue, so the first boot is fresh either way. What changes is the **second** boot — exactly the case the operator is protecting.

**2. The one-shot `--fresh` escape hatch.** `raise_start_failure` now names it, because that report is what the operator is actually reading when the moment arrives. It rides on the same suffix as the diagnostics, so `start_failure_diag.log` carries it too — a false-negative start leaves no registry row, so that log is often the only reader there is.

It is **conditional**: emitted only when the resolved `claude.session` is not already `fresh`. An already-fresh start cannot be wedged on a resumed session, so naming `--fresh` there would be the report asserting a cause it never observed — the disease `raise_start_failure` exists to kill. The negative test is paired with a positive control on the same message, so a blank or truncated report cannot pass it by accident.

It says **ONCE**, and says the spec stays on resume. That boundary is the operator's own wording and it is load-bearing: an unqualified "try --fresh" is how a one-shot recovery becomes a habit that quietly erases the fleet's memory.

## Tests

- `test_an_unenumerated_coordinator_role_still_continues` pins the regression **by role string**, not by the set, so re-adding an allowlist cannot make it pass again.
- `test__start_failure_fresh_hint.py` — 9 tests covering both failure modes (missing / over-eager), the persisted-record path, and a config whose attribute access genuinely raises.
- No mocks: every config is a real object driven through the production entry point.

## Also

Corrects the `_loaders` comment that still asserted "`claude.session` now defaults to `fresh`" and described the role allowlist as a gate. The polarity was inverted in this same branch; a comment stating the opposite of the code beside it is how a correction fails to reach its copies.

## Not in this PR

`develop` is red on **PS-226** (`JobSpec(name='sac.accounts-refresh')`), which this branch does not touch — `_jobs/` is untouched here. It is fixed separately in `fix/ps226-accounts-refresh-job-name`, which has to land first for this one to go green.