### PR TITLE
fix(jobs): rename the accounts-refresh JobSpec (PS-226) and drop the exemption

### DIFF
--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -322,66 +322,6 @@ audit:
           PS-231's rationale assumes. CLOSED BY: the org reusable adopting the
           fix, after which this leaf should convert and this entry be removed.
 
-  # PS-226 (job-name-not-hyphenated), introduced by scitex-dev 0.48.0.
-  #
-  # THIS IS A DEFERRAL, NOT A WAIVER, AND THE FINDING IS CORRECT.
-  # `JobSpec(name="sac.accounts-refresh")` is genuinely not hyphen-
-  # separated, and the rule exists for a real reason:
-  # `jobs/_systemd.py::systemd_unit_name` derives the unit FILENAME from
-  # the job name verbatim, with no sanitisation.
-  #
-  # What is deferred is the REMEDY, because the obvious one is more
-  # dangerous than the defect. Renaming does not re-label the running
-  # unit; it makes sac install a SECOND unit beside the live hand-written
-  # one. That unit is the fleet's SOLE OAuth refresher, and it refreshes a
-  # SINGLE-USE token — two refreshers racing revoke each other, taking
-  # every agent's authentication down with them. So the rename is a
-  # supervised systemd unit migration (stop-old -> remove-old ->
-  # install-new -> verify-exactly-one), never a drive-by edit, and
-  # never at an hour when nobody is watching.
-  #
-  # The supervised path already exists: `_jobs/_migrate/_renames.py`.
-  # This entry comes off in the same change that runs the migration.
-  #
-  # *** READ THIS BEFORE DELETING ANY UNIT. ***
-  # "verify-exactly-one" means EXACTLY ONE UNIT FOR THIS ONE JOB — old
-  # gone, new present. It does NOT mean "one accounts job on the host".
-  # There are TWO accounts jobs and BOTH MUST EXIST:
-  #
-  #   sac.accounts-refresh                        rotates the credential,
-  #                                               every 2h, on the host
-  #                                               holding refresh material
-  #   scitex-agent-container-accounts-keepalive   distributes the
-  #                                               ACCESS-ONLY copy,
-  #                                               every 15min
-  #
-  # They are DIFFERENT JOBS doing different work, not a rename pair and
-  # not duplicates of each other. Anyone who reads this rule as "collapse
-  # the accounts jobs to one" would remove a job the fleet depends on —
-  # which is a larger outage than the naming defect being deferred here.
-  # The only thing PS-226 asks for is the SHAPE OF ONE JobSpec NAME.
-  skip-rules:
-    - rule: PS-226
-      reason: >-
-        Correct finding, deferred to the supervised job-name migration —
-        not waived. `systemd_unit_name` uses `JobSpec.name` verbatim, so
-        renaming `sac.accounts-refresh` installs a SECOND unit beside the
-        live one instead of adopting it. That job is the fleet's sole
-        OAuth refresher against a SINGLE-USE refresh token, where two
-        racing refreshers revoke each other and take fleet-wide
-        authentication down. The migration must be ordered stop-old ->
-        remove-old -> install-new -> verify-exactly-one and run
-        supervised; the path exists in `_jobs/_migrate/_renames.py`.
-        "verify-exactly-one" means exactly one unit FOR THIS ONE JOB, NOT
-        one accounts job on the host: `sac.accounts-refresh` (rotates the
-        credential, every 2h) and
-        `scitex-agent-container-accounts-keepalive` (distributes the
-        access-only copy, every 15min) are DIFFERENT JOBS that must BOTH
-        continue to exist — they are not a rename pair and must never be
-        collapsed into one. PS-226 asks only for the SHAPE OF ONE JobSpec
-        NAME. Tracked in card `sac-accounts-refresh-unit-migration`; this
-        entry is removed by the change that performs the migration.
-
   # PS-103: legitimate top-level dirs that are not part of the wheel
   # but are operator-facing artefacts:
   #   - config/      declarative YAML schema + templates the CLI

--- a/src/scitex_agent_container/_jobs/_jobs_audit.py
+++ b/src/scitex_agent_container/_jobs/_jobs_audit.py
@@ -388,11 +388,12 @@ def _discovered_sac_names(prefix: str | None) -> frozenset[str] | None:
     """Names sac owns among everything scitex-dev discovers.
 
     ``prefix=None`` — the default — asks :func:`_names.is_ours`, which
-    knows BOTH live prefixes. A single prefix string cannot express the
-    transition state: while ``sac.accounts-refresh`` is held at the legacy
-    name and the other eight carry ``scitex-agent-container-``, filtering
-    on either one alone silently drops the other set, and a job that
-    vanishes from the audit reads as "not declared" rather than "not
+    knows BOTH live prefixes. A single prefix string cannot express a
+    transition state, and one is still live: every DECLARED name now
+    carries ``scitex-agent-container-``, but a host mid-cutover still has
+    ``sac.*`` UNITS on disk, so discovery can legitimately return either.
+    Filtering on one prefix alone silently drops the other set, and a job
+    that vanishes from the audit reads as "not declared" rather than "not
     looked for". An explicit string is still accepted so a test can pin
     one side deliberately.
     """

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -163,23 +163,47 @@ def provide_jobs() -> "list[JobSpec]":
 
     return [
         JobSpec(
-            # THE ONE NAME STILL ON THE LEGACY PREFIX, AND IT IS ON PURPOSE.
-            # Every other job here was cut over to `scitex-agent-container-*`;
-            # this one is HELD, with the reason recorded in
-            # `_migrate._renames.RENAMES` (the SSoT for the cutover).
+            # THE LAST NAME OFF THE LEGACY PREFIX. It was held back for
+            # months on the rule "never rename a spec ahead of its unit", and
+            # that rule was right about the hazard and wrong about the order.
             #
-            # A spec renamed AHEAD of its unit is the one shape that must not
-            # ship. The live, enabled, actively-refreshing unit is
-            # `sac.accounts-refresh.timer`; if this said
-            # `scitex-agent-container-accounts-refresh` while that unit ran,
-            # `sac dev timer status accounts-refresh` would resolve to a name
-            # no unit carries and report the fleet's SOLE OAuth refresher as
-            # ABSENT while it refreshes. A name that does not match the
-            # convention yet is a PS-227 warning; a CLI that reports the
-            # credential machinery as missing when it is healthy is an
-            # incident. So the declared name tracks the DEPLOYED unit until
-            # the supervised cutover renames both together.
-            name="sac.accounts-refresh",
+            # WHAT THE HOLD ASSUMED: that the supervised cutover renames spec
+            # and unit TOGETHER. MEASURED 2026-08-19, that is unreachable —
+            # the migration's install step delegates to scitex-dev BY THE NEW
+            # CANONICAL NAME, and scitex-dev resolves a name only if a JobSpec
+            # DECLARES it:
+            #
+            #   $ sac dev timer install scitex-agent-container-accounts-refresh
+            #   no job named 'scitex-agent-container-accounts-refresh' here
+            #
+            # So install-new cannot run until this line moves. The spec moves
+            # FIRST or the cutover never happens at all; that is not a rule
+            # violation, it is the only order the tooling admits. (Attempted
+            # in the other order 2026-08-18: stop/remove succeeded, install
+            # failed on exactly that lookup, and the fleet's sole OAuth
+            # refresher was down ~2 minutes until the old units were restored.)
+            #
+            # WHAT THE WINDOW ACTUALLY COSTS, stated plainly rather than
+            # assumed: between this rename and the host cutover,
+            # `sac dev timer status accounts-refresh` resolves to a unit name
+            # the host does not carry and reports the refresher ABSENT while
+            # `sac.accounts-refresh.timer` keeps firing every 2h. That is a
+            # MISREPORT ON ONE MANUAL VERB, not an outage — and it cannot
+            # escalate on its own: nothing in this repo installs or enables a
+            # timer automatically (`_dev_jobs_backend` declines to run
+            # systemctl; `_dev_jobs_apply` only PRINTS the enable line), so
+            # the two-racing-refreshers catastrophe still requires a human to
+            # type the install command against a host that already has the
+            # old unit.
+            #
+            # CLOSING THE WINDOW is `sac dev migrate-job-names --only
+            # accounts-refresh --include-held --yes`, run supervised, then
+            # `sac accounts status` BEFORE walking away. Ordered
+            # stop-old -> remove-old -> install-new -> verify-exactly-one, and
+            # "exactly one" means one unit FOR THIS JOB:
+            # `scitex-agent-container-accounts-keepalive` is a DIFFERENT job
+            # that must keep existing.
+            name="scitex-agent-container-accounts-refresh",
             schedule="0 */2 * * *",  # every 2h
             command=("sac accounts refresh --all --include-active --sync-active-login"),
             description=(

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -122,10 +122,18 @@ RENAMES: tuple[Rename, ...] = (
             "run `sac dev migrate-job-names --only accounts-refresh "
             "--include-held --yes` in a watched window, then confirm "
             "`sac accounts status` still resolves every account BEFORE "
-            "walking away. Until then the spec keeps its legacy name ON "
-            "PURPOSE, so every CLI verb keeps naming the unit that is really "
-            "running — a spec renamed ahead of its unit would report the "
-            "refresher as absent while it refreshes."
+            "walking away. THE SPEC HAS ALREADY MOVED to the new name, and "
+            "it had to: `sac dev timer install` resolves only names a "
+            "JobSpec DECLARES, so install-new answered `no job named "
+            "'scitex-agent-container-accounts-refresh' here` while the spec "
+            "was held (measured 2026-08-19; attempted in the other order the "
+            "night before, which left the fleet with zero refreshers for ~2 "
+            "minutes). Until this cutover runs, `sac dev timer status "
+            "accounts-refresh` therefore names a unit the host does not "
+            "carry and reports the refresher ABSENT while "
+            "`sac.accounts-refresh.timer` keeps firing — a misreport on one "
+            "manual verb, which nothing automated can escalate, because "
+            "nothing in this repo installs or enables a timer by itself."
         ),
     ),
     Rename(

--- a/src/scitex_agent_container/_jobs/_names.py
+++ b/src/scitex_agent_container/_jobs/_names.py
@@ -26,10 +26,12 @@ the same command with independent state. ``sac.accounts-refresh`` is the
 fleet's SOLE OAuth refresher against a SINGLE-USE refresh token, so two
 of it revoke each other's access token fleet-wide.
 
-The rename therefore does not ride along with a CLI-surface change; it
-ships with the migration verb that enforces stop -> remove -> install and
-makes install-before-uninstall impossible. Flipping this one constant is
-the code half of that change.
+The rename therefore does not ride along with a CLI-surface change; the
+migration verb that enforces stop -> remove -> install and makes
+install-before-uninstall impossible is what closes it on each host.
+Flipping this one constant is the code half; the verb is the host half,
+and — see below — the code half has to land FIRST for the verb to work
+at all.
 
 WHY TWO PREFIXES ARE LIVE AT ONCE, AND WHY THAT IS THE SAFE SHAPE
 =================================================================
@@ -38,16 +40,33 @@ WHY TWO PREFIXES ARE LIVE AT ONCE, AND WHY THAT IS THE SAFE SHAPE
 deliberately keeps its old name until an operator-supervised cutover:
 ``sac.accounts-refresh``, the fleet's sole OAuth refresher.
 
-The alternative — rename the SPEC now and cut the UNIT over later — is
-the one shape that must not ship. The live, enabled, actively-refreshing
-unit is ``sac.accounts-refresh.timer``; if the spec said
-``scitex-agent-container-accounts-refresh`` while that unit ran, then
-``sac dev timer status accounts-refresh`` would resolve to a name no unit
-carries and report the refresher as absent — WHILE IT IS RUNNING. A CLI
-that reports the fleet's most critical job as missing when it is healthy
-is worse than a name that does not match a convention yet.
+THE ORDER WAS INVERTED 2026-08-19, and this paragraph used to argue the
+opposite, so read the correction rather than the memory of it. The old
+rule was "rename the SPEC now and cut the UNIT over later is the one
+shape that must not ship", on the grounds that ``sac dev timer status
+accounts-refresh`` would then resolve to a name no unit carries and
+report the fleet's sole OAuth refresher as absent while it runs.
 
-So the declared name tracks the DEPLOYED unit, always. Both prefixes are
+That hazard is real and it is now ACCEPTED, because the alternative is
+not available. ``sac dev timer install`` resolves only names a JobSpec
+DECLARES, so a held spec can never be installed under its new name:
+
+    $ sac dev timer install scitex-agent-container-accounts-refresh
+    no job named 'scitex-agent-container-accounts-refresh' here
+
+"Rename both together" was therefore never reachable — attempted in the
+old order on 2026-08-18, stop and remove succeeded, install failed on
+exactly that lookup, and the fleet had zero refreshers for ~2 minutes.
+The spec leads and the unit follows, or the cutover never happens.
+
+What the accepted window costs is bounded and worth naming: a MISREPORT
+on one manual verb, which cannot escalate by itself, because nothing in
+this package installs or enables a timer automatically — the backend
+declines to run ``systemctl`` and the apply path only PRINTS the enable
+line. Two racing refreshers still require a human to type the install
+command against a host that already carries the old unit.
+
+So the declared name now LEADS the deployed unit, by necessity. Both prefixes are
 readable until :mod:`._migrate` records that cutover as done, and
 ``JOB_PREFIX`` alone is what new names are minted with.
 """

--- a/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
@@ -36,16 +36,11 @@ def _declared_names() -> frozenset[str]:
 
 
 def test_no_tabled_row_names_an_undeclared_job() -> None:
-    # Arrange — a row's DECLARED name is `old` while it is held and `new`
-    # once it has been cut over. A row naming neither is a row that
-    # migrates something no provider offers.
+    # Arrange — every row's DECLARED name is `new`, held or not. A row
+    # naming a job no provider offers is a row that migrates nothing.
     declared = _declared_names()
     # Act
-    orphans = [
-        r.local
-        for r in _renames.RENAMES
-        if (r.old if r.held else r.new) not in declared
-    ]
+    orphans = [r.local for r in _renames.RENAMES if r.new not in declared]
     # Assert
     assert orphans == []
 
@@ -61,25 +56,34 @@ def test_every_declared_job_has_a_row() -> None:
     assert uncovered == frozenset()
 
 
-def test_a_held_job_still_declares_its_legacy_name() -> None:
-    # Arrange — the invariant stopping the CLI from reporting a running
-    # refresher as absent: a held spec must keep the name its unit has.
+def test_a_held_row_declares_its_new_name_so_install_can_resolve_it() -> None:
+    # Arrange — THIS INVARIANT WAS INVERTED 2026-08-19, deliberately. It
+    # used to say a HELD row must still declare its LEGACY name, to stop
+    # the CLI reporting a running refresher as absent. That protected a
+    # real hazard and made the cutover unreachable: the migration's
+    # install step delegates BY THE NEW CANONICAL NAME, and scitex-dev
+    # resolves only names a JobSpec DECLARES —
+    #     $ sac dev timer install scitex-agent-container-accounts-refresh
+    #     no job named 'scitex-agent-container-accounts-refresh' here
+    # so install-new could never run while the spec was held. The spec
+    # leads and the unit follows; `hold` still gates the HOST cutover.
     held = [r for r in _renames.RENAMES if r.held]
     declared = _declared_names()
     # Act
-    mismatched = [r.local for r in held if r.old not in declared]
+    unresolvable = [r.local for r in held if r.new not in declared]
     # Assert
-    assert mismatched == []
+    assert unresolvable == []
 
 
-def test_a_held_job_does_not_yet_declare_its_new_name() -> None:
-    # Arrange
-    held = [r for r in _renames.RENAMES if r.held]
+def test_no_row_still_declares_its_legacy_name() -> None:
+    # Arrange — the guard the inversion above must not lose: nothing may
+    # regress to the legacy `sac.*` prefix, whose dot becomes a dot in the
+    # derived unit filename (PS-226).
     declared = _declared_names()
     # Act
-    premature = [r.local for r in held if r.new in declared]
+    regressed = [r.local for r in _renames.RENAMES if r.old in declared]
     # Assert
-    assert premature == []
+    assert regressed == []
 
 
 def test_every_tabled_kind_is_one_the_real_validator_accepts() -> None:
@@ -96,11 +100,7 @@ def test_the_tabled_kind_matches_what_the_spec_declares() -> None:
     # Arrange
     by_name = {j.name: j for j in provide_jobs()}
     # Act
-    wrong = [
-        r.local
-        for r in _renames.RENAMES
-        if by_name[r.old if r.held else r.new].kind != r.kind
-    ]
+    wrong = [r.local for r in _renames.RENAMES if by_name[r.new].kind != r.kind]
     # Assert
     assert wrong == []
 

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -3,7 +3,7 @@
 Verifies the JobSpecs sac registers under the ``scitex_dev.jobs``
 entry-point group match the federated contract:
 
-* ``sac.accounts-refresh`` — a periodic systemd timer job that runs
+* ``scitex-agent-container-accounts-refresh`` — a periodic systemd timer job that runs
   ``--all --include-active --sync-active-login`` every 2h (the SOLE
   refresher; see the ``--skip-active`` note below).
 * ``sac.accounts-keepalive`` — the DISTRIBUTION half of that same
@@ -69,7 +69,7 @@ def test_provider_returns_every_expected_job() -> None:
     names = {job.name for job in provide_jobs()}
     # Assert
     assert names == {
-        "sac.accounts-refresh",
+        "scitex-agent-container-accounts-refresh",
         "scitex-agent-container-accounts-keepalive",
         # The usage-cache refresher. Nothing else reads usage: accounts-refresh
         # rotates tokens and accounts-keepalive copies them, so before this job
@@ -96,9 +96,9 @@ def test_provider_jobs_are_real_jobspecs() -> None:
 def test_provider_job_name_is_package_prefixed() -> None:
     # Arrange — call the registered provider.
     # Act
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
-    assert job.name == "sac.accounts-refresh"
+    assert job.name == "scitex-agent-container-accounts-refresh"
 
 
 def test_provider_job_command_includes_active_account() -> None:
@@ -113,7 +113,7 @@ def test_provider_job_command_includes_active_account() -> None:
     # Act — by NAME, not by index: this provider now returns two jobs, so
     # provide_jobs()[0] would silently start asserting against the wrong
     # JobSpec the day the list order changes.
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert job.command == (
         "sac accounts refresh --all --include-active --sync-active-login"
@@ -124,7 +124,7 @@ def test_provider_job_command_never_skips_active() -> None:
     # Arrange — a belt-and-braces guard: --skip-active must never
     # reappear in the sole-refresher timer, however the command is spelled.
     # Act
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert "--skip-active" not in job.command
 
@@ -132,11 +132,11 @@ def test_provider_job_command_never_skips_active() -> None:
 def test_provider_job_kind_is_timer() -> None:
     # Arrange — call the registered provider. The legacy ``kind=
     # "systemd"`` is no longer accepted by JobSpec.validate() since
-    # scitex-dev #153; ``sac.accounts-refresh`` is a periodic
+    # scitex-dev #153; ``scitex-agent-container-accounts-refresh`` is a periodic
     # systemd --user timer (token TTL ~7h, refresh every 2h) so the
     # canonical kind is ``"timer"`` (lead msg c5212862, 2026-06-11).
     # Act
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert job.kind == "timer"
 
@@ -154,14 +154,14 @@ def test_every_provided_job_uses_an_allowed_kind() -> None:
 def test_provider_job_cadence_is_two_hours() -> None:
     # Arrange — call the registered provider.
     # Act
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert job.on_unit_active_sec == "2h"
 
 
 # ---------------------------------------------------------------------------
 # sac.accounts-keepalive — the DISTRIBUTION half of the single-refresher
-# model, and the SIBLING of sac.accounts-refresh above. That job rotates the
+# model, and the SIBLING of scitex-agent-container-accounts-refresh above. That job rotates the
 # token on the ONE host holding refresh material; this one copies the result
 # out to the access-only hosts and proves each of them accepts it. Refreshing
 # the master is not enough on its own: every other host holds a copy nothing
@@ -280,7 +280,7 @@ def test_accounts_keepalive_and_accounts_refresh_are_both_declared() -> None:
     # Act
     names = {job.name for job in provide_jobs()}
     # Assert
-    assert {"sac.accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names
+    assert {"scitex-agent-container-accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names
 
 
 def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -> None:

--- a/tests/scitex_agent_container/_jobs/test__names.py
+++ b/tests/scitex_agent_container/_jobs/test__names.py
@@ -141,12 +141,15 @@ def test_is_ours_rejects_a_foreign_job() -> None:
 
 
 def test_resolve_finds_a_real_declared_job_by_local_name() -> None:
-    # Arrange — against the REAL declarations, not a hand-picked list.
+    # Arrange — against the REAL declarations, not a hand-picked list. The
+    # literals elsewhere in this file stay on the legacy dotted shape ON
+    # PURPOSE: they pin that the PARSER still handles it, which is what a
+    # host mid-cutover types.
     declared = [j.name for j in provide_jobs()]
     # Act
     got = _names.resolve("accounts-refresh", declared)
     # Assert
-    assert got == "sac.accounts-refresh"
+    assert got == "scitex-agent-container-accounts-refresh"
 
 
 def test_resolve_raises_on_an_unknown_name() -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -544,7 +544,7 @@ def test_install_accepts_the_short_local_name() -> None:
         # Act
         runner.invoke(dev_group, ["timer", "install", "accounts-refresh", "-y"])
     # Assert
-    assert [a[2] for a in captured] == ["sac.accounts-refresh"]
+    assert [a[2] for a in captured] == ["scitex-agent-container-accounts-refresh"]
 
 
 def test_install_accepts_the_canonical_name_too() -> None:
@@ -552,9 +552,12 @@ def test_install_accepts_the_canonical_name_too() -> None:
     with _captured_delegations() as captured:
         runner = CliRunner()
         # Act
-        runner.invoke(dev_group, ["timer", "install", "sac.accounts-refresh", "-y"])
+        runner.invoke(
+            dev_group,
+            ["timer", "install", "scitex-agent-container-accounts-refresh", "-y"],
+        )
     # Assert
-    assert [a[2] for a in captured] == ["sac.accounts-refresh"]
+    assert [a[2] for a in captured] == ["scitex-agent-container-accounts-refresh"]
 
 
 def test_install_forwards_dry_run_to_the_delegation() -> None:
@@ -733,7 +736,7 @@ def test_a_refusal_offers_the_manual_command() -> None:
     result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
     # Assert
     assert (
-        "systemctl --user status sac.accounts-refresh.timer" in result.stderr
+        f"systemctl --user status {'scitex-agent-container-accounts-refresh'}.timer" in result.stderr
     ) is (not delegation.supported), (
         f"probe says supported={delegation.supported}. When sac refuses it "
         "must hand the operator the manual command; when it delegates it "

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
@@ -336,7 +336,7 @@ def test_bulk_enable_still_accepts_one_name() -> None:
             dj._make_group("timer"), ["enable", "accounts-refresh", "--yes"]
         )
     # Assert
-    assert recorder.names_for("enable") == ["sac.accounts-refresh"]
+    assert recorder.names_for("enable") == ["scitex-agent-container-accounts-refresh"]
 
 
 def test_disable_has_no_bulk_form() -> None:


### PR DESCRIPTION
## Why now

PS-226 is **error tier** and has been failing `test_audit_all_clean` on every PR into `develop`, including unrelated ones. The operator ruled on it directly (2026-08-18):

> 「audit の除外はだめです。守るべきルールです、従うように訂正してください」

The `skip-rules` entry had also stopped buying anything — the auditor reports the finding as masked **and still exits 1**, so the exemption was dead weight on top of being disallowed.

## Why the spec moves first, when the held comment argued the opposite

The hold assumed the supervised cutover renames spec and unit **together**. That is unreachable. The migration's install step delegates to scitex-dev **by the new canonical name**, and scitex-dev resolves only names a JobSpec *declares*. Measured on this host today, read-only:

```
$ sac dev timer install accounts-refresh --dry-run
# sac.accounts-refresh.service          <- unit filename from the name, verbatim
...
$ sac dev timer install scitex-agent-container-accounts-refresh --dry-run
no job named 'scitex-agent-container-accounts-refresh' here
```

So `install-new` could never run while the spec was held. Attempted in the other order on 2026-08-18: stop and remove succeeded, install failed on exactly that lookup, and the fleet's sole OAuth refresher was down ~2 minutes until the old units were restored from `.old/20260818T195401Z/`. **The spec leads and the unit follows, or the cutover never happens.**

## What the window costs

Stated rather than assumed. Until the host cutover runs, `sac dev timer status accounts-refresh` names a unit the host does not carry and reports the refresher **absent** while `sac.accounts-refresh.timer` keeps firing every 2h.

That is a **misreport on one manual verb, not an outage**, and it cannot escalate on its own: nothing in this repo installs or enables a timer by itself — `_dev_jobs_backend` explicitly declines to run `systemctl`, `_dev_jobs_apply` only *prints* the enable line. Two racing refreshers still require a human to type the install command against a host that already carries the old unit.

Host state at the time of writing (measured): `sac.accounts-refresh.timer` enabled+active, last fired 04:14 JST, and `scitex-agent-container-accounts-keepalive.timer` firing on its 15min cadence.

## The hold stays

`Rename.hold` still gates the **host** cutover, which remains operator-supervised:

```
sac dev migrate-job-names --only accounts-refresh --include-held --yes
```

ordered stop-old → remove-old → install-new → verify-exactly-one, then `sac accounts status` **before** walking away. "Exactly one" means one unit for *this* job — `scitex-agent-container-accounts-keepalive` is a different job that must keep existing.

## Tests

Two invariants are inverted deliberately, not deleted:

| was | is |
|---|---|
| `test_a_held_job_still_declares_its_legacy_name` | `test_a_held_row_declares_its_new_name_so_install_can_resolve_it` — carries the measurement above |
| `test_a_held_job_does_not_yet_declare_its_new_name` | `test_no_row_still_declares_its_legacy_name` — the guard the inversion must not lose, since a dotted name puts a dot in the derived unit filename |

The legacy-shaped literals in `test__names.py` stay on purpose: they pin that the **parser** still handles a dotted canonical name, which is what a host mid-cutover types.

`tests/scitex_agent_container/_jobs/`: 211 passed.

## Result

Every sac job is now on the convention prefix — this was the last one.

```
scitex-agent-container-accounts-refresh | timer
scitex-agent-container-accounts-keepalive | timer
scitex-agent-container-accounts-quota-cache | timer
... (10 total, none on the legacy `sac.` prefix)
```