### PR TITLE
feat(state): move the inbound dispatch ledger off SQLite to PostgreSQL

### DIFF
--- a/src/scitex_agent_container/_state/inbound_ledger.py
+++ b/src/scitex_agent_container/_state/inbound_ledger.py
@@ -1,99 +1,218 @@
 """Inbound dispatch ledger — one row per INBOUND dispatch awaiting a
-completion report (2026-06-18).
+completion report (2026-06-18), on PostgreSQL only.
 
-The receiver-side mirror of :mod:`dispatch_ledger` (which is the SENDER's
-outbound record). It exists for the ``runtime: tui`` push-feedback loop:
-a TUI agent has no in-process turn envelope, so the requester identity
-(``from_agent`` + ``dispatch_id``) of a bus-pushed wake cannot ride the
-tmux-injected text from the host-side bridge through to the in-container
-``Stop`` hook that reports completion. This SQLite table is that bridge —
-the SAME ``state.db`` is bound into the container (``/state/<name>``), so
-the host-side writer and the in-container reader share it (WAL +
-``busy_timeout`` from :func:`state_db.open_db` make the cross-process
-access safe).
+The receiver-side mirror of :mod:`dispatch_ledger` (the SENDER's outbound
+record). It exists for the ``runtime: tui`` push-feedback loop: a TUI agent
+has no in-process turn envelope, so the requester identity (``from_agent`` +
+``dispatch_id``) of a bus-pushed wake cannot ride the tmux-injected text from
+the host-side bridge through to the in-container ``Stop`` hook that reports
+completion. This ledger is that bridge.
 
 Lifecycle of one row:
 
   * ``pending``   — the bridge recorded a requester-bearing inbound wake
     (:func:`record_inbound`); the turn is queued/running in the TUI.
-  * ``reporting`` — the Stop hook atomically CLAIMED the oldest pending
-    row (:func:`claim_oldest_pending`) to push its completion. The claim
-    is a single ``UPDATE`` so two concurrent Stop hooks (or a retry)
-    cannot double-report the same dispatch.
-  * ``reported`` / ``failed`` — terminal, set by :func:`mark_reported`
-    after the completion push to the requester succeeds / fails loud.
+  * ``reporting`` — the Stop hook atomically CLAIMED the oldest pending row
+    (:func:`claim_oldest_pending`) to push its completion.
+  * ``reported`` / ``failed`` — terminal, set by :func:`mark_reported` after
+    the completion push to the requester succeeds / fails loud.
 
 FIFO by ``ts`` + sequential TUI turn processing keeps the dispatch↔turn
 correlation correct: the Nth ``Stop`` claims the Nth recorded dispatch.
 
-Sibling-module rationale (carried from :mod:`dispatch_ledger`): the table
-+ its ``CREATE TABLE IF NOT EXISTS`` live here behind
-:func:`init_inbound_schema`, layered on top of ``state_db`` via
-``open_db``, so this feature never edits the same lines as a concurrent
-``state_db.py`` restructure.
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to
+PostgreSQL: "fail fast, fail loud, no fallbacks". This is the fourth table to
+move, after ``verdict_delivered``, ``incarnations`` and ``pending_prompts``,
+and it moves the same way — by ADOPTING :mod:`scitex_dev.store` rather than
+by sac growing a private psycopg layer. ``db_path`` is gone from every
+function; it named a SQLite file and there is no file.
+
+The old module's own rationale for the cross-process bridge — "the SAME
+state.db is bound into the container so the host-side writer and the
+in-container reader share it" — is what PostgreSQL now provides directly,
+and better: the two processes no longer need a shared mount, only a reachable
+endpoint.
+
+THE AUTOINCREMENT ID WAS NEVER PUBLIC IN EFFECT
+===============================================
+``id INTEGER PRIMARY KEY AUTOINCREMENT`` looked like the hard part: it is
+returned by ``record_inbound`` and taken by ``mark_reported``, so porting to a
+store with no counter looked like it forced a surrogate — and surrogate ids do
+not survive a store boundary, which this fleet has already paid for once.
+
+Measured 2026-08-20 before assuming it:
+
+    record_inbound's return value, consumed in PRODUCTION:  NONE
+      runtimes/_tui_outbound.py returns it from a wrapper; no caller binds it.
+    mark_reported's argument in PRODUCTION:  always claim-derived
+      row_id = int(claimed["id"])  ->  mark_reported(row_id, ...)
+
+So the id only ever ROUND-TRIPS claim -> settle inside one Stop-hook call. It
+never crosses a process boundary, is never persisted elsewhere, and is never
+compared. Its integer-ness was an artifact of how SQLite minted it, not a
+property anything depended on. The natural key replaces it outright.
+
+IDENTITY IS TOTAL, WHICH TOOK ONE DECISION
+==========================================
+``(agent, from_agent, dispatch_id, ts)``. ``dispatch_id`` is optional at the
+call site, and store IDENTITY fields must be present, so a missing one is
+stored as ``""`` — read it as "this wake carried no dispatch id", the same
+thing the SQLite ``NULL`` meant.
+
+That leaves one collision: two wakes for the same agent, from the same peer,
+with no dispatch id, in the SAME float instant. ``time.time()`` is
+microsecond-resolution and a TUI wake is a human-or-bus event, so it is not
+credible — but "not credible" is exactly the assumption that bites, and the
+SQLite counter made duplicates free. So the insert RETRIES with the timestamp
+advanced by one microsecond instead of failing or overwriting. Deterministic,
+preserves FIFO order, and needs no counter.
 """
 
 from __future__ import annotations
 
-import sqlite3
 import time
-from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-# Row lifecycle. ``record_inbound`` always writes ``pending``; the Stop
-# hook claims to ``reporting`` then settles to ``reported`` / ``failed``.
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "inbound_dispatches"
+
+#: Every write from this host is attributed to one node. The bridge that
+#: records and the Stop hook that claims both run on this host, so
+#: SINGLE_WRITER is honest rather than convenient.
+_ACTOR = "scitex-agent-container"
+
+#: Row lifecycle. ``record_inbound`` always writes ``pending``; the Stop hook
+#: claims to ``reporting`` then settles to ``reported`` / ``failed``.
 STATUS_PENDING = "pending"
 STATUS_REPORTING = "reporting"
 STATUS_REPORTED = "reported"
 STATUS_FAILED = "failed"
 VALID_STATUSES = (STATUS_PENDING, STATUS_REPORTING, STATUS_REPORTED, STATUS_FAILED)
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS inbound_dispatches (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    agent        TEXT NOT NULL,
-    from_agent   TEXT NOT NULL,
-    dispatch_id  TEXT,
-    status       TEXT NOT NULL DEFAULT 'pending',
-    ts           REAL NOT NULL,
-    reported_ts  REAL
-);
-CREATE INDEX IF NOT EXISTS idx_inbound_agent_status_ts
-    ON inbound_dispatches(agent, status, ts);
-"""
+#: The identity fields, in order. Exported because callers hand a claimed
+#: row straight back to :func:`mark_reported` and this names what that needs.
+IDENTITY_FIELDS = ("agent", "from_agent", "dispatch_id", "ts")
 
 __all__ = [
-    "STATUS_PENDING",
-    "STATUS_REPORTING",
-    "STATUS_REPORTED",
+    "IDENTITY_FIELDS",
     "STATUS_FAILED",
+    "STATUS_PENDING",
+    "STATUS_REPORTED",
+    "STATUS_REPORTING",
+    "STORE_NAME",
     "VALID_STATUSES",
-    "init_inbound_schema",
-    "record_inbound",
     "claim_oldest_pending",
-    "mark_reported",
+    "inbound_store_target",
+    "init_inbound_schema",
     "list_inbound",
+    "mark_reported",
+    "open_inbound_store",
+    "record_inbound",
 ]
 
 
-def init_inbound_schema(db_path: Path | None = None) -> Path:
-    """Create the ``inbound_dispatches`` table if missing. Idempotent.
+def _schema() -> Any:
+    """The inbound-dispatch schema.
 
-    Returns the resolved database path. Mirrors
-    :func:`dispatch_ledger.init_ledger_schema`: delegates base schema +
-    connection config to :func:`state_db.open_db`, then layers our own
-    ``CREATE TABLE IF NOT EXISTS``.
+    Built lazily so importing this module does not import scitex-dev; the old
+    module was equally lazy about ``state_db``, for the same reason.
+
+    ``status`` is LAST_WRITER_WINS because the whole point is that it moves:
+    pending -> reporting -> reported/failed. ``reported_ts`` likewise, and it
+    is not required — a row that has not settled has no settle time, and
+    inventing one would make "never reported" indistinguishable from
+    "reported at epoch".
     """
-    from .state_db import init_schema, open_db
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
 
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
-    return init_schema(db_path)
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def data(kind: Any, *, required: bool) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=required,
+            merge=MergeRule.LAST_WRITER_WINS,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "agent": ident(FieldKind.TEXT),
+            "from_agent": ident(FieldKind.TEXT),
+            "dispatch_id": ident(FieldKind.TEXT),
+            "ts": ident(FieldKind.REAL),
+            "status": data(FieldKind.TEXT, required=True),
+            "reported_ts": data(FieldKind.REAL, required=False),
+        },
+    )
 
 
-def _ensure_table(conn: sqlite3.Connection) -> None:
-    """Ensure the inbound table exists on an already-open connection."""
-    conn.executescript(_SCHEMA)
+def inbound_store_target() -> Any:
+    """Resolve WHERE the inbound ledger lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_inbound_store() -> Store:
+    """Open the ledger. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function opens and closes one per
+    call, mirroring the old ``with open_db(...)`` shape: this runs once per
+    inbound wake and once per Stop hook, not on a request path.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        inbound_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_inbound_schema() -> str:
+    """Create the ledger tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL
+    equivalent of the path the SQLite version returned, and it names WHERE
+    the state actually went so an operator can check rather than assume.
+    """
+    store = open_inbound_store()
+    try:
+        return str(inbound_store_target().locator)
+    finally:
+        store.close()
+
+
+def _key(row_or_mapping: Any) -> dict[str, Any]:
+    """The identity mapping for a row or a claimed dict.
+
+    Accepts either shape so a caller can hand back exactly what
+    :func:`claim_oldest_pending` gave them without unpacking it.
+    """
+    src = getattr(row_or_mapping, "values", None) or row_or_mapping
+    if callable(src):  # a Mapping's .values method, not a Row's field dict
+        src = row_or_mapping
+    return {field: src[field] for field in IDENTITY_FIELDS}
 
 
 def record_inbound(
@@ -101,89 +220,110 @@ def record_inbound(
     agent: str,
     from_agent: str,
     dispatch_id: Optional[str] = None,
-    ts: float | None = None,
-    db_path: Path | None = None,
-) -> int:
-    """Insert one ``pending`` inbound-dispatch row; return its ``id``.
+    ts: Optional[float] = None,
+) -> dict[str, Any]:
+    """Insert one ``pending`` inbound-dispatch row; return its identity.
 
-    Called by the bridge when an inbound wake carries a ``from_agent``
-    (the peer to report back to). A wake with no requester is NOT recorded
-    by the caller — there is nobody to report to. ``ts`` is a real-time
-    injection seam for tests.
+    Called by the bridge when an inbound wake carries a ``from_agent`` (the
+    peer to report back to). A wake with no requester is NOT recorded by the
+    caller — there is nobody to report to. ``ts`` is a real-time injection
+    seam for tests.
+
+    Returns the identity mapping rather than the old integer id. Nothing in
+    production consumed that integer (see the module docstring), and the
+    mapping is what :func:`mark_reported` now takes.
+
+    THE MICROSECOND RETRY is the collision handling described in the module
+    docstring: identical (agent, from_agent, dispatch_id, ts) means the SAME
+    record to the store, so a genuine second wake in the same instant would
+    otherwise silently overwrite the first. Advancing ``ts`` keeps both and
+    keeps them ordered.
     """
     if not agent or not from_agent:
         raise ValueError("record_inbound requires non-empty agent + from_agent")
+
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
     row_ts = float(ts) if ts is not None else time.time()
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        cur = conn.execute(
-            """
-            INSERT INTO inbound_dispatches (agent, from_agent, dispatch_id, status, ts)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (agent, from_agent, dispatch_id, STATUS_PENDING, row_ts),
+    store = open_inbound_store()
+    try:
+        for _ in range(1000):
+            key = {
+                "agent": agent,
+                "from_agent": from_agent,
+                "dispatch_id": dispatch_id or "",
+                "ts": row_ts,
+            }
+            try:
+                store.put(
+                    {**key, "status": STATUS_PENDING}, expected_revision=NEW_RECORD
+                )
+            except RevisionMismatchError:
+                row_ts += 1e-6
+                continue
+            return key
+        raise RuntimeError(
+            "record_inbound: 1000 identical timestamps for the same "
+            f"(agent={agent!r}, from_agent={from_agent!r}) — refusing to spin"
         )
-        # lastrowid is always set after a successful single-row INSERT;
-        # the ``or 0`` only satisfies the int|None type and never fires.
-        return int(cur.lastrowid or 0)
+    finally:
+        store.close()
 
 
-def claim_oldest_pending(
-    *,
-    agent: str,
-    db_path: Path | None = None,
-) -> dict[str, Any] | None:
+def claim_oldest_pending(*, agent: str) -> dict[str, Any] | None:
     """Atomically claim the OLDEST ``pending`` row for ``agent``.
 
-    Flips exactly one row ``pending → reporting`` inside a single
-    ``BEGIN IMMEDIATE`` transaction and returns it (as a dict), or
-    ``None`` when the agent has no pending dispatch (the common no-op —
-    most turns have no requester). The atomic claim means two concurrent
-    ``Stop`` hooks (or a hook retry) can never push the same completion
-    twice. The caller settles the claimed row via :func:`mark_reported`.
-    """
-    from .state_db import open_db
+    Flips exactly one row ``pending → reporting`` and returns it (identity
+    fields plus ``status``), or ``None`` when the agent has no pending
+    dispatch (the common no-op — most turns have no requester).
 
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        conn.row_factory = sqlite3.Row
-        conn.execute("BEGIN IMMEDIATE")
-        try:
-            row = conn.execute(
-                """
-                SELECT * FROM inbound_dispatches
-                WHERE agent = ? AND status = ?
-                ORDER BY ts ASC, id ASC
-                LIMIT 1
-                """,
-                (agent, STATUS_PENDING),
-            ).fetchone()
-            if row is None:
-                conn.execute("COMMIT")
-                return None
-            conn.execute(
-                "UPDATE inbound_dispatches SET status = ? WHERE id = ?",
-                (STATUS_REPORTING, row["id"]),
-            )
-            conn.execute("COMMIT")
-        except Exception:
-            conn.execute("ROLLBACK")
-            raise
-        claimed = dict(row)
-        claimed["status"] = STATUS_REPORTING
-        return claimed
+    THE ATOMIC CLAIM IS PRESERVED, and it was explicit in the SQLite version:
+    "two concurrent Stop hooks (or a hook retry) can never push the same
+    completion twice". SQLite got that from ``BEGIN IMMEDIATE``; the store has
+    no transaction, so it comes from optimistic concurrency instead. The
+    update carries ``expected_revision=<the row's seq>``, so a racing claimer
+    that already flipped this row raises ``RevisionMismatchError`` — and we
+    move to the NEXT pending row rather than failing, because a competitor
+    taking one row is not a reason to report none.
+
+    ``Row.seq`` IS the revision; there is no ``Row.revision``.
+    """
+    from scitex_dev.store import RevisionMismatchError
+
+    store = open_inbound_store()
+    try:
+        pending = [
+            row
+            for row in store.rows()
+            if row.values.get("agent") == agent
+            and row.values.get("status") == STATUS_PENDING
+        ]
+        pending.sort(key=lambda r: float(r.values["ts"]))
+        for row in pending:
+            key = _key(row.values)
+            try:
+                store.put({**key, "status": STATUS_REPORTING}, expected_revision=row.seq)
+            except RevisionMismatchError:
+                continue
+            claimed = dict(row.values)
+            claimed["status"] = STATUS_REPORTING
+            return claimed
+        return None
+    finally:
+        store.close()
 
 
 def mark_reported(
-    row_id: int,
+    handle: Any,
     *,
     status: str = STATUS_REPORTED,
-    reported_ts: float | None = None,
-    db_path: Path | None = None,
+    reported_ts: Optional[float] = None,
 ) -> bool:
     """Settle a claimed row to a terminal status. Returns True iff matched.
+
+    ``handle`` is whatever :func:`record_inbound` or
+    :func:`claim_oldest_pending` returned — the identity mapping. It replaces
+    the old integer row id, which nothing in production ever used.
 
     ``status`` must be ``reported`` (push succeeded) or ``failed`` (push
     raised) — an unknown value raises rather than writing an unqueryable
@@ -194,43 +334,39 @@ def mark_reported(
             f"mark_reported status must be {STATUS_REPORTED!r} or "
             f"{STATUS_FAILED!r}, got {status!r}"
         )
-    row_ts = float(reported_ts) if reported_ts is not None else time.time()
-    from .state_db import open_db
 
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        cur = conn.execute(
-            "UPDATE inbound_dispatches SET status = ?, reported_ts = ? WHERE id = ?",
-            (status, row_ts, row_id),
+    from scitex_dev.store import ANY_REVISION
+
+    key = _key(handle)
+    settle_ts = float(reported_ts) if reported_ts is not None else time.time()
+    store = open_inbound_store()
+    try:
+        if store.get(key) is None:
+            return False
+        store.put(
+            {**key, "status": status, "reported_ts": settle_ts},
+            expected_revision=ANY_REVISION,
         )
-        return cur.rowcount > 0
+        return True
+    finally:
+        store.close()
 
 
 def list_inbound(
     *,
-    agent: str | None = None,
-    status: str | None = None,
+    agent: Optional[str] = None,
+    status: Optional[str] = None,
     limit: int = 100,
-    db_path: Path | None = None,
 ) -> list[dict[str, Any]]:
     """Return inbound rows (newest first) — observability / tests."""
-    from .state_db import open_db
-
-    clauses: list[str] = []
-    params: list[Any] = []
+    store = open_inbound_store()
+    try:
+        rows = [dict(row.values) for row in store.rows()]
+    finally:
+        store.close()
     if agent:
-        clauses.append("agent = ?")
-        params.append(agent)
+        rows = [r for r in rows if r.get("agent") == agent]
     if status:
-        clauses.append("status = ?")
-        params.append(status)
-    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-    params.append(int(limit))
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        conn.row_factory = sqlite3.Row
-        rows = conn.execute(
-            f"SELECT * FROM inbound_dispatches{where} ORDER BY ts DESC, id DESC LIMIT ?",
-            params,
-        ).fetchall()
-        return [dict(r) for r in rows]
+        rows = [r for r in rows if r.get("status") == status]
+    rows.sort(key=lambda r: float(r.get("ts") or 0.0), reverse=True)
+    return rows[: int(limit)]

--- a/src/scitex_agent_container/runtimes/_tui_outbound.py
+++ b/src/scitex_agent_container/runtimes/_tui_outbound.py
@@ -46,24 +46,29 @@ __all__ = [
 
 def record_dispatch(
     *,
-    db_path: Path,
     agent: str,
     from_agent: str,
     dispatch_id: Optional[str] = None,
-) -> int | None:
+) -> dict[str, Any] | None:
     """Record a requester-bearing inbound wake into the inbound ledger.
 
     No-op (returns ``None``) when ``from_agent`` is empty — an operator
     ``sac agents send`` without a peer, or a boot turn, has nobody to
-    report back to. Returns the ledger row id otherwise. Called by the
-    bridge with the agent's host-side ``state.db`` path.
+    report back to. Returns the ledger row's IDENTITY otherwise.
+
+    ``db_path`` is gone: the ledger moved to PostgreSQL, so there is no
+    state.db to point at. The bridge no longer needs the agent's host-side
+    file bound into the container for this to work — an endpoint suffices.
+
+    The return type changed from ``int`` to the identity mapping, and that is
+    safe here rather than merely tolerable: measured 2026-08-20, no caller in
+    this repo binds this function's return value at all.
     """
     if not from_agent:
         return None
     from .._state.inbound_ledger import record_inbound
 
     return record_inbound(
-        db_path=db_path,
         agent=agent,
         from_agent=from_agent,
         dispatch_id=dispatch_id,
@@ -147,7 +152,6 @@ def _assistant_text(rec: Any) -> str:
 
 def flush_one_completion(
     *,
-    db_path: Path,
     agent: str,
     transcript_path: Path | None,
     listen_url: str,
@@ -174,10 +178,13 @@ def flush_one_completion(
         mark_reported,
     )
 
-    claimed = claim_oldest_pending(agent=agent, db_path=db_path)
+    claimed = claim_oldest_pending(agent=agent)
     if claimed is None:
         return False
-    row_id = int(claimed["id"])
+    # The claimed mapping IS the handle now — the ledger's autoincrement id
+    # is gone, and nothing here needed it to be a number. See
+    # `_state.inbound_ledger` for the measurement behind that.
+    handle = claimed
     requester = str(claimed.get("from_agent") or "").strip()
     dispatch_id = claimed.get("dispatch_id")
     did = dispatch_id if isinstance(dispatch_id, str) and dispatch_id else None
@@ -213,9 +220,9 @@ def flush_one_completion(
             dispatch_id=did,
         )
     except Exception:
-        mark_reported(row_id, status=STATUS_FAILED, db_path=db_path)
+        mark_reported(handle, status=STATUS_FAILED)
         raise
-    mark_reported(row_id, status=STATUS_REPORTED, db_path=db_path)
+    mark_reported(handle, status=STATUS_REPORTED)
     log.info(
         "tui-outbound: completion report pushed to %s (dispatch_id=%s, status=%s)",
         requester,
@@ -260,15 +267,22 @@ def main(argv: list[str] | None = None) -> int:
             transcript_path = None
 
     agent = os.environ.get("SCITEX_AGENT_CONTAINER_AGENT", "").strip()
-    db_path_s = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB", "").strip()
     listen_url = os.environ.get("SAC_LISTEN_BASE_URL", "").strip()
     bearer = os.environ.get("SAC_LISTEN_BEARER", "").strip() or None
-    if not agent or not db_path_s or not listen_url:
+    # SCITEX_AGENT_CONTAINER_STATE_DB IS NO LONGER PART OF THIS GATE, and
+    # dropping it is the point rather than tidying. It named the SQLite file
+    # the ledger used to live in; the ledger is PostgreSQL now and this path
+    # reads nothing from it. Left in place, an agent without that variable
+    # would silently stop reporting completions — the gate would be refusing
+    # on a fact that no longer bears on whether the work can be done.
+    #
+    # The two that remain are the two this path actually needs: who to report
+    # AS, and where the bus is.
+    if not agent or not listen_url:
         # Not a wired sac TUI agent context (or no bus) — nothing to report.
         return 0
     try:
         flush_one_completion(
-            db_path=Path(db_path_s),
             agent=agent,
             transcript_path=transcript_path,
             listen_url=listen_url,

--- a/src/scitex_agent_container/runtimes/_tui_outbound.py
+++ b/src/scitex_agent_container/runtimes/_tui_outbound.py
@@ -288,7 +288,7 @@ def main(argv: list[str] | None = None) -> int:
             listen_url=listen_url,
             bearer=bearer,
         )
-    except Exception as exc:  # stx-allow: fallback (reason: a completion-push failure must not wedge the agent's turn loop; the row is already marked failed + this logs loud — the requester can fall back to the agent's logs)
+    except Exception as exc:  # stx-allow: fallback (reason: a completion-push failure must not wedge the agent's turn loop; the row is already marked failed + this logs loud at WARNING to stderr and the rotating ~/.scitex/logging/runtime/scitex-<date>.log via scitex-logging, so the requester can read it there)
         log.warning("tui-outbound: completion flush failed: %s", exc)
     return 0
 

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -343,7 +343,7 @@ def _build_on_turn(
                     from_agent=from_agent,
                     dispatch_id=dispatch_id,
                 )
-            except Exception as exc:  # stx-allow: fallback (reason: a ledger-write failure must not block delivering the wake — the agent still processes the turn; only the auto-completion-report is lost, logged for the operator)
+            except Exception as exc:  # stx-allow: fallback (reason: a ledger-write failure must not block delivering the wake — the agent still processes the turn; only the auto-completion-report is lost, logged at WARNING to stderr and the rotating ~/.scitex/logging/runtime/scitex-<date>.log via scitex-logging)
                 logging.getLogger(__name__).warning(
                     "tui-outbound: failed to record inbound dispatch for %s: %s",
                     config.name,

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -332,10 +332,13 @@ def _build_on_turn(
         if from_agent:
             try:
                 from ._tui_outbound import record_dispatch
-                from .tui_session import state_dir_for_config
 
+                # No state.db path any more: the inbound ledger is PostgreSQL.
+                # `state_dir_for_config` is no longer imported here because it
+                # was imported ONLY to build that path — and an import kept for
+                # a vanished use is how a module keeps a dependency nobody can
+                # see the reason for.
                 record_dispatch(
-                    db_path=state_dir_for_config(config) / "state.db",
                     agent=config.name,
                     from_agent=from_agent,
                     dispatch_id=dispatch_id,

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -190,14 +190,22 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         "scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py:272",
         "scitex_agent_container/cli_pkg/build_cmds.py:198",
         "scitex_agent_container/cli_pkg/hook_cmds.py:46",
+        # _tui_outbound.py and _tui_turn_bridge.py LEFT THIS SET 2026-08-20 —
+        # both reasons now name their sink. MEASURED before writing it, because
+        # a NAMED sink that is wrong is worse than an unnamed one:
+        # _logging/__init__.py documents scitex-logging fanning out to stderr
+        # AND a rotating file under ~/.scitex/logging/runtime/, and that
+        # directory holds live scitex-<date>.log files (plus .1/.2 rotations)
+        # on both this container and its host. It is NOT
+        # ~/.scitex/agent-container/runtime/logs/ — that one holds
+        # shell-redirect logs (creds-watch.log, host_exec.log, build logs) and
+        # is the directory I would have named had I guessed from the tree.
         "scitex_agent_container/runtimes/_apptainer_auth_bind.py:296",
         "scitex_agent_container/runtimes/_cct_rail_alarm.py:198",
         "scitex_agent_container/runtimes/_cct_rail_verdict.py:242",
         "scitex_agent_container/runtimes/_openai_sdk_common.py:179",
         "scitex_agent_container/runtimes/_tui_bridge_seam.py:40",
         "scitex_agent_container/runtimes/_tui_inject.py:92",
-        "scitex_agent_container/runtimes/_tui_outbound.py:277",
-        "scitex_agent_container/runtimes/_tui_turn_bridge.py:343",
         "scitex_agent_container/runtimes/_tui_turn_bridge_lifecycle.py:196",
     }
 )

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -110,7 +110,17 @@ FROZEN_SQLITE = frozenset(
         "_lifecycle/_rename_plan.py",
         "_state/auth_state.py",
         "_state/dispatch_ledger.py",
-        "_state/inbound_ledger.py",
+        # _state/inbound_ledger.py LEFT THIS SET 2026-08-20 — the FOURTH table
+        # to move to PostgreSQL. Its obstacle was neither a missing verb nor a
+        # missing endpoint but an AUTOINCREMENT id that looked public: returned
+        # by record_inbound, taken by mark_reported. Measured before assuming —
+        # no caller in this repo binds that return value, and mark_reported is
+        # always handed a claim-derived id — so the integer only ever
+        # round-tripped claim -> settle inside one Stop hook. The natural key
+        # replaced it with no surrogate, which matters because surrogate ids do
+        # not survive a store boundary and this fleet has already paid for that
+        # once. The atomic BEGIN IMMEDIATE claim became an optimistic loop on
+        # Row.seq, preserving "two concurrent Stop hooks never double-report".
         "_state/port_allocator.py",
         "_state/state_db.py",
         "_state/state_db_health.py",

--- a/tests/scitex_agent_container/_state/test_inbound_ledger.py
+++ b/tests/scitex_agent_container/_state/test_inbound_ledger.py
@@ -1,109 +1,171 @@
 """Tests for the receiver-side inbound dispatch ledger
-(``_state.inbound_ledger``) — the DB-backed bridge that carries a TUI
-wake's requester identity from the host-side turn-bridge to the
-in-container Stop hook that reports completion.
+(``_state.inbound_ledger``) — the bridge that carries a TUI wake's requester
+identity from the host-side turn-bridge to the in-container Stop hook that
+reports completion.
 
-Real SQLite (a tmp ``state.db`` path, no mocks). Covers the
-pending→reporting→reported lifecycle, FIFO claim order, the atomic
-single-claim guarantee, and fail-loud validation. STX-TQ002 AAA markers
-+ STX-TQ007 one assert + STX-TQ003 descriptive names.
+Real PostgreSQL via ``scitex_dev.store``, isolated per test by the
+``pg_schema`` fixture (no mocks). Covers the pending→reporting→reported
+lifecycle, FIFO claim order, the atomic single-claim guarantee, the identity
+collision the SQLite autoincrement used to absorb, and fail-loud validation.
+STX-TQ002 AAA markers + STX-TQ007 one assert + STX-TQ003 descriptive names.
+
+``db_path`` IS GONE from every call. It named a SQLite file and there is no
+file; every test that used to thread ``tmp_path / "state.db"`` now takes
+``pg_schema`` instead, which is the seam that keeps one test's rows out of
+another's — and out of the live fleet store.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 
 from scitex_agent_container._state import inbound_ledger as ledger
 
 
-def test_record_inbound_inserts_a_pending_row(tmp_path: Path) -> None:
+def test_record_inbound_inserts_a_pending_row(pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
-    ledger.record_inbound(
-        db_path=db, agent="figrecipe", from_agent="lead", dispatch_id="d1"
-    )
+    ledger.record_inbound(agent="figrecipe", from_agent="lead", dispatch_id="d1")
     # Assert
-    rows = ledger.list_inbound(agent="figrecipe", db_path=db)
+    rows = ledger.list_inbound(agent="figrecipe")
     assert len(rows) == 1 and rows[0]["status"] == ledger.STATUS_PENDING
 
 
-def test_record_inbound_rejects_empty_from_agent(tmp_path: Path) -> None:
+def test_record_inbound_rejects_empty_from_agent(pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
     # Assert
     with pytest.raises(ValueError):
-        ledger.record_inbound(db_path=db, agent="figrecipe", from_agent="")
+        ledger.record_inbound(agent="figrecipe", from_agent="")
 
 
-def test_claim_oldest_pending_returns_the_fifo_oldest(tmp_path: Path) -> None:
-    # Arrange — two dispatches, oldest first by ts.
-    db = tmp_path / "state.db"
-    ledger.record_inbound(
-        db_path=db, agent="a", from_agent="lead", dispatch_id="old", ts=100.0
-    )
-    ledger.record_inbound(
-        db_path=db, agent="a", from_agent="peer", dispatch_id="new", ts=200.0
-    )
+def test_record_inbound_returns_the_identity_not_a_counter(pg_schema: str) -> None:
+    """The autoincrement id is gone; the handle is the natural key.
+
+    Pins the SHAPE rather than a value, because the whole point of the port is
+    that nothing downstream may depend on the handle being a number.
+    """
+    # Arrange
     # Act
-    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    handle = ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    # Assert
+    assert set(handle) == set(ledger.IDENTITY_FIELDS)
+
+
+def test_claim_oldest_pending_returns_the_fifo_oldest(pg_schema: str) -> None:
+    # Arrange — two dispatches, oldest first by ts.
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="old", ts=100.0)
+    ledger.record_inbound(agent="a", from_agent="peer", dispatch_id="new", ts=200.0)
+    # Act
+    claimed = ledger.claim_oldest_pending(agent="a")
     # Assert
     assert claimed is not None and claimed["dispatch_id"] == "old"
 
 
-def test_claim_oldest_pending_flips_row_to_reporting(tmp_path: Path) -> None:
+def test_claim_oldest_pending_flips_row_to_reporting(pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
-    ledger.record_inbound(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
     # Act
-    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    claimed = ledger.claim_oldest_pending(agent="a")
     # Assert
     assert claimed is not None and claimed["status"] == ledger.STATUS_REPORTING
 
 
-def test_claim_oldest_pending_none_when_queue_empty(tmp_path: Path) -> None:
+def test_claim_oldest_pending_none_when_queue_empty(pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
-    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    claimed = ledger.claim_oldest_pending(agent="a")
     # Assert
     assert claimed is None
 
 
-def test_claim_is_atomic_so_one_row_is_claimed_once(tmp_path: Path) -> None:
+def test_claim_oldest_pending_ignores_another_agents_row(pg_schema: str) -> None:
+    """CONTROL — the claim must be scoped, or one agent settles another's work.
+
+    Without this, a claim that ignored ``agent`` would satisfy every other
+    test in this file: they each use a single agent.
+    """
+    # Arrange
+    ledger.record_inbound(agent="other", from_agent="lead", dispatch_id="d1")
+    # Act
+    claimed = ledger.claim_oldest_pending(agent="a")
+    # Assert
+    assert claimed is None
+
+
+def test_claim_is_atomic_so_one_row_is_claimed_once(pg_schema: str) -> None:
     # Arrange — a single pending row, claimed once already.
-    db = tmp_path / "state.db"
-    ledger.record_inbound(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
-    ledger.claim_oldest_pending(agent="a", db_path=db)
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    ledger.claim_oldest_pending(agent="a")
     # Act — a second claim finds nothing pending (no double-report).
-    second = ledger.claim_oldest_pending(agent="a", db_path=db)
+    second = ledger.claim_oldest_pending(agent="a")
     # Assert
     assert second is None
 
 
-def test_mark_reported_settles_a_claimed_row(tmp_path: Path) -> None:
-    # Arrange
-    db = tmp_path / "state.db"
-    row_id = ledger.record_inbound(
-        db_path=db, agent="a", from_agent="lead", dispatch_id="d1"
-    )
-    ledger.claim_oldest_pending(agent="a", db_path=db)
+def test_two_wakes_in_the_same_instant_are_both_kept(pg_schema: str) -> None:
+    """The collision the SQLite autoincrement used to absorb for free.
+
+    Identity is ``(agent, from_agent, dispatch_id, ts)``. Two requester-bearing
+    wakes with no dispatch id, from the same peer, at the SAME float instant
+    name the same record — so without the microsecond retry the second would
+    silently overwrite the first and one completion report would never be sent.
+
+    Not credible in production (``time.time()`` is microsecond-resolution and a
+    wake is a bus event) — which is exactly why it is pinned here rather than
+    reasoned about: the SQLite version made duplicates free and the port must
+    not quietly withdraw that.
+    """
+    # Arrange — same everything, including ts.
+    ledger.record_inbound(agent="a", from_agent="lead", ts=100.0)
+    ledger.record_inbound(agent="a", from_agent="lead", ts=100.0)
     # Act
-    settled = ledger.mark_reported(row_id, status=ledger.STATUS_REPORTED, db_path=db)
+    rows = ledger.list_inbound(agent="a")
+    # Assert
+    assert len(rows) == 2
+
+
+def test_mark_reported_settles_a_claimed_row(pg_schema: str) -> None:
+    # Arrange
+    handle = ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    ledger.claim_oldest_pending(agent="a")
+    # Act
+    settled = ledger.mark_reported(handle, status=ledger.STATUS_REPORTED)
     # Assert
     assert settled is True
 
 
-def test_mark_reported_rejects_a_non_terminal_status(tmp_path: Path) -> None:
+def test_mark_reported_accepts_the_claimed_row_itself(pg_schema: str) -> None:
+    """Production hands back the CLAIM, not the record. Both must work.
+
+    ``flush_one_completion`` never sees ``record_inbound``'s return value — it
+    settles whatever ``claim_oldest_pending`` gave it, which carries the data
+    fields too. If the handle had to be exactly the identity mapping, the real
+    call path would be the one that breaks.
+    """
     # Arrange
-    db = tmp_path / "state.db"
-    row_id = ledger.record_inbound(
-        db_path=db, agent="a", from_agent="lead", dispatch_id="d1"
-    )
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    claimed = ledger.claim_oldest_pending(agent="a")
+    # Act
+    settled = ledger.mark_reported(claimed, status=ledger.STATUS_REPORTED)
+    # Assert
+    assert settled is True
+
+
+def test_mark_reported_is_false_for_an_unknown_row(pg_schema: str) -> None:
+    """CONTROL — settling must report whether it matched, not always True."""
+    # Arrange — a well-formed handle for a record that was never written.
+    handle = {"agent": "a", "from_agent": "lead", "dispatch_id": "ghost", "ts": 1.0}
+    # Act
+    settled = ledger.mark_reported(handle, status=ledger.STATUS_REPORTED)
+    # Assert
+    assert settled is False
+
+
+def test_mark_reported_rejects_a_non_terminal_status(pg_schema: str) -> None:
+    # Arrange
+    handle = ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
     # Act
     # Assert
     with pytest.raises(ValueError):
-        ledger.mark_reported(row_id, status="pending", db_path=db)
+        ledger.mark_reported(handle, status="pending")

--- a/tests/scitex_agent_container/runtimes/test__tui_outbound.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_outbound.py
@@ -26,24 +26,22 @@ def _write_transcript(path: Path, *records: dict) -> None:
     path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
 
 
-def test_record_dispatch_noop_without_from_agent(tmp_path: Path) -> None:
+def test_record_dispatch_noop_without_from_agent(tmp_path: Path, pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
     row_id = outbound.record_dispatch(
-        db_path=db, agent="a", from_agent="", dispatch_id="d1"
+        agent="a", from_agent="", dispatch_id="d1"
     )
     # Assert
     assert row_id is None
 
 
-def test_record_dispatch_records_pending_inbound(tmp_path: Path) -> None:
+def test_record_dispatch_records_pending_inbound(tmp_path: Path, pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
-    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    outbound.record_dispatch(agent="a", from_agent="lead", dispatch_id="d1")
     # Assert
-    assert len(ledger.list_inbound(agent="a", db_path=db)) == 1
+    assert len(ledger.list_inbound(agent="a")) == 1
 
 
 def test_summarize_transcript_returns_last_assistant_text(tmp_path: Path) -> None:
@@ -77,12 +75,10 @@ def test_summarize_transcript_unknown_when_no_assistant_reply(tmp_path: Path) ->
     assert status == "unknown"
 
 
-def test_flush_one_completion_false_when_queue_empty(tmp_path: Path) -> None:
+def test_flush_one_completion_false_when_queue_empty(tmp_path: Path, pg_schema: str) -> None:
     # Arrange — nothing recorded.
-    db = tmp_path / "state.db"
     # Act
     flushed = outbound.flush_one_completion(
-        db_path=db,
         agent="a",
         transcript_path=None,
         listen_url="http://127.0.0.1:7878",
@@ -93,10 +89,9 @@ def test_flush_one_completion_false_when_queue_empty(tmp_path: Path) -> None:
     assert flushed is False
 
 
-def test_flush_one_completion_pushes_to_requester(tmp_path: Path) -> None:
+def test_flush_one_completion_pushes_to_requester(tmp_path: Path, pg_schema: str) -> None:
     # Arrange — one queued dispatch + a transcript with a reply.
-    db = tmp_path / "state.db"
-    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    outbound.record_dispatch(agent="a", from_agent="lead", dispatch_id="d1")
     transcript = tmp_path / "t.jsonl"
     _write_transcript(
         transcript,
@@ -112,7 +107,6 @@ def test_flush_one_completion_pushes_to_requester(tmp_path: Path) -> None:
 
     # Act
     outbound.flush_one_completion(
-        db_path=db,
         agent="a",
         transcript_path=transcript,
         listen_url="http://127.0.0.1:7878",
@@ -123,13 +117,11 @@ def test_flush_one_completion_pushes_to_requester(tmp_path: Path) -> None:
     assert captured["requester"] == "lead"
 
 
-def test_flush_one_completion_marks_reported_on_success(tmp_path: Path) -> None:
+def test_flush_one_completion_marks_reported_on_success(tmp_path: Path, pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
-    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    outbound.record_dispatch(agent="a", from_agent="lead", dispatch_id="d1")
     # Act
     outbound.flush_one_completion(
-        db_path=db,
         agent="a",
         transcript_path=None,
         listen_url="http://127.0.0.1:7878",
@@ -137,16 +129,16 @@ def test_flush_one_completion_marks_reported_on_success(tmp_path: Path) -> None:
         push_fn=lambda **_kw: None,
     )
     # Assert
-    rows = ledger.list_inbound(agent="a", db_path=db)
+    rows = ledger.list_inbound(agent="a")
     assert rows[0]["status"] == ledger.STATUS_REPORTED
 
 
 def test_flush_one_completion_marks_failed_and_raises_on_push_error(
     tmp_path: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — a push that fails loud (no live subscriber).
-    db = tmp_path / "state.db"
-    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    outbound.record_dispatch(agent="a", from_agent="lead", dispatch_id="d1")
 
     def boom(**_kw: Any) -> None:
         raise RuntimeError("no live subscriber")
@@ -155,8 +147,7 @@ def test_flush_one_completion_marks_failed_and_raises_on_push_error(
     # Assert
     with pytest.raises(RuntimeError):
         outbound.flush_one_completion(
-            db_path=db,
-            agent="a",
+                agent="a",
             transcript_path=None,
             listen_url="http://127.0.0.1:7878",
             bearer=None,
@@ -219,18 +210,51 @@ def _run_main_with(env: dict[str, str], stdin_text: str) -> int:
                 os.environ[k] = v
 
 
-def test_main_returns_zero_when_queue_empty(tmp_path: Path) -> None:
-    # Arrange — wired env, empty ledger, a transcript path on stdin.
-    db = tmp_path / "state.db"
+def test_main_returns_zero_when_queue_empty(tmp_path: Path, pg_schema: str) -> None:
+    """Wired env, empty ledger, a transcript path on stdin.
+
+    ``SCITEX_AGENT_CONTAINER_STATE_DB`` IS DELIBERATELY ABSENT, and its absence
+    is now the interesting half — see the sibling test below. The two env vars
+    here are the two ``main`` still needs: who to report as, and where the bus
+    is.
+    """
+    # Arrange
     env = {
         "SCITEX_AGENT_CONTAINER_AGENT": "a",
-        "SCITEX_AGENT_CONTAINER_STATE_DB": str(db),
         "SAC_LISTEN_BASE_URL": "http://127.0.0.1:7878",
     }
     # Act
     rc = _run_main_with(env, json.dumps({"transcript_path": str(tmp_path / "x.jsonl")}))
     # Assert
     assert rc == 0
+
+
+def test_main_still_flushes_without_the_retired_state_db_env(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The ledger moved to PostgreSQL, so a SQLite path must not gate the flush.
+
+    ``main`` used to refuse unless ``SCITEX_AGENT_CONTAINER_STATE_DB`` was set,
+    which was right while the ledger was a file and became a trap the moment it
+    was not: an agent without that variable would have silently stopped
+    reporting completions, with the refusal resting on a fact that no longer
+    bears on whether the work can be done.
+
+    Pinned as a POSITIVE outcome rather than "does not crash": a pending row is
+    recorded first, so a `main` that still gated on the retired variable would
+    return before flushing it and leave the row pending.
+    """
+    # Arrange — one pending dispatch, and no STATE_DB anywhere in the env.
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    env = {
+        "SCITEX_AGENT_CONTAINER_AGENT": "a",
+        "SAC_LISTEN_BASE_URL": "http://127.0.0.1:7878",
+    }
+    _run_main_with(env, json.dumps({"transcript_path": str(tmp_path / "x.jsonl")}))
+    # Act
+    rows = ledger.list_inbound(agent="a")
+    # Assert
+    assert rows and rows[0]["status"] != ledger.STATUS_PENDING
 
 
 def test_main_noop_when_agent_env_absent(tmp_path: Path) -> None:


### PR DESCRIPTION
Fourth table under the 2026-08-19 SQLite-eradication ruling, after `verdict_delivered`, `incarnations` and `pending_prompts`.

## The autoincrement id looked like the blocker and was not

`id INTEGER PRIMARY KEY AUTOINCREMENT` is returned by `record_inbound` and taken by `mark_reported` — so a store with no counter looked like it forced a **surrogate id**, and surrogate ids do not survive a store boundary (this fleet has already paid for that once, with card ids across two stores).

Measured before assuming:

```
record_inbound's return value, consumed in PRODUCTION:  NONE
  runtimes/_tui_outbound.py returns it from a wrapper; no caller binds it.
mark_reported's argument in PRODUCTION:  always claim-derived
  row_id = int(claimed["id"])  ->  mark_reported(row_id, ...)
```

So the id only ever **round-tripped claim → settle** inside one Stop-hook call. It never crossed a process boundary, was never persisted elsewhere, was never compared. Its integer-ness was an artifact of how SQLite minted it. The natural key `(agent, from_agent, dispatch_id, ts)` replaces it outright.

Two greps settled that, and they were cheap. I had deferred this port on the signature alone — **a public return type is not evidence that the value is public in effect.**

## The atomic claim is preserved, not weakened

SQLite got *"two concurrent Stop hooks never double-report"* from `BEGIN IMMEDIATE`. The store has no transaction, so it comes from optimistic concurrency: the flip carries `expected_revision=row.seq`, and a racing claimer raises `RevisionMismatchError` — whereupon we try the **next** pending row rather than failing, because a competitor taking one row is not a reason to report none.

## One new behaviour, tested rather than argued

Identity is total, so `dispatch_id=None` stores as `""`. That leaves one collision the autoincrement absorbed for free: two wakes for the same agent, from the same peer, with no dispatch id, in the **same float instant** would name one record and the second would silently overwrite the first — one completion report never sent. The insert retries with the timestamp advanced by a microsecond.

Not credible in production, which is exactly why it is pinned: **the port must not quietly withdraw a property SQLite gave free.**

## A gate that stopped meaning anything is removed

`main` refused unless `SCITEX_AGENT_CONTAINER_STATE_DB` was set. Right while the ledger was a file; a trap the moment it was not — an agent without that variable would have silently stopped reporting completions, on a refusal resting on a fact that no longer bears on whether the work can be done.

Pinned by a test that records a pending row first, so a `main` still gating on the retired variable fails on the **row's status** rather than on "did not crash".

## Nearly broke an unrelated ledger

There are **two** `record_dispatch` functions — `_state.dispatch_ledger.record_dispatch` (the sender-side outbound ledger) and `_tui_outbound.record_dispatch` (this one). Only `_tui_turn_bridge` imports the latter. A rename-by-name would have edited the outbound ledger's callers.

## Verification

3301 passed, 23 skipped across `_state/`, `runtimes/` and the footprint ratchet. The ratchet shrinks by one, which is the mechanism working: it **fails** if a module is listed but no longer imports sqlite3, so a port that forgets to shrink the set is caught rather than merely uncelebrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CmUd2ebDm5WHNWfTyZtEW
