### PR TITLE
fix(listen): inbox_reachable could never say "reachable" in production

### DIFF
--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -195,7 +195,16 @@ async def _annotate_status_reachability(
 
     try:
         counts = await request.app.state.inbox.subscriber_counts()
-        local_host = getattr(request.app.state, "local_host", None)
+        # Prefer the per-app ``local_host``; fall back to the env resolver —
+        # mirroring ``_node_channel`` for the identical question. The fallback
+        # is load-bearing: ``create_app`` defaults it to None and the one
+        # production caller never passes it, so without this EVERY row with a
+        # host was annotated ``unknown``, including rows on this host.
+        from .._state.state_db import _resolve_host as _resolve_local_host
+
+        local_host = getattr(request.app.state, "local_host", None) or (
+            _resolve_local_host(None)
+        )
     except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict)
         import logging
 

--- a/tests/scitex_agent_container/_listen/test_server_reachability_local_host.py
+++ b/tests/scitex_agent_container/_listen/test_server_reachability_local_host.py
@@ -1,0 +1,107 @@
+"""``_annotate_status_reachability`` must resolve its own host.
+
+WHY THIS FILE EXISTS. ``create_app`` defaults ``local_host=None`` and the one
+production caller (``cli_pkg/listen_cmds.py``) does not pass it. So
+``app.state.local_host`` was None on every running daemon,
+``_reachability._is_locally_observable`` hit its ``if not local_host: return
+False``, and EVERY row carrying a host was annotated ``unknown`` — including
+rows on the very host answering the request. Reported by scitex-dev as all 11
+a2a peers reading ``unknown``.
+
+That made ``inbox_reachable`` a three-valued field that could only ever return
+one of its values, while its own tool description tells callers to check it
+before sending. The sibling ``_node_channel`` path already carried the env
+fallback for the identical question; this one did not.
+
+A SEPARATE FILE, not an addition to ``test_server.py``: that mirror is already
+1,647 lines against a 512-line cap, and the package convention is focused
+``test_server_<topic>.py`` files (``test_server_lineage_acl.py``,
+``test_server_agent_card_path.py``, …).
+
+PA-306: no mocks. ``_Req`` is a hand-written stand-in holding exactly the two
+attributes the function reads — the same "configuration, not mocking" pattern
+``test_server.py`` documents for its module-attribute re-pointing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from scitex_agent_container._listen.server import _annotate_status_reachability
+from scitex_agent_container._state.state_db import _resolve_host
+
+
+class _Inbox:
+    """The broker seam: returns a real subscriber-count mapping."""
+
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    async def subscriber_counts(self) -> dict[str, int]:
+        return dict(self._counts)
+
+
+class _State:
+    def __init__(self, inbox: _Inbox, local_host: str | None) -> None:
+        self.inbox = inbox
+        self.local_host = local_host
+
+
+class _App:
+    def __init__(self, state: _State) -> None:
+        self.state = state
+
+
+class _Req:
+    def __init__(self, app: _App) -> None:
+        self.app = app
+
+
+def _annotate(row: dict, *, counts: dict[str, int], local_host: str | None) -> dict:
+    req = _Req(_App(_State(_Inbox(counts), local_host)))
+    return asyncio.run(_annotate_status_reachability(req, row))
+
+
+def test_local_row_is_reachable_when_app_state_local_host_is_unset():
+    # Arrange — reproduces production exactly: create_app was called without
+    # local_host, so app.state.local_host is None, and the row names THIS host.
+    host = _resolve_host(None)
+    row = {"name": "alpha", "host": host}
+    # Act
+    out = _annotate(row, counts={"alpha": 1}, local_host=None)
+    # Assert — before the fix this was "unknown" for every host-carrying row.
+    assert out["inbox_reachable"] == "reachable"
+
+
+def test_local_row_reports_its_subscriber_count_when_local_host_is_unset():
+    # Arrange — the count is the other half: an "unknown" verdict also nulls
+    # inbox_subscribers, so asserting only the verdict leaves that unpinned.
+    host = _resolve_host(None)
+    row = {"name": "alpha", "host": host}
+    # Act
+    out = _annotate(row, counts={"alpha": 3}, local_host=None)
+    # Assert
+    assert out["inbox_subscribers"] == 3
+
+
+def test_a_row_on_another_host_stays_unknown():
+    # Arrange — POSITIVE CONTROL for the assertions above. They check that a
+    # value is NOT "unknown", which a function that always said "reachable"
+    # would also satisfy. A remote row must still be unknown: this daemon has
+    # no window into another host's broker, and inventing a zero there would
+    # be a false accusation of deafness.
+    row = {"name": "beta", "host": "some-other-host-that-is-not-us"}
+    # Act
+    out = _annotate(row, counts={}, local_host=None)
+    # Assert
+    assert out["inbox_reachable"] == "unknown"
+
+
+def test_an_explicit_local_host_still_wins():
+    # Arrange — the fallback must not shadow a caller that DID pin the host,
+    # which is what in-process multi-host tests rely on.
+    row = {"name": "alpha", "host": "pinned-host"}
+    # Act
+    out = _annotate(row, counts={"alpha": 1}, local_host="pinned-host")
+    # Assert
+    assert out["inbox_reachable"] == "reachable"


### PR DESCRIPTION
fix(listen): inbox_reachable could never say "reachable" in production

`_annotate_status_reachability` read `app.state.local_host` with no
fallback. `create_app` defaults that to None and the one production
caller — `cli_pkg/listen_cmds.py`, `create_app(token=...,
health_watchdog_port=...)` — never passes it. So it was None on every
running daemon, `_reachability._is_locally_observable` hit its

    if not local_host:
        return False    # we don't know who WE are -> cannot claim locality

and EVERY row carrying a host was annotated `unknown` — including rows on
the very host answering the request.

Reported by scitex-dev: all 11 a2a peers reading
`inbox_subscribers: null` / `inbox_reachable: "unknown"`, same-host rows
included.

WHY THIS IS WORSE THAN A MISSING ARGUMENT. The field exists to answer
"will a message actually wake this agent", and the a2a_peers tool
description instructs callers to check it before sending. A three-valued
field that can only ever return one of its values is not cautious — it is
the constitution's §2 gate-that-cannot-fail in another costume. Every
caller who obeyed the docstring correctly refused to trust peers that
were in fact reachable.

RULED OUT FIRST, so this is not a guess between two branches. The other
route to `unknown` is the broker read failing, which logs
"could not read inbox broker". Occurrences in the sac-listen journal over
6 hours: 0, against a control of 1,452 journal lines in the same window.
The broker is readable; the locality predicate was the whole cause.

THE FIX WAS ALREADY WRITTEN, ONE MODULE OVER. `_node_channel` asks the
identical question and carries the env fallback:

    local_host = getattr(request.app.state, "local_host", None) or _resolve_local_host(None)

Two sibling call sites, one with the fallback and one without — which is
why the channel path worked while reachability was universally unknown.
This adds the same fallback here.

Fixed at the READ site rather than by passing `local_host` in
listen_cmds, on purpose: a default that silently disables a feature is
the defect, not the caller who omitted the argument. Passing it at the
one call site would leave the trap armed for the next one.

TESTING. New focused file rather than an addition to `test_server.py`,
which is already 1,647 lines against a 512 cap; the package convention is
`test_server_<topic>.py`. PA-306: no mocks — the stand-ins hold exactly
the two attributes the function reads.

Mutation-checked by restoring production exactly as it was (dropping the
fallback): the two local-host tests fail, and the two controls —
a remote row must STAY unknown, an explicitly pinned host must still win
— keep passing. That discrimination is the point: assertions that a
verdict is not "unknown" would also be satisfied by a function that
always said "reachable".

NOT FIXED HERE: a row with a NULL a2a_port is still SELECTED as a forward
target and then 502s, instead of being skipped as unusable. Same family —
a three-valued fact collapsed to two at the moment of choosing — and it
is the second item on the card.

Card: sac-a2a-reachability-all-unknown-and-null-port-rows-get-selected-20260821
