### PR TITLE
chore(binds): retire the ~/.scitex/todo fleet default, archived not deleted

### DIFF
--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -2,17 +2,28 @@
 
 Two classes of fleet-wide bind live here today:
 
-* **P3a-2 single-shared-store** — every agent's apptainer container
-  mounts the host's ``~/.scitex/todo/`` so scitex-todo's precedence-4
-  user-scope store resolves to the SAME global ``tasks.yaml``
-  fleet-wide. Operator directive
-  ``feedback_scitex_todo_single_shared_store``
-  (lead-learnings/22, P3a unlock). Lead a2a
-  ``214dd26d3fd24e088c75a34329895fa4``. This module is the SOLE
-  source of the bind — no fleet ``_shared/spec.yaml`` carries an
-  explicit ``~/.scitex/todo:`` line (lead audit 2026-06-13 a2a
-  ``f33cbc78c2074594b513439d93748810``), so the helper here is what
-  every sac-launched agent picks up at boot.
+* **single-shared-store** — every agent's apptainer container mounts
+  the host copy of a shared store, so a resolver keying off the
+  AGENT's ``$HOME=/home/agent`` reaches the SAME data fleet-wide.
+  Today that is ``~/.scitex/cards`` and
+  ``~/.scitex/claude-code-telegrammer``; see each entry's own note
+  for the incident that bought it.
+
+  The original member of this class, ``~/.scitex/todo``, was RETIRED
+  2026-08-19 and is archived in place at the end of the tuple rather
+  than deleted. Its P3a-2 provenance (operator directive
+  ``feedback_scitex_todo_single_shared_store``, lead-learnings/22,
+  lead a2a ``214dd26d3fd24e088c75a34329895fa4``) is recorded there.
+
+  This module remains the SOLE source of these binds — no fleet
+  ``_shared/spec.yaml`` carries them explicitly (lead audit
+  2026-06-13 a2a ``f33cbc78c2074594b513439d93748810``), so the helper
+  here is what every sac-launched agent picks up at boot. That is
+  itself under review: the operator ruled 2026-08-19 that a bind must
+  be declared in the spec rather than injected from code
+  (「必ずスペックで明示的に渡して下さい」), with sac's own wiring the
+  stated exception. See card
+  ``sac-remove-implicit-fleet-default-binds-20260819``.
 
 * **2026-06-13 SAC overlay stopgap** — bind the host's working
   ``scitex_agent_container`` source over the in-SIF install so
@@ -32,7 +43,7 @@ Mechanism — see :func:`apply_default_binds`:
     destination path REPLACES the default (operator override
     wins; we de-dupe by destination, not by full string).
   * Missing host source dir → SKIP that default silently. The
-    operator may not have a ``~/.scitex/todo/`` yet (clean
+    operator may not have a ``~/.scitex/cards/`` yet (clean
     install, fresh laptop), or a fresh deploy host may not have
     the canonical ``~/proj/scitex-agent-container/`` checkout —
     we don't create either from sac code.
@@ -57,11 +68,8 @@ __all__ = [
 # ``host:container[:mode]`` apptainer's ``--bind`` consumes.
 # ``~`` is expanded against the host's ``$HOME`` at resolution time.
 _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
-    # P3a-2 — scitex-todo single shared store (operator directive
-    # feedback_scitex_todo_single_shared_store).
-    "~/.scitex/todo:/home/agent/.scitex/todo:rw",
-    # S6 store migration (scitex-todo -> scitex-cards). Same shape and same
-    # reason as the todo bind above, and the reason is NOT obvious: the store
+    # S6 store migration (scitex-todo -> scitex-cards). The reason this bind
+    # has to exist at all is NOT obvious: the store
     # resolver keys off the AGENT's $HOME=/home/agent, so host-side reach is
     # not enough. An agent whose spec binds the operator's ENTIRE home rw
     # still cannot resolve ~/.scitex/cards — the data is present and
@@ -221,6 +229,43 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # bounded, deterministic checks and does NOT run the test suite. CI runs
     # the tests. There is no test suite in the commit path for a testmon cache
     # to accelerate.
+    #
+    # RETIRED 2026-08-19 — "~/.scitex/todo:/home/agent/.scitex/todo:rw"
+    #   (was: P3a-2, scitex-todo single shared store, operator directive
+    #    feedback_scitex_todo_single_shared_store)
+    #
+    # Archived rather than deleted, on the operator's instruction that a
+    # retired thing should stay findable: 「消すというよりアーカイブでいい
+    # んじゃないですかね。すなわち探そうと思えば探せるみたいな」. A silent
+    # absence tells the next reader nothing about why the entry went, and
+    # invites someone to "fix" its absence by adding it back.
+    #
+    # WHY IT WENT: scitex-todo was superseded by scitex-cards, and the
+    # HOME-level store the bind targets is no longer read by anything.
+    # Measured 2026-08-19 with rg --no-ignore over every checkout under
+    # ~/proj, carrying a control term in the same pass so a zero could not
+    # mean "the search did not run":
+    #     scitex-cards       0 hits in *.py (docs/logs only)
+    #     scitex-live-paper  prose in docs/research/, and a PROJECT-LOCAL
+    #                        .scitex/todo/tasks.yaml, not ~/.scitex/todo
+    #     scitex-hub         LIVE CODE at apps/workspace/todo_app/
+    #                        middleware.py:302 — but it builds
+    #                        base / project.slug / ".scitex" / "todo" /
+    #                        "tasks.yaml" where base is a WORKSPACE root, not
+    #                        $HOME, and refuses any store escaping it
+    # The host directory itself held one 4-byte board.pid naming a pid that
+    # is not running.
+    #
+    # THE TRAP, recorded because the naive check gets it backwards: the
+    # string ".scitex/todo" names TWO unrelated things — a per-project store
+    # under a workspace, and this HOME-level one. A substring search cannot
+    # tell them apart, and hub's five hits argued for keeping the bind until
+    # the paths were actually read. Matching the string is not matching the
+    # dependency.
+    #
+    # If something turns out to need it, prefer an EXPLICIT bind in that
+    # agent's spec over restoring a fleet-wide default (operator, same day:
+    # 「必ずスペックで明示的に渡して下さい」).
 )
 
 

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -50,18 +50,20 @@ def fake_home(tmp_path: Path) -> Iterator[Path]:
 # ---------------------------------------------------------------------------
 
 
-def test_default_binds_for_host_returns_todo_bind_when_host_dir_exists(
+def test_default_binds_for_host_returns_cards_bind_when_host_dir_exists(
     fake_home: Path,
 ) -> None:
-    # Arrange
-    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    # Arrange — retargeted from the retired todo bind. The cards store had
+    # NO coverage of its own, so this closes a real gap rather than merely
+    # relocating an assertion.
+    (fake_home / ".scitex" / "cards").mkdir(parents=True)
     # Act
     binds = default_binds_for_host()
     # Assert
-    assert any("/.scitex/todo:" in b for b in binds)
+    assert any("/.scitex/cards:" in b for b in binds)
 
 
-def test_default_binds_for_host_skips_todo_bind_when_host_dir_missing(
+def test_default_binds_for_host_skips_cards_bind_when_host_dir_missing(
     fake_home: Path,
 ) -> None:
     # Arrange — fake_home (tmp_path) is freshly created with no .scitex
@@ -69,7 +71,7 @@ def test_default_binds_for_host_skips_todo_bind_when_host_dir_missing(
     # Act
     binds = default_binds_for_host()
     # Assert
-    assert not any("/.scitex/todo:" in b for b in binds)
+    assert not any("/.scitex/cards:" in b for b in binds)
 
 
 def test_default_binds_for_host_returns_telegrammer_bind_when_host_dir_exists(
@@ -141,12 +143,14 @@ def test_apply_default_binds_prepends_defaults_when_spec_has_no_overlap(
     fake_home: Path,
 ) -> None:
     # Arrange
-    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    (fake_home / ".scitex" / "cards").mkdir(parents=True)
     spec_binds = ["~/proj:/home/agent/proj:ro"]
     # Act
     result = apply_default_binds(spec_binds)
-    # Assert — first entry is the P3a-2 default, second is the spec entry.
-    assert "/.scitex/todo:" in result[0] and result[-1] == "~/proj:/home/agent/proj:ro"
+    # Assert — defaults come first, the spec entry last. (Was pinned on the
+    # todo bind purely because it happened to head the tuple; cards heads it
+    # now, and the ORDERING is what this test is actually about.)
+    assert "/.scitex/cards:" in result[0] and result[-1] == "~/proj:/home/agent/proj:ro"
 
 
 def test_apply_default_binds_lets_explicit_spec_entry_override_default(
@@ -154,13 +158,13 @@ def test_apply_default_binds_lets_explicit_spec_entry_override_default(
 ) -> None:
     # Arrange — spec carries the SAME destination as the default; the
     # spec wins (de-dup by destination).
-    (fake_home / ".scitex" / "todo").mkdir(parents=True)
-    spec_binds = ["/tmp/operator-todo:/home/agent/.scitex/todo:rw"]
+    (fake_home / ".scitex" / "cards").mkdir(parents=True)
+    spec_binds = ["/tmp/operator-cards:/home/agent/.scitex/cards:rw"]
     # Act
     result = apply_default_binds(spec_binds)
-    # Assert — exactly one entry whose destination is /home/agent/.scitex/todo.
-    todo_entries = [b for b in result if "/home/agent/.scitex/todo" in b]
-    assert todo_entries == ["/tmp/operator-todo:/home/agent/.scitex/todo:rw"]
+    # Assert — exactly one entry whose destination is /home/agent/.scitex/cards.
+    cards_entries = [b for b in result if "/home/agent/.scitex/cards" in b]
+    assert cards_entries == ["/tmp/operator-cards:/home/agent/.scitex/cards:rw"]
 
 
 def test_apply_default_binds_returns_spec_only_when_host_dir_missing(
@@ -180,11 +184,11 @@ def test_apply_default_binds_returns_spec_only_when_host_dir_missing(
 
 def test_apply_default_binds_handles_empty_spec_binds(fake_home: Path) -> None:
     # Arrange
-    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    (fake_home / ".scitex" / "cards").mkdir(parents=True)
     # Act
     result = apply_default_binds([])
     # Assert
-    assert any("/.scitex/todo:" in b for b in result)
+    assert any("/.scitex/cards:" in b for b in result)
 
 
 def test_apply_default_binds_accepts_iterable_of_strings(fake_home: Path) -> None:
@@ -430,6 +434,37 @@ def test_fleet_defaults_include_host_tmp_handoff_bind_read_only() -> None:
 # sac never used testmon itself. The assertion is INVERTED so that re-adding the
 # plumbing fails loudly rather than quietly reappearing on every agent.
 # ---------------------------------------------------------------------------
+
+
+def test_fleet_defaults_carry_no_todo_bind() -> None:
+    # Arrange — read the static fleet-default tuple directly.
+    from scitex_agent_container.runtimes._p3a_default_binds import (
+        _FLEET_DEFAULT_BINDS,
+    )
+
+    # Act
+    todo = [b for b in _FLEET_DEFAULT_BINDS if "/.scitex/todo" in b]
+    # Assert — scitex-todo was superseded by scitex-cards and nothing in the
+    # fleet reads the HOME-level store. Measured 2026-08-19 across every
+    # checkout under ~/proj with a control term: cards has 0 hits in *.py,
+    # live-paper's are prose, and hub's todo_app builds a WORKSPACE-scoped
+    # path (base / slug / .scitex / todo / tasks.yaml), never ~/.scitex/todo.
+    assert todo == []
+
+
+def test_the_retired_todo_bind_stays_findable_in_the_source() -> None:
+    # Arrange — the operator asked for retirement by ARCHIVE, not deletion:
+    # 「消すというよりアーカイブでいいんじゃないですかね。すなわち探そうと
+    # 思えば探せるみたいな」. A bare removal satisfies the test above and
+    # loses the reason, which is what invites someone to add it back.
+    from pathlib import Path
+
+    import scitex_agent_container.runtimes._p3a_default_binds as mod
+
+    # Act
+    source = Path(mod.__file__).read_text(encoding="utf-8")
+    # Assert
+    assert "RETIRED 2026-08-19" in source
 
 
 def test_fleet_defaults_carry_no_testmon_cache_bind() -> None:


### PR DESCRIPTION
## What

`~/.scitex/todo` was mounted **rw into every agent**, declared in no spec, serving nothing. scitex-todo was superseded by scitex-cards, and nothing in the fleet reads the HOME-level store this bind targets.

## The count argued for keeping it — reading the paths reversed that

Measured with `rg --no-ignore` across every checkout under `~/proj`, carrying a **control term** in the same pass so a zero could not mean "the search did not run":

| repo | `scitex/todo` | control (cards) |
|---|---|---|
| scitex-cards | 14 | 365 |
| scitex-dev | 18 | 7 |
| scitex-hub | 5 | 1 |
| scitex-live-paper | 2 | **0** |
| scitex-app | 0 | 1 |

Five repos still mention the path, so the naive read is "keep it". What the hits actually are:

- **scitex-cards** — 0 hits in `*.py`; the 14 are docs and logs. Their "zero in source" claim holds.
- **scitex-live-paper** — prose in `docs/research/`, naming a *project-local* `.scitex/todo/tasks.yaml`. Control 0 just means that repo never mentions cards.
- **scitex-hub** — **live code**, `apps/workspace/todo_app/middleware.py:302`:
  ```python
  store = base / project.slug / ".scitex" / "todo" / "tasks.yaml"
  ```
  Not a docstring. But `base` is `get_org_base_path()` / `get_user_base_path()` — a **workspace** root, not `$HOME` — with an explicit guard refusing any store that escapes it.

The string `.scitex/todo` names **two unrelated things**: a per-project store under a workspace, and this HOME-level one. A substring search cannot tell them apart. Matching the string is not matching the dependency, and hub's five hits would otherwise have blocked this indefinitely.

The host directory itself held one 4-byte `board.pid` naming a pid that is not running.

## Archived, not deleted

Per the operator: 「消すというよりアーカイブでいいんじゃないですかね。すなわち探そうと思えば探せるみたいな」

The entry, its P3a-2 provenance and the reason it went are recorded **in place** at the end of the tuple, following the precedent already set there by the retired testmon entry. A bare removal passes the test and loses the reason — which is exactly what invites someone to add it back.

The **module docstring** is corrected too: it opened by describing the todo bind as the defining member of the single-shared-store class. Left alone, the file would have lied about itself.

## Tests: retargeted, not deleted

Five existing tests were built on the todo bind. Their intent — skip-if-missing, default ordering, spec-override-wins-by-destination — is unchanged and still valuable, so they now exercise the **cards** bind.

That closes a real gap as a side effect: the cards bind had **no coverage of its own**, only the todo bind's by proximity.

Two new tests pin the retirement in both directions — the bind stays out of the tuple, **and** the archive note stays in the source.

## Verification — against a sabotaged build

| code | result |
|---|---|
| bind restored + archive marker stripped | **2 failed**, 23 passed |
| this branch | 25 passed |

The 2 that fail are exactly the retirement pair. Plus **1942 passed / 20 skipped** across the full `runtimes` suite.

## Scope

Part of `sac-remove-implicit-fleet-default-binds-20260819`. This step is **independent** of the dotfiles child card — the todo bind is being *retired*, not *declared*, so no spec has to carry it first. The cards and telegrammer binds still wait on that child, since removing those before specs carry them would leave every agent unable to resolve its card store.
