### PR TITLE
perf(ci-ring): stop polling repos GitHub says do not exist

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_ci_owner.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_owner.py
@@ -93,8 +93,36 @@ def resolve_owner(
 #: ``gh`` call per repo per tick.
 _CANONICAL_CACHE: dict = {}
 
+#: Cache sentinel. ``None`` is now a MEANINGFUL cached value ("GitHub says this
+#: repo does not exist"), so a plain ``.get(repo)`` returning ``None`` can no
+#: longer be read as "not cached" — that would re-probe every absent repo on
+#: every tick and lose the whole saving.
+_UNCACHED = object()
 
-def _canonical_name_with_owner(repo: str) -> str:
+#: Substrings that mean GitHub ANSWERED and the answer was "no such repository".
+#: Deliberately narrow. The asymmetry is the point: a false ABSENT silently
+#: drops a real repo from the poll set and CI verdicts for it stop arriving with
+#: nothing to notice; a false UNKNOWN merely keeps polling, which is today's
+#: behaviour. So anything not clearly an absence is treated as unknown.
+#: A BARE "not found" is deliberately NOT in this list. It would match
+#: `gh: command not found` — a missing binary, which is the most UNKNOWN
+#: situation there is — and turn it into "every repo is absent", emptying the
+#: poll set on a host where gh simply is not installed. Each marker below has
+#: to name a REPOSITORY.
+_ABSENT_MARKERS = (
+    "could not resolve to a repository",
+    "no such repository",
+    "404: not found",
+)
+
+
+def _says_no_such_repo(stderr: str) -> bool:
+    """True only when gh's stderr states the repository does not exist."""
+    low = (stderr or "").lower()
+    return any(m in low for m in _ABSENT_MARKERS)
+
+
+def _canonical_name_with_owner(repo: str) -> str | None:
     """Return GitHub's canonical ``owner/name`` for ``repo``.
 
     A constructed ``<org>/<project>`` string is a GUESS about who owns the
@@ -110,19 +138,31 @@ def _canonical_name_with_owner(repo: str) -> str:
     previous behaviour, so a gh outage degrades to a guess rather than to
     an empty poll list.
     """
-    cached = _CANONICAL_CACHE.get(repo)
-    if cached is not None:
+    # NOTE the default. Plain ``.get(repo)`` returns None for a MISSING key,
+    # which is indistinguishable from the cached value None ("absent repo") —
+    # so without the sentinel default this returns None for every uncached
+    # repo and never probes at all.
+    cached = _CANONICAL_CACHE.get(repo, _UNCACHED)
+    if cached is not _UNCACHED:
         return cached
     try:
-        from ._github_ci import _run_gh
+        from ._github_ci import _run_gh_probe
 
-        raw = _run_gh(
+        probe = _run_gh_probe(
             ["repo", "view", repo, "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
         )
-    except Exception:  # stx-allow: fallback (gh missing → keep the constructed name)
-        raw = ""
-    resolved = (raw or "").strip()
-    out = resolved if "/" in resolved else repo
+    except Exception:  # stx-allow: fallback (gh missing → UNKNOWN, keep the constructed name)
+        probe = None
+    resolved = (probe.stdout if probe else "").strip()
+    if "/" in resolved:
+        out = resolved
+    elif probe is not None and _says_no_such_repo(probe.stderr):
+        # GitHub answered, and the answer was "there is no such repository".
+        out = None
+    else:
+        # UNKNOWN — network, auth, rate limit, gh missing. Keep the constructed
+        # guess, which is exactly the previous behaviour.
+        out = repo
     _CANONICAL_CACHE[repo] = out
     return out
 
@@ -164,7 +204,23 @@ def tracked_repos(
             continue
         if isinstance(project, str) and project.strip():
             projects.add(project.strip())
-    return sorted({canonicalize(f"{resolved_org}/{p}") for p in projects})
+    # DROP the ones GitHub says do not exist. Measured 2026-08-20: 22 of the 94
+    # names built from agent specs resolve to no repo in either org
+    # (SAC_PLACEHOLDER_PROJECT, <PROJECT>, handyman-01..08, canary-resume-test,
+    # …). Each cost one REST call per tick per host, forever, to be told 404 —
+    # and the poller cannot deliver a verdict for a repo that does not exist, so
+    # polling it was never doing anything but spending the shared budget.
+    #
+    # ``canonicalize`` returns None ONLY for a definite absence; an unknown
+    # answer keeps the constructed guess, so a gh outage still degrades to
+    # today's behaviour rather than to an empty poll list.
+    return sorted(
+        {
+            name
+            for name in (canonicalize(f"{resolved_org}/{p}") for p in projects)
+            if name
+        }
+    )
 
 
 __all__ = [

--- a/src/scitex_agent_container/_lifecycle/_github_ci.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Callable
+from typing import Callable, NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,39 @@ def _run_gh(args: list) -> str:
         logger.warning("_github_ci: gh invocation failed: %s", exc)
         return ""
     return proc.stdout or ""
+
+
+class GhProbe(NamedTuple):
+    """A gh invocation with its failure INTACT.
+
+    ``_run_gh`` deliberately flattens every failure to ``""`` — right for the
+    verdict path, where a missing answer and an unreadable one both mean "no
+    verdict this tick". It is wrong for any caller that must tell "GitHub says
+    this does not exist" from "I could not ask GitHub", because those two
+    warrant opposite actions and ``""`` is the same value for both.
+
+    Added BESIDE ``_run_gh`` rather than widening it: that function has several
+    callers who rely on the flattening, and changing its return shape to serve
+    one new caller would make every one of them handle a case they do not have.
+    """
+
+    stdout: str
+    returncode: int
+    stderr: str
+
+
+def _run_gh_probe(args: list) -> GhProbe:
+    """Run ``gh <args>`` and return stdout, exit code and stderr separately."""
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, check=False
+        )
+    except Exception as exc:  # stx-allow: fallback (gh missing / spawn error is UNKNOWN, not absence — see GhProbe)
+        logger.warning("_github_ci: gh probe failed to spawn: %s", exc)
+        return GhProbe("", -1, str(exc))
+    return GhProbe(proc.stdout or "", proc.returncode, proc.stderr or "")
 
 
 #: REST check-run ``conclusion`` -> the bucket vocabulary `gh pr checks`

--- a/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
+import contextlib
 from pathlib import Path
 
 from scitex_agent_container._lifecycle._ci_owner import resolve_owner, tracked_repos
@@ -160,43 +161,117 @@ def test_tracked_repos_collapses_two_projects_that_resolve_to_one_repo(
     assert repos == ["an-org/new-name"]
 
 
+def _probe_seam(stdout="", returncode=0, stderr="", calls=None):
+    """Build a fake ``_run_gh_probe``. Returns the real GhProbe shape."""
+    from scitex_agent_container._lifecycle._github_ci import GhProbe
+
+    def fake(args):
+        if calls is not None:
+            calls.append(args)
+        return GhProbe(stdout, returncode, stderr)
+
+    return fake
+
+
+@contextlib.contextmanager
+def _seamed_probe(**kw):
+    """Swap ``_github_ci._run_gh_probe`` and clear the canonical cache.
+
+    The cache MUST be cleared on both sides: it is module-global and now
+    caches ``None`` as a meaningful value, so a leaked entry would make the
+    next test read a verdict it never produced.
+    """
+    from scitex_agent_container._lifecycle import _ci_owner as mod
+    import scitex_agent_container._lifecycle._github_ci as ghmod
+
+    mod._CANONICAL_CACHE.clear()
+    real = ghmod._run_gh_probe
+    ghmod._run_gh_probe = _probe_seam(**kw)
+    try:
+        yield mod
+    finally:
+        ghmod._run_gh_probe = real
+        mod._CANONICAL_CACHE.clear()
+
+
 def test_canonical_lookup_falls_back_to_the_guess_when_gh_gives_nothing():
     # Arrange — a gh outage must degrade to the previous behaviour (a
     # guess), never to an empty poll list that silently watches nothing.
-    from scitex_agent_container._lifecycle import _ci_owner as mod
-
-    mod._CANONICAL_CACHE.clear()
-    saved = mod._run_gh if hasattr(mod, "_run_gh") else None
-    import scitex_agent_container._lifecycle._github_ci as ghmod
-
-    real = ghmod._run_gh
-    ghmod._run_gh = lambda args: ""
-    try:
+    with _seamed_probe(stdout="", returncode=1, stderr="dial tcp: i/o timeout") as mod:
         # Act
         out = mod._canonical_name_with_owner("an-org/a-repo")
-    finally:
-        ghmod._run_gh = real
-        mod._CANONICAL_CACHE.clear()
     # Assert
     assert out == "an-org/a-repo"
+
+
+def test_canonical_lookup_returns_none_when_github_says_no_such_repo():
+    # Arrange — GitHub ANSWERED, and the answer was that it does not exist.
+    # This is the case worth one REST call per tick per host, forever.
+    with _seamed_probe(
+        stdout="",
+        returncode=1,
+        stderr="GraphQL: Could not resolve to a Repository with the name 'an-org/nope'. (repository)",
+    ) as mod:
+        # Act
+        out = mod._canonical_name_with_owner("an-org/nope")
+    # Assert
+    assert out is None
+
+
+def test_a_rate_limited_probe_is_unknown_and_keeps_the_repo():
+    # Arrange — THE ASYMMETRY THIS FIX TURNS ON. A 403 is GitHub declining to
+    # answer, not GitHub saying the repo is absent. Treating it as absence
+    # would drop the whole poll set during exactly the rate-limit incident
+    # this change exists to relieve — and it would do so silently.
+    with _seamed_probe(
+        stdout="",
+        returncode=1,
+        stderr="HTTP 403: API rate limit exceeded for user ID 1234 (https://api.github.com/...)",
+    ) as mod:
+        # Act
+        out = mod._canonical_name_with_owner("an-org/a-repo")
+    # Assert
+    assert out == "an-org/a-repo"
+
+
+def test_tracked_repos_drops_a_repo_github_says_does_not_exist(tmp_path: Path):
+    # Arrange — the end-to-end consequence: an absent name must not reach the
+    # poll set, because the loop spends a REST call on every member of it.
+    agents = tmp_path / "agents"
+    _write_spec(agents, "proj-real", "real-repo")
+    _write_spec(agents, "proj-ghost", "ghost-repo")
+    # Act
+    repos = tracked_repos(
+        agents_dir=agents,
+        org="an-org",
+        canonicalize=lambda repo: None if "ghost" in repo else repo,
+    )
+    # Assert
+    assert repos == ["an-org/real-repo"]
 
 
 def test_canonical_lookup_is_cached_so_a_tick_costs_one_call_per_repo():
     # Arrange — without a cache the poll loop spends one gh call per repo
     # per tick, forever.
-    from scitex_agent_container._lifecycle import _ci_owner as mod
-    import scitex_agent_container._lifecycle._github_ci as ghmod
-
-    mod._CANONICAL_CACHE.clear()
     calls: list = []
-    real = ghmod._run_gh
-    ghmod._run_gh = lambda args: calls.append(args) or "an-org/canonical"
-    try:
+    with _seamed_probe(stdout="an-org/canonical", calls=calls) as mod:
         # Act
         mod._canonical_name_with_owner("an-org/a-repo")
         mod._canonical_name_with_owner("an-org/a-repo")
-    finally:
-        ghmod._run_gh = real
-        mod._CANONICAL_CACHE.clear()
+    # Assert
+    assert len(calls) == 1
+
+
+def test_an_absent_verdict_is_cached_too():
+    # Arrange — None is now a MEANINGFUL cached value. If the cache treated it
+    # as "not cached", every absent repo would be re-probed every tick and the
+    # saving this change exists for would be exactly zero.
+    calls: list = []
+    with _seamed_probe(
+        stdout="", returncode=1, stderr="Could not resolve to a Repository", calls=calls
+    ) as mod:
+        # Act
+        mod._canonical_name_with_owner("an-org/nope")
+        mod._canonical_name_with_owner("an-org/nope")
     # Assert
     assert len(calls) == 1


### PR DESCRIPTION
## What

`tracked_repos` builds `<org>/<project>` from every agent spec and hands the lot to the poll loop, which spends **one REST call per member per tick per host**. `_canonical_name_with_owner` resolved each name once, but on *any* failure returned the constructed guess unchanged — so a name with no repo behind it stayed in the poll set forever, costing a call per tick to be told 404.

**Measured 2026-08-20 on scitex-compute-04: 22 of the 94 names resolve to no repository in either org** — `SAC_PLACEHOLDER_PROJECT`, `<PROJECT>`, `handyman-01..08`, `canary-resume-test`, `sdk-canary-20260814`, `spartan-dev` and others. The poller cannot deliver a verdict for a repo that does not exist, so polling them was never doing anything except spending a budget shared with every other agent on the fleet.

## Three-valued, and the asymmetry is the whole design

"GitHub says this does not exist" and "I could not ask GitHub" warrant opposite actions. The old code collapsed both, because `_run_gh` flattens every failure to `""`.

| answer | action |
|---|---|
| definite absence | dropped from the poll set |
| anything else | keep the guess — exactly today's behaviour |

The absence markers are deliberately narrow, because the two errors are **not symmetric**: a false ABSENT silently drops a real repo and its CI verdicts stop arriving with nothing to notice; a false UNKNOWN merely keeps polling.

- A rate-limited 403 is explicitly UNKNOWN. Treating it as absence would empty the poll set during precisely the incident this change exists to relieve. `test_a_rate_limited_probe_is_unknown_and_keeps_the_repo` pins it.
- A bare `"not found"` is deliberately **not** a marker — it would match `gh: command not found`, i.e. a missing binary, the most UNKNOWN situation there is.

`_run_gh_probe` is added **beside** `_run_gh`, not in place of it: that function has several callers who rely on the flattening (for the verdict path, a missing answer and an unreadable one really are the same thing), and changing its return shape would force every one of them to handle a case it does not have.

## The tests caught a real bug in this change

Four failed with `out is None` and `calls == []`. My first reading was wrong — I assumed the seam had gone stale and the tests were reaching the real `gh`. They were not: the sentinel lookup was written `_CANONICAL_CACHE.get(repo)` **without the default**, and `.get` returns `None` for a missing key, which `is not _UNCACHED` — so the function returned `None` for every uncached repo and never probed at all.

That is the exact failure the sentinel was introduced to prevent, reproduced in the line introducing it. Every repo would have been reported absent and the poll set would have emptied silently.

It was caught only because the new tests assert on the **call count** as well as the value — `calls == []` is what separated "returned the wrong answer" from "never asked".

`_lifecycle` suite: **2,241 passed, 2 skipped**.

Card: `sac-listen-ci-poller-burns-2x-the-graphql-pool-20260819`
