### PR TITLE
fix(tests): preflight tests inherited a 2G disk guard and went red on a full runner

### DIFF
--- a/tests/scitex_agent_container/runtimes/test__apptainer_preflight.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_preflight.py
@@ -6,6 +6,7 @@ See docs/adr/0001-isolation-hardening.md (D2 + D4).
 from __future__ import annotations
 
 import shlex
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,30 @@ from scitex_agent_container.runtimes._apptainer_runtime import (
 
 
 def _cfg(workdir: Path, **kw) -> AgentConfig:
+    # tmpfs_size="" is DECLARED here, never inherited.
+    #
+    # Every test in this file asserts on the INNER argv (everything
+    # after the SIF path). ``--workdir`` is an OUTER flag and no
+    # assertion here reads it. But building the argv calls
+    # ``tmpfs_workdir_flags``, which runs ``shutil.disk_usage`` against
+    # the real filesystem and raises ``TmpfsSpaceError`` when free space
+    # is below ``tmpfs_size``. Under the 2G default that makes these
+    # verdicts depend on ambient free disk the tests neither control nor
+    # are about.
+    #
+    # 2026-08-19: a shared CI runner at 91% full turned that dependency
+    # into named, code-shaped failures here — test_preflight_wrapper_*
+    # and test_preflight_script_* all went red on a full disk, which
+    # sends readers to their own diff for a condition no diff caused.
+    #
+    # The guard itself is correct and stays. It is covered
+    # deterministically in ``test__apptainer_tmpfs.py``, which requests
+    # 10 EiB so it fires on any host rather than only on a full one.
+    #
+    # Normalise on EVERY path, including callers that pass their own
+    # spec — a setdefault would leave those reinheriting the 2G default.
+    ap = kw.pop("apptainer", None) or ApptainerSpec()
+    kw["apptainer"] = replace(ap, tmpfs_size="")
     return AgentConfig(
         name=kw.pop("name", "iso"),
         runtime="apptainer",


### PR DESCRIPTION
`test__apptainer_preflight.py::_cfg()` built its `AgentConfig` without declaring `apptainer.tmpfs_size`, so it inherited the **2G default**. Building the argv calls `tmpfs_workdir_flags`, which runs `shutil.disk_usage` against the real filesystem and raises `TmpfsSpaceError` below that threshold. Fourteen tests verdicts therefore depended on ambient free disk they neither control nor test.

The cost is the misattribution, not the failure. It surfaces as *named* failures (`test_preflight_wrapper_invokes0`, `test_preflight_script_checks_r0`, ...), so readers go to their own diff first. An error that misattributes itself sends people to the wrong file. That is what happened on the shared runner today, to two agents independently.

`_cfg()` now declares `tmpfs_size=""` explicitly and normalises on **every** path via `dataclasses.replace`, including the two callers that pass their own `ApptainerSpec` (`relaxed=True`, `overlay=`). A `setdefault` would have left those silently reinheriting 2G.

Nothing under test changes: `--workdir` is an OUTER flag and all 18 tests inspect the INNER argv after the SIF path. The guard itself is correct and stays -- `test__apptainer_tmpfs.py` covers it deterministically by requesting 10 EiB, so it fires on any host rather than only a full one.

Verification -- sabotage control, `shutil.disk_usage` forced to 1 MiB free:

| control | condition | result |
|---|---|---|
| A | old code, forced low disk | 4 passed, **14 errors** (reproduces CI on demand) |
| B | patched code, forced low disk | 18 passed |
| C | patched code, real disk | 18 passed |

A is the point: green on a healthy disk would have proved nothing. Full runtimes suite: **1940 passed, 20 skipped**. ruff clean.