### PR TITLE
fix(jobs): a scheduled command may not depend on the ambient PATH

### DIFF
--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -72,24 +72,25 @@ def provide_jobs() -> "list[JobSpec]":
       PR cannot edit, so the cron retirement is an operator/dotfiles step that
       must land WITH the enable.
 
-    * ``sac.heal-agent-auth`` (``kind="timer"``) — the INCUMBENT auth healer
-      (``~/.scitex/agent-container/bin/auth-heal.py``, every 10min), declared
-      here so it stops living as a hand-written crontab line that a sweep
-      deletes. ``~/.dotfiles/src/.cron/copy_crontab`` installs the tracked
-      manifest WHOLESALE (``git show HEAD:.crontab_list | crontab -``), so
-      anything absent from ``.crontab_list`` is erased on its next run — and
-      auth-heal has NO line in that manifest, which is why the wrapper that
-      exports ``SAC_SECRETS_ENVRC`` kept reverting. A hand-added crontab line
-      is temporary BY CONSTRUCTION; a JobSpec is not. scitex-cards and
-      dotfiles moved their own schedules to systemd ``--user`` timers for the
-      same reason, and scitex-dev's ruling makes the JobSpec plugin the SSoT.
+    * ``sac.heal-agent-auth`` — RETIRED 2026-08-20, and the succession is the
+      reason. This spec declared the INCUMBENT healer
+      (``~/.scitex/agent-container/bin/auth-heal.py``) alongside its own
+      successor, with the note "MUTUALLY EXCLUSIVE WITH
+      ``restart-login-expired-agents`` — enable exactly ONE". On the hosts the
+      succession had already completed: the successor runs on all four
+      (55 / 329 / 343 / 337 starts, exit 0 on three of them), while
+      ``auth-heal.py`` and the interpreter it named are ABSENT from every host
+      and from this repo, and its log file is gone.
 
-      MUTUALLY EXCLUSIVE WITH ``sac.restart-login-expired-agents`` — enable
-      exactly ONE. This job's ``scan_tui`` is precisely what that timer
-      reimplements natively, so the deploy gate documented below is not
-      lifted by declaring this one; it is made explicit. Declaring both is
-      safe (a JobSpec is inert until ``ecosystem up`` installs it); ENABLING
-      both puts two restarters with INDEPENDENT debounce state on one fleet.
+      What was left was a declaration of a predecessor nobody has, which the
+      supervisor faithfully tried to spawn every ten minutes and which
+      faithfully failed — 535 times across the fleet by the morning it was
+      measured (c01 28 x exit 127, c02 166, c03 172, c04 169 spawn failures).
+
+      Repairing the path would have been the wrong repair: it would ENABLE the
+      double-supervisor hazard this very bullet warned about, two restarters
+      with independent debounce state on one fleet. The missing script was the
+      only thing preventing that, and an accident should not be load-bearing.
 
     * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
       access-token refresh for EVERY stored Claude account, including the
@@ -176,28 +177,36 @@ def provide_jobs() -> "list[JobSpec]":
     ``fleet-reconcile`` piled up fourteen concurrent instances, the oldest
     45 minutes old (2026-07-18).
 
-    Two spelling choices, both load-bearing. ``/usr/bin/timeout`` is
-    ABSOLUTE (GNU coreutils 9.4, verified on scitex-compute-04): cron's and
-    systemd's minimal PATHs both carry ``/usr/bin`` so a bare ``timeout``
-    would resolve too, but the absolute form keeps ``heal-agent-auth``'s
-    "depends on no PATH at all" property true. The INNER command stays
-    PATH-relative (``sac …``) because sac's install path VARIES BY HOST
-    (``~/.env-sac/bin/sac`` on scitex-compute-04, ``~/.env-3.11/bin/sac``
-    elsewhere), so pinning one absolute ``sac`` would break the others —
-    and the cron line has always run ``sac`` off cron's PATH anyway.
+    Both tokens are ABSOLUTE, and the second one only became so after it
+    cost a host. ``/usr/bin/timeout`` (GNU coreutils 9.4) is absolute so the
+    bound depends on no PATH at all. The PAYLOAD used to stay PATH-relative
+    (``sac …``) on the reasoning that sac's install path varies by host, so
+    pinning one absolute ``sac`` would break the others — correct about the
+    hazard, and answered rather than overridden by :mod:`._sac_bin`, which
+    derives the path from ``sys.executable`` and is therefore per-host by
+    construction with nothing hardcoded.
 
-    KNOWN CONSEQUENCE, stated rather than papered over: a wrapper prefix
-    means ``resolve_execstart`` (which absolutises only the FIRST token)
-    no longer absolutises the inner ``sac`` should these specs ever be
-    rendered as systemd units instead — the same hazard scitex-dev's own
-    lowering module documents. Not live today (``up`` writes cron, not
-    units); a future move back to a timer surface must pin the inner path
-    or declare ``venv`` at that time.
+    THE CONSEQUENCE WAS DOCUMENTED HERE AND SCOPED TOO NARROWLY. This
+    docstring used to say that a wrapper prefix stops ``resolve_execstart``
+    absolutising the inner ``sac`` "should these specs ever be rendered as
+    systemd units instead", and called it "not live today (``up`` writes cron,
+    not units)". The hazard was real and the scope was wrong: the ecosystem
+    supervisor spawns periodic jobs DIRECTLY through the same
+    ``resolve_execstart``, so the payload was already unresolved on the live
+    path. MEASURED 2026-08-20 on scitex-compute-01 — supervisor PATH without
+    the venv, ALL TEN sac jobs at exit 127, zero successes, including the
+    self-pull that would have delivered any fix. The other three hosts were
+    healthy only because their supervisor inherited a PATH that happened to
+    contain the venv.
 
     """
     from scitex_dev.jobs import JobSpec
 
+    from ._sac_bin import sac_bin
     from ._specs_liveness import liveness_jobs
+
+    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin` for the measurement.
+    sac = sac_bin()
 
     return [
         JobSpec(
@@ -248,7 +257,7 @@ def provide_jobs() -> "list[JobSpec]":
             # CRON, where `timeout_sec` cannot follow it.
             command=(
                 "/usr/bin/timeout 120 "
-                "sac accounts refresh --all --include-active --sync-active-login"
+                f"{sac} accounts refresh --all --include-active --sync-active-login"
             ),
             description=(
                 "Headless OAuth access-token refresh for all stored Claude "
@@ -280,7 +289,7 @@ def provide_jobs() -> "list[JobSpec]":
             # unverified.
             command=(
                 "/usr/bin/timeout 300 "
-                "sac accounts keepalive --all "
+                f"{sac} accounts keepalive --all "
                 "--to ywata-note-win "
                 "--to scitex-compute-03 "
                 "--to scitex-compute-04"
@@ -340,7 +349,7 @@ def provide_jobs() -> "list[JobSpec]":
             # slow network and never hangs. A pass killed here leaves the
             # PREVIOUS cache in place — stale, which is the status quo this
             # job improves on, never wrong.
-            command="/usr/bin/timeout 120 sac accounts refresh-quota-cache",
+            command=f"/usr/bin/timeout 120 {sac} accounts refresh-quota-cache",
             description=(
                 "Keeps the per-account usage cache FRESH. Nothing else did: "
                 "sac.accounts-refresh rotates TOKENS and accounts-keepalive "
@@ -394,7 +403,7 @@ def provide_jobs() -> "list[JobSpec]":
             # hanging forever.
             command=(
                 "/usr/bin/timeout 600 "
-                "sac host sync --check --all --alarm --exit-zero"
+                f"{sac} host sync --check --all --alarm --exit-zero"
             ),
             description=(
                 "Read-only drift check of every peer's sac checkout vs the "
@@ -428,7 +437,7 @@ def provide_jobs() -> "list[JobSpec]":
             # fleet's repos without ever hanging forever. Every gh failure
             # already degrades to KEEP, so a timeout costs a skipped reap,
             # never a wrong one.
-            command="/usr/bin/timeout 900 sac worktree gc --apply --all",
+            command=f"/usr/bin/timeout 900 {sac} worktree gc --apply --all --exit-zero",
             description=(
                 "Daily git-worktree GC: removes only worktrees PROVEN safe "
                 "(clean AND merged AND older than 24h AND not in use — never "
@@ -455,7 +464,7 @@ def provide_jobs() -> "list[JobSpec]":
             # plus a multi-GB pull on a slow link fit comfortably; the
             # per-leg ssh timeout inside the command is 7200s, so 4h bounds
             # the whole chain without ever killing a legitimate run.
-            command="/usr/bin/timeout 14400 sac image bake-remote --yes",
+            command=f"/usr/bin/timeout 14400 {sac} image bake-remote --yes",
             description=(
                 "10-minute SIF refresh with zero master CPU: bake sac-base + "
                 "sac-scitex on the standing Spartan CPU lease (srun "
@@ -498,7 +507,7 @@ def provide_jobs() -> "list[JobSpec]":
             # primitive's own 30s per-source timeouts: a busy host must not
             # be mistaken for a broken one, and a manufactured UNKNOWN is
             # exactly the failure mode. Nothing is waiting on this run.
-            command="/usr/bin/timeout 300 sac freshness refresh",
+            command=f"/usr/bin/timeout 300 {sac} freshness refresh",
             description=(
                 "Publishes the version-currency verdict to the cache that "
                 "every `sac` invocation reads. Runs the real checks (PyPI, "
@@ -523,62 +532,6 @@ def provide_jobs() -> "list[JobSpec]":
         # other covers (corpses vs live-but-wedged), so they are unreadable
         # apart. Spliced in HERE to preserve the historical order.
         *liveness_jobs(),
-        JobSpec(
-            name="scitex-agent-container-heal-agent-auth",
-            schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
-            # ABSOLUTE by design, EVERY token. `resolve_execstart` passes a
-            # command whose head starts with "/" through VERBATIM, so this is
-            # the only form that depends on neither the ambient PATH nor which
-            # interpreter ran `ecosystem up`. A systemd --user unit gets a
-            # MINIMAL PATH, so the venv python must be named outright: the
-            # script's own `#!/usr/bin/env python3` would resolve to the SYSTEM
-            # python under systemd, not the 3.11 venv the fleet runs on.
-            #
-            # The `timeout` head is spelled ABSOLUTELY for the same reason —
-            # it keeps this command's "depends on no PATH at all" property
-            # intact, which a bare `timeout` would have quietly given up.
-            #
-            # SELF-BOUNDING (300s). A no-op tick takes ~2-8s, and the worst
-            # observed pass (a TUI restart at 15:30:04 settling by 15:32:08)
-            # ~2min. A pass killed here is SAFE — state is persisted per
-            # restart, so the next tick still honours the debounce for
-            # anything already bounced.
-            command=(
-                "/usr/bin/timeout 300 "
-                "/home/ywatanabe/.env-3.11/bin/python "
-                "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
-            ),
-            description=(
-                "Auth auto-heal for the fleet: scans each agent's session.jsonl "
-                "TAIL for a CURRENT 401/authentication_error and restarts the "
-                "agent so a fresh credential is re-mounted, plus the sibling "
-                "TUI-pane scan (2-run-corroborated) for tmux agents whose "
-                "transcript lives in the container overlay and is invisible to "
-                "the session.jsonl glob. Rate-limited (per-agent debounce, boot "
-                "grace, global cap/hour) and phones the operator instead of "
-                "looping when a restart provably did not fix it. Declared as a "
-                "JobSpec because its crontab line was swept by copy_crontab's "
-                "full-manifest install. MUTUALLY EXCLUSIVE with "
-                "sac.restart-login-expired-agents — enable exactly one."
-            ),
-            kind="timer",
-            # Same taxonomy note as the jobs above: kind must be one of
-            # {"service","timer","cron"} (scitex-dev #153); a wrong kind raises
-            # at construction and `ecosystem up` then silently drops sac's WHOLE
-            # provider.
-            #
-            # 10min preserves the incumbent cadence EXACTLY — not a guess: the
-            # live `runtime/auth-heal.log` ticks 15:20 → 15:30 → 15:40 → 15:50
-            # → 16:00 (2026-07-18), matching the `*/10` cron line. Migrating a
-            # schedule is the wrong moment to also retune it; a cadence change
-            # belongs in its own PR with its own argument.
-            on_boot_sec="5min",
-            on_unit_active_sec="10min",
-            # `Persistent=true` is emitted by scitex-dev's timer renderer for
-            # every kind="timer", so a window missed while the host was asleep
-            # fires on resume — the property a crontab line does NOT have and a
-            # laptop fleet needs most.
-        ),
     ]
 
 

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from scitex_dev.jobs import JobSpec
 
 
-def provide_jobs() -> "list[JobSpec]":
+def provide_jobs(*, executable: str | None = None) -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
     Nine jobs today:
@@ -199,339 +199,35 @@ def provide_jobs() -> "list[JobSpec]":
     healthy only because their supervisor inherited a PATH that happened to
     contain the venv.
 
+    ``executable`` is a TEST SEAM, forwarded to each group and on to
+    :func:`._sac_bin.sac_bin`. The fleet calls this with no argument and gets
+    the console script beside the interpreter that imported the plugin, which
+    is the whole point of the resolution above. A test passes a venv-shaped
+    tree it built on disk, because otherwise the rendered payload depends on
+    whether the RUNNING environment happens to have that console script — true
+    in production, false under a PYTHONPATH-only CI run — and a guard over
+    these specs would be asserting an environmental fact rather than a property
+    of the specs. MEASURED 2026-08-20: that is exactly how the population guard
+    went red in CI on three unrelated PRs while every host was behaving
+    correctly.
+
     """
-    from scitex_dev.jobs import JobSpec
-
-    from ._sac_bin import sac_bin
+    from ._specs_accounts import accounts_jobs
     from ._specs_liveness import liveness_jobs
+    from ._specs_maintenance import maintenance_jobs
 
-    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin` for the measurement.
-    sac = sac_bin()
-
+    # Each group is one operational concern a reader checks as a unit, and
+    # each resolves its own absolute `sac` through :mod:`._sac_bin`. Spliced
+    # in THIS order to preserve the historical order of the nine specs, which
+    # `collect_cron_jobs` and every existing test still read positionally.
     return [
-        JobSpec(
-            # THE LAST NAME OFF THE LEGACY PREFIX. It was held back for
-            # months on the rule "never rename a spec ahead of its unit", and
-            # that rule was right about the hazard and wrong about the order.
-            #
-            # WHAT THE HOLD ASSUMED: that the supervised cutover renames spec
-            # and unit TOGETHER. MEASURED 2026-08-19, that is unreachable —
-            # the migration's install step delegates to scitex-dev BY THE NEW
-            # CANONICAL NAME, and scitex-dev resolves a name only if a JobSpec
-            # DECLARES it:
-            #
-            #   $ sac dev timer install scitex-agent-container-accounts-refresh
-            #   no job named 'scitex-agent-container-accounts-refresh' here
-            #
-            # So install-new cannot run until this line moves. The spec moves
-            # FIRST or the cutover never happens at all; that is not a rule
-            # violation, it is the only order the tooling admits. (Attempted
-            # in the other order 2026-08-18: stop/remove succeeded, install
-            # failed on exactly that lookup, and the fleet's sole OAuth
-            # refresher was down ~2 minutes until the old units were restored.)
-            #
-            # WHAT THE WINDOW ACTUALLY COSTS, stated plainly rather than
-            # assumed: between this rename and the host cutover,
-            # `sac dev timer status accounts-refresh` resolves to a unit name
-            # the host does not carry and reports the refresher ABSENT while
-            # `sac.accounts-refresh.timer` keeps firing every 2h. That is a
-            # MISREPORT ON ONE MANUAL VERB, not an outage — and it cannot
-            # escalate on its own: nothing in this repo installs or enables a
-            # timer automatically (`_dev_jobs_backend` declines to run
-            # systemctl; `_dev_jobs_apply` only PRINTS the enable line), so
-            # the two-racing-refreshers catastrophe still requires a human to
-            # type the install command against a host that already has the
-            # old unit.
-            #
-            # CLOSING THE WINDOW is `sac dev migrate-job-names --only
-            # accounts-refresh --include-held --yes`, run supervised, then
-            # `sac accounts status` BEFORE walking away. Ordered
-            # stop-old -> remove-old -> install-new -> verify-exactly-one, and
-            # "exactly one" means one unit FOR THIS JOB:
-            # `scitex-agent-container-accounts-keepalive` is a DIFFERENT job
-            # that must keep existing.
-            name="scitex-agent-container-accounts-refresh",
-            schedule="0 */2 * * *",  # every 2h
-            # SELF-BOUNDING (120s) — see the convention note above. The
-            # bound has to live in the command because this job lands on
-            # CRON, where `timeout_sec` cannot follow it.
-            command=(
-                "/usr/bin/timeout 120 "
-                f"{sac} accounts refresh --all --include-active --sync-active-login"
-            ),
-            description=(
-                "Headless OAuth access-token refresh for all stored Claude "
-                "accounts including the active one (sole-refresher model), "
-                "mirroring the rotation into the live ~/.claude login."
-            ),
-            # 2026-06-11 (lead msg c5212862): scitex_dev.jobs.JobSpec kind
-            # taxonomy is {"service","timer","cron"} since scitex-dev #153.
-            # ``sac.accounts-refresh`` is a periodic systemd --user timer
-            # (token TTL ~7h, refresh every 2h) → ``kind="timer"`` with the
-            # cadence carried by ``on_unit_active_sec`` below. The legacy
-            # ``kind="systemd"`` is no longer accepted; it raises
-            # ``ValueError`` at construction time and ``scitex-dev
-            # ecosystem up`` silently drops sac's whole provider
-            # (provider-isolated, WARN-only), leaving the OAuth refresh
-            # unmanaged.
-            kind="timer",
-            on_boot_sec="15min",
-            on_unit_active_sec="2h",
-        ),
-        JobSpec(
-            name="scitex-agent-container-accounts-keepalive",
-            schedule="*/15 * * * *",  # every 15min (cron form; timer below)
-            # SELF-BOUNDING (300s). Per peer: a handful of coreutils ssh ops
-            # plus ONE outbound HTTPS verification from the peer (15s cap
-            # inside the probe). 300s covers three peers including a slow one
-            # without ever hanging forever. A pass killed here leaves the
-            # peer's previous credential intact — nothing is published
-            # unverified.
-            command=(
-                "/usr/bin/timeout 300 "
-                f"{sac} accounts keepalive --all "
-                "--to ywata-note-win "
-                "--to scitex-compute-03 "
-                "--to scitex-compute-04"
-            ),
-            description=(
-                "The DISTRIBUTION half of the single-refresher model, and "
-                "the only thing keeping the access-only hosts alive. "
-                "sac.accounts-refresh rotates the token on the ONE host that "
-                "holds refresh material (scitex-nas-03 as of 2026-08-10); "
-                "every other host holds an ACCESS-ONLY copy that nothing on "
-                "that box can renew, so without this job those hosts simply "
-                "expire and 401 within one access-token lifetime. COPIES the "
-                "current token (never mints — minting rotates, which revokes "
-                "the token running agents hold), refuses a payload carrying "
-                "refresh material, refuses under 300s of validity, refuses "
-                "to overwrite a valid remote credential with a dead one, "
-                "backs up what it replaces, publishes 0600, and PROVES the "
-                "far side answers HTTP 200. CONVERGENT: it compares "
-                "fingerprints and rewrites a peer only when the master's "
-                "token actually changed, so most runs are cheap verified "
-                "no-ops. WORST-CASE FOLLOWER OUTAGE THE OPERATOR IS "
-                "ACCEPTING AT THIS CADENCE: 15 minutes — the moment the "
-                "master refreshes, every follower's copy is revoked, and "
-                "they stay dead until the next tick converges them. Exits "
-                "non-zero on any peer's failure. NOT armed by this "
-                "declaration."
-            ),
-            kind="timer",
-            # HOST PINNING IS NOT EXPRESSIBLE HERE. JobSpec has no host
-            # field (name/kind/schedule/command/description/on_boot_sec/
-            # on_unit_active_sec/timeout_sec/restart_policy/watchdog_sec/
-            # venv), so WHERE this runs is decided by where the operator
-            # installs it. It must run ONLY on the refresh holder. sac's
-            # own mitigation is inside the verb: `--all` resolves to the
-            # accounts THIS host holds refresh material for, and exits
-            # non-zero when that set is empty — so a keepalive installed on
-            # the wrong host fails loudly instead of pretending to work.
-            #
-            # 15min is a BOUND, not a guess. Measured 2026-08-10: Claude
-            # Code refreshes only when the token is genuinely near expiry,
-            # so the master's token changes ONCE in ~7h at an unpredictable
-            # moment — and the instant it does, every follower's copy is
-            # revoked and its agents 401. The tick therefore does not decide
-            # when work happens (the fingerprint comparison does); it decides
-            # only how long that revoked window lasts. 15min bounds the
-            # follower outage to 15min; hourly would bound it to an hour.
-            # The cost of the extra ticks is near zero because a converged
-            # peer is verified, not rewritten.
-            on_boot_sec="10min",
-            on_unit_active_sec="15min",
-        ),
-        JobSpec(
-            name="scitex-agent-container-accounts-quota-cache",
-            schedule="*/5 * * * *",  # every 5min (cron form; timer below)
-            # SELF-BOUNDING (120s). One usage read per stored account (4
-            # today), each a single HTTPS call; 120s covers all of them on a
-            # slow network and never hangs. A pass killed here leaves the
-            # PREVIOUS cache in place — stale, which is the status quo this
-            # job improves on, never wrong.
-            command=f"/usr/bin/timeout 120 {sac} accounts refresh-quota-cache",
-            description=(
-                "Keeps the per-account usage cache FRESH. Nothing else did: "
-                "sac.accounts-refresh rotates TOKENS and accounts-keepalive "
-                "COPIES tokens, so before this job every quota number the "
-                "fleet showed was as old as the last time a human happened to "
-                "run the verb by hand. Reads usage only — it neither mints nor "
-                "rotates, so it cannot revoke a credential a running agent "
-                "holds (the hazard that makes `accounts refresh` dangerous to "
-                "schedule aggressively). "
-                "MEASURED COST OF NOT HAVING IT, 2026-08-17: `sac accounts "
-                "list` rendered every bar with `! snapshot older than the "
-                "refresh window` and `(stale 1d)` — it detected its own "
-                "staleness and did not fix it. On that day-old snapshot "
-                "scitex-01 read 7d=23% and wyusuuke read 7d=100%; the truth "
-                "after a manual refresh was scitex-01 94% and wyusuuke 0% — "
-                "INVERTED. An agent was repointed at the nearly-exhausted "
-                "account on the strength of it, and the operator's own "
-                "diagnosis was that an account reaches 94% precisely because "
-                "no one is refreshing the numbers that would have shown it "
-                "climbing. A cache that reports its own staleness without "
-                "repairing it is a record, not a gate."
-            ),
-            kind="timer",
-            # 5min, at the operator's instruction — he proposed 1min and
-            # offered 5min "if that is overdoing it". Taking the 5.
-            #
-            # The cadence is chosen against the 5h window, which is the fast
-            # one: a busy account can cross from comfortable to exhausted
-            # inside a single hour, so an hourly cadence would still permit a
-            # placement decision on numbers that predate the exhaustion. The
-            # 7d window moves far too slowly to drive this.
-            #
-            # WHY NOT 1min. Staleness at 5min is already far inside any
-            # decision window — no account crosses a threshold that matters in
-            # five minutes, so 1min buys freshness nobody can act on while
-            # costing 5x the calls (4 accounts x 1440 = 5760/day against a
-            # third-party usage endpoint whose rate limits we do not control
-            # and have not measured). If a case ever appears where a 5min-old
-            # number caused a wrong decision, that is the evidence to go to
-            # 1min — and it would be evidence, not a guess.
-            on_boot_sec="2min",
-            on_unit_active_sec="5min",
-        ),
-        JobSpec(
-            name="scitex-agent-container-host-sync-check",
-            schedule="0 * * * *",  # hourly (cron form; timer cadence below)
-            # SELF-BOUNDING (600s). Sequential per-ssh probe over every peer,
-            # each capped at the verb's 120s default (an unreachable peer
-            # waits its ssh connect-timeout). 600s comfortably covers a
-            # handful of peers including a slow/unreachable one without ever
-            # hanging forever.
-            command=(
-                "/usr/bin/timeout 600 "
-                f"{sac} host sync --check --all --alarm --exit-zero"
-            ),
-            description=(
-                "Read-only drift check of every peer's sac checkout vs the "
-                "centre; records each verdict in sac's own event log so the "
-                "shout is DURABLE. Mutates nothing on any peer — never runs "
-                "the fast-forward remedy (Stage 1). "
-                "--exit-zero because FINDING drift is not this unit being "
-                "unhealthy. MEASURED 2026-08-17: without it, drift exits 1 "
-                "and undetermined exits 2, systemd recorded the unit "
-                "`failed`, compute-04 went `degraded`, and the dotfiles sync "
-                "installer read `is-system-running: degraded` as 'systemd "
-                "absent' and silently refused to install its timer — so that "
-                "host stopped receiving dotfiles sync altogether. The verdict "
-                "still reaches its real readers: the printed report, the JSON "
-                "`exit_code`, and the --alarm event-log record."
-            ),
-            kind="timer",
-            # First check 10min after boot/login (peers reachable, listen
-            # settled), then hourly. Drift is slow-moving relative to the
-            # 2h token refresh, so hourly is ample and gentle on ssh.
-            on_boot_sec="10min",
-            on_unit_active_sec="1h",
-        ),
-        JobSpec(
-            name="scitex-agent-container-worktree-gc",
-            schedule="30 4 * * *",  # daily 04:30 (cron form; timer cadence below)
-            # SELF-BOUNDING (900s). A pass is a handful of local `git` calls
-            # per worktree plus one `gh pr list` per unmerged branch (the
-            # squash-merge leg). A repo deep in sprawl with a slow/
-            # rate-limited gh is the worst case; 900s covers the whole
-            # fleet's repos without ever hanging forever. Every gh failure
-            # already degrades to KEEP, so a timeout costs a skipped reap,
-            # never a wrong one.
-            command=f"/usr/bin/timeout 900 {sac} worktree gc --apply --all --exit-zero",
-            description=(
-                "Daily git-worktree GC: removes only worktrees PROVEN safe "
-                "(clean AND merged AND older than 24h AND not in use — never "
-                "--force), prunes admin refs whose directory is already gone, "
-                "and records any repo still over its worktree cap in sac's "
-                "own event log (recorded as recovered when it drops back under). "
-                "The permanent countermeasure to worktree sprawl."
-            ),
-            kind="timer",
-            # Sprawl accumulates over days, not minutes, and the age gate is
-            # 24h — so a daily pass is the natural cadence and a faster one
-            # could not remove anything a daily one would miss. 20min after
-            # boot keeps it clear of the login/auth settling window.
-            on_boot_sec="20min",
-            on_unit_active_sec="1d",
-        ),
-        JobSpec(
-            name="scitex-agent-container-spartan-sif-bake",
-            schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
-            # SELF-BOUNDING (14400s = 4h), and the one where the bound
-            # matters most: at a */10 cadence an UNBOUNDED bake outlives its
-            # own tick by design, so a wedged run would pile up against every
-            # later one. Two full bakes (base ~15-25min + scitex ~10-20min)
-            # plus a multi-GB pull on a slow link fit comfortably; the
-            # per-leg ssh timeout inside the command is 7200s, so 4h bounds
-            # the whole chain without ever killing a legitimate run.
-            command=f"/usr/bin/timeout 14400 {sac} image bake-remote --yes",
-            description=(
-                "10-minute SIF refresh with zero master CPU: bake sac-base + "
-                "sac-scitex on the standing Spartan CPU lease (srun "
-                "--overlap into the job resolved BY NAME, never sbatch), "
-                "gate at build time (.def %post symbol gate) AND on the "
-                "artifact (apptainer-exec symbol probe), keep-3 rotate the "
-                "Spartan store, then PULL via rsync-over-ssh, re-verify "
-                "here (sha256 + the same symbol probe on the received "
-                "file) and only then atomically swap both live "
-                "sac-<layer>.sif symlinks + keep-3 rotate locally. A "
-                "failed leg leaves the live image untouched and exits "
-                "non-zero; a source-unchanged run is a loud SKIPPED, not "
-                "a transfer."
-            ),
-            kind="timer",
-            # 10min: the image is a point-in-time snapshot of @develop, and at
-            # our release rate a DAY-old SIF is mostly wrong. 30min was read
-            # off the operator's 「最低でも30分に1回」 — but that was his FLOOR,
-            # not his target (「なんで三十分に一回だけなの？」; 「例えば1分に1回焼いても
-            # 全く問題ないです」), so the cadence is set to what he wants, not to
-            # the minimum he would tolerate.
-            #
-            # Cheap by construction, which is what makes a 10min tick sane: a
-            # source-unchanged run is a SKIPPED verdict (check a git ref, one
-            # ssh round-trip, no transfer), so only a real @develop change ever
-            # costs a bake. A bake takes 8-30min, so at */10 most ticks land
-            # while one is still running — the script's `flock -n` makes those
-            # exit "already-running" immediately instead of piling up, which is
-            # exactly what that lock is for. The operator has separately
-            # accepted overlap outright (the swap is an atomic symlink flip at
-            # the end). Steady state: skip, skip, skip, … one real bake when
-            # something changed, the rest of that window bouncing off the lock.
-            on_boot_sec="30min",
-            on_unit_active_sec="10min",
-        ),
-        JobSpec(
-            name="scitex-agent-container-freshness-refresh",
-            schedule="7 * * * *",  # hourly (cron form; timer cadence below)
-            # SELF-BOUNDING (300s). Generous on purpose, matching the
-            # primitive's own 30s per-source timeouts: a busy host must not
-            # be mistaken for a broken one, and a manufactured UNKNOWN is
-            # exactly the failure mode. Nothing is waiting on this run.
-            command=f"/usr/bin/timeout 300 {sac} freshness refresh",
-            description=(
-                "Publishes the version-currency verdict to the cache that "
-                "every `sac` invocation reads. Runs the real checks (PyPI, "
-                "git tags, gh release runs, systemd running-vs-installed, "
-                "symbol probes) via scitex-dev's `versioning` primitive and "
-                "writes the result atomically. This is the half that pays "
-                "the network cost, so the CLI hot path never does — without "
-                "it the startup banner has nothing to read and stays "
-                "permanently silent."
-            ),
-            kind="timer",
-            # Hourly against the primitive's 24h cache TTL: 24 consecutive
-            # misses before the banner falls silent, so a laptop that is shut
-            # most of the day still has a trustworthy answer. Faster buys
-            # nothing — releases are not more frequent than hourly — and each
-            # pass makes real network calls.
-            on_boot_sec="25min",
-            on_unit_active_sec="1h",
-        ),
+        *accounts_jobs(executable=executable),
+        *maintenance_jobs(executable=executable),
         # The two AGENT-LIVENESS enforcers live together in
         # :mod:`._specs_liveness` — each one's scope is defined by what the
         # other covers (corpses vs live-but-wedged), so they are unreadable
-        # apart. Spliced in HERE to preserve the historical order.
-        *liveness_jobs(),
+        # apart.
+        *liveness_jobs(executable=executable),
     ]
 
 

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -157,11 +157,6 @@ RENAMES: tuple[Rename, ...] = (
         kind="timer",
     ),
     Rename(
-        old="sac.heal-agent-auth",
-        new="scitex-agent-container-heal-agent-auth",
-        kind="timer",
-    ),
-    Rename(
         old="sac.host-sync-check",
         new="scitex-agent-container-host-sync-check",
         kind="timer",

--- a/src/scitex_agent_container/_jobs/_sac_bin.py
+++ b/src/scitex_agent_container/_jobs/_sac_bin.py
@@ -1,0 +1,84 @@
+"""The absolute ``sac`` a scheduled command must name, resolved per host.
+
+WHY A JOB COMMAND MAY NOT SAY BARE ``sac``
+==========================================
+Every JobSpec here is self-bounding — its head is ``/usr/bin/timeout N`` — and
+that head is ABSOLUTE. scitex-dev's ``resolve_execstart`` absolutises only the
+FIRST token and passes a command that already starts with ``/`` through
+verbatim, so wrapping the command took the payload binary OUT of resolution.
+``timeout`` then looks ``sac`` up on whatever PATH its parent had.
+
+``_jobs_plugin``'s own docstring recorded that consequence and scoped it to a
+future in which these specs are "rendered as systemd units instead", calling it
+"not live today". MEASURED 2026-08-20, it was live: the ecosystem supervisor
+spawns periodic jobs DIRECTLY, through the same ``resolve_execstart``, so the
+payload was unresolved on that path too.
+
+THE FAILURE NEEDS TWO CONDITIONS, AND THIS FIXES ONE OF THEM. On
+scitex-compute-01, ALL TEN sac jobs sat at exit 127 with zero successes —
+self-pull included, so the host could not even fetch a fix. That took BOTH a
+relative payload AND a supervisor whose PATH lacked the venv. scitex-dev owns
+the second condition and has already closed it: ``build_supervisor_unit_text``
+emits ``Environment=PATH=<venv_bin>:...`` derived from the resolved ExecStart,
+since PR #713. compute-01 was failing because its UNIT was stale — the package
+had been upgraded and the unit was never regenerated, and installing a newer
+version does not rewrite an existing unit.
+
+So this module is not the repair for that host; regenerating its unit is (and
+that is sequenced behind a scitex-dev release, because ``ecosystem up`` on the
+older version would reinstall the cron block retired the same night). What this
+module removes is the DEPENDENCY: with an absolute payload, a stale unit, an
+unlucky manager env, or a hand-started supervisor can no longer produce this
+class of failure at all. The condition scitex-dev fixed must be re-established
+on every host after every upgrade; the one fixed here cannot regress.
+
+WHY NOT A LITERAL PATH
+======================
+The rejected option was pinning one absolute ``sac``, and the objection was
+correct: the install location VARIES BY HOST. This module answers that
+objection instead of overriding it. ``sys.executable`` is the interpreter that
+imported this plugin — the supervisor's own — and a console script installed
+with this package is by construction its sibling. The answer is therefore
+per-host by construction, with nothing hardcoded and no host list to maintain.
+
+It is also the rule scitex-dev already trusts: ``resolve_execstart``'s rule 1
+is ``Path(sys.executable).parent / head``, and its docstring explains at length
+why the parent must NOT be ``.resolve()``d (a venv's ``bin/python`` symlinks to
+an interpreter outside the venv, where no console scripts live). We inherit
+that reasoning by using the same unresolved parent.
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+__all__ = ["sac_bin"]
+
+
+def sac_bin(*, executable: str | None = None) -> str:
+    """Absolute path to the ``sac`` installed beside the running interpreter.
+
+    Returns the bare name ``"sac"`` when that sibling is absent, and WARNS when
+    it does — the same shape scitex-dev's own last-resort rule uses. That case
+    means sac is importable while its console script is not installed, which is
+    a broken install rather than a host we should paper over: the command will
+    still fail loudly at 127, but with a breadcrumb naming the reason.
+
+    ``executable`` is a test seam so a test can point at a venv-shaped tree it
+    built on disk instead of rewriting this module's globals.
+    """
+    candidate = Path(executable or sys.executable).parent / "sac"
+    if candidate.is_file():
+        return str(candidate)
+    warnings.warn(
+        f"no `sac` console script beside the running interpreter "
+        f"({candidate}); scheduled commands will fall back to a bare `sac` "
+        f"resolved against the ambient PATH, which is exactly how every sac "
+        f"job on scitex-compute-01 reached exit 127 on 2026-08-20. Install "
+        f"sac into this environment.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    return "sac"

--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -1,0 +1,229 @@
+"""The OAuth-credential beat: three jobs that keep sac able to log in.
+
+Split out of :mod:`._jobs_plugin` (at the per-file cap), following the
+convention :mod:`._specs_liveness` established for the same reason.
+
+These three belong together because they share ONE failure mode — an
+expired token — and their cadences are chosen against each other rather
+than in isolation: ``accounts-refresh`` renews on the beat the token
+lifetime dictates, ``accounts-keepalive`` covers the hosts that refresh
+cannot reach, and ``accounts-quota-cache`` publishes what both produce.
+A reader asking "why is the fleet logged out?" must see all three at
+once; asking it of any one of them gives an answer that is true and
+useless.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.jobs import JobSpec
+
+__all__ = ["accounts_jobs"]
+
+
+def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
+    """sac's OAuth-credential JobSpecs, in their historical order.
+
+    ``executable`` is the same test seam :func:`._sac_bin.sac_bin` exposes,
+    threaded through so a test can resolve the payload against a venv-shaped
+    tree it built on disk. Without it the rendered command depends on whether
+    the RUNNING environment happens to have a ``sac`` console script beside
+    its interpreter — true in production, false under a PYTHONPATH-only CI
+    run — and a population guard over these specs would then assert an
+    environmental fact rather than a property of the specs.
+    """
+    from scitex_dev.jobs import JobSpec
+
+    from ._sac_bin import sac_bin
+
+    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin` for the measurement.
+    sac = sac_bin(executable=executable)
+
+    return [
+        JobSpec(
+            # THE LAST NAME OFF THE LEGACY PREFIX. It was held back for
+            # months on the rule "never rename a spec ahead of its unit", and
+            # that rule was right about the hazard and wrong about the order.
+            #
+            # WHAT THE HOLD ASSUMED: that the supervised cutover renames spec
+            # and unit TOGETHER. MEASURED 2026-08-19, that is unreachable —
+            # the migration's install step delegates to scitex-dev BY THE NEW
+            # CANONICAL NAME, and scitex-dev resolves a name only if a JobSpec
+            # DECLARES it:
+            #
+            #   $ sac dev timer install scitex-agent-container-accounts-refresh
+            #   no job named 'scitex-agent-container-accounts-refresh' here
+            #
+            # So install-new cannot run until this line moves. The spec moves
+            # FIRST or the cutover never happens at all; that is not a rule
+            # violation, it is the only order the tooling admits. (Attempted
+            # in the other order 2026-08-18: stop/remove succeeded, install
+            # failed on exactly that lookup, and the fleet's sole OAuth
+            # refresher was down ~2 minutes until the old units were restored.)
+            #
+            # WHAT THE WINDOW ACTUALLY COSTS, stated plainly rather than
+            # assumed: between this rename and the host cutover,
+            # `sac dev timer status accounts-refresh` resolves to a unit name
+            # the host does not carry and reports the refresher ABSENT while
+            # `sac.accounts-refresh.timer` keeps firing every 2h. That is a
+            # MISREPORT ON ONE MANUAL VERB, not an outage — and it cannot
+            # escalate on its own: nothing in this repo installs or enables a
+            # timer automatically (`_dev_jobs_backend` declines to run
+            # systemctl; `_dev_jobs_apply` only PRINTS the enable line), so
+            # the two-racing-refreshers catastrophe still requires a human to
+            # type the install command against a host that already has the
+            # old unit.
+            #
+            # CLOSING THE WINDOW is `sac dev migrate-job-names --only
+            # accounts-refresh --include-held --yes`, run supervised, then
+            # `sac accounts status` BEFORE walking away. Ordered
+            # stop-old -> remove-old -> install-new -> verify-exactly-one, and
+            # "exactly one" means one unit FOR THIS JOB:
+            # `scitex-agent-container-accounts-keepalive` is a DIFFERENT job
+            # that must keep existing.
+            name="scitex-agent-container-accounts-refresh",
+            schedule="0 */2 * * *",  # every 2h
+            # SELF-BOUNDING (120s) — see the convention note above. The
+            # bound has to live in the command because this job lands on
+            # CRON, where `timeout_sec` cannot follow it.
+            command=(
+                "/usr/bin/timeout 120 "
+                f"{sac} accounts refresh --all --include-active --sync-active-login"
+            ),
+            description=(
+                "Headless OAuth access-token refresh for all stored Claude "
+                "accounts including the active one (sole-refresher model), "
+                "mirroring the rotation into the live ~/.claude login."
+            ),
+            # 2026-06-11 (lead msg c5212862): scitex_dev.jobs.JobSpec kind
+            # taxonomy is {"service","timer","cron"} since scitex-dev #153.
+            # ``sac.accounts-refresh`` is a periodic systemd --user timer
+            # (token TTL ~7h, refresh every 2h) → ``kind="timer"`` with the
+            # cadence carried by ``on_unit_active_sec`` below. The legacy
+            # ``kind="systemd"`` is no longer accepted; it raises
+            # ``ValueError`` at construction time and ``scitex-dev
+            # ecosystem up`` silently drops sac's whole provider
+            # (provider-isolated, WARN-only), leaving the OAuth refresh
+            # unmanaged.
+            kind="timer",
+            on_boot_sec="15min",
+            on_unit_active_sec="2h",
+        ),
+        JobSpec(
+            name="scitex-agent-container-accounts-keepalive",
+            schedule="*/15 * * * *",  # every 15min (cron form; timer below)
+            # SELF-BOUNDING (300s). Per peer: a handful of coreutils ssh ops
+            # plus ONE outbound HTTPS verification from the peer (15s cap
+            # inside the probe). 300s covers three peers including a slow one
+            # without ever hanging forever. A pass killed here leaves the
+            # peer's previous credential intact — nothing is published
+            # unverified.
+            command=(
+                "/usr/bin/timeout 300 "
+                f"{sac} accounts keepalive --all "
+                "--to ywata-note-win "
+                "--to scitex-compute-03 "
+                "--to scitex-compute-04"
+            ),
+            description=(
+                "The DISTRIBUTION half of the single-refresher model, and "
+                "the only thing keeping the access-only hosts alive. "
+                "sac.accounts-refresh rotates the token on the ONE host that "
+                "holds refresh material (scitex-nas-03 as of 2026-08-10); "
+                "every other host holds an ACCESS-ONLY copy that nothing on "
+                "that box can renew, so without this job those hosts simply "
+                "expire and 401 within one access-token lifetime. COPIES the "
+                "current token (never mints — minting rotates, which revokes "
+                "the token running agents hold), refuses a payload carrying "
+                "refresh material, refuses under 300s of validity, refuses "
+                "to overwrite a valid remote credential with a dead one, "
+                "backs up what it replaces, publishes 0600, and PROVES the "
+                "far side answers HTTP 200. CONVERGENT: it compares "
+                "fingerprints and rewrites a peer only when the master's "
+                "token actually changed, so most runs are cheap verified "
+                "no-ops. WORST-CASE FOLLOWER OUTAGE THE OPERATOR IS "
+                "ACCEPTING AT THIS CADENCE: 15 minutes — the moment the "
+                "master refreshes, every follower's copy is revoked, and "
+                "they stay dead until the next tick converges them. Exits "
+                "non-zero on any peer's failure. NOT armed by this "
+                "declaration."
+            ),
+            kind="timer",
+            # HOST PINNING IS NOT EXPRESSIBLE HERE. JobSpec has no host
+            # field (name/kind/schedule/command/description/on_boot_sec/
+            # on_unit_active_sec/timeout_sec/restart_policy/watchdog_sec/
+            # venv), so WHERE this runs is decided by where the operator
+            # installs it. It must run ONLY on the refresh holder. sac's
+            # own mitigation is inside the verb: `--all` resolves to the
+            # accounts THIS host holds refresh material for, and exits
+            # non-zero when that set is empty — so a keepalive installed on
+            # the wrong host fails loudly instead of pretending to work.
+            #
+            # 15min is a BOUND, not a guess. Measured 2026-08-10: Claude
+            # Code refreshes only when the token is genuinely near expiry,
+            # so the master's token changes ONCE in ~7h at an unpredictable
+            # moment — and the instant it does, every follower's copy is
+            # revoked and its agents 401. The tick therefore does not decide
+            # when work happens (the fingerprint comparison does); it decides
+            # only how long that revoked window lasts. 15min bounds the
+            # follower outage to 15min; hourly would bound it to an hour.
+            # The cost of the extra ticks is near zero because a converged
+            # peer is verified, not rewritten.
+            on_boot_sec="10min",
+            on_unit_active_sec="15min",
+        ),
+        JobSpec(
+            name="scitex-agent-container-accounts-quota-cache",
+            schedule="*/5 * * * *",  # every 5min (cron form; timer below)
+            # SELF-BOUNDING (120s). One usage read per stored account (4
+            # today), each a single HTTPS call; 120s covers all of them on a
+            # slow network and never hangs. A pass killed here leaves the
+            # PREVIOUS cache in place — stale, which is the status quo this
+            # job improves on, never wrong.
+            command=f"/usr/bin/timeout 120 {sac} accounts refresh-quota-cache",
+            description=(
+                "Keeps the per-account usage cache FRESH. Nothing else did: "
+                "sac.accounts-refresh rotates TOKENS and accounts-keepalive "
+                "COPIES tokens, so before this job every quota number the "
+                "fleet showed was as old as the last time a human happened to "
+                "run the verb by hand. Reads usage only — it neither mints nor "
+                "rotates, so it cannot revoke a credential a running agent "
+                "holds (the hazard that makes `accounts refresh` dangerous to "
+                "schedule aggressively). "
+                "MEASURED COST OF NOT HAVING IT, 2026-08-17: `sac accounts "
+                "list` rendered every bar with `! snapshot older than the "
+                "refresh window` and `(stale 1d)` — it detected its own "
+                "staleness and did not fix it. On that day-old snapshot "
+                "scitex-01 read 7d=23% and wyusuuke read 7d=100%; the truth "
+                "after a manual refresh was scitex-01 94% and wyusuuke 0% — "
+                "INVERTED. An agent was repointed at the nearly-exhausted "
+                "account on the strength of it, and the operator's own "
+                "diagnosis was that an account reaches 94% precisely because "
+                "no one is refreshing the numbers that would have shown it "
+                "climbing. A cache that reports its own staleness without "
+                "repairing it is a record, not a gate."
+            ),
+            kind="timer",
+            # 5min, at the operator's instruction — he proposed 1min and
+            # offered 5min "if that is overdoing it". Taking the 5.
+            #
+            # The cadence is chosen against the 5h window, which is the fast
+            # one: a busy account can cross from comfortable to exhausted
+            # inside a single hour, so an hourly cadence would still permit a
+            # placement decision on numbers that predate the exhaustion. The
+            # 7d window moves far too slowly to drive this.
+            #
+            # WHY NOT 1min. Staleness at 5min is already far inside any
+            # decision window — no account crosses a threshold that matters in
+            # five minutes, so 1min buys freshness nobody can act on while
+            # costing 5x the calls (4 accounts x 1440 = 5760/day against a
+            # third-party usage endpoint whose rate limits we do not control
+            # and have not measured). If a case ever appears where a 5min-old
+            # number caused a wrong decision, that is the evidence to go to
+            # 1min — and it would be evidence, not a guess.
+            on_boot_sec="2min",
+            on_unit_active_sec="5min",
+        ),
+    ]

--- a/src/scitex_agent_container/_jobs/_specs_liveness.py
+++ b/src/scitex_agent_container/_jobs/_specs_liveness.py
@@ -23,8 +23,17 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 __all__ = ["liveness_jobs"]
 
 
-def liveness_jobs() -> "list[JobSpec]":
-    """The fleet-liveness JobSpecs, in their historical order."""
+def liveness_jobs(*, executable: str | None = None) -> "list[JobSpec]":
+    """The fleet-liveness JobSpecs, in their historical order.
+
+    ``executable`` is the same test seam :func:`._sac_bin.sac_bin` exposes,
+    threaded through so a test can resolve the payload against a venv-shaped
+    tree it built on disk. Without it the rendered command depends on whether
+    the RUNNING environment happens to have a ``sac`` console script beside
+    its interpreter — true in production, false under a PYTHONPATH-only CI
+    run — and a population guard over these specs would then assert an
+    environmental fact rather than a property of the specs.
+    """
     from scitex_dev.jobs import JobSpec
 
     from ._sac_bin import sac_bin
@@ -33,7 +42,7 @@ def liveness_jobs() -> "list[JobSpec]":
     # after the absolute `timeout` head is invisible to resolve_execstart
     # and is looked up on the supervisor's PATH, which is how every sac
     # job on scitex-compute-01 sat at exit 127 (measured 2026-08-20).
-    sac = sac_bin()
+    sac = sac_bin(executable=executable)
 
     return [
         JobSpec(

--- a/src/scitex_agent_container/_jobs/_specs_liveness.py
+++ b/src/scitex_agent_container/_jobs/_specs_liveness.py
@@ -27,6 +27,14 @@ def liveness_jobs() -> "list[JobSpec]":
     """The fleet-liveness JobSpecs, in their historical order."""
     from scitex_dev.jobs import JobSpec
 
+    from ._sac_bin import sac_bin
+
+    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin`. A bare `sac`
+    # after the absolute `timeout` head is invisible to resolve_execstart
+    # and is looked up on the supervisor's PATH, which is how every sac
+    # job on scitex-compute-01 sat at exit 127 (measured 2026-08-20).
+    sac = sac_bin()
+
     return [
         JobSpec(
             name="scitex-agent-container-fleet-reconcile",
@@ -42,7 +50,7 @@ def liveness_jobs() -> "list[JobSpec]":
             # This is the job whose UNBOUNDED cron line was measured piling
             # up fourteen concurrent instances, the oldest 45 minutes old
             # (2026-07-18) — the incident that motivated the guard.
-            command="/usr/bin/timeout 300 sac agents reconcile --apply",
+            command=f"/usr/bin/timeout 300 {sac} agents reconcile --apply",
             description=(
                 "The enforcer of 'should be running => is running'. Restarts "
                 "agents whose tmux session is GONE while their spec asks to be "
@@ -84,7 +92,7 @@ def liveness_jobs() -> "list[JobSpec]":
             # history is persisted per restart, so the next tick still honours
             # the debounce for anything bounced.
             command=(
-                "/usr/bin/timeout 300 sac agents restart-login-expired --apply"
+                f"/usr/bin/timeout 300 {sac} agents restart-login-expired --apply"
             ),
             description=(
                 "Restarts LIVE agents wedged behind a frozen 'Login expired' "

--- a/src/scitex_agent_container/_jobs/_specs_maintenance.py
+++ b/src/scitex_agent_container/_jobs/_specs_maintenance.py
@@ -1,0 +1,177 @@
+"""The housekeeping beat: drift, worktrees, images, freshness.
+
+Split out of :mod:`._jobs_plugin` (at the per-file cap), following the
+convention :mod:`._specs_liveness` established for the same reason.
+
+Unlike the accounts group these four are INDEPENDENT — none depends on
+another's output and any one can be disabled without breaking the rest.
+What makes them one file is the shared property that every one of them
+REPORTS rather than repairs, so a finding is not the unit being
+unhealthy. That distinction is why ``host-sync-check`` carries
+``--exit-zero``; see its comment for the measurement that forced it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.jobs import JobSpec
+
+__all__ = ["maintenance_jobs"]
+
+
+def maintenance_jobs(*, executable: str | None = None) -> "list[JobSpec]":
+    """sac's housekeeping JobSpecs, in their historical order.
+
+    ``executable`` is the same test seam :func:`._sac_bin.sac_bin` exposes,
+    threaded through so a test can resolve the payload against a venv-shaped
+    tree it built on disk. Without it the rendered command depends on whether
+    the RUNNING environment happens to have a ``sac`` console script beside
+    its interpreter — true in production, false under a PYTHONPATH-only CI
+    run — and a population guard over these specs would then assert an
+    environmental fact rather than a property of the specs.
+    """
+    from scitex_dev.jobs import JobSpec
+
+    from ._sac_bin import sac_bin
+
+    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin` for the measurement.
+    sac = sac_bin(executable=executable)
+
+    return [
+        JobSpec(
+            name="scitex-agent-container-host-sync-check",
+            schedule="0 * * * *",  # hourly (cron form; timer cadence below)
+            # SELF-BOUNDING (600s). Sequential per-ssh probe over every peer,
+            # each capped at the verb's 120s default (an unreachable peer
+            # waits its ssh connect-timeout). 600s comfortably covers a
+            # handful of peers including a slow/unreachable one without ever
+            # hanging forever.
+            command=(
+                "/usr/bin/timeout 600 "
+                f"{sac} host sync --check --all --alarm --exit-zero"
+            ),
+            description=(
+                "Read-only drift check of every peer's sac checkout vs the "
+                "centre; records each verdict in sac's own event log so the "
+                "shout is DURABLE. Mutates nothing on any peer — never runs "
+                "the fast-forward remedy (Stage 1). "
+                "--exit-zero because FINDING drift is not this unit being "
+                "unhealthy. MEASURED 2026-08-17: without it, drift exits 1 "
+                "and undetermined exits 2, systemd recorded the unit "
+                "`failed`, compute-04 went `degraded`, and the dotfiles sync "
+                "installer read `is-system-running: degraded` as 'systemd "
+                "absent' and silently refused to install its timer — so that "
+                "host stopped receiving dotfiles sync altogether. The verdict "
+                "still reaches its real readers: the printed report, the JSON "
+                "`exit_code`, and the --alarm event-log record."
+            ),
+            kind="timer",
+            # First check 10min after boot/login (peers reachable, listen
+            # settled), then hourly. Drift is slow-moving relative to the
+            # 2h token refresh, so hourly is ample and gentle on ssh.
+            on_boot_sec="10min",
+            on_unit_active_sec="1h",
+        ),
+        JobSpec(
+            name="scitex-agent-container-worktree-gc",
+            schedule="30 4 * * *",  # daily 04:30 (cron form; timer cadence below)
+            # SELF-BOUNDING (900s). A pass is a handful of local `git` calls
+            # per worktree plus one `gh pr list` per unmerged branch (the
+            # squash-merge leg). A repo deep in sprawl with a slow/
+            # rate-limited gh is the worst case; 900s covers the whole
+            # fleet's repos without ever hanging forever. Every gh failure
+            # already degrades to KEEP, so a timeout costs a skipped reap,
+            # never a wrong one.
+            command=f"/usr/bin/timeout 900 {sac} worktree gc --apply --all --exit-zero",
+            description=(
+                "Daily git-worktree GC: removes only worktrees PROVEN safe "
+                "(clean AND merged AND older than 24h AND not in use — never "
+                "--force), prunes admin refs whose directory is already gone, "
+                "and records any repo still over its worktree cap in sac's "
+                "own event log (recorded as recovered when it drops back under). "
+                "The permanent countermeasure to worktree sprawl."
+            ),
+            kind="timer",
+            # Sprawl accumulates over days, not minutes, and the age gate is
+            # 24h — so a daily pass is the natural cadence and a faster one
+            # could not remove anything a daily one would miss. 20min after
+            # boot keeps it clear of the login/auth settling window.
+            on_boot_sec="20min",
+            on_unit_active_sec="1d",
+        ),
+        JobSpec(
+            name="scitex-agent-container-spartan-sif-bake",
+            schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
+            # SELF-BOUNDING (14400s = 4h), and the one where the bound
+            # matters most: at a */10 cadence an UNBOUNDED bake outlives its
+            # own tick by design, so a wedged run would pile up against every
+            # later one. Two full bakes (base ~15-25min + scitex ~10-20min)
+            # plus a multi-GB pull on a slow link fit comfortably; the
+            # per-leg ssh timeout inside the command is 7200s, so 4h bounds
+            # the whole chain without ever killing a legitimate run.
+            command=f"/usr/bin/timeout 14400 {sac} image bake-remote --yes",
+            description=(
+                "10-minute SIF refresh with zero master CPU: bake sac-base + "
+                "sac-scitex on the standing Spartan CPU lease (srun "
+                "--overlap into the job resolved BY NAME, never sbatch), "
+                "gate at build time (.def %post symbol gate) AND on the "
+                "artifact (apptainer-exec symbol probe), keep-3 rotate the "
+                "Spartan store, then PULL via rsync-over-ssh, re-verify "
+                "here (sha256 + the same symbol probe on the received "
+                "file) and only then atomically swap both live "
+                "sac-<layer>.sif symlinks + keep-3 rotate locally. A "
+                "failed leg leaves the live image untouched and exits "
+                "non-zero; a source-unchanged run is a loud SKIPPED, not "
+                "a transfer."
+            ),
+            kind="timer",
+            # 10min: the image is a point-in-time snapshot of @develop, and at
+            # our release rate a DAY-old SIF is mostly wrong. 30min was read
+            # off the operator's 「最低でも30分に1回」 — but that was his FLOOR,
+            # not his target (「なんで三十分に一回だけなの？」; 「例えば1分に1回焼いても
+            # 全く問題ないです」), so the cadence is set to what he wants, not to
+            # the minimum he would tolerate.
+            #
+            # Cheap by construction, which is what makes a 10min tick sane: a
+            # source-unchanged run is a SKIPPED verdict (check a git ref, one
+            # ssh round-trip, no transfer), so only a real @develop change ever
+            # costs a bake. A bake takes 8-30min, so at */10 most ticks land
+            # while one is still running — the script's `flock -n` makes those
+            # exit "already-running" immediately instead of piling up, which is
+            # exactly what that lock is for. The operator has separately
+            # accepted overlap outright (the swap is an atomic symlink flip at
+            # the end). Steady state: skip, skip, skip, … one real bake when
+            # something changed, the rest of that window bouncing off the lock.
+            on_boot_sec="30min",
+            on_unit_active_sec="10min",
+        ),
+        JobSpec(
+            name="scitex-agent-container-freshness-refresh",
+            schedule="7 * * * *",  # hourly (cron form; timer cadence below)
+            # SELF-BOUNDING (300s). Generous on purpose, matching the
+            # primitive's own 30s per-source timeouts: a busy host must not
+            # be mistaken for a broken one, and a manufactured UNKNOWN is
+            # exactly the failure mode. Nothing is waiting on this run.
+            command=f"/usr/bin/timeout 300 {sac} freshness refresh",
+            description=(
+                "Publishes the version-currency verdict to the cache that "
+                "every `sac` invocation reads. Runs the real checks (PyPI, "
+                "git tags, gh release runs, systemd running-vs-installed, "
+                "symbol probes) via scitex-dev's `versioning` primitive and "
+                "writes the result atomically. This is the half that pays "
+                "the network cost, so the CLI hot path never does — without "
+                "it the startup banner has nothing to read and stays "
+                "permanently silent."
+            ),
+            kind="timer",
+            # Hourly against the primitive's 24h cache TTL: 24 consecutive
+            # misses before the banner falls silent, so a laptop that is shut
+            # most of the day still has a trustworthy answer. Faster buys
+            # nothing — releases are not more frequent than hourly — and each
+            # pass makes real network calls.
+            on_boot_sec="25min",
+            on_unit_active_sec="1h",
+        ),
+    ]

--- a/src/scitex_agent_container/cli_pkg/_worktree_gc.py
+++ b/src/scitex_agent_container/cli_pkg/_worktree_gc.py
@@ -164,6 +164,19 @@ def _print_report(outcome: GcOutcome, *, apply: bool) -> None:
         "--apply, off on a dry run (a report stays a pure report)."
     ),
 )
+@click.option(
+    "--exit-zero",
+    "exit_zero",
+    is_flag=True,
+    default=False,
+    help=(
+        "Always exit 0. The verdict is unchanged and still printed, still in "
+        "the JSON `exit_code`, and still recorded by --alarm — only the "
+        "PROCESS status is neutralised. For unattended runners where a "
+        "non-zero status means 'this job is unhealthy', not 'this job found "
+        "something a human must decide'."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON (for cron).")
 @click.pass_context
 def worktree_gc(
@@ -175,6 +188,7 @@ def worktree_gc(
     min_age_hours: float,
     cap: int,
     alarm: bool | None,
+    exit_zero: bool,
     as_json: bool,
 ) -> None:
     """Remove worktrees that are PROVABLY safe to remove. Keep everything else.
@@ -219,7 +233,8 @@ def worktree_gc(
     \b
     Exit codes:  0 = all repos under cap.  1 = a repo is still over cap
     after the pass.  2 = a repo could not be READ (unknown outranks
-    known-bad: it is a known-bad you cannot see).
+    known-bad: it is a known-bad you cannot see).  --exit-zero keeps the
+    verdict in the report and the JSON but always exits 0.
     """
     if bool(repos) == all_repos:
         raise click.UsageError(
@@ -247,6 +262,38 @@ def worktree_gc(
         cap=cap,
     )
     code = exit_code_for(outcome)
+    # MEASURED 2026-08-20: this verb runs as
+    # scitex-agent-container-worktree-gc under the ecosystem supervisor. It
+    # exited 1 on all three of its runs, which reads as a broken job — and it
+    # was not broken. Exit 1 here means "a repo is still over cap", i.e. every
+    # kept worktree failed a safety leg and a HUMAN must decide. That is a
+    # finding, not ill health.
+    #
+    # The cost was concrete: a duplicate systemd timer for this same job could
+    # not be retired, because the rule for retiring one was "the supervisor has
+    # a recorded exit-0 for it" and this job could never produce one. A finding
+    # rendered as a failure kept a second scheduler alive.
+    #
+    # Its sibling `sac host sync --check` carries the same flag for the same
+    # reason, and its comment records where that confusion led last time: a
+    # unit marked `failed` for doing its job put the host into `degraded`, and
+    # an installer read `degraded` as "systemd is absent" and silently stopped
+    # installing dotfiles sync there.
+    #
+    # THE FINDING IS NOT DISCARDED, and that is the condition for using this
+    # flag at all. A flag that always exits 0 does destroy the distinction if
+    # the exit code is the only place the distinction lives. Here it is not:
+    # `--alarm` (on by default with --apply, which is how the scheduled job
+    # runs) records every repo's cap verdict in sac's own event log, and the
+    # verdict is still printed and still in the JSON `exit_code`. Neutralising
+    # the PROCESS status moves the signal onto the rail built for it instead of
+    # the one systemd reads as health.
+    #
+    # A job with no such rail must NOT reach for this flag — for those, the
+    # runner needs to carry "finished with findings" as its own outcome rather
+    # than folding it into ok/not-ok. That belongs in the JobSpec contract, and
+    # scitex-dev owns it.
+    status = 0 if exit_zero else code
 
     # Make the shout DURABLE: record each cap verdict in sac's own event
     # log. Defaults to riding --apply only, so a dry run stays a pure report.
@@ -271,13 +318,13 @@ def worktree_gc(
                 "failed": list(alarm_outcome.failed),
             }
         click.echo(json.dumps(payload, indent=2))
-        raise SystemExit(code)
+        raise SystemExit(status)
 
     _print_report(outcome, apply=apply)
     console.print(f"[dim]{outcome.summary_line()}[/dim]")
     if alarm_outcome is not None:
         console.print(f"[dim]{alarm_outcome.summary_line()}[/dim]")
-    raise SystemExit(code)
+    raise SystemExit(status)
 
 
 def register(worktree_group) -> None:

--- a/tests/scitex_agent_container/_jobs/_jobspec_helpers.py
+++ b/tests/scitex_agent_container/_jobs/_jobspec_helpers.py
@@ -1,0 +1,42 @@
+"""Shared readers for the JobSpec assertions in this package.
+
+Both helpers were defined in ``test__jobs_plugin.py`` until that file was split
+into per-group modules. They live here rather than being imported from one test
+module into another: a test module that reaches into a sibling's private helper
+breaks the moment either file is reorganised, which is exactly what happened to
+produce this file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
+
+
+def _split_command(command: str) -> tuple[str, str, str]:
+    """``(bound, payload, rest)`` — the three things a job command can get wrong.
+
+    The whole-command assertions below used to pin a literal ``sac``. They
+    cannot any more: the payload is now the ABSOLUTE console script beside the
+    running interpreter (:mod:`._sac_bin`), so its text differs per machine and
+    a literal would pin the developer's venv into CI.
+
+    Splitting keeps every property those assertions were protecting — the bound
+    and the full argument list stay pinned character-for-character, so dropping
+    a ``--to`` or an ``--apply`` is still a red test — while the one token that
+    is legitimately machine-specific is checked by SHAPE instead. Asserting it
+    equals ``sac_bin()`` would be no test at all: a check parameterised by the
+    value it is checking cannot fail.
+    """
+    tokens = command.split()
+    return " ".join(tokens[:2]), tokens[2], " ".join(tokens[3:])
+
+def _job(name: str):
+    (match,) = [j for j in provide_jobs() if j.name == name]
+    return match

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -40,8 +40,6 @@ the provider import is lazy, so an old scitex-dev must not fail CI here.
 
 from __future__ import annotations
 
-import pathlib
-
 import re
 
 import pytest
@@ -53,30 +51,12 @@ jobs_mod = pytest.importorskip(
 
 from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
 
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
 
 
-def _split_command(command: str) -> tuple[str, str, str]:
-    """``(bound, payload, rest)`` — the three things a job command can get wrong.
-
-    The whole-command assertions below used to pin a literal ``sac``. They
-    cannot any more: the payload is now the ABSOLUTE console script beside the
-    running interpreter (:mod:`._sac_bin`), so its text differs per machine and
-    a literal would pin the developer's venv into CI.
-
-    Splitting keeps every property those assertions were protecting — the bound
-    and the full argument list stay pinned character-for-character, so dropping
-    a ``--to`` or an ``--apply`` is still a red test — while the one token that
-    is legitimately machine-specific is checked by SHAPE instead. Asserting it
-    equals ``sac_bin()`` would be no test at all: a check parameterised by the
-    value it is checking cannot fail.
-    """
-    tokens = command.split()
-    return " ".join(tokens[:2]), tokens[2], " ".join(tokens[3:])
 
 
-def _job(name: str):
-    (match,) = [j for j in provide_jobs() if j.name == name]
-    return match
+
 
 
 
@@ -172,113 +152,22 @@ def test_provider_job_cadence_is_two_hours() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_accounts_keepalive_job_name_is_package_prefixed() -> None:
-    # Arrange — the distribution half of the single-refresher model.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.name == "scitex-agent-container-accounts-keepalive"
 
 
-def test_accounts_keepalive_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer, so kind="timer". A kind
-    # outside JobSpec.ALLOWED_KINDS raises at construction, and `ecosystem up`
-    # then silently DROPS sac's WHOLE provider (provider-isolated, WARN-only)
-    # — taking the OAuth refresh, the drift check, the worktree GC and both
-    # heal enforcers down with it.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
-    # Arrange — the peer list IS the job. A keepalive that reaches two of the
-    # three access-only hosts looks healthy (exit 0, verified peers) while the
-    # third silently expires, which is the exact failure this job exists to
-    # end. Pin the whole command so dropping a `--to` is a red test, not a
-    # host nobody notices is dead.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    bound, _payload, rest = _split_command(job.command)
-    assert (bound, rest) == ("/usr/bin/timeout 300", "accounts keepalive --all --to ywata-note-win --to scitex-compute-03 --to scitex-compute-04")
 
 
-def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() -> None:
-    # Arrange — belt-and-braces, the counterpart of accounts-refresh's
-    # --skip-active guard. This job COPIES the master's current token; minting
-    # rotates it, and a rotation revokes the token every running agent is
-    # holding. Scheduling `accounts refresh` or `accounts login` here would
-    # turn a keepalive into a fleet-wide logout every 15 minutes, so pin the
-    # verb itself rather than trusting the full-command assertion above to be
-    # re-read whenever someone edits the peer list.
-    #
-    # Indexed PAST the self-bounding `/usr/bin/timeout <N>` prefix (tokens 0
-    # and 1), so this still pins the VERB rather than the wrapper.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    _bound, _payload, rest = _split_command(job.command)
-    assert rest.split()[:2] == ["accounts", "keepalive"]
 
 
-def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
-    # Arrange — the cadence IS the worst-case follower outage, not a guess at
-    # when work is needed. The master's token changes once in ~7h at an
-    # unpredictable moment, and the instant it does every follower's copy is
-    # revoked; the tick only decides how long that revoked window lasts. A
-    # converged peer is verified rather than rewritten, so the extra ticks are
-    # near free — which is what makes 15min affordable.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.on_unit_active_sec == "15min"
 
 
-def test_accounts_keepalive_schedule_mirrors_the_timer_cadence() -> None:
-    # Arrange — the cron form is kept alongside the timer cadence (as every
-    # sibling does) so `ecosystem cron` could derive an equivalent line, and
-    # so the two spellings cannot silently disagree about how often this runs.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.schedule == "*/15 * * * *"
 
 
-def test_accounts_keepalive_timeout_outlives_a_three_peer_pass() -> None:
-    # Arrange — per peer: a handful of ssh ops plus ONE outbound HTTPS
-    # verification (15s cap inside the probe). 300s covers three peers
-    # including a slow one. A pass killed here is SAFE — nothing is published
-    # unverified, so the peer keeps its previous credential.
-    #
-    # The bound is asserted on the COMMAND, not on `timeout_sec`, because
-    # this job is deployed to cron and a cron line cannot carry that field.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
-def test_accounts_keepalive_constructs_as_a_real_jobspec() -> None:
-    # Arrange — construction must not raise (a bad field would drop the whole
-    # provider). Assert it is the canonical contract type, not a look-alike.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert isinstance(job, jobs_mod.JobSpec)
 
 
-def test_accounts_keepalive_and_accounts_refresh_are_both_declared() -> None:
-    # Arrange — unlike the heal pair below, these two are NOT alternatives:
-    # they are the two halves of one model and BOTH must be enabled. Refresh
-    # without keepalive leaves the followers holding a revoked copy; keepalive
-    # without refresh distributes a token nothing renews. Deleting either one
-    # breaks the fleet in a way that looks like the other half working.
-    # Act
-    names = {job.name for job in provide_jobs()}
-    # Assert
-    assert {"scitex-agent-container-accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names
 
 
 def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -> None:
@@ -305,205 +194,40 @@ def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -
     assert "sac.listen" not in names
 
 
-def test_host_sync_check_job_name_is_package_prefixed() -> None:
-    # Arrange — the drift-alarm timer that makes the Stage-0 detector run.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert job.name == "scitex-agent-container-host-sync-check"
 
 
-def test_host_sync_check_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer (hourly), so kind="timer".
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_host_sync_check_command_is_the_readonly_check() -> None:
-    # Arrange — the scheduled command MUST carry --check. A timer that could
-    # fast-forward a peer unattended is Stage 1, explicitly out of scope.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert "--check" in job.command
 
 
-def test_host_sync_check_command_routes_to_a_seen_card() -> None:
-    # Arrange — --alarm is what turns the exit code into a SEEN board card
-    # instead of a journald line nobody reads.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert "--alarm" in job.command
 
 
-def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
-    # Arrange — belt-and-braces: the exact mutating form `sac host sync
-    # <peer>` (no --check) must never be what this timer runs. The command
-    # is the read-only detector, full stop.
-    #
-    # `--exit-zero` was added 2026-08-17 and does NOT weaken that intent: it
-    # touches only this process's exit status, never a peer. It is here
-    # because the tri-state verdict (1 = drift found, 2 = undetermined) was
-    # being read by systemd as unit failure, which put the host into
-    # `degraded`, which made the dotfiles sync installer conclude systemd
-    # was absent and silently stop installing its timer.
-    #
-    # Kept as EXACT EQUALITY on purpose. This assertion is the reason that
-    # change could not land unnoticed — a substring check would have let it
-    # through silently, and the next edit to this command deserves the same
-    # scrutiny. Update the literal deliberately; do not relax the operator.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert — the command is precisely the read-only check+alarm form.
-    bound, _payload, rest = _split_command(job.command)
-    assert (bound, rest) == ("/usr/bin/timeout 600", "host sync --check --all --alarm --exit-zero")
 
 
-def test_host_sync_check_cadence_is_hourly() -> None:
-    # Arrange — drift is slow-moving; hourly is ample and gentle on ssh.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert job.on_unit_active_sec == "1h"
 
 
-def test_worktree_gc_job_name_is_package_prefixed() -> None:
-    # Arrange — the daily GC that makes the worktree-sprawl countermeasure
-    # PERIODIC. A GC nobody schedules is a script, not a countermeasure —
-    # which is exactly how one repo reached 105 worktrees.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert job.name == "scitex-agent-container-worktree-gc"
 
 
-def test_worktree_gc_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer (daily), so kind="timer".
-    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_worktree_gc_command_is_the_apply_form() -> None:
-    # Arrange — the scheduled job must ACT, not just report: a timer that
-    # only dry-runs would print a nightly report nobody reads while the
-    # sprawl kept growing. The safety lives in the predicate, not in
-    # withholding --apply.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    bound, _payload, rest = _split_command(job.command)
-    assert (bound, rest) == (
-        "/usr/bin/timeout 900",
-        # --exit-zero is LOAD-BEARING and pinned here on purpose. Exit 1 from
-        # this verb means "a repo is over cap, a human decides" — a finding,
-        # not ill health. Without the flag the supervisor records the job as
-        # failed, and the rule for retiring its duplicate systemd timer was
-        # "the supervisor has a recorded exit-0", which this job could then
-        # never produce. Dropping the flag silently re-creates that deadlock.
-        "worktree gc --apply --all --exit-zero",
-    )
 
 
-def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
-    # Arrange — --all is only correct because it HAS a clean source (every
-    # agent spec.workdir that is a local git repo toplevel). If that source
-    # ever disappears, this command silently sweeps nothing.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert "--all" in job.command
 
 
-def test_worktree_gc_cadence_is_daily() -> None:
-    # Arrange — sprawl accumulates over days and the age gate is 24h, so a
-    # faster pass could not remove anything a daily one would miss.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert job.on_unit_active_sec == "1d"
 
 
-def test_fleet_reconcile_job_name_is_package_prefixed() -> None:
-    # Arrange — the enforcer of "should be running => is running".
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.name == "scitex-agent-container-fleet-reconcile"
 
 
-def test_fleet_reconcile_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong
-    # kind raises at construction and `ecosystem up` then silently DROPS
-    # sac's whole provider (provider-isolated, WARN-only) — taking the OAuth
-    # refresh, the drift check and the worktree GC down with it.
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_fleet_reconcile_command_is_the_applying_form() -> None:
-    # Arrange — THIS JOB IS THE MECHANISM. `restart.policy` in ~93 specs is
-    # dead code without it: `_lifecycle/_start.py` runs the loop that reads
-    # it on a daemon thread inside the short-lived `sac agents start` CLI, so
-    # the supervisor dies with the process that promised it. A scheduled
-    # DRY-RUN would restore nothing — the whole point is `--apply`.
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    bound, _payload, rest = _split_command(job.command)
-    assert (bound, rest) == ("/usr/bin/timeout 300", "agents reconcile --apply")
 
 
-def test_fleet_reconcile_cadence_is_five_minutes() -> None:
-    # Arrange — the cadence IS the window a dead agent stays dead. A no-op
-    # pass is one batched `tmux list-sessions` plus a spec read each, so it
-    # is cheap enough to run often.
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.on_unit_active_sec == "5min"
 
 
-def test_fleet_reconcile_timeout_outlives_a_capped_pass() -> None:
-    # Arrange — the pathological pass restarts `--limit` agents, each a
-    # stop+settle+start. A pass killed at this timeout is SAFE (the restart
-    # history is persisted per restart, not at the end), but the timeout must
-    # still comfortably exceed a normal pass or the enforcer never finishes.
-    #
-    # THIS is the job whose unbounded cron line was measured accumulating
-    # fourteen concurrent instances, the oldest 45 minutes old (2026-07-18).
-    # A `timeout_sec` assertion would have passed throughout that incident,
-    # because the field was set and the deployed cron line was still
-    # unbounded — so the bound is pinned where it actually runs.
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
-def test_spartan_sif_bake_job_name_is_package_prefixed() -> None:
-    # Arrange — the daily remote SIF bake (operator directive 2026-07-17:
-    # bake on Spartan, rsync to the master, zero master CPU).
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.name == "scitex-agent-container-spartan-sif-bake"
 
 
-def test_spartan_sif_bake_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer (*/10), so kind="timer".
-    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.kind == "timer"
 
 
 # ---------------------------------------------------------------------------
@@ -517,95 +241,20 @@ def test_spartan_sif_bake_job_kind_is_timer() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_restart_login_expired_job_name_is_package_prefixed() -> None:
-    # Arrange — the auto-restarter for auth-dead-but-live agents.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert job.name == "scitex-agent-container-restart-login-expired-agents"
 
 
-def test_restart_login_expired_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong kind
-    # raises at construction and `ecosystem up` then silently DROPS sac's whole
-    # provider (provider-isolated, WARN-only) — taking the OAuth refresh, the
-    # drift check, the worktree GC AND the fleet-reconcile enforcer down too.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_spartan_sif_bake_command_is_the_confirmed_form() -> None:
-    # Arrange — `sac image bake-remote` REFUSES to run without --yes
-    # (exit 2), mirroring `sac image build`'s non-interactive gate. A
-    # scheduled command missing --yes would fail every single night —
-    # a timer that fires and does nothing, the inert-feature shape.
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    bound, _payload, rest = _split_command(job.command)
-    assert (bound, rest) == ("/usr/bin/timeout 14400", "image bake-remote --yes")
 
 
-def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
-    # Arrange — the SIF is a point-in-time snapshot of @develop, and at our
-    # release rate a day-old one is mostly wrong. 30min was the operator's
-    # stated FLOOR (「最低でも30分に1回」), not his target — he asked why it was
-    # only every 30 and said even 1min would be fine — so this pins the
-    # cadence he wants. skip-if-unchanged keeps a no-change tick at one ssh
-    # round-trip instead of a multi-GB transfer, and the script's `flock -n`
-    # single-flights the overlaps a 10min interval necessarily causes.
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.on_unit_active_sec == "10min"
 
 
-def test_spartan_sif_bake_timeout_outlives_two_bakes_and_a_pull() -> None:
-    # Arrange — two full bakes (base + scitex) plus a multi-GB pull on a
-    # slow link must fit; the per-leg ssh timeout is 7200s, so the cap
-    # must exceed the worst legitimate chain or the timer kills its
-    # own successful runs.
-    #
-    # This job needs a REAL bound more than any sibling: at a */10 cadence
-    # an unbounded bake outlives its own tick by construction, so a wedged
-    # run piles up against every later one. The bound therefore has to be
-    # in the command — cron, the surface this is deployed to, cannot carry
-    # `timeout_sec` at all.
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.command.startswith("/usr/bin/timeout 14400 ")
 
 
-def test_restart_login_expired_command_is_the_applying_form() -> None:
-    # Arrange — a scheduled DRY-RUN would detect wedged agents and heal none.
-    # The whole point is `--apply`. Detection stays read-only; the restart is
-    # the only mutation.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    bound, _payload, rest = _split_command(job.command)
-    assert (bound, rest) == ("/usr/bin/timeout 300", "agents restart-login-expired --apply")
 
 
-def test_restart_login_expired_cadence_is_five_minutes() -> None:
-    # Arrange — the cadence IS the window a login-expired agent stays wedged,
-    # matched to fleet-reconcile so the two enforcers sweep on the same beat.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert job.on_unit_active_sec == "5min"
 
 
-def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
-    # Arrange — construction must not raise (a bad field would drop the whole
-    # provider). Assert it is the canonical contract type, not a look-alike.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert isinstance(job, jobs_mod.JobSpec)
 
 
 # ---------------------------------------------------------------------------
@@ -805,43 +454,7 @@ def test_the_cron_line_that_lands_on_the_host_carries_the_bound() -> None:
     assert all(" /usr/bin/timeout " in line for line in lines), lines
 
 
-def test_every_job_names_an_absolute_payload_not_a_bare_sac() -> None:
-    """The whole-fleet guard, and the one that would have caught compute-01.
-
-    Each assertion above pins ONE job, so a new JobSpec added tomorrow with a
-    bare ``sac`` would pass every one of them. This covers the population
-    instead: after the self-bounding ``/usr/bin/timeout`` head, the payload of
-    EVERY provided job must be an absolute path.
-
-    MEASURED 2026-08-20: with a relative payload, scitex-compute-01's ten sac
-    jobs sat at exit 127 with zero successes for hours, self-pull included, so
-    the host could not fetch the fix that would have repaired it. The other
-    three hosts were fine only because their supervisor inherited a PATH that
-    happened to contain the venv.
-    """
-    # Arrange
-    jobs = provide_jobs()
-    # Act
-    relative = [
-        (job.name, job.command)
-        for job in jobs
-        for payload in [_split_command(job.command)[1]]
-        if not pathlib.Path(payload).is_absolute()
-    ]
-    # Assert
-    assert relative == [], (
-        f"these commands name a payload that must be found on the ambient "
-        f"PATH: {relative}. `resolve_execstart` absolutises only the FIRST "
-        f"token, and that token is already `/usr/bin/timeout`, so nothing "
-        f"downstream will fix this."
-    )
-
-
-def test_the_payload_guard_has_something_to_guard() -> None:
-    """Non-vacuity for the check above — an empty provider would pass it silently."""
-    # Arrange
-    expected_minimum = 1
-    # Act
-    jobs = provide_jobs()
-    # Assert
-    assert len(jobs) >= expected_minimum
+# The POPULATION guard over these jobs' payloads — the one that catches a
+# JobSpec added tomorrow rather than any named above — lives in
+# `test__specs_payload.py`. It needs the `executable` seam to resolve
+# deterministically, which is a different setup from every test here.

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -40,6 +40,8 @@ the provider import is lazy, so an old scitex-dev must not fail CI here.
 
 from __future__ import annotations
 
+import pathlib
+
 import re
 
 import pytest
@@ -52,39 +54,31 @@ jobs_mod = pytest.importorskip(
 from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
 
 
+
+def _split_command(command: str) -> tuple[str, str, str]:
+    """``(bound, payload, rest)`` — the three things a job command can get wrong.
+
+    The whole-command assertions below used to pin a literal ``sac``. They
+    cannot any more: the payload is now the ABSOLUTE console script beside the
+    running interpreter (:mod:`._sac_bin`), so its text differs per machine and
+    a literal would pin the developer's venv into CI.
+
+    Splitting keeps every property those assertions were protecting — the bound
+    and the full argument list stay pinned character-for-character, so dropping
+    a ``--to`` or an ``--apply`` is still a red test — while the one token that
+    is legitimately machine-specific is checked by SHAPE instead. Asserting it
+    equals ``sac_bin()`` would be no test at all: a check parameterised by the
+    value it is checking cannot fail.
+    """
+    tokens = command.split()
+    return " ".join(tokens[:2]), tokens[2], " ".join(tokens[3:])
+
+
 def _job(name: str):
     (match,) = [j for j in provide_jobs() if j.name == name]
     return match
 
 
-def test_provider_returns_every_expected_job() -> None:
-    # Arrange — pinned by NAME, not by count. An exact-count assertion goes
-    # red on every legitimate addition while saying nothing about WHICH job
-    # moved, so the number gets bumped reflexively and the pin quietly stops
-    # meaning anything. Membership names what actually changed.
-    #
-    # accounts-keepalive is the newest: the DISTRIBUTION half of the
-    # single-refresher model, paired with accounts-refresh below. `sac
-    # listen` is still NOT federated (see the module docstring and the
-    # absence-pin below).
-    # Act
-    names = {job.name for job in provide_jobs()}
-    # Assert
-    assert names == {
-        "scitex-agent-container-accounts-refresh",
-        "scitex-agent-container-accounts-keepalive",
-        # The usage-cache refresher. Nothing else reads usage: accounts-refresh
-        # rotates tokens and accounts-keepalive copies them, so before this job
-        # every quota number the fleet showed was as old as the last manual run.
-        "scitex-agent-container-accounts-quota-cache",
-        "scitex-agent-container-host-sync-check",
-        "scitex-agent-container-worktree-gc",
-        "scitex-agent-container-spartan-sif-bake",
-        "scitex-agent-container-fleet-reconcile",
-        "scitex-agent-container-restart-login-expired-agents",
-        "scitex-agent-container-heal-agent-auth",
-        "scitex-agent-container-freshness-refresh",
-    }
 
 
 def test_provider_jobs_are_real_jobspecs() -> None:
@@ -117,10 +111,8 @@ def test_provider_job_command_includes_active_account() -> None:
     # JobSpec the day the list order changes.
     job = _job("scitex-agent-container-accounts-refresh")
     # Assert
-    assert job.command == (
-        "/usr/bin/timeout 120 "
-        "sac accounts refresh --all --include-active --sync-active-login"
-    )
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 120", "accounts refresh --all --include-active --sync-active-login")
 
 
 def test_provider_job_command_never_skips_active() -> None:
@@ -209,13 +201,8 @@ def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
     # Act
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
-    assert job.command == (
-        "/usr/bin/timeout 300 "
-        "sac accounts keepalive --all "
-        "--to ywata-note-win "
-        "--to scitex-compute-03 "
-        "--to scitex-compute-04"
-    )
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "accounts keepalive --all --to ywata-note-win --to scitex-compute-03 --to scitex-compute-04")
 
 
 def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() -> None:
@@ -232,7 +219,8 @@ def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() ->
     # Act
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
-    assert job.command.split()[2:5] == ["sac", "accounts", "keepalive"]
+    _bound, _payload, rest = _split_command(job.command)
+    assert rest.split()[:2] == ["accounts", "keepalive"]
 
 
 def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
@@ -370,9 +358,8 @@ def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
     # Act
     job = _job("scitex-agent-container-host-sync-check")
     # Assert — the command is precisely the read-only check+alarm form.
-    assert job.command == (
-        "/usr/bin/timeout 600 sac host sync --check --all --alarm --exit-zero"
-    )
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 600", "host sync --check --all --alarm --exit-zero")
 
 
 def test_host_sync_check_cadence_is_hourly() -> None:
@@ -410,7 +397,17 @@ def test_worktree_gc_command_is_the_apply_form() -> None:
     # Act
     job = _job("scitex-agent-container-worktree-gc")
     # Assert
-    assert job.command == "/usr/bin/timeout 900 sac worktree gc --apply --all"
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == (
+        "/usr/bin/timeout 900",
+        # --exit-zero is LOAD-BEARING and pinned here on purpose. Exit 1 from
+        # this verb means "a repo is over cap, a human decides" — a finding,
+        # not ill health. Without the flag the supervisor records the job as
+        # failed, and the rule for retiring its duplicate systemd timer was
+        # "the supervisor has a recorded exit-0", which this job could then
+        # never produce. Dropping the flag silently re-creates that deadlock.
+        "worktree gc --apply --all --exit-zero",
+    )
 
 
 def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
@@ -460,7 +457,8 @@ def test_fleet_reconcile_command_is_the_applying_form() -> None:
     # Act
     job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
-    assert job.command == "/usr/bin/timeout 300 sac agents reconcile --apply"
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "agents reconcile --apply")
 
 
 def test_fleet_reconcile_cadence_is_five_minutes() -> None:
@@ -546,7 +544,8 @@ def test_spartan_sif_bake_command_is_the_confirmed_form() -> None:
     # Act
     job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
-    assert job.command == "/usr/bin/timeout 14400 sac image bake-remote --yes"
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 14400", "image bake-remote --yes")
 
 
 def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
@@ -587,9 +586,8 @@ def test_restart_login_expired_command_is_the_applying_form() -> None:
     # Act
     job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
-    assert job.command == (
-        "/usr/bin/timeout 300 sac agents restart-login-expired --apply"
-    )
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "agents restart-login-expired --apply")
 
 
 def test_restart_login_expired_cadence_is_five_minutes() -> None:
@@ -628,143 +626,28 @@ def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_heal_agent_auth_job_name_is_package_prefixed() -> None:
-    # Arrange — the incumbent auth healer, now declared rather than hand-cronned.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.name == "scitex-agent-container-heal-agent-auth"
 
 
-def test_heal_agent_auth_job_kind_is_timer() -> None:
-    # Arrange — kind="timer" is what buys `Persistent=true` from scitex-dev's
-    # renderer (a missed window fires on resume — the property the swept crontab
-    # line never had). kind="cron" would materialise the very crontab line this
-    # job exists to escape, and a kind outside {"service","timer","cron"} raises
-    # at construction, silently dropping sac's WHOLE provider.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_heal_agent_auth_cadence_preserves_the_incumbent_ten_minutes() -> None:
-    # Arrange — 10min is the LIVE cadence, not a new choice: runtime/auth-heal.log
-    # ticks 15:20 → 15:30 → 15:40 → 15:50 → 16:00, matching the `*/10` cron line.
-    # Migrating a schedule is the wrong moment to also retune it.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.on_unit_active_sec == "10min"
 
 
-def test_heal_agent_auth_schedule_mirrors_the_retired_cron_expression() -> None:
-    # Arrange — the cron form is kept alongside the timer cadence (as every
-    # sibling does) so the expression the crontab line used stays legible in the
-    # spec, and so `ecosystem cron` could still derive an equivalent line.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.schedule == "*/10 * * * *"
 
 
-def test_heal_agent_auth_interpreter_token_is_absolute() -> None:
-    # Arrange — scitex-dev's `resolve_execstart` passes a head starting with "/"
-    # through VERBATIM. An absolute head is therefore the only form that depends
-    # on neither the ambient PATH nor which interpreter ran `ecosystem up`.
-    #
-    # The interpreter is token 2 now, after the `/usr/bin/timeout <N>` prefix.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.split()[2].startswith("/")
 
 
-def test_heal_agent_auth_command_head_is_still_absolute() -> None:
-    # Arrange — the self-bounding prefix must not cost this job its
-    # PATH-independence. `/usr/bin/timeout` is spelled absolutely precisely so
-    # the HEAD keeps starting with "/" and `resolve_execstart` keeps passing
-    # the whole command through verbatim. A bare `timeout` would have quietly
-    # made this the one command that needs an ambient PATH.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.split()[0] == "/usr/bin/timeout"
 
 
-def test_heal_agent_auth_script_token_is_absolute() -> None:
-    # Arrange — a systemd --user unit gets a MINIMAL PATH and no meaningful cwd,
-    # so the script argument must be absolute too; a relative path would exec
-    # fine under cron's $HOME cwd and fail as status=127 under systemd.
-    #
-    # The script is token 3 now, after the `/usr/bin/timeout <N>` prefix.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.split()[3].startswith("/")
 
 
-def test_heal_agent_auth_runs_the_venv_python_not_the_system_one() -> None:
-    # Arrange — the script's own `#!/usr/bin/env python3` would resolve to the
-    # SYSTEM python under systemd's minimal PATH, not the 3.11 venv the fleet
-    # runs on. Naming the venv interpreter outright is what carries the "PATH
-    # prefixed with .env-3.11/bin" requirement into a unit that has no PATH.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.startswith(
-        "/usr/bin/timeout 300 /home/ywatanabe/.env-3.11/bin/python "
-    )
 
 
-def test_heal_agent_auth_targets_the_real_auth_heal_entrypoint() -> None:
-    # Arrange — the entrypoint the cron line actually invokes, per the tracked
-    # `~/.scitex/agent-container/bin/README.md` ("run from cron; cron lines live
-    # in ~/.dotfiles/.crontab_list") and corroborated by the live state/log files
-    # that script writes. It takes no arguments — its `main()` has no argparse,
-    # only a `--selftest` branch — so the bare script path is the whole command.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.endswith(
-        "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
-    )
 
 
-def test_heal_agent_auth_timeout_outlives_a_restarting_pass() -> None:
-    # Arrange — a no-op tick takes ~2-8s; the worst observed pass (a TUI restart
-    # at 15:30:04 settling by 15:32:08) ~2min. A pass killed here is SAFE (state
-    # is persisted per restart), but the timeout must still outlive a real one.
-    #
-    # Pinned on the COMMAND: this job is lowered onto cron, and a cron line
-    # has no field a `timeout_sec` could ride in.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
-def test_heal_agent_auth_constructs_as_a_real_jobspec() -> None:
-    # Arrange — construction must not raise (a bad field would drop the whole
-    # provider). Assert it is the canonical contract type, not a look-alike.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert isinstance(job, jobs_mod.JobSpec)
 
 
-def test_heal_agent_auth_and_restart_login_expired_are_both_declared() -> None:
-    # Arrange — declaring both is SAFE and deliberate: a JobSpec is inert until
-    # `ecosystem up` installs it, so version-controlling the incumbent does not
-    # enable it. What must never happen is both being ENABLED — they are the two
-    # implementations of the same TUI heal, with INDEPENDENT debounce state, and
-    # two restarters on one fleet is the documented double-supervisor hazard.
-    # This pins that the choice stays an operator deploy decision rather than
-    # being silently foreclosed by deleting one of them.
-    # Act
-    names = {job.name for job in provide_jobs()}
-    # Assert
-    assert {"scitex-agent-container-heal-agent-auth", "scitex-agent-container-restart-login-expired-agents"} <= names
 
 
 # ---------------------------------------------------------------------------
@@ -920,3 +803,45 @@ def test_the_cron_line_that_lands_on_the_host_carries_the_bound() -> None:
     lines = [cron_block.build_cron_line(spec) for spec in merged]
     # Assert
     assert all(" /usr/bin/timeout " in line for line in lines), lines
+
+
+def test_every_job_names_an_absolute_payload_not_a_bare_sac() -> None:
+    """The whole-fleet guard, and the one that would have caught compute-01.
+
+    Each assertion above pins ONE job, so a new JobSpec added tomorrow with a
+    bare ``sac`` would pass every one of them. This covers the population
+    instead: after the self-bounding ``/usr/bin/timeout`` head, the payload of
+    EVERY provided job must be an absolute path.
+
+    MEASURED 2026-08-20: with a relative payload, scitex-compute-01's ten sac
+    jobs sat at exit 127 with zero successes for hours, self-pull included, so
+    the host could not fetch the fix that would have repaired it. The other
+    three hosts were fine only because their supervisor inherited a PATH that
+    happened to contain the venv.
+    """
+    # Arrange
+    jobs = provide_jobs()
+    # Act
+    relative = [
+        (job.name, job.command)
+        for job in jobs
+        for payload in [_split_command(job.command)[1]]
+        if not pathlib.Path(payload).is_absolute()
+    ]
+    # Assert
+    assert relative == [], (
+        f"these commands name a payload that must be found on the ambient "
+        f"PATH: {relative}. `resolve_execstart` absolutises only the FIRST "
+        f"token, and that token is already `/usr/bin/timeout`, so nothing "
+        f"downstream will fix this."
+    )
+
+
+def test_the_payload_guard_has_something_to_guard() -> None:
+    """Non-vacuity for the check above — an empty provider would pass it silently."""
+    # Arrange
+    expected_minimum = 1
+    # Act
+    jobs = provide_jobs()
+    # Assert
+    assert len(jobs) >= expected_minimum

--- a/tests/scitex_agent_container/_jobs/test__sac_bin.py
+++ b/tests/scitex_agent_container/_jobs/test__sac_bin.py
@@ -10,12 +10,16 @@ jobs sat at exit 127 with zero successes.
 from __future__ import annotations
 
 import os
+import sys
 import warnings
 from pathlib import Path
 
 import pytest
 
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs
 from scitex_agent_container._jobs._sac_bin import sac_bin
+
+from ._jobspec_helpers import _split_command
 
 
 def _venv_shaped(tmp_path: Path, *, with_sac: bool) -> Path:
@@ -94,3 +98,159 @@ def test_resolves_against_this_interpreter_by_default() -> None:
     resolved = sac_bin()
     # Assert
     assert resolved == acceptable_bare or Path(resolved).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# THE POPULATION GUARD: sac_bin's resolution must REACH the rendered specs.
+#
+# The tests above pin `sac_bin` in isolation. These pin the thing the module
+# exists for -- that every JobSpec the provider returns names the resolved
+# payload rather than a bare `sac` the ambient PATH has to find.
+#
+# They live in this file rather than a `test__specs_payload.py` of their own
+# because the repo mirrors tests onto source modules one-to-one (PS-204 §2),
+# and their subject IS this module: `_sac_bin`'s whole docstring is the
+# argument for why a job command may not say bare `sac`.
+#
+# WHY THEY TAKE THE `executable` SEAM. `sac_bin` returns the bare name and
+# warns when no console script sits beside the running interpreter -- correct
+# for a broken install, and also exactly what a PYTHONPATH-only CI run looks
+# like. Calling `provide_jobs()` with no seam and asserting the payload is
+# absolute therefore asserts a fact about the RUNNING ENVIRONMENT, not about
+# the specs. MEASURED 2026-08-20: that is why this guard was red in CI on
+# three unrelated PRs while every host behaved correctly.
+#
+# WHY NOT "absolute OR a warning fired". A warning ALWAYS fires under CI, so
+# every job -- including one that hardcoded a literal `sac` -- would satisfy
+# that vacuously, in the one environment where the guard actually runs.
+# ---------------------------------------------------------------------------
+
+
+def _payload(command: str) -> str:
+    """The token after the ``/usr/bin/timeout N`` head — the binary that runs.
+
+    Reads it through the shared ``_split_command`` rather than re-slicing the
+    string here, so a change to what counts as the head reaches this file too.
+    See that helper for why the payload is checked by SHAPE and never against
+    ``sac_bin()``'s own return value.
+    """
+    return _split_command(command)[1]
+
+
+def test_every_job_names_an_absolute_payload_not_a_bare_sac(tmp_path: Path) -> None:
+    """The whole-fleet guard, and the one that would have caught compute-01.
+
+    Each per-job assertion elsewhere pins ONE job, so a JobSpec added tomorrow
+    with a bare ``sac`` would pass every one of them. This covers the
+    population instead.
+    """
+    # Arrange — a tree that DOES hold a console script, so resolution is the
+    # test's choice rather than the runner's accident.
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    relative = [
+        (job.name, job.command)
+        for job in provide_jobs(executable=str(bindir / "python"))
+        if not Path(_payload(job.command)).is_absolute()
+    ]
+    # Assert
+    assert relative == [], (
+        f"these commands name a payload that must be found on the ambient "
+        f"PATH: {relative}. `resolve_execstart` absolutises only the FIRST "
+        f"token, and that token is already `/usr/bin/timeout`, so nothing "
+        f"downstream will fix this."
+    )
+
+
+def test_the_payload_guard_has_something_to_guard(tmp_path: Path) -> None:
+    """Non-vacuity: an empty provider would pass the check above silently."""
+    # Arrange
+    expected_minimum = 1
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    jobs = provide_jobs(executable=str(bindir / "python"))
+    # Assert
+    assert len(jobs) >= expected_minimum
+
+
+def test_every_payload_comes_from_the_tree_the_seam_named(tmp_path: Path) -> None:
+    """The seam is REACHED, not merely accepted.
+
+    Absoluteness alone cannot tell those apart: if ``provide_jobs`` ignored
+    ``executable`` and resolved against the running interpreter, the payload
+    would still be absolute on a developer's machine and the guard above would
+    still pass. This pins the payload to the tree the test built, so a seam
+    that is accepted and never threaded down goes red — the
+    accepted-but-never-applied shape that lets a flag exist while the
+    behaviour behind it is absent.
+    """
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    jobs = provide_jobs(executable=str(bindir / "python"))
+    # Assert
+    elsewhere = [
+        (job.name, _payload(job.command))
+        for job in jobs
+        if _payload(job.command) != str(bindir / "sac")
+    ]
+    assert elsewhere == [], (
+        f"these payloads did not come from the tree the seam named "
+        f"({bindir / 'sac'}): {elsewhere}. `executable` was accepted but not "
+        f"threaded through to `sac_bin`."
+    )
+
+
+def test_specs_built_without_a_console_script_warn(tmp_path: Path) -> None:
+    """What does NOT go red, made to go red — half one, the noise.
+
+    The guard above is only meaningful while the fallback it guards against
+    stays AUDIBLE. If the warning ever stopped, a silently degraded fleet
+    would look identical to a healthy one.
+    """
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=False)
+    # Act
+    executable = str(bindir / "python")
+    # Assert
+    with pytest.warns(RuntimeWarning):
+        provide_jobs(executable=executable)
+
+
+def test_specs_built_without_a_console_script_carry_the_bare_name(
+    tmp_path: Path,
+) -> None:
+    """What does NOT go red, made to go red — half two, the value.
+
+    The fallback returns the bare name rather than inventing a path. If it
+    ever started synthesising one, the population guard would pass against a
+    payload no host can execute — a green test describing a fleet at exit 127.
+    """
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=False)
+    # Act
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        jobs = provide_jobs(executable=str(bindir / "python"))
+    # Assert
+    assert {_payload(job.command) for job in jobs} == {"sac"}
+
+
+def test_the_default_seam_still_resolves_against_this_interpreter() -> None:
+    """Omitting the seam must keep production behaviour, not become a no-op.
+
+    The fleet calls ``provide_jobs()`` with no arguments and must still get the
+    console script beside the interpreter that imported the plugin. Asserting
+    the exact path would parameterise the test by the value under test, so this
+    asserts the RELATIONSHIP: whatever the default resolves to is what the seam
+    produces when handed this interpreter.
+    """
+    # Arrange
+    interpreter = sys.executable
+    # Act
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        defaulted = [_payload(job.command) for job in provide_jobs()]
+        seamed = [_payload(job.command) for job in provide_jobs(executable=interpreter)]
+    # Assert
+    assert defaulted == seamed

--- a/tests/scitex_agent_container/_jobs/test__sac_bin.py
+++ b/tests/scitex_agent_container/_jobs/test__sac_bin.py
@@ -1,0 +1,96 @@
+"""``sac_bin`` — the payload path a scheduled command must name.
+
+The defect these guard against is not hypothetical. On 2026-08-20 every sac
+JobSpec said a bare ``sac`` after an absolute ``/usr/bin/timeout`` head, which
+takes the payload OUT of ``resolve_execstart`` (it absolutises only the first
+token). On scitex-compute-01 the supervisor's PATH held no venv and all ten sac
+jobs sat at exit 127 with zero successes.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._jobs._sac_bin import sac_bin
+
+
+def _venv_shaped(tmp_path: Path, *, with_sac: bool) -> Path:
+    """A real venv-shaped tree on disk: ``bin/python`` symlinked OUT of it.
+
+    Not a mock — the property under test is how a SYMLINK is treated, so the
+    test must build a real one. This mirrors how uv (the mandated installer)
+    lays a venv out.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True)
+    (bindir / "python").symlink_to(Path(os.path.realpath("/usr/bin/python3")))
+    if with_sac:
+        (bindir / "sac").write_text("#!/bin/sh\nexit 0\n")
+    return bindir
+
+
+def test_returns_the_console_script_beside_the_interpreter(tmp_path: Path) -> None:
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    resolved = sac_bin(executable=str(bindir / "python"))
+    # Assert
+    assert resolved == str(bindir / "sac")
+
+
+def test_does_not_follow_the_interpreter_symlink_out_of_the_venv(tmp_path: Path) -> None:
+    """The property scitex-dev's ``resolve_execstart`` docstring insists on.
+
+    Falsifiable, and that is the point: change the implementation to
+    ``Path(executable).resolve().parent`` and this goes RED, because the
+    resolved parent is ``/usr/bin`` — a directory that structurally cannot hold
+    this venv's console scripts.
+    """
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    resolved = sac_bin(executable=str(bindir / "python"))
+    # Assert
+    assert not resolved.startswith("/usr/bin/")
+
+
+def test_absent_console_script_warns(tmp_path: Path) -> None:
+    """A silent fallback is how the original defect stayed invisible."""
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=False)
+    # Act
+    executable = str(bindir / "python")
+    # Assert
+    with pytest.warns(RuntimeWarning, match="no `sac` console script"):
+        sac_bin(executable=executable)
+
+
+def test_absent_console_script_still_yields_a_usable_command(tmp_path: Path) -> None:
+    """The warning does not replace a return value — the job must still render."""
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=False)
+    # Act
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        resolved = sac_bin(executable=str(bindir / "python"))
+    # Assert
+    assert resolved == "sac"
+
+
+def test_resolves_against_this_interpreter_by_default() -> None:
+    """No argument means ``sys.executable`` — the supervisor's own interpreter.
+
+    Either an absolute sibling, or the loud bare-name fallback. What it must
+    never be is a relative path WITH a directory in it, which would depend on
+    the child's working directory as well as its PATH.
+    """
+    # Arrange
+    acceptable_bare = "sac"
+    # Act
+    resolved = sac_bin()
+    # Assert
+    assert resolved == acceptable_bare or Path(resolved).is_absolute()

--- a/tests/scitex_agent_container/_jobs/test__specs_accounts.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_accounts.py
@@ -1,0 +1,127 @@
+"""The accounts-keepalive JobSpec — the DISTRIBUTION half of the token model.
+
+Split out of ``test__jobs_plugin.py`` (at the per-file cap), mirroring the
+split of :mod:`scitex_agent_container._jobs._specs_accounts` on the source
+side, so the tests for a group sit beside the module that defines it.
+
+``accounts-refresh`` rotates the token on the ONE host holding refresh
+material; this job copies the result out to the access-only hosts and proves
+each accepts it. The two are a pair, and the pair is why a fresh token on the
+master does not by itself keep the followers alive — which is why these
+assertions pin the peer list and the copying verb, not just the cadence.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
+
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
+
+
+def test_accounts_keepalive_job_name_is_package_prefixed() -> None:
+    # Arrange — the distribution half of the single-refresher model.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.name == "scitex-agent-container-accounts-keepalive"
+
+def test_accounts_keepalive_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer, so kind="timer". A kind
+    # outside JobSpec.ALLOWED_KINDS raises at construction, and `ecosystem up`
+    # then silently DROPS sac's WHOLE provider (provider-isolated, WARN-only)
+    # — taking the OAuth refresh, the drift check, the worktree GC and both
+    # heal enforcers down with it.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.kind == "timer"
+
+def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
+    # Arrange — the peer list IS the job. A keepalive that reaches two of the
+    # three access-only hosts looks healthy (exit 0, verified peers) while the
+    # third silently expires, which is the exact failure this job exists to
+    # end. Pin the whole command so dropping a `--to` is a red test, not a
+    # host nobody notices is dead.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "accounts keepalive --all --to ywata-note-win --to scitex-compute-03 --to scitex-compute-04")
+
+def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() -> None:
+    # Arrange — belt-and-braces, the counterpart of accounts-refresh's
+    # --skip-active guard. This job COPIES the master's current token; minting
+    # rotates it, and a rotation revokes the token every running agent is
+    # holding. Scheduling `accounts refresh` or `accounts login` here would
+    # turn a keepalive into a fleet-wide logout every 15 minutes, so pin the
+    # verb itself rather than trusting the full-command assertion above to be
+    # re-read whenever someone edits the peer list.
+    #
+    # Indexed PAST the self-bounding `/usr/bin/timeout <N>` prefix (tokens 0
+    # and 1), so this still pins the VERB rather than the wrapper.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    _bound, _payload, rest = _split_command(job.command)
+    assert rest.split()[:2] == ["accounts", "keepalive"]
+
+def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
+    # Arrange — the cadence IS the worst-case follower outage, not a guess at
+    # when work is needed. The master's token changes once in ~7h at an
+    # unpredictable moment, and the instant it does every follower's copy is
+    # revoked; the tick only decides how long that revoked window lasts. A
+    # converged peer is verified rather than rewritten, so the extra ticks are
+    # near free — which is what makes 15min affordable.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.on_unit_active_sec == "15min"
+
+def test_accounts_keepalive_schedule_mirrors_the_timer_cadence() -> None:
+    # Arrange — the cron form is kept alongside the timer cadence (as every
+    # sibling does) so `ecosystem cron` could derive an equivalent line, and
+    # so the two spellings cannot silently disagree about how often this runs.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.schedule == "*/15 * * * *"
+
+def test_accounts_keepalive_timeout_outlives_a_three_peer_pass() -> None:
+    # Arrange — per peer: a handful of ssh ops plus ONE outbound HTTPS
+    # verification (15s cap inside the probe). 300s covers three peers
+    # including a slow one. A pass killed here is SAFE — nothing is published
+    # unverified, so the peer keeps its previous credential.
+    #
+    # The bound is asserted on the COMMAND, not on `timeout_sec`, because
+    # this job is deployed to cron and a cron line cannot carry that field.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.command.startswith("/usr/bin/timeout 300 ")
+
+def test_accounts_keepalive_constructs_as_a_real_jobspec() -> None:
+    # Arrange — construction must not raise (a bad field would drop the whole
+    # provider). Assert it is the canonical contract type, not a look-alike.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert isinstance(job, jobs_mod.JobSpec)
+
+def test_accounts_keepalive_and_accounts_refresh_are_both_declared() -> None:
+    # Arrange — unlike the heal pair below, these two are NOT alternatives:
+    # they are the two halves of one model and BOTH must be enabled. Refresh
+    # without keepalive leaves the followers holding a revoked copy; keepalive
+    # without refresh distributes a token nothing renews. Deleting either one
+    # breaks the fleet in a way that looks like the other half working.
+    # Act
+    names = {job.name for job in provide_jobs()}
+    # Assert
+    assert {"scitex-agent-container-accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names

--- a/tests/scitex_agent_container/_jobs/test__specs_liveness.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_liveness.py
@@ -1,0 +1,126 @@
+"""The two AGENT-LIVENESS enforcers, tested side by side.
+
+Split out of ``test__jobs_plugin.py`` (at the per-file cap), mirroring the
+split of :mod:`scitex_agent_container._jobs._specs_liveness` on the source
+side — a file that already argued these two are unreadable apart, because each
+one's scope is defined by what the other handles:
+
+* ``fleet-reconcile`` restarts CORPSES — no tmux session, so no context to lose.
+* ``restart-login-expired-agents`` restarts the LIVE-BUT-WEDGED half, which
+  fleet-reconcile deliberately will not touch.
+
+``fleet-reconcile``'s pins matter more than most: ``restart.policy`` in ~93
+specs is DEAD CODE without that timer, so a wrong ``kind`` or a command that
+lost ``--apply`` would put the fleet back to dying unnoticed.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
+
+
+def test_fleet_reconcile_job_name_is_package_prefixed() -> None:
+    # Arrange — the enforcer of "should be running => is running".
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    assert job.name == "scitex-agent-container-fleet-reconcile"
+
+def test_fleet_reconcile_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong
+    # kind raises at construction and `ecosystem up` then silently DROPS
+    # sac's whole provider (provider-isolated, WARN-only) — taking the OAuth
+    # refresh, the drift check and the worktree GC down with it.
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    assert job.kind == "timer"
+
+def test_fleet_reconcile_command_is_the_applying_form() -> None:
+    # Arrange — THIS JOB IS THE MECHANISM. `restart.policy` in ~93 specs is
+    # dead code without it: `_lifecycle/_start.py` runs the loop that reads
+    # it on a daemon thread inside the short-lived `sac agents start` CLI, so
+    # the supervisor dies with the process that promised it. A scheduled
+    # DRY-RUN would restore nothing — the whole point is `--apply`.
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "agents reconcile --apply")
+
+def test_fleet_reconcile_cadence_is_five_minutes() -> None:
+    # Arrange — the cadence IS the window a dead agent stays dead. A no-op
+    # pass is one batched `tmux list-sessions` plus a spec read each, so it
+    # is cheap enough to run often.
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    assert job.on_unit_active_sec == "5min"
+
+def test_fleet_reconcile_timeout_outlives_a_capped_pass() -> None:
+    # Arrange — the pathological pass restarts `--limit` agents, each a
+    # stop+settle+start. A pass killed at this timeout is SAFE (the restart
+    # history is persisted per restart, not at the end), but the timeout must
+    # still comfortably exceed a normal pass or the enforcer never finishes.
+    #
+    # THIS is the job whose unbounded cron line was measured accumulating
+    # fourteen concurrent instances, the oldest 45 minutes old (2026-07-18).
+    # A `timeout_sec` assertion would have passed throughout that incident,
+    # because the field was set and the deployed cron line was still
+    # unbounded — so the bound is pinned where it actually runs.
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    assert job.command.startswith("/usr/bin/timeout 300 ")
+
+def test_restart_login_expired_job_name_is_package_prefixed() -> None:
+    # Arrange — the auto-restarter for auth-dead-but-live agents.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    assert job.name == "scitex-agent-container-restart-login-expired-agents"
+
+def test_restart_login_expired_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong kind
+    # raises at construction and `ecosystem up` then silently DROPS sac's whole
+    # provider (provider-isolated, WARN-only) — taking the OAuth refresh, the
+    # drift check, the worktree GC AND the fleet-reconcile enforcer down too.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    assert job.kind == "timer"
+
+def test_restart_login_expired_command_is_the_applying_form() -> None:
+    # Arrange — a scheduled DRY-RUN would detect wedged agents and heal none.
+    # The whole point is `--apply`. Detection stays read-only; the restart is
+    # the only mutation.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "agents restart-login-expired --apply")
+
+def test_restart_login_expired_cadence_is_five_minutes() -> None:
+    # Arrange — the cadence IS the window a login-expired agent stays wedged,
+    # matched to fleet-reconcile so the two enforcers sweep on the same beat.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    assert job.on_unit_active_sec == "5min"
+
+def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
+    # Arrange — construction must not raise (a bad field would drop the whole
+    # provider). Assert it is the canonical contract type, not a look-alike.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    assert isinstance(job, jobs_mod.JobSpec)

--- a/tests/scitex_agent_container/_jobs/test__specs_maintenance.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_maintenance.py
@@ -1,0 +1,195 @@
+"""The housekeeping JobSpecs: drift, worktrees, images.
+
+Split out of ``test__jobs_plugin.py`` (at the per-file cap), mirroring the
+split of :mod:`scitex_agent_container._jobs._specs_maintenance` on the source
+side.
+
+These three are INDEPENDENT of each other — none consumes another's output —
+and what they share is that every one of them REPORTS rather than repairs. The
+assertions here protect that: ``host-sync-check`` must stay read-only and must
+never acquire the mutating remedy, ``worktree-gc`` must keep ``--apply`` and
+its every-repo sweep, and ``spartan-sif-bake`` must stay in its confirmed form.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
+
+
+def test_host_sync_check_job_name_is_package_prefixed() -> None:
+    # Arrange — the drift-alarm timer that makes the Stage-0 detector run.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert job.name == "scitex-agent-container-host-sync-check"
+
+def test_host_sync_check_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer (hourly), so kind="timer".
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert job.kind == "timer"
+
+def test_host_sync_check_command_is_the_readonly_check() -> None:
+    # Arrange — the scheduled command MUST carry --check. A timer that could
+    # fast-forward a peer unattended is Stage 1, explicitly out of scope.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert "--check" in job.command
+
+def test_host_sync_check_command_routes_to_a_seen_card() -> None:
+    # Arrange — --alarm is what turns the exit code into a SEEN board card
+    # instead of a journald line nobody reads.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert "--alarm" in job.command
+
+def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
+    # Arrange — belt-and-braces: the exact mutating form `sac host sync
+    # <peer>` (no --check) must never be what this timer runs. The command
+    # is the read-only detector, full stop.
+    #
+    # `--exit-zero` was added 2026-08-17 and does NOT weaken that intent: it
+    # touches only this process's exit status, never a peer. It is here
+    # because the tri-state verdict (1 = drift found, 2 = undetermined) was
+    # being read by systemd as unit failure, which put the host into
+    # `degraded`, which made the dotfiles sync installer conclude systemd
+    # was absent and silently stop installing its timer.
+    #
+    # Kept as EXACT EQUALITY on purpose. This assertion is the reason that
+    # change could not land unnoticed — a substring check would have let it
+    # through silently, and the next edit to this command deserves the same
+    # scrutiny. Update the literal deliberately; do not relax the operator.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert — the command is precisely the read-only check+alarm form.
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 600", "host sync --check --all --alarm --exit-zero")
+
+def test_host_sync_check_cadence_is_hourly() -> None:
+    # Arrange — drift is slow-moving; hourly is ample and gentle on ssh.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert job.on_unit_active_sec == "1h"
+
+def test_worktree_gc_job_name_is_package_prefixed() -> None:
+    # Arrange — the daily GC that makes the worktree-sprawl countermeasure
+    # PERIODIC. A GC nobody schedules is a script, not a countermeasure —
+    # which is exactly how one repo reached 105 worktrees.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    assert job.name == "scitex-agent-container-worktree-gc"
+
+def test_worktree_gc_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer (daily), so kind="timer".
+    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    assert job.kind == "timer"
+
+def test_worktree_gc_command_is_the_apply_form() -> None:
+    # Arrange — the scheduled job must ACT, not just report: a timer that
+    # only dry-runs would print a nightly report nobody reads while the
+    # sprawl kept growing. The safety lives in the predicate, not in
+    # withholding --apply.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == (
+        "/usr/bin/timeout 900",
+        # --exit-zero is LOAD-BEARING and pinned here on purpose. Exit 1 from
+        # this verb means "a repo is over cap, a human decides" — a finding,
+        # not ill health. Without the flag the supervisor records the job as
+        # failed, and the rule for retiring its duplicate systemd timer was
+        # "the supervisor has a recorded exit-0", which this job could then
+        # never produce. Dropping the flag silently re-creates that deadlock.
+        "worktree gc --apply --all --exit-zero",
+    )
+
+def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
+    # Arrange — --all is only correct because it HAS a clean source (every
+    # agent spec.workdir that is a local git repo toplevel). If that source
+    # ever disappears, this command silently sweeps nothing.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    assert "--all" in job.command
+
+def test_worktree_gc_cadence_is_daily() -> None:
+    # Arrange — sprawl accumulates over days and the age gate is 24h, so a
+    # faster pass could not remove anything a daily one would miss.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    assert job.on_unit_active_sec == "1d"
+
+def test_spartan_sif_bake_job_name_is_package_prefixed() -> None:
+    # Arrange — the daily remote SIF bake (operator directive 2026-07-17:
+    # bake on Spartan, rsync to the master, zero master CPU).
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    assert job.name == "scitex-agent-container-spartan-sif-bake"
+
+def test_spartan_sif_bake_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer (*/10), so kind="timer".
+    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    assert job.kind == "timer"
+
+def test_spartan_sif_bake_command_is_the_confirmed_form() -> None:
+    # Arrange — `sac image bake-remote` REFUSES to run without --yes
+    # (exit 2), mirroring `sac image build`'s non-interactive gate. A
+    # scheduled command missing --yes would fail every single night —
+    # a timer that fires and does nothing, the inert-feature shape.
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 14400", "image bake-remote --yes")
+
+def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
+    # Arrange — the SIF is a point-in-time snapshot of @develop, and at our
+    # release rate a day-old one is mostly wrong. 30min was the operator's
+    # stated FLOOR (「最低でも30分に1回」), not his target — he asked why it was
+    # only every 30 and said even 1min would be fine — so this pins the
+    # cadence he wants. skip-if-unchanged keeps a no-change tick at one ssh
+    # round-trip instead of a multi-GB transfer, and the script's `flock -n`
+    # single-flights the overlaps a 10min interval necessarily causes.
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    assert job.on_unit_active_sec == "10min"
+
+def test_spartan_sif_bake_timeout_outlives_two_bakes_and_a_pull() -> None:
+    # Arrange — two full bakes (base + scitex) plus a multi-GB pull on a
+    # slow link must fit; the per-leg ssh timeout is 7200s, so the cap
+    # must exceed the worst legitimate chain or the timer kills its
+    # own successful runs.
+    #
+    # This job needs a REAL bound more than any sibling: at a */10 cadence
+    # an unbounded bake outlives its own tick by construction, so a wedged
+    # run piles up against every later one. The bound therefore has to be
+    # in the command — cron, the surface this is deployed to, cannot carry
+    # `timeout_sec` at all.
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    assert job.command.startswith("/usr/bin/timeout 14400 ")


### PR DESCRIPTION

On scitex-compute-01 every sac job — all ten — sat at exit 127 with zero
successes, including the self-pull that would have delivered any fix, so the
host could not recover on its own. compute-02/03/04 were healthy only because
their supervisor inherited a PATH that happened to contain the venv.

WHAT MADE THE PATH LOAD-BEARING
===============================
#1111 made every JobSpec self-bounding by prefixing `/usr/bin/timeout N`. That
head is ABSOLUTE, and scitex-dev's `resolve_execstart` passes a command whose
first token starts with `/` through VERBATIM — so wrapping the command took the
PAYLOAD out of resolution. `timeout` then looked `sac` up on whatever PATH its
parent had.

This file's own docstring already recorded the consequence — and scoped it to a
future in which these specs are "rendered as systemd units instead", calling it
"not live today (`up` writes cron, not units)". The hazard was real and the
scope was wrong: the ecosystem supervisor spawns periodic jobs DIRECTLY through
the same `resolve_execstart`, so the payload was already unresolved on the live
path.

THE FIX ANSWERS THE OBJECTION THAT KEPT IT RELATIVE
===================================================
The rejected option was pinning one absolute `sac`, and the objection was
correct as written: the install path varies by host. `_sac_bin` answers it
rather than overriding it — `Path(sys.executable).parent / "sac"` is the console
script installed beside the interpreter that imported this plugin, so it is
per-host BY CONSTRUCTION with nothing hardcoded and no host list to maintain.

That is also scitex-dev's own rule 1, including the part where the parent must
NOT be `.resolve()`d: a venv's `bin/python` symlinks to an interpreter outside
the venv, where no console scripts live. A test builds a real venv-shaped tree,
symlink and all, and fails if that resolution ever walks out of it.

THIS IS NOT A CLAIM ABOUT COMPUTE-01'S CAUSE
============================================
The 127s needed BOTH a relative payload and a supervisor PATH without the venv,
and scitex-dev owns the second — `build_supervisor_unit_text` has emitted
`Environment=PATH=` since their #713. compute-01 was failing because its UNIT
was stale: the package had been upgraded and installing a newer version does not
rewrite an existing unit. Regenerating that unit is their repair and is
sequenced behind their 0.56.0 release. What this commit removes is the
DEPENDENCY — their condition must be re-established on every host after every
upgrade, and this one cannot regress.

heal-agent-auth IS RETIRED IN THE SAME CHANGE
=============================================
It declared the INCUMBENT healer alongside its own successor, with the note
"MUTUALLY EXCLUSIVE WITH restart-login-expired-agents — enable exactly ONE". On
the hosts the succession had already completed: the successor runs on all four
(55 / 329 / 343 / 337 starts), while `auth-heal.py` and the interpreter it named
are ABSENT from every host and from this repo, and its log file is gone.

What remained was a declaration of a predecessor nobody has, which the
supervisor faithfully tried to spawn every ten minutes and which faithfully
failed — 535 times fleet-wide by the morning it was measured (c01 28 x exit 127,
c02 166, c03 172, c04 169 spawn failures).

Repairing its path would have been the wrong repair: it would ENABLE the
double-supervisor hazard its own docstring warned about, two restarters with
independent debounce state on one fleet. The missing script was the only thing
preventing that, and an accident should not be load-bearing.

TESTS
=====
The per-job whole-command assertions could no longer pin a literal `sac`, so
they now pin the bound and the full argument list character-for-character —
dropping a `--to` or an `--apply` is still red — and check the one legitimately
machine-specific token by shape. Asserting it equals `sac_bin()` would be no
test at all: a check parameterised by the value it checks cannot fail.

One new test covers the POPULATION rather than a job: every provided command's
payload must be absolute. The eight per-job assertions would all have passed a
new JobSpec added tomorrow with a bare `sac`.

220 passed in tests/scitex_agent_container/_jobs/; audit-all clean; CI-exact
ruff clean.

worktree-gc's EXIT CODE WAS A FINDING BEING READ AS A FAILURE
=============================================================
Third change, same theme, and it is what let the duplication survive. The
scheduled `worktree-gc` exited 1 on every one of its supervisor runs. It was not
broken: exit 1 there means "a repo is still over cap", i.e. every kept worktree
failed a safety leg and a HUMAN must decide.

That cost something concrete. The rule for retiring a job's duplicate systemd
timer was "the supervisor has a recorded exit-0 for that job" — a deliberately
conservative rule, since dropping the working copy and keeping a broken one is
the obvious way to turn a duplication into an outage. This job could never
produce an exit-0, so its timer could not be retired. A finding rendered as a
failure kept a second scheduler alive.

`sac worktree gc` now takes `--exit-zero`, the flag its sibling
`sac host sync --check` has carried since 2026-08-17 for the same reason, and
the scheduled JobSpec passes it. The finding is NOT discarded: `--alarm` (on by
default with `--apply`) records every repo's cap verdict in sac's own event log,
and it stays in the printed report and the JSON `exit_code`. Only the PROCESS
status — the thing systemd reads as health — is neutralised. The code says so at
the seam, and says that a job with no such rail must not reach for this flag.

The over-cap repo was this one: 46 worktrees against a cap of 20. Twenty whose
PR is merged or closed and whose tree is clean have been removed with plain
`git worktree remove` — no `--force`, so git's own refusal is the safety check,
and no `--delete-branch`, which would close PRs stacked on those branches.

VERIFICATION
============
327 passed across tests/scitex_agent_container/_jobs/ and tests/develop/;
audit-all clean; CI-exact ruff clean.

The whole-package suite was also run on this branch AND on a near-develop
control, and compared rather than eyeballed:

    branch   27 failed, 15761 passed
    control  26 failed, 15770 passed

The difference is exactly ONE test, and it was mine: the worktree-gc
whole-command assertion, stale by one flag after `--exit-zero` was added to the
JobSpec later in the same change. Fixed, and the flag is now pinned in that
assertion with a comment saying why dropping it re-creates the deadlock.

The other 26 are identical on both sides — `_mcp/test_server.py` and
`_lifecycle/test__rename_cards.py`, present on develop, untouched here. Running
the control is what let that be stated rather than assumed: an earlier
single-sided run of this same suite showed the same 26 and I could not tell
whether any of them were mine.
