### PR TITLE
fix(tests): stop asserting on a dependency's display form, which turned develop red

### DIFF
--- a/tests/scitex_agent_container/_state/test_state_db_incarnations.py
+++ b/tests/scitex_agent_container/_state/test_state_db_incarnations.py
@@ -141,13 +141,32 @@ def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> 
     scitex'``. Pinned as discovered rather than quietly weakened: an
     operator following this string reaches the right server, and still has
     to know which schema to look in.
+
+    ASSERTS ON THE PARTS, NOT THE PUNCTUATION, and that is the fix for how
+    this test broke. The quotation in the paragraph above is the locator as
+    scitex-dev 0.56.0 rendered it — ``postgres://127.0.0.1:55432/scitex`` —
+    and the old assertion spliced the tail off ``_BASE_DSN`` and looked for
+    that substring verbatim. 0.56.1 renders the same endpoint as
+    ``postgres[host=127.0.0.1 db=scitex port=55432]``.
+
+    Nothing about where the state goes changed. A developer machine pinned
+    to 0.56.0 stayed green while CI, which resolves the newest, went red —
+    so this was invisible to every local run and only a full CI
+    reproduction found it.
+
+    The locator is a REDACTED DISPLAY FORM, deliberately: the real
+    connection string is ``target.dsn``. A display form is not a contract
+    and must not be asserted on as if it were. What this test means is "the
+    locator names this host, this port and this database", which survives
+    any reformatting that still names them — including both forms above.
     """
     # Arrange: the endpoint the fixture routed this test's writes through.
-    endpoint = _BASE_DSN.split("@", 1)[-1]
+    host_port, _, database = _BASE_DSN.split("@", 1)[-1].partition("/")
+    host, _, port = host_port.partition(":")
     # Act
     locator = init_incarnations_schema()
     # Assert
-    assert endpoint in locator
+    assert all(part in locator for part in (host, port, database))
 
 
 # ----------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -132,13 +132,38 @@ def test_without_the_injection_the_resolver_goes_somewhere_else() -> None:
     container, and opening a Store against it raises StoreTargetError naming
     the missing path. That loud refusal — with no SQLite to slip into — is
     scitex-dev's stated design and the behaviour the operator asked for.
+
+    THE DISCRIMINATOR WAS A RENDERING DETAIL, and a dependency bump exposed
+    it. This asserted ``"55432" not in locator`` — reading the ABSENCE of a
+    port as proof the unset arm went elsewhere. Measured on both versions:
+
+        scitex-dev 0.56.0   set: postgres://127.0.0.1:55432/scitex
+                          unset: postgres://?/scitex            <- no port
+        scitex-dev 0.56.1 unset: postgres[... port=55432]       <- port
+
+    The behaviour never changed; only ``__str__`` did. That is the whole
+    reason this ran green on a developer machine pinned to 0.56.0 and red in
+    CI, which resolves the newest — and why it took a full CI reproduction,
+    not a local run, to see it. Both failing tests on develop shared this
+    single cause, and between them they blocked every open PR, including
+    ones touching no state code at all.
+
+    The locator is a DISPLAY FORM (the real connection string is
+    ``target.dsn``, redacted here deliberately). A display form is not a
+    contract. So state the predicate this docstring already describes: the
+    two arms must DIFFER. That is exactly what "the variable is not inert"
+    means, it needs no knowledge of WHICH field carries the difference, and
+    no reformatting on either side can defeat it.
+
+    Mutation-checked: pointing the unset arm at the injected DSN makes the
+    two identical and this test fails, so it still discriminates.
     """
     # Arrange
-    expected_absent = "55432"
+    with_injection = _resolved_store_locator(FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"])
     # Act
-    locator = _resolved_store_locator(None)
+    without_injection = _resolved_store_locator(None)
     # Assert
-    assert expected_absent not in locator
+    assert without_injection != with_injection
 
 
 def test_declared_defaults_do_not_mutate_the_module_constant(tmp_path: Path) -> None:


### PR DESCRIPTION
`develop` has been red since scitex-dev 0.56.1, and **every open PR inherited it** — including ones that touch no state code at all. This fixes the two tests.

## The measurement

Ran CI's own entry point on a runner host (`exec-in-sif.sh run-in-sif.sh 3.11`), not a local subset:

```
2 failed, 17223 passed, 84 skipped in 192.78s

_state/test_state_db_incarnations.py::test_init_returns_a_locator_naming_the_postgres_endpoint
  assert '127.0.0.1:55432/scitex' in 'postgres[host=127.0.0.1 db=scitex port=55432]'

runtimes/test__fleet_env.py::test_without_the_injection_the_resolver_goes_somewhere_else
  assert '55432' not in 'postgres[ho... port=55432]'
```

## One cause, two tests

Both assert on `str(StoreTarget.locator)`, which is a **redacted display form** — the real connection string is `target.dsn`. Its rendering changed between scitex-dev releases:

| | 0.56.0 | 0.56.1 |
|---|---|---|
| set arm | `postgres://127.0.0.1:55432/scitex` | — |
| **unset arm** | `postgres://?/scitex` (no port) | `postgres[... port=55432]` (port) |

A developer machine resolves to whatever it has installed — this one has 0.56.0, where both assertions pass. CI resolves the newest. So "green here, red there" was not flakiness and not CI drift: it was two versions of somebody else's `__str__`.

## The fixes state what each test means

**incarnations** — the point is that the locator *names* the endpoint, so assert host, port and database each appear. Holds under both renderings above.

**fleet_env** — the point, per its own docstring, is that the two arms must **differ**, or the variable is inert. It checked that by asserting the port was *absent* from the unset arm, which was never the discriminator; it only worked while 0.56.0 happened not to print one for the socket case. It now compares the two arms directly — no knowledge of which field carries the difference, and no rendering can defeat it.

## Verification

- **Mutation-checked**, not assumed: pointing the unset arm at the injected DSN makes the two locators identical and the test fails (`assert 'postgres://...' != 'postgres://...'`). File restored byte-identical afterwards.
- **Verified in CI's own SIF**, because a local pass proves nothing about the version that failed.

A PostgreSQL-absence hypothesis was raised first and killed by measurement (socket present on the host *and* visible inside the SIF under CI's exact interpreter) before reproducing the actual run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CmUd2ebDm5WHNWfTyZtEW
