### PR TITLE
fix(resolve): stop discarding a usable port sitting in the same row

### DIFF
--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -416,7 +416,7 @@ def resolve_node_host(
     with open_db(db_path) as conn:
         row = conn.execute(
             """
-            SELECT host, a2a_port
+            SELECT host, a2a_port, bound_port
               FROM instances
              WHERE name = ? AND ended_at IS NULL
              ORDER BY started_at DESC, id DESC
@@ -425,11 +425,34 @@ def resolve_node_host(
             (name,),
         ).fetchone()
     if row is not None:
+        # PREFER bound_port, fall back to the legacy a2a_port. Reading only
+        # a2a_port discarded a usable address that was sitting in the same
+        # row: `_send_resolve` has preferred bound_port over the legacy
+        # column since it was introduced, and the writers populate BOTH
+        # (`record_instance_start(a2a_port=bound, bound_port=bound)`), so a
+        # row where only bound_port survived resolved to "no port" here and
+        # 502'd at the forwarder while the sibling resolver would have
+        # reached it. Same row, same moment, two answers — the asymmetry was
+        # the defect, not the null.
+        port = row["a2a_port"]
+        if port is None:
+            port = row["bound_port"]
         return {
             "host": str(row["host"]),
-            "a2a_port": int(row["a2a_port"]) if row["a2a_port"] is not None else None,
+            "a2a_port": int(port) if port is not None else None,
         }
     # Fall through to comms_nodes (ADR-0014).
+    #
+    # NOT ALSO FALLING THROUGH WHEN THE ROW EXISTS BUT CARRIES NO PORT, and
+    # the reason is that this function answers TWO questions with one value.
+    # `is_local_node` consults it and reads ONLY ``host``: a live row means
+    # "the agent is on that host", which stays true whether or not a port is
+    # recorded. Falling through on a portless row would hand the locality
+    # decision to ``comms_nodes``, which may name a DIFFERENT host — so an
+    # agent that is genuinely local could start being forwarded away, and a
+    # routing repair would have silently changed what "local" means.
+    # Splitting locality from addressability is the real fix and it is a
+    # bigger change than this one; see the a2a card.
     return resolve_comms_node_host(name=name, db_path=db_path)
 
 

--- a/tests/scitex_agent_container/_state/test_state_db_nodes_bound_port_fallback.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes_bound_port_fallback.py
@@ -1,0 +1,119 @@
+"""``resolve_node_host`` must not discard a usable port sitting in its own row.
+
+The instances row carries BOTH ``a2a_port`` and ``bound_port`` — the writers
+populate them together (``record_instance_start(a2a_port=b, bound_port=b)``).
+``resolve_node_host`` selected only ``a2a_port``, so a row where just
+``bound_port`` survived resolved to "no port" and 502'd at the forwarder, while
+the sibling resolver ``_send_resolve`` — which has preferred ``bound_port`` over
+the legacy column since it was introduced — would have reached the same agent
+from the same row. Two resolvers, one row, one moment, two answers.
+
+The controls matter more than the fix here: preferring bound_port must not
+change WHICH HOST a name resolves to, and must not disturb the tombstone and
+fallback semantics that ``is_local_node`` and the comms_nodes fall-through
+depend on.
+
+PA-306: no mocks; real on-disk SQLite under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    is_local_node,
+    resolve_node_host,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    # Arrange
+    p = tmp_path / "state.db"
+    state_db.init_schema(p)
+    return p
+
+
+def _row(db_path: Path, *, a2a_port, bound_port) -> None:
+    """Insert one live instances row with the given port columns.
+
+    Written directly rather than through ``record_instance_start`` on
+    purpose: that writer sets ``a2a_port`` and ``bound_port`` from ONE
+    argument, so it cannot express the very state under test — a row
+    where only ``bound_port`` survives.
+    """
+    with state_db.open_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO instances (id, name, host, scope, a2a_port, "
+            " bound_port, started_at, ended_at) "
+            "VALUES ('id-1', 'peer', 'host-a', 'global', ?, ?, "
+            "        '2026-08-20T00:00:00Z', NULL)",
+            (a2a_port, bound_port),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The defect: a usable bound_port was thrown away
+# ---------------------------------------------------------------------------
+
+
+def test_bound_port_is_used_when_a2a_port_is_null(db_path: Path) -> None:
+    # Arrange — only bound_port survived on this row
+    _row(db_path, a2a_port=None, bound_port=19012)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert — resolved to 'no port' before the fix, then 502'd downstream
+    assert info is not None and info["a2a_port"] == 19012
+
+
+# ---------------------------------------------------------------------------
+# Controls — the preference must change the PORT and nothing else
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_port_still_wins_when_both_are_set(db_path: Path) -> None:
+    # Arrange — both populated and deliberately different
+    _row(db_path, a2a_port=19001, bound_port=19999)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert — the legacy column keeps precedence; this is a fallback, not a swap
+    assert info is not None and info["a2a_port"] == 19001
+
+
+def test_a_row_with_neither_port_still_resolves_to_none_port(db_path: Path) -> None:
+    # Arrange — the state that 502s; still reported, not invented
+    _row(db_path, a2a_port=None, bound_port=None)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert
+    assert info is not None and info["a2a_port"] is None
+
+
+def test_the_host_is_unchanged_by_the_port_preference(db_path: Path) -> None:
+    # Arrange
+    _row(db_path, a2a_port=None, bound_port=19012)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert — locality must not move when only the port source changes
+    assert info is not None and info["host"] == "host-a"
+
+
+def test_locality_is_unchanged_for_a_portless_row(db_path: Path) -> None:
+    # Arrange — the case deliberately NOT given a fall-through
+    _row(db_path, a2a_port=None, bound_port=None)
+    # Act
+    local = is_local_node(name="peer", local_host="host-a", db_path=db_path)
+    # Assert — a live row still means "the agent is on that host"
+    assert local is True
+
+
+def test_an_unknown_name_still_resolves_to_none(db_path: Path) -> None:
+    # Arrange — no row at all
+    unknown = "never-registered"
+    # Act
+    info = resolve_node_host(name=unknown, db_path=db_path)
+    # Assert — the fall-through must still return None, not a fabricated host
+    assert info is None


### PR DESCRIPTION
fix(resolve): stop discarding a usable port sitting in the same row

`resolve_node_host` SELECTed only `a2a_port`. The instances row also
carries `bound_port`, and the writers populate BOTH from one value
(`record_instance_start(a2a_port=b, bound_port=b)`). So a row where only
`bound_port` survived resolved to "no port" and 502'd at the forwarder —
while the sibling resolver `_send_resolve` reached the same agent from
the same row, because it has preferred `bound_port` over the legacy
column since it was introduced.

Two resolvers, one row, one moment, two answers. The asymmetry was the
defect, not the null.

Found while adversarially verifying a different claim on the a2a card:
one verifier noted `resolve_node_host` reads `a2a_port` ONLY, so a
populated `bound_port` would be a second discarded recovery route. On
the row that prompted it both columns are null, so nothing is recovered
THERE — this fixes the class, not that instance, and I am not claiming
otherwise.

DELIBERATELY NOT ALSO FALLING THROUGH TO comms_nodes WHEN THE ROW EXISTS
BUT HAS NO PORT. That was the obvious next step and it is wrong, because
this function answers TWO questions with one value: `is_local_node`
consults it and reads ONLY `host`. A live row means "the agent is on that
host", which stays true with or without a recorded port. Falling through
on a portless row would hand the LOCALITY decision to `comms_nodes`,
which may name a different host — so an agent that is genuinely local
could start being forwarded away, and a routing repair would have
silently redefined "local". Splitting locality from addressability is the
real fix and is a larger change; it stays on the a2a card.

TESTING. New focused file. PA-306: no mocks, real on-disk SQLite. The row
is written with a direct INSERT rather than `record_instance_start`
because that writer sets both port columns from one argument and
therefore cannot express the state under test.

Mutation-checked by restoring production exactly (fallback removed): the
one defect test fails and all FIVE controls keep passing — a2a_port still
wins when both are set (this is a fallback, not a swap), a row with
neither port still reports None rather than inventing one, the host is
unchanged, locality is unchanged for a portless row, and an unknown name
still resolves to None. Those controls are the point: "returns a port"
would also be satisfied by a function that fabricated one.

Executed vs collected: 44 collected / 44 passed (6 new + 38 existing
comms_nodes tests), 0 deselected.

Card: sac-a2a-reachability-all-unknown-and-null-port-rows-get-selected-20260821
