### PR TITLE
fix(a2a): split addressability from locality so a portless row stops routing

### DIFF
--- a/src/scitex_agent_container/_listen/_node_channel.py
+++ b/src/scitex_agent_container/_listen/_node_channel.py
@@ -108,7 +108,8 @@ async def node_message_send(request: Request) -> Response:
     # ``metadata.from_agent`` we received, so cross-group denials
     # fire at the receiving host (handoff §4 acceptance).
     from .._state.state_db import _resolve_host as _resolve_local_host
-    from .._state.state_db_nodes import is_local_node, resolve_node_host
+    from .._state.state_db_forward import resolve_forward_target
+    from .._state.state_db_nodes import is_local_node
 
     # Prefer the per-app ``local_host`` configured at ``create_app``
     # time; fall back to the env-based resolver for callers that
@@ -118,13 +119,20 @@ async def node_message_send(request: Request) -> Response:
         None
     )
     if not is_local_node(name=name, local_host=local_host):
-        target_info = resolve_node_host(name=name)
+        # ADDRESSABILITY, not locality. `is_local_node` above answers "which
+        # host", for which a live instances row suffices with or without a
+        # port; this asks "where do I POST", for which it does not. They used
+        # to be one call, so a live row with a NULL port was handed back as
+        # the answer and 502'd here — without ever consulting comms_nodes,
+        # which may hold a working address for the same name.
+        target_info = resolve_forward_target(name=name)
         if target_info is None:
             return JSONResponse(
                 {
                     "error": (
-                        f"target {name!r} resolves to a non-local host but no "
-                        "instance row carries its address — cannot forward"
+                        f"target {name!r} resolves to a non-local host but "
+                        "neither its instance row nor the comms_nodes graph "
+                        "carries a usable address — cannot forward"
                     )
                 },
                 status_code=502,

--- a/src/scitex_agent_container/_state/state_db_forward.py
+++ b/src/scitex_agent_container/_state/state_db_forward.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Where to SEND to a node — addressability, split from locality.
+
+``resolve_node_host`` answers LOCALITY ("which host is this agent on")
+and ``is_local_node`` consults it reading ONLY ``host``. The forwarder
+needed a different fact — an ADDRESS — and was reading the same return
+value for it. One function, two questions, and they disagree precisely
+when a live ``instances`` row carries no port:
+
+* locality      — still answerable. The row says which host, and that
+  stays true whether or not a port was recorded.
+* addressability — NOT answerable. There is nowhere to POST.
+
+Because both came from one call, the forwarder took ``{host,
+a2a_port: None}`` as its answer and ``_forward_to_remote`` 502'd on the
+falsy port, never consulting ``comms_nodes`` — which may hold a working
+address for that same name.
+
+MEASURED on ywata-note-win 2026-08-20::
+
+    instances: scitex-dev  host=scitex-compute-04
+               a2a_port=NULL  bound_port=NULL  ended_at=NULL
+
+Live, and PERMANENT: the GC never reaps cross-host rows (``AND
+remote=0``, deliberate per its own comment), and nothing back-fills the
+port — five ``UPDATE instances`` sites exist and none touches it. So the
+row cannot age out and cannot be repaired in place; the operator's
+documented repair verb writes ``comms_nodes``, the very table the
+unusable row was preventing anyone from reaching.
+
+WHY NOT JUST MAKE ``resolve_node_host`` FALL THROUGH. That one-liner was
+the obvious fix and it is wrong. Falling through on a portless row hands
+the LOCALITY decision to ``comms_nodes``, which may name a DIFFERENT
+host — so an agent that is genuinely local could start being forwarded
+away, and a routing repair would have silently redefined "local". The
+two questions get two functions instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+__all__ = ["resolve_forward_target"]
+
+
+def resolve_forward_target(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Return ``{host, a2a_port}`` usable for forwarding, else ``None``.
+
+    Resolution order matches :func:`..state_db_nodes.resolve_node_host` —
+    the live ``instances`` row first, then the ADR-0014 ``comms_nodes``
+    federated graph — with one difference that is the entire point: a row
+    that cannot supply a PORT does not end the search here.
+
+    ``a2a_port`` is preferred and ``bound_port`` is the fallback, matching
+    ``_send_resolve``; the writers populate both from one value, so a row
+    carrying only the latter is still a usable address.
+
+    ``None`` means no source could supply an address. The caller must
+    treat that as "cannot forward", never as "not registered" — the name
+    may be perfectly well known and simply unreachable.
+    """
+    if not name:
+        return None
+    from .state_db import open_db
+    from .state_db_comms_nodes import resolve_comms_node_host
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT host, a2a_port, bound_port
+              FROM instances
+             WHERE name = ? AND ended_at IS NULL
+             ORDER BY started_at DESC, id DESC
+             LIMIT 1
+            """,
+            (name,),
+        ).fetchone()
+    if row is not None:
+        port = row["a2a_port"]
+        if port is None:
+            port = row["bound_port"]
+        if port is not None:
+            return {"host": str(row["host"]), "a2a_port": int(port)}
+        # A live row recording no port is not an ADDRESS. Fall through
+        # rather than hand back a target the caller can only 502 on.
+    return resolve_comms_node_host(name=name, db_path=db_path)

--- a/tests/scitex_agent_container/_state/test_state_db_forward.py
+++ b/tests/scitex_agent_container/_state/test_state_db_forward.py
@@ -1,0 +1,136 @@
+"""A live row with no port must not end the search for an ADDRESS.
+
+`resolve_node_host` answers LOCALITY ("which host"), and `is_local_node` reads
+only its `host`. The forwarder needed ADDRESSABILITY ("where do I POST") and was
+reading the same value, so a live `instances` row with a NULL port was returned
+as the answer, the forwarder took it, and `_forward_to_remote` 502'd on the
+falsy port — never consulting `comms_nodes`, which may hold a working address
+for that same name.
+
+MEASURED on ywata-note-win 2026-08-20: `scitex-dev host=scitex-compute-04
+a2a_port=NULL bound_port=NULL ended_at=NULL`. Live and PERMANENT — the GC never
+reaps cross-host rows (`AND remote=0`, deliberate) and nothing back-fills the
+port, so it can neither age out nor be repaired in place.
+
+The controls are the weight-bearing half: locality must NOT move. A "fix" that
+made `resolve_node_host` fall through would hand the locality decision to
+`comms_nodes`, which may name a different host — silently redefining "local".
+
+PA-306: no mocks; real on-disk SQLite under `tmp_path`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_forward import resolve_forward_target
+from scitex_agent_container._state.state_db_nodes import (
+    is_local_node,
+    register_comms_node,
+    resolve_node_host,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    # Arrange
+    p = tmp_path / "state.db"
+    state_db.init_schema(p)
+    return p
+
+
+def _live_row(db_path: Path, *, a2a_port, bound_port, host: str = "host-a") -> None:
+    """One live instances row for 'peer' with the given port columns."""
+    with state_db.open_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO instances (id, name, host, scope, a2a_port, "
+            " bound_port, started_at, ended_at) "
+            "VALUES ('id-1', 'peer', ?, 'global', ?, ?, "
+            "        '2026-08-20T00:00:00Z', NULL)",
+            (host, a2a_port, bound_port),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The defect: a portless live row ended the search
+# ---------------------------------------------------------------------------
+
+
+def test_a_portless_live_row_falls_through_to_comms_nodes(db_path: Path) -> None:
+    # Arrange — the exact fleet state: live row, both ports NULL, and a
+    # comms_nodes entry that DOES carry an address.
+    _live_row(db_path, a2a_port=None, bound_port=None)
+    register_comms_node(
+        name="peer", host="host-b", a2a_port=19099, db_path=db_path
+    )
+    # Act
+    target = resolve_forward_target(name="peer", db_path=db_path)
+    # Assert — resolved to {host-a, None} before, and 502'd downstream
+    assert target is not None and target["a2a_port"] == 19099
+
+
+def test_no_address_anywhere_returns_none(db_path: Path) -> None:
+    # Arrange — live row with no port, and nothing in comms_nodes either
+    _live_row(db_path, a2a_port=None, bound_port=None)
+    # Act
+    target = resolve_forward_target(name="peer", db_path=db_path)
+    # Assert — "cannot forward", not a fabricated target
+    assert target is None
+
+
+# ---------------------------------------------------------------------------
+# Controls — the instances row still WINS when it can answer
+# ---------------------------------------------------------------------------
+
+
+def test_a_usable_instances_row_wins_over_comms_nodes(db_path: Path) -> None:
+    # Arrange — both sources have an address; instances is authoritative
+    _live_row(db_path, a2a_port=19001, bound_port=None)
+    register_comms_node(
+        name="peer", host="host-b", a2a_port=19099, db_path=db_path
+    )
+    # Act
+    target = resolve_forward_target(name="peer", db_path=db_path)
+    # Assert — the fall-through must not become a preference for comms_nodes
+    assert target is not None and target["a2a_port"] == 19001
+
+
+def test_bound_port_counts_as_a_usable_address(db_path: Path) -> None:
+    # Arrange — only bound_port survived on the row
+    _live_row(db_path, a2a_port=None, bound_port=19012)
+    register_comms_node(
+        name="peer", host="host-b", a2a_port=19099, db_path=db_path
+    )
+    # Act
+    target = resolve_forward_target(name="peer", db_path=db_path)
+    # Assert — still the instances row, via the fallback column
+    assert target is not None and target["a2a_port"] == 19012
+
+
+# ---------------------------------------------------------------------------
+# Controls — LOCALITY must be untouched by all of this
+# ---------------------------------------------------------------------------
+
+
+def test_locality_still_comes_from_the_instances_row(db_path: Path) -> None:
+    # Arrange — portless local row, with comms_nodes naming a DIFFERENT host
+    _live_row(db_path, a2a_port=None, bound_port=None, host="host-a")
+    register_comms_node(
+        name="peer", host="host-b", a2a_port=19099, db_path=db_path
+    )
+    # Act
+    local = is_local_node(name="peer", local_host="host-a", db_path=db_path)
+    # Assert — the agent IS on host-a; forwarding must not redefine that
+    assert local is True
+
+
+def test_resolve_node_host_still_reports_the_portless_row(db_path: Path) -> None:
+    # Arrange
+    _live_row(db_path, a2a_port=None, bound_port=None)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert — unchanged: it answers locality, port or no port
+    assert info is not None and info["host"] == "host-a"


### PR DESCRIPTION
fix(a2a): split addressability from locality so a portless row stops routing

`resolve_node_host` answered TWO questions with one value:

  * LOCALITY      "which host is this agent on" — `is_local_node` consults
    it and reads ONLY `host`. A live `instances` row answers this whether
    or not a port is recorded.
  * ADDRESSABILITY "where do I POST this turn" — a row with no port
    cannot answer it at all.

Because both came from one call, `_node_channel` took `{host, a2a_port:
None}` as its forwarding answer and `_forward_to_remote` 502'd on the
falsy port — WITHOUT ever consulting `comms_nodes`, which may hold a
working address for the same name.

MEASURED on ywata-note-win 2026-08-20:

    instances: scitex-dev  host=scitex-compute-04
               a2a_port=NULL  bound_port=NULL  ended_at=NULL

Live, and PERMANENT: the GC never reaps cross-host rows (`AND remote=0`,
deliberate per its own comment) and nothing back-fills the port — five
`UPDATE instances` sites, none touches it. The row can neither age out
nor be repaired in place, and the operator's documented repair verb
writes `comms_nodes`, the very table the unusable row was preventing
anyone from reaching.

WHY NOT THE ONE-LINE FIX. Making `resolve_node_host` itself fall through
was the obvious change and it is WRONG: it hands the LOCALITY decision to
`comms_nodes`, which may name a DIFFERENT host. An agent that is
genuinely local could then start being forwarded away — a routing repair
silently redefining "local". Two questions, two functions.

NEW MODULE rather than a new function in `state_db_nodes`, for two
reasons. `state_db_nodes.py` is 566 lines against a 512-line cap, so the
edit is blocked; and this is a new responsibility, so extraction is the
right shape regardless — growing an already-oversized module to add one
would be wrong even if permitted.

TESTING. PA-306: no mocks, real on-disk SQLite. Six tests, FOUR of them
controls, because the tempting fix is actively harmful:

    instances row with a usable port still WINS over comms_nodes
      (the fall-through must not become a preference)
    bound_port still counts as a usable address
    is_local_node still says LOCAL for a portless row whose comms_nodes
      entry names a different host
    resolve_node_host still reports that row's host, unchanged

Mutation-checked by restoring production exactly (portless row ends the
search again): the 2 defect tests fail and all 4 controls keep passing.
The locality controls surviving the mutant is the evidence that matters —
they are independent of the fix, so they would still catch a change that
moved locality.

Executed vs collected: 1031 passed, 0 failed across the new tests, the
comms_nodes suite and the full `_listen` suite (which exercises the
rewired `_node_channel`), 0 deselected.

Card: sac-a2a-reachability-all-unknown-and-null-port-rows-get-selected-20260821
