### PR TITLE
fix(check): refuse a raw_args env pair that has no --env before it

### DIFF
--- a/src/scitex_agent_container/cli_pkg/build_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/build_cmds.py
@@ -92,6 +92,14 @@ def check(name_or_path: str) -> None:
     # docs/adr/0001-isolation-hardening.md §D4.
     _warn_host_mirroring_bind_targets(config)
 
+    # raw_args as an APPTAINER ARGV, not merely as YAML. This check said
+    # "Ready to deploy" on a spec whose raw_args carried an env assignment
+    # with no `--env` before it, minutes before that agent failed to start
+    # (2026-08-18). Everything above validates shape and environment; this
+    # is the one that reads raw_args the way apptainer will.
+    if not _check_raw_args(config):
+        all_ok = False
+
     if all_ok:
         console.print("[green]Ready to deploy.[/green]")
     else:
@@ -99,6 +107,31 @@ def check(name_or_path: str) -> None:
             "[red]Preflight checks failed. Fix the issues above before deploying.[/red]"
         )
         sys.exit(1)
+
+
+def _check_raw_args(config) -> bool:
+    """Report whether ``spec.apptainer.raw_args`` is a well-formed argv.
+
+    FAILS the preflight rather than warning, because the failure it catches
+    is not a deviation the operator might have chosen — a positional in
+    raw_args cannot start the agent at all. Returns True when there is
+    nothing to say, so a spec with no raw_args is unaffected.
+    """
+    from ..runtimes._apptainer_argv_guard import ApptainerArgvError, validate_raw_args
+
+    ap = getattr(config, "apptainer", None)
+    raw = list(getattr(ap, "raw_args", None) or []) if ap is not None else []
+    if not raw:
+        console.print(f"  {'raw_args:':30s} [green]OK (none declared)[/green]")
+        return True
+    try:
+        validate_raw_args(raw, agent=getattr(config, "name", None))
+    except ApptainerArgvError as exc:
+        console.print(f"  {'raw_args:':30s} [red]FAIL[/red]")
+        console.print(f"[red]{exc}[/red]")
+        return False
+    console.print(f"  {'raw_args:':30s} [green]OK ({len(raw)} token(s))[/green]")
+    return True
 
 
 # Bind targets that start with these prefixes mirror host home / user

--- a/src/scitex_agent_container/runtimes/_apptainer_argv_guard.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_argv_guard.py
@@ -66,6 +66,9 @@ always printed, so the reader sees the actual argv instead of a rule.
 
 from __future__ import annotations
 
+import re
+from typing import Any, Iterable
+
 # apptainer ``exec`` options that REQUIRE a following value. A subset
 # focused on the ones sac itself emits or operators commonly pass via
 # raw_args; an unknown value-flag not listed here simply isn't guarded
@@ -239,9 +242,108 @@ def _flag_region(argv: list[str]) -> list[str]:
     return region
 
 
+#: An env assignment as raw_args can only have been meant as an ``--env``
+#: value. UPPER_SNAKE before the ``=`` is what makes this precise rather
+#: than broad: every environment variable the fleet sets is upper-snake,
+#: while the value-shaped ``k=v`` tokens that legitimately follow flags
+#: this module does NOT track (``--network-args portmap=8080:tcp``,
+#: ``--security uid:1000``) are not. Broadening it would trade a real
+#: catch for a false refusal, and this module's whole doctrine is that a
+#: guard must never block a launch it merely failed to recognise.
+_ENV_ASSIGNMENT = re.compile(r"^[A-Z][A-Z0-9_]*=")
+
+
+def find_stray_env_pair(raw_args: Iterable[Any] | None) -> tuple[int, str] | None:
+    """First ``(index, token)`` in ``raw_args`` that is a POSITIONAL env pair.
+
+    ``spec.apptainer.raw_args`` must contain ZERO positionals: sac supplies
+    the image and the inner command itself, so the first bare token the
+    operator adds becomes the token apptainer reads as the IMAGE PATH.
+
+    THE INCIDENT (2026-08-18). A bulk edit added the new board-identity
+    variable to ~100 specs and inserted only the VALUE, without the
+    ``- --env`` that has to precede it::
+
+        - --env
+        - SCITEX_TODO_AGENT_ID=business
+        - SCITEX_CARDS_AGENT_ID=business      <- positional, in flag position
+
+    apptainer resolved that bare token against the launch cwd and reported::
+
+        FATAL: While checking container encryption: could not open image
+          /home/ywatanabe/proj/business/SCITEX_CARDS_AGENT_ID=business
+
+    — a message that names an image nobody wrote, blames encryption, and
+    never mentions the missing flag. ``sac agents check`` answered "Ready to
+    deploy" on that spec minutes before the start failed, because it
+    validates raw_args as YAML and as a schema and not as an apptainer argv.
+
+    WHY THE SIBLING GUARD MISSES IT: :func:`validate_flag_argv` inspects
+    ``_flag_region(argv)``, which by construction STOPS at the first
+    positional. The stray token does not break the flag region — it ENDS
+    it, and everything after is read as the container's business. So the
+    two checks are complementary, not redundant: one finds a flag with no
+    value, this one finds a value with no flag.
+
+    Returns ``None`` for well-formed input (including ``None`` / empty).
+    """
+    tokens = [str(a) for a in (raw_args or [])]
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in VALUE_TAKING_FLAGS:
+            index += 2  # the flag CONSUMES the next token; it is not a positional
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        if _ENV_ASSIGNMENT.match(token):
+            return index, token
+        index += 1  # a bare non-env token: not ours to judge, see _ENV_ASSIGNMENT
+    return None
+
+
+def validate_raw_args(
+    raw_args: Iterable[Any] | None,
+    *,
+    agent: str | None = None,
+) -> None:
+    """Fail loud if ``raw_args`` carries an env pair with no ``--env`` flag.
+
+    A no-op for well-formed raw_args. See :func:`find_stray_env_pair` for
+    what this catches and why apptainer's own error cannot say it.
+    """
+    found = find_stray_env_pair(raw_args)
+    if found is None:
+        return
+    index, token = found
+    key = token.split("=", 1)[0]
+    who = f" for agent {agent!r}" if agent else ""
+    raise ApptainerArgvError(
+        f"spec.apptainer.raw_args[{index}]{who} is {token!r} — an environment "
+        f"assignment sitting in FLAG position with no `--env` before it.\n"
+        f"\n"
+        f"apptainer does not read that as an environment variable. It reads "
+        f"the first bare token as the IMAGE PATH, resolves it against the "
+        f"launch directory, and fails with a message that names a path "
+        f"nobody wrote:\n"
+        f"    FATAL: ... could not open image <workdir>/{token}\n"
+        f"\n"
+        f"FIX: insert `--env` immediately before it, i.e.\n"
+        f"    - --env\n"
+        f"    - {token}\n"
+        f"\n"
+        f"(If {key} was NOT meant as an environment variable, remove it: "
+        f"raw_args must contain no positionals at all — sac supplies the "
+        f"image and the inner command itself.)"
+    )
+
+
 __all__ = [
     "ApptainerArgvError",
     "VALUE_TAKING_FLAGS",
     "find_missing_value",
+    "find_stray_env_pair",
     "validate_flag_argv",
+    "validate_raw_args",
 ]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard_stray_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard_stray_env.py
@@ -154,11 +154,21 @@ def test_a_none_raw_args_is_silent():
 
 
 def test_validate_raises_on_the_incident_shape():
-    # Arrange — the callable the CLI and the launch path use.
+    # Arrange — the callable the CLI and the launch path use. Bound as a
+    # closure so Act and Assert stay separable: STX-TQ002 wants each marker
+    # on its own line, and a raises-block wrapped directly around the call
+    # fuses the two. Same shape the repo already uses in
+    # tests/_jobs/test__names.py.
     raw_args = INCIDENT
-    # Act / Assert
+
+    def _call():
+        return validate_raw_args(raw_args)
+
+    # Act
+    call = _call
+    # Assert
     with pytest.raises(ApptainerArgvError):
-        validate_raw_args(raw_args)
+        call()
 
 
 def test_validate_is_a_no_op_on_the_repaired_shape():

--- a/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard_stray_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard_stray_env.py
@@ -66,6 +66,18 @@ REPAIRED = [
 ]
 
 
+def _message_for(raw_args, **kw) -> str:
+    """The refusal text for ``raw_args``. Fails loudly if it does NOT refuse.
+
+    Exists because STX-TQ007 counts a ``pytest.raises`` block as an assertion,
+    so a test that raises and then inspects the message would carry two. The
+    raise belongs here; what the message SAYS is what each test asserts.
+    """
+    with pytest.raises(ApptainerArgvError) as excinfo:
+        validate_raw_args(raw_args, **kw)
+    return str(excinfo.value)
+
+
 def test_the_incident_shape_is_detected():
     # Arrange — THE REGRESSION.
     raw_args = INCIDENT
@@ -163,9 +175,7 @@ def test_the_message_shows_the_exact_two_yaml_lines_to_write():
     # lines, not a rule to apply.
     raw_args = INCIDENT
     # Act
-    with pytest.raises(ApptainerArgvError) as excinfo:
-        validate_raw_args(raw_args)
-    message = str(excinfo.value)
+    message = _message_for(raw_args)
     # Assert
     assert "- --env\n    - SCITEX_CARDS_AGENT_ID=business" in message
 
@@ -175,9 +185,7 @@ def test_the_message_explains_what_apptainer_does_with_it():
     # wrote. Say what actually happens, or the reader chases the path.
     raw_args = INCIDENT
     # Act
-    with pytest.raises(ApptainerArgvError) as excinfo:
-        validate_raw_args(raw_args)
-    message = str(excinfo.value)
+    message = _message_for(raw_args)
     # Assert
     assert "IMAGE PATH" in message
 
@@ -187,8 +195,6 @@ def test_the_message_names_the_agent_when_it_is_known():
     # opened the wrong spec because the message never named the file.
     raw_args = INCIDENT
     # Act
-    with pytest.raises(ApptainerArgvError) as excinfo:
-        validate_raw_args(raw_args, agent="business")
-    message = str(excinfo.value)
+    message = _message_for(raw_args, agent="business")
     # Assert
     assert "'business'" in message

--- a/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard_stray_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard_stray_env.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""An env pair with no ``--env`` is a POSITIONAL, and apptainer calls it the image.
+
+2026-08-18 incident. A bulk edit added the new board-identity variable to ~100
+specs' ``raw_args`` and inserted only the VALUE, without the ``- --env`` that
+has to precede it::
+
+    - --env
+    - SCITEX_TODO_AGENT_ID=business
+    - SCITEX_CARDS_AGENT_ID=business      <- positional, in flag position
+
+apptainer resolved that bare token against the launch directory and reported::
+
+    FATAL: While checking container encryption: could not open image
+      /home/ywatanabe/proj/business/SCITEX_CARDS_AGENT_ID=business
+
+The message names an image nobody wrote, blames encryption, and never mentions
+the missing flag. ``sac agents check`` had answered "Ready to deploy" on that
+spec minutes earlier, because it validated ``raw_args`` as YAML and as a schema
+and never as an apptainer argv.
+
+WHY THE SIBLING GUARD CANNOT CATCH IT: :func:`validate_flag_argv` inspects
+``_flag_region(argv)``, which by construction STOPS at the first positional. The
+stray token does not break the flag region — it ENDS it. One guard finds a flag
+with no value; this one finds a value with no flag.
+
+WHY THE MATCH IS NARROW, and why that is the point: the detector fires only on
+UPPER_SNAKE ``KEY=`` tokens. Value-shaped tokens legitimately follow flags this
+module does not track (``--network-args portmap=8080:tcp``, ``--security
+uid:1000``), and a broader rule would refuse launches it merely failed to
+recognise — the failure mode this module's own doctrine forbids. Both of those
+shapes are pinned below, so a later broadening trips a test.
+
+Measured before shipping: across 117 live specs on compute-04, 103 declare
+``raw_args`` and the detector flags NONE of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.runtimes._apptainer_argv_guard import (
+    ApptainerArgvError,
+    find_stray_env_pair,
+    validate_raw_args,
+)
+
+#: The exact shape that took the agent down, reproduced verbatim.
+INCIDENT = [
+    "--env",
+    "SCITEX_TODO_AGENT_ID=business",
+    "SCITEX_CARDS_AGENT_ID=business",
+    "--env",
+    "SCITEX_AGENT_CONTAINER_STATE_DB=/state/business/state.db",
+]
+
+#: The same spec after the missing flag is restored.
+REPAIRED = [
+    "--env",
+    "SCITEX_TODO_AGENT_ID=business",
+    "--env",
+    "SCITEX_CARDS_AGENT_ID=business",
+    "--env",
+    "SCITEX_AGENT_CONTAINER_STATE_DB=/state/business/state.db",
+]
+
+
+def test_the_incident_shape_is_detected():
+    # Arrange — THE REGRESSION.
+    raw_args = INCIDENT
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is not None
+
+
+def test_the_detector_names_the_offending_token():
+    # Arrange — a guard that says "something is wrong" makes the reader
+    # re-derive what. Name the token.
+    raw_args = INCIDENT
+    # Act
+    _, token = find_stray_env_pair(raw_args)
+    # Assert
+    assert token == "SCITEX_CARDS_AGENT_ID=business"
+
+
+def test_the_detector_names_the_index_so_the_line_is_findable():
+    # Arrange — raw_args is a YAML list; the index IS the line to open.
+    raw_args = INCIDENT
+    # Act
+    index, _ = find_stray_env_pair(raw_args)
+    # Assert
+    assert index == 2
+
+
+def test_the_repaired_spec_is_silent():
+    # Arrange — POSITIVE CONTROL for every negative below: the detector
+    # must go quiet once the flag is restored, or "silent" proves nothing.
+    raw_args = REPAIRED
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is None
+
+
+@pytest.mark.parametrize(
+    "raw_args",
+    [
+        pytest.param(["--network-args", "portmap=8080:tcp"], id="network-args-value"),
+        pytest.param(["--security", "uid:1000"], id="security-value"),
+        pytest.param(["--app", "myapp"], id="app-value"),
+        pytest.param(["--hostname", "box=1"], id="hostname-value-with-equals"),
+    ],
+)
+def test_no_false_positive_on_values_of_untracked_flags(raw_args):
+    # Arrange — VALUE_TAKING_FLAGS is a deliberate SUBSET, so values of
+    # flags outside it look like positionals. Refusing those would block
+    # launches the guard merely failed to recognise.
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is None
+
+
+def test_an_empty_raw_args_is_silent():
+    # Arrange — most specs declare none at all.
+    raw_args = []
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is None
+
+
+def test_a_none_raw_args_is_silent():
+    # Arrange — the field is optional; absent must not be an error.
+    raw_args = None
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is None
+
+
+def test_validate_raises_on_the_incident_shape():
+    # Arrange — the callable the CLI and the launch path use.
+    raw_args = INCIDENT
+    # Act / Assert
+    with pytest.raises(ApptainerArgvError):
+        validate_raw_args(raw_args)
+
+
+def test_validate_is_a_no_op_on_the_repaired_shape():
+    # Arrange — POSITIVE CONTROL for the raise above.
+    raw_args = REPAIRED
+    # Act
+    result = validate_raw_args(raw_args)
+    # Assert
+    assert result is None
+
+
+def test_the_message_shows_the_exact_two_yaml_lines_to_write():
+    # Arrange — the operator is looking at a YAML list. Hand them the
+    # lines, not a rule to apply.
+    raw_args = INCIDENT
+    # Act
+    with pytest.raises(ApptainerArgvError) as excinfo:
+        validate_raw_args(raw_args)
+    message = str(excinfo.value)
+    # Assert
+    assert "- --env\n    - SCITEX_CARDS_AGENT_ID=business" in message
+
+
+def test_the_message_explains_what_apptainer_does_with_it():
+    # Arrange — the real FATAL blames encryption and names a path nobody
+    # wrote. Say what actually happens, or the reader chases the path.
+    raw_args = INCIDENT
+    # Act
+    with pytest.raises(ApptainerArgvError) as excinfo:
+        validate_raw_args(raw_args)
+    message = str(excinfo.value)
+    # Assert
+    assert "IMAGE PATH" in message
+
+
+def test_the_message_names_the_agent_when_it_is_known():
+    # Arrange — the sibling guard's own documented lesson: an operator
+    # opened the wrong spec because the message never named the file.
+    raw_args = INCIDENT
+    # Act
+    with pytest.raises(ApptainerArgvError) as excinfo:
+        validate_raw_args(raw_args, agent="business")
+    message = str(excinfo.value)
+    # Assert
+    assert "'business'" in message


### PR DESCRIPTION
## What happened

`sac agents check business` answered **"Ready to deploy"** minutes before that agent failed to start. The spec was valid YAML and valid against the schema. It was not a valid apptainer argv:

```yaml
- --env
- SCITEX_TODO_AGENT_ID=business
- SCITEX_CARDS_AGENT_ID=business      # <- positional, in flag position
```

apptainer reads the first bare token as the **image path**, resolved against the launch directory, so the operator got:

```
FATAL: While checking container encryption: could not open image
  /home/ywatanabe/proj/business/SCITEX_CARDS_AGENT_ID=business
```

— an image nobody wrote, blamed on encryption, with no mention of the missing flag.

Cause and fleet-wide repair belong to **dotfiles** (a bulk edit that inserted the value without its `- --env`; 88 specs fixed, their PR #331). This PR is the half that makes the class visible at check time instead of at FATAL time.

## Why the existing guard cannot see it

`validate_flag_argv` inspects `_flag_region(argv)`, which **by construction stops at the first positional**. The stray token does not *break* the flag region — it *ends* it, and everything after is read as the container's business.

One guard finds **a flag with no value**. This one finds **a value with no flag**. Complementary, not redundant.

## The match is deliberately narrow

It fires only on `UPPER_SNAKE KEY=` tokens not consumed by a flag in `VALUE_TAKING_FLAGS`. That set is a deliberate subset, so values of flags outside it look like positionals — all of these are pinned as **non**-findings:

```
--network-args portmap=8080:tcp
--security uid:1000
--app myapp
--hostname box=1
```

Broadening the rule would trade a real catch for refusing launches the guard merely failed to recognise, which is the failure mode this module's own docstring forbids.

## Measured before shipping

On the **host** — the first attempt ran inside my container, where the glob matched nothing and reported a meaningless zero, so the re-run carries a positive control:

```
spec files visible from this vantage: 117
specs with raw_args scanned:          103
flagged by the new guard:               0
detector fires on the incident shape: (2, 'SCITEX_CARDS_AGENT_ID=business')
detector is silent on the fixed shape: None
```

Zero findings across the live fleet is why this **fails** the preflight rather than warning — and it is not a matter of taste later: a positional in `raw_args` cannot start the agent at all.

## Tests

15 new, covering: the incident shape detected; the token named; the **index** named (raw_args is a YAML list, so the index is the line to open); silence on the repaired shape as the positive control for every negative; the four false-positive shapes above; `None`/empty input; the raising wrapper; and three assertions on the message itself — that it shows the exact two YAML lines, says what apptainer does with the token, and names the agent (the sibling guard's own documented lesson: an operator once opened the wrong spec because the message never named the file).

`1964 passed` across `tests/runtimes/` + `test_build_cmds.py`.