### PR TITLE
fix(cli): the completion installer wrote into a git-tracked rc file

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_completion_install.py
+++ b/src/scitex_agent_container/cli_pkg/_completion_install.py
@@ -40,6 +40,52 @@ _BINARIES = (
 _SOURCE_MAP = {"bash": "bash_source", "zsh": "zsh_source"}
 
 
+def _tracked_in_a_git_repo(path: Path) -> Path | None:
+    """The repo root when ``path`` is a TRACKED file in a git repo, else None.
+
+    MEASURED 2026-08-20, found by the dotfiles agent while building the fleet
+    git sync. On every fleet host `~/.bashrc` is a symlink:
+
+        /home/ywatanabe/.bashrc -> /home/ywatanabe/.dotfiles/src/.bashrc
+
+    so appending to it writes a TRACKED file in the dotfiles repo. Four hosts
+    ended up carrying the same "local edit" — not four humans, one installer.
+    Those checkouts are permanently dirty, an ff-only pull will not apply, and
+    that is a direct contributor to the fleet running five different dotfiles
+    heads.
+
+    The path is RESOLVED first, because the symlink is the whole mechanism: the
+    file we would open is not the file the name refers to.
+
+    `git ls-files --error-unmatch` rather than `git status`, because the
+    question is "is this file under version control", not "is it currently
+    modified" — an unmodified tracked file is exactly as wrong to append to,
+    and would silently become the modified one.
+    """
+    import subprocess
+
+    real = path.resolve()
+    try:
+        root = subprocess.run(
+            ["git", "-C", str(real.parent), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if root.returncode != 0:
+            return None
+        tracked = subprocess.run(
+            ["git", "-C", str(real.parent), "ls-files", "--error-unmatch", str(real)],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # An unusable git is not evidence that the file is untracked, but it is
+        # also not a reason to block a local install. Fall through to appending
+        # and say nothing false.
+        return None
+    if tracked.returncode != 0:
+        return None
+    return Path(root.stdout.strip())
+
+
 def _install_cached(*args, **kwargs) -> None:
     """Replacement callback for ``install-shell-completion``."""
     # Re-resolve Path.home() each call (not at attach time) so $HOME
@@ -94,6 +140,24 @@ def _install_cached(*args, **kwargs) -> None:
 
         # Add the source line in rc if not already present.
         if rc_path.is_file() and marker in rc_path.read_text():
+            continue
+        repo = _tracked_in_a_git_repo(rc_path)
+        if repo is not None:
+            # REFUSE, and say exactly what to add and where. The line belongs
+            # IN the dotfiles repo — committed once and carried to every host
+            # by the sync that already exists — not appended per host forever
+            # by an installer that makes the checkout dirty each time.
+            click.echo(
+                f"refusing to append to {rc_path}: it resolves to "
+                f"{rc_path.resolve()}, a file tracked in {repo}. Appending "
+                f"would leave that checkout permanently dirty and block an "
+                f"ff-only pull, on this host and on every host that installs "
+                f"sac.\n"
+                f"  Add this line to that file yourself and commit it, so it "
+                f"reaches every host once:\n"
+                f"    {source_line}  {marker}",
+                err=True,
+            )
             continue
         with rc_path.open("a") as fh:
             fh.write(f"\n{source_line}  {marker}\n")

--- a/tests/scitex_agent_container/cli_pkg/test__completion_install.py
+++ b/tests/scitex_agent_container/cli_pkg/test__completion_install.py
@@ -1,0 +1,101 @@
+"""The completion installer must not write into a git-tracked rc file.
+
+MEASURED 2026-08-20, found by the dotfiles agent while building the fleet git
+sync. On every fleet host `~/.bashrc` is a SYMLINK:
+
+    /home/ywatanabe/.bashrc -> /home/ywatanabe/.dotfiles/src/.bashrc
+
+so appending to it modified a TRACKED file in the dotfiles repo. Four hosts
+carried the same "local edit" — not four humans, one installer. Those checkouts
+were permanently dirty, an ff-only pull would not apply, and that was a direct
+contributor to the fleet running five different dotfiles heads.
+
+No-mocks (PA-306): every test builds a REAL git repository on disk. The property
+under test is how a SYMLINK into a repo is treated, and a fake cannot exhibit
+that — it is exactly the thing the production code got wrong.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scitex_agent_container.cli_pkg._completion_install import _tracked_in_a_git_repo
+
+
+def _repo_with(tmp_path: Path, *, filename: str, tracked: bool) -> Path:
+    """A real git repo containing ``filename``, committed or not."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run = lambda *a: subprocess.run(  # noqa: E731 - local, one line, one use
+        ["git", "-C", str(repo), *a], capture_output=True, check=True
+    )
+    run("init", "-q")
+    run("config", "user.email", "t@example.invalid")
+    run("config", "user.name", "t")
+    (repo / filename).write_text("# rc\n")
+    if tracked:
+        run("add", filename)
+        run("commit", "-qm", "add rc")
+    return repo
+
+
+def test_a_tracked_file_reports_its_repo_root(tmp_path: Path) -> None:
+    # Arrange
+    repo = _repo_with(tmp_path, filename=".bashrc", tracked=True)
+    # Act
+    found = _tracked_in_a_git_repo(repo / ".bashrc")
+    # Assert
+    assert found == repo
+
+
+def test_a_symlink_into_a_repo_reports_the_repo_root(tmp_path: Path) -> None:
+    """THE ACTUAL BUG SHAPE — the file opened is not the file named.
+
+    Falsifiable, and it is the one that matters: drop the `.resolve()` from the
+    implementation and this goes RED while every other test here stays green,
+    because only this one names the file from outside the repo.
+    """
+    # Arrange
+    repo = _repo_with(tmp_path, filename=".bashrc", tracked=True)
+    link = tmp_path / "home-bashrc"
+    link.symlink_to(repo / ".bashrc")
+    # Act
+    found = _tracked_in_a_git_repo(link)
+    # Assert
+    assert found == repo
+
+
+def test_an_untracked_file_in_a_repo_is_not_refused(tmp_path: Path) -> None:
+    """Being INSIDE a repo is not the condition — being tracked is.
+
+    A user whose rc file merely sits in a repo directory, unversioned, has
+    nothing to lose from an append, and refusing there would be a false alarm
+    that sends them looking for a commit that does not exist.
+    """
+    # Arrange
+    repo = _repo_with(tmp_path, filename=".bashrc", tracked=False)
+    # Act
+    found = _tracked_in_a_git_repo(repo / ".bashrc")
+    # Assert
+    assert found is None
+
+
+def test_a_file_outside_any_repo_is_not_refused(tmp_path: Path) -> None:
+    # Arrange
+    plain = tmp_path / ".bashrc"
+    plain.write_text("# rc\n")
+    # Act
+    found = _tracked_in_a_git_repo(plain)
+    # Assert
+    assert found is None
+
+
+def test_a_missing_file_is_not_refused(tmp_path: Path) -> None:
+    """The installer creates the rc file when absent; that path must stay open."""
+    # Arrange
+    absent = tmp_path / "never-created"
+    # Act
+    found = _tracked_in_a_git_repo(absent)
+    # Assert
+    assert found is None


### PR DESCRIPTION

`sac install-shell-completion` appends one `source` line to `~/.bashrc`. On every
fleet host that path is a SYMLINK:

    /home/ywatanabe/.bashrc -> /home/ywatanabe/.dotfiles/src/.bashrc

so the append landed on a TRACKED file in the dotfiles repo. Four hosts ended up
carrying the identical "local edit" — not four humans, one installer. Those
checkouts are permanently dirty, an ff-only pull will not apply, and that is a
direct contributor to the fleet running five different dotfiles heads.

FOUND BY the dotfiles agent while building the fleet git sync, and confirmed
here on compute-04: `git status --porcelain` shows ` M src/.bashrc` and the diff
is exactly the two sac-completion lines. scitex-hpc and scitex-resource append
to the same file the same way; those lines are theirs, these are ours.

THE FIX IS A REFUSAL, NOT A DIFFERENT PATH
==========================================
The line belongs IN the dotfiles repo — committed once and carried to every host
by the sync that already exists — not appended per host forever by an installer
that dirties the checkout each time. So the installer now resolves the rc path,
and if it resolves to a file git TRACKS it refuses and prints the exact line and
the exact file, so the operator adds it deliberately.

Checking out the file would have been the wrong repair: the installer writes it
back, which fixes the instance and leaves the generator. The dotfiles agent
declined to revert for exactly that reason.

THREE CHOICES IN THE PREDICATE, EACH LOAD-BEARING
=================================================
* RESOLVE FIRST. The symlink is the whole mechanism — the file we would open is
  not the file the name refers to. A test builds a real repo, symlinks to it
  from outside, and fails if resolution is dropped.
* `git ls-files --error-unmatch`, not `git status`. The question is "is this
  under version control", not "is it currently modified": an unmodified tracked
  file is exactly as wrong to append to, and would silently become the modified
  one.
* TRACKED, not merely INSIDE a repo. An rc file that happens to sit in a repo
  directory unversioned has nothing to lose, and refusing there would send the
  reader looking for a commit that does not exist.

An unusable git returns None rather than blocking a local install: a broken git
is not evidence the file is untracked, and it is also not a reason to refuse.

TESTS
=====
Five, all against REAL git repositories built on disk (PA-306), because the
property under test is how a SYMLINK is treated and no fake exhibits that.

The falsifiability claim in the symlink test's docstring was VERIFIED, not
asserted: removing `.resolve()` from the implementation turns exactly that one
test red and leaves the other four green, and the file was restored
byte-identical afterwards.

audit-all clean; CI-exact ruff clean.

NOT FIXED HERE: `installation_group.py` touches `~/.bashrc` and `~/.zshrc` the
same way. Same treatment, separate change — it is a different verb with its own
tests, and folding it in would hide one behind the other.
