### PR TITLE
perf(ci-ring): the poll tick must not re-fetch a sha it already holds

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
@@ -167,7 +167,7 @@ async def github_ci_poll_loop(
                 )
             except asyncio.CancelledError:
                 raise
-            except Exception as exc:  # stx-allow: fallback (loop must survive a transient GitHub/registry error; logged, retried next tick)
+            except Exception as exc:  # stx-allow: fallback (loop must survive a transient GitHub/registry error; retried next tick). SINK, measured 2026-08-20: logger.warning on this module's logger, which reaches journald because the poller only ever runs inside `sac listen` and sac-listen.service is a systemd user unit with the default StandardOutput=journal — `journalctl --user -u sac-listen.service | grep github_ci_poll_loop` is the check, and it is how the abandoned-tick ERRO on the line below was actually found today.
                 logger.warning(
                     "github_ci_poll_loop: tick failed (%s); retry next tick", exc
                 )

--- a/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
@@ -134,11 +134,21 @@ async def github_ci_poll_loop(
         # the listen server even after bind.
         for repo in list(repos_source()):
             for pr in list_prs(repo):
+                head_sha = pr.get("head_sha", "")
                 deliver(
                     repo,
                     pr["number"],
-                    pr.get("head_sha", ""),
-                    conclusion_for(repo, pr["number"]),
+                    head_sha,
+                    # PASS THE SHA WE ALREADY HAVE. ``pr_ci_conclusion`` falls
+                    # back to its own ``gh api repos/<r>/pulls/<n>`` lookup when
+                    # ``head_sha`` is empty, and ``list_open_prs`` has ALREADY
+                    # returned it in the very dict being read on this line — so
+                    # omitting it bought a third REST call per PR per tick for
+                    # a value sitting in local memory. The source comment on
+                    # ``pr_ci_conclusion`` asked for this ("the poll loop
+                    # already holds it ... and should pass it to save the
+                    # call"); it had simply never been done.
+                    conclusion_for(repo, pr["number"], head_sha=head_sha),
                     pr_body=pr.get("body", ""),
                 )
 

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -140,7 +140,14 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         # sac-listen.service is StandardOutput=journal, and per-agent logs
         # live under runtime/logs/<agent>/ — asserted rather than assumed,
         # because a NAMED sink that is wrong is worse than an unnamed one.
-        "scitex_agent_container/_lifecycle/_github_ci_poll_loop.py:160",
+        # _github_ci_poll_loop.py:160 LEFT THIS LIST 2026-08-20. Its sink is now
+        # named in the reason itself (journald via sac-listen.service). It came
+        # off the list the hard way: this change shifted the claim from line 160
+        # to 170, which rotted the entry AND made the same claim reappear as a
+        # NEW unnamed one — two failures from one insertion, and green locally
+        # because the frozen list is keyed on a line number that only moves when
+        # the file is edited. That is the guard working, not misfiring: an entry
+        # pinned by line is a claim about a LOCATION, and the location changed.
         "scitex_agent_container/_lifecycle/_in_sif_http_client.py:141",
         "scitex_agent_container/_lifecycle/_instances.py:263",
         "scitex_agent_container/_lifecycle/_listen_client_resolve.py:178",

--- a/tests/scitex_agent_container/_lifecycle/test__github_ci_poll_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__github_ci_poll_loop.py
@@ -28,7 +28,7 @@ async def test_loop_disabled_when_gh_not_ready_delivers_nothing():
         ready_check=lambda: False,
         repos_source=lambda: ["o/r"],
         list_prs=lambda repo: [{"number": 1, "head_sha": "s", "body": ""}],
-        conclusion_for=lambda repo, pr: "success",
+        conclusion_for=lambda repo, pr, *, head_sha="": "success",
         deliver=lambda *a, **k: calls.append(a),
     )
     # Assert
@@ -50,7 +50,7 @@ async def test_loop_disabled_via_env_var_delivers_nothing():
             ready_check=lambda: True,
             repos_source=lambda: ["o/r"],
             list_prs=lambda repo: [{"number": 1, "head_sha": "s", "body": ""}],
-            conclusion_for=lambda repo, pr: "success",
+            conclusion_for=lambda repo, pr, *, head_sha="": "success",
             deliver=lambda *a, **k: calls.append(a),
         )
     finally:
@@ -72,7 +72,7 @@ async def test_loop_delivers_open_pr_verdict_in_one_tick():
             ready_check=lambda: True,
             repos_source=lambda: ["o/r"],
             list_prs=lambda repo: [{"number": 7, "head_sha": "abc", "body": ""}],
-            conclusion_for=lambda repo, pr: "success",
+            conclusion_for=lambda repo, pr, *, head_sha="": "success",
             deliver=lambda repo, pr, head_sha, conclusion, **k: calls.append(
                 (repo, pr, head_sha, conclusion)
             ),
@@ -101,7 +101,7 @@ async def test_loop_survives_a_tick_exception_then_cancels_cleanly():
             ready_check=lambda: True,
             repos_source=lambda: ["o/r"],
             list_prs=boom,
-            conclusion_for=lambda repo, pr: "success",
+            conclusion_for=lambda repo, pr, *, head_sha="": "success",
             deliver=lambda *a, **k: None,
         )
     )
@@ -123,7 +123,7 @@ async def test_loop_honours_cancellation_cleanly():
             ready_check=lambda: True,
             repos_source=lambda: [],
             list_prs=lambda repo: [],
-            conclusion_for=lambda repo, pr: "none",
+            conclusion_for=lambda repo, pr, *, head_sha="": "none",
             deliver=lambda *a, **k: None,
         )
     )
@@ -133,6 +133,52 @@ async def test_loop_honours_cancellation_cleanly():
     # Assert — the finally must re-raise CancelledError, not swallow it.
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+# --- the tick must not re-fetch a sha it is already holding ------------
+# ``list_open_prs`` returns head_sha, and ``pr_ci_conclusion`` falls back to
+# its own `gh api repos/<r>/pulls/<n>` REST call when head_sha is empty. So
+# omitting it costs one extra REST call PER PR PER TICK for a value already
+# in local memory — measured 2026-08-20 as ~1,560 wasted calls/hour against
+# a 5,000/hour budget, on a pool that was fully exhausted at the time.
+#
+# WHY THIS ASSERTS THE SHA AND NOT "the call happened". A test that merely
+# accepted a `head_sha` keyword would pass against a loop that forwards the
+# empty string — which is precisely the bug, since empty is what triggers
+# the fallback fetch. The captured VALUE is the only thing that separates
+# "wired" from "wired to nothing".
+
+
+@pytest.mark.asyncio
+async def test_tick_forwards_the_head_sha_it_already_has_to_the_conclusion_call():
+    # Arrange — capture what the loop hands the conclusion seam.
+    seen: list = []
+
+    def conclusion_for(repo, pr, *, head_sha=""):
+        seen.append(head_sha)
+        return "success"
+
+    task = asyncio.create_task(
+        github_ci_poll_loop(
+            poll_interval_s=0.05,
+            ready_check=lambda: True,
+            repos_source=lambda: ["o/r"],
+            list_prs=lambda repo: [
+                {"number": 7, "head_sha": "deadbeef", "body": ""}
+            ],
+            conclusion_for=conclusion_for,
+            deliver=lambda *a, **k: None,
+        )
+    )
+    # Act
+    await asyncio.sleep(0.08)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    # Assert — the sha from list_prs, not "" (which would re-fetch it).
+    assert "deadbeef" in seen
 
 
 # --- the post budget must fit inside the tick that starts it -----------


### PR DESCRIPTION
## What

`_tick_body` calls `pr_ci_conclusion` without the `head_sha` it is already holding, so that function falls back to its own `gh api repos/<r>/pulls/<n>` REST call — one extra call per PR per tick, for a value sitting in local memory on the line above.

`pr_ci_conclusion` has accepted a `head_sha` keyword all along, and its own source comment asked for this: *"the poll loop already holds it from `list_open_prs` and should pass it to save the call."* It had never been done.

## Why it is not a micro-optimisation

Found while diagnosing a fleet-wide outage: the shared GitHub account was refusing **every** REST call with 403 for most of each hour, so no agent could merge anything.

The 403's own response headers named the limit:

```
X-Ratelimit-Resource:  core
X-Ratelimit-Used:      5000
X-Ratelimit-Remaining: 0
```

`GET /rate_limit` reported `core 4800/5000` in the same second — from its own **headers** as well as its body — so the exempt endpoint cannot observe this refusal, and no sampler built on it can either. That cost three separate instruments in this investigation before the right one was found.

Measured on scitex-compute-04, 2026-08-20:

| | |
|---|---|
| repos tracked per host | 94 (from 122 agent specs; **22 resolve to no repo at all** — `SAC_PLACEHOLDER_PROJECT`, `<PROJECT>`, `handyman-01..08`, …) |
| `sac listen` daemons, each polling all of them | 4 |
| ticks/hour | 12 (`DEFAULT_CI_POLL_INTERVAL_S = 300.0`) |
| open PRs | 130 (counted via GraphQL, so the count did not spend the exhausted pool) |
| REST calls per PR | **3 → 2 with this change** |

This one call is ~1,560 wasted calls/hour at four hosts.

## Verification

Attribution is an **intervention**, not a correlation — sampling the enforced counter once a minute while stopping pollers partway through:

```
16:26  +595
16:27  +593
16:28  +608   <- compute-01 poller stopped
16:29  +572
16:30  +252   <- compute-02 and compute-03 stopped
16:31   +77
```

It could have refuted the diagnosis: had the rate held at ~600/min with three pollers stopped, the suspect was wrong.

`_lifecycle` suite: **2,238 passed, 2 skipped in 77s**.

## On the new test

It asserts the **value** forwarded, not that a keyword was accepted. A loop passing `head_sha=""` satisfies the signature, makes the call, raises nothing, and leaves the bug fully intact — empty is exactly what triggers the fallback fetch. Mutation-checked: with the loop forwarding `""` the test fails with `assert 'deadbeef' in ['', '']`; restored, 8 pass.

## Not fixed here — both matter more than this change

1. **All four listen daemons poll the same 94 repos**, so three quarters of the work is duplicate; delivery is deduped anyway. Mitigated for now by a systemd drop-in on compute-01/02/03, which is host-local config and therefore *not* the fix — it is the "deployed but not in the repo" state the constitution warns about. One-host polling has to be declared in code. Note a per-host PostgreSQL cannot arbitrate it: the stores are per-host and synced asynchronously, so a lease there gives no mutual exclusion.

2. **A tick can exceed its own 300s bound**, and `run_blocking_or` *abandons* rather than cancels, so an over-running tick keeps issuing `gh` calls while the loop sleeps and starts the next one. Observed directly in the log:

   ```
   ERRO: github_ci_poll_loop tick (gh reads) exceeded 300.0s and was abandoned
   ```

   The module docstring **predicted** this overlap and dismissed it, because the delivered-set is keyed on `(repo, pr, head_sha, conclusion)` so duplicates dedup away. That reasoning is correct about *delivery*. The dedup makes the output idempotent and leaves the **cost** compounding — an invariant was verified on the axis someone named, and the axis nobody named was the expensive one. It is also why removing three of four hosts bought ~8x rather than 4x.

3. Even one poller at 300s projects to ~5,800/hour against a 5,000 budget — measured at ~95 calls/min after the other three were stopped. Interim drop-in raises the interval to 600s on compute-04; the durable fix is the per-tick cost.

Card: `sac-listen-ci-poller-burns-2x-the-graphql-pool-20260819`
