### PR TITLE
fix(ci-poller): spend REST, not GraphQL — the loop burned 2.1x the pool

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_github_ci.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci.py
@@ -65,7 +65,38 @@ def _run_gh(args: list) -> str:
     return proc.stdout or ""
 
 
-def pr_ci_conclusion(repo: str, pr: int, *, run: GhRunner = _run_gh) -> str:
+#: REST check-run ``conclusion`` -> the bucket vocabulary `gh pr checks`
+#: uses, so the mapping below this stays untouched. Anything unrecognised is
+#: PENDING, never SUCCESS: an unknown state must not read as green.
+_BUCKET_FOR_CONCLUSION = {
+    "success": "pass",
+    "skipped": "skipping",
+    "neutral": "skipping",
+    "failure": "fail",
+    "timed_out": "fail",
+    "action_required": "fail",
+    "startup_failure": "fail",
+    "stale": "fail",
+    "cancelled": "cancel",
+}
+
+#: REST commit-status ``state`` -> the same vocabulary. Same rule: unknown
+#: is pending, not pass.
+_BUCKET_FOR_STATE = {
+    "success": "pass",
+    "failure": "fail",
+    "error": "fail",
+    "pending": "pending",
+}
+
+
+def pr_ci_conclusion(
+    repo: str,
+    pr: int,
+    *,
+    head_sha: str = "",
+    run: GhRunner = _run_gh,
+) -> str:
     """Return the PR's overall CI conclusion.
 
     One of :data:`CONCLUSION_SUCCESS`, :data:`CONCLUSION_FAILURE`,
@@ -77,14 +108,57 @@ def pr_ci_conclusion(repo: str, pr: int, *, run: GhRunner = _run_gh) -> str:
       * else (all ``pass``/``skipping``, non-empty) → ``success``
       * empty list or unparseable output → ``none`` (deliver nothing)
     """
-    raw = run(["pr", "checks", str(pr), "-R", repo, "--json", "bucket"])
+    # REST, not `gh pr checks --json bucket` (a GraphQL POST). See
+    # `list_open_prs` for the quota measurement that forced this.
+    #
+    # PARITY MATTERS HERE AND IS EASY TO GET WRONG. `gh pr checks` merges TWO
+    # GitHub concepts: check-runs (the Actions/App API) AND commit statuses
+    # (the older Status API that external CI still uses). Substituting only
+    # `/check-runs` would silently DROP the statuses — a green verdict that is
+    # green because it stopped looking. MEASURED 2026-08-19 on one open PR per
+    # repo: scitex-agent-container check_runs=8 statuses=0, but scitex-dev
+    # check_runs=16 statuses=1. The status arm is NOT hypothetical today, and
+    # even where it is empty the code must ask, because "no external CI right
+    # now" is a fleet fact and not a guarantee.
+    #
+    # The sha is fetched via REST (`pr_head_sha`, already REST in this
+    # module) when the caller does not supply one; the poll loop already
+    # holds it from `list_open_prs` and should pass it to save the call.
+    # `pr_head_sha` is defined BELOW this function, so it is resolved at
+    # call time rather than at import — Python looks the name up in the
+    # module globals when the call executes, by which point it exists.
+    sha = (head_sha or "").strip()
+    if not sha:
+        sha = pr_head_sha(repo, pr, run=run)
+    if not sha:
+        return CONCLUSION_NONE
+    buckets: set[str] = set()
+
+    raw = run(["api", f"repos/{repo}/commits/{sha}/check-runs?per_page=100"])
     try:
-        rows = json.loads(raw) if raw.strip() else []
+        payload = json.loads(raw) if raw.strip() else {}
     except (ValueError, TypeError):
+        payload = {}
+    for cr in (payload or {}).get("check_runs", []) or []:
+        if not isinstance(cr, dict):
+            continue
+        if str(cr.get("status", "")) != "completed":
+            buckets.add("pending")
+            continue
+        buckets.add(_BUCKET_FOR_CONCLUSION.get(str(cr.get("conclusion", "")), "pending"))
+
+    raw_st = run(["api", f"repos/{repo}/commits/{sha}/status"])
+    try:
+        st = json.loads(raw_st) if raw_st.strip() else {}
+    except (ValueError, TypeError):
+        st = {}
+    for one in (st or {}).get("statuses", []) or []:
+        if not isinstance(one, dict):
+            continue
+        buckets.add(_BUCKET_FOR_STATE.get(str(one.get("state", "")), "pending"))
+
+    if not buckets:
         return CONCLUSION_NONE
-    if not isinstance(rows, list) or not rows:
-        return CONCLUSION_NONE
-    buckets = {str(r.get("bucket", "")) for r in rows if isinstance(r, dict)}
     if buckets & _FAILING_BUCKETS:
         return CONCLUSION_FAILURE
     if "pending" in buckets:
@@ -136,16 +210,21 @@ def list_open_prs(repo: str, *, run: GhRunner = _run_gh) -> list:
     for the dedup key, body for the ``Owner:`` fallback). Unparseable /
     empty output → ``[]`` (the tick polls nothing for this repo).
     """
+    # REST, not `gh pr list --json`. MEASURED 2026-08-19: this poller ran on
+    # five hosts against one account and burned 10,634 GraphQL points/hour
+    # against a 5,000/hour pool — the account was dead for 32 minutes of every
+    # hour and every agent's PR operations failed during that window. `gh pr
+    # list --json` is a GraphQL POST; `gh api repos/<r>/pulls` is REST, and
+    # REST sat at 4,300/5,000 unused throughout. Same data, the other pool.
+    #
+    # `head_sha_for` in this same module already uses REST for exactly this
+    # reason; this call site simply had not followed it.
     raw = run(
         [
-            "pr",
-            "list",
-            "-R",
-            repo,
-            "--state",
-            "open",
-            "--json",
-            "number,headRefOid,body",
+            "api",
+            f"repos/{repo}/pulls?state=open&per_page=100",
+            "--jq",
+            "[.[] | {number: .number, headRefOid: .head.sha, body: .body}]",
         ]
     )
     try:

--- a/tests/scitex_agent_container/_lifecycle/test__github_ci.py
+++ b/tests/scitex_agent_container/_lifecycle/test__github_ci.py
@@ -22,44 +22,81 @@ from scitex_agent_container._lifecycle._github_ci import (
 )
 
 
+
+
+def _rest(check_runs=None, statuses=None, sha="deadbeef"):
+    """A ``run`` double speaking the REST shapes ``pr_ci_conclusion`` now reads.
+
+    The function used to make ONE call (`gh pr checks --json bucket`) and the
+    tests could answer with a single string. It now makes up to three REST
+    calls — head sha, check-runs, commit statuses — because `gh pr checks`
+    merged check-runs AND commit statuses and dropping the second would have
+    made a green verdict green by stopping looking (measured 2026-08-19:
+    scitex-dev had check_runs=16 statuses=1 on a live PR).
+
+    So the double DISPATCHES ON THE URL rather than returning one blob. Each
+    test below still asserts exactly the property it asserted before; only
+    the wire shape moved.
+    """
+    import json as _json
+
+    def run(args):
+        url = args[1] if len(args) > 1 else ""
+        if "/check-runs" in url:
+            return _json.dumps({"check_runs": check_runs or []})
+        if url.endswith("/status"):
+            return _json.dumps({"statuses": statuses or []})
+        return sha
+
+    return run
+
+
+def _completed(conclusion):
+    return {"status": "completed", "conclusion": conclusion}
+
+
 def test_all_pass_buckets_yield_success_conclusion():
-    # Arrange
-    out = json.dumps([{"bucket": "pass"}, {"bucket": "skipping"}])
+    # Arrange — every check completed green or skipped.
+    run = _rest(check_runs=[_completed("success"), _completed("skipped")])
     # Act
-    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
     # Assert
     assert conclusion == "success"
 
 
 def test_any_fail_bucket_yields_failure_conclusion():
-    # Arrange
-    out = json.dumps([{"bucket": "pass"}, {"bucket": "fail"}])
+    # Arrange — one red among greens must dominate.
+    run = _rest(check_runs=[_completed("success"), _completed("failure")])
     # Act
-    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
     # Assert
     assert conclusion == "failure"
 
 
 def test_cancel_bucket_yields_failure_conclusion():
-    # Arrange
-    out = json.dumps([{"bucket": "pass"}, {"bucket": "cancel"}])
+    # Arrange — a cancelled run is NOT a pass; it is unfinished work whose
+    # verdict nobody has. It counted as failure before and must still.
+    run = _rest(check_runs=[_completed("success"), _completed("cancelled")])
     # Act
-    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
     # Assert
     assert conclusion == "failure"
 
 
 def test_pending_without_fail_yields_pending_conclusion():
-    # Arrange
-    out = json.dumps([{"bucket": "pass"}, {"bucket": "pending"}])
+    # Arrange — an in-flight run (status != completed) with no red.
+    run = _rest(
+        check_runs=[_completed("success"), {"status": "in_progress"}]
+    )
     # Act
-    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
     # Assert
     assert conclusion == "pending"
 
 
 def test_empty_checks_list_yields_none_conclusion():
-    # Arrange
+    # Arrange — no check-runs AND no statuses: nothing to report, and the
+    # poller must deliver nothing rather than invent a verdict.
     out = json.dumps([])
     # Act
     conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
@@ -177,3 +214,62 @@ def test_failing_check_names_dedupes_and_sorts():
     names = failing_check_names("o/r", 1, run=lambda args: payload)
     # Assert
     assert names == ["alpha", "zeta"]
+
+def test_a_commit_status_is_not_dropped():
+    """`gh pr checks` merged check-runs AND commit statuses; REST does not.
+
+    Substituting only /check-runs would silently ignore external CI that
+    reports through the older Status API — a green verdict produced by
+    looking at less. scitex-dev had exactly one such status on a live PR
+    when this was measured, so it is not hypothetical.
+    """
+    # Arrange — all check-runs green, one commit status red.
+    run = _rest(
+        check_runs=[_completed("success")],
+        statuses=[{"state": "failure"}],
+    )
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
+    # Assert
+    assert conclusion == "failure"
+
+
+def test_an_unknown_conclusion_is_pending_not_success():
+    """A conclusion GitHub adds later must never read as green.
+
+    The mapping is explicit and closed; anything outside it falls to
+    pending. Defaulting the other way would make a future GitHub release
+    turn unknown states into passes, silently, everywhere.
+    """
+    # Arrange
+    run = _rest(check_runs=[_completed("some_new_state_github_added")])
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
+    # Assert
+    assert conclusion == "pending"
+
+
+def test_the_caller_can_supply_the_head_sha_and_save_a_call():
+    """The poll loop already has the sha from `list_open_prs`.
+
+    Passing it removes one REST call per PR per tick — the whole point of
+    this change being about call VOLUME, not just which pool it spends.
+    """
+    # Arrange
+    seen: list = []
+
+    def run(args):
+        seen.append(args[1] if len(args) > 1 else "")
+        if "/check-runs" in (args[1] if len(args) > 1 else ""):
+            return json.dumps({"check_runs": [_completed("success")]})
+        return json.dumps({"statuses": []})
+
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, head_sha="cafe1234", run=run)
+    # Assert
+    assert conclusion == "success" and not any(
+        u.endswith("/pulls/1") for u in seen
+    )
+
+
+# EOF


### PR DESCRIPTION
fix(ci-poller): spend REST, not GraphQL — the loop burned 2.1x the pool

MEASURED 2026-08-19 by direct observation. `sac listen`'s
`github_ci_poll_loop` runs on five hosts against one GitHub account and
consumed 10,634 GraphQL points/hour against a 5,000/hour pool. The account
was therefore EXHAUSTED ~28 minutes into every 60-minute window and DEAD for
the remaining 32 — every agent's `gh pr create` / `gh pr merge` /
`gh pr view --json` failed during that window. Two agents fell back to REST
by hand six times in one evening without knowing why.

THE MEASUREMENT

Clean window opened at a reset, sampled with the exempt `gh api rate_limit`:

    +631s   graphql used 2127   core used 193   ratio 11:1
    +1204s  graphql used 3557   core used 248   ratio 14.3:1
    = 2.95 pts/s = 10,634 pts/hr against a 5,000/hr pool

Attribution, by counting fleet burn and per-host `gh` spawns in ONE 90s
window rather than inferring:

    fleet graphql  +250 points
    `gh` children of `sac listen`:  117 + 30 + 25 + 0 + 0 = 172 calls
    -> >=69% of the burn, and that is a FLOOR (the 0.4s sampler cannot see
       invocations shorter than itself)

Duty cycle on one host: a `gh` child alive in 19 of 20 one-second samples.

THE RATIO IS THE DISCRIMINATOR. 14.3:1 GraphQL:REST can only come from a
consumer that spends GraphQL and no REST. This loop is exactly that. A
1-GraphQL-to-1-REST consumer cannot produce it, which is how the other
nominated call site was ruled out.

THE CHANGE

    list_open_prs     gh pr list --json          -> gh api repos/{r}/pulls
    pr_ci_conclusion  gh pr checks --json bucket -> gh api .../check-runs
                                                  + gh api .../status

`pr_head_sha` in this same module was ALREADY REST; these two call sites
simply had not followed it.

PARITY IS THE PART THAT IS EASY TO GET WRONG, so it is tested

`gh pr checks` merges TWO GitHub concepts: check-runs (Actions/Apps) and
commit statuses (the older Status API external CI still uses). Substituting
only `/check-runs` would silently drop the second — a green verdict that is
green because it stopped looking. Measured on one live PR per repo:
scitex-agent-container check_runs=8 statuses=0, but scitex-dev check_runs=16
statuses=1. The status arm is not hypothetical.

The conclusion->bucket map is CLOSED, and anything outside it falls to
PENDING, never SUCCESS. A conclusion GitHub adds next year must not read as
green everywhere, silently.

TESTS: 18 pass. The six existing properties are preserved exactly — only the
mock's wire shape moved, and the double now dispatches on URL because the
function makes three calls where it made one. Three properties are NEW
because the REST move creates them, and each was SABOTAGE-CONTROLLED rather
than assumed:

    remove the commit-status arm  -> test_a_commit_status_is_not_dropped
                                     FAILS, alone (1 failed, 17 passed)
    default unknown -> "pass"     -> test_an_unknown_conclusion_is_pending
                                     FAILS, alone (1 failed, 17 passed)
    restored                      -> 18 passed

One test failing rather than all of them is the point: a test that fires on
everything is too coarse to locate anything, and one that fires on nothing
is decoration.

WHAT THIS DOES NOT FIX, stated because it is the larger half

The tick is STRICTLY SERIAL — for each of ~94 repos, list PRs, then for each
of ~130 open PRs, fetch a conclusion — so one tick costs ~225 subprocess
calls at ~2.1s each, about 470 SECONDS. The interval is 300s. The runner
therefore times out EVERY tick and ABANDONS the thread (the module's own
docstring flags abandonment) before sleeping and starting another, so the
poller effectively never idles. Moving to REST changes which pool that
spends; it does not make the tick fit its interval. That needs batching, or
an interval that follows the tick, and is a separate change.

`pr_ci_conclusion` now accepts `head_sha=`, which the poll loop already holds
from `list_open_prs` — passing it removes one REST call per PR per tick. The
loop is not yet updated to pass it; that is the cheapest next step.

AND NOTHING ALARMS ON EXHAUSTION. `gh api rate_limit` is exempt from both
pools, so a check costs nothing. The fleet found this by having merges fail,
six times, across two agents, in one evening.

CONTROL TO RUN BEFORE ANYONE CALLS THIS FIXED: the loop is per-host and the
pool is per-account, so stopping one host changes the slope by ~20% and would
read as "not the cause". Sample graphql remaining across a full reset window
with the new build on ALL FIVE hosts.
