### PR TITLE
fix(migrate): verify the job it migrated, and fail when a rename disarms it

### DIFF
--- a/src/scitex_agent_container/_jobs/_migrate/_verify.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_verify.py
@@ -1,11 +1,53 @@
-"""EXACTLY ONE SUPERVISOR — the claim the migration exists to make good on.
+"""EXACTLY ONE SUPERVISOR, AND IT IS ACTUALLY SUPERVISING.
 
-"The new unit exists" is not the claim. "ONLY the new unit exists" is.
-A migration that installed the new name and left the old one behind would
-report success while doubling the supervision of the fleet's credential
-machinery, which is the precise failure this whole change is written to
-prevent. So verification counts BOTH names and treats any survivor of the
-old one as a failure, however healthy the new one looks.
+"The new unit exists" is not the claim. "ONLY the new unit exists" is not the
+whole claim either. A migration that installed the new name and left the old one
+behind would report success while doubling the supervision of the fleet's
+credential machinery, which is the precise failure this whole change is written
+to prevent. So verification counts BOTH names and treats any survivor of the old
+one as a failure, however healthy the new one looks.
+
+WHY ARMING IS PART OF THE CLAIM (measured 2026-08-19, on the real cutover)
+=========================================================================
+``sac dev migrate-job-names --only accounts-refresh --include-held --yes`` ran
+all ten steps green on scitex-compute-04 and left the fleet's OAuth refresher
+**installed and disabled**::
+
+    scitex-agent-container-accounts-keepalive.timer   enabled   enabled
+    scitex-agent-container-accounts-refresh.timer     disabled  enabled
+
+The old timer had been ``enabled`` and firing; the new one was not enabled at
+all and did not appear in ``list-timers``. For the window between the two, the
+sole-refresher host had NO refresher — and the verification pass said nothing,
+because counting unit FILES cannot see it. Zero active supervisors satisfies
+"not two supervisors" perfectly.
+
+That is §2's *a gate that cannot fail is not a gate*: the check ran, on time, in
+writing, and could not have caught the one outcome that mattered. The rule that
+does catch it is the definition of a correct rename:
+
+    **A RENAME MUST PRESERVE ARMING.** If the old unit was enabled before the
+    cutover, the new unit must be enabled after it. If it was disabled, it stays
+    disabled.
+
+Stated that way it needs no policy input and no allow-list. It reads the host's
+own pre-state as the expectation, which is why it flags accounts-refresh (old
+was enabled) and stays silent about heal-agent-auth (old was deliberately
+disabled — it is mutually exclusive with restart-login-expired-agents, and
+"enable exactly one" is its own unit description's instruction). A guard that
+demanded "every timer must be enabled" would have been wrong about the second
+one, and being wrong about a deliberate disablement is how a guard teaches
+people to ignore it.
+
+ARMING IS THREE-VALUED, and collapsing it is the bug §2 warns about
+===================================================================
+A host may not be readable, or a caller may not have measured enablement at all.
+"I could not tell" must not render as "armed correctly" — that is exactly the
+unknown-collapsed-into-a-pole failure — and it must not render as a FAILURE
+either, or every caller that does not measure starts reporting false alarms.
+So ``armed_ok`` is ``True`` / ``False`` / ``None``, and ``None`` prints as NOT
+CHECKED. ``ok`` keeps its original, narrower meaning — the installation claim —
+so a caller that never looked at arming behaves exactly as before.
 """
 
 from __future__ import annotations
@@ -17,25 +59,51 @@ from typing import Callable, Iterable
 from ._renames import Rename
 
 
+def _suffix(unit: str, name: str) -> str:
+    """The ``.service``/``.timer`` tail of ``unit`` under job ``name``."""
+    return unit[len(name) :] if unit.startswith(name) else unit
+
+
 @dataclass(frozen=True)
 class Supervisors:
-    """What is supervising one job after its cutover."""
+    """What is supervising one job after its cutover, and whether it is armed."""
 
     job: str
     expected: tuple[str, ...]
     found_new: tuple[str, ...]
     found_old: tuple[str, ...]
+    #: New units that MUST be armed, because their old counterpart was.
+    should_be_armed: tuple[str, ...] = ()
+    #: New units observed armed. ``None`` means enablement was never measured.
+    found_armed: tuple[str, ...] | None = None
 
     @property
     def ok(self) -> bool:
-        """True only when the new set is complete and NOTHING old survives."""
+        """True only when the new set is complete and NOTHING old survives.
+
+        Deliberately unchanged: this is the INSTALLATION claim. Arming is a
+        separate signal so that a caller which never measured it is not
+        silently told its migration passed a check it did not run.
+        """
         return not self.found_old and set(self.found_new) == set(self.expected)
+
+    @property
+    def unarmed(self) -> tuple[str, ...]:
+        """Units that were armed before the cutover and are not armed now."""
+        if self.found_armed is None:
+            return ()
+        return tuple(u for u in self.should_be_armed if u not in self.found_armed)
+
+    @property
+    def armed_ok(self) -> bool | None:
+        """True / False / ``None`` when enablement was not measured."""
+        if self.found_armed is None:
+            return None
+        return not self.unarmed
 
     @property
     def verdict(self) -> str:
         """One line an operator can act on, naming what was actually found."""
-        if self.ok:
-            return f"OK   {self.job}: exactly one supervisor {list(self.found_new)}"
         if self.found_old and self.found_new:
             return (
                 f"FAIL {self.job}: TWO SUPERVISORS — old {list(self.found_old)} "
@@ -46,18 +114,68 @@ class Supervisors:
                 f"FAIL {self.job}: still on the OLD name {list(self.found_old)}; "
                 "the cutover did not happen"
             )
-        missing = sorted(set(self.expected) - set(self.found_new))
-        return f"FAIL {self.job}: NO supervisor — missing {missing}"
+        if not self.ok:
+            missing = sorted(set(self.expected) - set(self.found_new))
+            return f"FAIL {self.job}: NO supervisor — missing {missing}"
+        if self.armed_ok is False:
+            units = list(self.unarmed)
+            return (
+                f"FAIL {self.job}: INSTALLED BUT NOT ARMED — {units} "
+                "was enabled before the cutover and is not now, so this job is "
+                "supervised by nothing. Fix: systemctl --user enable --now "
+                + " ".join(units)
+            )
+        if self.armed_ok is None:
+            return (
+                f"OK   {self.job}: exactly one supervisor {list(self.found_new)} "
+                "(arming NOT CHECKED — caller measured no enablement)"
+            )
+        return (
+            f"OK   {self.job}: exactly one supervisor {list(self.found_new)}, armed"
+        )
 
 
-def verify_exactly_one(rename: Rename, *, present: Iterable[str]) -> Supervisors:
-    """Count the supervisors for one job against the host's unit files."""
+def verify_exactly_one(
+    rename: Rename,
+    *,
+    present: Iterable[str],
+    armed_before: Iterable[str] | None = None,
+    armed_now: Iterable[str] | None = None,
+) -> Supervisors:
+    """Count the supervisors for one job, and check the rename preserved arming.
+
+    ``armed_before`` is the set of enabled units observed BEFORE the plan ran —
+    it has to be captured then, because the plan's own ``disable`` step destroys
+    the evidence. Passing neither set leaves arming unmeasured (``None``) rather
+    than assumed.
+    """
     on_host = frozenset(present)
+    new_units = rename.new_units()
+
+    if armed_before is None or armed_now is None:
+        should: tuple[str, ...] = ()
+        found_armed: tuple[str, ...] | None = None
+    else:
+        was = frozenset(armed_before)
+        now = frozenset(armed_now)
+        # Map old -> new by unit SUFFIX rather than by position, so the pairing
+        # survives any future change to KIND_UNIT_SUFFIXES' ordering. This is
+        # also what keeps the rule honest for a timer job: only the .timer is
+        # ever enabled (the .service is static), so only the .timer can appear
+        # here — the data decides, not a hardcoded suffix.
+        armed_suffixes = {
+            _suffix(u, rename.old) for u in rename.old_units() if u in was
+        }
+        should = tuple(u for u in new_units if _suffix(u, rename.new) in armed_suffixes)
+        found_armed = tuple(u for u in new_units if u in now)
+
     return Supervisors(
         job=rename.new,
-        expected=rename.new_units(),
-        found_new=tuple(u for u in rename.new_units() if u in on_host),
+        expected=new_units,
+        found_new=tuple(u for u in new_units if u in on_host),
         found_old=tuple(u for u in rename.old_units() if u in on_host),
+        should_be_armed=should,
+        found_armed=found_armed,
     )
 
 

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
@@ -68,6 +68,27 @@ def _measure(unit_dir: Path) -> tuple[frozenset[str], frozenset[str]]:
     return frozenset(files), frozenset(dirs)
 
 
+def _measure_armed(unit_dir: Path) -> frozenset[str]:
+    """Which units are ARMED — i.e. enabled to fire.
+
+    Read from the same directory as :func:`_measure`, not from ``systemctl``,
+    for two reasons. It honours ``--unit-dir`` (so this is testable without a
+    live systemd), and enablement genuinely IS a filesystem fact: ``systemctl
+    --user enable`` creates a symlink under ``<target>.wants/`` and says so —
+
+        Created symlink .../timers.target.wants/foo.timer -> .../foo.timer
+
+    so the ``.wants`` entries are the enablement, not a proxy for it.
+    """
+    if not unit_dir.is_dir():
+        return frozenset()
+    armed: set[str] = set()
+    for child in unit_dir.iterdir():
+        if child.is_dir() and child.name.endswith(".wants"):
+            armed.update(entry.name for entry in child.iterdir())
+    return frozenset(armed)
+
+
 def _displace_dir(unit_dir: Path, stamp: str) -> Path:
     """``.old/<timestamp>/`` beside the units. NOTHING is ever deleted."""
     return unit_dir / ".old" / stamp
@@ -240,6 +261,10 @@ def register_migrate_command(dev_group: click.Group) -> None:
 
         renames = _select(tuple(only), include_held)
         present, dropins = _measure(directory)
+        # Captured BEFORE the plan runs, because the plan's own `disable` step
+        # destroys the evidence. Without this, "was it armed before?" becomes
+        # unanswerable the moment the migration starts.
+        armed_before = _measure_armed(directory)
         steps = _migrate.plan(
             renames,
             present=present,
@@ -284,14 +309,25 @@ def register_migrate_command(dev_group: click.Group) -> None:
         )
 
         after, _ = _measure(directory)
-        click.echo("\nVerification (exactly one supervisor per job):")
+        armed_now = _measure_armed(directory)
+        click.echo("\nVerification (exactly one supervisor per job, and armed):")
         bad = 0
         for rename in renames:
-            if rename.held:
-                continue
-            result = _migrate.verify_exactly_one(rename, present=after)
+            # NOT skipped when `rename.held`. `_select` has ALREADY decided what
+            # this invocation acts on — a held job is only in `renames` because
+            # --include-held asked for it — so re-testing `held` here silently
+            # undid the caller's decision and verified NOTHING for the one job
+            # being migrated. Measured 2026-08-19: the accounts-refresh cutover
+            # printed the "Verification" header with nothing beneath it, which
+            # reads as "nothing to report" and meant "nothing was checked".
+            result = _migrate.verify_exactly_one(
+                rename,
+                present=after,
+                armed_before=armed_before,
+                armed_now=armed_now,
+            )
             click.echo("  " + result.verdict)
-            if not result.ok:
+            if not result.ok or result.armed_ok is False:
                 bad += 1
 
         if failed:

--- a/tests/scitex_agent_container/_jobs/_migrate/test__verify.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__verify.py
@@ -145,3 +145,119 @@ def test_a_host_without_systemctl_cannot_supervise_units() -> None:
     got = _verify.systemd_user_available(which=which)
     # Assert
     assert got is False
+
+
+# ---------------------------------------------------------------------------
+# ARMING — a rename must preserve it
+#
+# Measured 2026-08-19 on the real accounts-refresh cutover: every step ran
+# green and left the fleet's sole OAuth refresher INSTALLED AND DISABLED. Unit
+# files were counted; enablement was not. Zero active supervisors satisfies
+# "not two supervisors" perfectly, so the check could not have caught the one
+# outcome that mattered.
+# ---------------------------------------------------------------------------
+
+#: Only the .timer is ever enabled — a timer job's .service is `static`.
+ARMED_OLD = frozenset({WORKTREE_GC.old + ".timer"})
+ARMED_NEW = frozenset({WORKTREE_GC.new + ".timer"})
+NOTHING_ARMED: frozenset[str] = frozenset()
+
+
+def test_a_rename_that_disarms_the_job_is_not_armed_ok() -> None:
+    # Arrange — THE incident: armed before, installed disabled after.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=ARMED_OLD,
+        armed_now=NOTHING_ARMED,
+    ).armed_ok
+    # Assert
+    assert got is False
+
+
+def test_the_installation_claim_alone_cannot_see_a_disarmed_rename() -> None:
+    # Arrange — the regression documented: this is the OLD check's verdict on
+    # the incident. It passes, which is exactly why arming needed its own
+    # signal rather than being folded into `ok`.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=ARMED_OLD,
+        armed_now=NOTHING_ARMED,
+    ).ok
+    # Assert
+    assert got is True
+
+
+def test_a_deliberately_disabled_job_stays_a_non_finding() -> None:
+    # Arrange — heal-agent-auth's shape: disabled BEFORE the cutover on
+    # purpose (it is mutually exclusive with restart-login-expired-agents,
+    # "enable exactly one"). A guard demanding every timer be enabled would
+    # cry wolf here, and a guard that cries wolf gets ignored.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=NOTHING_ARMED,
+        armed_now=NOTHING_ARMED,
+    ).armed_ok
+    # Assert
+    assert got is True
+
+
+def test_arming_preserved_across_the_rename_is_armed_ok() -> None:
+    # Arrange — the correct cutover.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=ARMED_OLD,
+        armed_now=ARMED_NEW,
+    ).armed_ok
+    # Assert
+    assert got is True
+
+
+def test_unmeasured_arming_is_unknown_not_a_pass() -> None:
+    # Arrange — a caller that never looked. Collapsing this into True is the
+    # unknown-into-a-pole bug; collapsing it into False makes every such
+    # caller report a false alarm.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(WORKTREE_GC, present=present).armed_ok
+    # Assert
+    assert got is None
+
+
+def test_the_unarmed_verdict_carries_the_command_that_fixes_it() -> None:
+    # Arrange — an operator reading "FAIL" must not have to re-derive the fix.
+    # Asserting on the UNIT NAME would be vacuous: every verdict lists the new
+    # units, so such a test passes even when the unarmed branch is dead. A
+    # sabotage control caught exactly that, so this asserts on something only
+    # the unarmed branch emits.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    verdict = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=ARMED_OLD,
+        armed_now=NOTHING_ARMED,
+    ).verdict
+    # Assert
+    assert "systemctl --user enable --now" in verdict
+
+
+def test_the_unmeasured_verdict_says_arming_was_not_checked() -> None:
+    # Arrange — an OK line that silently omits an unrun check is how a
+    # migration gets believed for a property nobody verified.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    verdict = _verify.verify_exactly_one(WORKTREE_GC, present=present).verdict
+    # Assert
+    assert "NOT CHECKED" in verdict


### PR DESCRIPTION
## What happened

The PS-226 cutover ran on scitex-compute-04 today. All ten steps reported `ok`, and it left the fleet's **sole OAuth refresher installed and disabled**:

```
scitex-agent-container-accounts-keepalive.timer   enabled    enabled
scitex-agent-container-accounts-refresh.timer     disabled   enabled
```

For the window between the old timer being stopped and me noticing, that host had no refresher at all. The verification pass said nothing about it.

## Two defects, and both had to be true for it to stay silent

**1. It verified nothing at all.** The loop skipped `if rename.held: continue` — but a held job is only in `renames` because `--include-held` asked for it. `_select()` already applies exactly that rule:

```python
if rename.held and not (include_held and only):
    continue
```

So re-testing `held` in the verify loop silently undid the caller's own decision, and the one job being migrated was excluded from its own verification. The pass printed the `Verification` header with nothing beneath it — which reads as "nothing to report" and meant "nothing was checked".

**2. Counting unit files cannot see arming.** `verify_exactly_one` compared filename sets. Zero active supervisors satisfies "not two supervisors" perfectly, so the check could not have caught the one outcome that mattered.

## The rule

> **A rename must preserve arming.** If the old unit was enabled before the cutover, the new unit must be enabled after it. If it was disabled, it stays disabled.

Stated that way it needs no policy input and no allow-list — it reads the host's own pre-state as the expectation. That is what makes it correct on **both** live cases:

| job | old state | new state | verdict |
|---|---|---|---|
| `accounts-refresh` | enabled | disabled | **FAIL** — the incident |
| `heal-agent-auth` | disabled | disabled | OK — deliberate, it is mutually exclusive with `restart-login-expired-agents` ("enable exactly one", per its own unit description) |

A guard demanding "every timer must be enabled" would have been wrong about the second, and a guard that cries wolf gets ignored.

## Design notes

- **Arming is three-valued.** A caller that never measured enablement gets `armed_ok is None` and an `arming NOT CHECKED` verdict — never a silent pass. `ok` keeps its original narrower meaning (the installation claim), so existing callers are unchanged.
- **Enablement is read as a filesystem fact** — a symlink under `<target>.wants/`, which is precisely what `systemctl enable` creates and says it creates. So it honours the `--unit-dir` test seam and needs no subprocess.
- **Captured before the plan runs**, because the plan's own `disable` step destroys the evidence.
- The old→new unit pairing is by **suffix**, not position, so it survives any reordering of `KIND_UNIT_SUFFIXES`. That also keeps it honest for timer jobs: only the `.timer` is ever enabled (the `.service` is `static`), so only the `.timer` can appear — the data decides rather than a hardcoded rule.

## Tests

7 new, and a positive control earns them: sabotaging `armed_ok` to always-`True` turns **3 of them red**.

That control also caught one of my own tests passing for the wrong reason — it asserted on a unit name that appears in *every* verdict, so it was green whether or not the unarmed branch worked. It now asserts on the fix command, which only that branch emits.

```
126 passed  tests/scitex_agent_container/_jobs/_migrate/
3301 passed  _migrate + cli_pkg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA7NSZViCFRyftkU7bBzxH
