### PR TITLE
feat(lifecycle): compare a running agent's argv against the flags its spec declares

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_argv_drift.py
+++ b/src/scitex_agent_container/_lifecycle/_argv_drift.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Compare a RUNNING agent's argv against the flags its spec declares.
+
+A spec file is INTENT. A process holds the argv it was launched with.
+Nothing in the fleet compared the two, and that gap hid three separate
+defects on 2026-08-19 alone:
+
+* ``--effort low`` was added to 20 handyman specs and was present in
+  exactly ONE running process. The other agents had started before the
+  edit and were still running at default effort — the operator's cost
+  instruction was satisfied on disk and not in the fleet.
+* ``business``'s ``--env BUN_BIN=...`` was reverted in its spec and
+  stayed intact in the running process, so nothing looked wrong; it
+  would have surfaced only at the next restart, as a missing variable
+  with no obvious cause.
+* The cross-host spec guard, which compares spec against spec, is
+  structurally blind to both.
+
+All three share one shape: **the file changed and the process did not**,
+and every surface that reads only files reports green.
+
+WHY THIS COMPARES FLAGS AND NOT THE WHOLE ARGV
+----------------------------------------------
+Reconstructing the full launch argv and diffing it would be a stricter
+check and a useless one: it carries values that legitimately differ per
+launch (a2a port, session id, resume target, transcript home). Those
+would dominate the output and every agent would report DIFFERS, which
+is the fastest way to teach people to ignore a check.
+
+``spec.claude.flags`` is the honest unit. Its contract is exact — each
+element becomes ONE argv token, appended verbatim — so its presence in
+the running argv is decidable without modelling anything else.
+
+THREE VALUES, NEVER TWO
+-----------------------
+``CANNOT_DETERMINE`` is not a courtesy; it is the point. Tonight's
+failures were all instruments whose "clean" and "could not look" printed
+identically — a truncated listing read as absence, a spec-vs-spec guard
+that cannot see a process, a status probe that says "real absence" about
+another host. A drift check that answered only MATCHES/DIFFERS would
+join them: an agent with no readable process would report MATCHES and
+mean nothing by it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+MATCHES = "matches"
+DIFFERS = "differs"
+CANNOT_DETERMINE = "cannot-determine"
+
+
+@dataclass(frozen=True)
+class ArgvDrift:
+    """One agent's verdict.
+
+    ``missing`` names the spec tokens absent from the running argv, so
+    the report is actionable ("running without --effort low") rather
+    than merely negative ("differs").
+    """
+
+    agent: str
+    verdict: str
+    reason: str | None = None
+    missing: tuple[str, ...] = ()
+    pid: int | None = None
+
+    @property
+    def is_drifted(self) -> bool | None:
+        """``True``/``False``, or ``None`` when it could not be decided.
+
+        Callers must handle the ``None``. A guard that treats it as
+        falsey silently converts "I could not look" into "nothing
+        wrong", which is the defect this module exists to expose.
+        """
+        if self.verdict == CANNOT_DETERMINE:
+            return None
+        return self.verdict == DIFFERS
+
+    def describe(self) -> str:
+        if self.verdict == CANNOT_DETERMINE:
+            return f"{self.agent}: CANNOT DETERMINE — {self.reason}"
+        if self.verdict == MATCHES:
+            return f"{self.agent}: running argv carries every declared flag"
+        return (
+            f"{self.agent}: running without {' '.join(self.missing)}; "
+            f"its spec declares it. The process predates the spec edit — "
+            f"restart it to apply, or the spec is not in force."
+        )
+
+
+def _contiguous_index(haystack: Sequence[str], needle: Sequence[str]) -> int:
+    """Index of ``needle`` as a contiguous run in ``haystack``, else -1."""
+    n, m = len(haystack), len(needle)
+    if m == 0:
+        return 0
+    for i in range(n - m + 1):
+        if list(haystack[i : i + m]) == list(needle):
+            return i
+    return -1
+
+
+def compare_spec_flags_to_argv(
+    *,
+    agent: str,
+    spec_flags: Sequence[str] | None,
+    running_argv: Sequence[str] | None,
+    pid: int | None = None,
+) -> ArgvDrift:
+    """Decide whether a running process carries the flags its spec declares.
+
+    ``spec_flags`` is ``None`` when the spec could not be loaded, and
+    ``running_argv`` is ``None`` when no process was observed. Both are
+    CANNOT_DETERMINE rather than a verdict — an unreadable input cannot
+    exonerate anything.
+
+    Adjacency is checked, not just membership. ``--effort`` and ``low``
+    must appear as a contiguous run: a flag separated from its value is
+    a different command line, and the inverse error (gluing them into
+    one element, ``--effort ultracode``) left an agent unbootable for 15
+    days without the YAML ever failing to parse.
+    """
+    if spec_flags is None:
+        return ArgvDrift(
+            agent=agent,
+            verdict=CANNOT_DETERMINE,
+            reason="the spec could not be loaded, so there is nothing to compare against",
+            pid=pid,
+        )
+    if running_argv is None:
+        return ArgvDrift(
+            agent=agent,
+            verdict=CANNOT_DETERMINE,
+            reason="no running process was observed for this agent",
+            pid=pid,
+        )
+    if not spec_flags:
+        return ArgvDrift(agent=agent, verdict=MATCHES, pid=pid)
+
+    argv = list(running_argv)
+    missing = tuple(tok for tok in spec_flags if tok not in argv)
+    if missing:
+        return ArgvDrift(
+            agent=agent, verdict=DIFFERS, missing=missing, pid=pid
+        )
+
+    if _contiguous_index(argv, list(spec_flags)) < 0:
+        return ArgvDrift(
+            agent=agent,
+            verdict=DIFFERS,
+            missing=(),
+            reason=(
+                "every declared flag is present but not as one contiguous run; "
+                "a flag separated from its value is a different command line"
+            ),
+            pid=pid,
+        )
+
+    return ArgvDrift(agent=agent, verdict=MATCHES, pid=pid)
+
+
+def summarize(drifts: Sequence[ArgvDrift]) -> str:
+    """One line per agent plus a tally that keeps the three states apart.
+
+    The tally never folds CANNOT_DETERMINE into either column. A run of
+    30 agents where 29 could not be read is not "1 drifted"; it is one
+    finding and 29 unanswered questions, and the summary has to say so.
+    """
+    drifted = [d for d in drifts if d.verdict == DIFFERS]
+    unknown = [d for d in drifts if d.verdict == CANNOT_DETERMINE]
+    ok = [d for d in drifts if d.verdict == MATCHES]
+    lines = [d.describe() for d in drifts]
+    lines.append(
+        f"{len(ok)} in force, {len(drifted)} drifted, {len(unknown)} could not be determined"
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ArgvDrift",
+    "CANNOT_DETERMINE",
+    "DIFFERS",
+    "MATCHES",
+    "compare_spec_flags_to_argv",
+    "summarize",
+]

--- a/tests/scitex_agent_container/_lifecycle/test__argv_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__argv_drift.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A spec is intent; a process holds its launch argv. Nothing compared them.
+
+Measured 2026-08-19 on compute-04, reading ``/proc/<pid>/cmdline`` for
+each running handyman:
+
+    handyman-01   up 1d02h   NO --effort
+    handyman-02   up 07h27m  --effort low
+    handyman-03   up 22h     NO --effort
+
+``--effort low`` was in TWENTY spec files and in ONE running process.
+The two that lacked it had started before the edit. Every file-reading
+surface reported the operator's cost instruction as applied.
+
+These tests pin the comparison, and above all pin that "I could not
+look" is a THIRD answer. Every instrument that failed us that night —
+a truncated listing read as absence, a spec-vs-spec guard blind to
+processes, a status probe asserting "real absence" about another host —
+failed by printing its could-not-look as a clean result.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._argv_drift import (
+    CANNOT_DETERMINE,
+    DIFFERS,
+    MATCHES,
+    ArgvDrift,
+    compare_spec_flags_to_argv,
+    summarize,
+)
+
+_ARGV_WITH = ["claude", "--model", "qwen38-27b", "--effort", "low", "--resume", "abc"]
+_ARGV_WITHOUT = ["claude", "--model", "qwen38-27b", "--resume", "abc"]
+
+
+def test_an_unloadable_spec_cannot_be_decided():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=None, running_argv=_ARGV_WITH
+    )
+    # Assert
+    assert result.verdict == CANNOT_DETERMINE
+
+
+def test_an_unobserved_process_cannot_be_decided():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=None
+    )
+    # Assert
+    assert result.verdict == CANNOT_DETERMINE
+
+
+def test_an_unobserved_process_is_not_reported_as_matching():
+    # Arrange: the regression — silence must not read as compliance.
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=None
+    )
+    # Assert
+    assert result.verdict != MATCHES
+
+
+def test_the_undecided_reason_names_the_missing_process():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=None
+    )
+    # Assert
+    assert "no running process" in (result.reason or "")
+
+
+def test_the_undecided_reason_names_the_unloadable_spec():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=None, running_argv=_ARGV_WITH
+    )
+    # Assert
+    assert "spec could not be loaded" in (result.reason or "")
+
+
+def test_is_drifted_is_none_when_undecided():
+    # Arrange: a caller treating this as falsey turns "did not look" into "fine".
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=None
+    )
+    # Assert
+    assert result.is_drifted is None
+
+
+def test_a_process_carrying_every_declared_flag_matches():
+    # Arrange
+    agent = "handyman-02"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=_ARGV_WITH
+    )
+    # Assert
+    assert result.verdict == MATCHES
+
+
+def test_the_measured_handyman_incident_is_reported_as_drift():
+    # Arrange: handyman-01, spec says --effort low, process predates the edit.
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=_ARGV_WITHOUT
+    )
+    # Assert
+    assert result.verdict == DIFFERS
+
+
+def test_the_drift_names_the_flag_that_is_missing():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=_ARGV_WITHOUT
+    )
+    # Assert
+    assert result.missing == ("--effort", "low")
+
+
+def test_the_drift_message_names_the_remedy():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=_ARGV_WITHOUT
+    )
+    # Assert
+    assert "restart it" in result.describe()
+
+
+def test_flags_present_but_not_adjacent_are_drift():
+    # Arrange: --effort separated from its value is a different command line.
+    agent = "handyman-03"
+    argv = ["claude", "--effort", "--model", "qwen38-27b", "low"]
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=argv
+    )
+    # Assert
+    assert result.verdict == DIFFERS
+
+
+def test_the_non_adjacent_drift_explains_itself():
+    # Arrange
+    agent = "handyman-03"
+    argv = ["claude", "--effort", "--model", "qwen38-27b", "low"]
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=argv
+    )
+    # Assert
+    assert "contiguous" in (result.reason or "")
+
+
+def test_a_spec_declaring_no_flags_matches_any_process():
+    # Arrange
+    agent = "scitex-cards"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=[], running_argv=_ARGV_WITHOUT
+    )
+    # Assert
+    assert result.verdict == MATCHES
+
+
+def test_the_summary_counts_undetermined_separately_from_matching():
+    # Arrange: 1 ok, 1 drifted, 1 unknown must never render as 2 ok.
+    drifts = [
+        ArgvDrift(agent="a", verdict=MATCHES),
+        ArgvDrift(agent="b", verdict=DIFFERS, missing=("--effort", "low")),
+        ArgvDrift(agent="c", verdict=CANNOT_DETERMINE, reason="no running process"),
+    ]
+    # Act
+    text = summarize(drifts)
+    # Assert
+    assert "1 in force, 1 drifted, 1 could not be determined" in text


### PR DESCRIPTION
## The gap

A spec file is **intent**. A process holds the argv it was launched with. Nothing in the fleet compared the two — and that gap hid three separate defects on 2026-08-19 alone:

| what | in the file | in the process |
|---|---|---|
| `--effort low` on handymen | 20 specs | **1** process |
| `business`'s `--env BUN_BIN=...` | reverted | still there |
| the cross-host spec guard | compares spec↔spec | **cannot see either** |

Measured on compute-04 by reading `/proc/<pid>/cmdline` (not `ps`, which kept matching my own probe's shell):

```
handyman-01   up 1d02h   NO --effort
handyman-02   up 07h27m  --effort low
handyman-03   up 22h     NO --effort
```

Two of three were running at **default effort** while every file-reading surface reported the operator's cost instruction as applied. They had simply started before the edit. The instruction was true on disk and false in the fleet.

## Scope: flags, not the whole argv

Reconstructing the full launch line and diffing it would be stricter and useless. It carries values that legitimately vary per launch — a2a port, session id, resume target, transcript home — so every agent would report DIFFERS, which is the fastest way to teach people to ignore a check.

`spec.claude.flags` has an exact contract (one element = one argv token, appended verbatim), so its presence in the running argv is decidable without modelling anything else.

## Three values, never two

`CANNOT_DETERMINE` is the point, not a courtesy. An agent with no readable process must **not** report MATCHES.

Every instrument that misled us this week failed the same way — by printing its *could-not-look* as a clean result:

- a truncated `ls | head -20` read as "no tests exist" (it cut off one line above the file)
- `sac agents status` claiming "the probe SUCCEEDED, so this is real absence" about an agent alive on another host
- a spec-vs-spec guard that is structurally blind to a stale process

`is_drifted` returns `None` for that state specifically so a caller cannot silently treat it as falsey, and `summarize()` never folds it into either column: 29 unreadable agents is not "1 drifted", it is one finding and 29 unanswered questions.

## Adjacency, not just membership

`--effort` and `low` must appear as a **contiguous run**. A flag separated from its value is a different command line — and the inverse error (gluing them into one element, `--effort ultracode`) left an agent unbootable for 15 days without the YAML ever failing to parse.

## Verification — against a sabotaged build, not merely green

| code | result |
|---|---|
| `CANNOT_DETERMINE` collapsed into `MATCHES` | **4 failed**, 10 passed |
| this branch | 14 passed |

The 4 that fail are exactly the property being guarded. A green-only run would not distinguish these tests from tests that pass for an unrelated reason.

## Deliberately not in this commit

No process enumeration and no CLI surface. Those carry host-vantage assumptions — container PID namespace vs host, and the cross-host case where "no process here" means nothing about elsewhere — and they deserve their own review. This commit is a pure comparison, testable without a running fleet.
