### PR TITLE
fix(listen): sac's card-event consumer has never been invoked in production

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -509,6 +509,62 @@ scitex-agent-container = "scitex_agent_container._store_plugin:provide"
 # filters for the card-event kinds and ignores everything else, incl.
 # sac's OWN liveness-tick anomaly events on the same bus. Bus-only
 # contract: no import of scitex_todo.
+# DECLARED IN BOTH GROUPS, and the duplication is the correct migration
+# state — not an oversight to tidy up later.
+#
+# MEASURED 2026-08-20 by scitex-cards: this consumer has NEVER been invoked in
+# production. The running notify daemon executes scitex-cards 0.42.0, whose
+# `_hooks/_plugins.py` reads `scitex_cards.hooks` and has ZERO references to
+# the retired group. sac was registered only under the retired name, so every
+# card event was dispatched to an EMPTY SET — succeeded, reported success,
+# called nobody. Corroborating symptoms, all explained by that one fact:
+#
+#     notifyd-liveness.json  last_delivery_at: null   never delivered, ever
+#     local inbox            150 rows, all unseen     enqueued, never pushed
+#     agents still get cards                          the PULL rail is separate
+#
+# Nothing anywhere reported a failure. That is the signature of this defect
+# class, and scitex-cards' own docstring recorded the identical state on
+# 2026-08-17 — the fix shipped in 0.48.0 and has never executed, because the
+# unit whose Description reads "supervised so a package upgrade actually
+# reaches it" points ExecStart at a hand-made venv that `pip install -U` never
+# touches.
+#
+# WHY BOTH RATHER THAN A MOVE. 0.42.0 (running now) reads only the new group,
+# so adding it revives delivery immediately. 0.48.0 reads both and dedupes, so
+# nothing double-fires. And leaving the retired entry in place preserves the
+# fleet's only registration under that name, which is what lets scitex-cards
+# verify the alias actually works when 0.48.0 finally runs — deleting it would
+# make "the alias works" indistinguishable from "nobody was left".
+#
+# THE NAME AND THE DOTTED PATH MUST STAY BYTE-IDENTICAL between the two
+# blocks. 0.48.0 dedupes on the tuple `(ep.name, ep.value)`:
+#
+#     seen  = {(ep.name, ep.value) for ep in current}
+#     extra = [ep for ep in retired if (ep.name, ep.value) not in seen]
+#
+# so renaming the entry or moving the callable on one side only turns the
+# alias meant to FIX delivery into a double-delivery bug. A migration is
+# exactly when tidying a name is tempting; do not, until the retired block
+# goes away entirely.
+#
+# C10 — sac's consumer on the shared card-event bus. When the board emits a
+# card-event (commented / created / reassigned / status_changed / completed /
+# committed / pushed / merged), this callable is invoked in the board's
+# process; it resolves the card's owner + collaborators + subscribers and
+# delivers the notification to each via the local ``sac listen`` daemon's
+# ``/v1/notify`` router endpoint — so a CONTAINERIZED owner-agent (whose a2a
+# port is unreachable inbound) still receives it. The consumer filters for the
+# card-event kinds and ignores everything else, incl. sac's OWN liveness-tick
+# anomaly events on the same bus. Bus-only contract: no import of the board
+# package.
+[project.entry-points."scitex_cards.hooks"]
+scitex-agent-container = "scitex_agent_container._listen._card_event_delivery:deliver_card_event"
+
+# The retired spelling, kept deliberately. See the note above: it is the
+# fleet's only registration under this group and therefore the only way to
+# verify the 0.48.0 alias when it runs. Remove it only once that verification
+# has happened and scitex-cards says the group is closed.
 [project.entry-points."scitex_todo.hooks"]
 scitex-agent-container = "scitex_agent_container._listen._card_event_delivery:deliver_card_event"
 


### PR DESCRIPTION
Fleet-wide, card notifications have **never** been delivered — and nothing anywhere reported a failure.

## Measured

scitex-cards read the running daemon's own venv:

```
scitex-cards 0.42.0 (RUNNING)
  ENTRY_POINT_GROUP = "scitex_cards.hooks"
  references to the retired group:  0        <- no alias

scitex-cards 0.48.0 (fleet venv, NOT running)
  RETIRED_ENTRY_POINT_GROUP = "scitex_todo.hooks"
  retired = _select_group(eps, ...)          <- reads both
```

sac declared this consumer **only** under the retired name. The daemon looked in `scitex_cards.hooks`, found nothing, dispatched every card event to an **empty set**, and reported success.

Symptoms that had been chased separately all reduce to that one fact:

| observation | explained by |
|---|---|
| `last_delivery_at: null` | never delivered, ever |
| inbox: 150 rows, all unseen | enqueued, never pushed |
| agents still received cards | the **pull** rail is independent and fine |

scitex-cards' own docstring records the identical state on 2026-08-17. The fix shipped in 0.48.0 and **has never executed**, because the unit whose Description reads *"supervised so a package upgrade actually reaches it"* points `ExecStart` at a hand-made venv that `pip install -U` never touches.

## Both groups, not a move

The duplication is the correct migration state:

- **0.42.0 is running now** and reads only the new group → adding it revives delivery immediately.
- **0.48.0 reads both and dedupes** → nothing double-fires.
- **Keeping the retired entry** preserves the fleet's only registration under that name — which is what lets scitex-cards verify the alias actually works when 0.48.0 runs. Delete it and *"the alias works"* becomes indistinguishable from *"nobody was left"*.

## The name and dotted path must stay byte-identical

0.48.0 dedupes on `(ep.name, ep.value)`:

```python
seen  = {(ep.name, ep.value) for ep in current}
extra = [ep for ep in retired if (ep.name, ep.value) not in seen]
```

Rename the entry or move the callable on one side only and the alias meant to **fix** delivery becomes a double-delivery bug. A migration is exactly when tidying a name is tempting. Verified after editing: both blocks parse to the same `{name: value}` mapping.

## On the evidence

The safety of dual registration was **not** taken on the 0.48.0 docstring's word — scitex-cards read 0.42.0's actual code, because a statement in one version's docs is not evidence about the version that is running. That distinction is the whole reason this defect survived three days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CmUd2ebDm5WHNWfTyZtEW
