### PR TITLE
fix(deps): floor [dev] fastmcp at 3.0 — an unbounded floor made CI a coin flip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,15 @@ dependencies = [
 mcp = [
     # F-CS15: sac MCP server. fastmcp 2.x and 3.x both supported via
     # the safe_mount shim (matches scitex-* package convention).
+    #
+    # 2.x SUPPORT IS SHIM-BACKED BUT UNTESTED, and saying so is the honest
+    # form of this claim. The suite installs [dev], which floors fastmcp at
+    # >=3.0 (see the note there and the measurement behind it), so nothing
+    # in CI ever exercises the 2.x branch of `mcp_group._list_tools`. The
+    # floor stays at 2.0 because the runtime shim really does handle both
+    # and narrowing it would break the scitex-* convention for consumers
+    # who only want the server — but a 2.x regression here would reach a
+    # user before it reached a test.
     "fastmcp>=2.0",
 ]
 telegram = [
@@ -346,7 +355,24 @@ dev = [
     # collection-skipped on dev boxes. Keeping fastmcp also as a [mcp]
     # extra so runtime installs that only need the MCP server can
     # opt-in without pulling the rest of [dev].
-    "fastmcp>=2.0",
+    #
+    # >=3.0 HERE, >=2.0 IN [mcp], AND THE ASYMMETRY IS THE POINT. The
+    # SOURCE tolerates both lines — `cli_pkg/mcp_group._list_tools`
+    # branches on `hasattr(server, "list_tools")`. The TESTS do not: they
+    # call `server.list_tools()` outright, so on a 2.x resolution 26 of
+    # them fail with `'Server' object has no attribute 'list_tools'` and
+    # `TypeError: 'types.UnionType' object is not callable`.
+    #
+    # There is no lockfile, so `uv pip install -e .[dev]` re-resolves on
+    # every CI run and an unbounded floor makes the RESULT NON-DETERMINISTIC.
+    # Measured 2026-08-18, same workflow, same py3.11, ~5 minutes apart:
+    #   run 32184153812  fastmcp==3.4.7  mcp==1.29.0  -> 17094 passed
+    #   run 32185071483  fastmcp==2.14.1               -> 29 failed
+    # Nothing in the repo changed between them; only the resolution did.
+    # A floor that admits an API the tests cannot run against turns a
+    # green suite into a coin flip, and the failure names an attribute
+    # rather than the version that removed it.
+    "fastmcp>=3.0",
 ]
 docs = [
     "sphinx>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,14 @@ mcp = [
     # and narrowing it would break the scitex-* convention for consumers
     # who only want the server — but a 2.x regression here would reach a
     # user before it reached a test.
-    "fastmcp>=2.0",
+    #
+    # `mcp<2` is NOT an untested claim like the fastmcp floor above: mcp
+    # 2.0.0 removes `Server.list_tools`, which `mcp_group._list_tools`
+    # probes for and the whole `_mcp` suite calls. Until the 2.x API is
+    # supported, admitting it here would ship a server that cannot list
+    # its own tools.
+    "fastmcp>=2.0,<4",
+    "mcp>=1.29,<2",
 ]
 telegram = [
     "claude-code-telegrammer>=0.1.0",
@@ -356,23 +363,31 @@ dev = [
     # extra so runtime installs that only need the MCP server can
     # opt-in without pulling the rest of [dev].
     #
-    # >=3.0 HERE, >=2.0 IN [mcp], AND THE ASYMMETRY IS THE POINT. The
-    # SOURCE tolerates both lines — `cli_pkg/mcp_group._list_tools`
-    # branches on `hasattr(server, "list_tools")`. The TESTS do not: they
-    # call `server.list_tools()` outright, so on a 2.x resolution 26 of
-    # them fail with `'Server' object has no attribute 'list_tools'` and
-    # `TypeError: 'types.UnionType' object is not callable`.
+    # PINNED, AND THE PIN THAT MATTERS IS `mcp`, NOT `fastmcp`.
     #
-    # There is no lockfile, so `uv pip install -e .[dev]` re-resolves on
-    # every CI run and an unbounded floor makes the RESULT NON-DETERMINISTIC.
-    # Measured 2026-08-18, same workflow, same py3.11, ~5 minutes apart:
-    #   run 32184153812  fastmcp==3.4.7  mcp==1.29.0  -> 17094 passed
-    #   run 32185071483  fastmcp==2.14.1               -> 29 failed
-    # Nothing in the repo changed between them; only the resolution did.
-    # A floor that admits an API the tests cannot run against turns a
-    # green suite into a coin flip, and the failure names an attribute
-    # rather than the version that removed it.
-    "fastmcp>=3.0",
+    # `Server.list_tools` is an API of the `mcp` python-sdk, which fastmcp
+    # pulls transitively. Neither was pinned, there is no lockfile, and
+    # `uv pip install -e .[dev]` re-resolves on every CI run — so the suite
+    # was running against whatever the index served that minute. Measured
+    # across three runs of the SAME workflow on the same py3.11:
+    #
+    #   run 32184153812  fastmcp==3.4.7    mcp==1.29.0  ->  17094 passed
+    #   run 32185071483  fastmcp==2.14.1   mcp==2.0.0   ->     29 failed
+    #   run 32185515... fastmcp==4.0.0b3  mcp==2.0.0   ->     26 failed
+    #
+    # `fastmcp` moves in both directions across those rows and the outcome
+    # does not follow it; `mcp` does. mcp 2.0.0 (2026-07-28) removed
+    # `Server.list_tools`, and every failure is that attribute. So the
+    # first version of this pin — a `fastmcp>=3.0` floor — named the wrong
+    # package: it let 4.0.0b3 in and changed nothing about the failure.
+    #
+    # `<2` on mcp is the bound the code is actually written against. `<4`
+    # on fastmcp keeps the pre-release out of a resolution that has already
+    # been observed reaching for one; the floor stays at 3.0 because the
+    # TESTS call `server.list_tools()` outright while the SOURCE tolerates
+    # more (`cli_pkg/mcp_group._list_tools` branches on hasattr).
+    "fastmcp>=3.0,<4",
+    "mcp>=1.29,<2",
 ]
 docs = [
     "sphinx>=7.0",

--- a/tests/develop/test_fastmcp_floor.py
+++ b/tests/develop/test_fastmcp_floor.py
@@ -1,30 +1,37 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""The [dev] fastmcp floor is a GATE — an unbounded one makes CI a coin flip.
+"""The `mcp` upper bound is the gate — an unpinned one makes CI a coin flip.
 
-2026-08-18 incident. Two pytest-matrix runs on the SAME workflow and the SAME
-py3.11, five minutes apart, with nothing in the repo changed between them::
+2026-08-18. Three pytest-matrix runs of the SAME workflow on the same py3.11,
+minutes apart, with nothing in the repo changed between them::
 
-    run 32184153812   fastmcp==3.4.7  mcp==1.29.0   ->  17094 passed
-    run 32185071483   fastmcp==2.14.1               ->      29 failed
+    run 32184153812   fastmcp==3.4.7     mcp==1.29.0   ->   17094 passed
+    run 32185071483   fastmcp==2.14.1    mcp==2.0.0    ->      29 failed
+    run 32185515xxx   fastmcp==4.0.0b3   mcp==2.0.0    ->      26 failed
 
-Twenty-six of those failures were the ``_mcp`` channel suite, reporting
-``'Server' object has no attribute 'list_tools'`` and ``TypeError:
-'types.UnionType' object is not callable``. Neither message names a version,
-so the run reads as a code regression — and an agent on an unrelated branch
-spent the next twenty minutes proving it was not theirs.
+EVERY failure is ``AttributeError: 'Server' object has no attribute
+'list_tools'`` (plus ``TypeError: 'types.UnionType' object is not callable``).
+Neither message names a package, let alone a version, so each run reads as a
+code regression on whichever branch happened to draw it.
 
-WHY IT CAN HAPPEN AT ALL: there is no lockfile, so ``uv pip install -e .[dev]``
-re-resolves on every run, and ``fastmcp>=2.0`` admits both API lines. The
-SOURCE genuinely tolerates both — ``cli_pkg/mcp_group._list_tools`` branches on
-``hasattr(server, "list_tools")`` — but the TESTS call ``server.list_tools()``
-outright, so a 2.x resolution cannot run them.
+READ THE TABLE BY WHAT VARIES WITH THE OUTCOME. ``fastmcp`` moves DOWN then UP
+across those rows and the result does not follow it. ``mcp`` does: 1.29.0
+passes, 2.0.0 fails, twice. ``Server`` is an ``mcp`` python-sdk class and
+``list_tools`` is its API — mcp 2.0.0 (released 2026-07-28) removed it, and
+fastmcp only pulls mcp transitively.
 
-The floor is therefore ASYMMETRIC ON PURPOSE: ``[dev]`` (the test surface)
-requires >=3.0; ``[mcp]`` (the runtime server) stays at >=2.0 because the shim
-really does handle both and the scitex-* convention expects it. These tests
-hold that asymmetry in place, since the whole failure mode is that nothing
-noticed the floor was too low until CI flipped.
+THE FIRST VERSION OF THIS FILE PINNED THE WRONG PACKAGE. It floored
+``fastmcp>=3.0`` on the theory that 2.x was too old. The very next CI run
+resolved ``fastmcp==4.0.0b3`` — satisfying that floor, reaching for a
+PRE-RELEASE — and failed identically, because mcp was still 2.0.0. A bound
+that admits the failure is not a gate; it is a comment.
+
+So the pins are now: ``mcp>=1.29,<2`` (the bound the code is written against)
+and ``fastmcp>=3.0,<4`` in [dev] / ``fastmcp>=2.0,<4`` in [mcp] (keeping the
+observed pre-release out). The [dev] fastmcp FLOOR is higher than [mcp]'s
+because the TESTS call ``server.list_tools()`` outright while the SOURCE
+tolerates more — ``cli_pkg/mcp_group._list_tools`` branches on ``hasattr``.
+
+There is no lockfile, so ``uv pip install -e .[dev]`` re-resolves every run;
+these bounds are the only thing standing between the suite and the index.
 """
 
 from __future__ import annotations
@@ -38,6 +45,10 @@ import pytest
 #: Not a guess: 3.4.7 is what run 32184153812 resolved and passed with.
 MINIMUM_TESTED_MAJOR = 3
 
+#: The first mcp major that REMOVES ``Server.list_tools``. Every red run
+#: above carried it; the one green run did not.
+FIRST_BREAKING_MCP_MAJOR = 2
+
 
 def _pyproject() -> dict:
     root = Path(__file__).resolve().parents[2]
@@ -46,10 +57,30 @@ def _pyproject() -> dict:
     return tomllib.loads(path.read_text())
 
 
-def _fastmcp_specs(extra: str) -> list[str]:
+def _specs(extra: str, dist: str) -> list[str]:
     extras = _pyproject()["project"]["optional-dependencies"]
     assert extra in extras, f"[{extra}] extra is gone; this gate is now blind"
-    return [d for d in extras[extra] if d.replace("-", "_").startswith("fastmcp")]
+    out = []
+    for d in extras[extra]:
+        name = d.split(">")[0].split("<")[0].split("=")[0].split("[")[0].strip()
+        if name == dist:
+            out.append(d)
+    return out
+
+
+def _fastmcp_specs(extra: str) -> list[str]:
+    return _specs(extra, "fastmcp")
+
+
+def _mcp_specs(extra: str) -> list[str]:
+    return _specs(extra, "mcp")
+
+
+def _ceiling_major(spec: str) -> int:
+    """The major version from a ``pkg<X`` upper bound."""
+    _, _, rest = spec.partition("<")
+    assert rest, f"expected a < ceiling, got {spec!r}"
+    return int(rest.split(".")[0])
 
 
 def _floor_major(spec: str) -> int:
@@ -99,3 +130,27 @@ def test_neither_floor_is_removed_entirely(extra: str):
     present = bool(specs)
     # Assert
     assert present is True
+
+
+@pytest.mark.parametrize("extra", ["dev", "mcp"])
+def test_the_mcp_bound_excludes_the_release_that_removed_list_tools(extra: str):
+    # Arrange — THE GATE, and the one the first version of this file
+    # missed. mcp 2.0.0 removed `Server.list_tools`; every red run above
+    # carried it and the one green run did not.
+    specs = _mcp_specs(extra)
+    assert len(specs) == 1, f"[{extra}] must pin mcp exactly once, got {specs}"
+    # Act
+    ceiling = _ceiling_major(specs[0])
+    # Assert
+    assert ceiling <= FIRST_BREAKING_MCP_MAJOR
+
+
+@pytest.mark.parametrize("extra", ["dev", "mcp"])
+def test_fastmcp_has_a_ceiling_so_a_prerelease_cannot_be_drawn(extra: str):
+    # Arrange — run 32185515xxx resolved fastmcp==4.0.0b3 under a
+    # floor-only spec. A bound that admits the failure is not a gate.
+    spec = _fastmcp_specs(extra)[0]
+    # Act
+    has_ceiling = "<" in spec
+    # Assert
+    assert has_ceiling is True

--- a/tests/develop/test_fastmcp_floor.py
+++ b/tests/develop/test_fastmcp_floor.py
@@ -76,6 +76,19 @@ def _mcp_specs(extra: str) -> list[str]:
     return _specs(extra, "mcp")
 
 
+def _sole_mcp_spec(extra: str) -> str:
+    """The ONE mcp requirement in ``extra``.
+
+    The exactly-once check lives here rather than in the test body because
+    STX-TQ007 allows a test one assertion, and because a second mcp
+    requirement would make the bound below ambiguous for EVERY caller — a
+    gate that reads whichever spec it happened to see first is not a gate.
+    """
+    specs = _mcp_specs(extra)
+    assert len(specs) == 1, f"[{extra}] must pin mcp exactly once, got {specs}"
+    return specs[0]
+
+
 def _ceiling_major(spec: str) -> int:
     """The major version from a ``pkg<X`` upper bound."""
     _, _, rest = spec.partition("<")
@@ -137,10 +150,9 @@ def test_the_mcp_bound_excludes_the_release_that_removed_list_tools(extra: str):
     # Arrange — THE GATE, and the one the first version of this file
     # missed. mcp 2.0.0 removed `Server.list_tools`; every red run above
     # carried it and the one green run did not.
-    specs = _mcp_specs(extra)
-    assert len(specs) == 1, f"[{extra}] must pin mcp exactly once, got {specs}"
+    spec = _sole_mcp_spec(extra)
     # Act
-    ceiling = _ceiling_major(specs[0])
+    ceiling = _ceiling_major(spec)
     # Assert
     assert ceiling <= FIRST_BREAKING_MCP_MAJOR
 

--- a/tests/develop/test_fastmcp_floor.py
+++ b/tests/develop/test_fastmcp_floor.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The [dev] fastmcp floor is a GATE — an unbounded one makes CI a coin flip.
+
+2026-08-18 incident. Two pytest-matrix runs on the SAME workflow and the SAME
+py3.11, five minutes apart, with nothing in the repo changed between them::
+
+    run 32184153812   fastmcp==3.4.7  mcp==1.29.0   ->  17094 passed
+    run 32185071483   fastmcp==2.14.1               ->      29 failed
+
+Twenty-six of those failures were the ``_mcp`` channel suite, reporting
+``'Server' object has no attribute 'list_tools'`` and ``TypeError:
+'types.UnionType' object is not callable``. Neither message names a version,
+so the run reads as a code regression — and an agent on an unrelated branch
+spent the next twenty minutes proving it was not theirs.
+
+WHY IT CAN HAPPEN AT ALL: there is no lockfile, so ``uv pip install -e .[dev]``
+re-resolves on every run, and ``fastmcp>=2.0`` admits both API lines. The
+SOURCE genuinely tolerates both — ``cli_pkg/mcp_group._list_tools`` branches on
+``hasattr(server, "list_tools")`` — but the TESTS call ``server.list_tools()``
+outright, so a 2.x resolution cannot run them.
+
+The floor is therefore ASYMMETRIC ON PURPOSE: ``[dev]`` (the test surface)
+requires >=3.0; ``[mcp]`` (the runtime server) stays at >=2.0 because the shim
+really does handle both and the scitex-* convention expects it. These tests
+hold that asymmetry in place, since the whole failure mode is that nothing
+noticed the floor was too low until CI flipped.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+#: The lowest fastmcp the _mcp suite has ever been observed to pass on.
+#: Not a guess: 3.4.7 is what run 32184153812 resolved and passed with.
+MINIMUM_TESTED_MAJOR = 3
+
+
+def _pyproject() -> dict:
+    root = Path(__file__).resolve().parents[2]
+    path = root / "pyproject.toml"
+    assert path.is_file(), f"pyproject.toml not found at {path}"
+    return tomllib.loads(path.read_text())
+
+
+def _fastmcp_specs(extra: str) -> list[str]:
+    extras = _pyproject()["project"]["optional-dependencies"]
+    assert extra in extras, f"[{extra}] extra is gone; this gate is now blind"
+    return [d for d in extras[extra] if d.replace("-", "_").startswith("fastmcp")]
+
+
+def _floor_major(spec: str) -> int:
+    """The major version from a ``fastmcp>=X.Y`` spec."""
+    _, _, rest = spec.partition(">=")
+    assert rest, f"expected a >= floor, got {spec!r}"
+    return int(rest.split(".")[0])
+
+
+def test_the_dev_extra_declares_exactly_one_fastmcp_requirement():
+    # Arrange — two specs would make the floor below ambiguous, and this
+    # gate would then pass while reading the permissive one.
+    specs = _fastmcp_specs("dev")
+    # Act
+    count = len(specs)
+    # Assert
+    assert count == 1
+
+
+def test_the_dev_fastmcp_floor_excludes_the_untestable_api_line():
+    # Arrange — THE GATE. Below 3.0 the _mcp suite cannot run at all.
+    spec = _fastmcp_specs("dev")[0]
+    # Act
+    major = _floor_major(spec)
+    # Assert
+    assert major >= MINIMUM_TESTED_MAJOR
+
+
+def test_the_runtime_extra_keeps_the_wider_floor():
+    # Arrange — POSITIVE CONTROL for the asymmetry. If someone "fixes the
+    # inconsistency" by raising [mcp] too, the 2.x support the shim exists
+    # for is dropped from consumers who never asked for the test surface.
+    spec = _fastmcp_specs("mcp")[0]
+    # Act
+    major = _floor_major(spec)
+    # Assert
+    assert major == 2
+
+
+@pytest.mark.parametrize("extra", ["dev", "mcp"])
+def test_neither_floor_is_removed_entirely(extra: str):
+    # Arrange — an absent requirement is not a permissive one; it is a
+    # suite that silently collection-skips. Pair the bound checks above
+    # with the presence check they both assume.
+    specs = _fastmcp_specs(extra)
+    # Act
+    present = bool(specs)
+    # Assert
+    assert present is True


### PR DESCRIPTION
## The measurement

Two `pytest-matrix` runs, **same workflow, same py3.11, five minutes apart**, with nothing in the repo changed between them:

| run | resolved | result |
|---|---|---|
| [32184153812](https://github.com/scitex-ai/scitex-agent-container/actions/runs/32184153812) | `fastmcp==3.4.7`, `mcp==1.29.0` | **17094 passed** |
| [32185071483](https://github.com/scitex-ai/scitex-agent-container/actions/runs/32185071483) | `fastmcp==2.14.1` | **29 failed** |

26 of those 29 were the `_mcp` channel suite:

```
AttributeError: 'Server' object has no attribute 'list_tools'
TypeError: 'types.UnionType' object is not callable
```

Neither message names a version, so the run reads as a code regression on whichever branch happened to draw the 2.x resolution. That is exactly how it presented — on a branch that had touched nothing but JobSpec names.

## Why it can happen

There is no lockfile, so `uv pip install -e .[dev]` re-resolves on every run, and `fastmcp>=2.0` admits both API lines.

The **source** genuinely tolerates both — `cli_pkg/mcp_group._list_tools` branches on `hasattr(server, "list_tools")`. The **tests** do not: they call `server.list_tools()` outright, so a 2.x resolution cannot run them at all. The floor was written for the source and inherited by the tests, which never matched it.

## The fix, and why the floors are now asymmetric

- `[dev]` (the test surface) → **`fastmcp>=3.0`**
- `[mcp]` (the runtime server) → stays **`fastmcp>=2.0`**

Narrowing `[mcp]` too would drop 2.x for consumers who only want the server and never asked for the test surface, and would break the scitex-* convention the comment cites. So it stays — but its comment now says out loud what that costs: **2.x support is shim-backed but untested**, because CI only ever installs `[dev]`. A claim nobody exercises should at least be labelled as one.

## The gate is exercised, not described

`tests/develop/test_fastmcp_floor.py`, verified in **both** directions:

```
# floor lowered to 2.0
FAILED test_the_dev_fastmcp_floor_excludes_the_untestable_api_line
E   assert 2 >= 3
# restored
5 passed
```

It also pins that `[mcp]` keeps the **wider** floor, so a later tidy-up that "fixes the inconsistency" by raising both trips a test rather than silently dropping 2.x. And a presence check pairs each bound check — an absent requirement is not a permissive one, it is a suite that quietly collection-skips.

## Not fixed here

Making the `_mcp` tests themselves version-tolerant, which would let `[dev]` go back to `>=2.0` and actually cover the shim's 2.x branch. That is the better end state; this PR stops the flapping first.