### PR TITLE
fix(listen): a missing host is not evidence of locality — read turn_url

### DIFF
--- a/src/scitex_agent_container/_listen/_reachability.py
+++ b/src/scitex_agent_container/_listen/_reachability.py
@@ -65,22 +65,69 @@ def _is_locally_observable(row: Mapping[str, Any], local_host: str | None) -> bo
 
     Mirrors the locality rule the publish path already uses
     (:func:`_state.state_db_nodes.is_local_node`): a node whose host we
-    cannot distinguish from our own — including one that declares no host
-    at all — is served by the LOCAL broker, so the local subscriber count
-    is authoritative for it.
+    cannot distinguish from our own is served by the LOCAL broker, so the
+    local subscriber count is authoritative for it.
 
     A row that declares a host we can see is NOT ours is served by a
     different ``sac listen`` process with a different in-memory broker.
     We have no window into it, so we must say :data:`UNKNOWN` rather than
     invent a zero — a fabricated zero would be a false accusation of
     deafness against a perfectly reachable remote agent.
+
+    A MISSING ``host`` IS NOT EVIDENCE OF LOCALITY. It used to be treated
+    as such, and that is how the false accusation above got made anyway:
+    see :func:`_host_from_turn_url` for the measured case. The row's
+    ``turn_url`` is consulted as a fallback, and only a row carrying
+    NEITHER field falls through to "local" — which is the honest reading,
+    because then there genuinely is no host evidence to weigh.
     """
-    host = row.get("host")
+    host = row.get("host") or _host_from_turn_url(row)
     if not isinstance(host, str) or not host:
-        return True  # no host declared → the local publish path serves it
+        return True  # no host evidence at all → the local publish path serves it
     if not local_host:
         return False  # we don't know who WE are → cannot claim locality
     return host == local_host
+
+
+def _host_from_turn_url(row: Mapping[str, Any]) -> str | None:
+    """Recover the row's host from ``turn_url`` when ``host`` is absent.
+
+    A row with no ``host`` key used to be treated as LOCAL outright, and
+    that is the hole: absence of a declaration is absence of INFORMATION,
+    not evidence of locality. Reading it as local lets the local broker's
+    zero subscriber count stand as authoritative for an agent living on
+    another machine — and a fabricated zero is exactly the false
+    accusation the rest of this module is written to avoid.
+
+    Measured 2026-08-19. ``agent_status paper-scitex-clew``, run on
+    compute-04, returned a row with NO ``host`` key and::
+
+        turn_url : http://ywata-note-win:19012/v1/turn
+
+    The agent was alive on compute-02 with a heartbeat 2 seconds old.
+    Because the row looked local, it was annotated ``unreachable``
+    instead of ``unknown``; ``classify_fault``'s cross-host guard
+    (``inbox_reachable == UNKNOWN -> None``) therefore never fired, and
+    the verdict read "NOT RUNNING ... the probe SUCCEEDED, so this is
+    real absence, not a failed look" about a healthy agent on a host
+    this daemon cannot see. The operator and I both believed it.
+
+    So the fix is not new evidence — the row already carried the host in
+    its ``turn_url``. It was simply not consulted.
+
+    Returns ``None`` when there is no usable hostname, which preserves
+    the original "no evidence → local" behaviour for genuinely local
+    rows that declare neither field.
+    """
+    url = row.get("turn_url")
+    if not isinstance(url, str) or not url:
+        return None
+    try:
+        from urllib.parse import urlparse
+
+        return urlparse(url).hostname or None
+    except Exception:  # stx-allow: fallback (reason: a malformed turn_url must not break annotation; falling through to None restores the prior behaviour for this row)
+        return None
 
 
 def annotate_reachability(

--- a/tests/scitex_agent_container/_listen/test__reachability.py
+++ b/tests/scitex_agent_container/_listen/test__reachability.py
@@ -201,3 +201,88 @@ def test_annotate_rows_separates_reachable_from_deaf_peers():
     deaf = [r["name"] for r in out if r["inbox_reachable"] == UNREACHABLE]
     # Assert
     assert deaf == ["claude-code-telegrammer", "scitex-dev"]
+
+
+# ---------------------------------------------------------------------------
+# A hostless row is not automatically LOCAL — turn_url still names its host.
+#
+# Measured 2026-08-19. `agent_status paper-scitex-clew`, run on compute-04,
+# returned a row with NO `host` key and turn_url http://ywata-note-win:19012/…
+# while the agent was alive on compute-02 with a 2-second-old heartbeat.
+# The hostless row was treated as local, so the local broker's zero stood as a
+# real observation, `inbox_reachable` became UNREACHABLE instead of UNKNOWN,
+# and classify_fault's cross-host guard (UNKNOWN -> no fault) never fired. The
+# verdict read "the probe SUCCEEDED, so this is real absence, not a failed
+# look" about a healthy agent on a machine this daemon cannot see.
+#
+# The row already carried the host. Nothing consulted it.
+# ---------------------------------------------------------------------------
+
+
+def test_hostless_row_whose_turn_url_is_remote_is_unknown():
+    """The measured clew case: no host key, turn_url on another machine."""
+    # Arrange
+    row = {"name": "paper-scitex-clew", "turn_url": "http://elsewhere:19012/v1/turn"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNKNOWN
+
+
+def test_hostless_remote_row_reports_null_subscribers_not_a_fabricated_zero():
+    """A zero we did not observe is a false accusation, not a reading."""
+    # Arrange
+    row = {"name": "paper-scitex-clew", "turn_url": "http://elsewhere:19012/v1/turn"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_subscribers"] is None
+
+
+def test_hostless_row_whose_turn_url_is_local_is_still_observed_locally():
+    """The fix must not make every hostless row unknown — that would lose
+    genuine deaf-inbox detection for local agents."""
+    # Arrange
+    row = {"name": "local-agent", "turn_url": f"http://{LOCAL}:19001/v1/turn"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_an_explicit_host_still_wins_over_the_turn_url():
+    """turn_url is a FALLBACK. A declared host is the stronger statement and
+    must not be second-guessed by a URL that may be stale."""
+    # Arrange
+    row = {
+        "name": "declared",
+        "host": LOCAL,
+        "turn_url": "http://elsewhere:19012/v1/turn",
+    }
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_a_malformed_turn_url_falls_back_to_the_previous_behaviour():
+    """An unparseable URL yields no host evidence, so the row is treated as
+    local exactly as it was before this fix — the change adds a reading, it
+    does not introduce a new way to fail."""
+    # Arrange
+    row = {"name": "hostless", "turn_url": "::::not a url::::"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_a_non_string_turn_url_does_not_raise():
+    """Registry rows are not schema-guaranteed here; a wrong type must not
+    take down GET /agents for every other row in the same response."""
+    # Arrange
+    row = {"name": "hostless", "turn_url": 19012}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE


### PR DESCRIPTION
## The failure

`agent_status paper-scitex-clew`, run on compute-04:

```
fault        : not_running
fault_detail : "NOT RUNNING … no live session was observed for it (the probe
                SUCCEEDED, so this is real absence, not a failed look) …
                waiting for a reply will never succeed."
turn_url     : http://ywata-note-win:19012/v1/turn
```

The agent was **alive on compute-02, heartbeat 2 seconds old**.

The operator had independently asked me to check because he also believed it was down. I read the registry, confirmed his belief, and told him so. Two of us agreed on a false fact — and nothing broke only because I happened to try starting it on compute-02 rather than acting on the verdict. Acting on it would have meant restarting a healthy research agent.

## Root cause — one line

```python
host = row.get("host")
if not isinstance(host, str) or not host:
    return True   # no host declared → the local publish path serves it
```

**Absence of a declaration is absence of information, not evidence of locality.** Reading it as local let the local broker's zero subscriber count stand as authoritative for an agent on another machine, so the row was annotated `unreachable` instead of `unknown` — and `classify_fault`'s cross-host guard never fired:

```python
if row.get("inbox_reachable") == UNKNOWN:
    return None   # "not ours to observe — a remote host's agent"
```

## The guard was already there, and already correct

So was the module's own stated doctrine:

> we must say `UNKNOWN` rather than invent a zero — a fabricated zero would be a false accusation of deafness against a perfectly reachable remote agent

This is not a missing idea. It is **one input that bypassed an idea the module already had**. Nor is it new evidence — the row already carried the host in `turn_url`. Nothing consulted it.

## Deliberately narrow

Making every hostless row `UNKNOWN` is the obvious change and would be a regression: it would lose genuine deaf-inbox detection for local agents, which is the fault this module exists to name.

- an explicit `host` still wins — `turn_url` is only a fallback, since a URL may be stale
- a row with **neither** field still falls through to local, because then there genuinely is no host evidence to weigh
- a malformed or non-string `turn_url` yields no host and restores the prior behaviour for that row

## Verification — against a sabotaged build

| code | result |
|---|---|
| turn_url lookup removed | **2 failed**, 17 passed |
| this branch | 19 passed |

The 2 that fail are exactly the ones encoding the new reading. The other **four** new tests assert the *preserved* behaviour and pass in both directions — they guard the regression I was most likely to introduce, which is why they are there rather than only the two that prove the fix.

37 passed across `test__reachability.py` + `test__inbox_fault.py` together.

## Card

`sac-registry-says-not-running-while-process-alive-and-port-bound-20260817` — third independent reproduction, and the first that reached the operator rather than only me.

Worth noting what this does **not** fix: clew's `turn_url` named ywata-note-win while the agent ran on compute-02, so that field was itself stale. This change makes a stale-but-remote host produce `UNKNOWN` (honest) instead of a confident false verdict, but the staleness is a separate finding and is recorded on the card.
