### PR TITLE
test(lifecycle): stop leaking the health_monitor thread into every later test

### DIFF
--- a/tests/scitex_agent_container/_lifecycle/test__start_retracts_marker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_retracts_marker.py
@@ -106,6 +106,49 @@ class FakeRuntime:
         return ""
 
 
+class FakeThread:
+    """Hand-rolled stand-in for ``threading.Thread`` that NEVER runs.
+
+    ``_write_spec`` enables ``health``, so ``agent_start`` reaches
+    ``_start_supervision``, which does::
+
+        thread = thread_factory(target=health_monitor, ..., daemon=True)
+        thread.start()
+
+    With the real ``threading.Thread`` that daemon thread OUTLIVES the test
+    and keeps looping ``health_monitor -> restart_and_record ->
+    write_birth_certificate`` for the rest of the worker process. Its
+    ``logger.error`` then lands in whatever capture buffer happens to be open
+    -- an unrelated test's ``CliRunner`` -- ahead of that command's own
+    output, which is how a PASSING test here turns a stranger's assertion red
+    three files later. Measured on develop 2026-08-21: 31 stray certificates
+    in one run, plus ``ValueError: I/O operation on closed file`` from writing
+    into a stream pytest had already torn down.
+
+    Recording ``start()`` rather than swallowing it keeps the seam honest: a
+    test that wants to assert the monitor was launched still can. Same shape
+    as ``_RecordingThread`` in ``test__start_supervision.py`` and
+    ``_CapturingThread`` in ``test__instances_auto_grant.py``.
+
+    PA-306: a hand-written stand-in, not a mock.
+    """
+
+    def __init__(self, *, target=None, args=(), daemon=False, **_kw) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self, timeout=None) -> None:
+        return None
+
+    def is_alive(self) -> bool:
+        return False
+
+
 class FakeHandover:
     def ensure_instance_uuid(self, config: AgentConfig) -> str:
         return "fake-uuid"
@@ -150,6 +193,7 @@ def test_the_already_running_noop_returns_the_already_running_outcome(
     # Act
     ok = agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -171,6 +215,7 @@ def test_the_already_running_noop_retracts_an_existing_marker(
     # Act
     agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -192,6 +237,7 @@ def test_the_already_running_noop_leaves_the_retracted_copy(
     # Act
     agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -213,6 +259,7 @@ def test_the_already_running_noop_with_no_marker_does_not_raise(
     # Act
     ok = agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -244,6 +291,7 @@ def test_a_launch_that_merely_returned_keeps_the_marker(
     # Act
     agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -271,6 +319,7 @@ def test_a_dry_run_on_an_alive_agent_keeps_the_marker(
     # Act
     agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -299,6 +348,7 @@ def test_a_failed_start_keeps_the_marker(
     try:
         agent_start(
             str(spec),
+            thread_factory=FakeThread,
             registry=registry,
             runtime_factory=lambda _c: runtime,
             handover_mod=FakeHandover(),

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_force_clears_session.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_force_clears_session.py
@@ -112,6 +112,49 @@ class FakeRuntime:
         return ""
 
 
+class FakeThread:
+    """Hand-rolled stand-in for ``threading.Thread`` that NEVER runs.
+
+    ``_write_spec`` enables ``health``, so ``agent_start`` reaches
+    ``_start_supervision``, which does::
+
+        thread = thread_factory(target=health_monitor, ..., daemon=True)
+        thread.start()
+
+    With the real ``threading.Thread`` that daemon thread OUTLIVES the test
+    and keeps looping ``health_monitor -> restart_and_record ->
+    write_birth_certificate`` for the rest of the worker process. Its
+    ``logger.error`` then lands in whatever capture buffer happens to be open
+    -- an unrelated test's ``CliRunner`` -- ahead of that command's own
+    output, which is how a PASSING test here turns a stranger's assertion red
+    three files later. Measured on develop 2026-08-21: 31 stray certificates
+    in one run, plus ``ValueError: I/O operation on closed file`` from writing
+    into a stream pytest had already torn down.
+
+    Recording ``start()`` rather than swallowing it keeps the seam honest: a
+    test that wants to assert the monitor was launched still can. Same shape
+    as ``_RecordingThread`` in ``test__start_supervision.py`` and
+    ``_CapturingThread`` in ``test__instances_auto_grant.py``.
+
+    PA-306: a hand-written stand-in, not a mock.
+    """
+
+    def __init__(self, *, target=None, args=(), daemon=False, **_kw) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self, timeout=None) -> None:
+        return None
+
+    def is_alive(self) -> bool:
+        return False
+
+
 class FakeHandover:
     """Real collaborator implementing the handover module surface."""
 
@@ -201,6 +244,7 @@ def test_force_removes_persisted_session_id_file(
     # Act
     lc.agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -233,6 +277,7 @@ def test_force_leaves_other_runtime_state_alone(
     # Act
     lc.agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -260,6 +305,7 @@ def test_no_force_leaves_session_id(
     # Act
     lc.agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -282,6 +328,7 @@ def test_missing_session_id_file_under_force_is_no_op(
     # Act
     ok = lc.agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),


### PR DESCRIPTION

develop went red on py3.12 and py3.13 with two failures that look unrelated to
each other and to their own files:

    test_ci_group.py::test_why_green_run_says_no_failures
      assert 'ERRO: birth ...\nno failures' == 'no failures'
    test_guard_group.py::test_json_top_level_keys_are_stable
      JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Neither test is at fault. The call stack, from a full xdist run:

    File "threading.py", line 1030, in _bootstrap          <- BACKGROUND THREAD
      _lifecycle/health.py:409          health_monitor -> restart_fn(config)
      _lifecycle/_instances.py:400      _restart
      _lifecycle/_instances.py:354      restart_and_record
      _lifecycle/_instances.py:307      record_local_instance
      _lifecycle/_birth_certificate.py:171  logger.error(...)
    ValueError: I/O operation on closed file.

THE MECHANISM. `_write_spec` in these files writes `health.enabled: true`, so
`agent_start` reaches `_start_supervision.py:49`:

    thread = thread_factory(target=health_monitor, ..., daemon=True)

`thread_factory` defaults to the real `threading.Thread`. Nothing joins it, so
the daemon thread OUTLIVES the test and keeps looping for the rest of the
worker process. Its `logger.error` writes into a stream pytest has already
torn down, so the record lands in whatever capture buffer is open — an
unrelated test's `CliRunner` — AHEAD of that command's own output. A JSON
consumer then reads `E` at char 0, which is byte-identical to the error an
EMPTY stdout produces. That ambiguity is what made this expensive to find.

WHY IT SURVIVED. Every guilty test PASSES. 169 passed while leaking. The
offending tests are correct about their own subject; they corrupt a stranger's
assertion three files later, so nothing local ever points here. Serially the
victims are green, so it reads as an xdist flake and a re-run "fixes" it.

THE FIX. A hand-rolled `FakeThread` in both files, wired into all 11
`agent_start` call sites. It records `start()` rather than swallowing it, so a
test that wants to assert the monitor was launched still can. This is not a
new pattern: `_RecordingThread` in `test__start_supervision.py` and
`_CapturingThread` in `test__instances_auto_grant.py` already do exactly this,
which is why those files do not leak. PA-306: hand-written stand-in, no mock.

Health stays ENABLED in the specs, so the health-enabled start path keeps its
coverage — only the real thread is withheld.

MEASURED, with a detection-only pytest plugin (snapshot threads at setup, diff
at teardown, never fails a test):

    before   5 leaked health_monitor threads across 5 tests, daemon=True
    after    0

The first "verification" of this fix reported "no leaked threads observed"
while collection was BROKEN by a bad edit — a clean reading from an instrument
that could not have produced a dirty one. Re-run with a run-control printing
the test count beside the leak count; the numbers above are from that run.

A/B AGAINST A STASHED BASELINE, because 4 teardown errors appeared alongside
this change and I did not want to assume they were mine:

    baseline (edit stashed)   4 passed, 4 errors
    patched  (edit applied)   4 passed, 4 errors

Identical. Those errors are a PRE-EXISTING state-floor breach
(`conftest.py:541 _assert_state_floor_intact`) that fires when that file runs
alone and is masked when earlier files establish the floor. NOT introduced
here and NOT fixed here.

NOT IN THIS CHANGE, deliberately:
  * a `_worker` leak (daemon=FALSE) in `cli_pkg/lifecycle/test__start.py` —
    real, separate target, untouched.
  * the pre-existing state-floor breach above.
  * a GATE. What exists is a diagnostic I ran by hand; a record is not a check
    (constitution §2). The barrier belongs in `tests/conftest.py` beside
    `_assert_state_floor_intact`, which already encodes this exact failure
    class, and it must land AFTER the known leaks are fixed or it simply turns
    develop redder.

Executed vs collected:
    test__start_retracts_marker.py            7 passed / 7 collected / 0 failed
    test__start_force_clears_session.py       4 passed / 4 collected,
                                              4 pre-existing teardown errors
    ruff                                      All checks passed

Card: sac-develop-red-guard-json-empty-stdout-under-xdist-20260821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hVyawtS49QrMsxkQ2R6TD