### PR TITLE
fix(runtime): move the tmpfs free-space check off the argv path to the launch path

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -204,6 +204,21 @@ class ApptainerContainerRuntime(RuntimeBase):
             _write_redacted_argv(state_dir / "apptainer_run.argv.txt", argv)
             return True
 
+        # FREE-SPACE GUARANTEE — fail loud before starting a container onto a
+        # host that cannot hold its scratch, rather than letting the agent
+        # discover the shortfall mid-run as an opaque ENOSPC.
+        #
+        # HERE, past the dry_run return, for the same reason the overlay
+        # reconcile below is here: `build_run_argv` is also called by
+        # `sac agents explain` and by the dry-run path, and a read-only
+        # command must not fail on a launch-time resource condition. It used
+        # to live inside `tmpfs_workdir_flags`, which made `explain` unusable
+        # on exactly the full host it would have helped diagnose, and wired
+        # ~21 argv-building test files to ambient free disk.
+        from ._apptainer_tmpfs import verify_tmpfs_headroom
+
+        verify_tmpfs_headroom(config, state_dir)
+
         # OVERLAY VENV INVALIDATION CONTRACT — an image rebuild must invalidate
         # the `venv-sac` slice of this agent's overlay, or the overlay's stale
         # site-packages shadow the new image forever. Contract, measurement and

--- a/src/scitex_agent_container/runtimes/_apptainer_tmpfs.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_tmpfs.py
@@ -89,9 +89,38 @@ def tmpfs_workdir_flags(config, state_dir: Path) -> list[str]:
       * the operator already declared ``-W``/``--workdir`` in
         ``apptainer.raw_args`` (relaxed escape-hatch — don't duplicate).
 
-    Creates the scratch dir under ``<state_dir>/tmp-scratch`` and
-    verifies the backing filesystem has at least ``tmpfs_size`` bytes
-    free, raising :class:`TmpfsSpaceError` if not.
+    Creates the scratch dir under ``<state_dir>/tmp-scratch``.
+
+    Does NOT check free space — that is :func:`verify_tmpfs_headroom`,
+    called on the real launch path only. This function is reached by
+    ``sac agents explain`` and by ``run(dry_run=True)``, which start
+    nothing and must not fail on a host condition they do not depend on.
+    """
+    resolved = _resolve_scratch(config, state_dir)
+    if resolved is None:
+        return []
+
+    scratch, _size, _need_bytes = resolved
+    scratch.mkdir(parents=True, exist_ok=True)
+    return ["--workdir", str(scratch)]
+
+
+def _resolve_scratch(config, state_dir: Path) -> tuple[Path, str, int] | None:
+    """Resolve ``(scratch_dir, size_str, need_bytes)``, or ``None`` when sac
+    does not manage this agent's workdir (operator opt-out, or an explicit
+    ``-W``/``--workdir`` in ``raw_args``).
+
+    Shared by :func:`tmpfs_workdir_flags` and :func:`verify_tmpfs_headroom`
+    so the two can never disagree about WHICH directory is being sized —
+    the flag and the check must describe the same path or the guarantee is
+    about a directory the container does not use.
+
+    ``parse_tmpfs_size_bytes`` is called HERE, so an unparseable
+    ``tmpfs_size`` still fails loud at argv-construction time. That is
+    deliberate: a bad size string is a CONFIG error, present on every host
+    regardless of disk, and it should surface the moment the spec is read.
+    Only the free-space check — a RESOURCE condition, true on one host at
+    one moment — belongs at launch.
     """
     ap = getattr(config, "apptainer", None)
     if ap is None:
@@ -104,15 +133,43 @@ def tmpfs_workdir_flags(config, state_dir: Path) -> list[str]:
         raw_args = list(getattr(ap, "raw_args", None) or [])
 
     if not size:
-        return []
+        return None
 
     # Operator already pinned a workdir → respect it, emit nothing.
     if any(a in ("-W", "--workdir") for a in raw_args):
-        return []
+        return None
 
-    need_bytes = parse_tmpfs_size_bytes(size)
+    return state_dir.expanduser() / "tmp-scratch", size, parse_tmpfs_size_bytes(size)
 
-    scratch = state_dir.expanduser() / "tmp-scratch"
+
+def verify_tmpfs_headroom(config, state_dir: Path) -> None:
+    """Raise :class:`TmpfsSpaceError` unless the filesystem backing the
+    scratch dir has at least ``spec.apptainer.tmpfs_size`` bytes free.
+
+    CALL THIS ONLY ON A REAL LAUNCH PATH. It asks a question about the host
+    RIGHT NOW, so it is only meaningful immediately before starting a
+    container — and it is actively wrong anywhere else.
+
+    Why it is not in ``tmpfs_workdir_flags`` (which is where it used to
+    live): that function is also reached by ``sac agents explain`` and by
+    ``run(dry_run=True)``, neither of which starts anything. A full disk
+    therefore made two READ-ONLY commands fail — so an operator diagnosing
+    a full host could not run ``explain`` at exactly the moment it was
+    most useful. It also wired ~21 argv-building test files' verdicts to
+    ambient free disk they neither control nor test, which on a 91%-full
+    shared CI runner (2026-08-19) produced failures carrying unrelated
+    TEST NAMES and sent readers to their own diffs for hours.
+
+    This mirrors the placement ``_apptainer_runtime`` already chose for
+    ``reconcile_overlay_venv_for_launch`` — past the ``dry_run`` return,
+    for the same stated reason: a read-only command must not do
+    launch-time work.
+    """
+    resolved = _resolve_scratch(config, state_dir)
+    if resolved is None:
+        return
+
+    scratch, size, need_bytes = resolved
     scratch.mkdir(parents=True, exist_ok=True)
 
     usage = shutil.disk_usage(scratch)
@@ -125,7 +182,10 @@ def tmpfs_workdir_flags(config, state_dir: Path) -> list[str]:
             "lower spec.apptainer.tmpfs_size."
         )
 
-    return ["--workdir", str(scratch)]
 
-
-__all__ = ["tmpfs_workdir_flags", "parse_tmpfs_size_bytes", "TmpfsSpaceError"]
+__all__ = [
+    "tmpfs_workdir_flags",
+    "verify_tmpfs_headroom",
+    "parse_tmpfs_size_bytes",
+    "TmpfsSpaceError",
+]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -38,7 +38,6 @@ from scitex_agent_container.config._types import (
 )
 from scitex_agent_container.runtimes import _apptainer_runtime as mod
 from scitex_agent_container.runtimes._apptainer_creds import PinnedAccountError
-from scitex_agent_container.runtimes._apptainer_tmpfs import TmpfsSpaceError
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
     RUNNER_MODULE_AGENT,
     RUNNER_MODULE_PROXY,
@@ -49,6 +48,7 @@ from scitex_agent_container.runtimes._apptainer_runtime import (
     ApptainerContainerRuntime,
     _safe_image_tag,
 )
+from scitex_agent_container.runtimes._apptainer_tmpfs import TmpfsSpaceError
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -38,6 +38,7 @@ from scitex_agent_container.config._types import (
 )
 from scitex_agent_container.runtimes import _apptainer_runtime as mod
 from scitex_agent_container.runtimes._apptainer_creds import PinnedAccountError
+from scitex_agent_container.runtimes._apptainer_tmpfs import TmpfsSpaceError
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
     RUNNER_MODULE_AGENT,
     RUNNER_MODULE_PROXY,
@@ -1481,6 +1482,55 @@ def test_start_returns_false_when_sif_cannot_be_resolved(
     started = rt.start(cfg)
     # Assert
     assert started is False
+
+
+def test_start_dry_run_succeeds_on_a_host_too_full_to_launch(
+    state_root: Path, tmp_path: Path, apptainer_on_path: Path
+) -> None:
+    # Arrange — an impossible headroom request (10 EiB), which NO host can
+    # satisfy. A dry run starts nothing, so it must not consult the disk.
+    # While the free-space check lived inside ``tmpfs_workdir_flags`` this
+    # raised TmpfsSpaceError, making ``sac agents start --dry-run`` and
+    # ``sac agents explain`` fail on exactly the full host they would have
+    # been most useful for diagnosing.
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(image=str(sif), tmpfs_size="10737418240G"),
+    )
+
+    # Act
+    ok = rt.start(cfg, dry_run=True)
+
+    # Assert
+    assert ok is True
+
+
+def test_start_refuses_a_real_launch_when_headroom_is_insufficient(
+    state_root: Path, tmp_path: Path, apptainer_on_path: Path
+) -> None:
+    # Arrange — SABOTAGE CONTROL. This is the one test of the pair that must
+    # never be deleted or weakened. Moving the free-space check off the argv
+    # path is only correct if it STILL FIRES on a real launch; a guard that
+    # was silently dropped instead of moved passes every other test in this
+    # suite, including the dry-run case directly above. Same impossible size,
+    # so the only difference between the two tests is dry_run.
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(image=str(sif), tmpfs_size="10737418240G"),
+    )
+
+    # Act
+    ctx = pytest.raises(TmpfsSpaceError)
+
+    # Assert
+    with ctx:
+        rt.start(cfg)
 
 
 def test_start_dry_run_returns_true(

--- a/tests/scitex_agent_container/runtimes/test__apptainer_tmpfs.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_tmpfs.py
@@ -11,6 +11,7 @@ from scitex_agent_container.runtimes._apptainer_tmpfs import (
     TmpfsSpaceError,
     parse_tmpfs_size_bytes,
     tmpfs_workdir_flags,
+    verify_tmpfs_headroom,
 )
 
 # ---------------------------------------------------------------------------
@@ -131,22 +132,50 @@ def test_flags_skips_when_operator_declares_short_workdir(tmp_path: Path) -> Non
     assert flags == []
 
 
-def test_flags_fail_loud_when_space_insufficient(tmp_path: Path) -> None:
+def test_verify_headroom_fails_loud_when_space_insufficient(tmp_path: Path) -> None:
     # Arrange — request more than any real filesystem can offer so the
     # free-space guard fires deterministically (10 EiB exceeds every disk).
+    # This is the GUARD-IS-ALIVE control: if it ever stops raising, the
+    # launch-time guarantee has been silently removed.
     cfg = _Cfg(ApptainerSpec(tmpfs_size="10737418240G"))
     # Act
     ctx = pytest.raises(TmpfsSpaceError)
     # Assert
     with ctx:
-        tmpfs_workdir_flags(cfg, tmp_path)
+        verify_tmpfs_headroom(cfg, tmp_path)
+
+
+def test_flags_do_not_check_space_even_when_it_is_insufficient(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the SAME impossible size that makes verify_tmpfs_headroom
+    # raise above. Building argv must not consult the disk at all: this
+    # function is reached by `sac agents explain` and by run(dry_run=True),
+    # which start nothing.
+    cfg = _Cfg(ApptainerSpec(tmpfs_size="10737418240G"))
+    # Act
+    flags = tmpfs_workdir_flags(cfg, tmp_path)
+    # Assert — emits the workdir, raises nothing
+    assert flags == ["--workdir", str(tmp_path / "tmp-scratch")]
 
 
 def test_flags_propagates_parse_error_on_bad_size(tmp_path: Path) -> None:
-    # Arrange
+    # Arrange — an unparseable size is a CONFIG error, not a resource
+    # condition: it is wrong on every host regardless of disk, so it must
+    # still surface at argv-construction time rather than at launch.
     cfg = _Cfg(ApptainerSpec(tmpfs_size="garbage"))
     # Act
     ctx = pytest.raises(ValueError)
     # Assert
     with ctx:
         tmpfs_workdir_flags(cfg, tmp_path)
+
+
+def test_verify_headroom_is_a_noop_when_operator_opted_out(tmp_path: Path) -> None:
+    # Arrange — tmpfs_size="" means the operator declined sac's workdir, so
+    # there is no scratch dir to size and nothing to guarantee.
+    cfg = _Cfg(ApptainerSpec(tmpfs_size=""))
+    # Act
+    result = verify_tmpfs_headroom(cfg, tmp_path)
+    # Assert
+    assert result is None


### PR DESCRIPTION
`tmpfs_workdir_flags` did two things at argv-construction time: emit `--workdir`, and verify host free space. Only the first belongs there.

## The production bug this fixes

`build_run_argv` is also called by **`sac agents explain`** (`cli_pkg/_explain.py:45`) and by **`run(dry_run=True)`**. Both are read-only and start nothing — yet on a full disk both raised `TmpfsSpaceError`. An operator diagnosing a full host could not run `explain` at exactly the moment it was most useful. The diagnostic failed for the condition it would have diagnosed.

The same coupling wired ~21 argv-building test files' verdicts to ambient free disk they neither control nor test. On a 91%-full shared CI runner that produced failures carrying *unrelated test names* (`test_provider_column_specs`, `test__start_verbose_plan`), which sent readers to their own diffs for hours. An error that misattributes itself sends people to the wrong file.

## Shape

| | |
|---|---|
| `_resolve_scratch()` | shared resolver, so the flag and the check can never describe different directories |
| `tmpfs_workdir_flags()` | emits `--workdir`, creates the dir, **no disk check** |
| `verify_tmpfs_headroom()` | the check, launch path only |

Called from `ApptainerContainerRuntime.start()` immediately after the `dry_run` return — the placement and reasoning this module **already** uses for `reconcile_overlay_venv_for_launch`, whose comment says: *"`build_run_argv` is also called by `sac agents explain` and by the dry-run path above — a read-only command must not move files."*

**Deliberate asymmetry:** `parse_tmpfs_size_bytes` stays in `_resolve_scratch`, so an unparseable `tmpfs_size` still fails at argv construction. A bad size string is a **config** error — wrong on every host regardless of disk. Only the free-space check is a **resource** condition, true on one host at one instant.

## Verification

`shutil.disk_usage` forced to 1 MiB free, against the two files that actually failed in CI:

| control | condition | result |
|---|---|---|
| A | old code, forced low disk | **9 failed**, 14 passed |
| B | new code, forced low disk | 23 passed |
| C | new code, real disk | 23 passed |

C is why B means anything: green on a healthy disk is also the answer the *broken* code gives, so B only carries information because A establishes the condition can produce a red at all.

**Mutation test on the guard itself.** Deleting the `verify_tmpfs_headroom` call makes `test_start_refuses_a_real_launch_when_headroom_is_insufficient` fail with `DID NOT RAISE TmpfsSpaceError`. That is the point of the pair: a guard silently **dropped** rather than **moved** passes every other test in the suite, including the dry-run one. The two launch tests differ only in `dry_run`.

Full runtimes suite: **1944 passed, 20 skipped, exit 0**.
