### PR TITLE
fix(runtimes): an agent with no identity line in its spec now launches with one

### DIFF
--- a/src/scitex_agent_container/runtimes/_board_identity_env.py
+++ b/src/scitex_agent_container/runtimes/_board_identity_env.py
@@ -179,6 +179,7 @@ def apply_board_identity_alias(
     env: Mapping[str, Any],
     *,
     raw_args: Iterable[Any] | None = None,
+    agent_name: str | None = None,
 ) -> dict[str, str]:
     """Ensure the CANONICAL board identity is set. Returns a NEW dict.
 
@@ -226,20 +227,58 @@ def apply_board_identity_alias(
         from_raw.get(LEGACY_BOARD_ID_ENV) or merged.get(LEGACY_BOARD_ID_ENV) or ""
     ).strip()
     identity = current or legacy
+    derived_from_name = False
     if not identity:
-        return merged
+        # NEITHER SPELLING IS DECLARED. Before 2026-08-20 this returned an env
+        # with NO board identity at all, and the agent launched unable to say
+        # who it was. proj-scitex-hub reported exactly that: scitex-cards
+        # unusable, no SCITEX_CARDS_AGENT_ID, no SCITEX_CARDS_DB. The fleet
+        # baseline promises every agent that its identity "is already wired
+        # into your environment" and tells it to report a failure to resolve
+        # as a sac bug rather than work around it. This is that bug.
+        #
+        # THE AGENT'S OWN NAME IS NOT A GUESS, and that is measured rather than
+        # asserted. Across compute-03's 136 specs and compute-04's 121: 96
+        # declare an identity and it EQUALS the agent name; 9 differ, of which
+        # 6 are TEMPLATES carrying placeholders and 3 are deliberate aliases
+        # (scitex-agent-container-04 -> scitex-agent-container,
+        # scitex-hub-mobile-ux -> scitex-hub, _template_handyman ->
+        # local-coder); 16-17 declare nothing at all. Every one of the aliases
+        # DECLARES its identity, and this branch only runs when none is
+        # declared — so deriving can never override a deliberate alias. It
+        # only fills the hole the 16-17 fall into.
+        #
+        # This is the opposite of the silent default this module warns about.
+        # That warning is about substituting a value when the answer is
+        # UNKNOWN, which puts a wrong author on a card. Here the answer is
+        # known: the spec's own name is the authority sac launched the agent
+        # under. Writing nothing is what produced a wrong (empty) author.
+        if not agent_name or not str(agent_name).strip():
+            return merged
+        identity = str(agent_name).strip()
+        assert_expanded(BOARD_ID_ENV, identity)
+        derived_from_name = True
 
     if BOARD_ID_ENV in from_raw or (merged.get(BOARD_ID_ENV) or "").strip():
         return merged
 
     merged[BOARD_ID_ENV] = identity
-    logger.info(
-        "board_identity: injected %s=%s (derived from the legacy %s, which is "
-        "read but deliberately NOT written back)",
-        BOARD_ID_ENV,
-        identity,
-        LEGACY_BOARD_ID_ENV,
-    )
+    if derived_from_name:
+        logger.info(
+            "board_identity: injected %s=%s (the spec declared NEITHER "
+            "spelling, so the identity is the agent's own name — without this "
+            "the agent launches unable to say who it is)",
+            BOARD_ID_ENV,
+            identity,
+        )
+    else:
+        logger.info(
+            "board_identity: injected %s=%s (derived from the legacy %s, which "
+            "is read but deliberately NOT written back)",
+            BOARD_ID_ENV,
+            identity,
+            LEGACY_BOARD_ID_ENV,
+        )
     return merged
 
 

--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -309,7 +309,13 @@ def effective_env(
     merged = merge_fleet_env(getattr(config, "env", None), defaults=defaults)
     apptainer = getattr(config, "apptainer", None)
     raw_args = getattr(apptainer, "raw_args", None) if apptainer is not None else None
-    return apply_board_identity_alias(merged, raw_args=raw_args)
+    # The agent's own name is passed so a spec that declares NEITHER identity
+    # spelling still launches with one. See the branch in
+    # ``apply_board_identity_alias`` for why the name is the right answer and
+    # why it cannot override a deliberate alias.
+    return apply_board_identity_alias(
+        merged, raw_args=raw_args, agent_name=getattr(config, "name", None)
+    )
 
 
 def fleet_env_flags(

--- a/tests/scitex_agent_container/runtimes/test__board_identity_env.py
+++ b/tests/scitex_agent_container/runtimes/test__board_identity_env.py
@@ -393,3 +393,77 @@ def test_the_legacy_name_reaches_the_rendered_env_flags() -> None:
     flags = fleet_env_flags(config, defaults={})
     # Assert
     assert f"{LEGACY_BOARD_ID_ENV}=scitex-agent-container" in flags
+
+
+# ----------------------------------------------------------------------
+# Deriving the identity from the agent's own name (2026-08-20)
+# ----------------------------------------------------------------------
+#
+# proj-scitex-hub launched with NEITHER identity spelling declared and could
+# not use scitex-cards at all. Measured across the fleet's specs that day: 96
+# declare an identity equal to the agent name, 9 differ (6 templates carrying
+# placeholders, 3 deliberate aliases), and 16-17 declare nothing. Every alias
+# DECLARES its identity, so filling in from the name cannot override one.
+
+
+def test_absent_identity_is_filled_in_from_the_agent_name() -> None:
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="proj-scitex-hub")
+    # Assert
+    assert result[BOARD_ID_ENV] == "proj-scitex-hub"
+
+
+def test_a_declared_identity_beats_the_agent_name() -> None:
+    """The deliberate-alias case: scitex-agent-container-04 -> scitex-agent-container.
+
+    Falsifiable, and it is the one that matters: make the derivation
+    unconditional and this goes RED, because three real specs on the fleet
+    declare an identity that is NOT their directory name on purpose.
+    """
+    # Arrange
+    env = {BOARD_ID_ENV: "scitex-agent-container"}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="scitex-agent-container-04")
+    # Assert
+    assert result[BOARD_ID_ENV] == "scitex-agent-container"
+
+
+def test_a_legacy_declared_identity_also_beats_the_agent_name() -> None:
+    # Arrange
+    env = {LEGACY_BOARD_ID_ENV: "scitex-hub"}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="scitex-hub-mobile-ux")
+    # Assert
+    assert result[BOARD_ID_ENV] == "scitex-hub"
+
+
+def test_no_name_and_no_declaration_still_injects_nothing() -> None:
+    """Without a name there IS no answer, and inventing one is the bug this
+    module exists to prevent — a wrong author is worse than an absent launch."""
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    result = apply_board_identity_alias(env, agent_name=None)
+    # Assert
+    assert BOARD_ID_ENV not in result
+
+
+def test_a_blank_agent_name_is_not_an_identity() -> None:
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="   ")
+    # Assert
+    assert BOARD_ID_ENV not in result
+
+
+def test_the_legacy_name_is_still_never_written_back() -> None:
+    """Deriving must not undo the migration this module's docstring describes."""
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="proj-scitex-hub")
+    # Assert
+    assert LEGACY_BOARD_ID_ENV not in result

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -559,3 +559,19 @@ def test_an_empty_fleet_default_env_is_a_valid_state() -> None:
     flags = fleet_env_flags(config, defaults={})
     # Assert
     assert flags == []
+
+
+def test_effective_env_gives_an_unlabelled_spec_its_own_name() -> None:
+    """The end-to-end path proj-scitex-hub fell through on 2026-08-20.
+
+    The unit test above covers the alias function; this covers the WIRING —
+    that ``effective_env`` actually hands the agent's name down. Drop the
+    ``agent_name=`` argument at the call site and the unit tests stay green
+    while this one goes red, which is the point of having both.
+    """
+    # Arrange
+    config = SimpleNamespace(name="proj-scitex-hub", env={})
+    # Act
+    env = effective_env(config)
+    # Assert
+    assert env["SCITEX_CARDS_AGENT_ID"] == "proj-scitex-hub"


### PR DESCRIPTION

proj-scitex-hub reported that scitex-cards was unusable from it: no
`SCITEX_CARDS_AGENT_ID`, no `SCITEX_CARDS_DB`. The fleet baseline promises every
agent that its identity "is already wired into your environment" and tells the
agent to report a failure to resolve as a sac bug rather than work around it.
This is that bug, and the agent was right to escalate it.

`apply_board_identity_alias` already bridged one gap — a spec declaring only the
legacy `SCITEX_TODO_AGENT_ID` still gets a working canonical identity. But when
NEITHER spelling was declared it returned early, and the container launched with
no board identity at all.

THE AGENT'S OWN NAME IS NOT A GUESS
===================================
That distinction matters here more than usual, because this module's docstring
exists to warn against exactly the wrong version of this change: the 2026-07-19
incident where `${SCITEX_CARDS_AGENT_ID}` — a substitution that did not happen —
was written into live cards as their author. Its rule is that a value meaning "I
could not resolve this" must never be stored, and that a silent default would
put a WRONG author on a card.

Deriving from the name is the opposite case. A default is a substitute for an
UNKNOWN answer; the spec's name is the authority sac launched the agent under.
Writing nothing is what produced a wrong (empty) author.

MEASURED, not assumed, across compute-03's 136 specs and compute-04's 121:

    declared and EQUALS the agent name   96
    declared and DIFFERS                  9
    not declared at all                  16-17

All 9 differences are accounted for. Six are TEMPLATES carrying placeholders
(`SAC_PLACEHOLDER_AGENT_ID`, `proj-`, `local-coder`). Three are deliberate
aliases: `scitex-agent-container-04` -> `scitex-agent-container`,
`scitex-hub-mobile-ux` -> `scitex-hub`, and the handyman template. Every one of
them DECLARES its identity, and this branch runs only when none is declared — so
the derivation cannot override a deliberate alias. It fills exactly the hole the
16-17 fall into.

Two tests pin that boundary from the deliberate-alias side, one for each
spelling; make the derivation unconditional and they go red. A third pins that
no name still means no injection, and a fourth that a blank name is not an
identity. A fifth checks the legacy name is still never written back — deriving
must not quietly undo the migration this module is bridging.

The unit tests cover the alias function; a separate test covers the WIRING
through `effective_env`, because dropping the `agent_name=` argument at the call
site would leave every unit test green while restoring the original bug.

WHAT THIS DOES NOT FIX: `SCITEX_CARDS_DB`. That value carries a password and is
host-specific, so it belongs in the host's declared fleet defaults rather than in
this source tree. proj-scitex-hub's spec has been given both by hand and the
agent restarted; the durable home for the DB half is a separate change.

VERIFICATION
============
80 passed in the two touched test modules; 4224 passed across
tests/scitex_agent_container/runtimes/ and _lifecycle/. Six failures, all in
_lifecycle/test__rename_cards.py, and all six appear identically in a
whole-package run of near-develop — same six test ids, so they are pre-existing
and untouched here. audit-all clean; CI-exact ruff clean.
