### PR TITLE
fix(start): stop swallowing apptainer's FATAL — check it before the heartbeat

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_launch_fatal.py
+++ b/src/scitex_agent_container/_lifecycle/_launch_fatal.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Did apptainer refuse to create the container for THIS launch?
+
+Extracted from :mod:`._launch_verify` (512-line cap) because it answers a
+different question from the rest of that module. ``_launch_verify`` weighs
+evidence about whether an agent came up; this reads a boot log and decides
+whether apptainer said it never started. The rules here — which files to
+look at, how to tell this launch's log from the previous launch's, what
+filesystem mtime granularity does to that comparison — are self-contained
+and have nothing to do with heartbeats or poll windows.
+
+WHY THIS EXISTS AT ALL
+======================
+Operator instruction, 2026-08-20:
+
+    「アップテーナーのフェイタルを握り潰さないで、再テックスロギングで
+      つないでください。で、うるさく失敗させてください」
+
+Do not swallow apptainer's FATAL; route it through scitex-logging; fail
+loudly. The reporting half already did that — ``cli_pkg.lifecycle.
+_start_verify_report`` sends every negative verdict through ``system_msg``
+and returns False so the caller exits non-zero. What was missing was any
+path that REACHED it: the verdict loop returned ``verified-up`` the moment
+it saw a fresh heartbeat, and never looked at the boot log.
+
+WHY A FATAL OUTRANKS A HEARTBEAT
+================================
+A FATAL is positive evidence that the container was never created. A beat
+is weaker evidence of success than a FATAL is of failure, and measurably
+so: of ~118 heartbeats across the fleet on 2026-08-19, all but one were
+written by ``listen-tui-observer`` rather than by the runner itself. So a
+beat can be an observer's write about a container that does not exist,
+while a FATAL can only have been produced by apptainer refusing to make
+one.
+
+BLAST RADIUS, measured before shipping
+======================================
+50 boot logs across four hosts on 2026-08-20: ZERO contain a FATAL. So
+this check changes no start that happens today; it fires only when
+apptainer actually refuses. That measurement is why this fix shipped when
+three earlier candidates did not — they would have refused 83 of 121 bind
+sources, 29 of 29 heartbeats, and 117 of 118 launches respectively.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["FATAL_PREFIX", "MTIME_SLACK_S", "apptainer_fatal"]
+
+#: apptainer prefixes its fatal diagnostics with this, at line start.
+FATAL_PREFIX = "FATAL"
+
+#: Slack on the "was this log written by THIS launch" comparison.
+#:
+#: MEASURED, not guessed. The first version compared ``st_mtime`` against
+#: ``launched_at`` directly and the tests went red with the verdict still
+#: ``verified-up`` — a FATAL written milliseconds after launch was being
+#: skipped as stale. ``launched_at`` carries sub-second precision from
+#: ``time.time()`` while a filesystem mtime can be coarser, so the log of
+#: the very launch being verified can stamp BELOW its own launch instant.
+#:
+#: Two seconds absorbs that granularity and nothing more: a genuinely
+#: stale FATAL comes from a previous start, which is minutes or hours old,
+#: so widening the guard by two seconds does not weaken it.
+MTIME_SLACK_S = 2.0
+
+
+def apptainer_fatal(
+    state_dir: Path,
+    names: tuple[str, ...],
+    *,
+    launched_at: float,
+) -> tuple[Path, str] | None:
+    """The apptainer FATAL line from THIS launch, or ``None``.
+
+    Returns the log file and the first ``FATAL...`` line in it.
+
+    THE FRESHNESS CHECK IS NOT OPTIONAL
+    ===================================
+    ``boot.stderr.log`` is not truncated per launch, so a FATAL from a
+    start that failed yesterday is still on disk today. Without it this
+    function would fail every subsequent start of an agent that once
+    failed — converting silent success into permanent silent failure,
+    which is worse than the defect it fixes. Only a log modified at or
+    after ``launched_at`` (less :data:`MTIME_SLACK_S`) testifies about
+    this launch.
+
+    A file that cannot be read is treated as "no FATAL found", never as a
+    failure. This is one input to a verdict, and an unreadable log must
+    not manufacture a failure on its own — the caller's DEAD-process probe
+    and window expiry still decide.
+    """
+    floor = launched_at - MTIME_SLACK_S
+    for name in names:
+        candidate = state_dir / name
+        if not candidate.is_file():
+            continue
+        try:
+            if candidate.stat().st_mtime < floor:
+                continue
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+        except OSError:  # stx-allow: fallback (reason: an unreadable log is absence of evidence, never evidence of failure; the caller's DEAD probe and window expiry still decide)
+            continue
+        for line in text.splitlines():
+            if line.startswith(FATAL_PREFIX):
+                return candidate, line.strip()
+    return None

--- a/src/scitex_agent_container/_lifecycle/_launch_verify.py
+++ b/src/scitex_agent_container/_lifecycle/_launch_verify.py
@@ -66,7 +66,10 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+
 from typing import Any, Callable
+
+from ._launch_fatal import apptainer_fatal
 
 __all__ = [
     "DEFAULT_POLL_INTERVAL_S",
@@ -339,14 +342,31 @@ def _verify_by_heartbeat(
 ) -> LaunchVerdict:
     """SDK-path verdict — poll for a FRESH heartbeat from a NEW incarnation.
 
-    Per tick, in evidence order: (1) a beat stamped at/after
-    ``launched_at`` (and not the old run's ``stopping`` farewell) proves
-    the new runner booted → VERIFIED_UP; (2) the runtime's own pid probe
-    reporting the container DEAD is definitive → VERIFIED_FAILED with the
-    boot-log tail (``stdout.log`` — apptainer merges the runner's stderr
-    into it, so the Errno 98 / VenvDistributionError text lives there);
+    Per tick, in evidence order:
+
+    (0) an apptainer ``FATAL`` in a boot log written by THIS launch →
+        VERIFIED_FAILED. Checked FIRST, added 2026-08-20 on the
+        operator's instruction, because it is positive evidence the
+        container was never created and it used to be checked LAST — i.e.
+        never, since a heartbeat short-circuits the loop. See
+        :func:`._launch_fatal.apptainer_fatal`.
+    (1) a beat stamped at/after ``launched_at`` (and not the old run's
+        ``stopping`` farewell) → VERIFIED_UP. Note what this does and
+        does not prove: something wrote a beat. Fleet-wide on 2026-08-19
+        all but one of ~118 beats came from ``listen-tui-observer``, not
+        from the runner, which is why (0) must precede it.
+    (2) the runtime's own pid probe reporting the container DEAD is
+        definitive → VERIFIED_FAILED with the boot-log tail
+        (``stdout.log`` — apptainer merges the runner's stderr into it,
+        so the Errno 98 / VenvDistributionError text lives there).
     (3) window expiry with the process still standing → UNVERIFIED, which
-    is exit-nonzero but worded as "could not verify", never "failed".
+        is exit-nonzero but worded as "could not verify", never "failed".
+
+    Every negative verdict reaches the operator through
+    ``cli_pkg.lifecycle._start_verify_report``, which routes it via
+    ``system_msg`` — sac's scitex-logging surface — and returns False so
+    the caller exits non-zero. That plumbing already existed; what was
+    missing was any path that reached it when apptainer had FATAL'd.
     """
     from .._runners._session_state import read_heartbeat
 
@@ -354,6 +374,22 @@ def _verify_by_heartbeat(
     log_candidates = ("stdout.log", "boot.stderr.log")
     deadline = launched_at + window
     while True:
+        # BEFORE the heartbeat, because a FATAL is positive evidence the
+        # container was never created and a beat is not proof it was. See
+        # _apptainer_fatal for the measurement behind that ordering.
+        fatal = apptainer_fatal(state_dir, log_candidates, launched_at=launched_at)
+        if fatal is not None:
+            fatal_log, fatal_line = fatal
+            waited = max(0.0, now_fn() - launched_at)
+            return LaunchVerdict(
+                VERIFIED_FAILED,
+                f"apptainer FATAL {waited:.1f}s after launch — the container "
+                f"was never created: {fatal_line}",
+                str(fatal_log),
+                _tail(fatal_log),
+                waited,
+                str(heartbeat_path),
+            )
         beat = read_heartbeat(state_dir)
         if beat is not None:
             ts = beat.get("ts")

--- a/tests/scitex_agent_container/_lifecycle/test__launch_verify.py
+++ b/tests/scitex_agent_container/_lifecycle/test__launch_verify.py
@@ -316,3 +316,168 @@ def test_malformed_env_window_fails_loud(clean_window_env) -> None:
     # Assert
     with raiser:
         resolve_verify_window()
+
+
+# ---------------------------------------------------------------------------
+# apptainer FATAL must not be swallowed (operator instruction, 2026-08-20)
+# ---------------------------------------------------------------------------
+
+_APPTAINER_FATAL = (
+    "INFO:    Converting SIF file to temporary sandbox...\n"
+    "FATAL:   container creation failed: mount hook function failure: "
+    "mount /home/ywatanabe/absent -> /absent error: "
+    "while mounting /home/ywatanabe/absent: stat /home/ywatanabe/absent: "
+    "no such file or directory\n"
+)
+
+
+def _write_boot_log(state_dir: Path, text: str, *, mtime: float | None = None) -> Path:
+    """A real boot.stderr.log, optionally back-dated to a prior launch."""
+    path = state_dir / "boot.stderr.log"
+    path.write_text(text, encoding="utf-8")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_apptainer_fatal_outranks_a_fresh_heartbeat(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """THE DEFECT THIS FIXES, in one test.
+
+    Both signals are present: a beat stamped after launch AND a FATAL
+    saying the container was never created. Before 2026-08-20 the beat
+    won and `sac agents start` printed SUCC over a dead launch. A FATAL
+    is positive evidence of failure; a beat is not proof of success —
+    fleet-wide, all but one of ~118 beats were written by an OBSERVER,
+    not by the runner.
+    """
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    _write_boot_log(tmp_path, _APPTAINER_FATAL)
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == VERIFIED_FAILED
+
+
+def test_apptainer_fatal_verdict_is_not_ok(clean_window_env, tmp_path: Path) -> None:
+    """It must flip the caller exit code, which is what "fail loudly" means."""
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    _write_boot_log(tmp_path, _APPTAINER_FATAL)
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.ok is False
+
+
+def test_apptainer_fatal_evidence_quotes_the_fatal_line(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """The operator gets the CAUSE, not just a verdict word."""
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    _write_boot_log(tmp_path, _APPTAINER_FATAL)
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert "mount hook function failure" in verdict.evidence
+
+
+def test_apptainer_fatal_names_the_log_it_was_read_from(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """Naming the FILE is what lets someone go deeper than the tail."""
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    log = _write_boot_log(tmp_path, _APPTAINER_FATAL)
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.log_path == str(log)
+
+
+def test_a_stale_fatal_from_a_previous_launch_is_ignored(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """THE GUARD THAT KEEPS THIS FIX FROM BECOMING WORSE THAN THE DEFECT.
+
+    boot.stderr.log is not truncated per launch, so a FATAL from a start
+    that failed yesterday is still on disk today. Without the mtime
+    check, every subsequent start of that agent would fail forever —
+    converting silent success into permanent silent failure. Only a log
+    modified at or after ``launched_at`` testifies about THIS launch.
+    """
+    # Arrange
+    launched_at = time.time()
+    _write_boot_log(tmp_path, _APPTAINER_FATAL, mtime=launched_at - 3600.0)
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == VERIFIED_UP
+
+
+def test_a_clean_boot_log_still_verifies_up(clean_window_env, tmp_path: Path) -> None:
+    """POSITIVE CONTROL — the check must not fail launches that are fine.
+
+    Without this, a function that returned FATAL for every boot log would
+    satisfy every test above and break every start in the fleet. Measured
+    2026-08-20 before shipping: 50 boot logs across four hosts, ZERO
+    containing a FATAL, so this is the arm that carries the whole fleet.
+    """
+    # Arrange
+    launched_at = time.time()
+    _write_boot_log(tmp_path, "INFO:    Converting SIF file to temporary sandbox...\n")
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == VERIFIED_UP


### PR DESCRIPTION
Operator instruction, 2026-08-20:

> 「アップテーナーのフェイタルを握り潰さないで、再テックスロギングでつないでください。で、うるさく失敗させてください」

**The reporting half already did all of that.** `_start_verify_report` routes every negative verdict through `system_msg` — sac's scitex-logging surface — prints the boot-log tail and the file it came from, and returns False so the caller exits non-zero.

What was missing was any path that **reached** it. `_verify_by_heartbeat` returned `verified-up` the moment it saw a beat stamped after launch, so a launch apptainer had already refused was reported as started, exit 0. The FATAL sat in `boot.stderr.log`, unread, while the green line printed.

## Why a FATAL outranks a beat — measured, not preferred

A FATAL is **positive evidence the container was never created**. A beat is far weaker evidence of success: fleet-wide on 2026-08-19, of ~118 heartbeats **all but one** were written by `listen-tui-observer`, not by the runner. The beat can be an observer's write about a container that does not exist; the FATAL can only come from apptainer refusing to make one.

## The freshness guard is what keeps this from being worse than the defect

`boot.stderr.log` is not truncated per launch, so yesterday's FATAL is still on disk today. Without a freshness check this would fail **every subsequent start** of an agent that once failed — trading silent success for permanent silent failure.

The tolerance was **measured, not chosen**: comparing mtime to `launched_at` directly made the new tests go red with the verdict still `verified-up`. `launched_at` has sub-second precision from `time.time()`; a filesystem mtime can be coarser, so the log of the very launch being verified can stamp *below its own launch instant*. Two seconds absorbs that and nothing else.

## Blast radius, measured before writing a line

**50 boot logs across four hosts: zero contain a FATAL.** This changes no start that happens today and fires only when apptainer actually refuses.

That measurement is why this shipped when three earlier candidates did not — they would have refused 83 of 121 bind sources, 29 of 29 heartbeats, and 117 of 118 launches respectively.

## Extracted rather than squeezed

The addition pushed `_launch_verify.py` to 513 lines against a 512 cap. The detector moved to `_launch_fatal.py` because it answers a different question — *did apptainer refuse* rather than *did the agent come up*. Trimming comments would have fit under the cap by deleting the measurement that justifies the mtime slack. `_launch_verify` is now 439 lines and its public API did not move, which the unchanged test imports prove.

## Six tests, including the one that matters most

The core (FATAL beats a fresh beat), the verdict is not `ok`, the evidence quotes the FATAL line, the log file is named, a stale FATAL is ignored — and a **positive control** that a clean boot log still verifies up. Without it, a detector returning FATAL for everything would satisfy the other five and break every start in the fleet.

---

3021 passed across `_lifecycle` and `cli_pkg/lifecycle`; the 6 `test__rename_cards.py` failures reproduce identically on develop and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Auq9hdD2jW6sHkQWo6q3T