### PR TITLE
feat(state): move the birth certificate off SQLite to per-host PostgreSQL

### DIFF
--- a/scripts/migrate_incarnations_to_postgres.py
+++ b/scripts/migrate_incarnations_to_postgres.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``incarnations`` table into per-host PostgreSQL.
+
+Companion to the ``state_db_incarnations`` port (2026-08-19). The code stopped
+reading SQLite; this moves the rows that are already there so the history is
+not stranded in a file nothing opens any more.
+
+RUN IT ON THE HOST, NOT IN A CONTAINER
+======================================
+``DEFAULT_DB_PATH`` resolves differently in the two places: a container gets
+its own per-agent shard under ``/state/<agent>/state.db``, the host gets
+``~/.scitex/agent-container/runtime/state.db``. The rows are on the HOST —
+measured 2026-08-19, compute-04 held 242 of them — so a container run would
+faithfully migrate an empty shard and report success.
+
+RUN IT TWICE
+============
+The table is live: ``sac`` writes a birth certificate on every launch. Run it
+once now, restart the daemons so they pick up the new code, then run it again
+to sweep anything written through the old path in between. The second run is
+expected to find few or no stragglers; that it finds ANY is the reason it
+exists.
+
+WHY IT DOES NOT CALL ``record_incarnation_birth``
+=================================================
+That function stamps ``born_at`` with ``now_iso()`` — correct for a real
+launch, destructive here. A migration that rewrote every birth time to the
+migration's own clock would look like the whole fleet was born at 00:40 on
+2026-08-20, which is precisely the "backfilled timestamp makes old things
+look new" failure. So this writes through the store directly, preserving
+every recorded value verbatim.
+
+IT IS IDEMPOTENT and it VERIFIES: each record is read back through the same
+dialect production reads through, and a mismatch is reported rather than
+counted as a success. Nothing is deleted from SQLite — the old table stays
+as a fallback for a human, untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+_COLUMNS = (
+    "incarnation_id",
+    "agent_id",
+    "spec_id",
+    "spec_git_sha",
+    "host",
+    "born_at",
+    "compiled_spec_json",
+    "exit_reason",
+    "exit_code",
+    "exited_at",
+)
+
+
+def _sqlite_rows(db_path: Path) -> list[dict]:
+    """Every incarnations row, read-only. Empty list when the table is gone."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        cols = ", ".join(_COLUMNS)
+        return [dict(r) for r in conn.execute(f"SELECT {cols} FROM incarnations")]
+    except sqlite3.OperationalError as exc:
+        print(f"  no incarnations table in {db_path}: {exc}")
+        return []
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="SQLite state.db to read (default: sac's resolved DEFAULT_DB_PATH)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would move, write nothing",
+    )
+    args = ap.parse_args()
+
+    from scitex_dev.store import ANY_REVISION
+
+    from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+    from scitex_agent_container._state.state_db_incarnations import (
+        get_incarnation,
+        incarnation_store_target,
+        open_incarnation_store,
+    )
+
+    db_path = args.db or DEFAULT_DB_PATH
+    print(f"source (sqlite) : {db_path}")
+    print(f"target (postgres): {incarnation_store_target().locator}")
+
+    if not Path(db_path).exists():
+        print("source does not exist — nothing to migrate")
+        return 0
+
+    rows = _sqlite_rows(Path(db_path))
+    print(f"rows in sqlite  : {len(rows)}")
+    if not rows:
+        return 0
+
+    if args.dry_run:
+        print("--dry-run: writing nothing")
+        return 0
+
+    store = open_incarnation_store()
+    written = 0
+    try:
+        for row in rows:
+            store.put(dict(row), expected_revision=ANY_REVISION)
+            written += 1
+    finally:
+        store.close()
+    print(f"written         : {written}")
+
+    # VERIFY through the production read path, not the write handle: a store
+    # that accepted every write and can be read by nobody is the exact defect
+    # scitex-dev 0.49.0 shipped.
+    missing = [r["incarnation_id"] for r in rows if get_incarnation(r["incarnation_id"]) is None]
+    mismatched = [
+        r["incarnation_id"]
+        for r in rows
+        if (got := get_incarnation(r["incarnation_id"])) is not None
+        and got.get("born_at") != r["born_at"]
+    ]
+    print(f"verified present: {len(rows) - len(missing)} / {len(rows)}")
+    if missing:
+        print(f"MISSING after write: {missing[:10]}")
+    if mismatched:
+        print(f"BORN_AT CHANGED (must be empty): {mismatched[:10]}")
+    return 1 if (missing or mismatched) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_agent_container/_lifecycle/_birth_certificate.py
+++ b/src/scitex_agent_container/_lifecycle/_birth_certificate.py
@@ -132,16 +132,21 @@ def spec_git_sha(config_path: str | None, *, timeout_s: float = 5.0) -> str:
 def write_birth_certificate(
     config: Any,
     incarnation_id: str,
-    *,
-    db_path: Path | None = None,
 ) -> bool:
     """Record the birth certificate for ``incarnation_id``. Best-effort.
 
-    Returns True iff the row was written. A failure is LOGGED with its
+    Returns True iff the record was written. A failure is LOGGED with its
     origin and swallowed — the certificate is bookkeeping about a launch
     that already succeeded, and failing the launch over it would destroy
     the very run it documents (same contract as the sibling
     ``record_local_instance`` side-writes).
+
+    ``db_path`` was dropped on 2026-08-19 when the incarnations table moved
+    to per-host PostgreSQL. It named a SQLite file this function no longer
+    writes to, and an ignored parameter in a signature is a lie a caller
+    cannot see through: ``_instances.write_instance_records`` was still
+    threading its own state.db path in here, which would have read as
+    "the certificate lands in that file" long after it stopped being true.
     """
     try:
         spec_id = (
@@ -160,10 +165,9 @@ def write_birth_certificate(
             spec_git_sha=spec_git_sha(spec_id),
             host=None,
             compiled_spec_json=payload,
-            db_path=db_path,
         )
         return True
-    except Exception as exc:  # stx-allow: fallback (reason: the certificate documents a launch that already succeeded; failing the launch over bookkeeping would destroy the run it documents — logged with origin, never silent)
+    except Exception as exc:  # stx-allow: fallback (reason: the certificate documents a launch that already succeeded; failing the launch over bookkeeping would destroy the run it documents. SINK, measured 2026-08-20: logger.error on this module's logger, which for a listen-brokered start reaches journald via sac-listen.service (StandardOutput=journal) and for a direct CLI start reaches the caller's stderr — `journalctl --user | grep 'birth certificate NOT recorded'` is the check)
         logger.error(
             "birth certificate NOT recorded for incarnation %s (agent %s): %s "
             "(origin: _lifecycle/_birth_certificate.write_birth_certificate)",

--- a/src/scitex_agent_container/_lifecycle/_instances.py
+++ b/src/scitex_agent_container/_lifecycle/_instances.py
@@ -299,7 +299,12 @@ def record_local_instance(
     # sibling side-writes above — see ``_birth_certificate``.
     from ._birth_certificate import write_birth_certificate
 
-    write_birth_certificate(config, instance_id, db_path=db_path)
+    # No ``db_path``: the certificate went to per-host PostgreSQL on
+    # 2026-08-19. This function's own ``db_path`` still names the SQLite
+    # state.db that ``record_local_instance`` above writes to — the two
+    # records now live in two different databases, which is exactly what
+    # the migration is doing, one table at a time.
+    write_birth_certificate(config, instance_id)
     return instance_id
 
 

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -93,7 +93,12 @@ KNOWN_TABLES = (
     "comms_nodes",
     "node_comms_policy",
     "acl_deny_notify_log",
-    "incarnations",
+    # ``incarnations`` was here until 2026-08-19. It now lives in per-host
+    # PostgreSQL via :mod:`.state_db_incarnations`, so it is NOT queryable
+    # through `sac db query`. Removed rather than left behind: a whitelisted
+    # name with no table returns an EMPTY result, and an empty result reads
+    # as "this agent has no incarnations" when the truth is "you are asking
+    # the wrong database". An unknown-table error is the honest answer.
 )
 
 
@@ -198,14 +203,13 @@ def init_schema(db_path: Path | None = None) -> Path:
 
         conn.executescript(_pp._SCHEMA)
         conn.executescript(_blocks._SCHEMA)
-        # v4 step 5 — the ``incarnations`` birth-certificate table
-        # (compiled-spec-at-launch + exit mirror), keyed by the same
-        # incarnation id the beats and the ExitRecord carry. Lives in
-        # the EXISTING sqlite factory ON PURPOSE so the separately-
-        # carded sqlite→Postgres migration carries it along.
-        from . import state_db_incarnations as _incarn
-
-        conn.executescript(_incarn._SCHEMA_INCARNATIONS)
+        # The ``incarnations`` birth-certificate table used to be created
+        # here. It moved to per-host PostgreSQL on 2026-08-19; the promise
+        # this comment block used to make — "lives in the EXISTING sqlite
+        # factory ON PURPOSE so the separately-carded sqlite→Postgres
+        # migration carries it along" — is now kept. Its schema is created
+        # on first open by :func:`state_db_incarnations.open_incarnation_store`,
+        # so there is nothing to run here.
         # sac-comms item D (lead a2a c42b3e3c): rate-limit log for
         # synthetic ACL-deny notifications published at the target
         # receiver. One row per (sender, target) pair carrying the

--- a/src/scitex_agent_container/_state/state_db_incarnations.py
+++ b/src/scitex_agent_container/_state/state_db_incarnations.py
@@ -1,4 +1,4 @@
-"""``incarnations`` — the birth certificate (+ death mirror) table.
+"""``incarnations`` — the birth certificate (+ death mirror), on PostgreSQL only.
 
 v4 step 5, operator requirement verbatim (card sac-v4-layering-refactor-
 harness-runtime-inference-20260813, 2026-08-14): 「起動した後にコンパイル
@@ -8,7 +8,7 @@ harness-runtime-inference-20260813, 2026-08-14): 「起動した後にコンパ�
 (post-inheritance, post-defaults) as the agent's birth certificate,
 keyed by incarnation id, in the DB.
 
-One row joins the three settled identities:
+One record joins the three settled identities:
 
   * ``incarnation_id`` — one process lifetime (== ``instances.id``; the
     beat and the ExitRecord carry the same key);
@@ -22,45 +22,189 @@ serialized WITH SECRETS REDACTED — credentials are referenced by
 slot/source name (account slug, env-var NAME, credentials-file PATH),
 never by value (see ``_lifecycle._birth_certificate``).
 
-STORAGE NOTE (stated deliberately): the fleet target for running state
-is per-host Postgres :55432 (operator ruling), but sac's state layer
-today is this sqlite ``state.db`` behind :func:`state_db.open_db`'s
-central factory. The birth record therefore goes through the EXISTING
-factory — a new table beside ``instances``/``heartbeats`` — so the
-separately-carded sqlite→Postgres migration carries it along instead of
-this PR front-running it.
+THE STORAGE NOTE THIS MODULE USED TO CARRY IS NOW DISCHARGED
+============================================================
+The previous docstring said, in as many words, that the birth record went
+through the SQLite factory so that "the separately-carded sqlite→Postgres
+migration carries it along instead of this PR front-running it". This IS
+that migration. The note was a promise; this module is it being kept.
 
-Sibling-module convention (``state_db_diary`` / ``state_db_instances``):
-``state_db.init_schema`` runs :data:`_SCHEMA_INCARNATIONS`; the helpers
-here import ``open_db`` lazily to stay cycle-free.
+The move is by ADOPTING :mod:`scitex_dev.store` — the fleet's own store
+primitive — rather than by sac growing a private psycopg layer, exactly as
+:mod:`.state_db_verdict_dedup` did before it. That primitive implements the
+operator's 2026-08-19 rule ("fail fast, fail loud, no fallbacks") in its own
+``resolve_target``: exactly two steps (``SCITEX_STORE_DSN`` or the per-host
+Postgres) and deliberately NO SQLite fallback. A host whose PostgreSQL is
+unreachable raises ``StoreTargetError`` naming the DSN it could not reach.
+
+``db_path`` IS GONE from every function. It named a SQLite file; there is no
+file. Callers that used to thread it through simply stop.
+
+TWO DELIBERATE DIVERGENCES FROM THE verdict_dedup TEMPLATE
+==========================================================
+1. TIMESTAMPS STAY ISO-8601 TEXT, not the unix-seconds REAL that the dedup
+   tables use. ``born_at``/``exited_at`` are READ BY CALLERS as strings, and
+   a birth certificate is an operator-facing artifact. Switching the wire
+   format while switching the backend would be a second, silent, breaking
+   change riding along inside the first — the kind that shows up months
+   later as an unparseable timestamp. Same clock (:func:`state_db.now_iso`),
+   same format, different storage.
+
+2. THE BIRTH FIELDS ARE ``LAST_WRITER_WINS``, NOT ``IMMUTABLE``. The SQLite
+   version was ``INSERT OR REPLACE`` and its docstring said why: "a retried
+   launch that re-records the same id must refresh rather than crash".
+   ``IMMUTABLE`` would make that retry raise. This is the opposite call from
+   verdict_dedup, where a moved timestamp silently reorders a failure streak
+   — there the immutability IS the invariant; here refreshability is.
+
+THE ONE INVARIANT THAT MUST NOT BE LOST
+=======================================
+``record_incarnation_exit`` returns True iff a birth record existed, and a
+missing one is a False, NEVER an insert. The old docstring states the
+reason and it survives the port unchanged: "a death with no recorded birth
+is a real signal (a pre-artifact incarnation, or a birth write that failed)
+and fabricating a birth here would hide it."
+
+The store has no UPDATE-only verb — ``put`` writes whatever record you hand
+it — so the SQLite ``UPDATE ... WHERE`` no longer refuses on its own. The
+refusal is therefore EXPLICIT here: read first, return False on a miss, and
+only then write. Written out rather than relied upon, because the guard
+moved from the database into this function and a reader needs to see it.
+
+For the same reason the exit write sends the WHOLE merged record rather than
+the three exit fields alone: it does not depend on the store's per-field
+merge semantics to preserve the birth data, so the row cannot be hollowed
+out by a partial write. The cost is one extra read per exit, on a path that
+runs once per process lifetime.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "incarnations"
+
+#: Every write from this host is attributed to one node. A birth certificate
+#: is written by the launcher ON the host that launched it, and the death
+#: mirror by that same incarnation's runner, so SINGLE_WRITER is the honest
+#: policy rather than a convenience.
+_ACTOR = "scitex-agent-container"
 
 __all__ = [
+    "STORE_NAME",
     "get_incarnation",
+    "incarnation_store_target",
+    "init_incarnations_schema",
+    "open_incarnation_store",
     "record_incarnation_birth",
     "record_incarnation_exit",
 ]
 
-_SCHEMA_INCARNATIONS = """
-CREATE TABLE IF NOT EXISTS incarnations (
-    incarnation_id      TEXT PRIMARY KEY,
-    agent_id            TEXT NOT NULL,
-    spec_id             TEXT,
-    spec_git_sha        TEXT NOT NULL,
-    host                TEXT NOT NULL,
-    born_at             TEXT NOT NULL,
-    compiled_spec_json  TEXT NOT NULL,
-    exit_reason         TEXT,
-    exit_code           INTEGER,
-    exited_at           TEXT
-);
-CREATE INDEX IF NOT EXISTS idx_incarnations_agent
-    ON incarnations(agent_id, born_at);
-"""
+
+def _schema() -> Any:
+    """The birth-certificate schema.
+
+    Built lazily so importing this module does not import scitex-dev; the
+    old module was equally lazy about ``state_db``, for the same reason
+    (import cost off the hot path).
+
+    ``incarnation_id`` is the sole IDENTITY field and is IMMUTABLE because
+    the store enforces it on identities — "changing one does not update the
+    record, it names a different record", which is exactly right for a
+    process lifetime. Every other field is data ABOUT that lifetime and
+    takes ``LAST_WRITER_WINS`` (see the module docstring for why this
+    differs from verdict_dedup).
+
+    ``agent_id`` is indexed: the SQLite table carried
+    ``idx_incarnations_agent ON (agent_id, born_at)``, and the queries that
+    index served — "every incarnation of this agent" — are the ones a
+    future reader will write.
+    """
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
+
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def fact(kind: Any, *, required: bool = False, indexed: bool = False) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=required,
+            merge=MergeRule.LAST_WRITER_WINS,
+            indexed=indexed,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "incarnation_id": ident(FieldKind.TEXT),
+            # --- birth: written once at launch, refreshed by a retry ---
+            "agent_id": fact(FieldKind.TEXT, required=True, indexed=True),
+            "spec_id": fact(FieldKind.TEXT),
+            "spec_git_sha": fact(FieldKind.TEXT, required=True),
+            "host": fact(FieldKind.TEXT, required=True),
+            "born_at": fact(FieldKind.TEXT, required=True),
+            "compiled_spec_json": fact(FieldKind.TEXT, required=True),
+            # --- death: absent until the incarnation ends ---
+            "exit_reason": fact(FieldKind.TEXT),
+            "exit_code": fact(FieldKind.INTEGER),
+            "exited_at": fact(FieldKind.TEXT),
+        },
+    )
+
+
+def incarnation_store_target() -> Any:
+    """Resolve WHERE the birth certificates live. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_incarnation_store() -> Store:
+    """Open the incarnations store. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function here opens and closes
+    one per call, mirroring the old ``with open_db(...)`` shape: births and
+    deaths happen once per process lifetime, so the connection cost sits on
+    a launch path, never on a request path.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        incarnation_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_incarnations_schema() -> str:
+    """Create the incarnations tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL
+    equivalent of the ``Path`` the SQLite version returned, and useful in
+    exactly the same way: it names WHERE the state actually went, so an
+    operator can check it rather than assume it.
+    """
+    store = open_incarnation_store()
+    try:
+        return str(incarnation_store_target().locator)
+    finally:
+        store.close()
 
 
 def record_incarnation_birth(
@@ -71,35 +215,38 @@ def record_incarnation_birth(
     spec_git_sha: str,
     host: str | None,
     compiled_spec_json: str,
-    db_path: Path | None = None,
 ) -> str:
-    """Insert the birth certificate row for one incarnation.
+    """Write the birth certificate for one incarnation. Returns the id.
 
-    ``INSERT OR REPLACE`` on the primary key: the launch path writes
-    exactly once per incarnation, and a retried launch that re-records
-    the same id must refresh rather than crash. Returns the id.
+    Upsert, preserving the old ``INSERT OR REPLACE``: the launch path writes
+    exactly once per incarnation, and a retried launch that re-records the
+    same id must refresh rather than crash.
+
+    A retry refreshes ``born_at`` too. That matches the SQLite behaviour
+    exactly — ``INSERT OR REPLACE`` rewrote the whole row — and is the
+    correct reading: the birth being recorded is the one that took.
     """
-    from .state_db import now_iso, open_db
+    from scitex_dev.store import ANY_REVISION
+
+    from .state_db import now_iso
     from .state_db_hostname import resolve_host
 
-    with open_db(db_path) as conn:
-        conn.execute(
-            """
-            INSERT OR REPLACE INTO incarnations (
-                incarnation_id, agent_id, spec_id, spec_git_sha,
-                host, born_at, compiled_spec_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                incarnation_id,
-                agent_id,
-                spec_id,
-                spec_git_sha,
-                resolve_host(host),
-                now_iso(),
-                compiled_spec_json,
-            ),
+    store = open_incarnation_store()
+    try:
+        store.put(
+            {
+                "incarnation_id": incarnation_id,
+                "agent_id": agent_id,
+                "spec_id": spec_id,
+                "spec_git_sha": spec_git_sha,
+                "host": resolve_host(host),
+                "born_at": now_iso(),
+                "compiled_spec_json": compiled_spec_json,
+            },
+            expected_revision=ANY_REVISION,
         )
+    finally:
+        store.close()
     return incarnation_id
 
 
@@ -108,37 +255,56 @@ def record_incarnation_exit(
     *,
     reason: str,
     code: int,
-    db_path: Path | None = None,
 ) -> bool:
-    """Mirror the terminal ExitRecord onto the incarnation's row.
+    """Mirror the terminal ExitRecord onto the incarnation's record.
 
-    Returns True iff a birth row existed to update. A missing row is a
-    False, not an insert — a death with no recorded birth is a real
-    signal (a pre-artifact incarnation, or a birth write that failed)
-    and fabricating a birth here would hide it. Idempotent-by-overwrite:
-    the LAST exit write wins, matching ``exit.json`` semantics.
+    Returns True iff a birth record existed to update. A missing record is a
+    False, not an insert — a death with no recorded birth is a real signal
+    (a pre-artifact incarnation, or a birth write that failed) and
+    fabricating a birth here would hide it. Idempotent-by-overwrite: the
+    LAST exit write wins, matching ``exit.json`` semantics.
+
+    The read-then-write is not an optimisation and must not be collapsed
+    into a bare ``put``: the store has no UPDATE-only verb, so this function
+    IS the refusal that the SQLite ``UPDATE ... WHERE`` used to perform.
     """
-    from .state_db import now_iso, open_db
+    from scitex_dev.store import ANY_REVISION
 
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            "UPDATE incarnations SET exit_reason=?, exit_code=?, exited_at=? "
-            "WHERE incarnation_id=?",
-            (reason, int(code), now_iso(), incarnation_id),
+    from .state_db import now_iso
+
+    key = {"incarnation_id": incarnation_id}
+    store = open_incarnation_store()
+    try:
+        existing = store.get(key)
+        if existing is None:
+            return False
+        merged = dict(existing.values)
+        merged.update(
+            {
+                "incarnation_id": incarnation_id,
+                "exit_reason": reason,
+                "exit_code": int(code),
+                "exited_at": now_iso(),
+            }
         )
-        return cur.rowcount > 0
+        store.put(merged, expected_revision=ANY_REVISION)
+    finally:
+        store.close()
+    return True
 
 
-def get_incarnation(
-    incarnation_id: str,
-    db_path: Path | None = None,
-) -> dict | None:
-    """Return one incarnation row as a dict, or None when unknown."""
-    from .state_db import open_db
+def get_incarnation(incarnation_id: str) -> dict | None:
+    """Return one incarnation record as a dict, or None when unknown.
 
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT * FROM incarnations WHERE incarnation_id=?",
-            (incarnation_id,),
-        ).fetchone()
-        return dict(row) if row is not None else None
+    ``Row.values`` is the schema fields only — the store's own bookkeeping
+    (hlc, seq, origin, owner) hangs off sibling attributes and deliberately
+    does NOT ride along in the returned dict. The SQLite version returned
+    ``dict(sqlite3.Row)``, which was likewise exactly the table columns, so
+    callers see the same shape they always did.
+    """
+    store = open_incarnation_store()
+    try:
+        row = store.get({"incarnation_id": incarnation_id})
+    finally:
+        store.close()
+    return dict(row.values) if row is not None else None

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -133,7 +133,13 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         "scitex_agent_container/_agentstate/_journal.py:226",
         "scitex_agent_container/_authheal/_pass.py:283",
         "scitex_agent_container/_authheal/_pass.py:431",
-        "scitex_agent_container/_lifecycle/_birth_certificate.py:166",
+        # _birth_certificate.py LEFT THIS SET 2026-08-20 — the reason now
+        # names its sink (journald via sac-listen.service for a brokered
+        # start, the caller's stderr for a direct one) and carries the
+        # journalctl invocation that checks it. Measured before writing:
+        # sac-listen.service is StandardOutput=journal, and per-agent logs
+        # live under runtime/logs/<agent>/ — asserted rather than assumed,
+        # because a NAMED sink that is wrong is worse than an unnamed one.
         "scitex_agent_container/_lifecycle/_github_ci_poll_loop.py:160",
         "scitex_agent_container/_lifecycle/_in_sif_http_client.py:141",
         "scitex_agent_container/_lifecycle/_instances.py:263",

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -66,6 +66,13 @@ they hand their DDL to `state_db.open_db` to execute —
     _state/state_db_acl_policy.py        _state/state_db_acl_deny_notify.py
     _state/state_db_pending_approval.py
 
+(That enumeration is the original 2026-08-19 measurement, kept as written
+because it is what motivated the second list. ``state_db_incarnations.py``
+left the set later the same day when the birth certificate moved to
+PostgreSQL — the live set is always ``FROZEN_SQLITE_DDL`` below, never this
+prose, which is exactly why the gate reads the constant and not the
+docstring.)
+
 So the shape "add a new SQLite table without appearing in FROZEN_SQLITE" is
 not hypothetical — it is the IDIOMATIC way tables are added in this package,
 with five existing examples. A new `state_db_<thing>.py` written that way
@@ -134,9 +141,14 @@ FROZEN_SQLITE_DDL = frozenset(
         "_state/state_db_acl_deny_notify.py",
         "_state/state_db_acl_policy.py",
         "_state/state_db_blocks.py",
-        "_state/state_db_incarnations.py",
         "_state/state_db_pending_approval.py",
         "_state/state_db_schema.py",
+        # _state/state_db_incarnations.py LEFT THIS SET 2026-08-19 — the
+        # SECOND table to move to PostgreSQL, and the first to leave via
+        # THIS list rather than FROZEN_SQLITE (it never imported sqlite3;
+        # it handed its DDL to state_db.open_db, which is exactly the hole
+        # this second list was added to close). The birth certificate now
+        # lives in per-host PostgreSQL via scitex_dev.store.
     }
 )
 

--- a/tests/scitex_agent_container/_lifecycle/test__birth_certificate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__birth_certificate.py
@@ -17,7 +17,6 @@ import json
 import subprocess
 from pathlib import Path
 
-import pytest
 
 from scitex_agent_container._lifecycle._birth_certificate import (
     SPEC_SHA_UNRESOLVABLE,

--- a/tests/scitex_agent_container/_lifecycle/test__birth_certificate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__birth_certificate.py
@@ -4,9 +4,11 @@ Operator requirement (2026-08-14): record the COMPILED final spec as
 "this agent was born like this", keyed by incarnation id, in the DB —
 and reference credentials by slot/source NAME, never by value.
 
-Real AgentConfigs, a real on-disk SQLite via explicit ``db_path``, and a
-REAL git repo for the sha tests (git invoked as a subprocess with -C,
-signing disabled per-invocation). No mocks.
+Real AgentConfigs, a REAL PostgreSQL via the ``pg_schema`` fixture (the
+certificate moved off SQLite on 2026-08-19; the fixture gives each test a
+throwaway schema so the live fleet state is never touched), and a REAL git
+repo for the sha tests (git invoked as a subprocess with -C, signing
+disabled per-invocation). No mocks.
 """
 
 from __future__ import annotations
@@ -152,62 +154,57 @@ def test_sha_resolves_head_in_a_real_repo(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def db(tmp_path: Path) -> Path:
-    return tmp_path / "state.db"
-
-
-def test_certificate_row_lands_keyed_by_incarnation(db: Path) -> None:
+def test_certificate_row_lands_keyed_by_incarnation(pg_schema: str) -> None:
     # Arrange
     cfg = AgentConfig(name="alpha")
     # Act
-    ok = write_birth_certificate(cfg, "inc-b1", db_path=db)
+    ok = write_birth_certificate(cfg, "inc-b1")
     # Assert
-    assert ok is True and get_incarnation("inc-b1", db_path=db) is not None
+    assert ok is True and get_incarnation("inc-b1") is not None
 
 
-def test_certificate_names_the_agent_identity(db: Path) -> None:
+def test_certificate_names_the_agent_identity(pg_schema: str) -> None:
     # Arrange
     cfg = AgentConfig(name="alpha")
     # Act
-    write_birth_certificate(cfg, "inc-b2", db_path=db)
+    write_birth_certificate(cfg, "inc-b2")
     # Assert
-    assert get_incarnation("inc-b2", db_path=db)["agent_id"] == "alpha"
+    assert get_incarnation("inc-b2")["agent_id"] == "alpha"
 
 
-def test_certificate_records_unresolvable_sha_honestly(db: Path) -> None:
+def test_certificate_records_unresolvable_sha_honestly(pg_schema: str) -> None:
     # Arrange: no config_path at all — nothing to fake a sha from.
     cfg = AgentConfig(name="alpha")
     # Act
-    write_birth_certificate(cfg, "inc-b3", db_path=db)
+    write_birth_certificate(cfg, "inc-b3")
     # Assert
-    assert get_incarnation("inc-b3", db_path=db)["spec_git_sha"] == (
+    assert get_incarnation("inc-b3")["spec_git_sha"] == (
         SPEC_SHA_UNRESOLVABLE
     )
 
 
-def test_certificate_records_the_spec_repo_head(db: Path, tmp_path: Path) -> None:
+def test_certificate_records_the_spec_repo_head(pg_schema: str, tmp_path: Path) -> None:
     # Arrange: a spec tracked in a real git repo.
     repo = tmp_path / "specs"
     head = _git_repo_with_commit(repo)
     cfg = AgentConfig(name="alpha", config_path=str(repo / "spec.yaml"))
     # Act
-    write_birth_certificate(cfg, "inc-b4", db_path=db)
+    write_birth_certificate(cfg, "inc-b4")
     # Assert
-    assert get_incarnation("inc-b4", db_path=db)["spec_git_sha"] == head
+    assert get_incarnation("inc-b4")["spec_git_sha"] == head
 
 
-def test_certificate_compiled_spec_is_redacted_json(db: Path) -> None:
+def test_certificate_compiled_spec_is_redacted_json(pg_schema: str) -> None:
     # Arrange
     cfg = AgentConfig(name="alpha", env={"API_KEY": "sk-live"})
     # Act
-    write_birth_certificate(cfg, "inc-b5", db_path=db)
-    stored = json.loads(get_incarnation("inc-b5", db_path=db)["compiled_spec_json"])
+    write_birth_certificate(cfg, "inc-b5")
+    stored = json.loads(get_incarnation("inc-b5")["compiled_spec_json"])
     # Assert: no secret material in the record.
     assert stored["env"]["API_KEY"] == "<redacted:API_KEY>"
 
 
-def test_certificate_compiled_spec_carries_residency(db: Path, tmp_path: Path) -> None:
+def test_certificate_compiled_spec_carries_residency(pg_schema: str, tmp_path: Path) -> None:
     # Arrange: a compiled config declaring the v4 residency axis — the
     # birth certificate must record it (provenance for "why did this
     # incarnation end at oneshot-complete?").
@@ -215,16 +212,16 @@ def test_certificate_compiled_spec_carries_residency(db: Path, tmp_path: Path) -
 
     cfg = AgentConfig(name="alpha", residency=ONE_SHOT)
     # Act
-    write_birth_certificate(cfg, "inc-b7", db_path=db)
-    stored = json.loads(get_incarnation("inc-b7", db_path=db)["compiled_spec_json"])
+    write_birth_certificate(cfg, "inc-b7")
+    stored = json.loads(get_incarnation("inc-b7")["compiled_spec_json"])
     # Assert
     assert stored["residency"] == ONE_SHOT
 
 
-def test_certificate_failure_is_false_not_raise(db: Path) -> None:
+def test_certificate_failure_is_false_not_raise(pg_schema: str) -> None:
     # Arrange: a config whose serialization cannot work (not a dataclass).
     broken = object()
     # Act
-    ok = write_birth_certificate(broken, "inc-b6", db_path=db)
+    ok = write_birth_certificate(broken, "inc-b6")
     # Assert: best-effort — the launch it documents must not die over it.
     assert ok is False

--- a/tests/scitex_agent_container/_lifecycle/test__instances_birth.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_birth.py
@@ -4,8 +4,14 @@ The launch path is the ONE place the compiled config and the freshly
 minted incarnation id are both in hand; the certificate must land there
 as an intrinsic side-effect, keyed by the same id the ``instances`` row,
 the beats and the ExitRecord carry. Same no-mocks arrangement as
-``test__instances.py`` — a real on-disk state.db via explicit
-``db_path`` and the honest runtime stub.
+``test__instances.py`` — the honest runtime stub, a real on-disk state.db
+via explicit ``db_path`` for the ``instances`` row, and a REAL PostgreSQL
+via ``pg_schema`` for the certificate.
+
+The two databases in one test are the migration in miniature: the
+``instances`` row is still SQLite, the birth certificate moved to per-host
+PostgreSQL on 2026-08-19, and this file asserts they still agree on the
+incarnation id that joins them.
 """
 
 from __future__ import annotations
@@ -29,39 +35,39 @@ class _RuntimeStub:
         return self._root / config.name
 
 
-def test_local_start_records_a_birth_certificate(tmp_path: Path) -> None:
+def test_local_start_records_a_birth_certificate(pg_schema: str, tmp_path: Path) -> None:
     # Arrange
     db = tmp_path / "state.db"
     cfg = AgentConfig(name="born-1", runtime="apptainer")
     # Act
     incarnation = record_local_instance(cfg, _RuntimeStub(tmp_path), db_path=db)
     # Assert: the row exists under the SAME id the instances row minted.
-    assert get_incarnation(incarnation, db_path=db) is not None
+    assert get_incarnation(incarnation) is not None
 
 
-def test_birth_certificate_names_the_agent(tmp_path: Path) -> None:
+def test_birth_certificate_names_the_agent(pg_schema: str, tmp_path: Path) -> None:
     # Arrange
     db = tmp_path / "state.db"
     cfg = AgentConfig(name="born-2", runtime="apptainer")
     # Act
     incarnation = record_local_instance(cfg, _RuntimeStub(tmp_path), db_path=db)
     # Assert
-    assert get_incarnation(incarnation, db_path=db)["agent_id"] == "born-2"
+    assert get_incarnation(incarnation)["agent_id"] == "born-2"
 
 
-def test_birth_certificate_carries_the_compiled_spec(tmp_path: Path) -> None:
+def test_birth_certificate_carries_the_compiled_spec(pg_schema: str, tmp_path: Path) -> None:
     # Arrange: a resolved value that only exists post-compile (the model
     # default) must be readable straight off the record.
     db = tmp_path / "state.db"
     cfg = AgentConfig(name="born-3", runtime="apptainer")
     # Act
     incarnation = record_local_instance(cfg, _RuntimeStub(tmp_path), db_path=db)
-    stored = json.loads(get_incarnation(incarnation, db_path=db)["compiled_spec_json"])
+    stored = json.loads(get_incarnation(incarnation)["compiled_spec_json"])
     # Assert
     assert stored["model"] == cfg.model
 
 
-def test_birth_certificate_redacts_env_secrets(tmp_path: Path) -> None:
+def test_birth_certificate_redacts_env_secrets(pg_schema: str, tmp_path: Path) -> None:
     # Arrange
     db = tmp_path / "state.db"
     cfg = AgentConfig(
@@ -69,6 +75,6 @@ def test_birth_certificate_redacts_env_secrets(tmp_path: Path) -> None:
     )
     # Act
     incarnation = record_local_instance(cfg, _RuntimeStub(tmp_path), db_path=db)
-    stored = json.loads(get_incarnation(incarnation, db_path=db)["compiled_spec_json"])
+    stored = json.loads(get_incarnation(incarnation)["compiled_spec_json"])
     # Assert: slot name kept, value never recorded.
     assert stored["env"]["MY_API_KEY"] == "<redacted:MY_API_KEY>"

--- a/tests/scitex_agent_container/_state/test_state_db_incarnations.py
+++ b/tests/scitex_agent_container/_state/test_state_db_incarnations.py
@@ -1,130 +1,336 @@
-"""``incarnations`` — the birth-certificate table (v4 step 5).
+"""``incarnations`` — the birth certificate, on a REAL PostgreSQL.
 
-One row joins the three settled identities (spec / agent / incarnation)
+Mirrors ``src/scitex_agent_container/_state/state_db_incarnations.py``.
+
+One record joins the three settled identities (spec / agent / incarnation)
 plus the compiled-spec snapshot at launch; the exit mirror completes the
-life-and-death record. Real on-disk SQLite via explicit ``db_path`` —
-no env juggling, no mocks.
+life-and-death record.
+
+WHY THESE TESTS TALK TO A REAL DATABASE
+=======================================
+The module under test is PostgreSQL-only by the operator's 2026-08-19 order
+("fail fast, fail loud, no fallbacks"), and it reaches PostgreSQL through
+``scitex_dev.store``. A suite that exercised the store's SQLite dialect
+instead would be testing a code path production can never take — the exact
+defect scitex-dev 0.49.0 shipped, where the PostgreSQL backend could be
+WRITTEN to and never READ from.
+
+AND WHY THEY MUST NOT SKIP
+==========================
+There is deliberately NO ``skipif`` on database availability. A skip that
+reads as a pass is the defect this migration exists to remove (same shape as
+the ``importorskip`` bug fixed in #1108). Every runner in the gate pool has a
+PostgreSQL on 127.0.0.1:55432, so an unreachable store is a broken fleet,
+not a test-environment quirk, and the red is correct.
+
+ISOLATION WITHOUT PRIVILEGE
+===========================
+Each test gets its own PostgreSQL SCHEMA inside the existing ``scitex``
+database, selected through ``search_path`` in the DSN, and dropped with
+``CASCADE`` afterwards — a schema and not a database because creating a
+database needs ``CREATEDB`` and the fleet is not uniform there (compute-03's
+``scitex_cards`` role has ``rolcreatedb=False``), which would make the suite
+pass on three runners and fail on the fourth.
+
+Real ``os.environ`` save/restore, not ``monkeypatch`` — PA-306 forbids mocks,
+and the point is that the REAL resolver reads the REAL variable.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
+import uuid
+from typing import Iterator
 
+import psycopg
 import pytest
 
 from scitex_agent_container._state.state_db_incarnations import (
+    STORE_NAME,
     get_incarnation,
+    init_incarnations_schema,
     record_incarnation_birth,
     record_incarnation_exit,
 )
 
+#: The per-host store. Loopback only — every fleet PostgreSQL refuses
+#: non-local connections at pg_hba, measured 2026-08-19.
+_BASE_DSN = os.environ.get(
+    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
+)
 
-@pytest.fixture
-def db(tmp_path: Path) -> Path:
-    return tmp_path / "state.db"
+
+@pytest.fixture()
+def pg_schema() -> Iterator[str]:
+    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
+
+    Yields the schema name. Anything the module writes lands here and is
+    dropped afterwards, so the live birth-certificate store is never
+    touched.
+    """
+    schema = "sac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = f"{_BASE_DSN}?options=-csearch_path%3D{schema}"
+    try:
+        yield schema
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
 
 
-def _birth(db: Path, incarnation: str = "inc-1") -> str:
+def _tables_in(schema: str) -> set[str]:
+    """The table names PostgreSQL actually holds in ``schema``."""
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
+            (schema,),
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _birth(incarnation: str = "inc-1", *, sha: str = "abc123") -> str:
     return record_incarnation_birth(
         incarnation,
         agent_id="alpha",
         spec_id="/specs/alpha/spec.yaml",
-        spec_git_sha="abc123",
+        spec_git_sha=sha,
         host="h1",
         compiled_spec_json='{"name": "alpha"}',
-        db_path=db,
     )
 
 
-def test_birth_row_is_readable_by_incarnation_id(db: Path) -> None:
-    # Arrange
-    _birth(db)
+# ----------------------------------------------------------------------
+# The store exists, and it is PostgreSQL.
+# ----------------------------------------------------------------------
+
+
+def test_init_creates_the_incarnations_store_in_postgres(pg_schema: str) -> None:
+    """POSITIVE CONTROL for every test below.
+
+    Read through a SECOND, INDEPENDENT client (raw psycopg, plain SQL): if
+    this passes, the rows the other tests assert on are demonstrably in
+    PostgreSQL and not in some in-process stand-in. Without it, a suite that
+    silently wrote nowhere would still be green.
+    """
+    # Arrange: the fixture created an empty schema and pointed the resolver
+    # at it. Captured so the assertion below reads a TRANSITION rather than
+    # a snapshot — a table that had always been there would pass a bare
+    # membership check without this module having done anything.
+    before = _tables_in(pg_schema)
     # Act
-    row = get_incarnation("inc-1", db_path=db)
+    init_incarnations_schema()
+    # Assert
+    assert f"{STORE_NAME}_rows" in _tables_in(pg_schema) - before
+
+
+def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> None:
+    """The return value names WHERE the state went, so it can be checked.
+
+    It names the DATABASE and not the ``search_path`` schema layered on top
+    — measured 2026-08-19, when this test was first written asserting the
+    schema and failed with ``'sac_test_...' in 'postgres://127.0.0.1:55432/
+    scitex'``. Pinned as discovered rather than quietly weakened: an
+    operator following this string reaches the right server, and still has
+    to know which schema to look in.
+    """
+    # Arrange: the endpoint the fixture routed this test's writes through.
+    endpoint = _BASE_DSN.split("@", 1)[-1]
+    # Act
+    locator = init_incarnations_schema()
+    # Assert
+    assert endpoint in locator
+
+
+# ----------------------------------------------------------------------
+# Birth
+# ----------------------------------------------------------------------
+
+
+def test_birth_record_is_readable_by_incarnation_id(pg_schema: str) -> None:
+    # Arrange
+    _birth()
+    # Act
+    row = get_incarnation("inc-1")
     # Assert
     assert row is not None and row["agent_id"] == "alpha"
 
 
-def test_birth_row_carries_the_spec_git_sha(db: Path) -> None:
+def test_birth_record_carries_the_spec_git_sha(pg_schema: str) -> None:
     # Arrange
-    _birth(db)
+    _birth()
     # Act
-    row = get_incarnation("inc-1", db_path=db)
+    row = get_incarnation("inc-1")
     # Assert
     assert row["spec_git_sha"] == "abc123"
 
 
-def test_birth_row_carries_the_compiled_spec_json(db: Path) -> None:
+def test_birth_record_carries_the_compiled_spec_json(pg_schema: str) -> None:
     # Arrange
-    _birth(db)
+    _birth()
     # Act
-    row = get_incarnation("inc-1", db_path=db)
+    row = get_incarnation("inc-1")
     # Assert
     assert row["compiled_spec_json"] == '{"name": "alpha"}'
 
 
-def test_birth_is_upsert_on_the_incarnation_key(db: Path) -> None:
+def test_birth_is_upsert_on_the_incarnation_key(pg_schema: str) -> None:
     # Arrange: a retried launch re-records the same incarnation.
-    _birth(db)
-    record_incarnation_birth(
-        "inc-1",
-        agent_id="alpha",
-        spec_id="/specs/alpha/spec.yaml",
-        spec_git_sha="def456",
-        host="h1",
-        compiled_spec_json='{"name": "alpha"}',
-        db_path=db,
-    )
+    _birth()
+    _birth(sha="def456")
     # Act
-    row = get_incarnation("inc-1", db_path=db)
+    row = get_incarnation("inc-1")
     # Assert: refreshed, not duplicated / not crashed.
     assert row["spec_git_sha"] == "def456"
 
 
-def test_exit_mirror_updates_the_birth_row(db: Path) -> None:
+def test_birth_returns_the_incarnation_id(pg_schema: str) -> None:
     # Arrange
-    _birth(db)
+    incarnation = "inc-returns"
     # Act
-    record_incarnation_exit("inc-1", reason="harness-returned", code=1, db_path=db)
-    row = get_incarnation("inc-1", db_path=db)
+    returned = _birth(incarnation)
+    # Assert
+    assert returned == incarnation
+
+
+# ----------------------------------------------------------------------
+# Death
+# ----------------------------------------------------------------------
+
+
+def test_exit_mirror_updates_the_birth_record(pg_schema: str) -> None:
+    # Arrange
+    _birth()
+    # Act
+    record_incarnation_exit("inc-1", reason="harness-returned", code=1)
+    row = get_incarnation("inc-1")
     # Assert
     assert (row["exit_reason"], row["exit_code"]) == ("harness-returned", 1)
 
 
-def test_exit_mirror_stamps_exited_at(db: Path) -> None:
+def test_exit_mirror_stamps_exited_at(pg_schema: str) -> None:
     # Arrange
-    _birth(db)
+    _birth()
     # Act
-    record_incarnation_exit("inc-1", reason="stopped-by-signal", code=0, db_path=db)
-    row = get_incarnation("inc-1", db_path=db)
+    record_incarnation_exit("inc-1", reason="stopped-by-signal", code=0)
+    row = get_incarnation("inc-1")
     # Assert
     assert row["exited_at"] is not None
 
 
-def test_exit_without_birth_reports_false_not_insert(db: Path) -> None:
-    # Arrange: no birth row for this id.
-    _birth(db, "inc-other")
+def test_exit_does_not_hollow_out_the_birth_fields(pg_schema: str) -> None:
+    """The exit write must not blank the certificate it is completing.
+
+    The store has no UPDATE-only verb, so the exit path READS the record and
+    writes the whole thing back. If that ever collapses into a bare ``put``
+    of the three exit fields, the birth data would depend on the store's
+    per-field merge to survive — this asserts it survives outright.
+    """
+    # Arrange
+    _birth()
     # Act
-    updated = record_incarnation_exit("inc-ghost", reason="crashed", code=1, db_path=db)
+    record_incarnation_exit("inc-1", reason="harness-returned", code=1)
+    row = get_incarnation("inc-1")
+    # Assert
+    assert row["compiled_spec_json"] == '{"name": "alpha"}'
+
+
+def test_exit_without_birth_reports_false_not_insert(pg_schema: str) -> None:
+    # Arrange: no birth record for this id.
+    _birth("inc-other")
+    # Act
+    updated = record_incarnation_exit("inc-ghost", reason="crashed", code=1)
     # Assert: a death with no recorded birth is a real signal, not an
     # excuse to fabricate one.
     assert updated is False
 
 
-def test_unknown_incarnation_reads_none(db: Path) -> None:
+def test_exit_without_birth_writes_nothing(pg_schema: str) -> None:
+    """The False above must mean "wrote nothing", not "wrote and said no"."""
     # Arrange
-    _birth(db)
+    _birth("inc-other")
     # Act
-    row = get_incarnation("inc-nope", db_path=db)
+    record_incarnation_exit("inc-ghost", reason="crashed", code=1)
+    # Assert
+    assert get_incarnation("inc-ghost") is None
+
+
+def test_last_exit_write_wins(pg_schema: str) -> None:
+    # Arrange: exit.json semantics — the LAST write is the record.
+    _birth()
+    record_incarnation_exit("inc-1", reason="first", code=1)
+    # Act
+    record_incarnation_exit("inc-1", reason="second", code=2)
+    row = get_incarnation("inc-1")
+    # Assert
+    assert (row["exit_reason"], row["exit_code"]) == ("second", 2)
+
+
+# ----------------------------------------------------------------------
+# Reads
+# ----------------------------------------------------------------------
+
+
+def test_unknown_incarnation_reads_none(pg_schema: str) -> None:
+    # Arrange
+    _birth()
+    # Act
+    row = get_incarnation("inc-nope")
     # Assert
     assert row is None
 
 
-def test_incarnations_is_a_known_table(db: Path) -> None:
+def test_returned_dict_carries_no_store_bookkeeping(pg_schema: str) -> None:
+    """Callers see the schema fields, the same shape ``sqlite3.Row`` gave.
+
+    The store hangs hlc / seq / origin / owner off sibling attributes rather
+    than the values mapping, and this pins that: a caller iterating the dict
+    must not suddenly meet store internals it never asked for.
+    """
+    # Arrange
+    _birth()
+    # Act
+    row = get_incarnation("inc-1")
+    # Assert
+    assert set(row) == {
+        "incarnation_id",
+        "agent_id",
+        "spec_id",
+        "spec_git_sha",
+        "host",
+        "born_at",
+        "compiled_spec_json",
+        "exit_reason",
+        "exit_code",
+        "exited_at",
+    }
+
+
+# ----------------------------------------------------------------------
+# The SQLite table is gone, and asking for it must SAY so.
+# ----------------------------------------------------------------------
+
+
+def test_incarnations_is_no_longer_a_sqlite_known_table() -> None:
+    """Inverted on 2026-08-19, and the inversion is the point.
+
+    While ``incarnations`` stayed whitelisted, ``sac db query
+    --table=incarnations`` would open state.db, find no such table, and
+    return an EMPTY result — which reads as "this agent has no
+    incarnations" when the truth is "you are asking the wrong database".
+    Removing the name turns that silent lie into an unknown-table error.
+    """
     # Arrange
     from scitex_agent_container._state.state_db import KNOWN_TABLES
 
     # Act
     known = set(KNOWN_TABLES)
-    # Assert: `sac db query --table=incarnations` can reach the record.
-    assert "incarnations" in known
+    # Assert
+    assert "incarnations" not in known

--- a/tests/scitex_agent_container/conftest.py
+++ b/tests/scitex_agent_container/conftest.py
@@ -80,3 +80,68 @@ def _clear_agent_identity() -> Iterator[None]:
     agent's value would otherwise win over test-controlled overrides.
     """
     yield from _save_restore_yield(_AGENT_IDENTITY_KEYS)
+
+
+# ----------------------------------------------------------------------
+# PostgreSQL isolation for the sqlite -> Postgres migration (2026-08-19)
+# ----------------------------------------------------------------------
+
+#: The per-host store. Loopback only — every fleet PostgreSQL refuses
+#: non-local connections at pg_hba, measured 2026-08-19.
+PG_BASE_DSN = os.environ.get(
+    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
+)
+
+
+@pytest.fixture()
+def pg_schema() -> Iterator[str]:
+    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
+
+    Yields the schema name. Anything a module-under-test writes through
+    ``scitex_dev.store`` lands here and is dropped afterwards, so the live
+    fleet state is never touched.
+
+    NOT AUTOUSE, and the two fixtures above are: this one is opt-in because
+    it CONNECTS, and a test that does not need PostgreSQL must not fail
+    because PostgreSQL is down.
+
+    A SCHEMA rather than a database, deliberately: creating a database needs
+    ``CREATEDB`` and the fleet is not uniform there (compute-03's
+    ``scitex_cards`` role has ``rolcreatedb=False``), so a create-a-database
+    fixture would pass on three runners and fail on the fourth — a flake
+    that looks like the code. The name carries a uuid because the three-way
+    python matrix can put concurrent jobs on ONE runner.
+
+    ``psycopg`` is imported INSIDE the fixture, not at module scope. A
+    top-level import here would make it a hard dependency of every test in
+    this package, so a missing psycopg would turn into a collection error
+    for hundreds of tests that never touch a database.
+
+    Real ``os.environ`` save/restore, not ``monkeypatch`` — PA-306 forbids
+    mocks, and the point is that the REAL resolver reads the REAL variable.
+
+    (``_state/test_state_db_verdict_dedup.py`` still carries its own copy of
+    this fixture, written before this shared one existed. It is the same
+    code; consolidating it is a tidy-up for a PR that already touches that
+    file, not for this one.)
+    """
+    import uuid
+
+    import psycopg
+
+    schema = "sac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = f"{PG_BASE_DSN}?options=-csearch_path%3D{schema}"
+    try:
+        yield schema
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')


### PR DESCRIPTION
Second table under the 2026-08-19 SQLite-eradication ruling, and the first to leave via the **DDL half** of the freeze rather than the import half — `state_db_incarnations.py` never imported `sqlite3`, it handed its DDL to `open_db`, which is exactly the hole that second list was added to close.

The module docstring promised this migration by name. It said the table lived in the SQLite factory *"ON PURPOSE so the separately-carded sqlite→Postgres migration carries it along instead of this PR front-running it"*. This is that promise being kept.

## Two deliberate divergences from the `verdict_dedup` template

| | verdict_dedup | incarnations | why |
|---|---|---|---|
| timestamps | unix REAL | **ISO-8601 TEXT** | callers read `born_at`/`exited_at` as strings; changing the wire format while changing the backend is a second silent breaking change riding inside the first |
| data merge | IMMUTABLE | **LAST_WRITER_WINS** | the old code was `INSERT OR REPLACE` so *"a retried launch that re-records the same id must refresh rather than crash"*; IMMUTABLE would make that retry raise |

## The invariant that moved house

`record_incarnation_exit` returns True iff a birth record existed — a missing one is False, **never an insert**, because a death with no recorded birth is a real signal. The store has no UPDATE-only verb, so the refusal SQLite's `UPDATE ... WHERE` performed is now **explicit in the function**, and the exit write sends the whole merged record so the certificate cannot be hollowed out by a partial write. Both pinned by tests.

## `KNOWN_TABLES` shrinks too

Leaving `incarnations` whitelisted would make `sac db query --table=incarnations` return an **empty result**, which reads as "this agent has no incarnations" when the truth is "you are asking the wrong database". An unknown-table error is the honest answer.

## Tests

Real PostgreSQL, no skip when it is down — a skip that reads as a pass is the defect this migration exists to remove. The throwaway-schema fixture moves to the package `conftest.py` so three files share one copy, with `psycopg` imported **inside** it so a missing driver cannot become a collection error for hundreds of tests that never touch a database.

Verified on the host: **142 passed, 1 skipped** across `tests/develop` plus the three affected modules.

The six failures in `test__rename_cards.py` seen during the full run reproduce **identically on develop@1f0cc8b9** and are unrelated to this change.

## Migration script

Dry-run verified against the **242 rows** on compute-04. It writes through the store directly rather than calling `record_incarnation_birth`, because that function stamps `born_at` with `now_iso()` — correct for a launch, and it would have restamped every birth in the fleet to the migration's own clock.

## One thing found on the way, not fixed here

All 242 of those rows have `exited_at IS NULL`. **242 births, zero deaths, ever.** The `exit-record DB mirror failed` warning has never appeared in 30 days of journald (control: journald is readable, 1.39M lines in 2 days), so the exit write is not failing — it is never called. Carded separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Auq9hdD2jW6sHkQWo6q3T