### PR TITLE
ci: a hung test now dumps its own stack instead of dying silently

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -842,6 +842,33 @@ required_plugins = ["pytest-asyncio", "pytest-xdist"]
 
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+
+# DUMP EVERY THREAD'S STACK WHEN A TEST STOPS MAKING PROGRESS.
+#
+# Purely diagnostic: pytest arms faulthandler and dumps tracebacks after this
+# many seconds in ONE test. It does not fail, kill or skip anything — a slow
+# test that finishes still passes, and the dump is the only side effect. That
+# is why this is safe to set on a suite whose normal full run is ~6 minutes.
+#
+# WHY IT EXISTS. A matrix leg has now hung THREE times by this repo's own
+# count (see the comments in pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml:
+# PR #594's 1h39m, a duplicate py3.11 leg at 40+ min while its siblings
+# finished in 11). MEASURED 2026-08-21 on run 32482771853: the py3.13 leg
+# stalled at 67-68% and produced NO OUTPUT AT ALL for 36.5 minutes before the
+# job's 45-minute timeout killed it — no test line, no traceback, nine orphan
+# python processes reaped by the runner. Its py3.11 sibling passed in 6m12s on
+# the same diff, concurrently, on a different host.
+#
+# Two agents then spent an evening refuting six hypotheses (the diff, an
+# ambient Postgres error at the stall boundary, the host's store, within-run
+# collision, a third repo's CI, and both runners on that box) and still could
+# not say WHAT it blocked on — because the log cannot answer that question.
+# This line makes the next occurrence answer it by itself.
+#
+# 300s is chosen against the observed suite: the whole run takes ~6 minutes, so
+# no healthy single test comes near five minutes, and a real hang exceeds it
+# long before the job's 45-minute wall.
+faulthandler_timeout = 300
 addopts = "-v --tb=short -p tests._store_isolation -m 'not integration and not docker_smoke'"
 markers = [
     "integration: slow end-to-end tests that spawn a real Claude Code agent (require claude CLI + tmux + ANTHROPIC_API_KEY or SAC_ANTHROPIC_API_KEY). Opt in with '-m integration'.",


### PR DESCRIPTION
## The problem

A matrix leg has hung **three times** by this repo's own count — the workflow's own comments record PR #594's 1h39m42s, and a duplicate py3.11 leg at 40+ minutes while its two siblings finished in 11. Every time, **the log could not say what it was blocked on.**

Measured 2026-08-21 on run `32482771853`:

| | |
|---|---|
| py3.13 leg | stalled at 67-68%, **no output at all for 36.5 minutes**, killed by the job's 45-min cap |
| py3.11 sibling | passed in **6m12s**, same diff, concurrently, different host |
| orphans reaped | 9 vs 0 |

Two agents then refuted six hypotheses — the diff, an ambient connection error at the stall boundary (113 of the same on the *passing* leg), the host's store (up, load 0.25), within-run collision (the legs overlapped but on different hosts), a third repo's CI, and both runners on that box — and still could not say **what** it blocked on, because no instrument in that run could answer it.

## The change

```toml
faulthandler_timeout = 300
```

One line. The next hang dumps every thread's stack and answers for itself.

## Why it is safe

Purely diagnostic. Stacks are dumped after 300s in **one** test; nothing fails, is killed, or is skipped. A slow test that finishes still passes — the dump is the only side effect.

`300` is chosen against the observed suite: a full run is ~6 minutes, so no healthy single test comes near five minutes, while a real hang exceeds it long before the job's 45-minute wall.

## Verified by making it fire

My first check was **worthless and I threw it away**: I confirmed "no unknown-ini-key warning appeared" — then ran the control and found a *definitely bogus* key produces zero warnings too. Absence of warning proved nothing.

The only thing that proves the mechanism is firing it:

```
faulthandler_timeout=2 against a 4s test   ->  35 stack-dump lines
no setting, same test                      ->   0 stack-dump lines
```

Positive and negative control. It fires when armed and stays silent when it is not.

## What this does not do

It does not explain run `32482771853`. That remains "different machine, mechanism unknown", tracked separately. This makes the *fourth* occurrence self-explaining instead of costing another evening.
