### PR TITLE
fix(event-log): previews wrote unredacted secrets to a durable JSONL

### DIFF
--- a/src/scitex_agent_container/_state/event_log.py
+++ b/src/scitex_agent_container/_state/event_log.py
@@ -34,6 +34,36 @@ DEFAULT_CAP_LINES = 500
 PREVIEW_MAX_CHARS = 300
 
 
+def _redacted_preview(text: Any) -> str:
+    """Redact secret-shaped values, THEN truncate to the preview cap.
+
+    Every preview this module writes lands in a DURABLE per-agent JSONL under
+    the events root. Tool inputs and tool responses are arbitrary text an agent
+    happened to handle, so anything the agent read — a credential file, an
+    environment dump, a command that echoed a token — was being written to disk
+    in cleartext and kept.
+
+    Redaction runs BEFORE truncation so the matcher always sees the whole
+    string. Stated honestly: against the CURRENT patterns that ordering is
+    defence in depth rather than a demonstrated fix — a truncated ``sk-ant-``
+    fragment still matches its own pattern, so truncate-first would usually
+    redact too. The order is chosen because it cannot be worse and because the
+    pattern set is expected to grow: any future pattern anchored on a suffix,
+    a length, or a checksum WOULD be defeated by seeing 300 characters instead
+    of the text. Do not reorder these two steps to save a slice.
+
+    ``_redact_secrets`` is imported, never modified — it already has three
+    other consumers (interactive_login, agent_meta, config_files) and widening
+    it for this caller would change their output too.
+    """
+    from ._meta.secrets import _redact_secrets
+
+    s = text if isinstance(text, str) else str(text)
+    if not s:
+        return ""
+    return _redact_secrets(s)[:PREVIEW_MAX_CHARS]
+
+
 def _default_root() -> Path:
     """Resolve the per-agent events ring-buffer root.
 
@@ -86,7 +116,7 @@ def _preview_tool_input(tool_name: str, tool_input: dict | None) -> str:
         s = ""
     if not isinstance(s, str):
         s = str(s)
-    return s[:PREVIEW_MAX_CHARS]
+    return _redacted_preview(s)
 
 
 def append_event(
@@ -119,10 +149,10 @@ def append_event(
                         content = " ".join(
                             c.get("text", "") for c in content if isinstance(c, dict)
                         )
-                    record["result_preview"] = str(content)[:PREVIEW_MAX_CHARS]
+                    record["result_preview"] = _redacted_preview(content)
         if kind == "prompt":
             prompt = payload.get("prompt") or payload.get("user_prompt") or ""
-            record["prompt_preview"] = str(prompt)[:PREVIEW_MAX_CHARS]
+            record["prompt_preview"] = _redacted_preview(prompt)
         if kind == "stop":
             record["stop_hook_active"] = bool(payload.get("stop_hook_active"))
 

--- a/tests/scitex_agent_container/_state/test_event_log.py
+++ b/tests/scitex_agent_container/_state/test_event_log.py
@@ -721,3 +721,86 @@ class TestOpenAgentCalls:
         out = summarize("ag-e", root=tmp_root)
         # Assert
         assert out["open_agent_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# secret redaction in the on-disk previews
+#
+# Every preview below lands in a DURABLE per-agent JSONL. Before this, an
+# agent that happened to read a credential file, or run a command that echoed
+# a token, wrote that value to disk in cleartext and kept it.
+#
+# EVERY SECRET IN THIS BLOCK IS SYNTHETIC. Never put a real credential in a
+# test: the fixture would then be the leak it exists to prevent.
+# ---------------------------------------------------------------------------
+
+# Shaped to match the third pattern in _state/_meta/secrets.py —
+# (token|secret|api_key|password|bearer) followed by = or : — with a value
+# distinctive enough that an assertion on its absence cannot pass by accident.
+FAKE_SECRET_LINE = "declare -x GITHUB_TOKEN=ZZZsyntheticNotARealTokenZZZ"
+FAKE_SECRET_VALUE = "ZZZsyntheticNotARealTokenZZZ"
+
+
+class TestPreviewsRedactSecrets:
+    def test_result_preview_masks_a_secret_value(self, tmp_root: Path):
+        # Arrange — a posttool response carrying a secret-shaped line.
+        append_event(
+            "ag-redact-1",
+            "posttool",
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "env"},
+                "tool_response": {"output": FAKE_SECRET_LINE},
+            },
+            root=tmp_root,
+        )
+        # Act
+        events = read_recent("ag-redact-1", root=tmp_root)
+        # Assert
+        assert FAKE_SECRET_VALUE not in events[-1]["result_preview"]
+
+    def test_result_preview_still_records_something(self, tmp_root: Path):
+        # Arrange — redaction must MASK, not blank the record; a preview that
+        # became empty would silently destroy the diagnostic value the log
+        # exists for, and would also pass the assertion above.
+        append_event(
+            "ag-redact-2",
+            "posttool",
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "env"},
+                "tool_response": {"output": FAKE_SECRET_LINE},
+            },
+            root=tmp_root,
+        )
+        # Act
+        preview = read_recent("ag-redact-2", root=tmp_root)[-1]["result_preview"]
+        # Assert
+        assert "GITHUB_TOKEN" in preview
+
+    def test_prompt_preview_masks_a_secret_value(self, tmp_root: Path):
+        # Arrange
+        append_event(
+            "ag-redact-3", "prompt", {"prompt": FAKE_SECRET_LINE}, root=tmp_root
+        )
+        # Act
+        events = read_recent("ag-redact-3", root=tmp_root)
+        # Assert
+        assert FAKE_SECRET_VALUE not in events[-1]["prompt_preview"]
+
+    def test_input_preview_masks_a_secret_value(self):
+        # Arrange — the tool-input path has its own preview builder.
+        # Act
+        preview = _preview_tool_input("Bash", {"command": FAKE_SECRET_LINE})
+        # Assert
+        assert FAKE_SECRET_VALUE not in preview
+
+    def test_a_benign_preview_is_left_alone(self):
+        # Arrange — POSITIVE CONTROL for the assertions above: they check for
+        # ABSENCE, which is also what a redactor that blanks everything, or a
+        # preview builder that silently returns "", would produce. This pins
+        # that ordinary text survives untouched.
+        # Act
+        preview = _preview_tool_input("Bash", {"command": "ls -la /tmp"})
+        # Assert
+        assert preview == "ls -la /tmp"


### PR DESCRIPTION
## What

`append_event` writes three previews per hook event — `input_preview`, `result_preview`, `prompt_preview` — and each was a plain 300-character slice of arbitrary text the agent had just handled. Those land in a **durable per-agent JSONL** under the events root and stay there.

So any agent that read a credential file, ran a command that echoed a token, or received a tool response containing one, wrote that value to disk in cleartext. No flag, no login shell, no unusual usage — the normal path did it.

All three now route through `_redacted_preview`, which applies the existing `_redact_secrets` before truncating.

## How this was found

While mapping a reported leak where `host_exec(peer, ["bash","-lc", …])` returned ~60 production credentials into an agent transcript. That report attributed the leak to a sac wrapper emitting the environment. **It doesn't** — sac never adds `-l` on that path and deliberately uses `bash -c` (`_state/_host_ssh.py:144-153`). The `-l` came from the caller.

The mapping turned up this instead: a leak that needs no `-l`, no caller mistake, and no unusual command, and that had been running on every agent the whole time.

## Why a helper and not three inline calls

So the **order** is stated once, with its reason. Redaction runs before truncation so the matcher always sees the whole string.

Stated honestly, because my first draft of this claimed more than it could show: against the *current* patterns that ordering is defence in depth, not a demonstrated fix — a truncated `sk-ant-` fragment still matches its own pattern, so truncate-first would usually redact too. It is chosen because it cannot be worse, and because any future pattern anchored on a suffix, a length, or a checksum **would** be defeated by seeing 300 characters instead of the text.

`_redact_secrets` is imported, never modified — it already has three other consumers (`interactive_login`, `agent_meta`, `config_files`) and widening it here would change their output too.

## Testing

Every secret in the tests is **synthetic**. A test carrying a real credential would be the leak it exists to prevent.

The absence assertions are paired with two controls, because "the value is not in the preview" is also what a builder returning `""` would produce:

- `test_result_preview_still_records_something` — the key survives, so the log keeps its diagnostic value
- `test_a_benign_preview_is_left_alone` — ordinary text is untouched

Mutation-checked: reverting all three sites to the previous truncate-only behaviour fails 3 tests; restored, **57 pass**.

## Scope — what this does not do

- It stops **new** cleartext. It does not clean what is already on disk; a count-only sweep for existing exposure is a separate change.
- It does not address the wider hole it was found under: sac's agent-facing exec surfaces return a child's raw stdout **and** stderr into an agent's context with no output redaction and no argv screening (`cli_pkg/host_group.py:270-277`, `_listen/_host_exec.py:487-495`, with `merged_env = None  # inherit parent env`). `-- printenv` leaks identically with no shell involved at all, so stripping `-l` alone would close the reported call and leave the hole.
- Credential rotation remains the operator's decision.

Card: `sac-host-exec-login-shell-leaks-the-entire-secret-environment-into-agent-context-20260820`
