### PR TITLE
fix(reachability): the LIST endpoint never resolved its own host, so #1174 fixed nothing anyone could see

### DIFF
--- a/src/scitex_agent_container/_listen/_agents_list.py
+++ b/src/scitex_agent_container/_listen/_agents_list.py
@@ -188,12 +188,16 @@ async def _annotate_reachability(request: Request, rows: list[dict]) -> list[dic
     healthy agents of being deaf, and the remedy a caller reaches for on a
     false death verdict is destructive.
     """
-    from ._reachability import UNKNOWN, annotate_rows
+    from ._reachability import UNKNOWN, annotate_rows, resolve_annotation_host
 
     try:
         broker = request.app.state.inbox
         counts = await broker.subscriber_counts()
-        local_host = getattr(request.app.state, "local_host", None)
+        # NOT a bare ``app.state.local_host`` read. That is ``None`` in
+        # production (see ``resolve_annotation_host``), and reading it alone is
+        # what kept every row on THIS host annotated ``unknown`` on the very
+        # endpoint the reachability reports come from.
+        local_host = resolve_annotation_host(request.app.state)
     except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict against healthy agents)
         log.warning(
             "list_agents: could not read inbox broker (reporting reachability "

--- a/src/scitex_agent_container/_listen/_reachability.py
+++ b/src/scitex_agent_container/_listen/_reachability.py
@@ -57,7 +57,35 @@ __all__ = [
     "UNREACHABLE",
     "annotate_reachability",
     "annotate_rows",
+    "resolve_annotation_host",
 ]
+
+
+def resolve_annotation_host(app_state: Any) -> str | None:
+    """The host identity to weigh rows against, for BOTH annotate paths.
+
+    ``create_app`` declares ``local_host`` and defaults it to ``None``, and
+    the one production caller (``cli_pkg.listen_cmds``) never passes it. So
+    ``app.state.local_host`` is ``None`` in production, always. Read alone it
+    makes :func:`_is_locally_observable` answer ``False`` for every row that
+    carries any host evidence, and every such row is annotated ``unknown`` —
+    including rows on THIS host, whose subscriber count we can see perfectly.
+
+    The env resolver is therefore not a nicety, it is the only thing that
+    supplies an identity in production. It lives here, in one function, for a
+    measured reason: the fallback was added to the single-row path in #1174
+    and NOT to the list path, so ``GET /agents`` — the endpoint ``a2a_peers``
+    reads and the one every "nobody is reachable" report comes through — kept
+    returning ``unknown`` for the whole fleet after the fix shipped. Two call
+    sites asking one question is how half a fix looks like a whole one.
+
+    Returns ``None`` only if the resolver itself cannot answer, which
+    ``_is_locally_observable`` correctly reads as "we don't know who WE are"
+    and degrades to ``unknown`` — never to a fabricated ``unreachable``.
+    """
+    from .._state.state_db import _resolve_host
+
+    return getattr(app_state, "local_host", None) or _resolve_host(None)
 
 
 def _is_locally_observable(row: Mapping[str, Any], local_host: str | None) -> bool:

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -191,20 +191,15 @@ async def _annotate_status_reachability(
     Degrades to ``unknown`` (never ``unreachable``) if the broker cannot be
     read — "I could not check" must not be rendered as death.
     """
-    from ._reachability import UNKNOWN, annotate_reachability
+    from ._reachability import (
+        UNKNOWN,
+        annotate_reachability,
+        resolve_annotation_host,
+    )
 
     try:
         counts = await request.app.state.inbox.subscriber_counts()
-        # Prefer the per-app ``local_host``; fall back to the env resolver —
-        # mirroring ``_node_channel`` for the identical question. The fallback
-        # is load-bearing: ``create_app`` defaults it to None and the one
-        # production caller never passes it, so without this EVERY row with a
-        # host was annotated ``unknown``, including rows on this host.
-        from .._state.state_db import _resolve_host as _resolve_local_host
-
-        local_host = getattr(request.app.state, "local_host", None) or (
-            _resolve_local_host(None)
-        )
+        local_host = resolve_annotation_host(request.app.state)
     except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict)
         import logging
 

--- a/tests/scitex_agent_container/_listen/test__agents_list_reachability_local_host.py
+++ b/tests/scitex_agent_container/_listen/test__agents_list_reachability_local_host.py
@@ -1,0 +1,197 @@
+"""The LIST endpoint must resolve its own host, exactly as the single-row one does.
+
+WHY THIS FILE EXISTS, and why the sibling test was not enough. #1174 added the
+env fallback to ``server._annotate_status_reachability`` — the SINGLE-row path
+— and its test (``test_server_reachability_local_host.py``) proved that path
+correct. It shipped, and the reported symptom did not move: ``a2a_peers`` still
+returned ``inbox_reachable: "unknown"`` for all eleven peers.
+
+Because ``a2a_peers`` reads ``GET /agents``, and that route annotates through
+``_agents_list._annotate_reachability``, which kept the bare
+``getattr(request.app.state, "local_host", None)``. ``create_app`` defaults
+that to ``None`` and ``cli_pkg/listen_cmds.py`` never passes it, so
+``_is_locally_observable`` hit ``if not local_host: return False`` for every
+row carrying host evidence and annotated the whole fleet ``unknown``.
+
+MEASURED on scitex-compute-04 2026-08-20T21:35Z, with the daemon restarted and
+verifiably running the #1174 code: 11 of 11 rows ``unknown``, every one of them
+with a ``turn_url`` naming this very host.
+
+So the lesson this file encodes is not "add a fallback". It is that a fix
+verified on the call site it PATCHED says nothing about the call site the
+SYMPTOM arrives through, and both existed here.
+
+PA-306: no mocks. The stand-ins below are hand-written objects holding exactly
+the attributes the function reads — the same "configuration, not mocking"
+pattern the sibling file documents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from scitex_agent_container._listen._agents_list import _annotate_reachability
+from scitex_agent_container._listen._reachability import (
+    REACHABLE,
+    UNKNOWN,
+    UNREACHABLE,
+)
+from scitex_agent_container._state.state_db import _resolve_host
+
+
+class _Inbox:
+    """The broker seam: returns a real subscriber-count mapping."""
+
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    async def subscriber_counts(self) -> dict[str, int]:
+        return dict(self._counts)
+
+
+class _BrokenInbox:
+    """A broker that cannot be read — the degrade-safely control."""
+
+    async def subscriber_counts(self) -> dict[str, int]:
+        raise RuntimeError("broker unreadable")
+
+
+class _State:
+    def __init__(self, inbox: object, local_host: str | None) -> None:
+        self.inbox = inbox
+        self.local_host = local_host
+
+
+class _App:
+    def __init__(self, state: _State) -> None:
+        self.state = state
+
+
+class _Req:
+    def __init__(self, app: _App) -> None:
+        self.app = app
+
+
+def _annotate(
+    rows: list[dict],
+    *,
+    counts: dict[str, int] | None = None,
+    local_host: str | None = None,
+    inbox: object | None = None,
+) -> list[dict]:
+    box = inbox if inbox is not None else _Inbox(counts or {})
+    req = _Req(_App(_State(box, local_host)))
+    return asyncio.run(_annotate_reachability(req, rows))
+
+
+def _local_row() -> dict:
+    """A row shaped like production: no ``host`` key, host named by turn_url."""
+    return {"name": "peer", "turn_url": f"http://{_resolve_host(None)}:19001/v1/turn"}
+
+
+# ---------------------------------------------------------------------------
+# The defect: production has local_host=None, and the list path read it bare
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_row_is_reachable_when_app_state_has_no_host() -> None:
+    # Arrange
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, counts={"peer": 1}, local_host=None)
+    # Assert — was UNKNOWN for all 11 peers on the live fleet
+    assert out[0]["inbox_reachable"] == REACHABLE
+
+
+def test_a_local_row_reports_its_subscriber_count() -> None:
+    # Arrange
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, counts={"peer": 1}, local_host=None)
+    # Assert — the count was None alongside the unknown verdict
+    assert out[0]["inbox_subscribers"] == 1
+
+
+def test_a_local_row_with_no_subscribers_is_unreachable() -> None:
+    # Arrange — an OBSERVED zero on a bus we can see is the one case
+    # that earns UNREACHABLE rather than UNKNOWN.
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, counts={}, local_host=None)
+    # Assert — the field must be able to reach its third value too
+    assert out[0]["inbox_reachable"] == UNREACHABLE
+
+
+def test_a_local_row_with_no_subscribers_reports_zero() -> None:
+    # Arrange
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, counts={}, local_host=None)
+    # Assert
+    assert out[0]["inbox_subscribers"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Controls — the fix must not buy reachability by fabricating locality
+# ---------------------------------------------------------------------------
+
+
+def test_a_remote_row_stays_unknown() -> None:
+    # Arrange — a row on a DIFFERENT host, served by a different broker whose
+    # subscriber table we cannot see.
+    rows = [{"name": "peer", "host": "some-other-host-entirely"}]
+    # Act
+    out = _annotate(rows, counts={}, local_host=None)
+    # Assert — a fabricated zero here is a false accusation of deafness
+    assert out[0]["inbox_reachable"] == UNKNOWN
+
+
+def test_a_remote_row_reports_no_subscriber_count() -> None:
+    # Arrange
+    rows = [{"name": "peer", "host": "some-other-host-entirely"}]
+    # Act
+    out = _annotate(rows, counts={}, local_host=None)
+    # Assert — None, not 0: we did not observe, we declined to guess
+    assert out[0]["inbox_subscribers"] is None
+
+
+def test_an_explicit_app_state_host_still_wins() -> None:
+    # Arrange — when create_app IS given a host, that declaration is
+    # authoritative and the env resolver must not override it.
+    rows = [{"name": "peer", "host": "declared-host"}]
+    # Act
+    out = _annotate(rows, counts={"peer": 2}, local_host="declared-host")
+    # Assert — the fallback is a fallback, not a replacement
+    assert out[0]["inbox_reachable"] == REACHABLE
+
+
+def test_an_unreadable_broker_degrades_to_unknown() -> None:
+    # Arrange — the safe-direction guarantee this route is written around
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, inbox=_BrokenInbox(), local_host=None)
+    # Assert — "could not check" must never render as death
+    assert out[0]["inbox_reachable"] == UNKNOWN
+
+
+def test_an_unreadable_broker_reports_no_count() -> None:
+    # Arrange
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, inbox=_BrokenInbox(), local_host=None)
+    # Assert
+    assert out[0]["inbox_subscribers"] is None
+
+
+def test_every_row_is_annotated_not_just_the_first() -> None:
+    # Arrange — the list path's own responsibility: it maps over N rows
+    here = _resolve_host(None)
+    rows = [
+        {"name": "a", "turn_url": f"http://{here}:19001/v1/turn"},
+        {"name": "b", "turn_url": f"http://{here}:19002/v1/turn"},
+        {"name": "c", "host": "elsewhere"},
+    ]
+    # Act
+    out = _annotate(rows, counts={"a": 1}, local_host=None)
+    # Assert
+    assert [r["inbox_reachable"] for r in out] == [REACHABLE, UNREACHABLE, UNKNOWN]


### PR DESCRIPTION

#1174 added the env fallback for `local_host` to the SINGLE-row path
(`server._annotate_status_reachability`), proved it with a focused test,
and merged. The reported symptom did not move.

MEASURED on scitex-compute-04 2026-08-20T21:35Z, with `sac listen`
restarted and verifiably running the #1174 code (ActiveEnterTimestamp
21:30:38 > every touched file's mtime):

    a2a_peers -> 11 of 11 rows  inbox_reachable = "unknown"
                                inbox_subscribers = null

Every one of those rows carries a `turn_url` naming that very host.

WHY. `a2a_peers` reads `GET /agents`, which annotates through
`_agents_list._annotate_reachability` — a SECOND call site asking the
identical question, and it kept the bare read:

    local_host = getattr(request.app.state, "local_host", None)

`create_app` defaults `local_host=None` and the one production caller
(`cli_pkg/listen_cmds.py:289`) never passes it, so that is `None` on
every running daemon. `_is_locally_observable` then hits its
`if not local_host: return False` and annotates `unknown` for every row
carrying host evidence — including rows served by the very broker
answering the request.

#1174's own comment states this reasoning verbatim ("the fallback is
load-bearing: create_app defaults it to None and the one production
caller never passes it"). The reasoning was right and was applied to one
of the two places it held.

THE SHAPE, since it is more useful than the fix: a fix verified on the
call site it PATCHED says nothing about the call site the SYMPTOM
arrives through. The #1174 test exercised `_annotate_status_reachability`
because that is what #1174 changed. Nothing in that loop could notice
that every actual report came through `annotate_rows`.

ONE RESOLVER, NOT TWO READS. Rather than copy the fallback into the
second site — which is how the first divergence happened — the question
now has a single answer: `_reachability.resolve_annotation_host()`.
Both annotate paths call it. A third caller cannot silently get a
different rule.

This also buys headroom where it was tight: `server.py` goes 500 -> 495
lines against the 512-line cap, because the inline fallback collapses to
one call.

NOT TOUCHED. `_node_channel.py:118` carries the same fallback for a
DIFFERENT question — routing locality, not reachability annotation. It
is already correct and folding it in would widen a routing-sensitive
diff for tidiness. Named here so the next reader knows it was considered.

TESTING. PA-306: no mocks; hand-written stand-ins holding exactly the
attributes the function reads, matching the sibling file's documented
pattern. Ten tests, FIVE of them controls, because the tempting fix
(assume locality when unsure) is actively harmful — a fabricated zero is
a false accusation of deafness against a healthy remote agent:

    a remote row stays unknown, and reports subscribers=None not 0
    an explicit app.state.local_host still wins over the resolver
    an unreadable broker degrades to unknown, never to unreachable
      (verdict and count asserted separately)

Mutation-checked by restoring the bare `getattr` exactly: the 5 defect
tests fail and all 5 controls keep passing. The controls surviving the
mutant is the evidence that matters — they do not depend on the fix, so
they would still catch a change that fabricated locality.

Executed vs collected: 41 passed across the new file, the #1174 sibling,
`test__agents_list.py` and `test__reachability.py`; then the full
`_listen` suite. 0 deselected.

Card: sac-a2a-reachability-all-unknown-and-null-port-rows-get-selected-20260821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hVyawtS49QrMsxkQ2R6TD