### PR TITLE
fix(listen): a spawn refusal must name its reason, not answer 502 for everything

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -339,16 +339,37 @@ async def agents_start(request: Request) -> JSONResponse:
             pass
 
         from .._lifecycle._start_decline import start_was_declined
+        from ._start_failure_status import classify_start_failure
 
+        # hub, 2026-08-19: a 5xx cannot distinguish "your request was
+        # wrong" from "the server is broken", and those need opposite
+        # responses from the caller. Every non-zero child exit used to
+        # answer 502, so an UNREGISTERED NAME and a broken container
+        # were the same status. Classify instead; unmatched failures
+        # still answer 502, so this narrows the opaque case rather than
+        # trading it for a guess.
+        #
+        # ``declined`` is computed ONCE and passed in rather than being
+        # re-derived inside the classifier, so the body's field and the
+        # status code can never disagree about the same output.
+        declined = start_was_declined(proc.stdout, proc.stderr)
+        failure = classify_start_failure(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            declined=declined,
+        )
         return JSONResponse(
             {
                 "name": name,
                 "returncode": proc.returncode,
                 "stdout": proc.stdout,
                 "stderr": proc.stderr,
-                "declined": start_was_declined(proc.stdout, proc.stderr),
+                "declined": declined,
+                "kind": failure.kind,
+                "hint": failure.hint,
             },
-            status_code=502,
+            status_code=failure.status,
         )
 
     # Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg

--- a/src/scitex_agent_container/_listen/_start_failure_status.py
+++ b/src/scitex_agent_container/_listen/_start_failure_status.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Map a failed ``sac agents start`` child onto an HTTP status that means something.
+
+``POST /agents`` answered **502 for every non-zero child exit**, whatever
+the cause. hub hit it standing up a scholar agent on 2026-08-19 and put
+the problem better than the code did:
+
+    a 500 cannot distinguish "your request was wrong" from "the server
+    is broken", and those need OPPOSITE responses from the caller.
+
+They could not tell whether to fix their call or wait for the daemon
+owner, so they waited, and reported a permissions bug that did not
+exist. The body carried the real reason the whole time; the status code
+threw it away.
+
+WHY THE DEFAULT STAYS 502
+-------------------------
+Every unmatched failure keeps today's behaviour. A misclassification is
+harmful in both directions and this picks the direction that is merely
+unhelpful rather than actively misleading:
+
+* a server fault reported as 4xx tells the caller to fix a call that is
+  already correct, and they stop retrying something that would have
+  recovered
+* a caller fault reported as 502 leaves them waiting — bad, but it is
+  the status quo and it does not send them to fix the wrong thing
+
+So a pattern earns a 4xx only when it is unambiguous. Silence maps to
+502, not to a guess.
+
+MATCH ON MARKERS, NOT ON SENTENCES
+----------------------------------
+The patterns below are deliberately short and structural. Matching a
+whole human-readable sentence would make this classifier break the next
+time somebody improves the wording — the message is written for a
+person, and a person's message is not a stable interface.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+SERVER_FAULT = "server-fault"
+UNREGISTERED = "unregistered-agent"
+STALE_SPEC = "stale-spec"
+DECLINED = "declined"
+
+
+@dataclass(frozen=True)
+class StartFailure:
+    """What kind of failure this was, and what the caller should do."""
+
+    status: int
+    kind: str
+    hint: str
+
+    @property
+    def is_caller_fixable(self) -> bool:
+        """``True`` when the caller can act; ``False`` when they must wait."""
+        return 400 <= self.status < 500
+
+
+# An unresolvable / unloadable spec. Both spellings are matched: the
+# resolver's own FileNotFoundError, and the refusal added when the lead
+# credential fallback was removed.
+_UNREGISTERED = re.compile(
+    r"(spec could not be loaded|Agent '[^']*' not found|no such agent)",
+    re.IGNORECASE,
+)
+
+# The drift guard refusing a spec source that is behind its remote. The
+# agent exists and the request is well-formed; the HOST needs a pull, so
+# this is a conflict rather than a bad request or a server fault.
+_STALE_SPEC = re.compile(r"(sac-drift|commit\(s\) BEHIND|STALE)", re.IGNORECASE)
+
+
+def classify_start_failure(
+    *,
+    returncode: int,
+    stdout: str = "",
+    stderr: str = "",
+    declined: bool = False,
+) -> StartFailure:
+    """Classify a failed start into an HTTP status with a reason and a hint.
+
+    ``declined`` comes from the existing
+    :func:`_lifecycle._start_decline.start_was_declined`, which already
+    recognises an agent that refused its own start. It is passed in
+    rather than re-derived so the two can never disagree.
+    """
+    blob = f"{stdout}\n{stderr}"
+
+    # A DECLINE KEEPS 502 — deliberately, and it returns early so no
+    # pattern below can reclassify it.
+    #
+    # It is tempting to call this a client error: it is not a crash, and
+    # 409 reads well. But the caller cannot fix it by changing their
+    # request — the AGENT refused its own start — so a 4xx would tell
+    # them to correct a call that was already correct, which is the
+    # precise harm this module exists to avoid. It is also an existing
+    # wire contract with its own named test
+    # (test_a_declined_brokered_start_returns_502), and narrowing the
+    # opaque 502 does not license redefining the cases that already have
+    # a decided meaning.
+    if declined:
+        return StartFailure(
+            status=502,
+            kind=DECLINED,
+            hint=(
+                "the agent declined its own start; read its stdout for the "
+                "reason rather than retrying"
+            ),
+        )
+
+    if _UNREGISTERED.search(blob):
+        return StartFailure(
+            status=404,
+            kind=UNREGISTERED,
+            hint=(
+                "no spec for this agent on the target host — check the name, "
+                "or deliver the spec there first. This is not a server fault "
+                "and retrying unchanged will not help"
+            ),
+        )
+
+    if _STALE_SPEC.search(blob):
+        return StartFailure(
+            status=409,
+            kind=STALE_SPEC,
+            hint=(
+                "the target host's spec source is behind its remote; pull the "
+                "spec repo on that host, then retry"
+            ),
+        )
+
+    return StartFailure(
+        status=502,
+        kind=SERVER_FAULT,
+        hint=(
+            f"the start subprocess exited {returncode} for a reason this "
+            "daemon does not recognise; read stderr in the body"
+        ),
+    )
+
+
+__all__ = [
+    "DECLINED",
+    "SERVER_FAULT",
+    "STALE_SPEC",
+    "UNREGISTERED",
+    "StartFailure",
+    "classify_start_failure",
+]

--- a/tests/scitex_agent_container/_listen/test__start_failure_status.py
+++ b/tests/scitex_agent_container/_listen/test__start_failure_status.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A refusal must name its reason; 5xx is for genuine server faults.
+
+``POST /agents`` answered 502 for EVERY non-zero child exit. hub hit it
+on 2026-08-19 standing up a scholar agent, and stated the defect better
+than the code did:
+
+    a 500 cannot distinguish "your request was wrong" from "the server
+    is broken", and those need OPPOSITE responses from the caller.
+
+They waited for the daemon owner and reported a permissions bug that did
+not exist. The response BODY carried the real reason throughout — an
+expired-credential message that was true about a file and silent about
+the request. The status code was what threw the distinction away.
+
+These tests pin that unambiguous, caller-fixable failures get a 4xx that
+says which, and that everything else still gets 502. The default matters
+as much as the classification: a server fault misreported as 4xx sends
+someone to fix a call that was already correct.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._listen._start_failure_status import (
+    DECLINED,
+    SERVER_FAULT,
+    STALE_SPEC,
+    UNREGISTERED,
+    classify_start_failure,
+)
+
+_MEASURED_CREDENTIAL_STDERR = (
+    "Error: OAuth token in /home/ywatanabe/.claude/.credentials.json "
+    "expired 257594 seconds ago. Run `claude login` to refresh."
+)
+_MEASURED_DRIFT_STDERR = (
+    "sac-drift ERROR for agent 'business': the spec source is 3 commit(s) "
+    "BEHIND origin/develop — you may be launching a STALE spec."
+)
+
+
+def test_an_unresolvable_agent_is_a_client_error():
+    # Arrange
+    stderr = "Error: cannot start 'scitex-scholar': its spec could not be loaded"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.status == 404
+
+
+def test_an_unresolvable_agent_is_named_as_such():
+    # Arrange
+    stderr = "FileNotFoundError: Agent 'scitex-scholar' not found"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.kind == UNREGISTERED
+
+
+def test_an_unresolvable_agent_is_reported_as_caller_fixable():
+    # Arrange
+    stderr = "Error: cannot start 'scitex-scholar': its spec could not be loaded"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.is_caller_fixable is True
+
+
+def test_the_unregistered_hint_says_retrying_will_not_help():
+    # Arrange
+    stderr = "no such agent"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert "retrying unchanged will not help" in result.hint
+
+
+def test_a_stale_spec_source_is_a_conflict_not_a_bad_request():
+    # Arrange: the agent exists and the call is well-formed; the HOST is behind.
+    stderr = _MEASURED_DRIFT_STDERR
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.status == 409
+
+
+def test_a_stale_spec_source_is_named_as_such():
+    # Arrange
+    stderr = _MEASURED_DRIFT_STDERR
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.kind == STALE_SPEC
+
+
+def test_the_stale_spec_hint_names_the_remedy():
+    # Arrange
+    stderr = _MEASURED_DRIFT_STDERR
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert "pull the spec repo" in result.hint
+
+
+def test_a_self_declined_start_keeps_its_existing_status():
+    # Arrange: an existing wire contract, and not caller-fixable — the
+    # AGENT refused itself, so a 4xx would tell the caller to correct a
+    # call that was already correct.
+    # Act
+    result = classify_start_failure(returncode=1, stderr="", declined=True)
+    # Assert
+    assert result.status == 502
+
+
+def test_a_self_declined_start_is_named_as_such():
+    # Arrange
+    # Act
+    result = classify_start_failure(returncode=1, stderr="", declined=True)
+    # Assert
+    assert result.kind == DECLINED
+
+
+def test_an_unrecognised_failure_keeps_the_existing_status():
+    # Arrange: the conservative default — unmatched must not become a guess.
+    stderr = "apptainer: FATAL: while extracting image: root filesystem missing"
+    # Act
+    result = classify_start_failure(returncode=255, stderr=stderr)
+    # Assert
+    assert result.status == 502
+
+
+def test_an_unrecognised_failure_is_named_a_server_fault():
+    # Arrange
+    stderr = "apptainer: FATAL: while extracting image"
+    # Act
+    result = classify_start_failure(returncode=255, stderr=stderr)
+    # Assert
+    assert result.kind == SERVER_FAULT
+
+
+def test_a_server_fault_is_not_reported_as_caller_fixable():
+    # Arrange: the harmful direction — never tell someone to fix a correct call.
+    stderr = "apptainer: FATAL: while extracting image"
+    # Act
+    result = classify_start_failure(returncode=255, stderr=stderr)
+    # Assert
+    assert result.is_caller_fixable is False
+
+
+def test_an_empty_stderr_falls_back_to_a_server_fault():
+    # Arrange: silence must not be classified as a caller error.
+    # Act
+    result = classify_start_failure(returncode=1, stdout="", stderr="")
+    # Assert
+    assert result.status == 502
+
+
+def test_the_measured_credential_failure_is_no_longer_a_bare_server_fault():
+    # Arrange: hub's actual 502. Post-#1135 the child names the spec fault,
+    # so the SAME start now classifies as unregistered rather than opaque.
+    stderr = (
+        "Error: cannot start 'scitex-scholar': its spec could not be loaded "
+        "(FileNotFoundError: Agent 'scitex-scholar' not found)"
+    )
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.status == 404
+
+
+def test_the_pre_fix_credential_message_alone_stays_a_server_fault():
+    # Arrange: on its own the old message says nothing about the request,
+    # so it must NOT be promoted to a caller error by pattern-matching hope.
+    # Act
+    result = classify_start_failure(
+        returncode=1, stderr=_MEASURED_CREDENTIAL_STDERR
+    )
+    # Assert
+    assert result.status == 502
+
+
+def test_a_declined_start_outranks_a_matching_spec_pattern():
+    # Arrange: an agent that declined, whose output also mentions a spec.
+    stderr = "no such agent mentioned in passing"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr, declined=True)
+    # Assert
+    assert result.kind == DECLINED
+
+
+def test_a_declined_start_is_not_promoted_to_a_client_error_by_a_stray_match():
+    # Arrange: the early return is what stops the 404 pattern firing here.
+    stderr = "no such agent mentioned in passing"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr, declined=True)
+    # Assert
+    assert result.is_caller_fixable is False


### PR DESCRIPTION
## The defect

`POST /agents` answered **502 for every non-zero child exit**, whatever the cause. `hub` hit it standing up a scholar agent on 2026-08-19 and stated the problem better than the code did:

> a 500 cannot distinguish "your request was wrong" from "the server is broken", and those need **opposite** responses from the caller.

They could not tell whether to fix their call or wait for the daemon owner, so they waited — and reported a permissions bug that did not exist. The response **body** carried the real reason throughout; the status code threw the distinction away.

## What changes

| condition | before | after |
|---|---|---|
| unregistered / unloadable spec | 502 | **404** — "retrying unchanged will not help" |
| spec source behind its remote | 502 | **409** — "pull the spec repo on that host" |
| everything else | 502 | 502, unchanged |

Each response now also carries `kind` and `hint`.

## The default is the load-bearing part

Unmatched failures keep today's behaviour. Misclassification is harmful in **both** directions, and this deliberately picks the merely-unhelpful one:

- a **server fault reported as 4xx** tells someone to fix a call that was already correct, and they stop retrying something that would have recovered
- a **caller fault reported as 502** leaves them waiting — bad, but it is the status quo and it does not send them to fix the wrong thing

So a pattern earns a 4xx only when unambiguous. Silence maps to 502, never to a guess.

Patterns are short and structural rather than whole sentences: a human-readable message is written for a person and is not a stable interface, so matching one would break the next time somebody improves the wording.

## I got this wrong once, and the existing suite caught it

My first version promoted a self-declined start to 409. That failed `test_a_declined_brokered_start_returns_502` — and the test was right, not me.

A caller cannot fix a decline by changing their request: the **agent** refused its own start. A 4xx would misdirect them, which is precisely the harm this PR exists to prevent. A decline now returns 502 explicitly and returns **early**, so no later pattern can reclassify it.

Narrowing the opaque case does not license redefining cases that already have a decided meaning.

## Deliberately untouched

The post-ack-liveness 502. An agent that acked `rc=0` and then died silently **is** a server fault, and that branch already carries `kind` + `hint`.

`declined` is now computed once and passed in rather than re-derived inside the classifier, so the body's field and the status code cannot disagree about the same output.

## Verification — against a sabotaged build, not merely green

| code | result |
|---|---|
| both classifications disabled | **8 failed**, 9 passed |
| this branch | 17 passed |

The 8 that fail are exactly the promotions; the 9 that pass are the server-fault and declined cases, which correctly still return 502. Plus 24/24 including the declined contract test, and 970 passed across the full `_listen` suite.

## Related

Pairs with #1135, which makes the child *name* the spec fault instead of reporting an expired credential. Together: the child says what went wrong, and the status code says who can fix it.
