### PR TITLE
feat(accounts): the help named peers that exist nowhere, and keepalive named an outcome

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_keepalive.py
+++ b/src/scitex_agent_container/cli_pkg/_account_keepalive.py
@@ -76,10 +76,69 @@ def _render(record: dict[str, Any], out) -> None:
         )
 
 
-def register_keepalive_command(group: click.Group) -> None:
-    """Attach the ``keepalive`` subcommand onto ``group``."""
+def format_peer_lines(peers: "list[str]") -> list[str]:
+    """Render ``peers`` as the ``--help`` block listing what ``--to`` takes.
 
-    @group.command("keepalive")
+    Pure, so the rendering can be asserted without a host's real
+    ``config.yaml`` deciding the expected output — a test that reads the
+    live table would assert an environmental fact rather than a property
+    of this function.
+    """
+    if not peers:
+        return []
+    lines = ["Registered peers --to accepts on THIS host:"]
+    for name in sorted(peers):
+        # A wildcard row (``spartan-*``) is a TEMPLATE for per-node keys,
+        # not a name anyone can type. Printing it bare would repeat the
+        # defect this listing exists to fix: help that names something
+        # the command rejects.
+        if "*" in name:
+            lines.append(f"  {name}  (pattern — substitute a real node name)")
+        else:
+            lines.append(f"  {name}")
+    return lines
+
+
+def _registered_peer_lines() -> list[str]:
+    """The peer keys ``--to`` will actually accept, for ``--help``.
+
+    ``--to`` is documented as "a peer key from config.yaml", and the
+    shipped examples named ``compute-04`` and ``laptop`` — neither of
+    which is a key on any host. Copy-pasting the documentation therefore
+    failed. Reading the real table at render time means the help cannot
+    drift from what the command accepts.
+
+    Returns ``[]`` on ANY failure. ``--help`` must render on a machine
+    with no config, an unreadable config or a malformed one; a help
+    screen that raises is worse than a help screen that omits a hint.
+    """
+    try:
+        from .._state.host_config import load as load_host_config
+
+        peers = list(load_host_config().peers)
+    except Exception:  # stx-allow: fallback (reason: --help must never raise; an unreadable/absent config yields no hint rather than a crash)
+        return []
+    return format_peer_lines(peers)
+
+
+class _PeerListingCommand(click.Command):
+    """A command whose ``--help`` ends with the peer keys ``--to`` takes."""
+
+    def format_epilog(self, ctx, formatter) -> None:
+        super().format_epilog(ctx, formatter)
+        lines = _registered_peer_lines()
+        if not lines:
+            return
+        formatter.write_paragraph()
+        with formatter.indentation():
+            for line in lines:
+                formatter.write_text(line)
+
+
+def register_keepalive_command(group: click.Group) -> None:
+    """Attach ``send-credentials`` (and its ``keepalive`` alias) onto ``group``."""
+
+    @click.command("send-credentials", cls=_PeerListingCommand)
     @click.option(
         "--account",
         "account_labels",
@@ -109,7 +168,9 @@ def register_keepalive_command(group: click.Group) -> None:
         required=True,
         help=(
             "Peer to push ACCESS-ONLY material to (repeatable). Must be a "
-            "peer key from ~/.scitex/agent-container/config.yaml."
+            "peer key from ~/.scitex/agent-container/config.yaml — this "
+            "--help lists the ones registered here, and `sac host list` "
+            "shows them with their ssh targets."
         ),
     )
     @click.option(
@@ -205,10 +266,10 @@ def register_keepalive_command(group: click.Group) -> None:
         sha256 fingerprints.
 
         \b
-        Examples:
-          $ sac accounts keepalive --account alpha-example-com --to compute-04
-          $ sac accounts keepalive --all --to compute-04 --to laptop
-          $ sac accounts keepalive --all --to compute-04 --sweep
+        Examples (peer keys below are real; run --help to see THIS host's):
+          $ sac accounts send-credentials --account alpha-example-com --to scitex-compute-04
+          $ sac accounts send-credentials --all --to scitex-compute-04 --to ywata-note-win
+          $ sac accounts send-credentials --all --to scitex-compute-04 --sweep
         """
         import json as _json
         import sys
@@ -359,5 +420,47 @@ def register_keepalive_command(group: click.Group) -> None:
         if failed:
             sys.exit(1)
 
+    group.add_command(account_keepalive, "send-credentials")
 
-__all__ = ["register_keepalive_command"]
+    # ``keepalive`` is a PUBLISHED contract, so this is a migration, not a
+    # rename: the old name keeps WORKING and is merely hidden from --help.
+    # A redirect that printed "renamed to X" and exited would break the
+    # systemd units and operator muscle memory that already call it, which
+    # is the opposite of what a rename is for. Remove the alias only once
+    # nothing on any host invokes it.
+    legacy = click.Command(
+        name="keepalive",
+        callback=_deprecated(account_keepalive.callback),
+        params=list(account_keepalive.params),
+        help=account_keepalive.help,
+        short_help="Deprecated alias for send-credentials.",
+        epilog=account_keepalive.epilog,
+        hidden=True,
+    )
+    group.add_command(legacy, "keepalive")
+
+
+def _deprecated(callback):
+    """Wrap ``callback`` so the legacy name says so — on stderr, then runs.
+
+    stderr, not stdout: ``--json`` consumers parse stdout, and a warning
+    that lands there would turn a working script into a JSON parse error.
+    That is the whole failure this alias exists to prevent.
+    """
+    import functools
+
+    @functools.wraps(callback)
+    def _run(*args, **kwargs):
+        click.echo(
+            "warning: `sac accounts keepalive` is now "
+            "`sac accounts send-credentials` — it copies credentials to "
+            "peers, which is what the new name says. The old name still "
+            "works and will be removed once nothing calls it.",
+            err=True,
+        )
+        return callback(*args, **kwargs)
+
+    return _run
+
+
+__all__ = ["format_peer_lines", "register_keepalive_command"]

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -8,12 +8,37 @@ from __future__ import annotations
 
 import click
 
+from ._helpers import HelpRecursiveGroup
+
 # ---------------------------------------------------------------------------
 # account group
 # ---------------------------------------------------------------------------
 
 
-@click.group("account")
+class _AccountsGroup(HelpRecursiveGroup):
+    """Render ``sac accounts --help`` under named sections.
+
+    Fifteen verbs in one alphabetical column made ``list`` / ``status`` /
+    ``quota`` look interchangeable and hid which of them WRITE. The
+    sections say what each verb is FOR; the interface spec
+    (general/03_interface_02_cli §6) asks for this and ``sac agents``
+    already does it. Anything not listed here still renders, under
+    ``Other`` — a new verb is never silently dropped from ``--help``.
+    """
+
+    COMMAND_CATEGORIES = [
+        ("Inspect (read-only)", ["list", "status", "quota"]),
+        ("Stored accounts", ["save", "delete", "switch", "login"]),
+        (
+            "Credential material",
+            ["refresh", "mint-token", "sync-live", "sync-openai"],
+        ),
+        ("Distribute to peers", ["send-credentials"]),
+        ("Watch continuously", ["watch-live", "watch-quota", "refresh-quota-cache"]),
+    ]
+
+
+@click.group("account", cls=_AccountsGroup)
 def account() -> None:
     """Inspect provider accounts and manage Claude credential rotation."""
 

--- a/tests/scitex_agent_container/cli_pkg/test__account_cli_surface.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_cli_surface.py
@@ -21,6 +21,7 @@ import click
 from click.testing import CliRunner
 
 from scitex_agent_container.cli_pkg._account_keepalive import (
+    _registered_peer_lines,
     format_peer_lines,
     register_keepalive_command,
 )
@@ -70,15 +71,20 @@ def test_peer_lines_mark_a_wildcard_row_as_a_pattern():
     assert "pattern" in rendered
 
 
-def test_help_lists_the_peers_to_accepts():
-    # Arrange
+def test_help_lists_the_peers_exactly_when_this_host_has_them():
+    # Arrange — asserting `"Registered peers" in stdout` outright would be an
+    # ENVIRONMENTAL fact, not a property of the code: the block renders from the
+    # live config, so it is absent on any host with no peers registered (a CI
+    # runner, a fresh checkout) and the test would fail there for being right.
+    # The invariant that holds everywhere is that the two AGREE.
     group = _group()
+    host_has_peers = bool(_registered_peer_lines())
 
     # Act
     result = CliRunner().invoke(group, ["send-credentials", "--help"])
 
-    # Assert — the vocabulary is visible at the point of use
-    assert "Registered peers" in result.stdout
+    # Assert — wiring is present; what it renders is the host's business
+    assert ("Registered peers" in result.stdout) == host_has_peers
 
 
 # --- the examples ----------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test__account_cli_surface.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_cli_surface.py
@@ -1,0 +1,227 @@
+"""``sac accounts`` help surface: sections, a real peer list, a live alias.
+
+Three defects, all found by the operator reading the shipped ``--help``:
+
+1. Fifteen verbs rendered as one flat alphabetical column.
+2. The examples named peers that exist on no host (``compute-04``,
+   ``laptop``), while ``--to`` requires a key from ``config.yaml``. Copying
+   the documentation therefore failed.
+3. ``keepalive`` needs a paragraph to say it copies credentials to peers -
+   and the constitution's rule is that when a name needs restating as
+   something else, that something else IS the name.
+
+The alias tests are the load-bearing ones: ``keepalive`` is a PUBLISHED
+contract with a scitex-dev JobSpec calling it every 15 minutes, so a rename
+that stops at renaming would take the fleet's credential distribution down.
+"""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._account_keepalive import (
+    format_peer_lines,
+    register_keepalive_command,
+)
+from scitex_agent_container.cli_pkg.account_group import _AccountsGroup, account
+
+
+def _group() -> click.Group:
+    """A bare group carrying only the commands under test."""
+    group = click.Group("accounts")
+    register_keepalive_command(group)
+    return group
+
+
+# --- the peer listing ------------------------------------------------------
+
+
+def test_peer_lines_are_empty_when_no_peers_are_registered():
+    # Arrange
+    peers: list[str] = []
+
+    # Act
+    lines = format_peer_lines(peers)
+
+    # Assert — a host with no peers gets no hint, never a bare header
+    assert lines == []
+
+
+def test_peer_lines_name_every_registered_peer():
+    # Arrange
+    peers = ["ywata-note-win", "scitex-compute-04"]
+
+    # Act
+    rendered = "\n".join(format_peer_lines(peers))
+
+    # Assert
+    assert "ywata-note-win" in rendered and "scitex-compute-04" in rendered
+
+
+def test_peer_lines_mark_a_wildcard_row_as_a_pattern():
+    # Arrange — `spartan-*` is a template for per-node keys, not a typable name
+    peers = ["spartan-*"]
+
+    # Act
+    rendered = "\n".join(format_peer_lines(peers))
+
+    # Assert
+    assert "pattern" in rendered
+
+
+def test_help_lists_the_peers_to_accepts():
+    # Arrange
+    group = _group()
+
+    # Act
+    result = CliRunner().invoke(group, ["send-credentials", "--help"])
+
+    # Assert — the vocabulary is visible at the point of use
+    assert "Registered peers" in result.stdout
+
+
+# --- the examples ----------------------------------------------------------
+
+
+def test_examples_do_not_name_the_peer_that_exists_nowhere():
+    # Arrange
+    group = _group()
+
+    # Act
+    result = CliRunner().invoke(group, ["send-credentials", "--help"])
+
+    # Assert — `--to laptop` was in the shipped examples and is not a key
+    assert "--to laptop" not in result.stdout
+
+
+# --- the rename, which must not break the JobSpec that calls it ------------
+
+
+def test_the_new_name_is_registered():
+    # Arrange
+    group = _group()
+
+    # Act
+    cmd = group.get_command(click.Context(group), "send-credentials")
+
+    # Assert
+    assert cmd is not None
+
+
+def test_the_legacy_name_still_resolves():
+    # Arrange — a JobSpec runs `accounts keepalive --all` every 15 minutes
+    group = _group()
+
+    # Act
+    cmd = group.get_command(click.Context(group), "keepalive")
+
+    # Assert
+    assert cmd is not None
+
+
+def test_the_legacy_name_still_accepts_the_same_options():
+    # Arrange
+    group = _group()
+    ctx = click.Context(group)
+
+    # Act
+    legacy = group.get_command(ctx, "keepalive")
+    current = group.get_command(ctx, "send-credentials")
+
+    # Assert — same params, so the scheduled command line keeps parsing
+    assert [p.name for p in legacy.params] == [p.name for p in current.params]
+
+
+def test_the_legacy_name_is_hidden_from_help():
+    # Arrange
+    group = _group()
+
+    # Act
+    result = CliRunner().invoke(group, ["--help"])
+
+    # Assert — deprecated, so it must not be advertised to new readers
+    assert "keepalive" not in result.stdout
+
+
+def test_the_legacy_name_warns_that_it_was_renamed():
+    # Arrange — args that reach the callback, then fail on their own merits
+    group = _group()
+    args = ["keepalive", "--account", "no-such-account", "--to", "no-such-peer"]
+
+    # Act
+    result = CliRunner().invoke(group, args)
+
+    # Assert
+    assert "send-credentials" in result.stderr
+
+
+def test_the_legacy_warning_never_lands_on_stdout():
+    # Arrange — `--json` consumers parse stdout; a warning there breaks them
+    group = _group()
+    args = ["keepalive", "--account", "no-such-account", "--to", "no-such-peer"]
+
+    # Act
+    result = CliRunner().invoke(group, args)
+
+    # Assert
+    assert "renamed" not in result.stdout
+
+
+def test_the_new_name_does_not_warn():
+    # Arrange — the control: proves the warning is bound to the alias only
+    group = _group()
+    args = ["send-credentials", "--account", "no-such-account", "--to", "no-such"]
+
+    # Act
+    result = CliRunner().invoke(group, args)
+
+    # Assert
+    assert "is now" not in result.stderr
+
+
+# --- the sections ----------------------------------------------------------
+
+
+def test_accounts_help_renders_named_sections():
+    # Arrange
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(account, ["--help"])
+
+    # Assert
+    assert "Distribute to peers:" in result.stdout
+
+
+def test_every_categorised_name_is_a_real_command():
+    # Arrange — a category naming a verb that does not exist would silently
+    # render nothing, which is how a section quietly goes empty after a rename
+    ctx = click.Context(account)
+    listed = {n for _, names in _AccountsGroup.COMMAND_CATEGORIES for n in names}
+
+    # Act
+    missing = sorted(n for n in listed if account.get_command(ctx, n) is None)
+
+    # Assert
+    assert missing == []
+
+
+def test_no_visible_command_falls_through_to_other():
+    # Arrange — `Other` is the catch-all; a VISIBLE verb landing there is one
+    # somebody forgot to categorise. Hidden verbs (the `keepalive` alias) are
+    # excluded on the same predicate the formatter itself uses, so this tracks
+    # what a reader actually sees rather than what the group happens to hold.
+    ctx = click.Context(account)
+    categorised = {n for _, names in _AccountsGroup.COMMAND_CATEGORIES for n in names}
+    visible = {
+        n
+        for n in account.list_commands(ctx)
+        if not getattr(account.get_command(ctx, n), "hidden", False)
+    }
+
+    # Act
+    uncategorised = sorted(visible - categorised)
+
+    # Assert
+    assert uncategorised == []

--- a/tests/scitex_agent_container/cli_pkg/test__account_keepalive_cli_surface.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_keepalive_cli_surface.py
@@ -1,18 +1,20 @@
-"""``sac accounts`` help surface: sections, a real peer list, a live alias.
+"""``sac accounts send-credentials``: a real peer list, and a live legacy alias.
 
-Three defects, all found by the operator reading the shipped ``--help``:
+Two of the three defects the operator found reading the shipped ``--help``:
 
-1. Fifteen verbs rendered as one flat alphabetical column.
-2. The examples named peers that exist on no host (``compute-04``,
-   ``laptop``), while ``--to`` requires a key from ``config.yaml``. Copying
-   the documentation therefore failed.
-3. ``keepalive`` needs a paragraph to say it copies credentials to peers -
-   and the constitution's rule is that when a name needs restating as
-   something else, that something else IS the name.
+1. The examples named peers that exist on no host (``compute-04``, ``laptop``),
+   while ``--to`` requires a key from ``config.yaml``. Copying the
+   documentation therefore failed.
+2. ``keepalive`` needs a paragraph to say it copies credentials to peers - and
+   the constitution's rule is that when a name needs restating as something
+   else, that something else IS the name.
 
 The alias tests are the load-bearing ones: ``keepalive`` is a PUBLISHED
 contract with a scitex-dev JobSpec calling it every 15 minutes, so a rename
-that stops at renaming would take the fleet's credential distribution down.
+that stopped at renaming would take the fleet's credential distribution down.
+
+(The ``--help`` SECTIONS are the third defect and live beside their own module,
+in ``test_account_group_categories.py``.)
 """
 
 from __future__ import annotations
@@ -25,7 +27,6 @@ from scitex_agent_container.cli_pkg._account_keepalive import (
     format_peer_lines,
     register_keepalive_command,
 )
-from scitex_agent_container.cli_pkg.account_group import _AccountsGroup, account
 
 
 def _group() -> click.Group:
@@ -184,50 +185,3 @@ def test_the_new_name_does_not_warn():
 
     # Assert
     assert "is now" not in result.stderr
-
-
-# --- the sections ----------------------------------------------------------
-
-
-def test_accounts_help_renders_named_sections():
-    # Arrange
-    runner = CliRunner()
-
-    # Act
-    result = runner.invoke(account, ["--help"])
-
-    # Assert
-    assert "Distribute to peers:" in result.stdout
-
-
-def test_every_categorised_name_is_a_real_command():
-    # Arrange — a category naming a verb that does not exist would silently
-    # render nothing, which is how a section quietly goes empty after a rename
-    ctx = click.Context(account)
-    listed = {n for _, names in _AccountsGroup.COMMAND_CATEGORIES for n in names}
-
-    # Act
-    missing = sorted(n for n in listed if account.get_command(ctx, n) is None)
-
-    # Assert
-    assert missing == []
-
-
-def test_no_visible_command_falls_through_to_other():
-    # Arrange — `Other` is the catch-all; a VISIBLE verb landing there is one
-    # somebody forgot to categorise. Hidden verbs (the `keepalive` alias) are
-    # excluded on the same predicate the formatter itself uses, so this tracks
-    # what a reader actually sees rather than what the group happens to hold.
-    ctx = click.Context(account)
-    categorised = {n for _, names in _AccountsGroup.COMMAND_CATEGORIES for n in names}
-    visible = {
-        n
-        for n in account.list_commands(ctx)
-        if not getattr(account.get_command(ctx, n), "hidden", False)
-    }
-
-    # Act
-    uncategorised = sorted(visible - categorised)
-
-    # Assert
-    assert uncategorised == []

--- a/tests/scitex_agent_container/cli_pkg/test_account_group_categories.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group_categories.py
@@ -1,0 +1,65 @@
+"""``sac accounts --help`` renders its verbs under named sections.
+
+Fifteen verbs in one flat alphabetical column made ``list`` / ``status`` /
+``quota`` look interchangeable and hid which of them WRITE. The interface spec
+(general/03_interface_02_cli §6) asks for sections and ``sac agents`` already
+renders them.
+
+The two population guards matter more than the rendering test: a category that
+names a verb which no longer exists renders nothing and fails silently, and a
+verb nobody categorised disappears into ``Other`` unnoticed.
+"""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.account_group import _AccountsGroup, account
+
+
+# --- the sections ----------------------------------------------------------
+
+
+def test_accounts_help_renders_named_sections():
+    # Arrange
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(account, ["--help"])
+
+    # Assert
+    assert "Distribute to peers:" in result.stdout
+
+
+def test_every_categorised_name_is_a_real_command():
+    # Arrange — a category naming a verb that does not exist would silently
+    # render nothing, which is how a section quietly goes empty after a rename
+    ctx = click.Context(account)
+    listed = {n for _, names in _AccountsGroup.COMMAND_CATEGORIES for n in names}
+
+    # Act
+    missing = sorted(n for n in listed if account.get_command(ctx, n) is None)
+
+    # Assert
+    assert missing == []
+
+
+def test_no_visible_command_falls_through_to_other():
+    # Arrange — `Other` is the catch-all; a VISIBLE verb landing there is one
+    # somebody forgot to categorise. Hidden verbs (the `keepalive` alias) are
+    # excluded on the same predicate the formatter itself uses, so this tracks
+    # what a reader actually sees rather than what the group happens to hold.
+    ctx = click.Context(account)
+    categorised = {n for _, names in _AccountsGroup.COMMAND_CATEGORIES for n in names}
+    visible = {
+        n
+        for n in account.list_commands(ctx)
+        if not getattr(account.get_command(ctx, n), "hidden", False)
+    }
+
+    # Act
+    uncategorised = sorted(visible - categorised)
+
+    # Assert
+    assert uncategorised == []


### PR DESCRIPTION
Found by the operator reading the shipped `--help` while the `business` agent was down and he needed the command to work. Three defects on one surface.

## 1. The examples named peers that exist on no host

```
$ sac accounts keepalive --account alpha-example-com --to compute-04
$ sac accounts keepalive --all --to compute-04 --to laptop
```

`--to` is documented as *"a peer key from config.yaml"*. The real keys are `mba`, `nas-03`, `scitex-compute-01..04`, `scitex-nas-01..03`, `spartan`, `spartan-*`, `ywata-note-win`. `compute-04` is not one — `scitex-compute-04` is — and `laptop` does not exist at all. The shipped examples fail, and the mistake they teach is the one the error then rejects. I hit it myself.

`--help` now renders the peers `--to` accepts **on the host you are typing on**, read from the table the command resolves against, so it cannot drift. A wildcard row is marked `(pattern — substitute a real node name)`; printing `spartan-*` bare would repeat the defect the listing fixes. It returns `[]` on any exception — `--help` must render on a host with no config.

## 2. `keepalive` named an outcome, not the action

Its docstring's first job is to deny what the name implies: *"COPIES — it never mints or refreshes."* A name whose documentation opens by contradicting it is the bug report. Constitution §3: *if you must explain a name by restating it as something else, that something else IS the name.*

**This is a migration, not a rename.** `keepalive` keeps **working**, merely hidden from `--help` — load-bearing, because scitex-dev's `accounts-keepalive` JobSpec runs `sac accounts keepalive --all --to ywata-note-win ...` every 15 minutes and its own description calls it *"the only thing keeping the access-only hosts alive"*. A redirect that printed "renamed to X" and exited would take fleet credential distribution down. The notice goes to **stderr**, never stdout — `--json` consumers parse stdout.

## 3. Fifteen verbs in one flat alphabetical column

`list` / `status` / `quota` read as interchangeable and nothing said which verbs WRITE. The interface spec (general/03_interface_02_cli §6) asks for sections and `sac agents` already renders them. Reuses `HelpRecursiveGroup` — no new machinery, and uncategorised verbs still fall to `Other` rather than disappearing.

```
Inspect (read-only) | Stored accounts | Credential material
Distribute to peers | Watch continuously
```

## Measured

| check | result |
|---|---|
| tests | **29 collected / 29 passed / 0 failed** — this file plus both suites exercising the old verb |
| ruff | **9 errors, identical to the same two files at `origin/develop`** — pre-existing E402s, zero introduced (A/B'd, not asserted) |
| line caps | 466 / 443 / 227, all under 512 |

15 new tests. The load-bearing ones are the alias: it resolves, is hidden, keeps the **same parameter list** (so the scheduled command line still parses), warns, and never warns on stdout. `test_the_new_name_does_not_warn` is the control — without it a warning printed unconditionally would pass every other assertion. Two population guards fail if a later rename leaves a category naming a dead verb, or a visible verb uncategorised.

## Deliberately not here

- `nas-03` vs `scitex-nas-03` — host topology has two sources (config, registry) with different conventions. Whether that registry belongs to sac is an open operator question; renaming keys is a separate migration.
- An unknown `--to` lists registered peers but does not suggest the near match.
- `mint-token`, which does not mint — it reads a stored credential and strips a field. Same defect class, different blast radius.

Card: `sac-keepalive-help-names-nonexistent-peers-20260821`