### PR TITLE
fix(tests): a unit test was SSHing `sac agents stop` to a production host

### DIFF
--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
@@ -41,6 +41,28 @@ def _swap(name: str, fn: Callable) -> Iterator[None]:
         setattr(stop_mod, name, saved)
 
 
+#: Fixture agent names. The prefix is LOAD-BEARING — do not shorten these.
+#:
+#: They used to be "a" and "b", and that reached the REAL FLEET. Measured
+#: 2026-08-19: `_stop` resolves each target name through
+#: `config._resolve.resolve_with_prefix`, which PREFIX-MATCHED "b" to the
+#: live agent "business", decided it was REMOTE, and issued
+#:
+#:     ssh ywata-note-win-net -- 'sac agents stop b --json'
+#:
+#: The `_swap("agent_stop", ...)` above does not cover that path — a remote
+#: target never calls the local function — so the swap gave the APPEARANCE
+#: of isolation while a production stop went out over SSH. It failed only
+#: because this container could not resolve that hostname; anywhere DNS
+#: works, the test would have stopped a real agent AND THEN PASSED, since
+#: `exit_code == 0` is what it asserts.
+#:
+#: A `tmp_path` fixture bounds what the test SETS UP, never what the code
+#: under test REACHES FOR. These names are chosen so that no real agent can
+#: ever be a prefix-extension of them.
+FIXTURE_AGENTS = ("pytest-fixture-a", "pytest-fixture-b")
+
+
 def _seed(tmp_path: Path, names) -> Path:
     """Seed a directory with N agents (each <name>/<name>.yaml)."""
     root = tmp_path / "agents"
@@ -64,7 +86,7 @@ class _FakeCfg:
 @pytest.fixture
 def dry_run_result(tmp_path):
     # Arrange
-    root = _seed(tmp_path, ["a", "b"])
+    root = _seed(tmp_path, FIXTURE_AGENTS)
     runner = CliRunner()
     # Act
     result = runner.invoke(stop, [str(root), "extra", "--dry-run"])
@@ -107,7 +129,7 @@ def test_dry_run_lists_targets_mentions_bulk_yaml(dry_run_result):
 @pytest.fixture
 def bulk_no_yes_result(tmp_path):
     # Arrange
-    root = _seed(tmp_path, ["a", "b"])
+    root = _seed(tmp_path, FIXTURE_AGENTS)
     runner = CliRunner()
     # Act
     result = runner.invoke(stop, [str(root)])
@@ -141,7 +163,7 @@ def test_bulk_without_yes_refuses_prints_message(bulk_no_yes_result):
 @pytest.fixture
 def bulk_with_yes_run(tmp_path):
     # Arrange
-    root = _seed(tmp_path, ["a", "b"])
+    root = _seed(tmp_path, FIXTURE_AGENTS)
     stopped: list = []
     # Act
     with (
@@ -172,7 +194,7 @@ def test_bulk_with_yes_stops_all_invokes_agent_stop_per_agent(bulk_with_yes_run)
     # Act
     names = sorted(s[0] for s in stopped)
     # Assert
-    assert names == ["a", "b"]
+    assert names == sorted(FIXTURE_AGENTS)
 
 
 # ---------------------------------------------------------------------------
@@ -186,7 +208,7 @@ def bulk_failure_result(tmp_path):
     def _boom(_name, _force, *, prune_runtime=False):
         raise RuntimeError("boom")
 
-    root = _seed(tmp_path, ["a", "b"])
+    root = _seed(tmp_path, FIXTURE_AGENTS)
     # Act
     with (
         _swap("load_config", lambda p: _FakeCfg(Path(p).stem)),


### PR DESCRIPTION
fix(tests): a unit test was SSHing `sac agents stop` to a production host

`test__stop.py` seeded two fake agents named "a" and "b" under `tmp_path`.
sac's resolver prefix-matched "b" to the LIVE agent `business`, decided it
was remote, and issued:

    INFO config._resolve: resolved 'b' -> 'business' (prefix match)
    ssh ... ywata-note-win-net -- 'sac agents stop b --json'
    ssh: Could not resolve hostname ywata-note-win-net

THE ONLY THING THAT STOPPED IT WAS DNS. The test failed with `assert 1 == 0`
because this container cannot resolve that hostname. That is not a safety
mechanism — it is an accident of where the suite ran. Anywhere the name
resolves, the same test STOPS A PRODUCTION AGENT and then PASSES, because
`exit_code == 0` is exactly what it asserts. The red was the safe outcome
and a green would have meant an agent went down.

WHY THE EXISTING ISOLATION DID NOT COVER IT — this is the part worth reading

The file already tries: an autouse fixture repoints `$HOME` at `tmp_path`,
and the fixture swaps `load_config` and `agent_stop` in the module
namespace. Both are real precautions and neither reaches this path.
`_stop` resolves each target through `config._resolve.resolve_with_prefix`,
which is NOT swapped; a name that resolves REMOTE never calls the local
`agent_stop` at all — it builds an ssh argv and executes it. So the swap
gave the APPEARANCE of isolation for exactly the case that escapes it.

The failure output says so precisely: `assert ['a'] == ['a', 'b']`. "a"
went through the swapped local path and was collected; "b" went out over
the network.

I read this test's Arrange block and concluded "tmp_path, seeded root,
injected stop — it does not touch the real fleet", and said so, minutes
before running it. A fixture bounds what a test SETS UP, never what the code
under test REACHES FOR. Isolation is a property of reachability.

THE FIX, and why it is a test defect rather than a workaround

Fixture identities must not be able to collide with production ones. "a" and
"b" are one-character names and the prefix matcher will find a real agent
for almost any letter, so these were unsafe by construction regardless of
the resolver's behaviour. They become `pytest-fixture-a` / `pytest-fixture-b`
— names no real agent can be a prefix-extension of — with the incident
written above the constant so nobody shortens them back.

MEASURED IN BOTH ARMS, same command, same host:

    names "a"/"b"                ssh lines: 3   prefix matches: 3
                                 2 failed, 49 passed
    names pytest-fixture-a/b     ssh lines: 0   prefix matches: 0
                                 51 passed

Zero is the number that matters: the fleet reach is gone, not narrowed.

WHAT THIS DOES NOT FIX, stated so the summary cannot drift

The resolver still prefix-matches a name to a different agent for a
DESTRUCTIVE verb, and still falls through from a scoped request to the live
registry. Guessing "business" from "b" in order to STOP it is a guess with
an irreversible consequence, and no test can be the last line of defence
against it. That is a production-code change to a fleet-wide resolver and it
wants its own decision; carded as
sac-unit-test-can-stop-real-fleet-agents-via-prefix-match-20260819.
