### PR TITLE
fix(send): a refusal must not name a cause it has not established

### DIFF
--- a/src/scitex_agent_container/cli_pkg/send_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/send_cmds.py
@@ -211,6 +211,13 @@ def _refuse_uncontained_send(name: str) -> NoReturn:
     ``~/.claude/projects/`` store, so a host-side resume either finds
     nothing or resumes some unrelated host session — which is worse than
     an error, because it looks like it worked.
+
+    THIS MESSAGE IS FOR A DEFINED AGENT ONLY. A name that was never an
+    agent reaches the same dead end, and until 2026-08-20 it got this
+    same text — which describes the other cause in vocabulary that
+    presupposes the agent EXISTS ("the agent's live session", "(re)start
+    the agent"). ``_refuse_unknown_agent`` handles that case; the caller
+    decides which applies.
     """
     raise click.ClickException(
         f"agent {name!r}: no A2A port is recorded, so this turn has no "
@@ -224,6 +231,99 @@ def _refuse_uncontained_send(name: str) -> NoReturn:
         f"`sac agents start {name} -y` — then re-send. Verify with "
         f"`sac agents list {name} --json`: a2a_port must be non-null.\n"
         f"  State dir: {state_dir_for(name)}"
+    )
+
+
+def _is_known_agent(name: str) -> bool:
+    """Whether ``name`` is an agent AT ALL — a spec on disk, or any row.
+
+    DELIBERATELY BROADER than "running" and broader than "reachable". A
+    stopped agent, an agent whose row is tombstoned, and one recorded
+    with ``a2a_port=None`` are all KNOWN — they exist and the operator
+    can act on them, so the port-oriented refusal is the right advice.
+    Only a name with no spec in the agents/ cascade AND no ``instances``
+    row it has ever had is unknown.
+
+    The two halves are both needed and neither implies the other: an
+    agent defined but never started has a spec and no row, and a row can
+    outlive (or arrive without) a locally visible spec — a cross-host
+    agent's row is written into this host's store by dispatch/sync while
+    its spec lives on the peer. Checking only one half would call a real
+    agent nonexistent, which is the same class of wrong answer this
+    whole change exists to remove.
+    """
+    from ..config._resolve import enumerate_agent_names
+
+    # `enumerate_agent_names` and NOT `_discover_defined_agents`: the
+    # latter hardcodes its roots (project scope + ~/.scitex/.../agents)
+    # and does not honour SCITEX_AGENT_CONTAINER_YAML_DIRS, so an agent
+    # reachable through the operator-env cascade would be reported
+    # NONEXISTENT — the precise wrong answer this function exists to
+    # stop. It only stats `<dir>/<name>/spec.{yaml,yml}`, so the refusal
+    # path still parses no YAML on its way to refusing.
+    #
+    # It can also RAISE (AmbiguousRegistryScope: both the project-local
+    # and fleet registries exist and $SAC_AGENT_SCOPE is unset). Treat
+    # that as KNOWN, not as unknown. "I could not determine whether this
+    # agent exists" is the third value, and collapsing it into "it does
+    # not exist" would make this function assert the very kind of
+    # unestablished cause it was written to remove — and would turn a
+    # clean refusal into an unrelated crash on any host with both
+    # registries. Erring toward the port-oriented message keeps the
+    # pre-existing behaviour whenever existence is undecidable.
+    try:
+        if name in enumerate_agent_names():
+            return True
+    except Exception:  # stx-allow: fallback (reason: see comment above)
+        return True
+    from .._state.state_db import open_db
+
+    with open_db() as conn:
+        row = conn.execute(
+            "SELECT 1 FROM instances WHERE name = ? LIMIT 1", (name,)
+        ).fetchone()
+    return row is not None
+
+
+def _refuse_unknown_agent(name: str) -> NoReturn:
+    """Refuse a send to a name that was never an agent.
+
+    Delivery declines identically whether an agent is defined-but-
+    unreachable or was never defined at all, so both land at the same
+    dead end. Until 2026-08-20 both also got the SAME message —
+    ``_refuse_uncontained_send``'s — which says "no A2A port is
+    recorded" and prescribes ``sac agents start <name>``. Every word of
+    that presupposes the agent exists.
+
+    MEASURED: ``ci-watch`` dispatched to five names
+    (``proj-scitex-{stats,str,types,dict,datetime}``) 351 times, each
+    refused here, 0 successes. A peer read the text, took the named
+    cause at face value, and reported the failures as instances of an
+    unrelated port-registration defect then under active investigation.
+    The state DB showed those five with ``definitions=0`` and
+    ``instances=0`` EVER — not stopped, not tombstoned, never
+    registered. The remedy was trusted precisely because it was
+    specific, and it pointed at the wrong thing.
+
+    A refusal must not name a cause it has not established. Where two
+    states share one symptom, the message says which one was observed.
+    """
+    raise click.ClickException(
+        f"agent {name!r}: NOT DEFINED — no spec.yaml for this name under "
+        f"any agents/ tree (project-scope .scitex/agent-container/agents/ "
+        f"or ~/.scitex/agent-container/agents/).\n"
+        f"  This is NOT a missing-port problem and NOT a stopped agent: "
+        f"there is nothing to (re)start, because this name has never been "
+        f"an agent. Starting it is not the fix and will fail the same way.\n"
+        f"  Fix: check the name for a typo (`sac agents list`), or define "
+        f"the agent first (`sac agents create {name}`), then start it, "
+        f"then re-send.\n"
+        f"  If a SCHEDULED JOB is sending here, it is dispatching to a name "
+        f"that does not exist — fix the job's target list rather than this "
+        f"agent.\n"
+        f"  (There is still deliberately NO host-side fallback: every sac "
+        f"agent runs inside {CONTAINER_ENGINE}, so sac never runs the turn "
+        f"on the bare host. That guarantee holds for both causes.)"
     )
 
 
@@ -340,4 +440,11 @@ def send(
 
     # Every delivery path declined. Refuse — do NOT run the turn on the
     # bare host. See _refuse_uncontained_send for what used to happen here.
+    #
+    # Two different states land here and they need different remedies, so
+    # establish WHICH before naming a cause: an agent that exists but has
+    # no reachable port, versus a name that was never an agent at all.
+    # Telling the second to `sac agents start` is advice that cannot work.
+    if not _is_known_agent(name):
+        _refuse_unknown_agent(name)
     _refuse_uncontained_send(name)

--- a/tests/scitex_agent_container/cli_pkg/test_send_cmds_unknown_agent.py
+++ b/tests/scitex_agent_container/cli_pkg/test_send_cmds_unknown_agent.py
@@ -1,0 +1,172 @@
+"""A send to a name that was never an agent must say so, not blame the port.
+
+Delivery declines identically for "defined agent, no reachable port" and for
+"this name was never an agent", so both reach the same refusal. Until
+2026-08-20 both also got the SAME text — "no A2A port is recorded", prescribing
+`sac agents start <name>` — which presupposes the agent exists.
+
+MEASURED: ci-watch dispatched to five names that had never been registered
+(definitions=0, instances=0 EVER), 351 times, 0 successes. A peer read this
+refusal, took the named cause at face value, and reported the failures as
+instances of an unrelated port-registration defect. The remedy was trusted
+because it was specific, and it pointed at the wrong thing.
+
+The controls here carry the weight: it is easy to write a "not defined" branch
+that fires for everything, and the resulting message would still look correct
+in the one case you tested.
+
+Separate file because ``test_send_cmds.py`` is 566 lines against a 512 cap.
+PA-306: no mocks — real spec files under ``tmp_path`` and a real isolated
+SQLite state db.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.send_cmds import send
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+_YAML_DIRS = "SCITEX_AGENT_CONTAINER_YAML_DIRS"
+_STATE_DB = "SCITEX_AGENT_CONTAINER_STATE_DB"
+
+
+def _write_spec(yaml_root: Path, name: str) -> None:
+    agent_dir = yaml_root / name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "spec.yaml").write_text(
+        explicitize_yaml(f"""apiVersion: scitex-agent-container/v3
+kind: Agent
+spec:
+  runtime: apptainer
+  host: ${{HOSTNAME}}
+  workdir: {yaml_root.parent / "workdir"}
+  apptainer:
+    image: /x.sif
+    binds: []
+  claude:
+    model: sonnet
+""")
+    )
+
+
+@contextmanager
+def _env(key: str, value: str) -> Iterator[None]:
+    saved = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+@pytest.fixture
+def only_alpha_defined(tmp_path: Path) -> Iterator[Path]:
+    """Exactly one agent (``alpha``) exists; the state db is empty.
+
+    So ``alpha`` is defined-but-unreachable and any other name is unknown —
+    the two states this refusal must tell apart.
+    """
+    import importlib
+
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    yaml_root = tmp_path / "agents"
+    yaml_root.mkdir()
+    _write_spec(yaml_root, "alpha")
+    (tmp_path / "workdir").mkdir()
+    with _env(_YAML_DIRS, str(yaml_root)), _env(
+        _STATE_DB, str(tmp_path / "isolated-state.db")
+    ):
+        importlib.reload(_state_db_mod)
+        try:
+            yield tmp_path
+        finally:
+            importlib.reload(_state_db_mod)
+
+
+def _refuse(name: str) -> str:
+    return CliRunner().invoke(send, [name, "hi"]).output
+
+
+# ---------------------------------------------------------------------------
+# The defect: an unknown name was told its port was missing
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_name_is_reported_as_not_defined(only_alpha_defined: Path) -> None:
+    # Arrange
+    unknown = "proj-scitex-stats"
+    # Act
+    out = _refuse(unknown)
+    # Assert
+    assert "NOT DEFINED" in out, out
+
+
+def test_an_unknown_name_is_not_told_to_start_the_agent(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange
+    unknown = "proj-scitex-stats"
+    # Act
+    out = _refuse(unknown)
+    # Assert — the remedy that sent a reader to the wrong cause
+    assert "sac agents start proj-scitex-stats" not in out, out
+
+
+def test_an_unknown_name_does_not_claim_a_missing_port(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange
+    unknown = "proj-scitex-stats"
+    # Act
+    out = _refuse(unknown)
+    # Assert — naming an unestablished cause is the whole defect
+    assert "no A2A port is recorded" not in out, out
+
+
+# ---------------------------------------------------------------------------
+# Controls — the branch must DISCRIMINATE, not fire for everything
+# ---------------------------------------------------------------------------
+
+
+def test_a_defined_agent_still_gets_the_missing_port_message(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange — alpha has a spec and no reachable port
+    defined = "alpha"
+    # Act
+    out = _refuse(defined)
+    # Assert
+    assert "no A2A port is recorded" in out, out
+
+
+def test_a_defined_agent_is_never_called_not_defined(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange
+    defined = "alpha"
+    # Act
+    out = _refuse(defined)
+    # Assert — the false negative that would break every real send
+    assert "NOT DEFINED" not in out, out
+
+
+def test_both_refusals_keep_the_containment_guarantee(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange
+    both = ("alpha", "proj-scitex-stats")
+    # Act
+    outs = [_refuse(name) for name in both]
+    # Assert — sac never runs the turn on the bare host, either way
+    assert all("apptainer" in out for out in outs), outs


### PR DESCRIPTION
fix(send): a refusal must not name a cause it has not established

`sac agents send <name>` refused an UNKNOWN name with the message for a
DIFFERENT cause:

    no A2A port is recorded, so this turn has no way to reach the
    agent's live session
    Fix: (re)start the agent so its A2A sidecar binds a port —
         `sac agents start <name> -y`

Every clause presupposes the agent EXISTS — "the agent's live session",
"(re)start". Delivery declines identically for "defined agent, no
reachable port" and for "this name was never an agent", so both landed on
the text for the first.

MEASURED 2026-08-20. A scheduled job dispatched to five names —
proj-scitex-{stats,str,types,dict,datetime} — 351 times, 0 successes.
Those names have definitions=0 and instances=0 EVER: not stopped, not
tombstoned, never registered. A peer read this refusal, took the named
cause at face value, and reported the failures as instances of an
unrelated port-registration defect that was under active investigation
the same night. The remedy was trusted BECAUSE it was specific, and it
sent a careful reader to the wrong place.

It is a three-valued fact rendered in two-valued vocabulary:

    name unknown            no row at all         <- the actual case
    name known, port NULL   registered, unusable
    name known, port set    fine

WHAT CHANGED. The discrimination lives at the decision point, not inside
the message function: `_is_known_agent` + a branch at the call site, with
`_refuse_unknown_agent` for the new case. `_refuse_uncontained_send` is
byte-for-byte unchanged, so every existing test of the port message keeps
testing exactly what it was written to test.

TWO THINGS THE EXISTING SUITE CAUGHT, both real:

1. My first predicate asked "is there a spec.yaml" via
   `_discover_defined_agents`, which HARDCODES its roots and does not
   honour SCITEX_AGENT_CONTAINER_YAML_DIRS. `test_send_cmds.py` drives a
   seeded agent through exactly that env var, so a real agent was being
   called nonexistent — the same class of wrong answer this change
   exists to remove. Now uses `config._resolve.enumerate_agent_names`,
   the cascade that honours it.

2. `test_send_cmds.py` also seeds `record_instance_start(name="local-b",
   a2a_port=None)` — a LIVE row with a NULL port. A spec-only predicate
   calls that unknown; it is not. "Known" is therefore spec-on-disk OR
   any instances row ever, and neither half implies the other: an agent
   defined but never started has a spec and no row, while a cross-host
   agent's row is written into this host's store by dispatch/sync while
   its spec lives on the peer.

UNDECIDABLE IS NOT ABSENT. `enumerate_agent_names` raises
AmbiguousRegistryScope when both the project-local and fleet registries
exist with $SAC_AGENT_SCOPE unset. That is treated as KNOWN — falling
back to the pre-existing port message — because "I cannot determine
whether this agent exists" is the third value, and collapsing it into
"it does not exist" would have this function assert precisely the kind of
unestablished cause it was written to remove. It would also have turned a
clean refusal into an unrelated crash on any host holding both
registries.

TESTING. New focused file — `test_send_cmds.py` is 566 lines against a
512 cap. PA-306: no mocks; real spec files under tmp_path and a real
isolated SQLite state db.

Mutation-checked by restoring production exactly (branch removed): the 3
defect tests fail and the 3 CONTROLS keep passing — a defined agent still
gets the port message, a defined agent is never called NOT DEFINED, and
both refusals still state the containment guarantee. That split is the
evidence: controls that merely tracked the branch's presence would have
fallen with the rest, and "stops saying the wrong thing" would otherwise
be satisfied by deleting the message entirely.

Executed vs collected: 6 collected / 6 passed in the new file. Combined
cli_pkg + config legs: 4235 passed, 1 skipped, 16 DESELECTED in 205s.
The 16 are pre-existing deselections, not introduced here — reported
because a bare pass count is exactly how a suite that quietly tests less
keeps looking green.

Card: sac-host-sync-check-unit-drifted-from-its-jobspec-20260818
