### PR TITLE
feat(state): inject SCITEX_STORE_DSN so sac can adopt the fleet store

### DIFF
--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -105,14 +105,75 @@ CONFIG_SECTION = "fleet_default_env"
 # per agent until each restarts onto this cleaned environment; that is correct
 # behaviour, not a leftover. Do NOT "fix" it by reintroducing the key.
 #
-# FLEET_DEFAULT_ENV is now EMPTY, and that is a valid state — the mechanism
-# survives for operator overrides via ``config.yaml``'s ``fleet_default_env``.
-# Asserted by test_dead_read_routing_key_* in
-# tests/scitex_agent_container/runtimes/test__fleet_env.py.
+# FLEET_DEFAULT_ENV was EMPTY between 2026-07-29 and 2026-08-19, and that was
+# a valid state — the mechanism survives for operator overrides via
+# ``config.yaml``'s ``fleet_default_env``. Asserted by
+# test_an_empty_fleet_default_env_is_a_valid_state.
+#
+# SCITEX_STORE_DSN (2026-08-19, the operator's SQLite-eradication order:
+# 「sqlite 根絶をしてください」「fail fast, fail loud, no fallbacks」).
+#
+# READ THE TWO PARAGRAPHS ABOVE BEFORE ADDING ANOTHER KEY HERE. Two store
+# variables were declared here and later retired for STATING a routing policy
+# nothing enforced, and one of them cost a live diagnosis: an inert setting
+# that appears to answer the question spends the diagnostician's trust. So the
+# bar for a third store variable is not "it seems right" — it is that the
+# variable is demonstrably READ FOR BEHAVIOUR by its consumer.
+#
+# THAT BAR IS MET, AND MEASURED IN BOTH ARMS rather than argued:
+#
+#     with SCITEX_STORE_DSN set     scitex_dev.store.host_store() resolves to
+#                                   the injected DSN; Store opens; a put/get
+#                                   round trip returns typed values, and the
+#                                   row is visible in Postgres through a
+#                                   SECOND, INDEPENDENT client (raw psycopg,
+#                                   plain SQL) rather than through the library
+#                                   that chose the backend
+#     with it UNSET                 host_store() resolves to a UNIX socket and
+#                                   Store() raises StoreTargetError naming the
+#                                   missing socket path
+#
+# The unset arm is the point: the failure is LOUD and there is no SQLite path
+# to slip into. That is scitex-dev's design, in their own words at
+# ``resolve_target``: "deliberately no SQLite fallback ... a host whose
+# Postgres is down must fail loudly rather than start writing to a private
+# local file that shares nothing."
+#
+# test_store_dsn_is_read_for_behaviour_by_its_consumer asserts BOTH arms, so
+# if scitex-dev ever stops honouring the variable, sac goes RED here instead
+# of quietly injecting an inert string into every container for months. That
+# test is the guard the two retired variables never had.
+#
+# WHY THE DEFAULT IS NEEDED AT ALL — sac containers cannot use scitex-dev's
+# own default. ``host_store`` derives a socket path from ``$HOME`` and assumes
+# PostgreSQL's default port, giving
+# ``/home/agent/.scitex/pg/.s.PGSQL.5432`` inside a container. Two things are
+# wrong with that here, and only the second is sac's fault:
+#
+#   * the fleet's Postgres listens on 55432, and the port is part of the
+#     SOCKET FILENAME, so the socket that exists
+#     (``~/.scitex/pg/run/.s.PGSQL.55432``) can never be found by a resolver
+#     that has no port parameter. Reported to scitex-dev.
+#   * ``$HOME`` inside the container is ``/home/agent``, not the operator's
+#     home where the socket actually lives.
+#
+# TCP RATHER THAN THE SOCKET, deliberately: this mirrors SCITEX_CARDS_DB,
+# which is the DSN shape already proven fleet-wide in production, and the
+# same ``.pgpass`` line authenticates it — the entry wildcards the DATABASE
+# (``127.0.0.1:55432:*:scitex_cards``), so the credential is not a lucky
+# match. Following the working neighbour beats inventing a second shape.
+#
+# HOST-SPECIFIC OVERRIDES ARE THE OPERATOR'S LAYER, not a reason to compute
+# this value: a host whose Postgres is elsewhere sets
+# ``spec.fleet_default_env`` in ``config.yaml``, and a single agent that must
+# not receive it sets the key in its own ``spec.env``. A host with no
+# Postgres at all gets a loud refusal, which is the requested behaviour.
 #
 # These are opaque strings to sac. It never reads, parses or branches on them.
 # --------------------------------------------------------------------------
-FLEET_DEFAULT_ENV: dict[str, str] = {}
+FLEET_DEFAULT_ENV: dict[str, str] = {
+    "SCITEX_STORE_DSN": "postgresql://scitex_cards@127.0.0.1:55432/scitex",
+}
 
 
 def _config_path() -> Path:

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -43,20 +43,102 @@ def _write_config_yaml(path: Path, mapping: dict) -> Path:
 # ----------------------------------------------------------------------
 
 
-def test_sac_declares_no_fleet_defaults_of_its_own() -> None:
-    """Replaces test_fleet_defaults_seeded_with_the_cards_sqlite_read_backend.
+def test_sac_declares_the_store_dsn_and_nothing_else() -> None:
+    """Replaces test_sac_declares_no_fleet_defaults_of_its_own.
 
-    sac used to seed SCITEX_CARDS_READ_BACKEND=sqlite. Dropped 2026-07-29 on the
-    store owner's ruling — nothing reads it, and it actively misled a diagnosis
-    by stating a read policy that was never enforced. sac now declares nothing;
-    the cascade exists purely for operator overrides.
+    sac declared NOTHING between 2026-07-29 and 2026-08-19, after two store
+    variables were retired for stating a routing policy nothing enforced.
+    SCITEX_STORE_DSN is the third store variable declared here, and the
+    similarity is the reason this test pins the whole mapping rather than
+    just asserting the new key is present: an EXACT match is what makes a
+    fourth key someone adds casually show up as a failing test instead of as
+    another line in a container's environment that nobody chose.
     """
     # Arrange
     absent = Path("/nonexistent/config.yaml")
     # Act
     defaults = declared_fleet_defaults(absent)
     # Assert
-    assert defaults == {}
+    assert defaults == {
+        "SCITEX_STORE_DSN": "postgresql://scitex_cards@127.0.0.1:55432/scitex",
+    }
+
+
+def _resolved_store_locator(dsn: str | None) -> str:
+    """The locator scitex-dev resolves for sac, with SCITEX_STORE_DSN set or not.
+
+    Real ``os.environ`` with save/restore, the idiom this repo already uses
+    (``test__provider_common.py``, ``test_tui_session_settings_delivery.py``)
+    — NOT ``monkeypatch``. PA-306 forbids mocks here, and the point of these
+    two tests is that the REAL consumer reads the REAL variable, so a patched
+    environment would test the patch.
+
+    Resolution is PURE — it computes a target, it does not connect — so this
+    needs no Postgres. That is deliberate: a test that required a live
+    database would SKIP in CI, and a skip that reads as a pass is the defect
+    fixed in #1108.
+    """
+    import os
+
+    from scitex_dev.store import host_store  # HARD import; see the note below.
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    try:
+        if dsn is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = dsn
+        return str(host_store(pkg="scitex_agent_container", name="state").locator)
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+def test_the_injected_store_dsn_reaches_scitex_devs_resolver() -> None:
+    """Half of the guard the two RETIRED store variables never had.
+
+    SCITEX_CARDS_READ_BACKEND was injected into every container for months
+    while nothing read it. It was not merely useless: it STATED a read policy,
+    so an operator diagnosing an outage read that line, concluded the read
+    target was configured, and looked elsewhere. Nothing caught it, because no
+    test ever asked whether the consumer honoured the variable.
+
+    This asks. The import of ``scitex_dev.store`` is HARD rather than
+    ``importorskip`` for the same reason — scitex-dev is a [dev] dependency,
+    so an ImportError is a real breakage sac must see, and importorskip on a
+    dotted path is exactly the bug fixed in #1108.
+    """
+    # Arrange
+    dsn = FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"]
+    # Act
+    locator = _resolved_store_locator(dsn)
+    # Assert
+    assert "55432" in locator
+
+
+def test_without_the_injection_the_resolver_goes_somewhere_else() -> None:
+    """The other half: the two arms must DIFFER, or the variable is inert.
+
+    A test that only checked the "set" arm could pass even if scitex-dev
+    resolved to 55432 for its own reasons and ignored the variable entirely —
+    which is precisely the inert-but-plausible state that cost the live
+    diagnosis above. Requiring the UNSET arm to land elsewhere is what makes
+    "read for behaviour" an observation rather than an assumption.
+
+    The unset arm resolves to a UNIX socket that does not exist in a
+    container, and opening a Store against it raises StoreTargetError naming
+    the missing path. That loud refusal — with no SQLite to slip into — is
+    scitex-dev's stated design and the behaviour the operator asked for.
+    """
+    # Arrange
+    expected_absent = "55432"
+    # Act
+    locator = _resolved_store_locator(None)
+    # Assert
+    assert expected_absent not in locator
 
 
 def test_declared_defaults_do_not_mutate_the_module_constant(tmp_path: Path) -> None:


### PR DESCRIPTION
feat(state): inject SCITEX_STORE_DSN so sac can adopt the fleet store

The operator's order on 2026-08-19 was "sqlite 根絶" — eradicate SQLite,
migrate to Postgres — with "fail fast, fail loud, no fallbacks".

I WAS ABOUT TO BUILD THE WRONG THING. The plan was a private psycopg seam
in sac. scitex-dev already ships `scitex_dev.store`, and its own
`resolve_target` docstring states the operator's rule in its own words:

    "exactly two steps (SCITEX_STORE_DSN or the per-host Postgres) and
     deliberately NO SQLite fallback: a host whose Postgres is down must
     fail loudly rather than start writing to a private local file that
     shares nothing."

sac's pyproject already raised its scitex-dev floor to >=0.49.2 for exactly
this — "sac cannot adopt the fleet store primitive, the whole point of
moving state off SQLite, while this specifier excludes it". So the work is
ADOPTION, and I nearly reinvented what my own floor was raised to admit.

WHY AN INJECTION IS NEEDED AT ALL

`host_store` derives a socket path from $HOME and assumes Postgres's default
port. Inside a container that is `/home/agent/.scitex/pg/.s.PGSQL.5432`.
Two things are wrong, and only the second is sac's:

  * the fleet's Postgres listens on 55432, and THE PORT IS PART OF THE
    SOCKET FILENAME, so the socket that does exist
    (`~/.scitex/pg/run/.s.PGSQL.55432`) can never be found by a resolver
    with no port parameter. Reported to scitex-dev.
  * $HOME in the container is /home/agent, not where the socket lives.

I first reported the socket as absent. IT WAS NOT — my search was for
sockets by type and my positive control only proved the tree was searched,
not that sockets in it would be reported. A control has to exercise the
property the conclusion rests on. Corrected before anything was built on it.

MEASURED IN BOTH ARMS, NOT ARGUED

    with SCITEX_STORE_DSN   host_store resolves to the injected DSN; Store
                            opens; put/get returns TYPED values (int, float)
    with it UNSET           resolves to the socket; Store raises
                            StoreTargetError naming the missing path

The unset arm is the point: loud, immediate, and with no SQLite to slip
into. 0.49.0 shipped a Postgres backend that could be WRITTEN to and never
READ from, so "reads work now" was verified rather than assumed.

VERIFIED THROUGH A SECOND, INDEPENDENT CLIENT. Confirming a store with the
same library that chose the backend cannot distinguish "wrote to Postgres"
from "quietly wrote elsewhere". Raw psycopg, plain SQL, found the row in
`public.<name>_rows` with its op in `_oplog`. Run against a probe database;
only the four tables I created were dropped, and a pre-existing store's
tables were left untouched.

THE BAR FOR A THIRD STORE VARIABLE HERE, AND WHY IT IS MET

Two store variables were declared in this module and retired for STATING a
routing policy nothing enforced. One cost a live diagnosis: the board served
0 cards from a database holding 2,654 while its unit carried
`SCITEX_CARDS_READ_BACKEND=sqlite`, so everyone read that line, concluded
the read target was configured, and looked elsewhere. Nothing caught it
because no test ever asked whether the consumer honoured the variable.

test_store_dsn_is_read_for_behaviour_by_its_consumer asks. It drives
scitex-dev's resolver in both arms and REQUIRES THEM TO DIFFER. If the
variable is ever retired or renamed, the arms collapse and sac goes red
instead of shipping an inert string to every agent for months. That is the
guard the two retired variables never had.

Resolution is pure, so the test needs no Postgres and no mock — deliberate,
because a test needing a live database would SKIP in CI, and a skip that
reads as a pass is the defect fixed in #1108. The import of
`scitex_dev.store` is HARD for the same reason; importorskip on a dotted
path is precisely that bug.

SABOTAGE-CONTROLLED, because a green run proves nothing until it can go red:

    remove the key from the data layer  -> 2 failed, 38 passed
    rename the env var as if retired    -> 1 failed, 39 passed  (the
                                           behaviour test ALONE)
    restored                            -> 40 passed

One test failing rather than all of them is what makes it able to locate
anything.

SCOPE, STATED SO THE SUMMARY CANNOT DRIFT

This ships the SEAM only. No sac module reads the variable yet and no table
has moved, so nothing changes for any running agent — a container simply
carries one more env var. SQLite is still there: 16 modules import sqlite3.

Deployment measured so far, since the port that follows will need it:
scitex-compute-04 and -02 have the `scitex` database; -03 REFUSES
(its scitex_cards role lacks CREATEDB; a superuser role exists as a route);
-01 has a healthy Postgres but no psycopg on any host interpreter. The
fleet's Postgres accepts LOOPBACK ONLY — the tailnet .pgpass entries are
refused by pg_hba — so provisioning is per-host and is tracked, not assumed.
