### PR TITLE
fix(rename): ENV_RULES never listed the CURRENT board-identity variable

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_rename_spec.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_spec.py
@@ -20,9 +20,18 @@ Touchpoints (the SSOT — :data:`SPEC_TOUCHPOINTS` documents them for
   7. ``spec.apptainer.raw_args`` ``--env K=V`` for K in :data:`ENV_RULES`
   8. ``spec.apptainer.env.<K>`` for K in :data:`ENV_RULES`
 
-``ENV_RULES`` is where the DAMAGING one lives: ``SCITEX_TODO_AGENT_ID``
-is the agent's identity ON THE BOARD. Change it without migrating the
-cards and every card the agent owns is orphaned — see ``_rename_cards``.
+``ENV_RULES`` is where the DAMAGING one lives: the agent's identity ON
+THE BOARD. Change it without migrating the cards and every card the agent
+owns is orphaned — see ``_rename_cards``. FAILING to change it is the
+mirror-image damage: the renamed agent keeps writing under its former
+name, and the board cannot say who those cards belong to.
+
+That identity is spelled ``SCITEX_CARDS_AGENT_ID`` today and
+``SCITEX_TODO_AGENT_ID`` in specs written before the rename. BOTH are in
+``ENV_RULES`` because both are live in the fleet — 108 specs and 193
+specs respectively, measured 2026-08-19. Only the old one was listed
+until then, so renaming any of the 108 silently produced exactly the
+mirror-image damage above.
 
 Why ruamel round-trip and not PyYAML load+dump: specs carry load-bearing
 operator commentary (the live ``scitex-todo`` spec is ~40% comments
@@ -59,6 +68,20 @@ from typing import Any, Iterator
 # renamed.
 ENV_RULES: dict[str, str] = {
     "SCITEX_TODO_AGENT_ID": "identity",
+    # THE CURRENT SPELLING, and it was missing. Measured 2026-08-19 on
+    # compute-04: 108 specs declare SCITEX_CARDS_AGENT_ID and 193 still
+    # declare SCITEX_TODO_AGENT_ID. Only the old name was listed here, so
+    # renaming any of those 108 agents left the board identity pointing at
+    # the agent's FORMER name — and every card it then wrote was attributed
+    # to an agent that no longer exists. Exactly the damage the module
+    # docstring above warns this dict causes when it is wrong.
+    #
+    # BOTH are listed on purpose while both populations exist. This is not a
+    # compatibility fallback to be tidied away: it is the rename tool having
+    # to recognise what is ACTUALLY IN THE SPECS. Drop the old key only when
+    # no spec declares it — the same condition _board_identity_env.py states
+    # for dropping the legacy injection, and it is the same 193 specs.
+    "SCITEX_CARDS_AGENT_ID": "identity",
     "SCITEX_TODO_AGENT": "identity",
     "SAC_NAME": "identity",
     "SCITEX_AGENT_CONTAINER_NAME": "identity",

--- a/tests/scitex_agent_container/_lifecycle/test__rename_spec.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_spec.py
@@ -105,6 +105,39 @@ def test_sub_env_value_rewrites_the_board_identity():
     assert result == NEW
 
 
+def test_sub_env_value_rewrites_the_CURRENT_board_identity():
+    """The spelling 108 specs already use, and it was not in ENV_RULES.
+
+    Measured 2026-08-19 on compute-04: 108 specs declare
+    ``SCITEX_CARDS_AGENT_ID`` and 193 still declare the old
+    ``SCITEX_TODO_AGENT_ID``. Only the old key was listed, so renaming any of
+    those 108 agents left the board identity pointing at the agent's FORMER
+    name, and every card it then wrote was attributed to an agent that no
+    longer exists -- the damage this module's own docstring warns about.
+    """
+    # Arrange
+    key = "SCITEX_CARDS_AGENT_ID"
+    # Act
+    result = sub_env_value(key, OLD, OLD, NEW)
+    # Assert
+    assert result == NEW
+
+
+def test_sub_env_value_still_rewrites_the_legacy_board_identity():
+    """Both spellings, on purpose, while both populations exist.
+
+    Not a compatibility fallback to be tidied away: the rename tool has to
+    recognise what is ACTUALLY IN THE SPECS. Dropping this one early breaks
+    renames for the 193 specs that still carry it.
+    """
+    # Arrange
+    key = "SCITEX_TODO_AGENT_ID"
+    # Act
+    result = sub_env_value(key, OLD, OLD, NEW)
+    # Assert
+    assert result == NEW
+
+
 def test_sub_env_value_rewrites_the_state_db_path_component():
     # Arrange
     key = "SCITEX_AGENT_CONTAINER_STATE_DB"


### PR DESCRIPTION
## The bug

`sac agents rename` rewrites the env vars whose value identifies the agent. `ENV_RULES` listed `SCITEX_TODO_AGENT_ID` and **not** the current spelling `SCITEX_CARDS_AGENT_ID`.

So renaming any agent whose spec uses the current name left its board identity pointing at the agent's **former** name — and every card it then wrote was attributed to an agent that no longer exists.

That is the exact damage this module's own docstring warns `ENV_RULES` causes when it is wrong, in the mirror direction: it warns about *changing* the identity without migrating cards; this is *failing to change it*.

## Measured, with a control

On compute-04, so a zero could not mean "the search did not run":

| | count |
|---|---|
| specs declaring `SCITEX_CARDS_AGENT_ID` | **108** ← affected today |
| specs declaring `SCITEX_TODO_AGENT_ID` | 193 |

Both keys are now listed. That is **not** a compatibility fallback to be tidied away: the rename tool has to recognise what is *actually in the specs*, and both populations are live. The old key comes out when no spec declares it — the same condition `_board_identity_env.py` already states for dropping the legacy injection, and it is the same 193 specs.

## What I tried first, and reverted

A blanket source-wide rename of the old name to the new one.

It broke **16 tests**, and one break was serious: this very dict would have had its only identity rule *swapped* rather than extended, silently removing the rewrite for the 193 specs that carry the old name. **The cleanup would have caused the corruption it was meant to prevent.** The suite caught it; I did not.

dotfiles then measured the spec repo, which also rules out the sweep I had asked them for:

- of 162 tracked specs, **101 declare both names** — so the correct operation there is **deletion** of the legacy line, not a rename, which would produce a duplicate key
- only **3** are true renames
- one spec (`scitex-agent-container-04`) declares the two names with **different values**, so a blind rename would have re-attributed a live agent's card writes

## Verification — against a sabotaged build

Removing the added rule fails exactly one test, and its diff shows the identity staying at the old agent name after a rename to the new one:

```
- scitex-cards
+ scitex-todo
```

**126 passed / 4 skipped** across the three rename suites.

## Scope

Card `fleet-finish-the-todo-to-cards-identity-rename-20260819`.

This does **not** move the legacy-injection gate in `_board_identity_env.py`. That stays until the specs are migrated — removing it early re-creates the 2026-07-19 incident where cards DB rows carry `created_by = '${SCITEX_CARDS_AGENT_ID}'`, the literal placeholder stored as an answer.
