### PR TITLE
fix(dev-jobs): forward the two flags the refusal message names

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -164,7 +164,13 @@ def _kind_of(group: str) -> str:
 
 
 def _delegate(
-    kind: str, verb: str, name: str | None, yes: bool, dry_run: bool = False
+    kind: str,
+    verb: str,
+    name: str | None,
+    yes: bool,
+    dry_run: bool = False,
+    adopt: bool = False,
+    force: bool = False,
 ) -> int:
     """Resolve + run one ecosystem delegation. THE single mutation seam.
 
@@ -172,6 +178,12 @@ def _delegate(
     yes, dry_run)`` tuples a verb delegates with, rather than shelling out
     to a real ``scitex-dev`` that would rewrite the host's units and
     crontab. The delegation ARGUMENTS are what those tests are about.
+
+    ``adopt`` and ``force`` default to False and callers pass them BY
+    KEYWORD, so the positional call shape those tests capture is unchanged:
+    a five-element tuple before this parameter existed, five after. A
+    required parameter — or a positional call — would have rewritten every
+    one of those assertions to prove nothing about the behaviour that moved.
     """
     delegation = _backend.resolve(kind, verb)
     if not delegation.supported:
@@ -187,7 +199,14 @@ def _delegate(
             err=True,
         )
         raise SystemExit(4)
-    return _backend.invoke(delegation, name=name, yes=yes, dry_run=dry_run)
+    return _backend.invoke(
+        delegation,
+        name=name,
+        yes=yes,
+        dry_run=dry_run,
+        adopt=adopt,
+        force=force,
+    )
 
 
 def _resolve_one(group: str, typed: str) -> str:
@@ -239,6 +258,48 @@ def _add_list_command(grp, group: str) -> None:
             click.echo(f"  {'':24s} {j.description}")
 
 
+def _adoption_options(verb: str):
+    """``--adopt`` / ``--force``, attached ONLY to the verb that has them.
+
+    Both are real options on ``scitex-dev ecosystem timer install`` and on
+    nothing else in the group. Declaring them unconditionally would let
+    ``sac dev timer uninstall --force`` parse here and then fail downstream
+    on a command that has no such option — trading one misleading message
+    for another.
+
+    They exist at all because scitex-dev's refusal names them. MEASURED
+    2026-08-20: ``install`` on an existing unit prints "Use --adopt to keep
+    the existing supervisor (writes nothing), or --force to overwrite", and
+    following that advice returned ``Error: No such option '--force'``. The
+    wrapper forwarded the message and not the flags.
+    """
+
+    def decorate(fn):
+        if verb != "install":
+            return fn
+        fn = click.option(
+            "--force",
+            is_flag=True,
+            default=False,
+            help=(
+                "Overwrite even when another supervisor exists. Forwarded "
+                "to scitex-dev, which reports loudly what it replaced."
+            ),
+        )(fn)
+        fn = click.option(
+            "--adopt",
+            is_flag=True,
+            default=False,
+            help=(
+                "Keep an existing supervisor of ANY mechanism and write "
+                "nothing. Forwarded to scitex-dev."
+            ),
+        )(fn)
+        return fn
+
+    return decorate
+
+
 def _add_bulk_command(grp, group: str, verb: str) -> None:
     """Attach a verb that acts on every job of the kind, or one named one."""
 
@@ -258,7 +319,8 @@ def _add_bulk_command(grp, group: str, verb: str) -> None:
         default=False,
         help="Confirm. Forwarded to scitex-dev.",
     )
-    def _bulk(name, dry_run, yes, _verb=verb):
+    @_adoption_options(verb)
+    def _bulk(name, dry_run, yes, adopt=False, force=False, _verb=verb):
         _announce_deprecation(group)
         jobs = _jobs_or_degrade(group)
         if name is not None:
@@ -269,7 +331,20 @@ def _add_bulk_command(grp, group: str, verb: str) -> None:
             return
         rc = 0
         for j in jobs:
-            code = _delegate(_kind_of(group), _verb, j.name, yes, dry_run)
+            code = _delegate(
+                _kind_of(group),
+                _verb,
+                j.name,
+                yes,
+                dry_run,
+                # BY KEYWORD, and that is load-bearing. The tests replace
+                # `_delegate` with a lambda that captures `*args`, so passing
+                # these positionally would grow every captured tuple from five
+                # elements to seven and break assertions about a call shape
+                # this change does not alter.
+                adopt=adopt,
+                force=force,
+            )
             rc = rc or code
         raise SystemExit(rc)
 

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -299,6 +299,8 @@ def build_argv(
     name: str | None,
     yes: bool,
     dry_run: bool = False,
+    adopt: bool = False,
+    force: bool = False,
     exe: str = "scitex-dev",
     leaf: object | None = None,
 ) -> list[str]:
@@ -317,6 +319,20 @@ def build_argv(
     refresher; a pass-through that dropped either flag would convert a
     guarded command into an unguarded one, which is strictly worse than
     not offering the verb.
+
+    ``--adopt`` and ``--force`` are forwarded for the same reason, and the
+    argument is not hypothetical. MEASURED 2026-08-20 on scitex-compute-04:
+    ``sac dev timer install host-sync-check -y`` refused because a unit
+    already existed, and printed scitex-dev's own remedy — "Use --adopt to
+    keep the existing supervisor (writes nothing), or --force to overwrite."
+    Both flags are real options on ``scitex-dev ecosystem timer install``;
+    neither existed on the wrapper, so the command answered its own advice
+    with ``Error: No such option '--force'``.
+
+    A dropped flag is worse there than a missing verb, in the same way and
+    for a sharper reason: the reader meets that text while repairing a unit,
+    trusts it, and the failure it produces looks like a broken CLI rather
+    than a message describing a command that is not the one they ran.
 
     The job NAME follows :func:`name_style_for` — ``--name X`` or a bare
     positional, as the INSTALLED scitex-dev actually declares it. It was
@@ -339,6 +355,10 @@ def build_argv(
         argv.append("--dry-run")
     if yes:
         argv.append("--yes")
+    if adopt:
+        argv.append("--adopt")
+    if force:
+        argv.append("--force")
     return argv
 
 
@@ -348,6 +368,8 @@ def invoke(
     name: str | None,
     yes: bool,
     dry_run: bool = False,
+    adopt: bool = False,
+    force: bool = False,
 ) -> int:
     """Run the resolved ``scitex-dev ecosystem`` command; return its exit code.
 
@@ -364,7 +386,15 @@ def invoke(
             "scitex-dev to use `sac dev` job verbs"
         )
     return subprocess.call(
-        build_argv(delegation, name=name, yes=yes, dry_run=dry_run, exe=exe)
+        build_argv(
+            delegation,
+            name=name,
+            yes=yes,
+            dry_run=dry_run,
+            adopt=adopt,
+            force=force,
+            exe=exe,
+        )
     )
 
 

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
@@ -80,14 +80,25 @@ def _declared_timers() -> list[str]:
 
 
 class _Recorder:
-    """Capture every ``(kind, verb, name, yes, dry_run)`` delegation."""
+    """Capture every ``(kind, verb, name, yes, dry_run)`` delegation.
+
+    ``**passed`` absorbs the seam's OPTIONAL keyword arguments — ``adopt``
+    and ``force`` today — and keeps them out of ``calls``, so the five-element
+    tuple every assertion below reads is unchanged by a parameter being added
+    upstream. Without it a new keyword raises TypeError inside the Click
+    callback, which surfaces as a non-zero exit and an EMPTY ``calls`` list:
+    the tests then fail saying the verb delegated for no jobs, which is true
+    and describes the recorder rather than the code.
+    """
 
     def __init__(self, rc: int = 0) -> None:
         self.calls: list[tuple] = []
+        self.passed: list[dict] = []
         self._rc = rc
 
-    def __call__(self, kind, verb, name, yes, dry_run=False) -> int:
+    def __call__(self, kind, verb, name, yes, dry_run=False, **passed) -> int:
         self.calls.append((kind, verb, name, yes, dry_run))
+        self.passed.append(passed)
         return self._rc
 
     def names_for(self, verb: str) -> list[str]:
@@ -474,3 +485,27 @@ def test_every_rendered_service_has_an_execstart(rendered_units) -> None:
     without = [n for n, (_t, service) in rendered_units.items() if "ExecStart=" not in service]
     # Assert
     assert without == []
+
+
+def test_install_forwards_force_to_the_delegation_seam() -> None:
+    """The end-to-end shape of the defect: install's refusal names --force."""
+    # Arrange
+    recorder = _Recorder()
+    # Act
+    with _delegating_to(recorder):
+        CliRunner().invoke(
+            dj._make_group("timer"), ["install", "host-sync-check", "--yes", "--force"]
+        )
+    # Assert
+    assert recorder.passed and recorder.passed[0].get("force") is True
+
+
+def test_uninstall_rejects_force_because_upstream_has_no_such_option() -> None:
+    """Forwarding a flag the target verb lacks trades one wrong message for another."""
+    # Arrange
+    argv = ["uninstall", "host-sync-check", "--yes", "--force"]
+    # Act
+    with _delegating_to(_Recorder()):
+        result = CliRunner().invoke(dj._make_group("timer"), argv)
+    # Assert
+    assert result.exit_code != 0

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -468,3 +468,41 @@ def test_an_unreadable_tree_refuses_a_verb_that_never_shipped() -> None:
         backend.reset_capability_cache()
     # Assert
     assert got.supported is False
+
+
+def _install_delegation() -> "backend.Delegation":
+    """`timer install` — the only verb upstream carrying --adopt/--force."""
+    return backend.Delegation(
+        path=("timer",), verb="install", supported=True, evidence="fixture"
+    )
+
+
+def test_the_pass_through_forwards_adopt() -> None:
+    """MEASURED 2026-08-20: install's refusal names --adopt; the wrapper had no
+    such option, so following its own advice errored."""
+    # Arrange
+    delegation = _install_delegation()
+    # Act
+    argv = backend.build_argv(delegation, name="sac.x", yes=True, adopt=True, exe="sd")
+    # Assert
+    assert "--adopt" in argv
+
+
+def test_the_pass_through_forwards_force() -> None:
+    """The other half of that same refusal message."""
+    # Arrange
+    delegation = _install_delegation()
+    # Act
+    argv = backend.build_argv(delegation, name="sac.x", yes=True, force=True, exe="sd")
+    # Assert
+    assert "--force" in argv
+
+
+def test_neither_flag_appears_unless_asked() -> None:
+    """Non-vacuity: one that always appended both would pass the two above."""
+    # Arrange
+    delegation = _install_delegation()
+    # Act
+    argv = backend.build_argv(delegation, name="sac.x", yes=True, exe="sd")
+    # Assert
+    assert not {"--adopt", "--force"} & set(argv)


### PR DESCRIPTION
`sac dev timer install <name> -y` refuses when a unit already exists and prints scitex-dev's remedy verbatim:

> Use `--adopt` to keep the existing supervisor (writes nothing), or `--force` to overwrite.

**MEASURED 2026-08-20 on scitex-compute-04, following that advice:**

```
$ sac dev timer install host-sync-check -y --force
Error: No such option '--force'.
```

Both flags are real options upstream — `_jobs_timer.py` declares `--adopt` at line 261 and `--force` at 270 — so the message is accurate about the command it came from. sac's wrapper forwarded the message and dropped the flags, leaving a refusal whose only stated remedies the command rejects.

`build_argv`'s docstring already argued the general case: a pass-through that drops `--yes` "would convert a guarded command into an unguarded one, which is strictly worse than not offering the verb". Same reasoning, sharper edge — the reader meets this text *while* repairing a unit, so the resulting error reads as a broken CLI rather than as a message describing a different command.

## Scoped to `install`

Via a small conditional decorator. Declaring the flags on every bulk verb would let `sac dev timer uninstall --force` parse here and then fail downstream on a command that has no such option — trading one misleading message for another.

## One implementation detail is load-bearing

The new arguments reach `_delegate` **by keyword**. That seam is replaced in tests by a recorder capturing `*args`, so passing them positionally grew every captured tuple from five elements to seven and broke two `bulk enable` assertions about a call shape this change does not alter.

The failure was legible only on a second reading: an empty capture list makes those tests report that the verb delegated for **no jobs** — which is true, and describes the recorder rather than the code.

`_Recorder` now absorbs the optional keywords into `**passed` and records them separately, so `calls` keeps its five-element shape and a test can still assert the flag arrived.

## Verified

- `3193 passed, 5 skipped` across `tests/.../cli_pkg/`
- `ruff check --select F401,F811` — CI's actual lint scope — clean

Five tests, three at the argv layer and two end-to-end:

| test | pins |
|---|---|
| `forwards_adopt` | `--adopt` reaches the argv |
| `forwards_force` | `--force` reaches the argv |
| `neither_flag_appears_unless_asked` | non-vacuity — a `build_argv` that always appended both would satisfy the two above |
| `install_forwards_force_to_the_delegation_seam` | the flag survives the whole CLI path |
| `uninstall_rejects_force_...` | the scoping holds |

Found while trying to update two stale units on compute-04; carded as `sac-timer-install-remedy-names-a-flag-that-does-not-exist-20260820`.