### PR TITLE
test(guard): parse the CLI's stdout, and say what happened when it is not JSON

### DIFF
--- a/tests/scitex_agent_container/cli_pkg/test_guard_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_guard_group.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import traceback
 from pathlib import Path
 
 import pytest
@@ -85,6 +86,63 @@ def _run(*args: str):
     return CliRunner().invoke(main, ["guard", "deletions", *args])
 
 
+def _run_json(*args: str) -> dict:
+    """Parse the command's JSON stdout, or fail with everything the runner saw.
+
+    TWO defects, both measured on click 8.4.2 on 2026-08-20.
+
+    ONE — the wrong stream. ``result.output`` INTERLEAVES stdout and stderr.
+    Measured with a positive control (write to ``sys.stderr`` at call time, so
+    it reaches the stream CliRunner actually swapped in)::
+
+        .output -> '{"ok": true}\nSTDERR-MARKER\n'   json.loads FAILS
+        .stdout -> '{"ok": true}\n'                  json.loads OK
+
+    A control matters here because the obvious experiment does NOT work: a
+    logging handler created at import time holds the PRE-SWAP stderr, so its
+    output never enters the capture and ``.output`` looks stdout-clean. That
+    run cannot fail for any input.
+
+    The CLI's contract is JSON *on stdout*; any log line from any module on
+    stderr is not part of it. So parse ``.stdout``.
+
+    TWO — the silent report. When parsing did fail on develop, the entire
+    diagnostic was::
+
+        json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
+
+    `char 0` does NOT distinguish "stdout was empty" from "something non-JSON
+    came first" — both land there. So the message below prints all three
+    streams, the exit code, and the swallowed traceback, and lets the reader
+    tell those apart instead of guessing.
+
+    This does NOT tolerate the failure: an unparseable payload still fails the
+    test. It only makes the failure say something.
+    """
+    result = _run(*args)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        try:
+            stderr = result.stderr
+        except (ValueError, AttributeError):  # stx-allow: fallback (reason: click does not always capture stderr separately; a missing stderr must not replace the real failure with an error about reading it. SINK: the assertion message below, which pytest prints on failure)
+            stderr = "<not captured separately>"
+        detail = [
+            "guard deletions --json produced no parseable JSON on stdout.",
+            f"  json error : {exc}",
+            f"  exit_code  : {result.exit_code}",
+            f"  stdout     : {result.output!r}",
+            f"  stderr     : {stderr!r}",
+            f"  exception  : {result.exception!r}",
+        ]
+        if result.exc_info is not None:
+            detail.append(
+                "  traceback  :\n"
+                + "".join(traceback.format_exception(*result.exc_info))
+            )
+        raise AssertionError("\n".join(detail)) from exc
+
+
 def test_incident_exits_with_the_violations_code(incident_repo: Path) -> None:
     """3 — the declared domain code, never 1."""
     # Arrange
@@ -132,7 +190,7 @@ def test_json_still_lists_every_deleted_method(incident_repo: Path) -> None:
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert "transforms.py::class:Scaler.apply" in {
         d["key"] for d in payload["deletions"]
@@ -220,7 +278,7 @@ def test_missing_baseline_json_verdict_is_undetermined(repo: Path) -> None:
     # Arrange
     args = ("--repo", str(repo), "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert payload["verdict"] == "could-not-determine"
 
@@ -242,7 +300,7 @@ def test_json_verdict_is_violations_on_the_incident(
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert payload["verdict"] == "violations"
 
@@ -252,7 +310,7 @@ def test_json_carries_the_declared_exit_code(incident_repo: Path) -> None:
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert payload["exit_code"] == 3
 
@@ -262,7 +320,7 @@ def test_json_top_level_keys_are_stable(incident_repo: Path) -> None:
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert set(payload) == {
         "verdict", "exit_code", "baseline", "target", "files_compared",
@@ -278,7 +336,7 @@ def test_json_deletion_entry_carries_its_allow_key(
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert "transforms.py::class:Scaler" in {
         d["key"] for d in payload["deletions"]


### PR DESCRIPTION

Six tests did `json.loads(_run(*args).output)`. Two defects in that line,
both measured on click 8.4.2 on 2026-08-20.

ONE — THE WRONG STREAM. `result.output` is stdout THEN stderr, concatenated.
Measured with a positive control that writes to `sys.stderr` AT CALL TIME, so
it reaches the stream CliRunner actually swapped in:

    print("STDERR-MARKER", file=sys.stderr)   # emitted FIRST
    click.echo('{"ok": true}')                # emitted SECOND

    .output -> '{"ok": true}\nSTDERR-MARKER\n'   json.loads FAILS (Extra data)
    .stdout -> '{"ok": true}\n'                  json.loads OK

The control is load-bearing and the obvious experiment does NOT work: a
logging handler created at import time holds the PRE-SWAP stderr, so its
output never enters the capture and `.output` looks stdout-clean. That run
cannot fail for any input — a thermometer in a sealed box. I ran exactly that
version first and drew the opposite conclusion from it.

`sac guard deletions --json` promises JSON ON STDOUT. A log line on stderr
from any module is not part of that contract, so any such line broke these
tests. Parsing `.stdout` is both the correct contract and the fix for that
brittleness.

TWO — THE SILENT REPORT. When this broke on develop the entire diagnostic was:

    json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

No exit code, no swallowed exception, no traceback, no streams. The helper now
prints all of it on failure.

WHAT `char 0` ACTUALLY TELLS YOU, since it is the whole content of that report.
Given the stdout-then-stderr ordering above:

    stdout has JSON + stderr has noise  ->  "Extra data: line 2 column 1"
    stdout EMPTY    + stderr has noise  ->  "Expecting value ... char 0"

So `char 0` means stdout was EMPTY. And `deletions` echoes its payload
unconditionally, so an empty stdout means the command raised before reaching
that line — leaving exactly two candidates, the deferred
`from .._guard import check_deletions, render` and `check_deletions(...)`.
The exception naming which one is precisely what the bare `json.loads`
discarded.

SCOPE, stated plainly. This does NOT claim to fix the develop failure. An
empty stdout stays empty whichever attribute you parse. What it changes is
that the next occurrence names the exception instead of printing `char 0`,
and that a stderr line from an unrelated module can no longer break a passing
run. Instrument plus a real brittleness fix — not a cure, and the card stays
open until the exception has a name.

It does not tolerate failure either: an unparseable payload still fails the
test. `raise AssertionError(...) from exc` keeps the original as the cause.

Executed vs collected: 21 passed, 21 collected, 0 deselected, 0 failed
(tests/scitex_agent_container/cli_pkg/test_guard_group.py). ruff clean.

Card: sac-develop-red-guard-json-empty-stdout-under-xdist-20260821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hVyawtS49QrMsxkQ2R6TD