### PR TITLE
fix(tests): the audit gate probed a binary the auditor never runs

### DIFF
--- a/tests/develop/test_audit.py
+++ b/tests/develop/test_audit.py
@@ -52,8 +52,9 @@ this — drift goes silent.
 
 from __future__ import annotations
 
+import importlib.util
 import inspect
-import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -98,10 +99,41 @@ def _verified_repo_root() -> Path:
 
 @pytest.fixture
 def scitex_dev_audit():
-    if shutil.which("scitex-dev") is None:
+    # PROBE WHAT THE AUDITOR ACTUALLY RUNS, NOT A CONSOLE SCRIPT IT IGNORES.
+    #
+    # This used to be `shutil.which("scitex-dev") is None -> skip`. The
+    # auditor never invokes that binary. `_audit_conformance.py` builds its
+    # argv as `[sys.executable, "-m", "scitex_dev", ...]`, with the comment
+    # "`sys.executable -m` binds the auditor to the interpreter running the
+    # tests" — so what matters is whether THIS interpreter can import
+    # scitex_dev, and the console script's presence on $PATH is unrelated.
+    #
+    # The two disagree in the common case and the gate lost. Measured
+    # 2026-08-20 on scitex-compute-04: scitex-dev is installed in
+    # ~/.venv/bin, which is not on the $PATH the test process inherits, so
+    # `which` returned None and this gate SKIPPED — while the same
+    # interpreter ran `python -m scitex_dev ecosystem audit-all` to
+    # completion, exit 0. Re-running the suite with that directory on $PATH
+    # turned "1 passed, 1 skipped" into "2 passed in 83s".
+    #
+    # THE COST WAS PAID THE SAME DAY. PR #1155 added a test file in a
+    # location PS-204 rejects. Local runs of tests/develop/ reported
+    # "1 passed, 1 skipped" three times and looked like coverage; the
+    # skipped one WAS the gate. CI caught it, and the message told me
+    # scitex-dev was "not installed" — false, and it points at a fix that
+    # changes nothing.
+    #
+    # So: skip only when the MODULE is genuinely unavailable, which is the
+    # condition the auditor cannot survive. importlib rather than a bare
+    # try/import so that an ImportError raised from INSIDE scitex_dev — a
+    # real breakage — still propagates instead of being read as absence.
+    if importlib.util.find_spec("scitex_dev") is None:
         pytest.skip(
-            "scitex-dev not installed — add `scitex-dev[cli-audit]` "
-            "to [project.optional-dependencies.dev]"
+            "scitex_dev is not importable by this interpreter "
+            f"({sys.executable}) — add `scitex-dev[cli-audit]` to "
+            "[project.optional-dependencies.dev]. Note this is about the "
+            "MODULE, not the `scitex-dev` console script: the auditor runs "
+            "`sys.executable -m scitex_dev` and never looks at $PATH."
         )
     from scitex_dev.testing import audit_all_for_package
 


### PR DESCRIPTION
`test_audit_all_clean` skipped on developer hosts with **\"scitex-dev not installed\"**. scitex-dev *was* installed. The gate has been silently disarmed locally for as long as the probe has been there.

```
before:  1 passed, 1 skipped in 0.02s
after:   2 passed in 76.87s
```

The `0.02s` was the tell, and I missed it three times tonight.

## What was measured vs what is used

The fixture skipped on `shutil.which("scitex-dev") is None` — the console script on `$PATH`. **The auditor never invokes it.** `_audit_conformance.py` builds `[sys.executable, "-m", "scitex_dev", ...]` and says why in its own comment: *\"`sys.executable -m` binds the auditor to the interpreter running the tests\"*. So the question is whether **this interpreter** can import `scitex_dev`; `$PATH` is unrelated.

They disagree in the ordinary case. On scitex-compute-04, scitex-dev lives in `~/.venv/bin`, which is not on the `$PATH` the test process inherits — so `which` returned None while the same interpreter ran `python -m scitex_dev ecosystem audit-all` to completion, exit 0. Putting that directory on `$PATH` turned the skip into an 83s pass, which is what **proved** the diagnosis rather than merely fitting it.

## The cost was paid the same day

PR #1155 added a test file in a location PS-204 rejects. I ran `tests/develop/` three times, saw `1 passed, 1 skipped` each time, and read it as coverage. **The skipped one was the gate.** CI caught it — and the message said scitex-dev was \"not installed\", which is false and prescribes a fix that changes nothing. A developer following it would add a dependency that is already present and still see the skip.

## The fix

Skip only when the **module** is unavailable — the condition the auditor genuinely cannot survive. `importlib.util.find_spec` rather than a bare try/import, so an `ImportError` raised from *inside* `scitex_dev` (a real breakage) still propagates instead of being read as absence. The message now names the interpreter and states that this is about the module, not the console script.

The two `pytest.fail` branches beside it are untouched — this file already fails loudly on a wrong tree and on a too-old scitex-dev. Only the one condition that could be true *while the gate was perfectly runnable* was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Auq9hdD2jW6sHkQWo6q3T