### PR TITLE
fix(config): the removed-field error told the reader to delete a live line

### DIFF
--- a/src/scitex_agent_container/config/_container_engine.py
+++ b/src/scitex_agent_container/config/_container_engine.py
@@ -52,15 +52,53 @@ CONTAINER_ENGINE = "apptainer"
 _REMOVED_MESSAGE = (
     "spec.container.runtime has been REMOVED — "
     f"{CONTAINER_ENGINE} is the only container engine, so there is "
-    "nothing left to select. DELETE the `runtime:` line from the "
-    "`container:` block; the agent runs inside "
-    f"{CONTAINER_ENGINE} either way. No launch path ever read this "
-    "field, so deleting the line changes nothing except what the spec "
-    "claims about itself."
+    "nothing left to select. No launch path ever read this field, so "
+    "deleting it changes nothing except what the spec claims about "
+    "itself.\n"
+    "\n"
+    "  DELETE the INDENTED one, under `container:`:\n"
+    "\n"
+    "      spec:\n"
+    "        container:\n"
+    "          runtime: ...      <-- DELETE THIS LINE\n"
+    "\n"
+    "  KEEP the one directly under `spec:` — it is a DIFFERENT, LIVE "
+    "field (the harness launch mode, e.g. `tui`) that merely shares the "
+    "name:\n"
+    "\n"
+    "      spec:\n"
+    "        runtime: tui        <-- LEAVE THIS ALONE\n"
+    "\n"
+    "  So do not act on a bare `grep runtime:` — check the indentation "
+    "first."
 )
 # The message names no other engine ON PURPOSE — not even to say one is
 # gone. A removal notice that lists alternatives has rebuilt the menu it
 # was meant to close, and the reader now has a new thing to wonder about.
+#
+# BUT IT MUST NAME THE NESTING, and that is not stylistic. Measured
+# 2026-08-20 across the 122 live specs on compute-04:
+#
+#     with `spec.runtime` (LIVE)       122 / 122
+#     with `spec.container.runtime`      0 / 122
+#
+# So EVERY spec a reader could be holding contains a `runtime:` line that
+# must NOT be deleted, and the one this error is about is absent from all
+# of them. The earlier wording said only "DELETE the `runtime:` line from
+# the `container:` block". A reader who greps `runtime:` — the obvious
+# move, since the message quotes the leaf key — finds exactly one hit,
+# the live one, in 122 cases out of 122.
+#
+# That is not hypothetical. On 2026-08-20 the operator hit this error on a
+# host whose checkout still carried the removed key, ran the grep, and was
+# one keystroke from deleting `runtime: tui` from a working agent. The
+# error text was the whole cause: it was accurate about the field and
+# ambiguous about WHICH LINE, and ambiguity in a remedy is executed, not
+# puzzled over.
+#
+# A removal notice is an instruction someone will follow literally. It has
+# to be safe to follow literally on a spec that does NOT have the field,
+# because that is the spec most readers are looking at.
 
 
 def container_runtime_removed_error(spec: object) -> list[str]:

--- a/tests/scitex_agent_container/config/test__container_engine.py
+++ b/tests/scitex_agent_container/config/test__container_engine.py
@@ -441,3 +441,48 @@ def test_a_scaffolded_spec_cannot_reproduce_the_key():
         "the required/paste-ready block still emits container.runtime — a "
         "spec scaffolded from it would be born failing validation"
     )
+
+
+# ----------------------------------------------------------------------
+# The remedy must be SAFE TO FOLLOW LITERALLY
+#
+# `spec.runtime` (the harness launch mode) and `spec.container.runtime`
+# (removed) share a leaf name and nothing else. Measured 2026-08-20 over
+# the 122 live specs on compute-04:
+#
+#     with spec.runtime            122 / 122
+#     with spec.container.runtime    0 / 122
+#
+# So a reader who hits this error and greps `runtime:` finds exactly one
+# line — the LIVE one — in every spec they could be holding. On
+# 2026-08-20 the operator did exactly that and was one keystroke from
+# deleting `runtime: tui` from a working agent. An ambiguous remedy is
+# executed, not puzzled over, so the disambiguation is pinned here.
+# ----------------------------------------------------------------------
+
+
+def test_the_remedy_tells_the_reader_which_runtime_to_keep():
+    # Arrange — naming only the doomed line is what made this dangerous.
+    message = _runtime_errors({"runtime": "none"})[0]
+    # Act
+    protects_the_live_field = "KEEP" in message
+    # Assert
+    assert protects_the_live_field, message
+
+
+def test_the_remedy_shows_the_nesting_rather_than_the_leaf_name():
+    # Arrange — `container:` alone names a block, not a line.
+    message = _runtime_errors({"runtime": "none"})[0]
+    # Act
+    shows_the_parent_path = "spec:" in message
+    # Assert
+    assert shows_the_parent_path, message
+
+
+def test_the_remedy_warns_against_acting_on_a_bare_grep():
+    # Arrange — the grep is the obvious move and it finds the wrong line.
+    message = _runtime_errors({"runtime": "none"})[0]
+    # Act
+    warns = "grep" in message.lower()
+    # Assert
+    assert warns, message


### PR DESCRIPTION
The operator hit this today and it nearly cost a working agent.

```
Config validation failed for .../agents/business/spec.yaml:
  - spec.container.runtime has been REMOVED — ... DELETE the `runtime:`
    line from the `container:` block; ...
```

That spec has **no** `runtime:` under `container:`. Its only `runtime:` is `spec.runtime: tui` — the harness launch mode, a live field sharing the leaf name and nothing else. Following the instruction literally breaks the agent.

## Not an edge case

Measured across the 122 live specs on compute-04:

| | count |
|---|---|
| with `spec.runtime` (**live**) | **122 / 122** |
| with `spec.container.runtime` (the removed one) | **0 / 122** |

Every spec a reader could be holding contains a `runtime:` line that must **not** be deleted, and the field the error is about is absent from all of them. The message quoted the leaf key, so the obvious next move is `grep runtime:` — one hit, the wrong one, in 122 cases out of 122.

The error was accurate and ambiguous at once: right about *which field*, silent about *which line*. A remedy is executed, not solved, so ambiguity in one is a defect in the code that emits it.

## The fix

Show the nesting instead of naming the leaf; mark both the line to delete and the line to keep; say outright not to act on a bare grep.

```
spec:
  container:
    runtime: ...      <-- DELETE THIS LINE

spec:
  runtime: tui        <-- LEAVE THIS ALONE
```

## The validator is unchanged, deliberately

It was already correct — it fires only when `spec["container"]` is a mapping carrying `runtime`. This host's copy of that same spec validates clean. The operator's failure was a **stale checkout** (the corrected spec is committed and on origin; their machine had not pulled), which is a separate problem and one only that machine can fix — `ywata-note-win` takes no inbound ssh by design. What this changes is that a stale checkout is now merely inconvenient instead of dangerous.

## Verification

Mutation-checked rather than assumed: restoring the old one-line wording reddens all three new tests. File restored byte-identical afterwards. 43 passed in the container-engine suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CmUd2ebDm5WHNWfTyZtEW
