### PR TITLE
fix(worktree-gc): an ignored file was not enough to keep a worktree, and git does not help

### DIFF
--- a/src/scitex_agent_container/_maintenance/_worktree_gc_predicate.py
+++ b/src/scitex_agent_container/_maintenance/_worktree_gc_predicate.py
@@ -2,9 +2,14 @@
 
 A worktree is removable **iff ALL FOUR** legs pass:
 
-1. **CLEAN** — ``git status --porcelain`` is empty. Untracked files count
-   as DIRTY: an untracked file is work saved nowhere else, which makes it
-   the most expensive thing in the tree, not the cheapest.
+1. **CLEAN** — ``git status --porcelain --ignored`` is empty. Untracked
+   AND IGNORED files count as DIRTY: either one is work saved nowhere
+   else, which makes it the most expensive thing in the tree, not the
+   cheapest. ``--ignored`` was missing until 2026-08-20 and its absence
+   was a data-loss bug — git refuses to remove a worktree over an
+   untracked file and removes one over an ignored file without comment,
+   so ignored content had neither this guard nor git's. See
+   :func:`is_clean` for the measurement and the controls.
 2. **MERGED** — the ancestor check (``rev-list --count <base>..<head>``
    is 0 against ``develop`` or ``main``) OR a MERGED PR exists for the
    branch. BOTH styles are required: a squash-merged branch is not an
@@ -51,14 +56,46 @@ __all__ = ["is_clean", "is_idle", "is_merged", "is_old_enough", "verdict_for"]
 
 
 def is_clean(path: str) -> tuple[bool | None, str]:
-    """Leg 1 — clean tree. Untracked files count as DIRTY.
+    """Leg 1 — clean tree. Untracked AND IGNORED files count as DIRTY.
 
     An unreadable tree returns ``None`` with the ``dirty`` reason: we
-    could not prove it clean, so it is kept. ``--porcelain`` lists
-    untracked files by default (no ``-uno``), and that default is the
-    behaviour we want, not an accident.
+    could not prove it clean, so it is kept.
+
+    ``--ignored`` IS THE LOAD-BEARING FLAG, and its absence was a data-loss
+    bug. This function used to run plain ``--porcelain`` and its docstring
+    said the untracked default "is the behaviour we want, not an accident" —
+    true, and it settled only ONE of the two axes a working tree can be
+    non-empty on. Measured 2026-08-20 with a control:
+
+        worktree holding only GITIGNORED/lessons.md
+          git status --porcelain              ''              -> read CLEAN
+          git status --porcelain --ignored    '!! GITIGNORED/'
+          git worktree remove (no --force)    rc=0            -> NOTES GONE
+
+        CONTROL, same position, an UNTRACKED file instead
+          git status --porcelain              '?? scratch.txt' -> read DIRTY
+          git worktree remove (no --force)    rc=128           -> refused
+
+    So untracked content has TWO independent protections — this predicate
+    and git itself — and ignored content had NEITHER. git declines to delete
+    a worktree over an untracked file and deletes one over an ignored file
+    without comment, which is the opposite of the intuition the old docstring
+    was resting on.
+
+    That gap lands exactly where this fleet keeps its notes. CLAUDE.md
+    instructs every agent to write ``GITIGNORED/tasks/todo.md`` and
+    ``GITIGNORED/tasks/lessons.md``; ``GITIGNORED/`` is ignored by name. And
+    ``worktree-gc`` runs unattended on a timer, so the removal would be
+    reported as routine housekeeping. This module's own header states the
+    trade it exists to make — "REMOVE destroys work that exists nowhere else.
+    We pick annoying." — and ignored files were the one class where it was
+    silently picking the other way.
+
+    Found by applying dotfiles' parallel finding (git refuses to overwrite an
+    untracked file on a merge and silently overwrites an ignored one) to this
+    package rather than only acknowledging it.
     """
-    ok, out = run_git(path, "status", "--porcelain")
+    ok, out = run_git(path, "status", "--porcelain", "--ignored")
     if not ok:
         return None, KEEP_DIRTY
     return (True, "") if not out.strip() else (False, KEEP_DIRTY)

--- a/tests/scitex_agent_container/_maintenance/test__worktree_gc_ignored_is_dirty.py
+++ b/tests/scitex_agent_container/_maintenance/test__worktree_gc_ignored_is_dirty.py
@@ -1,0 +1,121 @@
+"""An IGNORED file must keep a worktree alive, exactly like an untracked one.
+
+WHY THIS FILE EXISTS — a data-loss bug, measured 2026-08-20 with a control.
+
+`worktree-gc` removes a worktree that is clean + merged + idle + old enough,
+and it runs UNATTENDED on a timer. `is_clean` asked `git status --porcelain`,
+which reports untracked files and says nothing about ignored ones:
+
+    worktree holding only GITIGNORED/lessons.md
+      git status --porcelain              ''               -> read CLEAN
+      git status --porcelain --ignored    '!! GITIGNORED/'
+      git worktree remove (no --force)    rc=0             -> NOTES GONE
+
+    CONTROL, same position, an UNTRACKED file instead
+      git status --porcelain              '?? scratch.txt' -> read DIRTY
+      git worktree remove (no --force)    rc=128           -> refused
+
+So untracked content had TWO independent protections — the predicate AND git
+refusing — and ignored content had NEITHER. The intuition the old code rested
+on is backwards: git guards the untracked file and deletes over the ignored
+one without comment.
+
+The gap lands where this fleet keeps its notes: CLAUDE.md instructs every
+agent to write `GITIGNORED/tasks/todo.md` and `GITIGNORED/tasks/lessons.md`,
+and `GITIGNORED/` is ignored by name. The module's header states the trade it
+means to make — "REMOVE destroys work that exists nowhere else. We pick
+annoying." — and this was the one class where it silently picked the other way.
+
+THE CONTROLS ARE THE POINT, not decoration. A test that only asserts the
+ignored case would pass against a predicate that called EVERYTHING dirty,
+which would disable the gc entirely and look like a fix. The untracked arm
+pins the pre-existing behaviour and the empty arm pins that a genuinely empty
+worktree is still collectable.
+
+PA-306: no mocks. Real `git init`, real worktrees, real ignored files.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._maintenance._worktree_gc_predicate import is_clean
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real repo whose .gitignore covers GITIGNORED/, as every fleet repo does."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q", str(root)], capture_output=True)
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "t")
+    (root / ".gitignore").write_text("GITIGNORED/\n")
+    _git(root, "add", ".gitignore")
+    _git(root, "commit", "-qm", "init")
+    return root
+
+
+def _worktree(repo: Path, name: str) -> Path:
+    path = repo.parent / name
+    _git(repo, "worktree", "add", "-q", "-b", name, str(path))
+    return path
+
+
+def test_a_worktree_holding_only_ignored_notes_is_not_clean(repo: Path):
+    """The bug: agent notes read as an empty tree and were collected."""
+    # Arrange — exactly what CLAUDE.md tells agents to write.
+    wt = _worktree(repo, "ignored-only")
+    (wt / "GITIGNORED").mkdir()
+    (wt / "GITIGNORED" / "lessons.md").write_text("hours of notes\n")
+    # Act
+    clean, _reason = is_clean(str(wt))
+    # Assert
+    assert clean is False
+
+
+def test_an_untracked_file_still_keeps_the_worktree(repo: Path):
+    """CONTROL — the behaviour that already worked must not regress."""
+    # Arrange
+    wt = _worktree(repo, "untracked-only")
+    (wt / "scratch.txt").write_text("x\n")
+    # Act
+    clean, _reason = is_clean(str(wt))
+    # Assert
+    assert clean is False
+
+
+def test_a_genuinely_empty_worktree_is_still_collectable(repo: Path):
+    """CONTROL — the fix must not disable the gc by calling everything dirty."""
+    # Arrange
+    wt = _worktree(repo, "empty")
+    # Act
+    clean, _reason = is_clean(str(wt))
+    # Assert
+    assert clean is True
+
+
+def test_git_itself_would_have_deleted_the_ignored_notes(repo: Path):
+    """Pins WHY the predicate must catch this: git does not.
+
+    Without this, a reader could assume `git worktree remove` refuses over any
+    leftover content and treat the predicate as belt-and-braces. It refuses for
+    untracked files and not for ignored ones, which is the whole asymmetry.
+    """
+    # Arrange
+    wt = _worktree(repo, "git-would-delete")
+    (wt / "GITIGNORED").mkdir()
+    (wt / "GITIGNORED" / "lessons.md").write_text("hours of notes\n")
+    # Act
+    removed = _git(repo, "worktree", "remove", str(wt))
+    # Assert
+    assert removed.returncode == 0


### PR DESCRIPTION
**Data loss, live until now, in the unattended path.** `worktree-gc` removes a worktree that is clean + merged + idle + old enough — and `is_clean` asked `status --porcelain`, which says nothing about **ignored** files.

## Measured, with a control

```
worktree holding only GITIGNORED/lessons.md
  status --porcelain              ''               -> read CLEAN
  status --porcelain --ignored    '!! GITIGNORED/'
  worktree remove (no --force)    rc=0             -> NOTES GONE

CONTROL, same position, an UNTRACKED file instead
  status --porcelain              '?? scratch.txt' -> read DIRTY
  worktree remove (no --force)    rc=128           -> refused
```

Untracked content had **two** independent protections — this predicate *and* git refusing — and ignored content had **neither**. The asymmetry runs opposite to intuition: git guards the untracked file and deletes over the ignored one without comment.

## Where it lands

CLAUDE.md instructs every agent in this fleet to write `GITIGNORED/tasks/todo.md` and `GITIGNORED/tasks/lessons.md`. `GITIGNORED/` is ignored by name. So **the files the instructions create are exactly the class with no protection**, and the timer would have reported the removal as routine housekeeping.

The module's header states the trade it exists to make — *"REMOVE destroys work that exists nowhere else. We pick annoying."* — and this was the one class where it silently picked the other way.

## The old docstring is the instructive part

> `--porcelain` "lists untracked files by default (no `-uno`), and that default is the behaviour we want, not an accident."

Every word true. It settles **one** of the two axes on which a tree can be non-empty, while reading as a considered decision about emptiness in general. A confident note about the axis you *did* check is how the axis you did not check stays invisible.

## Found by transfer, not by review

dotfiles reported the mirror defect in their sync — git refuses to overwrite an untracked file on a merge and silently overwrites an ignored one — and asked whether anything here decides "clean, so safe to overwrite". Two candidates existed. **This one is worse than theirs: it deletes rather than overwrites.**

## Verification

Mutation-checked rather than assumed: restoring the plain `--porcelain` call reddens **exactly** the ignored arm (1 failed, 3 passed) and leaves both controls green — so the fix is not "call everything dirty", which would disable the GC and look like a fix. File restored byte-identical afterwards.

Four tests, real repos and real worktrees, no mocks (PA-306). One pins that **git itself** would have deleted the notes, because otherwise a reader may assume `worktree remove` is a second line of defence. It is not.

373 passed in the `_maintenance` suite.

## Still open, named rather than silently left

`cron/post-merge-pull.sh` gates a pull on `status --porcelain` and has the same blind spot. It overwrites rather than deletes, so it is dotfiles' exact shape; not fixed here because it is a shell path with its own test story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CmUd2ebDm5WHNWfTyZtEW
