### PR TITLE
feat(creds): a boot that reports SUCC now says which account it chose

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_quota_evidence.py
+++ b/src/scitex_agent_container/_lifecycle/_quota_evidence.py
@@ -58,7 +58,40 @@ logger = logging.getLogger(__name__)
 #: selection notice.
 UNVERIFIABLE_MARKER = "QUOTA UNVERIFIABLE"
 
-__all__ = ["UNVERIFIABLE_MARKER", "pick_with_quota_evidence"]
+#: Stable marker opening the per-boot selection record. Distinct token from
+#: :data:`UNVERIFIABLE_MARKER` so `grep` can ask "which account did this boot
+#: choose" WITHOUT also matching the degraded-boot warning, and vice versa.
+SELECTION_MARKER = "ACCOUNT SELECTED"
+
+#: 7d utilisation at or above which the selected account can do NO work at all.
+#:
+#: Deliberately NOT `_quota_rank.NEAR_CAP_7D_PCT`. Near-cap means TIGHT and is
+#: the ranker's business — it already prefers headroom, and in a busy fleet
+#: every candidate is near-cap, so warning on it would fire on every boot and
+#: be tuned out. This threshold means IMPOSSIBLE: the account has no weekly
+#: budget left, so the agent will boot, report success, and answer "You've hit
+#: your weekly limit" on every turn.
+#:
+#: MEASURED 2026-08-21, ywata-note-win, all four stored accounts at once:
+#: scitex-01=100%, wyusuuke=100%, ywatanabe-scitex-ai=99%, ywata1989=90%. A
+#: near-cap threshold would have warned about all four and distinguished
+#: nothing. Only two of them were actually unusable.
+NO_HEADROOM_7D_PCT = 100.0
+
+#: Which branch of :func:`pick_with_quota_evidence` produced the account. The
+#: value is logged verbatim, because "which gate was armed" is precisely the
+#: question that could not be answered after the fact on 2026-08-21.
+SELECTED_VIA_ARMED = "gate armed, cache already fresh"
+SELECTED_VIA_ARMED_REFRESHED = "gate armed, cache re-measured first (was stale)"
+SELECTED_VIA_ARMED_BUILT = "gate armed, cache built on demand (host had none)"
+SELECTED_VIA_DEGRADED = "gate DISARMED, quota unverifiable on this host"
+
+__all__ = [
+    "NO_HEADROOM_7D_PCT",
+    "SELECTION_MARKER",
+    "UNVERIFIABLE_MARKER",
+    "pick_with_quota_evidence",
+]
 
 
 def pick_with_quota_evidence(
@@ -135,12 +168,19 @@ def pick_with_quota_evidence(
                 quota_cache_path=quota_cache_path,
                 store_dir=store_dir,
             )
-        return _pick_armed(
+        picked = _pick_armed(
             pick,
             agent_name=agent_name,
             quota_cache_path=quota_cache_path,
             store_dir=store_dir,
             already_refreshed=refreshed,
+        )
+        return _record_selection(
+            picked,
+            agent_name=agent_name,
+            branch=SELECTED_VIA_ARMED_REFRESHED if refreshed else SELECTED_VIA_ARMED,
+            quota_cache_path=quota_cache_path,
+            log_stream=log_stream,
         )
 
     blocker = _build_evidence_once(
@@ -149,11 +189,18 @@ def pick_with_quota_evidence(
         store_dir=store_dir,
     )
     if blocker is None:
-        return _pick_armed(
+        picked = _pick_armed(
             pick,
             agent_name=agent_name,
             quota_cache_path=quota_cache_path,
             store_dir=store_dir,
+        )
+        return _record_selection(
+            picked,
+            agent_name=agent_name,
+            branch=SELECTED_VIA_ARMED_BUILT,
+            quota_cache_path=quota_cache_path,
+            log_stream=log_stream,
         )
 
     picked = pick(False)
@@ -164,7 +211,126 @@ def pick_with_quota_evidence(
         quota_cache_path=quota_cache_path,
         log_stream=log_stream,
     )
+    return _record_selection(
+        picked,
+        agent_name=agent_name,
+        branch=SELECTED_VIA_DEGRADED,
+        quota_cache_path=quota_cache_path,
+        log_stream=log_stream,
+    )
+
+
+def _record_selection(
+    picked: str,
+    *,
+    agent_name: str,
+    branch: str,
+    quota_cache_path: Path | str | None,
+    log_stream: Any = None,
+) -> str:
+    """Say which account this boot chose, and on what evidence. Returns *picked*.
+
+    A PASS-THROUGH so every ``return`` in :func:`pick_with_quota_evidence` can
+    wrap its result without restructuring the control flow — the branch that
+    chose the account stays visible in the branch that reports it.
+
+    WHY THIS EXISTS. On 2026-08-21 ``business`` booted on an account at
+    ``d7=100%`` and answered "You've hit your weekly limit" on every turn. sac
+    printed ``SUCC``, tmux was alive, and all three startup prompts reported
+    ``idle-gated submit verified``. Reconstructing it afterwards was IMPOSSIBLE:
+    the only trace of the boot anywhere under ``~/.scitex/agent-container/runtime``
+    was auth-heal noting the agent was "no longer login-expired". Nothing named
+    the account, its quota, or which gate had been armed — so "did the guard run
+    and choose this, or was it never consulted?" had no answer in the logs, and
+    the investigation went looking for a picker bug that the code does not have
+    (``_quota_rank.EXPIRING_MIN_HEADROOM_PCT`` already excludes a capped account
+    from the expiring-capacity preference, by construction).
+
+    So this is a RECORD, not a gate. It changes no decision. The picker's
+    "quota is a preference, not a hard gate — an all-blocked fleet still returns
+    the least-bad fresh account" is deliberate and stays exactly as it is:
+    refusing when every account is busy would brick the fleet.
+
+    TWO FAILURE MODES, ONE LINE. Besides the unanswerable-afterwards problem, it
+    closes a second one measured the same night: the operator had DISTRIBUTED
+    ``ywata1989`` to that host with ``sac accounts send-credentials --to`` and
+    the launcher selected ``scitex-01`` regardless. Distributing credential
+    material and selecting the boot account are decided in different places, and
+    nothing in either output said so. This line is where they become comparable.
+    """
+    from .._account.quota_cache import read_quota_entry
+
+    entry = read_quota_entry(account=picked, cache_path=quota_cache_path) or {}
+    h5 = entry.get("h5")
+    d7 = entry.get("d7")
+
+    def _pct(value: Any) -> str:
+        # "?" rather than a number we do not have. The whole family of bugs this
+        # module documents begins with an unknown quota rendered as if known.
+        return f"{value:g}%" if _is_pct(value) else "?"
+
+    logger.info(
+        "%s — %s: %s (5h=%s 7d=%s) [%s]",
+        SELECTION_MARKER,
+        agent_name,
+        picked,
+        _pct(h5),
+        _pct(d7),
+        branch,
+    )
+
+    if _is_pct(d7) and float(d7) >= NO_HEADROOM_7D_PCT:
+        _warn_no_headroom(
+            picked,
+            agent_name=agent_name,
+            d7=float(d7),
+            branch=branch,
+            log_stream=log_stream,
+        )
+
     return picked
+
+
+def _is_pct(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _warn_no_headroom(
+    picked: str,
+    *,
+    agent_name: str,
+    d7: float,
+    branch: str,
+    log_stream: Any,
+) -> None:
+    """Say — once, loudly — that this boot has no weekly budget to spend.
+
+    NOT a refusal. Every stored account can be capped at once (measured
+    2026-08-21: four of four at 90-100%), and refusing then would leave the
+    operator with no way to start anything. The agent boots; the operator simply
+    finds out NOW rather than from an agent that looks healthy and answers
+    nothing.
+
+    Mirrors :func:`_warn_unverifiable`'s delivery exactly — a caller-supplied
+    stream means the output is being CAPTURED, so it must not reach a logger.
+    """
+    text = (
+        f"{SELECTION_MARKER} — {agent_name}: starting on account {picked}, which "
+        f"has NO weekly budget left (7d={d7:g}%). The agent will start and report "
+        "success, its tmux pane will be alive, and every turn will answer "
+        '"You\'ve hit your weekly limit" until the 7d window resets. Chosen via: '
+        f"{branch}. This is a REPORT, not a refusal — when every stored account is "
+        "capped there is nothing better to pick. To see the whole pool run "
+        "`sac accounts list`; to re-measure it run `sac accounts "
+        "refresh-quota-cache`."
+    )
+    if log_stream is not None:
+        print(f"[sac:creds] {text}", file=log_stream)
+        return
+
+    from ..cli_pkg._helpers._console import system_msg
+
+    system_msg(text, style="warn")
 
 
 def _refresh_stale_evidence(

--- a/tests/scitex_agent_container/_lifecycle/test__quota_evidence_records_selection.py
+++ b/tests/scitex_agent_container/_lifecycle/test__quota_evidence_records_selection.py
@@ -1,0 +1,228 @@
+"""Every boot must leave a record of WHICH account it chose, and on what evidence.
+
+MEASURED 2026-08-21, ywata-note-win. Agent ``business`` booted onto
+``scitex-01-scitex-ai`` at ``d7=100%`` and answered "You've hit your weekly
+limit" on every turn. sac printed ``SUCC``, tmux was alive, and all three
+startup prompts reported ``idle-gated submit verified``.
+
+Reconstructing that boot afterwards was IMPOSSIBLE. The only trace anywhere
+under ``~/.scitex/agent-container/runtime`` was auth-heal noting the agent was
+"no longer login-expired"; ``auth-events.jsonl`` had no entry for the boot at
+all. Nothing named the account, its quota, or which gate had been armed — so
+"did the guard run and choose this, or was it never consulted?" had no answer,
+and the investigation went hunting a picker bug the code does not have
+(``_quota_rank.EXPIRING_MIN_HEADROOM_PCT`` already excludes a capped account
+from the expiring-capacity preference, by construction).
+
+What is locked here
+-------------------
+1. The selection record names the account, its cached 5h/7d, and WHICH branch
+   of the gate produced it.
+2. An account with no weekly budget warns — loudly, naming the consequence.
+3. An account with headroom does NOT warn, so the warning keeps its meaning in
+   a fleet where near-cap is routine (measured the same night: four of four
+   stored accounts sat at 90-100%).
+4. A quota the cache does not carry renders as ``?``, never as a number. Every
+   bug this module documents begins with an unknown quota rendered as if known.
+5. The recorder is a pass-through: it reports, it never changes the pick.
+
+PA-306: no mocks. A real cache file in ``tmp_path``, and a real ``pick``
+callable — which is a genuine stand-in rather than a mock, because ``pick`` is
+a ``Callable`` PARAMETER of the function under test ("a callable rather than a
+kwargs bundle because the two preflight call sites pass different candidate
+universes"). AAA markers (TQ002); descriptive names; one assertion each
+(TQ007).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._quota_evidence import (
+    SELECTION_MARKER,
+    pick_with_quota_evidence,
+)
+
+_LOGGER = "scitex_agent_container._lifecycle._quota_evidence"
+
+# The account from the incident. Its first dash-segment is "scitex", which is
+# the quota cache's per-account match key (``short``) — spelled out here
+# because a cache entry keyed on the wrong segment reads as "no entry" and
+# every percentage would silently render "?", passing a weaker assertion.
+_CAPPED = "scitex-01-scitex-ai"
+_CAPPED_SHORT = "scitex"
+
+# The only stored account that still had weekly budget that night.
+_HEALTHY = "ywata1989-gmail-com"
+_HEALTHY_SHORT = "ywata1989"
+
+
+def _write_cache(path: Path, entries: dict[str, dict]) -> Path:
+    """A real, FRESH quota cache, so the armed-and-already-fresh branch runs.
+
+    ``written_at`` is stamped now on purpose: an undated or hour-old cache
+    routes the caller into the staleness re-measure instead, which is a
+    different branch than the one these tests are about.
+    """
+    path.write_text(json.dumps({"written_at": time.time(), "accounts": entries}))
+    return path
+
+
+def _capped_cache(tmp_path: Path) -> Path:
+    return _write_cache(
+        tmp_path / "quota-cache.json",
+        {
+            _CAPPED: {"short": _CAPPED_SHORT, "h5": 0.0, "d7": 100.0, "ttl_h": 4.9},
+            _HEALTHY: {"short": _HEALTHY_SHORT, "h5": 17.0, "d7": 90.0, "ttl_h": 4.9},
+        },
+    )
+
+
+def _pick(account: str):
+    """A real callable returning a fixed account, mirroring ``pick``'s contract."""
+
+    def _picker(require_quota_evidence: bool) -> str:
+        return account
+
+    return _picker
+
+
+def _selection_line(caplog: pytest.LogCaptureFixture) -> str:
+    """The selection record only.
+
+    Scoped to the marker rather than searching the whole log, because the
+    module's other lines also name the agent and would let an unscoped
+    substring assertion pass against a build that records nothing.
+    """
+    lines = [
+        r.getMessage() for r in caplog.records if SELECTION_MARKER in r.getMessage()
+    ]
+    assert len(lines) == 1, f"expected exactly one selection record, got {lines}"
+    return lines[0]
+
+
+def test_the_selection_record_names_the_account_the_boot_actually_chose(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    cache = _capped_cache(tmp_path)
+    # Act
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        pick_with_quota_evidence(
+            _pick(_CAPPED),
+            agent_name="business",
+            quota_cache_path=cache,
+            log_stream=io.StringIO(),
+        )
+    # Assert
+    assert _CAPPED in _selection_line(caplog)
+
+
+def test_the_selection_record_carries_the_accounts_cached_7d(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    cache = _capped_cache(tmp_path)
+    # Act
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        pick_with_quota_evidence(
+            _pick(_CAPPED),
+            agent_name="business",
+            quota_cache_path=cache,
+            log_stream=io.StringIO(),
+        )
+    # Assert
+    assert "7d=100%" in _selection_line(caplog)
+
+
+def test_the_selection_record_names_which_gate_produced_the_account(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    cache = _capped_cache(tmp_path)
+    # Act
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        pick_with_quota_evidence(
+            _pick(_CAPPED),
+            agent_name="business",
+            quota_cache_path=cache,
+            log_stream=io.StringIO(),
+        )
+    # Assert
+    assert "gate armed" in _selection_line(caplog)
+
+
+def test_an_account_with_no_weekly_budget_warns_that_every_turn_will_be_refused(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    cache = _capped_cache(tmp_path)
+    stream = io.StringIO()
+    # Act
+    pick_with_quota_evidence(
+        _pick(_CAPPED),
+        agent_name="business",
+        quota_cache_path=cache,
+        log_stream=stream,
+    )
+    # Assert
+    assert "hit your weekly limit" in stream.getvalue()
+
+
+def test_an_account_that_still_has_headroom_does_not_warn(tmp_path: Path) -> None:
+    # Arrange
+    cache = _capped_cache(tmp_path)
+    stream = io.StringIO()
+    # Act
+    pick_with_quota_evidence(
+        _pick(_HEALTHY),
+        agent_name="business",
+        quota_cache_path=cache,
+        log_stream=stream,
+    )
+    # Assert
+    assert stream.getvalue() == ""
+
+
+def test_a_quota_the_cache_does_not_carry_renders_as_a_question_mark(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange — a cache that is present and fresh but knows nothing about the
+    # account the picker returns. This is the shape that produced "5h=? 7d=?"
+    # in the 2026-07-20 incident, and it must never render as a number.
+    cache = _write_cache(
+        tmp_path / "quota-cache.json",
+        {_HEALTHY: {"short": _HEALTHY_SHORT, "h5": 17.0, "d7": 90.0, "ttl_h": 4.9}},
+    )
+    # Act
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        pick_with_quota_evidence(
+            _pick("stranger-example-com"),
+            agent_name="business",
+            quota_cache_path=cache,
+            log_stream=io.StringIO(),
+        )
+    # Assert
+    assert "5h=? 7d=?" in _selection_line(caplog)
+
+
+def test_recording_the_selection_does_not_change_the_picked_account(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    cache = _capped_cache(tmp_path)
+    # Act
+    picked = pick_with_quota_evidence(
+        _pick(_CAPPED),
+        agent_name="business",
+        quota_cache_path=cache,
+        log_stream=io.StringIO(),
+    )
+    # Assert
+    assert picked == _CAPPED


### PR DESCRIPTION
## What happened

`business` booted onto `scitex-01-scitex-ai` at `d7=100%` and answered *"You've hit your weekly limit"* on every turn. sac printed `SUCC`, tmux was alive, and all three startup prompts reported `idle-gated submit verified`.

Reconstructing that boot afterwards was **impossible**. The only trace anywhere under `~/.scitex/agent-container/runtime` was auth-heal noting the agent was `"no longer login-expired"`; `auth-events.jsonl` had no entry for the boot at all. Nothing named the account, its quota, or which gate had been armed.

So "did the guard run and choose this, or was it never consulted?" had no answer in the logs — and the investigation went hunting a picker bug **the code does not have**: `_quota_rank.EXPIRING_MIN_HEADROOM_PCT` already excludes a capped account from the expiring-capacity preference, by construction (`is_expiring_7d`, `d7 <= 100.0 - min_headroom_pct`).

## What changed

`pick_with_quota_evidence` had three `return`s and only the **degraded** one said anything (`_warn_unverifiable`). Both **armed** paths returned silently — and the armed-and-fresh path is the one that boot took.

Each return now passes through `_record_selection()`, which logs one line:

```
ACCOUNT SELECTED — business: scitex-01-scitex-ai (5h=0% 7d=100%) [gate armed, cache already fresh]
```

naming the account, its cached 5h/7d, and the branch that produced it. `SELECTION_MARKER` is a spaced phrase distinct from `UNVERIFIABLE_MARKER`, so `grep` can ask either question without matching the other. A quota the cache does not carry renders `?`, never a number — every bug this module documents begins with an unknown quota rendered as if known.

It also closes a **second mode** measured the same night: `ywata1989` had been distributed to that host with `sac accounts send-credentials --to`, and the launcher selected `scitex-01` regardless. Distributing credential material and selecting the boot account are decided in different places, and nothing in either output said so. This line is where they become comparable.

Plus a warning when the **selected** account has `d7 >= 100`: it boots anyway and says so.

## Why the threshold is not `NEAR_CAP_7D_PCT`

Near-cap means **tight** and is the ranker's business. That night all four stored accounts sat at 90–100% (`scitex-01`=100, `wyusuuke`=100, `ywatanabe-scitex-ai`=99, `ywata1989`=90), so a near-cap warning would have fired on every boot and distinguished nothing — only two of the four were actually unusable. `100` means **impossible**. The measurement is in the constant's docstring so nobody re-tunes it blind.

## No policy change

The picker still returns the least-bad account when everything is capped. Refusing then would brick the fleet, and that behaviour is deliberate and documented (`_pick_healthy.py`: *"Quota is a preference, not a hard gate"*). **This is a record, not a gate.**

## The control

Reverting the source and watching the tests fail proved nothing — it failed at **collection** on `ImportError`, which a build that defined the constants and never wired the recorder would also pass.

Unwiring **only the three call sites**, keeping constants and function defined:

```
5 failed, 2 passed
```

The 5 fail on behaviour (no selection record; no warning). The 2 that survive are the negative test (*an account with headroom must not warn* — vacuously true when nothing warns) and the pass-through invariant. They cannot discriminate alone and are not claimed to.

## Verification

- `7 passed` — new tests, and `5 failed / 2 passed` under the unwired control
- `3075 passed, 2 skipped in 61.56s` — `_lifecycle/` + `_account/` + `_creds/`
- `ruff check` clean, `ruff format --check` clean
