### PR TITLE
fix(ci): the status tool measured the wrong runner pool and quoted a withdrawn ruling

### DIFF
--- a/.github/ci/ci-status.py
+++ b/.github/ci/ci-status.py
@@ -45,8 +45,82 @@ REPO = "scitex-ai/scitex-agent-container"
 TERMINAL_BAD = {"failure", "timed_out", "startup_failure", "action_required"}
 
 
+def _required_runner_labels(repo: str) -> set[str]:
+    """The labels a job must match, read from the repo's own CI_RUNS_ON.
+
+    Returns an empty set when the variable is unset or unparseable, and the
+    caller then reports every online runner rather than pretending to know
+    which pool is targeted. Guessing a default here is what produced the bug
+    this replaces: a hardcoded label that no longer matched reality made the
+    capacity report confidently wrong instead of visibly unknown.
+    """
+    raw = gh_json(f"repos/{repo}/actions/variables/CI_RUNS_ON") or {}
+    try:
+        return {str(x) for x in json.loads(raw.get("value", ""))}
+    except (ValueError, TypeError):
+        return set()
+
+
+#: Exit code for "the instrument could not read", kept distinct from the
+#: verdict codes (0 green / 1 failed / 2 running) on purpose: a report nobody
+#: could produce must never be scored as one of the answers. Anything using
+#: this script as a gate can then treat 3 as "ask again", not as a pass and
+#: not as a failure.
+EXIT_UNMEASURED = 3
+
+
+def _stop_unmeasured(what: str, path: str, hint: str) -> None:
+    """Print why no verdict exists and exit ``EXIT_UNMEASURED``.
+
+    Separate from ``sys.exit(msg)`` deliberately: that form always exits 1,
+    which is this tool's code for "CI FAILED". Reporting an unreadable API as
+    a red build is the same error class the script exists to prevent — a
+    verdict asserted about something nobody looked at.
+    """
+    print(f"UNMEASURED: {what}", file=sys.stderr)
+    print(f"  failing path: {path}", file=sys.stderr)
+    print(f"  {hint}", file=sys.stderr)
+    sys.exit(EXIT_UNMEASURED)
+
+
 def gh_json(path: str):
+    """One `gh api` call, or a LOUD stop when the API refused to answer.
+
+    A REFUSAL IS NOT A DATA POINT. This used to fold every failure into
+    ``None`` — a 404, a 403 rate limit and a 401 all became the same value —
+    and callers then reported the *default* as the finding. Measured
+    2026-08-20: with the secondary rate limit active, this tool printed
+    "cannot resolve branch develop", which reads as "that branch is gone".
+    The branch was fine; GitHub was refusing.
+
+    Rate limit and auth failures are not partial data either: every
+    subsequent call fails the same way, so continuing yields a report made
+    entirely of false negatives — green-looking because nothing could be
+    read. So those two stop the run with ``EXIT_UNMEASURED``. A genuine 404
+    still returns ``None``, because "this object does not exist" IS an
+    answer and callers legitimately branch on it.
+
+    Note that ``gh api rate_limit`` will happily report thousands remaining
+    while this is happening: the SECONDARY limit does not appear there. The
+    only reliable signal is the refusal itself, which is why it is read here
+    rather than pre-checked.
+    """
     p = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    blob = (p.stdout or "") + (p.stderr or "")
+    low = blob.lower()
+    if "rate limit" in low or "secondary rate" in low:
+        _stop_unmeasured(
+            "GitHub is rate-limiting this token, so no verdict can be produced.",
+            path,
+            "`gh api rate_limit` may still show quota — the SECONDARY limit is "
+            "invisible there. Retry in a few minutes.",
+        )
+    if "bad credentials" in low or "requires authentication" in low:
+        _stop_unmeasured(
+            "GitHub rejected the credentials, so no verdict can be produced.",
+            path,
+            "Run `gh auth status`.",
+        )
     if p.returncode != 0:
         return None
     try:
@@ -150,19 +224,58 @@ def report(repo: str, pr: int | None, branch: str) -> int:
     for n, q, _ in sorted(queued_jobs, key=lambda x: -x[1]):
         print(f"  QUEUED   {n[:46]:<46} waiting={q:5.0f}s  <-- BLOCKED ON A RUNNER")
 
-    runners = gh_json(f"repos/{repo}/actions/runners") or {}
-    online = [x for x in runners.get("runners", []) if x["status"] == "online"]
-    busy = [x for x in online if x["busy"]]
-    local = [x for x in online if any(l["name"] == "scitex-local-cpu" for l in x["labels"])]
+    # CAPACITY IS ABOUT THE POOL THE JOBS ACTUALLY TARGET.
+    #
+    # This block used to read only `repos/{repo}/actions/runners` and count the
+    # ones labelled `scitex-local-cpu`. Both halves were wrong, and together
+    # they made the tool answer confidently about a pool nothing runs on:
+    #
+    #   * `vars.CI_RUNS_ON` for this repo is ["self-hosted","Linux","X64",
+    #     "scitex-org-cpu"], so every job lands on ORG runners. The repo-level
+    #     endpoint cannot see them.
+    #   * No runner in either pool carries `scitex-local-cpu` except the single
+    #     repo runner, so `local` was ~1 and `len(busy) >= len(local)` fired
+    #     on almost any input — a "diagnosis" that is nearly a constant.
+    #
+    # Measured 2026-08-20, when 22 PRs were queued: the old block would have
+    # reported the repo pool as 1 online / 0 busy and implied there was no
+    # contention at all. The truth was all four `scitex-org-cpu` runners busy
+    # and four Spartan runners idle and INELIGIBLE. Read the variable, resolve
+    # the pool it names, and report eligibility — never a fixed label.
+    org = repo.split("/", 1)[0]
+    want = _required_runner_labels(repo)
+    seen: dict[str, dict] = {}
+    for endpoint in (f"repos/{repo}/actions/runners", f"orgs/{org}/actions/runners"):
+        for x in (gh_json(endpoint) or {}).get("runners", []):
+            seen.setdefault(x["name"], x)
+    online = [x for x in seen.values() if x["status"] == "online"]
+
+    def _labels(x):
+        return {l["name"] for l in x["labels"]}
+
+    eligible = [x for x in online if want <= _labels(x)] if want else online
+    busy = [x for x in eligible if x["busy"]]
+    idle_ineligible = [x for x in online if not x["busy"] and x not in eligible]
+
     print("\n--- WHY (capacity) ---")
-    print(f"  runners online {len(online)}, busy {len(busy)}, "
-          f"local (scitex-local-cpu) {len(local)}")
+    print(f"  CI_RUNS_ON requires {sorted(want) if want else '(unset — showing all)'}")
+    print(f"  online {len(online)}, eligible {len(eligible)}, "
+          f"busy {len(busy)}, idle-but-ineligible {len(idle_ineligible)}")
     for x in sorted(online, key=lambda x: x["name"]):
-        labs = ",".join(l["name"] for l in x["labels"])
-        flag = "SPARTAN-BANNED" if "spartan" in labs else ""
-        print(f"    {x['name'][:34]:<34} busy={str(x['busy']):<5} {flag}")
-    if queued_jobs and len(busy) >= len(local):
-        print(f"  => {len(queued_jobs)} job(s) are waiting because every local slot is busy.")
+        mark = "eligible" if x in eligible else "NOT-ELIGIBLE"
+        print(f"    {x['name'][:34]:<34} busy={str(x['busy']):<5} {mark:<12} "
+              f"[{','.join(sorted(_labels(x)))}]")
+    if queued_jobs and eligible and len(busy) >= len(eligible):
+        print(f"  => {len(queued_jobs)} job(s) are waiting: every ELIGIBLE runner is busy.")
+        if idle_ineligible:
+            # The actionable half. A saturated pool next to idle machines is a
+            # LABEL problem, not a hardware one, and naming it is the whole
+            # point of printing eligibility rather than a raw busy count.
+            print(f"  => {len(idle_ineligible)} runner(s) are idle but do not carry "
+                  f"{sorted(want)} — widen the labels or the variable, not the fleet.")
+    elif queued_jobs and not eligible:
+        print(f"  => {len(queued_jobs)} job(s) can NEVER dispatch: no online runner "
+              f"carries {sorted(want)}.")
 
     if superseded:
         print("\n--- SUPERSEDED (other shas — NOT this PR's verdict) ---")

--- a/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
+++ b/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
@@ -35,10 +35,21 @@ name: no-hosted-runners
 #     ["self-hosted","Linux","X64","scitex-org-cpu"] (set 2026-08-12T02:27:58Z),
 #     which resolves to the four scitex-0{1..4}-org-cpu-01 runners. No job here
 #     has run on Spartan since that variable was narrowed.
-#   * BY RULING: the operator banned Spartan from CI outright on 2026-08-11
-#     (「spartan を CI に使うのは全面禁止です」). The literal default below still
-#     spells `scitex-ci`, a label that EVERY Spartan runner also carries — it is
-#     a fallback for a missing variable, not a target. Do not widen it.
+#   * BY RULING — AND THE RULING CHANGED. The 2026-08-11 ban
+#     (「spartan を CI に使うのは全面禁止です」) was WITHDRAWN on 2026-08-13:
+#     「あー憲法が古い、スパルタンのciを使ってください、圧倒的に早いので」.
+#     This comment said "Do not widen it" for a week after the reason to
+#     narrow it had gone, and that sentence was still here on 2026-08-20 with
+#     22 PRs queued behind four saturated `scitex-org-cpu` runners while four
+#     Spartan runners sat online and idle. A withdrawn ruling was doing the
+#     routing, in writing, unchallenged.
+#
+#     So: Spartan is ALLOWED, and preferred where it is faster. Whether to
+#     widen `CI_RUNS_ON` is a capacity decision for the fleet — the two pools
+#     are label-disjoint (`scitex-org-cpu` vs `spartan-cpu`+`scitex-ci`), so
+#     switching the variable TRADES pools rather than adding to them; reaching
+#     all of them needs a shared label on the runners themselves. What is NOT
+#     open is leaving a repealed prohibition standing as guidance.
 #
 # NOTE WHAT THIS GUARD DOES AND DOES NOT COVER: it proves no job lands on a
 # GitHub-HOSTED image. It cannot see which self-hosted POOL a job reaches,


### PR DESCRIPTION
22 PRs were queued tonight and `ci-status.py` — the tool whose whole job is "say where CI is stuck" — could not have found it. Three defects, all the same kind: an answer asserted about something never looked at.

## 1. Capacity measured a pool nothing runs on

It read `repos/{repo}/actions/runners` and counted `scitex-local-cpu`. But `vars.CI_RUNS_ON` is `["self-hosted","Linux","X64","scitex-org-cpu"]`, so every job lands on **org** runners, which that endpoint cannot see. Run tonight it would have reported 1 online / 0 busy and implied no contention.

Measured at 07:38Z:

| runner | busy | labels |
|---|---|---|
| `scitex-01..04-org-cpu-01` | **true** ×4 | `… scitex-org-cpu` |
| `spartan-cpu-org-01/02`, `spartan-pooled-cpu-01` | false ×3 | `… spartan-cpu, scitex-ci` |

The pools are **label-disjoint**. Four eligible runners, all busy; three idle runners no sac job can reach. It now reads the variable, resolves that pool across both endpoints, and reports **eligibility** — then says the actionable half: *"3 runner(s) are idle but do not carry [...] — widen the labels or the variable, not the fleet."*

Nothing is hardcoded now: a fixed label is what made this confidently wrong rather than visibly unknown, so an unset `CI_RUNS_ON` shows every runner instead of guessing.

## 2. It flagged Spartan runners `SPARTAN-BANNED`

That ban (2026-08-11) was **withdrawn 2026-08-13** — 「あー憲法が古い、スパルタンのciを使ってください、圧倒的に早いので」. The flag had been false for a week, printed beside the idle machines it was wrongly excusing. The guard workflow carried the same claim in prose and closed with *"Do not widen it"* — a repealed prohibition still issuing instructions.

`hosted-runner-allowlist.yaml` also says "three banned Spartan machines" and is **deliberately not touched**: it sits under `approved_on: 2026-08-12` and is a dated record of what was true then — it even anticipates re-admission. Editing a timestamped approval to match today falsifies the record rather than correcting it.

Whether to widen `CI_RUNS_ON` is a fleet capacity decision and is **not taken here** — disjoint pools mean switching the variable *trades* pools rather than adding to them. Raised with the operator.

## 3. Every API refusal became "cannot resolve branch develop"

`gh_json` folded 404, 403 rate-limit and 401 into one `None`, so callers reported the **default** as the finding. Reproduced live while testing this: the tool printed *"cannot resolve branch develop"* while develop was fine and GitHub was simply refusing.

Rate-limit and auth failures are not partial data — every later call fails identically, so continuing yields a report built entirely of false negatives. Both now stop with a new `EXIT_UNMEASURED` (3), distinct from 0/1/2 so a gate treats it as "ask again" rather than scoring an unreadable API as a red build. A genuine 404 still returns `None`, because "does not exist" is an answer.

Verified end-to-end against the live limit:

```
UNMEASURED: GitHub is rate-limiting this token, so no verdict can be produced.
  failing path: repos/scitex-ai/scitex-agent-container/commits/develop
  `gh api rate_limit` may still show quota — the SECONDARY limit is invisible there.
exit=3
```

That last line is measured, not assumed: `gh api rate_limit` reported `remaining=4660/5000` at the same moment calls were being refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CmUd2ebDm5WHNWfTyZtEW
