### PR TITLE
feat(state): move the ACL pending-prompt flag off SQLite to PostgreSQL

### DIFF
--- a/src/scitex_agent_container/_state/grant_flush.py
+++ b/src/scitex_agent_container/_state/grant_flush.py
@@ -79,7 +79,7 @@ def unblock_and_clear_pending(
 
     grant_send(sender=sender, target=target, db_path=db_path, note=note)
     unblocked = unblock_send(sender=sender, target=target, db_path=db_path)
-    cleared = clear_pending_prompt(sender=sender, target=target, db_path=db_path)
+    cleared = clear_pending_prompt(sender=sender, target=target)
     return {
         "sender": sender,
         "target": target,
@@ -124,7 +124,7 @@ def block_and_clear_pending(
     from .state_db_pending_approval import clear_pending_prompt
 
     block_send(sender=sender, target=target, db_path=db_path, note=note)
-    cleared = clear_pending_prompt(sender=sender, target=target, db_path=db_path)
+    cleared = clear_pending_prompt(sender=sender, target=target)
     return {
         "sender": sender,
         "target": target,

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -199,9 +199,11 @@ def init_schema(db_path: Path | None = None) -> Path:
         # ``init_schema`` stays atomic.
         from . import state_db_acl_deny_notify as _adn
         from . import state_db_blocks as _blocks
-        from . import state_db_pending_approval as _pp
 
-        conn.executescript(_pp._SCHEMA)
+        # ``pending_prompts`` was created here until 2026-08-20. It moved
+        # to per-host PostgreSQL; its schema is created on first open by
+        # ``state_db_pending_approval.open_pending_prompt_store``, so there
+        # is nothing to run here.
         conn.executescript(_blocks._SCHEMA)
         # The ``incarnations`` birth-certificate table used to be created
         # here. It moved to per-host PostgreSQL on 2026-08-19; the promise

--- a/src/scitex_agent_container/_state/state_db_pending_approval.py
+++ b/src/scitex_agent_container/_state/state_db_pending_approval.py
@@ -1,4 +1,4 @@
-"""Pending-prompt flag for the ACL block/unblock flow (task #27).
+"""Pending-prompt flag for the ACL block/unblock flow — on PostgreSQL only.
 
 Operator-requested via lead (2026-06-01). Lead's design amendment
 SUPERSEDED an earlier "hold the original message + replay on grant"
@@ -13,131 +13,257 @@ design in favour of a simpler BLOCK / UNBLOCK primitive:
   receiver already has the decision in front of them. This module
   owns that "is there a pending row" flag.
 * The receiver's decision (either ``unblock`` → ``grant_send`` or
-  ``block`` → ``block_send``) clears the pending row in the same
-  transaction. No held message replay — if the sender wants their
-  message delivered after unblock, they resend.
-* No TTL, no expiry sweep, no latest-wins dedupe. The original
-  spec's fragile spam-debounce logic is intentionally dropped — the
-  primitive is just "is there a pending decision yes/no".
+  ``block`` → ``block_send``) clears the pending row. No held message
+  replay — if the sender wants their message delivered after unblock,
+  they resend.
+* No TTL, no expiry sweep, no latest-wins dedupe. The primitive is
+  just "is there a pending decision yes/no".
 
-Schema is minimal: ``(sender, target, ts)``. The original message
-content is NEVER stored here (the receiver decides on identity, not
-on message content).
+The original message content is NEVER stored here (the receiver
+decides on identity, not on message content).
 
-No-mocks (PA-306) testing — real on-disk sqlite, no monkeypatch.
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to
+PostgreSQL: "fail fast, fail loud, no fallbacks". This is the third table
+to move, after ``verdict_delivered`` and ``incarnations``, and it moves
+the same way — by ADOPTING :mod:`scitex_dev.store` rather than by sac
+growing a private psycopg layer.
+
+``db_path`` IS GONE from every function. It named a SQLite file; there is
+no file. ``grant_flush`` was threading its own state.db path in here and
+stops; the two records now live in two different databases, which is what
+the migration is doing one table at a time.
+
+THE DELETE IS THE NEW GROUND, AND IT IS WHY THIS ONE NEEDED THOUGHT
+===================================================================
+The two tables that moved before this one only ever inserted. This one
+DELETES, and the store has no delete — it has ``hide``, which marks a
+record invisible to ``get``/``rows`` while keeping it in the oplog.
+
+That is the better primitive here (the decision history stays auditable),
+but it introduces a lifecycle the SQLite version did not have: a cleared
+pair is not ABSENT, it is HIDDEN. Written naively, the next denial for
+that pair would find ``get() -> None``, try to insert, collide with the
+hidden record, and return "already pending" — so the receiver would never
+be prompted again. A fix for a silent-success bug that silently suppresses
+prompts forever is worse than the bug.
+
+:meth:`Store.is_hidden` is what makes this expressible, because it answers
+in THREE values rather than two:
+
+    None    no record at all          -> insert, this is the first prompt
+    True    cleared earlier           -> unhide + refresh ts, prompt again
+    False   present and visible       -> already pending, suppress
+
+``get`` alone collapses the first two into "nothing there", and that
+collapse is exactly the bug.
+
+All times are unix-seconds (float), matching the SQLite column and the
+diary tables.
 """
 
 from __future__ import annotations
 
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "pending_prompts"
+
+#: Every write from this host is attributed to one node. The flag is
+#: written by the listen daemon that observed the denial and cleared by
+#: the same host's grant/block path, so SINGLE_WRITER is honest rather
+#: than convenient.
+_ACTOR = "scitex-agent-container"
 
 __all__ = [
-    "ensure_pending_prompts_table",
+    "STORE_NAME",
     "clear_pending_prompt",
     "has_pending_prompt",
+    "init_pending_prompts_schema",
+    "open_pending_prompt_store",
+    "pending_prompt_store_target",
     "record_pending_prompt",
 ]
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS pending_prompts (
-    sender TEXT NOT NULL,
-    target TEXT NOT NULL,
-    ts     REAL NOT NULL,
-    PRIMARY KEY (sender, target)
-);
-"""
+def _schema() -> Any:
+    """The pending-prompt schema.
 
+    Built lazily so importing this module does not import scitex-dev; the
+    old module was equally lazy about ``state_db``, for the same reason.
 
-def ensure_pending_prompts_table(db_path: Path | None = None) -> None:
-    """Idempotent CREATE TABLE for the pending-prompt flag store.
+    ``(sender, target)`` is the composite IDENTITY — the SQLite table's
+    PRIMARY KEY, unchanged. Identity fields must be IMMUTABLE and the
+    store enforces it: "changing one does not update the record, it names
+    a different record", which is exactly right for a pair.
 
-    Called from :func:`_state.state_db.init_schema` so a fresh
-    state.db carries the table; safe to call multiple times.
+    ``ts`` is LAST_WRITER_WINS rather than IMMUTABLE, and that is load
+    bearing: a pair that was cleared and then re-denied must carry the
+    time of the NEW prompt, not the old one. Nothing orders decisions on
+    this field today, so refreshing it cannot reorder anything.
     """
-    from .state_db import open_db
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
 
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "sender": ident(FieldKind.TEXT),
+            "target": ident(FieldKind.TEXT),
+            "ts": FieldPolicy(
+                kind=FieldKind.REAL,
+                role=FieldRole.DATA,
+                required=True,
+                merge=MergeRule.LAST_WRITER_WINS,
+                indexed=False,
+            ),
+        },
+    )
 
 
-def record_pending_prompt(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
+def pending_prompt_store_target() -> Any:
+    """Resolve WHERE the pending-prompt flags live. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_pending_prompt_store() -> Store:
+    """Open the flag store. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function opens and closes one
+    per call, mirroring the old ``with open_db(...)`` shape: this runs on a
+    denial and on a decision, not on a request path.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        pending_prompt_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_pending_prompts_schema() -> str:
+    """Create the flag tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL
+    equivalent of the ``None`` the SQLite version returned, and strictly
+    more useful: it names WHERE the state actually went, so an operator can
+    check it rather than assume it.
+    """
+    store = open_pending_prompt_store()
+    try:
+        return str(pending_prompt_store_target().locator)
+    finally:
+        store.close()
+
+
+def record_pending_prompt(*, sender: str, target: str) -> bool:
     """Mark ``(sender, target)`` as "prompt-emitted, awaiting decision".
 
-    Returns ``True`` iff this call is the FIRST pending-prompt for
-    the pair (caller should emit the receiver-facing push). Returns
-    ``False`` when a pending row already exists (caller suppresses
-    re-prompt). The check + insert is one atomic transaction so a
-    concurrent burst of denied attempts emits exactly one prompt.
+    Returns ``True`` iff this call is the FIRST pending-prompt for the pair
+    (caller should emit the receiver-facing push). Returns ``False`` when a
+    pending flag already exists (caller suppresses re-prompt).
 
     Fail-loud: empty ``sender`` / ``target`` raise ``ValueError``.
+
+    THE THREE-WAY BRANCH IS THE POINT — see the module docstring. A pair
+    that was CLEARED is hidden, not absent, and must be re-armed rather
+    than treated as already-pending; collapsing those two states is how
+    this becomes a prompt that never fires again.
+
+    CONCURRENCY IS PRESERVED, and it was explicit in the SQLite version:
+    "the check + insert is one atomic transaction so a concurrent burst of
+    denied attempts emits exactly one prompt". Here the insert carries
+    ``expected_revision=NEW_RECORD``, so a racing writer that created the
+    record between our check and our write raises ``RevisionMismatchError``
+    — which means "someone else prompted", the same answer the SQLite
+    transaction gave. Nothing else is caught: an unreachable store must
+    still be loud.
     """
     if not sender or not target:
         raise ValueError("record_pending_prompt: sender and target must be non-empty")
-    from .state_db import open_db
 
-    ensure_pending_prompts_table(db_path)
-    with open_db(db_path) as conn:
-        existing = conn.execute(
-            "SELECT 1 FROM pending_prompts WHERE sender = ? AND target = ?",
-            (sender, target),
-        ).fetchone()
-        if existing is not None:
+    from scitex_dev.store import ANY_REVISION, NEW_RECORD, RevisionMismatchError
+
+    key = {"sender": sender, "target": target}
+    store = open_pending_prompt_store()
+    try:
+        hidden = store.is_hidden(key)
+        if hidden is False:
             return False
-        conn.execute(
-            "INSERT INTO pending_prompts (sender, target, ts) VALUES (?, ?, ?)",
-            (sender, target, time.time()),
-        )
-    return True
+        if hidden is True:
+            store.unhide(key, expected_revision=ANY_REVISION)
+            store.put({**key, "ts": time.time()}, expected_revision=ANY_REVISION)
+            return True
+        try:
+            store.put({**key, "ts": time.time()}, expected_revision=NEW_RECORD)
+        except RevisionMismatchError:
+            return False
+        return True
+    finally:
+        store.close()
 
 
-def has_pending_prompt(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
+def has_pending_prompt(*, sender: str, target: str) -> bool:
     """Return True iff ``(sender, target)`` has a pending prompt awaiting
-    the receiver's block/unblock decision."""
-    if not sender or not target:
-        return False
-    from .state_db import open_db
+    the receiver's block/unblock decision.
 
-    ensure_pending_prompts_table(db_path)
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT 1 FROM pending_prompts WHERE sender = ? AND target = ?",
-            (sender, target),
-        ).fetchone()
-    return row is not None
-
-
-def clear_pending_prompt(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
-    """Delete the pending row for ``(sender, target)``. Returns True iff
-    a row was removed. Idempotent on absent rows.
-
-    Called from both decision paths: ``grant_send`` / ``block_send``
-    (unblock or block) clear the pending prompt in the same workflow.
+    ``get`` excludes hidden records by default, so a cleared pair reads as
+    absent here — which is precisely the SQLite DELETE semantics this
+    replaces.
     """
     if not sender or not target:
         return False
-    from .state_db import open_db
+    store = open_pending_prompt_store()
+    try:
+        return store.get({"sender": sender, "target": target}) is not None
+    finally:
+        store.close()
 
-    ensure_pending_prompts_table(db_path)
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            "DELETE FROM pending_prompts WHERE sender = ? AND target = ?",
-            (sender, target),
-        )
-    return int(cur.rowcount or 0) > 0
+
+def clear_pending_prompt(*, sender: str, target: str) -> bool:
+    """Clear the pending flag for ``(sender, target)``. Returns True iff a
+    visible flag was cleared. Idempotent on absent or already-cleared pairs.
+
+    Called from both decision paths: ``grant_send`` / ``block_send``
+    (unblock or block) clear the pending prompt in the same workflow.
+
+    HIDE RATHER THAN DELETE. The store has no delete verb, and that is the
+    better fit: the decision stays in the oplog with the actor that made
+    it, so "who cleared this, and when" survives — which a DELETE destroyed.
+    The read side is unchanged because ``get`` skips hidden records.
+    """
+    if not sender or not target:
+        return False
+
+    from scitex_dev.store import ANY_REVISION
+
+    key = {"sender": sender, "target": target}
+    store = open_pending_prompt_store()
+    try:
+        if store.get(key) is None:
+            return False
+        store.hide(key, expected_revision=ANY_REVISION)
+        return True
+    finally:
+        store.close()

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -141,7 +141,12 @@ FROZEN_SQLITE_DDL = frozenset(
         "_state/state_db_acl_deny_notify.py",
         "_state/state_db_acl_policy.py",
         "_state/state_db_blocks.py",
-        "_state/state_db_pending_approval.py",
+        # _state/state_db_pending_approval.py LEFT THIS SET 2026-08-20 — the
+        # THIRD table to move to PostgreSQL, and the first whose SQLite verb
+        # had no store equivalent: it DELETEd, and the store only hides. That
+        # turned out to be the better primitive (the decision stays in the
+        # oplog with its actor) but it introduced a lifecycle the SQLite
+        # version did not have, and the module documents it.
         "_state/state_db_schema.py",
         # _state/state_db_incarnations.py LEFT THIS SET 2026-08-19 — the
         # SECOND table to move to PostgreSQL, and the first to leave via

--- a/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
+++ b/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
@@ -109,7 +109,7 @@ def _send_payload(sender: str, content: str = "hi") -> dict:
 
 
 def test_record_pending_prompt_first_call_returns_true(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange
     from scitex_agent_container._state.state_db_pending_approval import (
@@ -118,24 +118,24 @@ def test_record_pending_prompt_first_call_returns_true(
 
     # Act
     first = record_pending_prompt(
-        sender="worker-a", target="lead", db_path=isolated_state
+        sender="worker-a", target="lead"
     )
     # Assert
     assert first is True
 
 
 def test_record_pending_prompt_dedupes_second_call(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — the second record for the same pair must NOT re-prompt.
     from scitex_agent_container._state.state_db_pending_approval import (
         record_pending_prompt,
     )
 
-    record_pending_prompt(sender="worker-a", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="worker-a", target="lead")
     # Act
     second = record_pending_prompt(
-        sender="worker-a", target="lead", db_path=isolated_state
+        sender="worker-a", target="lead"
     )
     # Assert
     assert second is False
@@ -182,7 +182,7 @@ def test_approval_prompt_body_does_not_leak_message_content() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_unblock_writes_comms_grants_row(isolated_state: Path) -> None:
+def test_unblock_writes_comms_grants_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     from scitex_agent_container._state.grant_flush import (
         unblock_and_clear_pending,
@@ -194,7 +194,7 @@ def test_unblock_writes_comms_grants_row(isolated_state: Path) -> None:
     assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
 
 
-def test_unblock_clears_the_pending_prompt(isolated_state: Path) -> None:
+def test_unblock_clears_the_pending_prompt(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — seed a pending row directly, then unblock.
     from scitex_agent_container._state.grant_flush import (
         unblock_and_clear_pending,
@@ -203,16 +203,16 @@ def test_unblock_clears_the_pending_prompt(isolated_state: Path) -> None:
         record_pending_prompt,
     )
 
-    record_pending_prompt(sender="worker-a", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="worker-a", target="lead")
     # Act
     unblock_and_clear_pending(sender="worker-a", target="lead")
     # Assert
     assert not has_pending_prompt(
-        sender="worker-a", target="lead", db_path=isolated_state
+        sender="worker-a", target="lead"
     )
 
 
-def test_unblock_removes_existing_block_row(isolated_state: Path) -> None:
+def test_unblock_removes_existing_block_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — block first, then unblock. The unblock MUST remove
     # the block row (otherwise the block-precedence rule in
     # ``check_send_acl`` would still silently drop sends post-
@@ -234,7 +234,7 @@ def test_unblock_removes_existing_block_row(isolated_state: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_block_writes_comms_blocks_row(isolated_state: Path) -> None:
+def test_block_writes_comms_blocks_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     from scitex_agent_container._state.grant_flush import (
         block_and_clear_pending,
@@ -246,7 +246,7 @@ def test_block_writes_comms_blocks_row(isolated_state: Path) -> None:
     assert has_block(sender="worker-a", target="lead", db_path=isolated_state)
 
 
-def test_block_clears_the_pending_prompt(isolated_state: Path) -> None:
+def test_block_clears_the_pending_prompt(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — seed a pending row directly, then block.
     from scitex_agent_container._state.grant_flush import (
         block_and_clear_pending,
@@ -255,16 +255,16 @@ def test_block_clears_the_pending_prompt(isolated_state: Path) -> None:
         record_pending_prompt,
     )
 
-    record_pending_prompt(sender="worker-a", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="worker-a", target="lead")
     # Act
     block_and_clear_pending(sender="worker-a", target="lead")
     # Assert
     assert not has_pending_prompt(
-        sender="worker-a", target="lead", db_path=isolated_state
+        sender="worker-a", target="lead"
     )
 
 
-def test_blocked_send_emits_no_receiver_push(isolated_state: Path) -> None:
+def test_blocked_send_emits_no_receiver_push(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — block first, then attempt a send. The receiver
     # MUST see NOTHING (no denied_attempt, no approve-prompt, no
     # new prompt re-fire). The sender still gets 403 (next test).
@@ -287,7 +287,7 @@ def test_blocked_send_emits_no_receiver_push(isolated_state: Path) -> None:
 
 
 def test_blocked_send_still_returns_403_to_sender(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — sender side learns their send did not land. The
     # silence is receiver-only; we are not in the business of
@@ -314,7 +314,7 @@ def test_blocked_send_still_returns_403_to_sender(
 # ---------------------------------------------------------------------------
 
 
-def test_cli_unblock_writes_comms_grants(isolated_state: Path) -> None:
+def test_cli_unblock_writes_comms_grants(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     from scitex_agent_container.cli_pkg.a2a_group import a2a
 
@@ -324,7 +324,7 @@ def test_cli_unblock_writes_comms_grants(isolated_state: Path) -> None:
     assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
 
 
-def test_cli_block_writes_comms_blocks(isolated_state: Path) -> None:
+def test_cli_block_writes_comms_blocks(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     from scitex_agent_container.cli_pkg.a2a_group import a2a
 
@@ -334,7 +334,7 @@ def test_cli_block_writes_comms_blocks(isolated_state: Path) -> None:
     assert has_block(sender="worker-a", target="lead", db_path=isolated_state)
 
 
-def test_cli_grant_alias_still_unblocks(isolated_state: Path) -> None:
+def test_cli_grant_alias_still_unblocks(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — legacy `sac a2a grant` MUST behave like unblock so
     # operator muscle memory keeps working.
     from scitex_agent_container.cli_pkg.a2a_group import a2a

--- a/tests/scitex_agent_container/_listen/test__acl_routes.py
+++ b/tests/scitex_agent_container/_listen/test__acl_routes.py
@@ -55,7 +55,7 @@ def _auth() -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def test_unblock_route_writes_comms_grants_row(isolated_state: Path) -> None:
+def test_unblock_route_writes_comms_grants_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -69,7 +69,7 @@ def test_unblock_route_writes_comms_grants_row(isolated_state: Path) -> None:
     assert has_grant(sender="alice", target="lead", db_path=isolated_state)
 
 
-def test_unblock_route_returns_200(isolated_state: Path) -> None:
+def test_unblock_route_returns_200(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -84,7 +84,7 @@ def test_unblock_route_returns_200(isolated_state: Path) -> None:
 
 
 def test_unblock_route_response_envelope_carries_decision_fields(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
@@ -105,7 +105,7 @@ def test_unblock_route_response_envelope_carries_decision_fields(
 # ---------------------------------------------------------------------------
 
 
-def test_block_route_writes_comms_blocks_row(isolated_state: Path) -> None:
+def test_block_route_writes_comms_blocks_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -125,7 +125,7 @@ def test_block_route_writes_comms_blocks_row(isolated_state: Path) -> None:
 
 
 def test_grant_route_writes_comms_grants_like_unblock(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
@@ -145,7 +145,7 @@ def test_grant_route_writes_comms_grants_like_unblock(
 # ---------------------------------------------------------------------------
 
 
-def test_missing_sender_returns_400(isolated_state: Path) -> None:
+def test_missing_sender_returns_400(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -159,7 +159,7 @@ def test_missing_sender_returns_400(isolated_state: Path) -> None:
     assert r.status_code == 400
 
 
-def test_missing_target_returns_400(isolated_state: Path) -> None:
+def test_missing_target_returns_400(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -173,7 +173,7 @@ def test_missing_target_returns_400(isolated_state: Path) -> None:
     assert r.status_code == 400
 
 
-def test_malformed_body_returns_400(isolated_state: Path) -> None:
+def test_malformed_body_returns_400(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -187,7 +187,7 @@ def test_malformed_body_returns_400(isolated_state: Path) -> None:
     assert r.status_code == 400
 
 
-def test_missing_bearer_returns_401_or_403(isolated_state: Path) -> None:
+def test_missing_bearer_returns_401_or_403(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — no Authorization header.
     app = create_app(token=_TOKEN)
     # Act

--- a/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
+++ b/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
@@ -7,20 +7,19 @@ identity, not on content. This module covers the flag CRUD in
 isolation; the integration (denied send records the flag, the CLI
 decision clears it) lives in its own test file.
 
-No-mocks (PA-306): real on-disk state.db, env + module constant
-save/restore. Each test: AAA markers (TQ002), one assertion (TQ007),
-3+-word name.
+No-mocks (PA-306): a REAL PostgreSQL via the shared ``pg_schema``
+fixture, which gives each test a throwaway schema so the live fleet
+store is never touched. The flag moved off SQLite on 2026-08-20; there
+is deliberately NO skipif on database availability, because a skip that
+reads as a pass is the defect this migration exists to remove.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
 """
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from typing import Iterator
-
 import pytest
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_pending_approval import (
     clear_pending_prompt,
     has_pending_prompt,
@@ -28,57 +27,39 @@ from scitex_agent_container._state.state_db_pending_approval import (
 )
 
 
-@pytest.fixture
-def isolated_state(tmp_path: Path) -> Iterator[Path]:
-    db = tmp_path / "state.db"
-    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
-    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
-    try:
-        yield db
-    finally:
-        state_db.DEFAULT_DB_PATH = saved_default
-        if saved_env is None:
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
-        else:
-            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
-
-
 # ---------------------------------------------------------------------------
 # record_pending_prompt — first-wins flag semantics
 # ---------------------------------------------------------------------------
 
 
-def test_first_record_returns_true(isolated_state: Path) -> None:
+def test_first_record_returns_true(pg_schema: str) -> None:
     # Arrange — fresh DB, no prior row.
     # Act
-    first = record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    first = record_pending_prompt(sender="alice", target="lead")
     # Assert — caller uses this signal to "emit the receiver-facing
     # push exactly once per pair until a decision".
     assert first is True
 
 
 def test_second_record_returns_false_no_duplicate_push(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — a pending row already exists.
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
     # Act
     second = record_pending_prompt(
-        sender="alice", target="lead", db_path=isolated_state
+        sender="alice", target="lead"
     )
     # Assert — duplicate denied attempts MUST NOT re-prompt.
     assert second is False
 
 
-def test_different_sender_target_pairs_both_emit(isolated_state: Path) -> None:
+def test_different_sender_target_pairs_both_emit(pg_schema: str) -> None:
     # Arrange — dedupe is per-pair, not global.
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
     # Act
     second_pair = record_pending_prompt(
-        sender="bob", target="lead", db_path=isolated_state
+        sender="bob", target="lead"
     )
     # Assert
     assert second_pair is True
@@ -90,22 +71,22 @@ def test_different_sender_target_pairs_both_emit(isolated_state: Path) -> None:
 
 
 def test_has_pending_prompt_returns_true_after_record(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
     # Act
-    flag = has_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    flag = has_pending_prompt(sender="alice", target="lead")
     # Assert
     assert flag is True
 
 
 def test_has_pending_prompt_returns_false_for_absent_pair(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — no record_pending_prompt call.
     # Act
-    flag = has_pending_prompt(sender="ghost", target="lead", db_path=isolated_state)
+    flag = has_pending_prompt(sender="ghost", target="lead")
     # Assert
     assert flag is False
 
@@ -115,48 +96,48 @@ def test_has_pending_prompt_returns_false_for_absent_pair(
 # ---------------------------------------------------------------------------
 
 
-def test_clear_removes_pending_row(isolated_state: Path) -> None:
+def test_clear_removes_pending_row(pg_schema: str) -> None:
     # Arrange
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
-    clear_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
+    clear_pending_prompt(sender="alice", target="lead")
     # Act
-    flag = has_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    flag = has_pending_prompt(sender="alice", target="lead")
     # Assert
     assert flag is False
 
 
-def test_clear_returns_true_when_row_existed(isolated_state: Path) -> None:
+def test_clear_returns_true_when_row_existed(pg_schema: str) -> None:
     # Arrange
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
     # Act
     removed = clear_pending_prompt(
-        sender="alice", target="lead", db_path=isolated_state
+        sender="alice", target="lead"
     )
     # Assert
     assert removed is True
 
 
-def test_clear_returns_false_when_row_absent(isolated_state: Path) -> None:
+def test_clear_returns_false_when_row_absent(pg_schema: str) -> None:
     # Arrange — no prior record.
     # Act
     removed = clear_pending_prompt(
-        sender="ghost", target="lead", db_path=isolated_state
+        sender="ghost", target="lead"
     )
     # Assert
     assert removed is False
 
 
 def test_after_clear_next_record_returns_true_again(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — record + clear + record again. The second record
     # MUST return True (i.e. emit the prompt) because the prior
     # decision was already made.
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
-    clear_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
+    clear_pending_prompt(sender="alice", target="lead")
     # Act
     second = record_pending_prompt(
-        sender="alice", target="lead", db_path=isolated_state
+        sender="alice", target="lead"
     )
     # Assert
     assert second is True
@@ -167,17 +148,101 @@ def test_after_clear_next_record_returns_true_again(
 # ---------------------------------------------------------------------------
 
 
-def test_empty_sender_raises(isolated_state: Path) -> None:
+def test_empty_sender_raises(pg_schema: str) -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError, match="non-empty"):
-        record_pending_prompt(sender="", target="lead", db_path=isolated_state)
+        record_pending_prompt(sender="", target="lead")
 
 
-def test_empty_target_raises(isolated_state: Path) -> None:
+def test_empty_target_raises(pg_schema: str) -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError, match="non-empty"):
-        record_pending_prompt(sender="alice", target="", db_path=isolated_state)
+        record_pending_prompt(sender="alice", target="")
+
+
+# ---------------------------------------------------------------------------
+# What the PostgreSQL move CHANGED — clearing hides, it does not delete
+# ---------------------------------------------------------------------------
+
+
+def test_clearing_hides_the_record_rather_than_destroying_it(pg_schema: str) -> None:
+    """The decision survives the clear, which the SQLite DELETE destroyed.
+
+    ``clear_pending_prompt`` maps to the store's ``hide``, so the record
+    stays in the oplog with the actor that cleared it. Reads are
+    unaffected — ``get`` skips hidden records — but "who cleared this
+    pair, and when" is now answerable, and under DELETE it was not.
+
+    Asserted through the store's own ``is_hidden`` rather than by peeking
+    at a physical table: the claim is about the RECORD's state, and a raw
+    table read would be a true statement about a different artifact.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db_pending_approval import (
+        open_pending_prompt_store,
+    )
+
+    record_pending_prompt(sender="alice", target="lead")
+    clear_pending_prompt(sender="alice", target="lead")
+    # Act
+    store = open_pending_prompt_store()
+    try:
+        hidden = store.is_hidden({"sender": "alice", "target": "lead"})
+    finally:
+        store.close()
+    # Assert — True means "record exists and is hidden", not "absent".
+    assert hidden is True
+
+
+def test_re_recording_after_a_clear_refreshes_the_timestamp(pg_schema: str) -> None:
+    """A re-armed pair carries the NEW prompt's time, not the old one.
+
+    This is why ``ts`` is LAST_WRITER_WINS rather than IMMUTABLE. Nothing
+    orders decisions on this field today, so the refresh cannot reorder
+    anything — but a stale timestamp on a live prompt would misreport when
+    the receiver was actually asked.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db_pending_approval import (
+        open_pending_prompt_store,
+    )
+
+    record_pending_prompt(sender="alice", target="lead")
+    store = open_pending_prompt_store()
+    try:
+        first_ts = store.get({"sender": "alice", "target": "lead"}).values["ts"]
+    finally:
+        store.close()
+    clear_pending_prompt(sender="alice", target="lead")
+    record_pending_prompt(sender="alice", target="lead")
+    # Act
+    store = open_pending_prompt_store()
+    try:
+        second_ts = store.get({"sender": "alice", "target": "lead"}).values["ts"]
+    finally:
+        store.close()
+    # Assert
+    assert second_ts >= first_ts
+
+
+def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> None:
+    """The return value names WHERE the state went, so it can be checked.
+
+    The SQLite version returned None. The locator names the DATABASE and
+    not the search_path schema layered on top — the same shape the
+    incarnations store has, pinned here so the two do not drift apart.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db_pending_approval import (
+        init_pending_prompts_schema,
+    )
+
+    expected = "55432"
+    # Act
+    locator = init_pending_prompts_schema()
+    # Assert
+    assert expected in locator

--- a/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
@@ -620,7 +620,7 @@ def isolated_state_db(tmp_path: Path, env_save_restore) -> Iterator[Path]:
         importlib.reload(_sdb)
 
 
-def test_grant_exit_zero_on_happy_path(isolated_state_db: Path) -> None:
+def test_grant_exit_zero_on_happy_path(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     # Act
@@ -629,7 +629,7 @@ def test_grant_exit_zero_on_happy_path(isolated_state_db: Path) -> None:
     assert res.exit_code == 0
 
 
-def test_grant_persists_row_into_comms_grants(isolated_state_db: Path) -> None:
+def test_grant_persists_row_into_comms_grants(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
@@ -641,7 +641,7 @@ def test_grant_persists_row_into_comms_grants(isolated_state_db: Path) -> None:
     assert any(r["sender"] == "worker-a" and r["target"] == "worker-b" for r in rows)
 
 
-def test_grant_stores_optional_note(isolated_state_db: Path) -> None:
+def test_grant_stores_optional_note(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b", "--note", "ticket-PA-512"])
@@ -653,7 +653,7 @@ def test_grant_stores_optional_note(isolated_state_db: Path) -> None:
     assert "ticket-PA-512" in notes
 
 
-def test_grant_idempotent_no_duplicate_rows(isolated_state_db: Path) -> None:
+def test_grant_idempotent_no_duplicate_rows(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange: grant twice with the same pair
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
@@ -670,7 +670,7 @@ def test_grant_idempotent_no_duplicate_rows(isolated_state_db: Path) -> None:
     assert len(rows) == 1
 
 
-def test_grant_empty_sender_exits_two(isolated_state_db: Path) -> None:
+def test_grant_empty_sender_exits_two(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     # Act
@@ -681,6 +681,7 @@ def test_grant_empty_sender_exits_two(isolated_state_db: Path) -> None:
 
 def test_grant_empty_sender_writes_error_to_stderr(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -692,6 +693,7 @@ def test_grant_empty_sender_writes_error_to_stderr(
 
 def test_grant_human_output_announces_direction(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -704,7 +706,7 @@ def test_grant_human_output_announces_direction(
 # --- revoke -----------------------------------------------------------------
 
 
-def test_revoke_existing_grant_exits_zero(isolated_state_db: Path) -> None:
+def test_revoke_existing_grant_exits_zero(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
@@ -714,7 +716,7 @@ def test_revoke_existing_grant_exits_zero(isolated_state_db: Path) -> None:
     assert res.exit_code == 0
 
 
-def test_revoke_removes_row_from_comms_grants(isolated_state_db: Path) -> None:
+def test_revoke_removes_row_from_comms_grants(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
@@ -731,7 +733,7 @@ def test_revoke_removes_row_from_comms_grants(isolated_state_db: Path) -> None:
     assert rows == []
 
 
-def test_revoke_missing_grant_is_noop_zero_exit(isolated_state_db: Path) -> None:
+def test_revoke_missing_grant_is_noop_zero_exit(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange: no grant exists
     runner = CliRunner()
     # Act
@@ -742,6 +744,7 @@ def test_revoke_missing_grant_is_noop_zero_exit(isolated_state_db: Path) -> None
 
 def test_revoke_missing_grant_emits_noop_marker(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -751,7 +754,7 @@ def test_revoke_missing_grant_emits_noop_marker(
     assert "no-op" in res.output
 
 
-def test_revoke_empty_sender_exits_two(isolated_state_db: Path) -> None:
+def test_revoke_empty_sender_exits_two(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     # Act
@@ -762,6 +765,7 @@ def test_revoke_empty_sender_exits_two(isolated_state_db: Path) -> None:
 
 def test_revoke_empty_target_writes_error_to_stderr(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -796,7 +800,7 @@ def test_grants_json_empty_table_is_empty_array(
     assert json.loads(res.output) == []
 
 
-def test_grants_json_lists_inserted_grant(isolated_state_db: Path) -> None:
+def test_grants_json_lists_inserted_grant(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b", "--note", "demo"])
@@ -812,6 +816,7 @@ def test_grants_json_lists_inserted_grant(isolated_state_db: Path) -> None:
 
 def test_grants_rich_table_shows_sender_and_target(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -822,7 +827,7 @@ def test_grants_rich_table_shows_sender_and_target(
     assert "alpha" in res.output and "beta" in res.output
 
 
-def test_grants_json_orders_by_insertion(isolated_state_db: Path) -> None:
+def test_grants_json_orders_by_insertion(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "first-sender", "first-target"])
@@ -838,6 +843,7 @@ def test_grants_json_orders_by_insertion(isolated_state_db: Path) -> None:
 
 def test_grants_json_after_revoke_drops_the_row(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -849,7 +855,7 @@ def test_grants_json_after_revoke_drops_the_row(
     assert json.loads(res.output) == []
 
 
-def test_grant_direction_is_one_way(isolated_state_db: Path) -> None:
+def test_grant_direction_is_one_way(isolated_state_db: Path, pg_schema: str) -> None:
     """Granting A→B must NOT auto-grant B→A (the ACL is directional)."""
     # Arrange
     runner = CliRunner()

--- a/tests/scitex_agent_container/conftest.py
+++ b/tests/scitex_agent_container/conftest.py
@@ -92,6 +92,21 @@ PG_BASE_DSN = os.environ.get(
     "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
 )
 
+#: The password file, resolved AT IMPORT and pinned for the fixture below.
+#:
+#: MEASURED 2026-08-20. `tests/.../_listen/test__acl_approve_flow.py` sandboxes
+#: `HOME` to a tmp_path — correctly, it is testing host-file behaviour. libpq
+#: finds its password file via `~/.pgpass`, so under that sandbox the lookup
+#: lands in an empty directory and the fixture's own CREATE SCHEMA fails with
+#: `fe_sendauth: no password supplied`. The same fixture works everywhere else,
+#: which is what made it look like a fixture bug rather than an interaction.
+#:
+#: Resolving here — while HOME is still the real one, before any test can move
+#: it — and passing it explicitly makes the fixture independent of a variable
+#: tests are entitled to change. `PGPASSFILE` is libpq's own override and takes
+#: precedence over the HOME lookup.
+_PGPASS_AT_IMPORT = os.environ.get("PGPASSFILE") or os.path.expanduser("~/.pgpass")
+
 #: A DSN that cannot reach anything, on purpose. Port 1 refuses instantly, and
 #: the database name is written to be legible in the error a stray write
 #: produces — the message itself states the rule it just enforced.
@@ -197,6 +212,12 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
 
     import psycopg
 
+    # Pin PGPASSFILE for the whole fixture: a test that sandboxes HOME (several
+    # legitimately do) would otherwise strand libpq's ~/.pgpass lookup.
+    pgpass_key = "PGPASSFILE"
+    saved_pgpass = os.environ.get(pgpass_key)
+    os.environ[pgpass_key] = _PGPASS_AT_IMPORT
+
     schema = "sac_test_" + uuid.uuid4().hex[:12]
     with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
         conn.execute(f'CREATE SCHEMA "{schema}"')
@@ -213,3 +234,7 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
             os.environ[key] = saved
         with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
             conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        if saved_pgpass is None:
+            os.environ.pop(pgpass_key, None)
+        else:
+            os.environ[pgpass_key] = saved_pgpass


### PR DESCRIPTION

Third table under the 2026-08-19 SQLite-eradication ruling, after
verdict_delivered and incarnations. Same adoption of scitex_dev.store,
same removal of db_path from every function and from the callers that
were threading it in.

THE DELETE IS WHY THIS ONE NEEDED DESIGN
========================================
The two tables that moved before this one only ever inserted. This one
DELETEs, and the store has no delete — it has `hide`, which marks a record
invisible to get/rows while keeping it in the oplog.

That is the better primitive here: the decision stays auditable with the
actor that made it, which DELETE destroyed. But it introduces a lifecycle
SQLite did not have — a cleared pair is not ABSENT, it is HIDDEN. Written
naively, the next denial for that pair would see get() -> None, try to
insert, collide with the hidden record, and report "already pending", so
the receiver would never be prompted again. A fix for a silent-success bug
that silently suppresses prompts forever is worse than the bug.

`Store.is_hidden` is what makes it expressible, because it answers in
THREE values where `get` answers in two:

    None    no record          -> insert; this is the first prompt
    True    cleared earlier    -> unhide + refresh ts; prompt again
    False   present, visible   -> already pending; suppress

`get` alone collapses the first two into "nothing there", and that
collapse IS the bug.

The existing suite already had `test_after_clear_next_record_returns_true_
again`, written for the SQLite version — so the naive implementation would
have been caught. It passes.

CONCURRENCY IS PRESERVED, and it was explicit in the original: "the check
+ insert is one atomic transaction so a concurrent burst of denied
attempts emits exactly one prompt". The insert now carries
expected_revision=NEW_RECORD, so a racing writer raises
RevisionMismatchError — which means "someone else prompted", the same
answer the transaction gave. Nothing else is caught.

NO MIGRATION SCRIPT, and that is measured rather than assumed: the table
holds ZERO rows on all four reachable hosts. It is a transient flag,
cleared on every decision, so it is empty at rest. ywata-note-win is
offline (operator is out with it) and therefore unmeasured — "zero
everywhere" would overstate what I checked.

ONE FIXTURE FIX RIDES ALONG, because this PR is what exposed it.
`tests/.../_listen/test__acl_approve_flow.py` sandboxes HOME to a
tmp_path — correctly, it tests host-file behaviour. libpq finds its
password file via ~/.pgpass, so under that sandbox `pg_schema`'s own
CREATE SCHEMA failed with "fe_sendauth: no password supplied". The fixture
now resolves PGPASSFILE at conftest import — while HOME is still real —
and pins it, so it no longer depends on a variable tests are entitled to
change.

The ACL tests that reach `grant_flush` now take `pg_schema` too: clearing
the flag is a PostgreSQL write, so those paths need a store. The two
databases in one test are the migration in miniature — grants and blocks
are still SQLite, the pending flag is not.

2423 passed across _listen, _state and develop. The 3 failures in
test_host_config_diagnose.py reproduce on develop with and without xdist
and are unrelated.
