### PR TITLE
fix(listen): the NOT RUNNING verdict must name the population it observed

### DIFF
--- a/src/scitex_agent_container/_listen/_inbox_fault.py
+++ b/src/scitex_agent_container/_listen/_inbox_fault.py
@@ -93,14 +93,40 @@ _DETAIL = {
         "scitex-cards card assigned to it), or ask the operator."
     ),
     FAULT_NOT_RUNNING: (
-        "NOT RUNNING — this registry row declares an agent, but no live session "
-        "was observed for it (the probe SUCCEEDED, so this is real absence, not "
-        "a failed look). The row outlived the process. Its 0 inbox subscribers "
-        "mean 'nobody is home', NOT 'a detached adapter': nothing will "
-        "reconnect to drain its queue until someone deliberately starts it, so "
-        "waiting for a reply will never succeed."
+        "NOT RUNNING ON {host} — this registry row declares an agent, and no "
+        "live tmux session for it exists ON THIS HOST. The probe ran and "
+        "observed a real absence HERE; it says nothing about any other host, "
+        "because it can only see {host}'s sessions. If the agent is pinned "
+        "elsewhere the row outlived the process ON THIS HOST ONLY — ASK THAT "
+        "HOST before concluding it is down; `sac agents start <name>` run "
+        "there reports whether it is already running. Once that is ruled out, "
+        "the row outlived the process: its 0 inbox subscribers mean 'nobody "
+        "is home', NOT 'a detached adapter', and nothing will reconnect to "
+        "drain its queue until someone deliberately starts it."
     ),
 }
+
+#: Resolved once. ``gethostname`` is cheap, but this is formatted per ROW on a
+#: fleet-sized response and the value cannot change within a process.
+_THIS_HOST: str | None = None
+
+
+def _this_host() -> str:
+    """This daemon's hostname, for naming the population a probe covered.
+
+    Falls back to the literal ``"this host"`` so the message degrades to the
+    previous, still-honest phrasing rather than raising inside an ADVISORY
+    overlay that must never fail the status route.
+    """
+    global _THIS_HOST
+    if _THIS_HOST is None:
+        try:
+            import socket
+
+            _THIS_HOST = socket.gethostname() or "this host"
+        except Exception:  # stx-allow: fallback (reason: the fault overlay is advisory; a hostname lookup must never fail the status route)
+            _THIS_HOST = "this host"
+    return _THIS_HOST
 
 
 def session_snapshot() -> dict | None:
@@ -241,7 +267,9 @@ def annotate_faults(
         new = dict(row)
         new["fault"] = fault
         if fault is not None:
-            new["fault_detail"] = _DETAIL[fault]
+            # `.format` on a template with no placeholders is a no-op, so the
+            # DEAF entry is unaffected and needs no branch here.
+            new["fault_detail"] = _DETAIL[fault].format(host=_this_host())
         out.append(new)
     return out
 

--- a/tests/scitex_agent_container/_listen/test__inbox_fault.py
+++ b/tests/scitex_agent_container/_listen/test__inbox_fault.py
@@ -257,3 +257,78 @@ def test_annotate_does_not_mutate_the_input_row():
     annotate_faults([row], snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
     # Assert
     assert "fault" not in row
+
+
+# ---------------------------------------------------------------------------
+# The NOT_RUNNING verdict must name the POPULATION its probe covered.
+#
+# Three independent reproductions, 2026-08-17..19 (hub twice, then
+# paper-scitex-clew). The message said "the probe SUCCEEDED, so this is real
+# absence, not a failed look" about agents alive on ANOTHER host — clew with a
+# 2-second-old heartbeat on compute-02, hub eight minutes into a live PR poll
+# on compute-03. It then told the reader "waiting for a reply will never
+# succeed", which is an instruction to restart a healthy agent.
+#
+# The sentence pre-empts the exact objection a careful reader would raise,
+# which is why it was believed. On the clew reading the OPERATOR and I agreed
+# on the false fact; nothing broke only because I tried starting it on the
+# other host rather than acting on the verdict.
+#
+# A probe of THIS host's tmux sessions can only speak for THIS host.
+# ---------------------------------------------------------------------------
+
+
+def _stopped_detail() -> str:
+    """The rendered NOT_RUNNING detail — empty snapshot means no session here."""
+    return annotate_faults([_row()], snapshot={}, runtime_is_tui_fn=TUI)[0][
+        "fault_detail"
+    ]
+
+
+def test_the_not_running_verdict_names_the_host_it_observed():
+    # Arrange
+    import socket
+
+    expected = socket.gethostname()
+    # Act
+    detail = _stopped_detail()
+    # Assert
+    assert expected in detail
+
+
+def test_the_not_running_verdict_no_longer_claims_unqualified_absence():
+    # Arrange: the exact phrase that was believed three times.
+    forbidden = "real absence, not a failed look"
+    # Act
+    detail = _stopped_detail()
+    # Assert
+    assert forbidden not in detail
+
+
+def test_the_not_running_verdict_says_it_cannot_speak_for_other_hosts():
+    # Arrange
+    expected = "says nothing about any other host"
+    # Act
+    detail = _stopped_detail()
+    # Assert
+    assert expected in detail
+
+
+def test_the_not_running_verdict_tells_the_reader_to_ask_the_pinned_host():
+    # Arrange: the remedy, so the message ends in the right ACTION rather than
+    # in a restart of a live agent.
+    expected = "ASK THAT HOST"
+    # Act
+    detail = _stopped_detail()
+    # Assert
+    assert expected in detail
+
+
+def test_the_deaf_verdict_survives_the_host_formatting():
+    # Arrange: the DEAF template carries no placeholder, so .format must be a
+    # no-op on it rather than raising or mangling it.
+    rows = [_row()]
+    # Act
+    out = annotate_faults(rows, snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert out[0]["fault_detail"].startswith("RUNNING BUT DEAF")


### PR DESCRIPTION
## The message, and what it said about live agents

```
"the probe SUCCEEDED, so this is real absence, not a failed look"
"waiting for a reply will never succeed"
```

Three independent reproductions, 2026-08-17..19 — `scitex-hub` twice, then `paper-scitex-clew`. clew had a **2-second-old heartbeat** on compute-02; hub was **eight minutes into a live PR poll** on compute-03. Both were reported dead by a probe that can only see *this* host's tmux sessions.

## The dangerous part is the certainty, not the wrong verdict

The first sentence pre-empts the exact objection a careful reader would raise, so it reads as though the question has already been asked and settled. The second converts that into an **instruction**: "waiting will never succeed" sends the reader to restart an agent that is mid-work.

On the clew reading the **operator and I agreed on the false fact** — he asked me to check because he believed it was down, I read the registry and confirmed his belief. Nothing broke only because I tried starting it on the other host rather than acting on the verdict.

## Now it names its population

```
NOT RUNNING ON <host> — … no live tmux session for it exists ON THIS HOST.
The probe ran and observed a real absence HERE; it says nothing about any
other host, because it can only see <host>'s sessions. If the agent is
pinned elsewhere … ASK THAT HOST before concluding it is down;
`sac agents start <name>` run there reports whether it is already running.
Once that is ruled out, the row outlived the process …
```

The claim is scoped to what was measured, and the remedy comes **before** the conclusion rather than after it.

## What is preserved, deliberately

The stopped case must still contradict the deaf case's advice, and still say "the row outlived the process" — there is an existing test asserting exactly that, and it was right.

**My first draft dropped the phrase and broke it.** The contract is that a genuinely stopped agent must not be told to wait for a reconnect; that is unchanged, now conditional on the cross-host question being settled first.

## Implementation notes

- hostname resolved **once** and cached — this formats per *row* on a fleet-sized response
- falls back to the literal `"this host"`, so the message degrades to the previous honest phrasing rather than raising inside an overlay that is explicitly advisory and must never fail the status route
- `.format` on the DEAF template is a no-op (no placeholder), so that entry needs no branch — covered by its own test

## Verification — against a sabotaged build

| code | result |
|---|---|
| original wording restored | **4 failed**, 19 passed |
| this branch | 23 passed |

The 4 that fail are exactly the new behaviours. The preserved-contract tests — deaf unchanged, "row outlived the process" — pass in **both** directions, which is what makes them guardrails rather than restatements of the change.

## Relationship to #1142

Complementary, not overlapping. #1142 stops one *class* of row (hostless, remote `turn_url`) from reaching this verdict at all. This makes the verdict honest for the rows that legitimately do reach it.

Card `sac-registry-says-not-running-while-process-alive-and-port-bound-20260817`.
