### PR TITLE
fix(comms-nodes): a tombstone must not refuse the restart after it

### DIFF
--- a/src/scitex_agent_container/_state/state_db_comms_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_comms_nodes.py
@@ -199,6 +199,37 @@ def register_comms_node(
                 f"ADR-0014: names are globally unique. Rename or "
                 f"unregister one and re-run `sac registry sync --all`."
             )
+        # Same source, but the existing row is a TOMBSTONE — the agent
+        # stopped, and ``unregister_comms_node`` recorded that. A dead
+        # row is a record of a past placement, NOT a live claim on
+        # ``(host, a2a_port)``, so it must not refuse the restart that
+        # follows it. Without this, an agent that stops and comes back
+        # on a DIFFERENT port can never re-register: the collision check
+        # below compares against the dead port, raises, and every caller
+        # swallows it best-effort — so the agent stays absent from the
+        # federated graph forever and peers only ever see
+        # ``unknown_target``. ``spec.a2a.port: auto`` makes "a different
+        # port" the NORMAL outcome of a restart, so this fires on
+        # ordinary lifecycle, not on an edge case. Reproduced on two
+        # hosts 2026-08-20: ``business`` live on 19012 behind a
+        # tombstone at 19033, and ``scitex-dev`` live on 19008 behind an
+        # 11-day-old tombstone at 19003.
+        #
+        # This is the same convergence the ``same_target`` branch above
+        # already performs ("re-activates a tombstoned row, which is the
+        # natural way a node came back sync converges") — it was simply
+        # unreachable whenever the port moved. Cross-host conflicts are
+        # deliberately NOT covered: that check runs first and still
+        # raises, because ADR-0014 name uniqueness is about WHO owns the
+        # name, which a tombstone does not answer.
+        if existing["ended_at"] is not None:
+            conn.execute(
+                "UPDATE comms_nodes SET host = ?, a2a_port = ?, "
+                "updated_at = ?, ended_at = NULL, source_host = ? "
+                "WHERE name = ?",
+                (host, a2a_port, now, source_host, name),
+            )
+            return
         # Same source, different target. PR L1 (operator directive
         # 12847) — fail loud on collision, no silent last-writer-wins.
         if not replace:

--- a/tests/scitex_agent_container/_state/test_state_db_comms_nodes_tombstone_reregister.py
+++ b/tests/scitex_agent_container/_state/test_state_db_comms_nodes_tombstone_reregister.py
@@ -1,0 +1,148 @@
+"""A tombstoned ``comms_nodes`` row must not refuse the restart after it.
+
+``unregister_comms_node`` tombstones a row (``ended_at`` set) when an agent
+stops. Until this fix, ``register_comms_node``'s collision check compared the
+incoming target against that DEAD row, so an agent that came back on a
+different port raised :class:`CommsNodeConflictError` and — because every
+production caller swallows it best-effort — vanished from the federated graph
+permanently, surfacing only as ``unknown_target`` at the far end.
+
+``spec.a2a.port: auto`` makes "a different port" the normal outcome of a
+restart, so this was ordinary lifecycle rather than an edge case. Reproduced
+independently on two hosts 2026-08-20: ``business`` live on 19012 behind a
+tombstone pinned at 19033 (ywata-note-win, 19 live / 132 tombstoned), and
+``scitex-dev`` live on 19008 behind an 11-day-old tombstone at 19003
+(compute-04, 3 live / 29 tombstoned).
+
+The revival assertions matter as much as the "does not raise" ones: fixing the
+SELECT makes the re-activation UPDATE three lines below it reachable for the
+first time, so a registration could stop raising and still leave a row that
+readers filter out.
+
+Separate file because ``test_state_db_comms_nodes.py`` is already 625 lines
+against a 512-line cap. PA-306: no mocks; real on-disk SQLite under
+``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    CommsNodeConflictError,
+    lookup_comms_node,
+    register_comms_node,
+    unregister_comms_node,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    # Arrange
+    p = tmp_path / "state.db"
+    state_db.init_schema(p)
+    return p
+
+
+def _stopped_agent(db_path: Path, *, port: int = 19033) -> None:
+    """Register an agent, then stop it — leaving a tombstone at ``port``."""
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=port, db_path=db_path
+    )
+    unregister_comms_node(name="business", db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# The defect: a dead row blocked the restart that followed it
+# ---------------------------------------------------------------------------
+
+
+def test_restart_on_a_new_port_is_visible_to_peers_again(db_path: Path) -> None:
+    # Arrange — stopped at 19033, comes back on 19012 (port: auto moved it)
+    _stopped_agent(db_path)
+    # Act — raised CommsNodeConflictError before the fix
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=19012, db_path=db_path
+    )
+    # Assert — lookup filters tombstones, so a non-None row proves both that
+    # the call was accepted AND that ended_at was cleared.
+    assert lookup_comms_node(name="business", db_path=db_path) is not None
+
+
+def test_the_revived_row_carries_the_new_port(db_path: Path) -> None:
+    # Arrange
+    _stopped_agent(db_path)
+    # Act
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=19012, db_path=db_path
+    )
+    # Assert — peers must route to where the agent actually listens
+    row = lookup_comms_node(name="business", db_path=db_path)
+    assert row is not None and int(row["a2a_port"]) == 19012
+
+
+# ---------------------------------------------------------------------------
+# Controls — the fix must not become "the guard is disabled"
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_row_on_a_different_port_still_refuses(db_path: Path) -> None:
+    # Arrange — LIVE registration, never unregistered
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=19033, db_path=db_path
+    )
+
+    # Act
+    def _reregister() -> None:
+        register_comms_node(
+            name="business", host="ywata-note-win", a2a_port=19012, db_path=db_path
+        )
+
+    # Assert — the collision this guard exists for must still fire
+    with pytest.raises(CommsNodeConflictError):
+        _reregister()
+
+
+def test_a_cross_host_tombstone_still_refuses(db_path: Path) -> None:
+    # Arrange — tombstone owned by one source_host
+    register_comms_node(
+        name="business",
+        host="ywata-note-win",
+        a2a_port=19033,
+        source_host="ywata-note-win",
+        db_path=db_path,
+    )
+    unregister_comms_node(name="business", db_path=db_path)
+
+    # Act
+    def _claim_from_another_host() -> None:
+        register_comms_node(
+            name="business",
+            host="scitex-compute-04",
+            a2a_port=19012,
+            source_host="scitex-compute-04",
+            db_path=db_path,
+        )
+
+    # Assert — another host claiming the name is an ADR-0014 uniqueness
+    # question, which a tombstone does not answer.
+    with pytest.raises(CommsNodeConflictError):
+        _claim_from_another_host()
+
+
+def test_an_unrelated_live_name_is_untouched_by_the_revival(db_path: Path) -> None:
+    # Arrange — a neighbour holding a port of its own
+    _stopped_agent(db_path)
+    register_comms_node(
+        name="scitex-hpc", host="ywata-note-win", a2a_port=19012, db_path=db_path
+    )
+    # Act — business revives onto a different port than the neighbour's
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=19099, db_path=db_path
+    )
+    # Assert — reviving one name must not disturb another's row
+    row = lookup_comms_node(name="scitex-hpc", db_path=db_path)
+    assert row is not None and int(row["a2a_port"]) == 19012


### PR DESCRIPTION
fix(comms-nodes): a tombstone must not refuse the restart after it

An agent that stops and comes back on a DIFFERENT port could never
re-register in the federated graph. It stayed invisible to every peer
forever, and the only symptom was `unknown_target` at the far end.

`unregister_comms_node` tombstones a row (`ended_at` set) on stop.
`register_comms_node`'s collision check then compared the incoming
target against that DEAD row:

    SELECT host, a2a_port, source_host, ended_at
      FROM comms_nodes WHERE name = ?     -- no ended_at IS NULL

Port differs (live 19012 vs dead 19033) -> CommsNodeConflictError. Every
production caller catches that best-effort and logs, so the failure was
silent and the agent simply never appeared.

`spec.a2a.port: auto` makes "a different port" the NORMAL outcome of a
restart. This fired on ordinary lifecycle, not on an edge case.

THE FIX WAS ALREADY WRITTEN, THREE LINES BELOW. The `same_target` branch
documents itself as re-activating a tombstone -- "the natural way a node
came back sync converges" -- and clears `ended_at`. That branch was
simply unreachable whenever the port moved. This adds the same
convergence for the moved-port case.

PLACED AFTER THE CROSS-HOST CHECK, deliberately. A tombstone says the
agent stopped; it does not say who OWNS the name. ADR-0014 global
uniqueness is a separate question, so a different `source_host` still
raises. The change narrows exactly one branch: same source, dead row.

MEASURED ON TWO HOSTS, so this is not one agent's accident:

    ywata-note-win  business    comms_nodes 19033 dead / instances 19012 live
                    19 live rows, 132 tombstoned
    compute-04      scitex-dev  comms_nodes 19003 dead / instances 19008 live
                    3 live rows, 29 tombstoned   (11 days stale)

Reproduced independently by scitex-dev on their own host.

SCOPE -- ruled out rather than assumed. scitex-dev read all three
comms_nodes readers: `lookup` (:284) and the forwarding path
(`resolve_node_host` -> `resolve_comms_node_host`) both filter
`ended_at IS NULL`. Only the collision check (:164) does not. So a
tombstone is never selected as a forward target, and an earlier
suggestion that this could MISDELIVER to a reused port does not hold --
both of us withdrew that. The symptom is non-delivery, not misdelivery.

NOT FIXED HERE, and it is a genuinely different state: an `instances`
row that is LIVE with a NULL `a2a_port` is still selected as a forward
target and then 502s. Confirmed on ywata-note-win --
`scitex-dev  host=scitex-compute-04  a2a_port=None  ended_at=None`.
Neither dead nor correct; a one-line SELECT fix cannot reach it. That is
the second item on the card.

TESTING. New focused file -- `test_state_db_comms_nodes.py` is already
625 lines against a 512 cap. PA-306: no mocks, real on-disk SQLite.

Mutation-checked by reverting production to exactly its previous state:
3 of 5 tests fail, and the 2 that keep passing are the CONTROLS -- a
LIVE row at a different port must still refuse, and a cross-host
tombstone must still refuse. That split is the point: it shows the suite
detects the fix's removal without the controls merely tracking the fix's
presence. Without them, "stops raising" would be satisfied by deleting
the guard.

The revival assertions matter as much as the "does not raise" ones:
repairing the SELECT makes the re-activation UPDATE reachable for the
first time, so a registration could stop raising and still leave a row
that every reader filters out.

Card: sac-a2a-reachability-all-unknown-and-null-port-rows-get-selected-20260821
