### PR TITLE
fix(host): `host exec` let the remote shell re-split the user's argv

### DIFF
--- a/src/scitex_agent_container/cli_pkg/host_group.py
+++ b/src/scitex_agent_container/cli_pkg/host_group.py
@@ -13,6 +13,7 @@ of ``sac network probe`` / ``sac installation boot``.
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 import sys
 
@@ -187,7 +188,42 @@ def host_exec(peer: str, argv: tuple[str, ...]) -> None:
             "error: no command supplied. Try: sac host exec PEER -- <cmd>", err=True
         )
         raise SystemExit(2)
-    ssh_argv = build_ssh_argv(peer, list(argv), peers)
+    # QUOTE HERE, NOT IN build_ssh_argv. The two have different contracts and
+    # conflating them has already caused one outage.
+    #
+    # ssh word-joins every token after the host and hands the result to the
+    # remote LOGIN SHELL, which re-parses it. So `build_ssh_argv` takes an
+    # ALREADY-QUOTED remote command — callers like `_spec_handoff.ssh_runner`
+    # deliberately pass a single element such as `sh -c 'echo REACHED'`. On
+    # 2026-08-17 a `shlex.join` was added inside that function, quoted those
+    # already-quoted elements a second time, and produced rc=127 on every
+    # preamble peer ("bash: line 1: sh -c 'echo REACHED': command not found"),
+    # taking scitex-hub down and unstartable by any path.
+    #
+    # `sac host exec` is the opposite contract: `argv` is a list of ARGV WORDS
+    # typed by a human, and nothing has quoted them. Passing them raw let the
+    # remote shell re-split on metacharacters, which is silent and wrong rather
+    # than loud and wrong. Measured 2026-08-20 by scitex-cards, then reproduced
+    # here on scitex-compute-03:
+    #
+    #   sac host exec <peer> -- echo AAA-scitex-BBB '|' grep -cE 'scitex|cards'
+    #     -> bash: line 1: cards: command not found
+    #   sac host exec <peer> -- bash -lc 'echo AAA-scitex-BBB | grep -cE "..."'
+    #     -> 0        (the answer is 1)
+    #
+    # The second is the dangerous one: a mangled command returned a plausible
+    # NUMBER. They had counted 3 cron lines on that host minutes earlier, and
+    # only that contradiction made them re-check instead of reporting "no cron
+    # lines" as a measurement. This module's own `_run_peer_command` docstring
+    # already states the rule this violates — "a transport must never render
+    # 'I could not run it' identically to 'it ran and produced nothing'". This
+    # is the same rule with a number instead of an empty string.
+    #
+    # shlex.quote is a NO-OP on any word that needs no quoting, so the rendered
+    # argv is byte-identical for every invocation that was already correct.
+    # Only arguments carrying metacharacters change — exactly the broken ones.
+    quoted = [shlex.quote(word) for word in argv]
+    ssh_argv = build_ssh_argv(peer, quoted, peers)
     raise SystemExit(_run_peer_command(ssh_argv))
 
 

--- a/tests/scitex_agent_container/cli_pkg/test_host_group_exec_captures_output.py
+++ b/tests/scitex_agent_container/cli_pkg/test_host_group_exec_captures_output.py
@@ -29,6 +29,9 @@ PA-306: no mocks. Real `subprocess`, real child processes, real CliRunner.
 
 from __future__ import annotations
 
+import shlex
+import subprocess
+
 import click
 import pytest
 from click.testing import CliRunner
@@ -140,3 +143,79 @@ def test_stdout_and_stderr_are_not_merged_into_one_stream():
     result = _run(*argv)
     # Assert
     assert "DIAGNOSTIC" not in result.stdout
+
+
+# ----------------------------------------------------------------------
+# ARGUMENT BOUNDARIES MUST SURVIVE THE TRANSPORT
+#
+# The same rule as the top of this file, with a NUMBER instead of an empty
+# string. ssh word-joins every token after the host and hands the result to
+# the remote LOGIN SHELL, which re-parses it — so `host exec` must quote the
+# user's argv words or the remote shell re-splits them.
+#
+# Measured 2026-08-20 by scitex-cards, reproduced here on compute-03:
+#
+#   host exec <peer> -- echo AAA-scitex-BBB '|' grep -cE 'scitex|cards'
+#     -> bash: line 1: cards: command not found
+#   host exec <peer> -- bash -lc 'echo AAA-scitex-BBB | grep -cE "scitex|cards"'
+#     -> 0                                            (the answer is 1)
+#
+# The second is the dangerous one: a mangled command returned a plausible
+# number, and only a contradiction with an earlier count stopped it being
+# reported as a measurement.
+#
+# The quoting belongs in `host_exec`, NOT in `build_ssh_argv`: that function's
+# contract is an ALREADY-QUOTED remote command, and adding a join there on
+# 2026-08-17 double-quoted callers that pre-quote correctly and produced
+# rc=127 on every preamble peer, taking scitex-hub down.
+# ----------------------------------------------------------------------
+
+
+def _as_ssh_would_join(words: list[str]) -> str:
+    """What the remote login shell actually receives, per OpenSSH's word-join."""
+    return " ".join(shlex.quote(w) for w in words)
+
+
+@pytest.mark.parametrize(
+    "words",
+    [
+        ["hostname"],
+        ["sac", "db", "export"],
+        ["agent", "list", "--json"],
+    ],
+)
+def test_ordinary_words_render_byte_identically(words):
+    """Quoting must not perturb any invocation that was already correct."""
+    # Arrange — words carrying no shell metacharacters.
+    # Act
+    rendered = [shlex.quote(w) for w in words]
+    # Assert
+    assert rendered == words
+
+
+def test_a_metacharacter_argument_survives_the_remote_reparse():
+    """The exact shape that returned a wrong NUMBER against the live fleet."""
+    # Arrange — a pipe as its own word, and a regex alternation inside one.
+    words = ["echo", "AAA-scitex-BBB", "|", "grep", "-cE", "scitex|cards"]
+    # Act — join as ssh does, then let a REAL shell re-parse it (no mocks).
+    recovered = shlex.split(_as_ssh_would_join(words))
+    # Assert
+    assert recovered == words
+
+
+def test_the_remote_shell_runs_the_command_the_caller_wrote():
+    """End to end through a real child: the pipe must NOT take effect here.
+
+    With the words quoted, `|` is an ARGUMENT to echo, so echo prints it and
+    nothing is piped. Unquoted, the remote shell would treat it as a pipeline
+    and hunt for a command named `cards` — which is exactly what compute-03
+    reported before the fix.
+    """
+    # Arrange
+    joined = _as_ssh_would_join(["echo", "a", "|", "b"])
+    # Act
+    out = subprocess.run(
+        ["bash", "-c", joined], capture_output=True, text=True
+    ).stdout.strip()
+    # Assert
+    assert out == "a | b"


### PR DESCRIPTION
A mangled command came back as a plausible **number**, one contradiction away from being published as a measurement.

## Measured

scitex-cards hit it against compute-02; reproduced here on compute-03 with a control whose answer is known:

```
sac host exec <peer> -- echo AAA-scitex-BBB '|' grep -cE 'scitex|cards'
  -> bash: line 1: cards: command not found

sac host exec <peer> -- bash -lc 'echo AAA-scitex-BBB | grep -cE "scitex|cards"'
  -> 0                                                (the answer is 1)
```

The first is loud. **The second is the dangerous one** — `0` reads as "ran fine, found nothing". They had counted 3 cron lines on that host minutes earlier, and only that contradiction made them re-check instead of reporting "no cron lines on compute-02". A single measurement carries no reason to doubt itself.

`hostname` worked throughout, which is what made the tool look verified.

## Cause

ssh word-joins every token after the host and hands the result to the remote **login shell**, which re-parses it. `host exec` passed the user's argv words through unquoted, so `|` became a pipeline and `scitex|cards` became two words.

## The fix goes in `host_exec`, not `build_ssh_argv`

That distinction is load-bearing, and the existing comment is what stopped me repeating an outage.

`build_ssh_argv` takes an **already-quoted** remote command — callers like `_spec_handoff.ssh_runner` deliberately pass a single element such as `sh -c 'echo REACHED'`. A `shlex.join` added inside that function on 2026-08-17 quoted those a second time, produced `rc=127` on every preamble peer, and took scitex-hub down and unstartable by any path.

`host exec` is the opposite contract: `argv` is a list of words a human typed, and nothing has quoted them.

## Byte-compatible where it was already correct

`shlex.quote` is a no-op on any word needing no quoting:

| argv | rendered |
|---|---|
| `['hostname']` | unchanged |
| `['sac','db','export']` | unchanged |
| `['agent','list','--json']` | unchanged |
| `['echo','\|','grep',…]` | quoted (the broken case) |

**Verified live** against compute-03 through the real CLI: the control that returned `0` now returns `1`.

## What these tests do NOT pin — stated, not papered over

They fix the **invariant** (quote-then-join survives a real shell's re-parse, with a real child process, no mocks per PA-306) but not the **call site**. Deleting the `shlex.quote` in `host_exec` would leave them green, because the only way to observe that call site is to reach an ssh peer.

That is the "test that cannot fail" shape this very file's header warns about, so it is named here rather than hidden behind a green run. A call-site assertion needs a fake peer whose sshd records its argv — a separate change, not smuggled in.

16 passed in the transport suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CmUd2ebDm5WHNWfTyZtEW
