### PR TITLE
fix(verify): a probe that could not RUN must not report the pane alive

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_launch_verify.py
+++ b/src/scitex_agent_container/_lifecycle/_launch_verify.py
@@ -224,18 +224,50 @@ def _iso(ts: float) -> str:
     return datetime.fromtimestamp(ts).astimezone().isoformat(timespec="seconds")
 
 
-def _runtime_reports_running(runtime: Any, config: Any) -> bool:
-    """The runtime's own liveness probe — a RAISING probe is UNKNOWN.
+#: Tri-state liveness readings from a runtime's own probe. ``UNKNOWN`` is
+#: the value the boolean form could not express, and its absence was a
+#: live defect: see :func:`_runtime_liveness`.
+PROBE_RUNNING = "running"
+PROBE_DEAD = "dead"
+PROBE_UNKNOWN = "unknown"
+
+
+def _runtime_liveness(runtime: Any, config: Any) -> str:
+    """The runtime's own liveness probe as THREE values, not two.
 
     A probe that could not run must not convict (the false-RED lesson of
-    :mod:`._start_verdict`): treat it as "still possibly alive" so the
-    wait continues and the window expiry reports UNVERIFIED, never a
-    fabricated death.
+    :mod:`._start_verdict`) — but it must not ACQUIT either, and the
+    boolean this replaces could only do one of those. It answered
+    ``True`` both when the runtime reported alive and when the probe
+    raised, so the two callers inherited opposite bugs from one value:
+
+    * the DEAD arm read only ``False``, so ``True`` meaning "unknown"
+      correctly declined to convict. That use was right, and is
+      unchanged.
+    * the TUI arm read ``True`` as PROOF and returned VERIFIED_UP with
+      the words "the tmux pane process is alive" — a claim about an
+      observation that never happened whenever the probe raised. That is
+      the success value doubling as the didn't-check value, on the path
+      109 of 122 fleet specs take (measured 2026-08-20: runtime tui 109,
+      claude-agent-sdk 11, apptainer 2).
+
+    Returning the third value lets each caller say what it actually saw.
     """
     try:
-        return bool(runtime.is_running(config))
-    except Exception:  # stx-allow: fallback (reason: a probe that cannot run is UNKNOWN liveness, not evidence of death — see _start_verdict's false-RED rationale)
-        return True
+        return PROBE_RUNNING if bool(runtime.is_running(config)) else PROBE_DEAD
+    except Exception:  # stx-allow: fallback (reason: a probe that cannot run is UNKNOWN liveness — neither death nor life; the tri-state is precisely so this need not masquerade as either)
+        return PROBE_UNKNOWN
+
+
+def _runtime_reports_running(runtime: Any, config: Any) -> bool:
+    """Back-compat boolean: True unless the probe positively reported DEAD.
+
+    Preserved verbatim in MEANING for the negative arm — only a definite
+    ``PROBE_DEAD`` is falsey — so the caller that convicts on ``False``
+    behaves identically. New code wanting positive evidence must call
+    :func:`_runtime_liveness` and check for ``PROBE_RUNNING``.
+    """
+    return _runtime_liveness(runtime, config) != PROBE_DEAD
 
 
 def verify_launch(
@@ -307,11 +339,29 @@ def _verify_tui(
     """
     waited = max(0.0, now_fn() - launched_at)
     log_path = _first_existing(state_dir, ("boot.stderr.log", "stdout.log"))
-    if _runtime_reports_running(runtime, config):
+    liveness = _runtime_liveness(runtime, config)
+    if liveness == PROBE_RUNNING:
         return LaunchVerdict(
             VERIFIED_UP,
             "ready: boot drain passed and the tmux pane process is alive "
             f"(probed {waited:.1f}s after launch)",
+            str(log_path) if log_path else None,
+            "",
+            waited,
+            None,
+        )
+    if liveness == PROBE_UNKNOWN:
+        # The probe RAISED. Previously this returned VERIFIED_UP with the
+        # words "the tmux pane process is alive" — asserting an
+        # observation that never happened. Report the absence of evidence
+        # instead of inventing evidence of presence; the agent may well be
+        # up, and this says exactly that.
+        return LaunchVerdict(
+            UNVERIFIED,
+            "CANNOT VERIFY: the runtime's own liveness probe could not run "
+            f"({waited:.1f}s after launch), so sac has no reading either "
+            "way. The agent may be up — confirm with `tmux ls` or "
+            "`sac agents list <name>`",
             str(log_path) if log_path else None,
             "",
             waited,

--- a/tests/scitex_agent_container/_lifecycle/test__launch_verify_probe_unknown.py
+++ b/tests/scitex_agent_container/_lifecycle/test__launch_verify_probe_unknown.py
@@ -1,0 +1,197 @@
+"""A liveness probe that could not RUN must not report the pane as alive.
+
+`_verify_tui` asked `_runtime_reports_running`, which returned True BOTH when
+the runtime reported alive and when the probe raised — then returned
+VERIFIED_UP with the words "the tmux pane process is alive". So whenever the
+probe raised, sac asserted an observation that never happened, on the path 109
+of 122 fleet specs take (measured 2026-08-20: tui 109, claude-agent-sdk 11,
+apptainer 2). The success value doubled as the didn't-check value.
+
+The boolean could not express the difference: refusing to convict on a raising
+probe (correct, and what the DEAD arm needs) and refusing to acquit on one
+(also correct, and what this arm needs) are opposite requirements on one value.
+Hence three values.
+
+The controls carry the weight: a fix that returned UNVERIFIED for everything
+would satisfy the defect test and break every start in the fleet.
+
+Separate file — `test__launch_verify.py` is 483 lines against a 512 cap.
+PA-306: no mocks; hand-written runtime doubles matching the seam shape the
+existing suite already uses.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._launch_verify import (
+    PROBE_DEAD,
+    PROBE_RUNNING,
+    PROBE_UNKNOWN,
+    UNVERIFIED,
+    VERIFIED_FAILED,
+    VERIFIED_UP,
+    _runtime_liveness,
+    _runtime_reports_running,
+    _verify_tui,
+)
+
+
+class _AliveRuntime:
+    def is_running(self, config) -> bool:  # noqa: ARG002 - runtime seam shape
+        return True
+
+
+class _DeadRuntime:
+    def is_running(self, config) -> bool:  # noqa: ARG002 - runtime seam shape
+        return False
+
+
+class _RaisingRuntime:
+    """A probe that cannot RUN — neither alive nor dead is observed."""
+
+    def is_running(self, config):  # noqa: ARG002 - runtime seam shape
+        raise OSError("tmux server not reachable")
+
+
+def _config(name: str = "probe-x") -> SimpleNamespace:
+    return SimpleNamespace(name=name)
+
+
+@pytest.fixture
+def clean_window() -> Iterator[None]:
+    """Unset the real env var and restore it — no fixture rewrites internals."""
+    # Arrange
+    key = "SAC_VERIFY_WINDOW_S"
+    saved = os.environ.pop(key, None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ[key] = saved
+
+
+def _verdict(runtime, tmp_path: Path):
+    """Exercise `_verify_tui` DIRECTLY — the function that changed.
+
+    Going through `verify_launch` would not reach it: dispatch is
+    `isinstance(runtime, TuiSessionRuntime)`, so a hand-written double
+    falls to the generic heartbeat path instead. That path ALSO returns
+    UNVERIFIED when no beat arrives, which would have made these tests
+    pass without touching the code under test — green for a reason
+    unrelated to the fix. Calling the function directly is what makes
+    the assertions mean what they say.
+    """
+    return _verify_tui(
+        _config(),
+        runtime,
+        tmp_path,
+        time.time(),
+        time.time,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The tri-state itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_raising_probe_reads_unknown(clean_window) -> None:
+    # Arrange
+    runtime = _RaisingRuntime()
+    # Act
+    reading = _runtime_liveness(runtime, _config())
+    # Assert
+    assert reading == PROBE_UNKNOWN
+
+
+def test_a_live_probe_reads_running(clean_window) -> None:
+    # Arrange
+    runtime = _AliveRuntime()
+    # Act
+    reading = _runtime_liveness(runtime, _config())
+    # Assert
+    assert reading == PROBE_RUNNING
+
+
+def test_a_false_probe_reads_dead(clean_window) -> None:
+    # Arrange
+    runtime = _DeadRuntime()
+    # Act
+    reading = _runtime_liveness(runtime, _config())
+    # Assert
+    assert reading == PROBE_DEAD
+
+
+# ---------------------------------------------------------------------------
+# The defect: an unobserved pane was reported alive
+# ---------------------------------------------------------------------------
+
+
+def test_a_raising_probe_does_not_report_the_pane_alive(
+    clean_window, tmp_path: Path
+) -> None:
+    # Arrange
+    runtime = _RaisingRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert — returned VERIFIED_UP before the fix
+    assert verdict.status != VERIFIED_UP, verdict.evidence
+
+
+def test_a_raising_probe_says_it_cannot_verify(clean_window, tmp_path: Path) -> None:
+    # Arrange
+    runtime = _RaisingRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert
+    assert verdict.status == UNVERIFIED, verdict.evidence
+
+
+def test_a_raising_probe_is_not_reported_as_death_either(
+    clean_window, tmp_path: Path
+) -> None:
+    # Arrange — the false-RED lesson: unknown must not convict
+    runtime = _RaisingRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert
+    assert verdict.status != VERIFIED_FAILED, verdict.evidence
+
+
+# ---------------------------------------------------------------------------
+# Controls — the fleet must keep starting
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_runtime_still_verifies_up(clean_window, tmp_path: Path) -> None:
+    # Arrange — the arm that carries every healthy start
+    runtime = _AliveRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert
+    assert verdict.status == VERIFIED_UP, verdict.evidence
+
+
+def test_a_dead_runtime_still_verifies_failed(clean_window, tmp_path: Path) -> None:
+    # Arrange — the arm that catches a stillborn container
+    runtime = _DeadRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert
+    assert verdict.status == VERIFIED_FAILED, verdict.evidence
+
+
+def test_the_boolean_shim_still_declines_to_convict_on_unknown(clean_window) -> None:
+    # Arrange — the DEAD arm reads this and must behave exactly as before
+    runtime = _RaisingRuntime()
+    # Act
+    reports_running = _runtime_reports_running(runtime, _config())
+    # Assert — only a definite DEAD is falsey
+    assert reports_running is True


### PR DESCRIPTION
fix(verify): a probe that could not RUN must not report the pane alive

`_verify_tui` returned VERIFIED_UP with the words "the tmux pane process
is alive" whenever `_runtime_reports_running` was true — and that helper
returns True BOTH when the runtime reports alive AND when the probe
RAISES:

    try:
        return bool(runtime.is_running(config))
    except Exception:
        return True   # a probe that could not run is UNKNOWN, not death

So on a raising probe sac asserted an observation that never happened.
The success value doubled as the didn't-check value, on the path 109 of
122 fleet specs take (measured 2026-08-20: runtime tui 109,
claude-agent-sdk 11, apptainer 2).

WHY THE BOOLEAN COULD NOT BE FIXED IN PLACE. Its two callers need
OPPOSITE things from the ambiguous value:

  * the DEAD arm reads only `False`, so "unknown" arriving as True
    correctly declines to CONVICT — that is the false-RED lesson from
    `_start_verdict` and it is right;
  * the TUI arm read `True` as proof, so "unknown" arriving as True
    wrongly ACQUITS.

One value cannot both refuse to convict and refuse to acquit. Hence
three: PROBE_RUNNING / PROBE_DEAD / PROBE_UNKNOWN.

`_runtime_reports_running` is kept as a shim meaning "not positively
dead", so the convicting caller is unchanged in behaviour — with a test
pinning exactly that.

The TUI arm now reports UNVERIFIED on an unreadable probe, in restart's
own register: "CANNOT VERIFY ... the agent may be up — confirm with
`tmux ls`". It states the absence of evidence instead of inventing
evidence of presence.

BLAST RADIUS. Only starts where the probe RAISES change verdict, and
those are exactly the starts that silently claimed success while
observing nothing. A start whose probe answers at all is untouched.

TESTING. New focused file — `test__launch_verify.py` is 483 lines
against a 512 cap. PA-306: no mocks; hand-written runtime doubles
matching the seam shape the existing suite already uses, and a real
env fixture (`monkeypatch` is banned fleet-wide).

The tests call `_verify_tui` DIRECTLY, and that detail is load-bearing:
dispatch is `isinstance(runtime, TuiSessionRuntime)`, so a hand-written
double routed to the GENERIC heartbeat path instead — which also returns
UNVERIFIED when no beat arrives. My first version passed for that
unrelated reason. A CONTROL caught it: `test_a_live_runtime_still_
verifies_up` failed with "no fresh heartbeat within 0.5s", which is how
I learned the tests never reached the code under test.

Mutation-checked by collapsing UNKNOWN back into RUNNING (production as
it was): the 2 defect tests fail and 7 others pass, including the
control that a raising probe must not be reported as DEATH either — it
survives the mutant because the mutant over-acquits rather than
over-convicts, which is the discrimination that matters.

Executed vs collected: 9 collected / 9 passed in the new file; with the
existing launch-verify suite, 27 collected / 27 passed, 0 deselected.

Card: sac-missing-bind-source-is-fatal-but-reported-as-success-20260819
