### PR TITLE
fix(state): move the CI delivered-set off SQLite onto the fleet store

### DIFF
--- a/scripts/migrate_verdict_delivered_to_postgres.py
+++ b/scripts/migrate_verdict_delivered_to_postgres.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``verdict_delivered`` rows into PostgreSQL.
+
+WHY THIS EXISTS AND WHY IT MUST RUN BEFORE THE PORT IS DEPLOYED
+===============================================================
+``_state/state_db_verdict_dedup`` moved from SQLite to PostgreSQL (via
+``scitex_dev.store``). The delivered-set is the ONLY thing standing between
+the CI poller and re-delivering verdicts that agents have already seen. An
+empty PostgreSQL store therefore does not mean "nothing delivered yet" — it
+means "deliver everything again".
+
+Measured 2026-08-19, rows at risk per host:
+
+    scitex-compute-04   722        scitex-compute-02   114
+    scitex-compute-03   358        scitex-compute-01   104
+    fleet                             1,298
+
+Most are for head SHAs that are no longer any open PR's head, so they would
+never be re-polled. The dangerous remainder is the currently-open PRs whose
+current verdict was already sent — those WOULD be re-delivered, and the
+failure streak would reset, un-capping PRs the cap had deliberately
+silenced. Neither failure is loud. Hence this script.
+
+IT LIVES IN scripts/, NOT IN src/, ON PURPOSE
+=============================================
+It imports ``sqlite3``, and ``tests/develop/test_sqlite_footprint_frozen.py``
+scans ``src/`` and fails on any new SQLite user there. That gate is right and
+this file must not weaken it: a migration tool is a one-time act, not a
+capability the package ships. Delete it once every host has run it.
+
+IDEMPOTENT, AND NON-DESTRUCTIVE
+===============================
+Writes go through ``record_verdict_delivered``, which is INSERT-OR-IGNORE and
+preserves ``delivered_at``, so re-running copies nothing new and never moves
+a timestamp. The SQLite file is opened READ-ONLY and is not modified or
+deleted — if the port has to be reverted, the old state is still there.
+
+RUN IT ON THE HOST, NOT INSIDE AN AGENT CONTAINER
+=================================================
+``DEFAULT_DB_PATH`` resolves to a DIFFERENT FILE depending on where you are,
+and both answers are correct for their own environment:
+
+    on the host          ~/.scitex/agent-container/runtime/state.db
+                         <- the real one; `sac listen` opens this
+    inside a container    /state/scitex-agent-container/state.db
+                         <- that agent's private shard, from
+                            $SCITEX_AGENT_CONTAINER_STATE_DB
+
+Measured 2026-08-19: the host db held 722 delivered-set rows and one
+container shard held NONE — it does not even have the table. So a migration
+run from inside a container reports "nothing to migrate", exits 0, and
+leaves every real row behind. The script PRINTS the source path it resolved
+for exactly this reason: check that line before trusting the result.
+
+USAGE (per host, before deploying the port)
+
+    python3 scripts/migrate_verdict_delivered_to_postgres.py            # dry run
+    python3 scripts/migrate_verdict_delivered_to_postgres.py --commit   # do it
+
+Exits non-zero on any failure. There is no partial-success-reported-as-
+success path: a row that cannot be written raises.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _sqlite_rows(db_path: Path) -> list[tuple]:
+    """Every delivered-set row in the SQLite state db, read-only.
+
+    A missing file or missing table is reported as such and yields nothing —
+    those are legitimate states (a host that never polled CI), and they are
+    DISTINGUISHED from an error rather than both landing on an empty list.
+    """
+    if not db_path.exists():
+        print(f"  no SQLite state db at {db_path} — nothing to migrate")
+        return []
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        present = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='verdict_delivered'"
+        ).fetchone()
+        if not present:
+            print("  SQLite db has no verdict_delivered table — nothing to migrate")
+            return []
+        return conn.execute(
+            "SELECT repo, pr, head_sha, conclusion, dispatch_id, delivered_at "
+            "FROM verdict_delivered"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--state-db",
+        type=Path,
+        default=None,
+        help="SQLite state.db (default: the package's DEFAULT_DB_PATH)",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="actually write; without it this is a dry run that writes nothing",
+    )
+    args = parser.parse_args(argv)
+
+    if args.state_db is None:
+        from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+
+        args.state_db = Path(DEFAULT_DB_PATH)
+
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        record_verdict_delivered,
+        verdict_already_delivered,
+        verdict_store_target,
+    )
+
+    print(f"SOURCE (SQLite) : {args.state_db}")
+    print(f"TARGET (Postgres): {verdict_store_target().locator}")
+
+    rows = _sqlite_rows(args.state_db)
+    print(f"rows in SQLite  : {len(rows)}")
+    if not rows:
+        return 0
+
+    missing = [
+        r
+        for r in rows
+        if not verdict_already_delivered(
+            repo=r[0], pr=int(r[1]), head_sha=r[2], conclusion=r[3]
+        )
+    ]
+    print(f"absent in Postgres: {len(missing)}  (already there: {len(rows) - len(missing)})")
+
+    if not args.commit:
+        print("DRY RUN — nothing written. Re-run with --commit.")
+        return 0
+
+    for repo, pr, head_sha, conclusion, dispatch_id, delivered_at in missing:
+        record_verdict_delivered(
+            repo=repo,
+            pr=int(pr),
+            head_sha=head_sha,
+            conclusion=conclusion,
+            dispatch_id=dispatch_id,
+            delivered_at=float(delivered_at),
+        )
+
+    # Verify by RE-READING rather than by counting what we sent. A write loop
+    # that completed is not evidence the rows are there.
+    still_missing = [
+        r
+        for r in rows
+        if not verdict_already_delivered(
+            repo=r[0], pr=int(r[1]), head_sha=r[2], conclusion=r[3]
+        )
+    ]
+    print(f"after commit, still absent: {len(still_missing)}")
+    if still_missing:
+        print("MIGRATION INCOMPLETE — the rows above did not land.", file=sys.stderr)
+        return 1
+    print("OK — every SQLite row is present in PostgreSQL.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate_verdict_delivered_to_postgres.py
+++ b/scripts/migrate_verdict_delivered_to_postgres.py
@@ -74,10 +74,39 @@ Each host's ``.env-sac`` resolves sac through an EDITABLE install pointing at
 ``~/proj/scitex-agent-container/src``, so step 1 really is a ``git pull`` and
 not a ``pip install``.
 
+RUN IT TWICE — THE TABLE IS LIVE AND A SNAPSHOT IS ALWAYS SLIGHTLY STALE
+========================================================================
+The delivered-set accrues while you work. Measured 2026-08-19, forty minutes
+apart, with nothing of mine touching it:
+
+    compute-04   722 -> 724      compute-02   114 -> 116
+    compute-03   358 -> 359      compute-01   104 -> 106
+
+So the old daemon keeps writing SQLite rows between step 2 and step 3, and
+those rows would be absent from PostgreSQL when the new daemon takes over —
+each one a verdict re-delivered once. At this rate that is zero or one row
+per host, which is small but not nothing, and it is silent.
+
+The script is IDEMPOTENT, so the fix is free: run it again AFTER the
+restart. The second pass sees whatever the old daemon wrote in the gap and
+copies it; from the restart onward nothing writes SQLite at all, so a third
+pass would find nothing.
+
+    1. git -C ~/proj/scitex-agent-container pull      new code on disk
+    2. migrate ... --commit                            bulk
+    3. restart `sac listen`                            new code in effect
+    4. migrate ... --commit                            the stragglers
+
 USAGE (per host, after step 1 above)
 
     python3 scripts/migrate_verdict_delivered_to_postgres.py            # dry run
     python3 scripts/migrate_verdict_delivered_to_postgres.py --commit   # do it
+
+The columns are IDENTICAL on all four hosts — repo, pr, head_sha,
+conclusion, dispatch_id, delivered_at — verified before relying on one
+SELECT everywhere, because the table COUNT differs per host (26/22/21/21;
+tables are created lazily by whichever module ran there) and a uniform
+schema could not be assumed from that.
 
 Exits non-zero on any failure. There is no partial-success-reported-as-
 success path: a row that cannot be written raises.

--- a/scripts/migrate_verdict_delivered_to_postgres.py
+++ b/scripts/migrate_verdict_delivered_to_postgres.py
@@ -52,7 +52,29 @@ run from inside a container reports "nothing to migrate", exits 0, and
 leaves every real row behind. The script PRINTS the source path it resolved
 for exactly this reason: check that line before trusting the result.
 
-USAGE (per host, before deploying the port)
+WHERE THIS SITS IN THE DEPLOYMENT, AND WHY THAT ORDER IS SAFE
+=============================================================
+This script IMPORTS the ported module, so it cannot run before the code is
+on the host. An earlier draft of the PR said "migrate, then deploy"; that
+order is not merely risky, it is impossible, and a dry run piped to three
+peer hosts proved it with an identical
+``ImportError: cannot import name 'verdict_store_target'`` on each.
+
+    1. git -C ~/proj/scitex-agent-container pull      (new code on disk)
+    2. python3 scripts/migrate_verdict_delivered_to_postgres.py --commit
+    3. restart `sac listen`                            (new code in effect)
+
+Step 1 does NOT change the running daemon — it holds the modules it imported
+at boot and keeps reading SQLite through step 2. That is what makes the
+window safe by construction rather than merely short: the migration finishes
+while the only live reader is still the old one. Step 3 switches the reader
+over, and by then the rows are there.
+
+Each host's ``.env-sac`` resolves sac through an EDITABLE install pointing at
+``~/proj/scitex-agent-container/src``, so step 1 really is a ``git pull`` and
+not a ``pip install``.
+
+USAGE (per host, after step 1 above)
 
     python3 scripts/migrate_verdict_delivered_to_postgres.py            # dry run
     python3 scripts/migrate_verdict_delivered_to_postgres.py --commit   # do it

--- a/src/scitex_agent_container/_lifecycle/_ci_deliver.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_deliver.py
@@ -138,8 +138,11 @@ def deliver_verdict(
 
         failure_streak = failures_since_last_success
 
+    # No `db_path`: the delivered-set moved to PostgreSQL via
+    # scitex_dev.store, which resolves its own target. `db_path` still
+    # reaches `ancestors` below, whose lineage table is still SQLite.
     if already_delivered(
-        repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion, db_path=db_path
+        repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion
     ):
         return {"delivered": [], "skipped": True, "reason": "already-delivered"}
 
@@ -149,14 +152,13 @@ def deliver_verdict(
     # it stall would un-cap the PR on the next tick.
     escalating = False
     if conclusion == "failure":
-        streak = failure_streak(repo=repo, pr=pr, db_path=db_path)
+        streak = failure_streak(repo=repo, pr=pr)
         if streak > CONSECUTIVE_FAILURE_CAP:
             record(
                 repo=repo,
                 pr=pr,
                 head_sha=head_sha,
                 conclusion=conclusion,
-                db_path=db_path,
             )
             return {"delivered": [], "skipped": True, "reason": "streak-capped"}
         escalating = streak == CONSECUTIVE_FAILURE_CAP
@@ -193,7 +195,7 @@ def deliver_verdict(
     # not re-delivered next tick. A total-delivery failure still records —
     # the agent picks the verdict up on its own heartbeat; re-spamming a
     # transiently-unreachable fleet every tick is worse than one miss.
-    record(repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion, db_path=db_path)
+    record(repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion)
     return {
         "delivered": delivered,
         "skipped": False,

--- a/src/scitex_agent_container/_state/state_db_verdict_dedup.py
+++ b/src/scitex_agent_container/_state/state_db_verdict_dedup.py
@@ -1,63 +1,186 @@
-"""CI-verdict delivery dedup — the "delivered-set" (sac #404).
+"""CI-verdict delivery dedup — the "delivered-set", on PostgreSQL only.
 
-feedback.pdf §3: sac polls GitHub CI on its OWN schedule and a2a-delivers
-each verdict to the pusher EXACTLY ONCE — deduping on
-``(repo, pr, head_sha, conclusion)`` in sac's own state so a re-poll (or a
-``sac listen`` restart) never re-delivers a verdict the agent already saw.
-This module owns that delivered-set table in ``state.db``.
+sac polls GitHub CI on its own schedule and a2a-delivers each verdict to the
+pusher EXACTLY ONCE, deduping on ``(repo, pr, head_sha, conclusion)`` so a
+re-poll or a ``sac listen`` restart never re-delivers a verdict the agent
+already saw. A re-run that flips the conclusion on the same ``head_sha`` is a
+DISTINCT key, so the flipped verdict IS delivered; a new push is likewise
+distinct. The dedup is per exact outcome, not per PR.
 
-A re-run that flips the conclusion (red→green on the same head_sha) is a
-DISTINCT key, so the flipped verdict IS delivered — the dedup is per exact
-outcome, not per PR. A new push (new ``head_sha``) is likewise distinct.
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to
+PostgreSQL: "fail fast, fail loud, no fallbacks". This is the first table to
+move, and it moves by ADOPTING :mod:`scitex_dev.store` — the fleet's own
+store primitive — rather than by sac growing a private psycopg layer.
 
-Sibling-module pattern (mirrors :mod:`dispatch_ledger`): own
-``CREATE TABLE IF NOT EXISTS`` behind :func:`init_verdict_dedup_schema`,
-layered on the shared connection from :func:`state_db.open_db`, and a
-lazy :func:`_ensure_table` so callers never need an explicit init. Kept
-out of ``state_db.py`` so this branch never collides with concurrent
-``state_db.py`` work (same rationale as the dispatch ledger).
+That primitive already implements the operator's rule, in its own words at
+``resolve_target``: "exactly two steps (``SCITEX_STORE_DSN`` or the per-host
+Postgres) and deliberately NO SQLite fallback: a host whose Postgres is down
+must fail loudly rather than start writing to a private local file that
+shares nothing."
 
-All times are ``REAL`` unix-seconds (float), matching the diary tables.
+So there is nothing here to fall back TO. A host whose PostgreSQL is
+unreachable raises ``StoreTargetError`` naming the DSN it could not reach.
+That is the intended behaviour: a verdict that cannot be recorded must not
+be silently re-delivered forever, and a dedup set written to a file nobody
+reads is worse than no dedup at all.
+
+WHAT REPLACED WHAT
+==================
+``db_path`` IS GONE from every function. It named a SQLite file; there is no
+file. The store target comes from :func:`scitex_dev.store.host_store`, which
+sac's containers reach because ``SCITEX_STORE_DSN`` is injected as a fleet
+default (see :mod:`.._fleet_env`). Callers that used to thread ``db_path``
+through simply stop.
+
+``failures_since_last_success`` was a correlated SQL aggregate. The store
+exposes ``get``/``put``/``rows``, not SQL, so the streak is now computed in
+Python. THE COST IS STATED RATHER THAN HIDDEN: ``rows()`` materialises the
+whole delivered-set, where the old query counted server-side. Measured
+2026-08-19 the largest host held 722 rows and the fleet 1,298, growing by a
+handful a day, so this is comfortable for years — but it is O(n) per call
+and if this table ever reaches six figures the streak wants an indexed
+query instead. Recorded so a future reader finds a decision, not a surprise.
+
+Writing is INSERT-OR-IGNORE, preserved exactly: a re-seen verdict must not
+move ``delivered_at``, because that timestamp is what ORDERS the streak. A
+re-poll that refreshed it would silently reorder history and the failure cap
+would stop capping, with no error anywhere.
+
+TWO INDEPENDENT GUARDS HOLD THAT INVARIANT, and I only learned there were
+two by trying to break it:
+
+  1. ``put`` is attempted only for a key that is ABSENT, with
+     ``expected_revision=NEW_RECORD``. A concurrent writer that wins the
+     race raises ``RevisionMismatchError``, which means "already recorded"
+     — the same outcome the old ``INSERT OR IGNORE`` produced. No other
+     exception is caught; an unreachable store must still be loud.
+  2. the DATA fields are ``MergeRule.IMMUTABLE`` in the schema, so the
+     store itself REFUSES a later write to them.
+
+Measured 2026-08-19, one arm at a time: breaking (1) alone (upsert with
+``ANY_REVISION``) leaves the invariant intact because (2) catches it, and
+breaking (2) alone (``LAST_WRITER_WINS``) leaves it intact because (1)
+catches it. Only with BOTH removed does the timestamp move, and the test
+then fails alone. So neither guard is redundant decoration and neither is
+load-bearing by itself — remove one and the test still passes, which is
+precisely why this note exists rather than a comment saying "idempotent".
+
+All times are unix-seconds (float), matching the diary tables.
 """
 
 from __future__ import annotations
 
-import sqlite3
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS verdict_delivered (
-    repo          TEXT NOT NULL,
-    pr            INTEGER NOT NULL,
-    head_sha      TEXT NOT NULL,
-    conclusion    TEXT NOT NULL,
-    dispatch_id   TEXT,
-    delivered_at  REAL NOT NULL,
-    PRIMARY KEY (repo, pr, head_sha, conclusion)
-);
-"""
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Row, Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "verdict_delivered"
+
+#: Every write from this host is attributed to one node. The dedup set is
+#: single-writer per host by construction — only that host's ``sac listen``
+#: polls CI for it — so SINGLE_WRITER is the honest policy rather than a
+#: convenience.
+_ACTOR = "scitex-agent-container"
 
 
-def init_verdict_dedup_schema(db_path: Path | None = None) -> Path:
-    """Create the ``verdict_delivered`` table if missing. Idempotent.
+def _schema() -> Any:
+    """The delivered-set schema.
 
-    Delegates the base schema + connection config to
-    :func:`state_db.open_db`, then layers our own
-    ``CREATE TABLE IF NOT EXISTS`` so the delivered-set lives in the same
-    ``state.db`` file as the registry + diary tables. Returns the
-    resolved database path.
+    Built lazily so importing this module does not import scitex-dev; the
+    old module was equally lazy about ``state_db``, for the same reason
+    (import cost off the hot path).
+
+    IDENTITY fields must be IMMUTABLE — the store enforces it, and the
+    reason is worth keeping: "changing one does not update the record, it
+    names a different record." The two DATA fields are IMMUTABLE too,
+    deliberately: a delivered verdict is a historical fact, and a merge that
+    could move ``delivered_at`` would silently reorder the failure streak.
     """
-    from .state_db import init_schema, open_db
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
 
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
-    return init_schema(db_path)
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def fact(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=False,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "repo": ident(FieldKind.TEXT),
+            "pr": ident(FieldKind.INTEGER),
+            "head_sha": ident(FieldKind.TEXT),
+            "conclusion": ident(FieldKind.TEXT),
+            "dispatch_id": fact(FieldKind.TEXT),
+            "delivered_at": fact(FieldKind.REAL),
+        },
+    )
 
 
-def _ensure_table(conn: sqlite3.Connection) -> None:
-    """Ensure the delivered-set table exists on an already-open connection."""
-    conn.executescript(_SCHEMA)
+def verdict_store_target() -> Any:
+    """Resolve WHERE the delivered-set lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_verdict_store() -> Store:
+    """Open the delivered-set store. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function here opens and closes
+    one per call, which mirrors the old ``with open_db(...)`` shape — the
+    connection cost was acceptable before and the call rate has not changed
+    (one CI poll tick, not a request path).
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        verdict_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_verdict_dedup_schema() -> str:
+    """Create the delivered-set tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL
+    equivalent of the ``Path`` the SQLite version returned, and useful in
+    exactly the same way: it names WHERE the state actually went, so an
+    operator can check it rather than assume it.
+
+    Opening the store is what creates the tables, so this connects. It is
+    the locator, NOT ``Store.identity`` — that is a property, and reaching
+    for it with a ``hasattr`` guard would have turned a typo into a silently
+    wrong return value instead of an error.
+    """
+    store = open_verdict_store()
+    try:
+        return str(verdict_store_target().locator)
+    finally:
+        store.close()
 
 
 def verdict_already_delivered(
@@ -66,23 +189,24 @@ def verdict_already_delivered(
     pr: int,
     head_sha: str,
     conclusion: str,
-    db_path: Path | None = None,
 ) -> bool:
     """Return ``True`` iff this exact verdict was already delivered.
 
-    The dedup key is the 4-tuple ``(repo, pr, head_sha, conclusion)``. A
-    miss — or a brand-new ``state.db`` — returns ``False`` so the caller
-    delivers. Never raises on a fresh db (the table is ensured first).
+    The dedup key is the 4-tuple ``(repo, pr, head_sha, conclusion)``. A miss
+    — or a brand-new store — returns ``False`` so the caller delivers.
     """
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        row = conn.execute(
-            "SELECT 1 FROM verdict_delivered "
-            "WHERE repo=? AND pr=? AND head_sha=? AND conclusion=?",
-            (repo, int(pr), head_sha, conclusion),
-        ).fetchone()
+    store = open_verdict_store()
+    try:
+        row = store.get(
+            {
+                "repo": repo,
+                "pr": int(pr),
+                "head_sha": head_sha,
+                "conclusion": conclusion,
+            }
+        )
+    finally:
+        store.close()
     return row is not None
 
 
@@ -94,68 +218,92 @@ def record_verdict_delivered(
     conclusion: str,
     dispatch_id: str | None = None,
     delivered_at: float | None = None,
-    db_path: Path | None = None,
 ) -> None:
     """Mark this verdict delivered. Idempotent (re-poll-safe).
 
-    Uses ``INSERT OR IGNORE`` on the 4-tuple primary key so re-seeing the
-    same verdict is a no-op rather than an ``IntegrityError`` — the loop
-    can record unconditionally after a successful delivery.
+    Re-seeing a verdict is a NO-OP rather than an overwrite: ``delivered_at``
+    orders the failure streak, so a re-poll that refreshed it would quietly
+    reorder history. This is the old ``INSERT OR IGNORE`` semantics, kept.
     """
-    from .state_db import open_db
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
 
+    key = {
+        "repo": repo,
+        "pr": int(pr),
+        "head_sha": head_sha,
+        "conclusion": conclusion,
+    }
     ts = float(delivered_at) if delivered_at is not None else time.time()
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        conn.execute(
-            "INSERT OR IGNORE INTO verdict_delivered "
-            "(repo, pr, head_sha, conclusion, dispatch_id, delivered_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (repo, int(pr), head_sha, conclusion, dispatch_id, ts),
-        )
+    store = open_verdict_store()
+    try:
+        if store.get(key) is not None:
+            return
+        try:
+            store.put(
+                {**key, "dispatch_id": dispatch_id, "delivered_at": ts},
+                expected_revision=NEW_RECORD,
+            )
+        except RevisionMismatchError:
+            # A concurrent writer created the same key between our get and
+            # our put. "Already recorded" is the outcome we wanted; this is
+            # the optimistic-concurrency contract, not a swallowed error.
+            # Deliberately narrow: nothing else is caught, so an unreachable
+            # store still raises.
+            return
+    finally:
+        store.close()
 
 
-def failures_since_last_success(
-    *,
-    repo: str,
-    pr: int,
-    db_path: Path | None = None,
-) -> int:
+def failures_since_last_success(*, repo: str, pr: int) -> int:
     """Count failure verdicts delivered for this PR since its last green.
 
     The dedup key includes ``head_sha``, so a PR whose head keeps moving
     re-fires forever — every push is a fresh key. That is correct for a
     branch someone is pushing fixes to, and wrong for a standing sync PR
-    whose head tracks its source branch: there, each unrelated merge
-    moves the head and earns another "fix-and-push" the recipient cannot
-    act on. This count is the streak the caller caps on.
+    whose head tracks its source branch: there, each unrelated merge moves
+    the head and earns another "fix-and-push" the recipient cannot act on.
+    This count is the streak the caller caps on.
 
-    Counts only rows *newer* than the most recent ``success`` for the
-    same ``(repo, pr)``, so a red→green→red sequence starts over rather
-    than staying capped forever. With no success on record the floor is
-    ``0.0``, which every real ``delivered_at`` exceeds.
+    Counts only rows NEWER than the most recent ``success`` for the same
+    ``(repo, pr)``, so a red -> green -> red sequence starts over rather than
+    staying capped forever. With no success on record the floor is ``0.0``,
+    which every real ``delivered_at`` exceeds.
 
-    Returns 0 on a fresh db (the table is ensured first).
+    Returns 0 on a brand-new store.
     """
-    from .state_db import open_db
+    store = open_verdict_store()
+    try:
+        rows: list[Row] = store.rows()
+    finally:
+        store.close()
 
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        row = conn.execute(
-            "SELECT count(*) FROM verdict_delivered "
-            "WHERE repo=? AND pr=? AND conclusion='failure' "
-            "  AND delivered_at > COALESCE(("
-            "        SELECT max(delivered_at) FROM verdict_delivered "
-            "        WHERE repo=? AND pr=? AND conclusion='success'"
-            "      ), 0.0)",
-            (repo, int(pr), repo, int(pr)),
-        ).fetchone()
-    return int(row[0]) if row else 0
+    mine = [
+        r.values
+        for r in rows
+        if r.values.get("repo") == repo and int(r.values.get("pr", -1)) == int(pr)
+    ]
+    last_success = max(
+        (
+            float(v.get("delivered_at") or 0.0)
+            for v in mine
+            if v.get("conclusion") == "success"
+        ),
+        default=0.0,
+    )
+    return sum(
+        1
+        for v in mine
+        if v.get("conclusion") == "failure"
+        and float(v.get("delivered_at") or 0.0) > last_success
+    )
 
 
 __all__ = [
+    "STORE_NAME",
+    "verdict_store_target",
     "failures_since_last_success",
     "init_verdict_dedup_schema",
+    "open_verdict_store",
     "record_verdict_delivered",
     "verdict_already_delivered",
 ]

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -75,7 +75,12 @@ FROZEN_SQLITE = frozenset(
         "_state/state_db_heartbeats.py",
         "_state/state_db_migrations.py",
         "_state/state_db_relocation.py",
-        "_state/state_db_verdict_dedup.py",
+        # _state/state_db_verdict_dedup.py LEFT THIS SET 2026-08-19 — the
+        # first table to move to PostgreSQL, by adopting
+        # scitex_dev.store rather than by sac growing its own psycopg
+        # layer. The ratchet is the point: this file FAILS if a module
+        # is listed here but no longer imports sqlite3, so a port that
+        # forgets to shrink the set is caught, not merely uncelebrated.
     }
 )
 

--- a/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
+++ b/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
@@ -1,277 +1,311 @@
-"""Tests for the CI-verdict delivery dedup table (sac #404).
+"""CI-verdict delivered-set — on a REAL PostgreSQL, never SQLite, never a mock.
 
-The CI-feedback ring (feedback.pdf §3) requires sac to deliver each
-GitHub CI verdict to the pusher EXACTLY ONCE, even though it polls
-GitHub repeatedly. Dedup key is ``(repo, pr, head_sha, conclusion)`` —
-sac's own ``delivered-set`` (the PDF's term), kept in ``state.db`` so it
-survives a ``sac listen`` restart.
+Mirrors ``src/scitex_agent_container/_state/state_db_verdict_dedup.py``.
 
-Conventions (mirroring test_dispatch_ledger.py):
+WHY THESE TESTS TALK TO A REAL DATABASE
+=======================================
+The module under test is PostgreSQL-only by the operator's 2026-08-19 order
+("fail fast, fail loud, no fallbacks"), and it reaches PostgreSQL through
+``scitex_dev.store``. A suite that exercised the store's SQLite dialect
+instead would be testing a code path production can never take.
 
-  * One assertion per test (STX-TQ007); related invariants via
-    ``pytest.parametrize``.
-  * AAA markers (Arrange / Act / Assert).
-  * No mocks / monkeypatch (STX-NM); real sqlite under ``tmp_path``,
-    isolated via the ``db_path`` env fixture (explicit save/restore).
+That is not a hypothetical. scitex-dev 0.49.0 shipped a PostgreSQL backend
+that could be WRITTEN to and never READ from — writes bind parameters and
+survived, reads addressed columns by name against a dialect that set no row
+factory. It shipped precisely because the PostgreSQL path had been written
+to and never read from. Any suite that proves this module works must
+therefore read back through the same dialect production uses.
+
+AND WHY THEY MUST NOT SKIP
+==========================
+There is deliberately NO ``skipif`` on database availability. A skip that
+reads as a pass is the defect this whole migration exists to remove, and it
+is the same shape as the ``importorskip`` bug fixed in #1108, where a
+missing submodule turned "cannot test" into a green run. If PostgreSQL is
+unreachable these tests FAIL, and that red is correct: every runner in the
+gate pool (measured 2026-08-19: scitex-01..04-org-cpu-01 sit on
+scitex-compute-01..04) has a PostgreSQL on 127.0.0.1:55432, so an
+unreachable store is a broken fleet, not a test-environment quirk.
+
+ISOLATION WITHOUT PRIVILEGE
+===========================
+Each test gets its own PostgreSQL SCHEMA inside the existing ``scitex``
+database, selected through ``search_path`` in the DSN, and dropped with
+``CASCADE`` afterwards. Deliberately a schema and not a database:
+
+  * creating a database needs ``CREATEDB``, and the fleet is NOT uniform —
+    compute-03's ``scitex_cards`` role has ``rolcreatedb=False``, so a
+    create-a-database fixture would pass on three runners and fail on the
+    fourth, which is the worst possible flake (it looks like the code).
+  * the three-way python matrix can put concurrent jobs on ONE runner, so
+    the name carries a uuid; two legs get two schemas and never collide.
+  * ``DROP SCHEMA ... CASCADE`` leaves nothing behind, verified in this
+    file's own teardown assertion rather than assumed.
+
+Real ``os.environ`` save/restore, not ``monkeypatch`` — PA-306 forbids mocks,
+and the point is that the REAL resolver reads the REAL variable.
 """
 
 from __future__ import annotations
 
-import importlib
 import os
-import sqlite3
-from pathlib import Path
+import uuid
+from typing import Iterator
 
+import psycopg
 import pytest
 
+from scitex_agent_container._state.state_db_verdict_dedup import (
+    failures_since_last_success,
+    init_verdict_dedup_schema,
+    record_verdict_delivered,
+    verdict_already_delivered,
+)
 
-@pytest.fixture
-def db_path(tmp_path: Path):
-    """Isolated state.db location, exported via env so callers pick it up.
+#: The per-host store. Loopback only — every fleet PostgreSQL refuses
+#: non-local connections at pg_hba, measured 2026-08-19.
+_BASE_DSN = os.environ.get(
+    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
+)
 
-    Explicit env save/restore (no monkeypatch fixture, PA-306).
+
+@pytest.fixture()
+def pg_schema() -> Iterator[str]:
+    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
+
+    Yields the schema name. Anything the module writes lands here and is
+    dropped afterwards, so the live delivered-set is never touched.
     """
-    p = tmp_path / "state.db"
-    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
-    saved = os.environ.get(key)
-    os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
+    schema = "sac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema}"')
 
-    importlib.reload(mod)
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = f"{_BASE_DSN}?options=-csearch_path%3D{schema}"
     try:
-        yield p
+        yield schema
     finally:
         if saved is None:
             os.environ.pop(key, None)
         else:
             os.environ[key] = saved
-        importlib.reload(mod)
+        with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
 
 
-# ---------------------------------------------------------------------------
-# Schema
-# ---------------------------------------------------------------------------
+def _tables_in(schema: str) -> set[str]:
+    """The table names PostgreSQL actually holds in ``schema``."""
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
+            (schema,),
+        ).fetchall()
+    return {r[0] for r in rows}
 
 
-def test_init_schema_creates_verdict_delivered_table(db_path: Path):
+# ----------------------------------------------------------------------
+# The store exists, and it is PostgreSQL.
+# ----------------------------------------------------------------------
+
+
+def test_init_creates_the_delivered_set_in_postgres(pg_schema: str) -> None:
+    """POSITIVE CONTROL for every test below.
+
+    Read through a SECOND, INDEPENDENT client (raw psycopg, plain SQL)
+    rather than through the store that created them. Asking a library
+    whether its own write landed cannot distinguish "wrote to PostgreSQL"
+    from "wrote somewhere else" — which is exactly how a store can look
+    healthy while sharing nothing.
+    """
     # Arrange
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        init_verdict_dedup_schema,
-    )
-
+    expected = "verdict_delivered_rows"
     # Act
     init_verdict_dedup_schema()
-    with sqlite3.connect(db_path) as conn:
-        names = {
-            r[0]
-            for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
-        }
     # Assert
-    assert "verdict_delivered" in names
+    assert expected in _tables_in(pg_schema)
 
 
-def test_record_creates_table_lazily_without_explicit_init(db_path: Path):
-    # Arrange — never call init; record must ensure the table itself.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
+def test_init_reports_where_the_state_went(pg_schema: str) -> None:
+    """The return value NAMES the target, so a caller can check it.
 
+    The SQLite version returned a Path for the same reason. A store that
+    cannot say where it is is a store nobody can verify.
+    """
+    # Arrange
+    expected_fragment = "55432"
+    # Act
+    locator = init_verdict_dedup_schema()
+    # Assert
+    assert expected_fragment in locator
+
+
+def test_record_creates_the_store_lazily_without_an_explicit_init(
+    pg_schema: str,
+) -> None:
+    """Callers never have to remember to initialise first."""
+    # Arrange
+    expected = "verdict_delivered_rows"
     # Act
     record_verdict_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=1, head_sha="abc", conclusion="success"
+        repo="o/r", pr=1, head_sha="abc", conclusion="success", delivered_at=1.0
     )
     # Assert
-    assert verdict_already_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=1, head_sha="abc", conclusion="success"
-    )
+    assert expected in _tables_in(pg_schema)
 
 
-# ---------------------------------------------------------------------------
-# Dedup semantics
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# The dedup key.
+# ----------------------------------------------------------------------
 
 
-def test_fresh_key_is_not_delivered(db_path: Path):
+def test_a_fresh_key_is_not_delivered(pg_schema: str) -> None:
+    """A miss must return False so the caller DELIVERS rather than swallows."""
     # Arrange
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        verdict_already_delivered,
-    )
+    key = dict(repo="o/r", pr=7, head_sha="abc", conclusion="success")
+    # Act
+    seen = verdict_already_delivered(**key)
+    # Assert
+    assert seen is False
 
+
+def test_a_recorded_key_is_delivered(pg_schema: str) -> None:
+    """The whole point: a re-poll must not re-deliver."""
+    # Arrange
+    key = dict(repo="o/r", pr=7, head_sha="abc", conclusion="success")
+    record_verdict_delivered(**key, delivered_at=1.0)
+    # Act
+    seen = verdict_already_delivered(**key)
+    # Assert
+    assert seen is True
+
+
+def test_a_different_conclusion_is_a_distinct_key(pg_schema: str) -> None:
+    """A re-run that flips red->green on the SAME head MUST be delivered."""
+    # Arrange
+    record_verdict_delivered(
+        repo="o/r", pr=7, head_sha="abc", conclusion="failure", delivered_at=1.0
+    )
     # Act
     seen = verdict_already_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="success"
+        repo="o/r", pr=7, head_sha="abc", conclusion="success"
     )
     # Assert
     assert seen is False
 
 
-def test_recorded_key_is_delivered(db_path: Path):
+def test_a_different_head_sha_is_a_distinct_key(pg_schema: str) -> None:
+    """A new push is a new verdict, even with the same conclusion."""
     # Arrange
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
-
-    # Act
     record_verdict_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="failure"
+        repo="o/r", pr=7, head_sha="abc", conclusion="failure", delivered_at=1.0
     )
-    # Assert
-    assert verdict_already_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="failure"
-    )
-
-
-def test_different_conclusion_is_a_distinct_key(db_path: Path):
-    # Arrange — a re-run flipping red→green is a NEW verdict to deliver.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
-
-    record_verdict_delivered(repo="r", pr=3, head_sha="sha1", conclusion="failure")
     # Act
-    seen_success = verdict_already_delivered(
-        repo="r", pr=3, head_sha="sha1", conclusion="success"
+    seen = verdict_already_delivered(
+        repo="o/r", pr=7, head_sha="def", conclusion="failure"
     )
     # Assert
-    assert seen_success is False
+    assert seen is False
 
 
-def test_different_head_sha_is_a_distinct_key(db_path: Path):
-    # Arrange — a new push (new head_sha) is a new verdict.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
+def test_recording_twice_does_not_move_the_timestamp(pg_schema: str) -> None:
+    """INSERT-OR-IGNORE semantics, and this is the one that would rot silently.
 
-    record_verdict_delivered(repo="r", pr=3, head_sha="sha1", conclusion="success")
-    # Act
-    seen_other = verdict_already_delivered(
-        repo="r", pr=3, head_sha="sha2", conclusion="success"
-    )
-    # Assert
-    assert seen_other is False
-
-
-def test_record_is_idempotent(db_path: Path):
-    # Arrange — re-seeing the same verdict (re-poll) must not raise.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
-
-    record_verdict_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
-    # Act
-    record_verdict_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
-    # Assert
-    assert verdict_already_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
-
-
-# ---------------------------------------------------------------------------
-# Failure streak — the consecutive-failure cap's counter
-#
-# `delivered_at` is passed explicitly throughout: the streak is defined by
-# comparison against the last green's timestamp, and two records written in
-# the same float tick would make the ordering ambiguous. Production ticks are
-# minutes apart, so this is a test-determinism concern, not a live one.
-# ---------------------------------------------------------------------------
-
-
-def test_failure_streak_counts_reds_for_this_pr(db_path: Path):
+    ``delivered_at`` ORDERS the failure streak. If a re-poll refreshed it,
+    every re-poll would quietly reorder history and the streak cap would
+    stop capping — with no error anywhere. So the second write must be a
+    no-op, not an upsert.
+    """
     # Arrange
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-        record_verdict_delivered,
-    )
+    key = dict(repo="o/r", pr=7, head_sha="abc", conclusion="failure")
+    record_verdict_delivered(**key, dispatch_id="first", delivered_at=100.0)
+    # Act
+    record_verdict_delivered(**key, dispatch_id="second", delivered_at=999.0)
+    # Assert
+    assert _delivered_at_of(pg_schema, **key) == 100.0
 
+
+def _delivered_at_of(schema: str, *, repo: str, pr: int, head_sha: str,
+                     conclusion: str) -> float:
+    """Read ``delivered_at`` straight out of PostgreSQL, bypassing the store."""
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        row = conn.execute(
+            f'SELECT delivered_at FROM "{schema}".verdict_delivered_rows '
+            "WHERE repo = %s AND pr = %s AND head_sha = %s AND conclusion = %s",
+            (repo, pr, head_sha, conclusion),
+        ).fetchone()
+    return float(row[0])
+
+
+# ----------------------------------------------------------------------
+# The failure streak.
+# ----------------------------------------------------------------------
+
+
+def test_the_streak_counts_reds_for_this_pr(pg_schema: str) -> None:
+    """Three reds on three pushes is a streak of three."""
+    # Arrange
     for i, sha in enumerate(("a", "b", "c")):
         record_verdict_delivered(
-            repo="o/r", pr=1, head_sha=sha, conclusion="failure", delivered_at=100.0 + i
+            repo="o/r", pr=7, head_sha=sha, conclusion="failure",
+            delivered_at=float(i + 1),
         )
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
     assert streak == 3
 
 
-def test_failure_streak_resets_after_a_green(db_path: Path):
-    # Arrange — two reds, a green, then one more red.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-        record_verdict_delivered,
-    )
-
-    record_verdict_delivered(
-        repo="o/r", pr=1, head_sha="a", conclusion="failure", delivered_at=100.0
-    )
-    record_verdict_delivered(
-        repo="o/r", pr=1, head_sha="b", conclusion="failure", delivered_at=101.0
-    )
-    record_verdict_delivered(
-        repo="o/r", pr=1, head_sha="g", conclusion="success", delivered_at=102.0
-    )
-    record_verdict_delivered(
-        repo="o/r", pr=1, head_sha="d", conclusion="failure", delivered_at=103.0
-    )
+def test_the_streak_resets_after_a_green(pg_schema: str) -> None:
+    """red -> green -> red starts over, so a fixed PR is not capped forever."""
+    # Arrange
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="a",
+                             conclusion="failure", delivered_at=1.0)
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="b",
+                             conclusion="success", delivered_at=2.0)
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="c",
+                             conclusion="failure", delivered_at=3.0)
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
     assert streak == 1
 
 
-def test_failure_streak_ignores_another_prs_reds(db_path: Path):
-    # Arrange — a noisy neighbour must not cap this PR.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-        record_verdict_delivered,
-    )
-
-    for i, sha in enumerate(("a", "b", "c", "d", "e")):
-        record_verdict_delivered(
-            repo="o/r",
-            pr=999,
-            head_sha=sha,
-            conclusion="failure",
-            delivered_at=100.0 + i,
-        )
+def test_the_streak_ignores_another_prs_reds(pg_schema: str) -> None:
+    """One noisy PR must not cap a quiet one."""
+    # Arrange
+    record_verdict_delivered(repo="o/r", pr=8, head_sha="a",
+                             conclusion="failure", delivered_at=1.0)
+    record_verdict_delivered(repo="o/r", pr=8, head_sha="b",
+                             conclusion="failure", delivered_at=2.0)
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="c",
+                             conclusion="failure", delivered_at=3.0)
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
-    assert streak == 0
+    assert streak == 1
 
 
-def test_failure_streak_ignores_another_repos_reds(db_path: Path):
-    # Arrange — same PR number in a different repo is a different PR.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-        record_verdict_delivered,
-    )
-
-    for i, sha in enumerate(("a", "b", "c", "d")):
-        record_verdict_delivered(
-            repo="other/repo",
-            pr=1,
-            head_sha=sha,
-            conclusion="failure",
-            delivered_at=100.0 + i,
-        )
+def test_the_streak_ignores_another_repos_reds(pg_schema: str) -> None:
+    """PR numbers collide across repos; the repo is part of the identity."""
+    # Arrange
+    record_verdict_delivered(repo="o/other", pr=7, head_sha="a",
+                             conclusion="failure", delivered_at=1.0)
+    record_verdict_delivered(repo="o/other", pr=7, head_sha="b",
+                             conclusion="failure", delivered_at=2.0)
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="c",
+                             conclusion="failure", delivered_at=3.0)
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
-    assert streak == 0
+    assert streak == 1
 
 
-def test_failure_streak_is_zero_on_a_fresh_db(db_path: Path):
-    # Arrange — never written; the table must be ensured lazily, not raise.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-    )
-
+def test_the_streak_is_zero_on_a_fresh_store(pg_schema: str) -> None:
+    """A brand-new store must not look like a capped PR."""
+    # Arrange
+    expected = 0
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
-    assert streak == 0
+    assert streak == expected


### PR DESCRIPTION
fix(state): move the CI delivered-set off SQLite onto the fleet store

FIRST TABLE OUT. The operator's 2026-08-19 order was "sqlite 根絶" —
eradicate SQLite, migrate to PostgreSQL — with "fail fast, fail loud, no
fallbacks". `_state/state_db_verdict_dedup` now imports no `sqlite3` at all
and reaches PostgreSQL through `scitex_dev.store`, the fleet's own store
primitive, rather than through a private psycopg layer sac would have had to
maintain alone.

There is nothing here to fall back TO, and that is the primitive's design,
not a choice I made: `resolve_target` resolves `SCITEX_STORE_DSN` or the
per-host Postgres and nothing else, because "a host whose Postgres is down
must fail loudly rather than start writing to a private local file that
shares nothing."

WHY THIS TABLE FIRST

Measured on all four hosts rather than assumed from one:

    compute-04  722    compute-03  358    compute-02  114    compute-01  104

Present and non-empty everywhere, so it exercises the real thing; off the
agent-startup path; a 4-column identity key; append-mostly and idempotent by
construction. Its worst failure is a duplicated or missed CI verdict —
annoying, not dangerous. The control-plane tables (`instances` 478,
`incarnations` 237, `a2a_ports`, `lineage`) are read by `sac listen` on every
operation and deliberately are NOT first.

THE MIGRATION IS PART OF THIS CHANGE, NOT A FOLLOW-UP

An empty PostgreSQL store does not mean "nothing delivered yet" — it means
"deliver everything again", and it would also reset every failure streak,
un-capping PRs the cap had deliberately silenced. Neither failure is loud.
`scripts/migrate_verdict_delivered_to_postgres.py` copies the rows, is
idempotent, opens SQLite READ-ONLY, deletes nothing, and VERIFIES BY
RE-READING rather than by counting what it sent. It lives in `scripts/` and
not `src/` on purpose: it imports sqlite3, and the freeze gate scans `src/`
— a migration tool is a one-time act, not a capability the package ships.

WHAT CHANGED IN THE API

`db_path` is GONE from all four functions; it named a SQLite file and there
is no file. `_ci_deliver` stops threading it into them — but KEEPS it for
`ancestors`, whose lineage table is still SQLite. One table moves at a time.

`failures_since_last_success` was a correlated SQL aggregate; the store
exposes get/put/rows, not SQL, so the streak is computed in Python. THE COST
IS MEASURED, NOT WAVED AWAY — and measured on a POPULATED store, because a
timing taken against an empty table would have been a true reading of the
wrong thing.

Measured, both against a POPULATED store (722 rows) because a timing taken
on an empty table would have been a true reading of the wrong thing:

    verdict_already_delivered      13.5 ms/call  (flat — an indexed get)
    failures_since_last_success    31.6 ms/call  (13.3 ms when the table is
                                                  empty, so ~18 ms is the
                                                  full-table load)

The poller calls the first once per open PR (~130) and the second only for
failing ones, against a tick that already takes ~470 s. So ~1.8 s, under
half a percent. If this table ever reaches six figures the streak wants an
indexed query instead; that is written into the module, not left to be
rediscovered.

Writing stays INSERT-OR-IGNORE, and this is the part that would have rotted
silently: `delivered_at` ORDERS the streak, so a re-poll that refreshed it
would quietly reorder history and the cap would stop capping, with no error
anywhere.

TWO INDEPENDENT GUARDS HOLD THAT, AND I ONLY LEARNED THERE WERE TWO BY
TRYING TO BREAK IT. My first sabotage — turn the insert-or-ignore into an
upsert — left the suite GREEN, which is the whole reason to run sabotage
controls rather than trust a passing suite. The reason was not a weak test:
the schema marks the DATA fields `MergeRule.IMMUTABLE`, so the store itself
refused the second write. Breaking the merge rule alone is likewise caught
by the get-first path. Only with BOTH removed does the timestamp move
100.0 -> 999.0, and the test then fails ALONE (1 failed, 12 passed).

Neither guard is decoration and neither is load-bearing by itself. That is
now recorded in the module, because a future reader deleting the "redundant"
one would find every test still green.

TESTS RUN AGAINST A REAL POSTGRES, AND DO NOT SKIP

13 tests, no mocks, no SQLite dialect. There is deliberately no `skipif` on
database availability: a skip that reads as a pass is the defect this whole
migration exists to remove, and the same shape as the `importorskip` bug
fixed in #1108. If Postgres is unreachable these FAIL.

That is affordable because it was measured rather than hoped: every runner
in the gate pool sits on a compute host. I did not infer this from the
runner names — that is exactly the mistake ADR-0024 made — I read each
runner's `.runner` file on each machine:

    scitex-01-org-cpu-01  agentId 640  ON scitex-compute-01
    scitex-02-org-cpu-01  agentId 641  ON scitex-compute-02
    scitex-03-org-cpu-01  agentId 642  ON scitex-compute-03
    scitex-04-org-cpu-01               ON scitex-compute-04

and every one of those hosts runs PostgreSQL on 127.0.0.1:55432 with a
`scitex` database (provisioned on all four for this change). So no
`services:` block, no Docker requirement, and no surgery on
pytest-matrix.yml — the gate's own definition.

ISOLATION IS A SCHEMA, NOT A DATABASE, and the reason is a fleet fact:
creating a database needs CREATEDB and compute-03's `scitex_cards` role has
`rolcreatedb=False`. A create-a-database fixture would pass on three runners
and fail on the fourth, which is the worst kind of flake because it looks
like the code. Each test gets a uuid-named schema via `search_path` in the
DSN, dropped CASCADE afterwards; concurrent matrix legs on one runner get
distinct schemas.

Also verified through a SECOND, INDEPENDENT client: the tests that prove a
row landed read it with raw psycopg and plain SQL, not through the store
that wrote it. Asking a library whether its own write landed cannot
distinguish "wrote to PostgreSQL" from "wrote somewhere else" — which is
precisely how scitex-dev 0.49.0 shipped a Postgres backend that could be
written to and never read from.

THE FREEZE GATE RATCHETS DOWN: 13 entries to 12. That file FAILS if a module
is listed but no longer imports sqlite3, so a port that forgets to shrink
the set is caught rather than merely uncelebrated.

DEPLOYMENT ORDER — I HAD THIS WRONG AND A PRE-FLIGHT CAUGHT IT

I first wrote "migrate, THEN deploy". That order is IMPOSSIBLE: the
migration script imports the new module, so it cannot run before the code is
on the host. Found by piping the script to all three peer hosts and running
the dry run, which failed identically on each with
`ImportError: cannot import name 'verdict_store_target'`. A stated order
nobody had executed was simply not executable.

The same failure measured the deployment mechanism, which is the other half
of getting this right. The error names
`/home/ywatanabe/proj/scitex-agent-container/src/...` — so each host's
`.env-sac` resolves sac through an EDITABLE install pointing at the host
checkout. Deploying is therefore a `git pull`, not a `pip install`.

The correct order, and it has no hazard window by construction:

  1. git -C ~/proj/scitex-agent-container pull      (new code on disk)
  2. python scripts/migrate_..._to_postgres.py --commit
  3. restart `sac listen`                            (new code in effect)

Step 1 does NOT change the running daemon — it holds the modules it imported
at boot, so it keeps using SQLite through step 2. That property is what
makes the window safe rather than merely short: the migration completes
while the only live reader is still the old one. Only step 3 switches the
reader over, and by then the rows are there.

Getting it backwards is not loud: an empty PostgreSQL store does not say
"not migrated", it says "nothing delivered yet", and the poller re-delivers
up to 1,298 verdicts and resets every failure streak.

RUN IT ON THE HOST, NOT IN A CONTAINER. `DEFAULT_DB_PATH` resolves to the
per-agent shard inside a container (`/state/.../state.db`, which does not
even have this table) and to the real store on the host. A container run
would report "nothing to migrate", exit 0, and leave every row behind. The
script prints the source path it resolved so that is checkable rather than
assumed.
