### PR TITLE
chore: promote develop to main — main is red on an unpinned mcp 2.0.0

### DIFF
--- a/.github/ci/ci-status.py
+++ b/.github/ci/ci-status.py
@@ -45,8 +45,82 @@ REPO = "scitex-ai/scitex-agent-container"
 TERMINAL_BAD = {"failure", "timed_out", "startup_failure", "action_required"}
 
 
+def _required_runner_labels(repo: str) -> set[str]:
+    """The labels a job must match, read from the repo's own CI_RUNS_ON.
+
+    Returns an empty set when the variable is unset or unparseable, and the
+    caller then reports every online runner rather than pretending to know
+    which pool is targeted. Guessing a default here is what produced the bug
+    this replaces: a hardcoded label that no longer matched reality made the
+    capacity report confidently wrong instead of visibly unknown.
+    """
+    raw = gh_json(f"repos/{repo}/actions/variables/CI_RUNS_ON") or {}
+    try:
+        return {str(x) for x in json.loads(raw.get("value", ""))}
+    except (ValueError, TypeError):
+        return set()
+
+
+#: Exit code for "the instrument could not read", kept distinct from the
+#: verdict codes (0 green / 1 failed / 2 running) on purpose: a report nobody
+#: could produce must never be scored as one of the answers. Anything using
+#: this script as a gate can then treat 3 as "ask again", not as a pass and
+#: not as a failure.
+EXIT_UNMEASURED = 3
+
+
+def _stop_unmeasured(what: str, path: str, hint: str) -> None:
+    """Print why no verdict exists and exit ``EXIT_UNMEASURED``.
+
+    Separate from ``sys.exit(msg)`` deliberately: that form always exits 1,
+    which is this tool's code for "CI FAILED". Reporting an unreadable API as
+    a red build is the same error class the script exists to prevent — a
+    verdict asserted about something nobody looked at.
+    """
+    print(f"UNMEASURED: {what}", file=sys.stderr)
+    print(f"  failing path: {path}", file=sys.stderr)
+    print(f"  {hint}", file=sys.stderr)
+    sys.exit(EXIT_UNMEASURED)
+
+
 def gh_json(path: str):
+    """One `gh api` call, or a LOUD stop when the API refused to answer.
+
+    A REFUSAL IS NOT A DATA POINT. This used to fold every failure into
+    ``None`` — a 404, a 403 rate limit and a 401 all became the same value —
+    and callers then reported the *default* as the finding. Measured
+    2026-08-20: with the secondary rate limit active, this tool printed
+    "cannot resolve branch develop", which reads as "that branch is gone".
+    The branch was fine; GitHub was refusing.
+
+    Rate limit and auth failures are not partial data either: every
+    subsequent call fails the same way, so continuing yields a report made
+    entirely of false negatives — green-looking because nothing could be
+    read. So those two stop the run with ``EXIT_UNMEASURED``. A genuine 404
+    still returns ``None``, because "this object does not exist" IS an
+    answer and callers legitimately branch on it.
+
+    Note that ``gh api rate_limit`` will happily report thousands remaining
+    while this is happening: the SECONDARY limit does not appear there. The
+    only reliable signal is the refusal itself, which is why it is read here
+    rather than pre-checked.
+    """
     p = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    blob = (p.stdout or "") + (p.stderr or "")
+    low = blob.lower()
+    if "rate limit" in low or "secondary rate" in low:
+        _stop_unmeasured(
+            "GitHub is rate-limiting this token, so no verdict can be produced.",
+            path,
+            "`gh api rate_limit` may still show quota — the SECONDARY limit is "
+            "invisible there. Retry in a few minutes.",
+        )
+    if "bad credentials" in low or "requires authentication" in low:
+        _stop_unmeasured(
+            "GitHub rejected the credentials, so no verdict can be produced.",
+            path,
+            "Run `gh auth status`.",
+        )
     if p.returncode != 0:
         return None
     try:
@@ -150,19 +224,58 @@ def report(repo: str, pr: int | None, branch: str) -> int:
     for n, q, _ in sorted(queued_jobs, key=lambda x: -x[1]):
         print(f"  QUEUED   {n[:46]:<46} waiting={q:5.0f}s  <-- BLOCKED ON A RUNNER")
 
-    runners = gh_json(f"repos/{repo}/actions/runners") or {}
-    online = [x for x in runners.get("runners", []) if x["status"] == "online"]
-    busy = [x for x in online if x["busy"]]
-    local = [x for x in online if any(l["name"] == "scitex-local-cpu" for l in x["labels"])]
+    # CAPACITY IS ABOUT THE POOL THE JOBS ACTUALLY TARGET.
+    #
+    # This block used to read only `repos/{repo}/actions/runners` and count the
+    # ones labelled `scitex-local-cpu`. Both halves were wrong, and together
+    # they made the tool answer confidently about a pool nothing runs on:
+    #
+    #   * `vars.CI_RUNS_ON` for this repo is ["self-hosted","Linux","X64",
+    #     "scitex-org-cpu"], so every job lands on ORG runners. The repo-level
+    #     endpoint cannot see them.
+    #   * No runner in either pool carries `scitex-local-cpu` except the single
+    #     repo runner, so `local` was ~1 and `len(busy) >= len(local)` fired
+    #     on almost any input — a "diagnosis" that is nearly a constant.
+    #
+    # Measured 2026-08-20, when 22 PRs were queued: the old block would have
+    # reported the repo pool as 1 online / 0 busy and implied there was no
+    # contention at all. The truth was all four `scitex-org-cpu` runners busy
+    # and four Spartan runners idle and INELIGIBLE. Read the variable, resolve
+    # the pool it names, and report eligibility — never a fixed label.
+    org = repo.split("/", 1)[0]
+    want = _required_runner_labels(repo)
+    seen: dict[str, dict] = {}
+    for endpoint in (f"repos/{repo}/actions/runners", f"orgs/{org}/actions/runners"):
+        for x in (gh_json(endpoint) or {}).get("runners", []):
+            seen.setdefault(x["name"], x)
+    online = [x for x in seen.values() if x["status"] == "online"]
+
+    def _labels(x):
+        return {l["name"] for l in x["labels"]}
+
+    eligible = [x for x in online if want <= _labels(x)] if want else online
+    busy = [x for x in eligible if x["busy"]]
+    idle_ineligible = [x for x in online if not x["busy"] and x not in eligible]
+
     print("\n--- WHY (capacity) ---")
-    print(f"  runners online {len(online)}, busy {len(busy)}, "
-          f"local (scitex-local-cpu) {len(local)}")
+    print(f"  CI_RUNS_ON requires {sorted(want) if want else '(unset — showing all)'}")
+    print(f"  online {len(online)}, eligible {len(eligible)}, "
+          f"busy {len(busy)}, idle-but-ineligible {len(idle_ineligible)}")
     for x in sorted(online, key=lambda x: x["name"]):
-        labs = ",".join(l["name"] for l in x["labels"])
-        flag = "SPARTAN-BANNED" if "spartan" in labs else ""
-        print(f"    {x['name'][:34]:<34} busy={str(x['busy']):<5} {flag}")
-    if queued_jobs and len(busy) >= len(local):
-        print(f"  => {len(queued_jobs)} job(s) are waiting because every local slot is busy.")
+        mark = "eligible" if x in eligible else "NOT-ELIGIBLE"
+        print(f"    {x['name'][:34]:<34} busy={str(x['busy']):<5} {mark:<12} "
+              f"[{','.join(sorted(_labels(x)))}]")
+    if queued_jobs and eligible and len(busy) >= len(eligible):
+        print(f"  => {len(queued_jobs)} job(s) are waiting: every ELIGIBLE runner is busy.")
+        if idle_ineligible:
+            # The actionable half. A saturated pool next to idle machines is a
+            # LABEL problem, not a hardware one, and naming it is the whole
+            # point of printing eligibility rather than a raw busy count.
+            print(f"  => {len(idle_ineligible)} runner(s) are idle but do not carry "
+                  f"{sorted(want)} — widen the labels or the variable, not the fleet.")
+    elif queued_jobs and not eligible:
+        print(f"  => {len(queued_jobs)} job(s) can NEVER dispatch: no online runner "
+              f"carries {sorted(want)}.")
 
     if superseded:
         print("\n--- SUPERSEDED (other shas — NOT this PR's verdict) ---")

--- a/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
+++ b/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
@@ -35,10 +35,21 @@ name: no-hosted-runners
 #     ["self-hosted","Linux","X64","scitex-org-cpu"] (set 2026-08-12T02:27:58Z),
 #     which resolves to the four scitex-0{1..4}-org-cpu-01 runners. No job here
 #     has run on Spartan since that variable was narrowed.
-#   * BY RULING: the operator banned Spartan from CI outright on 2026-08-11
-#     (「spartan を CI に使うのは全面禁止です」). The literal default below still
-#     spells `scitex-ci`, a label that EVERY Spartan runner also carries — it is
-#     a fallback for a missing variable, not a target. Do not widen it.
+#   * BY RULING — AND THE RULING CHANGED. The 2026-08-11 ban
+#     (「spartan を CI に使うのは全面禁止です」) was WITHDRAWN on 2026-08-13:
+#     「あー憲法が古い、スパルタンのciを使ってください、圧倒的に早いので」.
+#     This comment said "Do not widen it" for a week after the reason to
+#     narrow it had gone, and that sentence was still here on 2026-08-20 with
+#     22 PRs queued behind four saturated `scitex-org-cpu` runners while four
+#     Spartan runners sat online and idle. A withdrawn ruling was doing the
+#     routing, in writing, unchallenged.
+#
+#     So: Spartan is ALLOWED, and preferred where it is faster. Whether to
+#     widen `CI_RUNS_ON` is a capacity decision for the fleet — the two pools
+#     are label-disjoint (`scitex-org-cpu` vs `spartan-cpu`+`scitex-ci`), so
+#     switching the variable TRADES pools rather than adding to them; reaching
+#     all of them needs a shared label on the runners themselves. What is NOT
+#     open is leaving a repealed prohibition standing as guidance.
 #
 # NOTE WHAT THIS GUARD DOES AND DOES NOT COVER: it proves no job lands on a
 # GitHub-HOSTED image. It cannot see which self-hosted POOL a job reaches,

--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -322,66 +322,6 @@ audit:
           PS-231's rationale assumes. CLOSED BY: the org reusable adopting the
           fix, after which this leaf should convert and this entry be removed.
 
-  # PS-226 (job-name-not-hyphenated), introduced by scitex-dev 0.48.0.
-  #
-  # THIS IS A DEFERRAL, NOT A WAIVER, AND THE FINDING IS CORRECT.
-  # `JobSpec(name="sac.accounts-refresh")` is genuinely not hyphen-
-  # separated, and the rule exists for a real reason:
-  # `jobs/_systemd.py::systemd_unit_name` derives the unit FILENAME from
-  # the job name verbatim, with no sanitisation.
-  #
-  # What is deferred is the REMEDY, because the obvious one is more
-  # dangerous than the defect. Renaming does not re-label the running
-  # unit; it makes sac install a SECOND unit beside the live hand-written
-  # one. That unit is the fleet's SOLE OAuth refresher, and it refreshes a
-  # SINGLE-USE token — two refreshers racing revoke each other, taking
-  # every agent's authentication down with them. So the rename is a
-  # supervised systemd unit migration (stop-old -> remove-old ->
-  # install-new -> verify-exactly-one), never a drive-by edit, and
-  # never at an hour when nobody is watching.
-  #
-  # The supervised path already exists: `_jobs/_migrate/_renames.py`.
-  # This entry comes off in the same change that runs the migration.
-  #
-  # *** READ THIS BEFORE DELETING ANY UNIT. ***
-  # "verify-exactly-one" means EXACTLY ONE UNIT FOR THIS ONE JOB — old
-  # gone, new present. It does NOT mean "one accounts job on the host".
-  # There are TWO accounts jobs and BOTH MUST EXIST:
-  #
-  #   sac.accounts-refresh                        rotates the credential,
-  #                                               every 2h, on the host
-  #                                               holding refresh material
-  #   scitex-agent-container-accounts-keepalive   distributes the
-  #                                               ACCESS-ONLY copy,
-  #                                               every 15min
-  #
-  # They are DIFFERENT JOBS doing different work, not a rename pair and
-  # not duplicates of each other. Anyone who reads this rule as "collapse
-  # the accounts jobs to one" would remove a job the fleet depends on —
-  # which is a larger outage than the naming defect being deferred here.
-  # The only thing PS-226 asks for is the SHAPE OF ONE JobSpec NAME.
-  skip-rules:
-    - rule: PS-226
-      reason: >-
-        Correct finding, deferred to the supervised job-name migration —
-        not waived. `systemd_unit_name` uses `JobSpec.name` verbatim, so
-        renaming `sac.accounts-refresh` installs a SECOND unit beside the
-        live one instead of adopting it. That job is the fleet's sole
-        OAuth refresher against a SINGLE-USE refresh token, where two
-        racing refreshers revoke each other and take fleet-wide
-        authentication down. The migration must be ordered stop-old ->
-        remove-old -> install-new -> verify-exactly-one and run
-        supervised; the path exists in `_jobs/_migrate/_renames.py`.
-        "verify-exactly-one" means exactly one unit FOR THIS ONE JOB, NOT
-        one accounts job on the host: `sac.accounts-refresh` (rotates the
-        credential, every 2h) and
-        `scitex-agent-container-accounts-keepalive` (distributes the
-        access-only copy, every 15min) are DIFFERENT JOBS that must BOTH
-        continue to exist — they are not a rename pair and must never be
-        collapsed into one. PS-226 asks only for the SHAPE OF ONE JobSpec
-        NAME. Tracked in card `sac-accounts-refresh-unit-migration`; this
-        entry is removed by the change that performs the migration.
-
   # PS-103: legitimate top-level dirs that are not part of the wheel
   # but are operator-facing artefacts:
   #   - config/      declarative YAML schema + templates the CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -509,6 +509,62 @@ scitex-agent-container = "scitex_agent_container._store_plugin:provide"
 # filters for the card-event kinds and ignores everything else, incl.
 # sac's OWN liveness-tick anomaly events on the same bus. Bus-only
 # contract: no import of scitex_todo.
+# DECLARED IN BOTH GROUPS, and the duplication is the correct migration
+# state — not an oversight to tidy up later.
+#
+# MEASURED 2026-08-20 by scitex-cards: this consumer has NEVER been invoked in
+# production. The running notify daemon executes scitex-cards 0.42.0, whose
+# `_hooks/_plugins.py` reads `scitex_cards.hooks` and has ZERO references to
+# the retired group. sac was registered only under the retired name, so every
+# card event was dispatched to an EMPTY SET — succeeded, reported success,
+# called nobody. Corroborating symptoms, all explained by that one fact:
+#
+#     notifyd-liveness.json  last_delivery_at: null   never delivered, ever
+#     local inbox            150 rows, all unseen     enqueued, never pushed
+#     agents still get cards                          the PULL rail is separate
+#
+# Nothing anywhere reported a failure. That is the signature of this defect
+# class, and scitex-cards' own docstring recorded the identical state on
+# 2026-08-17 — the fix shipped in 0.48.0 and has never executed, because the
+# unit whose Description reads "supervised so a package upgrade actually
+# reaches it" points ExecStart at a hand-made venv that `pip install -U` never
+# touches.
+#
+# WHY BOTH RATHER THAN A MOVE. 0.42.0 (running now) reads only the new group,
+# so adding it revives delivery immediately. 0.48.0 reads both and dedupes, so
+# nothing double-fires. And leaving the retired entry in place preserves the
+# fleet's only registration under that name, which is what lets scitex-cards
+# verify the alias actually works when 0.48.0 finally runs — deleting it would
+# make "the alias works" indistinguishable from "nobody was left".
+#
+# THE NAME AND THE DOTTED PATH MUST STAY BYTE-IDENTICAL between the two
+# blocks. 0.48.0 dedupes on the tuple `(ep.name, ep.value)`:
+#
+#     seen  = {(ep.name, ep.value) for ep in current}
+#     extra = [ep for ep in retired if (ep.name, ep.value) not in seen]
+#
+# so renaming the entry or moving the callable on one side only turns the
+# alias meant to FIX delivery into a double-delivery bug. A migration is
+# exactly when tidying a name is tempting; do not, until the retired block
+# goes away entirely.
+#
+# C10 — sac's consumer on the shared card-event bus. When the board emits a
+# card-event (commented / created / reassigned / status_changed / completed /
+# committed / pushed / merged), this callable is invoked in the board's
+# process; it resolves the card's owner + collaborators + subscribers and
+# delivers the notification to each via the local ``sac listen`` daemon's
+# ``/v1/notify`` router endpoint — so a CONTAINERIZED owner-agent (whose a2a
+# port is unreachable inbound) still receives it. The consumer filters for the
+# card-event kinds and ignores everything else, incl. sac's OWN liveness-tick
+# anomaly events on the same bus. Bus-only contract: no import of the board
+# package.
+[project.entry-points."scitex_cards.hooks"]
+scitex-agent-container = "scitex_agent_container._listen._card_event_delivery:deliver_card_event"
+
+# The retired spelling, kept deliberately. See the note above: it is the
+# fleet's only registration under this group and therefore the only way to
+# verify the 0.48.0 alias when it runs. Remove it only once that verification
+# has happened and scitex-cards says the group is closed.
 [project.entry-points."scitex_todo.hooks"]
 scitex-agent-container = "scitex_agent_container._listen._card_event_delivery:deliver_card_event"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -842,7 +842,7 @@ required_plugins = ["pytest-asyncio", "pytest-xdist"]
 
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = "-v --tb=short -m 'not integration and not docker_smoke'"
+addopts = "-v --tb=short -p tests._store_isolation -m 'not integration and not docker_smoke'"
 markers = [
     "integration: slow end-to-end tests that spawn a real Claude Code agent (require claude CLI + tmux + ANTHROPIC_API_KEY or SAC_ANTHROPIC_API_KEY). Opt in with '-m integration'.",
     "docker_smoke: real-Docker smoke tests for DockerRuntime (build image, start/stop newbie-docker agent, exec claude -p). Skipped unless docker daemon reachable. Opt in with '-m docker_smoke'.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,23 @@ dependencies = [
 mcp = [
     # F-CS15: sac MCP server. fastmcp 2.x and 3.x both supported via
     # the safe_mount shim (matches scitex-* package convention).
-    "fastmcp>=2.0",
+    #
+    # 2.x SUPPORT IS SHIM-BACKED BUT UNTESTED, and saying so is the honest
+    # form of this claim. The suite installs [dev], which floors fastmcp at
+    # >=3.0 (see the note there and the measurement behind it), so nothing
+    # in CI ever exercises the 2.x branch of `mcp_group._list_tools`. The
+    # floor stays at 2.0 because the runtime shim really does handle both
+    # and narrowing it would break the scitex-* convention for consumers
+    # who only want the server — but a 2.x regression here would reach a
+    # user before it reached a test.
+    #
+    # `mcp<2` is NOT an untested claim like the fastmcp floor above: mcp
+    # 2.0.0 removes `Server.list_tools`, which `mcp_group._list_tools`
+    # probes for and the whole `_mcp` suite calls. Until the 2.x API is
+    # supported, admitting it here would ship a server that cannot list
+    # its own tools.
+    "fastmcp>=2.0,<4",
+    "mcp>=1.29,<2",
 ]
 telegram = [
     "claude-code-telegrammer>=0.1.0",
@@ -346,7 +362,32 @@ dev = [
     # collection-skipped on dev boxes. Keeping fastmcp also as a [mcp]
     # extra so runtime installs that only need the MCP server can
     # opt-in without pulling the rest of [dev].
-    "fastmcp>=2.0",
+    #
+    # PINNED, AND THE PIN THAT MATTERS IS `mcp`, NOT `fastmcp`.
+    #
+    # `Server.list_tools` is an API of the `mcp` python-sdk, which fastmcp
+    # pulls transitively. Neither was pinned, there is no lockfile, and
+    # `uv pip install -e .[dev]` re-resolves on every CI run — so the suite
+    # was running against whatever the index served that minute. Measured
+    # across three runs of the SAME workflow on the same py3.11:
+    #
+    #   run 32184153812  fastmcp==3.4.7    mcp==1.29.0  ->  17094 passed
+    #   run 32185071483  fastmcp==2.14.1   mcp==2.0.0   ->     29 failed
+    #   run 32185515... fastmcp==4.0.0b3  mcp==2.0.0   ->     26 failed
+    #
+    # `fastmcp` moves in both directions across those rows and the outcome
+    # does not follow it; `mcp` does. mcp 2.0.0 (2026-07-28) removed
+    # `Server.list_tools`, and every failure is that attribute. So the
+    # first version of this pin — a `fastmcp>=3.0` floor — named the wrong
+    # package: it let 4.0.0b3 in and changed nothing about the failure.
+    #
+    # `<2` on mcp is the bound the code is actually written against. `<4`
+    # on fastmcp keeps the pre-release out of a resolution that has already
+    # been observed reaching for one; the floor stays at 3.0 because the
+    # TESTS call `server.list_tools()` outright while the SOURCE tolerates
+    # more (`cli_pkg/mcp_group._list_tools` branches on hasattr).
+    "fastmcp>=3.0,<4",
+    "mcp>=1.29,<2",
 ]
 docs = [
     "sphinx>=7.0",

--- a/scripts/migrate_incarnations_to_postgres.py
+++ b/scripts/migrate_incarnations_to_postgres.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``incarnations`` table into per-host PostgreSQL.
+
+Companion to the ``state_db_incarnations`` port (2026-08-19). The code stopped
+reading SQLite; this moves the rows that are already there so the history is
+not stranded in a file nothing opens any more.
+
+RUN IT ON THE HOST, NOT IN A CONTAINER
+======================================
+``DEFAULT_DB_PATH`` resolves differently in the two places: a container gets
+its own per-agent shard under ``/state/<agent>/state.db``, the host gets
+``~/.scitex/agent-container/runtime/state.db``. The rows are on the HOST —
+measured 2026-08-19, compute-04 held 242 of them — so a container run would
+faithfully migrate an empty shard and report success.
+
+RUN IT TWICE
+============
+The table is live: ``sac`` writes a birth certificate on every launch. Run it
+once now, restart the daemons so they pick up the new code, then run it again
+to sweep anything written through the old path in between. The second run is
+expected to find few or no stragglers; that it finds ANY is the reason it
+exists.
+
+WHY IT DOES NOT CALL ``record_incarnation_birth``
+=================================================
+That function stamps ``born_at`` with ``now_iso()`` — correct for a real
+launch, destructive here. A migration that rewrote every birth time to the
+migration's own clock would look like the whole fleet was born at 00:40 on
+2026-08-20, which is precisely the "backfilled timestamp makes old things
+look new" failure. So this writes through the store directly, preserving
+every recorded value verbatim.
+
+IT IS IDEMPOTENT and it VERIFIES: each record is read back through the same
+dialect production reads through, and a mismatch is reported rather than
+counted as a success. Nothing is deleted from SQLite — the old table stays
+as a fallback for a human, untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+_COLUMNS = (
+    "incarnation_id",
+    "agent_id",
+    "spec_id",
+    "spec_git_sha",
+    "host",
+    "born_at",
+    "compiled_spec_json",
+    "exit_reason",
+    "exit_code",
+    "exited_at",
+)
+
+
+def _sqlite_rows(db_path: Path) -> list[dict]:
+    """Every incarnations row, read-only. Empty list when the table is gone."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        cols = ", ".join(_COLUMNS)
+        return [dict(r) for r in conn.execute(f"SELECT {cols} FROM incarnations")]
+    except sqlite3.OperationalError as exc:
+        print(f"  no incarnations table in {db_path}: {exc}")
+        return []
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="SQLite state.db to read (default: sac's resolved DEFAULT_DB_PATH)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would move, write nothing",
+    )
+    args = ap.parse_args()
+
+    from scitex_dev.store import ANY_REVISION
+
+    from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+    from scitex_agent_container._state.state_db_incarnations import (
+        get_incarnation,
+        incarnation_store_target,
+        open_incarnation_store,
+    )
+
+    db_path = args.db or DEFAULT_DB_PATH
+    print(f"source (sqlite) : {db_path}")
+    print(f"target (postgres): {incarnation_store_target().locator}")
+
+    if not Path(db_path).exists():
+        print("source does not exist — nothing to migrate")
+        return 0
+
+    rows = _sqlite_rows(Path(db_path))
+    print(f"rows in sqlite  : {len(rows)}")
+    if not rows:
+        return 0
+
+    if args.dry_run:
+        print("--dry-run: writing nothing")
+        return 0
+
+    store = open_incarnation_store()
+    written = 0
+    try:
+        for row in rows:
+            store.put(dict(row), expected_revision=ANY_REVISION)
+            written += 1
+    finally:
+        store.close()
+    print(f"written         : {written}")
+
+    # VERIFY through the production read path, not the write handle: a store
+    # that accepted every write and can be read by nobody is the exact defect
+    # scitex-dev 0.49.0 shipped.
+    missing = [r["incarnation_id"] for r in rows if get_incarnation(r["incarnation_id"]) is None]
+    mismatched = [
+        r["incarnation_id"]
+        for r in rows
+        if (got := get_incarnation(r["incarnation_id"])) is not None
+        and got.get("born_at") != r["born_at"]
+    ]
+    print(f"verified present: {len(rows) - len(missing)} / {len(rows)}")
+    if missing:
+        print(f"MISSING after write: {missing[:10]}")
+    if mismatched:
+        print(f"BORN_AT CHANGED (must be empty): {mismatched[:10]}")
+    return 1 if (missing or mismatched) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_verdict_delivered_to_postgres.py
+++ b/scripts/migrate_verdict_delivered_to_postgres.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``verdict_delivered`` rows into PostgreSQL.
+
+WHY THIS EXISTS AND WHY IT MUST RUN BEFORE THE PORT IS DEPLOYED
+===============================================================
+``_state/state_db_verdict_dedup`` moved from SQLite to PostgreSQL (via
+``scitex_dev.store``). The delivered-set is the ONLY thing standing between
+the CI poller and re-delivering verdicts that agents have already seen. An
+empty PostgreSQL store therefore does not mean "nothing delivered yet" — it
+means "deliver everything again".
+
+Measured 2026-08-19, rows at risk per host:
+
+    scitex-compute-04   722        scitex-compute-02   114
+    scitex-compute-03   358        scitex-compute-01   104
+    fleet                             1,298
+
+Most are for head SHAs that are no longer any open PR's head, so they would
+never be re-polled. The dangerous remainder is the currently-open PRs whose
+current verdict was already sent — those WOULD be re-delivered, and the
+failure streak would reset, un-capping PRs the cap had deliberately
+silenced. Neither failure is loud. Hence this script.
+
+IT LIVES IN scripts/, NOT IN src/, ON PURPOSE
+=============================================
+It imports ``sqlite3``, and ``tests/develop/test_sqlite_footprint_frozen.py``
+scans ``src/`` and fails on any new SQLite user there. That gate is right and
+this file must not weaken it: a migration tool is a one-time act, not a
+capability the package ships. Delete it once every host has run it.
+
+IDEMPOTENT, AND NON-DESTRUCTIVE
+===============================
+Writes go through ``record_verdict_delivered``, which is INSERT-OR-IGNORE and
+preserves ``delivered_at``, so re-running copies nothing new and never moves
+a timestamp. The SQLite file is opened READ-ONLY and is not modified or
+deleted — if the port has to be reverted, the old state is still there.
+
+RUN IT ON THE HOST, NOT INSIDE AN AGENT CONTAINER
+=================================================
+``DEFAULT_DB_PATH`` resolves to a DIFFERENT FILE depending on where you are,
+and both answers are correct for their own environment:
+
+    on the host          ~/.scitex/agent-container/runtime/state.db
+                         <- the real one; `sac listen` opens this
+    inside a container    /state/scitex-agent-container/state.db
+                         <- that agent's private shard, from
+                            $SCITEX_AGENT_CONTAINER_STATE_DB
+
+Measured 2026-08-19: the host db held 722 delivered-set rows and one
+container shard held NONE — it does not even have the table. So a migration
+run from inside a container reports "nothing to migrate", exits 0, and
+leaves every real row behind. The script PRINTS the source path it resolved
+for exactly this reason: check that line before trusting the result.
+
+WHERE THIS SITS IN THE DEPLOYMENT, AND WHY THAT ORDER IS SAFE
+=============================================================
+This script IMPORTS the ported module, so it cannot run before the code is
+on the host. An earlier draft of the PR said "migrate, then deploy"; that
+order is not merely risky, it is impossible, and a dry run piped to three
+peer hosts proved it with an identical
+``ImportError: cannot import name 'verdict_store_target'`` on each.
+
+    1. git -C ~/proj/scitex-agent-container pull      (new code on disk)
+    2. python3 scripts/migrate_verdict_delivered_to_postgres.py --commit
+    3. restart `sac listen`                            (new code in effect)
+
+Step 1 does NOT change the running daemon — it holds the modules it imported
+at boot and keeps reading SQLite through step 2. That is what makes the
+window safe by construction rather than merely short: the migration finishes
+while the only live reader is still the old one. Step 3 switches the reader
+over, and by then the rows are there.
+
+Each host's ``.env-sac`` resolves sac through an EDITABLE install pointing at
+``~/proj/scitex-agent-container/src``, so step 1 really is a ``git pull`` and
+not a ``pip install``.
+
+RUN IT TWICE — THE TABLE IS LIVE AND A SNAPSHOT IS ALWAYS SLIGHTLY STALE
+========================================================================
+The delivered-set accrues while you work. Measured 2026-08-19, forty minutes
+apart, with nothing of mine touching it:
+
+    compute-04   722 -> 724      compute-02   114 -> 116
+    compute-03   358 -> 359      compute-01   104 -> 106
+
+So the old daemon keeps writing SQLite rows between step 2 and step 3, and
+those rows would be absent from PostgreSQL when the new daemon takes over —
+each one a verdict re-delivered once. At this rate that is zero or one row
+per host, which is small but not nothing, and it is silent.
+
+The script is IDEMPOTENT, so the fix is free: run it again AFTER the
+restart. The second pass sees whatever the old daemon wrote in the gap and
+copies it; from the restart onward nothing writes SQLite at all, so a third
+pass would find nothing.
+
+    1. git -C ~/proj/scitex-agent-container pull      new code on disk
+    2. migrate ... --commit                            bulk
+    3. restart `sac listen`                            new code in effect
+    4. migrate ... --commit                            the stragglers
+
+USAGE (per host, after step 1 above)
+
+    python3 scripts/migrate_verdict_delivered_to_postgres.py            # dry run
+    python3 scripts/migrate_verdict_delivered_to_postgres.py --commit   # do it
+
+The columns are IDENTICAL on all four hosts — repo, pr, head_sha,
+conclusion, dispatch_id, delivered_at — verified before relying on one
+SELECT everywhere, because the table COUNT differs per host (26/22/21/21;
+tables are created lazily by whichever module ran there) and a uniform
+schema could not be assumed from that.
+
+Exits non-zero on any failure. There is no partial-success-reported-as-
+success path: a row that cannot be written raises.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _sqlite_rows(db_path: Path) -> list[tuple]:
+    """Every delivered-set row in the SQLite state db, read-only.
+
+    A missing file or missing table is reported as such and yields nothing —
+    those are legitimate states (a host that never polled CI), and they are
+    DISTINGUISHED from an error rather than both landing on an empty list.
+    """
+    if not db_path.exists():
+        print(f"  no SQLite state db at {db_path} — nothing to migrate")
+        return []
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        present = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='verdict_delivered'"
+        ).fetchone()
+        if not present:
+            print("  SQLite db has no verdict_delivered table — nothing to migrate")
+            return []
+        return conn.execute(
+            "SELECT repo, pr, head_sha, conclusion, dispatch_id, delivered_at "
+            "FROM verdict_delivered"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--state-db",
+        type=Path,
+        default=None,
+        help="SQLite state.db (default: the package's DEFAULT_DB_PATH)",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="actually write; without it this is a dry run that writes nothing",
+    )
+    args = parser.parse_args(argv)
+
+    if args.state_db is None:
+        from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+
+        args.state_db = Path(DEFAULT_DB_PATH)
+
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        record_verdict_delivered,
+        verdict_already_delivered,
+        verdict_store_target,
+    )
+
+    print(f"SOURCE (SQLite) : {args.state_db}")
+    print(f"TARGET (Postgres): {verdict_store_target().locator}")
+
+    rows = _sqlite_rows(args.state_db)
+    print(f"rows in SQLite  : {len(rows)}")
+    if not rows:
+        return 0
+
+    missing = [
+        r
+        for r in rows
+        if not verdict_already_delivered(
+            repo=r[0], pr=int(r[1]), head_sha=r[2], conclusion=r[3]
+        )
+    ]
+    print(f"absent in Postgres: {len(missing)}  (already there: {len(rows) - len(missing)})")
+
+    if not args.commit:
+        print("DRY RUN — nothing written. Re-run with --commit.")
+        return 0
+
+    for repo, pr, head_sha, conclusion, dispatch_id, delivered_at in missing:
+        record_verdict_delivered(
+            repo=repo,
+            pr=int(pr),
+            head_sha=head_sha,
+            conclusion=conclusion,
+            dispatch_id=dispatch_id,
+            delivered_at=float(delivered_at),
+        )
+
+    # Verify by RE-READING rather than by counting what we sent. A write loop
+    # that completed is not evidence the rows are there.
+    still_missing = [
+        r
+        for r in rows
+        if not verdict_already_delivered(
+            repo=r[0], pr=int(r[1]), head_sha=r[2], conclusion=r[3]
+        )
+    ]
+    print(f"after commit, still absent: {len(still_missing)}")
+    if still_missing:
+        print("MIGRATION INCOMPLETE — the rows above did not land.", file=sys.stderr)
+        return 1
+    print("OK — every SQLite row is present in PostgreSQL.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scitex_agent_container/_jobs/_jobs_audit.py
+++ b/src/scitex_agent_container/_jobs/_jobs_audit.py
@@ -388,11 +388,12 @@ def _discovered_sac_names(prefix: str | None) -> frozenset[str] | None:
     """Names sac owns among everything scitex-dev discovers.
 
     ``prefix=None`` — the default — asks :func:`_names.is_ours`, which
-    knows BOTH live prefixes. A single prefix string cannot express the
-    transition state: while ``sac.accounts-refresh`` is held at the legacy
-    name and the other eight carry ``scitex-agent-container-``, filtering
-    on either one alone silently drops the other set, and a job that
-    vanishes from the audit reads as "not declared" rather than "not
+    knows BOTH live prefixes. A single prefix string cannot express a
+    transition state, and one is still live: every DECLARED name now
+    carries ``scitex-agent-container-``, but a host mid-cutover still has
+    ``sac.*`` UNITS on disk, so discovery can legitimately return either.
+    Filtering on one prefix alone silently drops the other set, and a job
+    that vanishes from the audit reads as "not declared" rather than "not
     looked for". An explicit string is still accepted so a test can pin
     one side deliberately.
     """

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -163,23 +163,47 @@ def provide_jobs() -> "list[JobSpec]":
 
     return [
         JobSpec(
-            # THE ONE NAME STILL ON THE LEGACY PREFIX, AND IT IS ON PURPOSE.
-            # Every other job here was cut over to `scitex-agent-container-*`;
-            # this one is HELD, with the reason recorded in
-            # `_migrate._renames.RENAMES` (the SSoT for the cutover).
+            # THE LAST NAME OFF THE LEGACY PREFIX. It was held back for
+            # months on the rule "never rename a spec ahead of its unit", and
+            # that rule was right about the hazard and wrong about the order.
             #
-            # A spec renamed AHEAD of its unit is the one shape that must not
-            # ship. The live, enabled, actively-refreshing unit is
-            # `sac.accounts-refresh.timer`; if this said
-            # `scitex-agent-container-accounts-refresh` while that unit ran,
-            # `sac dev timer status accounts-refresh` would resolve to a name
-            # no unit carries and report the fleet's SOLE OAuth refresher as
-            # ABSENT while it refreshes. A name that does not match the
-            # convention yet is a PS-227 warning; a CLI that reports the
-            # credential machinery as missing when it is healthy is an
-            # incident. So the declared name tracks the DEPLOYED unit until
-            # the supervised cutover renames both together.
-            name="sac.accounts-refresh",
+            # WHAT THE HOLD ASSUMED: that the supervised cutover renames spec
+            # and unit TOGETHER. MEASURED 2026-08-19, that is unreachable —
+            # the migration's install step delegates to scitex-dev BY THE NEW
+            # CANONICAL NAME, and scitex-dev resolves a name only if a JobSpec
+            # DECLARES it:
+            #
+            #   $ sac dev timer install scitex-agent-container-accounts-refresh
+            #   no job named 'scitex-agent-container-accounts-refresh' here
+            #
+            # So install-new cannot run until this line moves. The spec moves
+            # FIRST or the cutover never happens at all; that is not a rule
+            # violation, it is the only order the tooling admits. (Attempted
+            # in the other order 2026-08-18: stop/remove succeeded, install
+            # failed on exactly that lookup, and the fleet's sole OAuth
+            # refresher was down ~2 minutes until the old units were restored.)
+            #
+            # WHAT THE WINDOW ACTUALLY COSTS, stated plainly rather than
+            # assumed: between this rename and the host cutover,
+            # `sac dev timer status accounts-refresh` resolves to a unit name
+            # the host does not carry and reports the refresher ABSENT while
+            # `sac.accounts-refresh.timer` keeps firing every 2h. That is a
+            # MISREPORT ON ONE MANUAL VERB, not an outage — and it cannot
+            # escalate on its own: nothing in this repo installs or enables a
+            # timer automatically (`_dev_jobs_backend` declines to run
+            # systemctl; `_dev_jobs_apply` only PRINTS the enable line), so
+            # the two-racing-refreshers catastrophe still requires a human to
+            # type the install command against a host that already has the
+            # old unit.
+            #
+            # CLOSING THE WINDOW is `sac dev migrate-job-names --only
+            # accounts-refresh --include-held --yes`, run supervised, then
+            # `sac accounts status` BEFORE walking away. Ordered
+            # stop-old -> remove-old -> install-new -> verify-exactly-one, and
+            # "exactly one" means one unit FOR THIS JOB:
+            # `scitex-agent-container-accounts-keepalive` is a DIFFERENT job
+            # that must keep existing.
+            name="scitex-agent-container-accounts-refresh",
             schedule="0 */2 * * *",  # every 2h
             command=("sac accounts refresh --all --include-active --sync-active-login"),
             description=(

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -156,6 +156,44 @@ def provide_jobs() -> "list[JobSpec]":
     ``--sync-active-login`` keeps the operator's live session valid across
     the single-use refresh_token rotation.
 
+    EVERY COMMAND IS SELF-BOUNDING; NONE DECLARES ``timeout_sec``
+    ------------------------------------------------------------
+    Each command starts with a literal ``/usr/bin/timeout <N> ``, because
+    that is the only place a bound can survive. Since the supervisor
+    redesign (operator policy 2026-06-14) ``scitex-dev ecosystem up``
+    lowers every ``kind="timer"`` JobSpec onto the managed CRONTAB block,
+    and a cron line is ``<schedule> <command> # marker`` and nothing else
+    — it has no field a timeout could ride in.
+
+    ``timeout_sec`` is DROPPED rather than kept alongside the prefix:
+    scitex-dev's guard (``_up_timer_lowering.lowering_losses``) keys on the
+    FIELD BEING SET, not on whether the command is really bounded, so a
+    spec carrying both still counts as a dropped guarantee and still
+    REFUSES the lowering — ``ecosystem up`` aborts for the whole ecosystem,
+    measured, not assumed. Nothing is lost by dropping it: the bound moved
+    into the command, where both rendering targets honour it. Previously it
+    was a systemd-only promise that evaporated on cron, which is how
+    ``fleet-reconcile`` piled up fourteen concurrent instances, the oldest
+    45 minutes old (2026-07-18).
+
+    Two spelling choices, both load-bearing. ``/usr/bin/timeout`` is
+    ABSOLUTE (GNU coreutils 9.4, verified on scitex-compute-04): cron's and
+    systemd's minimal PATHs both carry ``/usr/bin`` so a bare ``timeout``
+    would resolve too, but the absolute form keeps ``heal-agent-auth``'s
+    "depends on no PATH at all" property true. The INNER command stays
+    PATH-relative (``sac …``) because sac's install path VARIES BY HOST
+    (``~/.env-sac/bin/sac`` on scitex-compute-04, ``~/.env-3.11/bin/sac``
+    elsewhere), so pinning one absolute ``sac`` would break the others —
+    and the cron line has always run ``sac`` off cron's PATH anyway.
+
+    KNOWN CONSEQUENCE, stated rather than papered over: a wrapper prefix
+    means ``resolve_execstart`` (which absolutises only the FIRST token)
+    no longer absolutises the inner ``sac`` should these specs ever be
+    rendered as systemd units instead — the same hazard scitex-dev's own
+    lowering module documents. Not live today (``up`` writes cron, not
+    units); a future move back to a timer surface must pin the inner path
+    or declare ``venv`` at that time.
+
     """
     from scitex_dev.jobs import JobSpec
 
@@ -205,7 +243,13 @@ def provide_jobs() -> "list[JobSpec]":
             # that must keep existing.
             name="scitex-agent-container-accounts-refresh",
             schedule="0 */2 * * *",  # every 2h
-            command=("sac accounts refresh --all --include-active --sync-active-login"),
+            # SELF-BOUNDING (120s) — see the convention note above. The
+            # bound has to live in the command because this job lands on
+            # CRON, where `timeout_sec` cannot follow it.
+            command=(
+                "/usr/bin/timeout 120 "
+                "sac accounts refresh --all --include-active --sync-active-login"
+            ),
             description=(
                 "Headless OAuth access-token refresh for all stored Claude "
                 "accounts including the active one (sole-refresher model), "
@@ -224,12 +268,18 @@ def provide_jobs() -> "list[JobSpec]":
             kind="timer",
             on_boot_sec="15min",
             on_unit_active_sec="2h",
-            timeout_sec=120,
         ),
         JobSpec(
             name="scitex-agent-container-accounts-keepalive",
             schedule="*/15 * * * *",  # every 15min (cron form; timer below)
+            # SELF-BOUNDING (300s). Per peer: a handful of coreutils ssh ops
+            # plus ONE outbound HTTPS verification from the peer (15s cap
+            # inside the probe). 300s covers three peers including a slow one
+            # without ever hanging forever. A pass killed here leaves the
+            # peer's previous credential intact — nothing is published
+            # unverified.
             command=(
+                "/usr/bin/timeout 300 "
                 "sac accounts keepalive --all "
                 "--to ywata-note-win "
                 "--to scitex-compute-03 "
@@ -281,17 +331,16 @@ def provide_jobs() -> "list[JobSpec]":
             # peer is verified, not rewritten.
             on_boot_sec="10min",
             on_unit_active_sec="15min",
-            # Per peer: a handful of coreutils ssh ops plus ONE outbound
-            # HTTPS verification from the peer (15s cap inside the probe).
-            # 300s covers three peers including a slow one without ever
-            # hanging forever. A pass killed here leaves the peer's previous
-            # credential intact — nothing is published unverified.
-            timeout_sec=300,
         ),
         JobSpec(
             name="scitex-agent-container-accounts-quota-cache",
             schedule="*/5 * * * *",  # every 5min (cron form; timer below)
-            command="sac accounts refresh-quota-cache",
+            # SELF-BOUNDING (120s). One usage read per stored account (4
+            # today), each a single HTTPS call; 120s covers all of them on a
+            # slow network and never hangs. A pass killed here leaves the
+            # PREVIOUS cache in place — stale, which is the status quo this
+            # job improves on, never wrong.
+            command="/usr/bin/timeout 120 sac accounts refresh-quota-cache",
             description=(
                 "Keeps the per-account usage cache FRESH. Nothing else did: "
                 "sac.accounts-refresh rotates TOKENS and accounts-keepalive "
@@ -334,17 +383,19 @@ def provide_jobs() -> "list[JobSpec]":
             # 1min — and it would be evidence, not a guess.
             on_boot_sec="2min",
             on_unit_active_sec="5min",
-            # One usage read per stored account (4 today), each a single
-            # HTTPS call. 120s covers all of them with a slow network and
-            # never hangs. A pass killed here leaves the previous cache in
-            # place — stale, which is the status quo this job improves on,
-            # never wrong.
-            timeout_sec=120,
         ),
         JobSpec(
             name="scitex-agent-container-host-sync-check",
             schedule="0 * * * *",  # hourly (cron form; timer cadence below)
-            command="sac host sync --check --all --alarm --exit-zero",
+            # SELF-BOUNDING (600s). Sequential per-ssh probe over every peer,
+            # each capped at the verb's 120s default (an unreachable peer
+            # waits its ssh connect-timeout). 600s comfortably covers a
+            # handful of peers including a slow/unreachable one without ever
+            # hanging forever.
+            command=(
+                "/usr/bin/timeout 600 "
+                "sac host sync --check --all --alarm --exit-zero"
+            ),
             description=(
                 "Read-only drift check of every peer's sac checkout vs the "
                 "centre; records each verdict in sac's own event log so the "
@@ -366,16 +417,18 @@ def provide_jobs() -> "list[JobSpec]":
             # 2h token refresh, so hourly is ample and gentle on ssh.
             on_boot_sec="10min",
             on_unit_active_sec="1h",
-            # Sequential per-ssh probe over every peer, each capped at the
-            # verb's 120s default (an unreachable peer waits its ssh
-            # connect-timeout). 600s comfortably covers a handful of peers
-            # including a slow/unreachable one without ever hanging forever.
-            timeout_sec=600,
         ),
         JobSpec(
             name="scitex-agent-container-worktree-gc",
             schedule="30 4 * * *",  # daily 04:30 (cron form; timer cadence below)
-            command="sac worktree gc --apply --all",
+            # SELF-BOUNDING (900s). A pass is a handful of local `git` calls
+            # per worktree plus one `gh pr list` per unmerged branch (the
+            # squash-merge leg). A repo deep in sprawl with a slow/
+            # rate-limited gh is the worst case; 900s covers the whole
+            # fleet's repos without ever hanging forever. Every gh failure
+            # already degrades to KEEP, so a timeout costs a skipped reap,
+            # never a wrong one.
+            command="/usr/bin/timeout 900 sac worktree gc --apply --all",
             description=(
                 "Daily git-worktree GC: removes only worktrees PROVEN safe "
                 "(clean AND merged AND older than 24h AND not in use — never "
@@ -391,18 +444,18 @@ def provide_jobs() -> "list[JobSpec]":
             # boot keeps it clear of the login/auth settling window.
             on_boot_sec="20min",
             on_unit_active_sec="1d",
-            # A pass is a handful of local `git` calls per worktree plus one
-            # `gh pr list` per unmerged branch (the squash-merge leg). A repo
-            # deep in sprawl with a slow/rate-limited gh is the worst case;
-            # 900s covers the whole fleet's repos without ever hanging
-            # forever. Every gh failure already degrades to KEEP, so a
-            # timeout costs a skipped reap, never a wrong one.
-            timeout_sec=900,
         ),
         JobSpec(
             name="scitex-agent-container-spartan-sif-bake",
             schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
-            command="sac image bake-remote --yes",
+            # SELF-BOUNDING (14400s = 4h), and the one where the bound
+            # matters most: at a */10 cadence an UNBOUNDED bake outlives its
+            # own tick by design, so a wedged run would pile up against every
+            # later one. Two full bakes (base ~15-25min + scitex ~10-20min)
+            # plus a multi-GB pull on a slow link fit comfortably; the
+            # per-leg ssh timeout inside the command is 7200s, so 4h bounds
+            # the whole chain without ever killing a legitimate run.
+            command="/usr/bin/timeout 14400 sac image bake-remote --yes",
             description=(
                 "10-minute SIF refresh with zero master CPU: bake sac-base + "
                 "sac-scitex on the standing Spartan CPU lease (srun "
@@ -437,16 +490,15 @@ def provide_jobs() -> "list[JobSpec]":
             # something changed, the rest of that window bouncing off the lock.
             on_boot_sec="30min",
             on_unit_active_sec="10min",
-            # Two full bakes (base ~15-25min + scitex ~10-20min) plus a
-            # multi-GB pull on a slow link fit comfortably; the per-leg
-            # ssh timeout inside the command is 7200s, so 4h bounds the
-            # whole chain without ever hanging forever.
-            timeout_sec=14_400,
         ),
         JobSpec(
             name="scitex-agent-container-freshness-refresh",
             schedule="7 * * * *",  # hourly (cron form; timer cadence below)
-            command="sac freshness refresh",
+            # SELF-BOUNDING (300s). Generous on purpose, matching the
+            # primitive's own 30s per-source timeouts: a busy host must not
+            # be mistaken for a broken one, and a manufactured UNKNOWN is
+            # exactly the failure mode. Nothing is waiting on this run.
+            command="/usr/bin/timeout 300 sac freshness refresh",
             description=(
                 "Publishes the version-currency verdict to the cache that "
                 "every `sac` invocation reads. Runs the real checks (PyPI, "
@@ -465,11 +517,6 @@ def provide_jobs() -> "list[JobSpec]":
             # pass makes real network calls.
             on_boot_sec="25min",
             on_unit_active_sec="1h",
-            # Generous on purpose, matching the primitive's own 30s per-source
-            # timeouts: a busy host must not be mistaken for a broken one, and
-            # a manufactured UNKNOWN is exactly the failure mode. Nothing is
-            # waiting on this run.
-            timeout_sec=300,
         ),
         # The two AGENT-LIVENESS enforcers live together in
         # :mod:`._specs_liveness` — each one's scope is defined by what the
@@ -479,14 +526,25 @@ def provide_jobs() -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-heal-agent-auth",
             schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
-            # ABSOLUTE by design, both tokens. `resolve_execstart` passes a
+            # ABSOLUTE by design, EVERY token. `resolve_execstart` passes a
             # command whose head starts with "/" through VERBATIM, so this is
             # the only form that depends on neither the ambient PATH nor which
             # interpreter ran `ecosystem up`. A systemd --user unit gets a
             # MINIMAL PATH, so the venv python must be named outright: the
             # script's own `#!/usr/bin/env python3` would resolve to the SYSTEM
             # python under systemd, not the 3.11 venv the fleet runs on.
+            #
+            # The `timeout` head is spelled ABSOLUTELY for the same reason —
+            # it keeps this command's "depends on no PATH at all" property
+            # intact, which a bare `timeout` would have quietly given up.
+            #
+            # SELF-BOUNDING (300s). A no-op tick takes ~2-8s, and the worst
+            # observed pass (a TUI restart at 15:30:04 settling by 15:32:08)
+            # ~2min. A pass killed here is SAFE — state is persisted per
+            # restart, so the next tick still honours the debounce for
+            # anything already bounced.
             command=(
+                "/usr/bin/timeout 300 "
                 "/home/ywatanabe/.env-3.11/bin/python "
                 "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
             ),
@@ -520,13 +578,6 @@ def provide_jobs() -> "list[JobSpec]":
             # every kind="timer", so a window missed while the host was asleep
             # fires on resume — the property a crontab line does NOT have and a
             # laptop fleet needs most.
-            #
-            # 300s matches the siblings and comfortably outlives a real pass:
-            # a no-op tick takes ~2-8s, and the worst observed pass (a TUI
-            # restart at 15:30:04 settling by 15:32:08) ~2min. A pass killed
-            # here is SAFE — state is persisted per restart, so the next tick
-            # still honours the debounce for anything already bounced.
-            timeout_sec=300,
         ),
     ]
 

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from scitex_dev.jobs import JobSpec
 
 
-def provide_jobs() -> "list[JobSpec]":
+def provide_jobs(*, executable: str | None = None) -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
     Nine jobs today:
@@ -72,24 +72,25 @@ def provide_jobs() -> "list[JobSpec]":
       PR cannot edit, so the cron retirement is an operator/dotfiles step that
       must land WITH the enable.
 
-    * ``sac.heal-agent-auth`` (``kind="timer"``) — the INCUMBENT auth healer
-      (``~/.scitex/agent-container/bin/auth-heal.py``, every 10min), declared
-      here so it stops living as a hand-written crontab line that a sweep
-      deletes. ``~/.dotfiles/src/.cron/copy_crontab`` installs the tracked
-      manifest WHOLESALE (``git show HEAD:.crontab_list | crontab -``), so
-      anything absent from ``.crontab_list`` is erased on its next run — and
-      auth-heal has NO line in that manifest, which is why the wrapper that
-      exports ``SAC_SECRETS_ENVRC`` kept reverting. A hand-added crontab line
-      is temporary BY CONSTRUCTION; a JobSpec is not. scitex-cards and
-      dotfiles moved their own schedules to systemd ``--user`` timers for the
-      same reason, and scitex-dev's ruling makes the JobSpec plugin the SSoT.
+    * ``sac.heal-agent-auth`` — RETIRED 2026-08-20, and the succession is the
+      reason. This spec declared the INCUMBENT healer
+      (``~/.scitex/agent-container/bin/auth-heal.py``) alongside its own
+      successor, with the note "MUTUALLY EXCLUSIVE WITH
+      ``restart-login-expired-agents`` — enable exactly ONE". On the hosts the
+      succession had already completed: the successor runs on all four
+      (55 / 329 / 343 / 337 starts, exit 0 on three of them), while
+      ``auth-heal.py`` and the interpreter it named are ABSENT from every host
+      and from this repo, and its log file is gone.
 
-      MUTUALLY EXCLUSIVE WITH ``sac.restart-login-expired-agents`` — enable
-      exactly ONE. This job's ``scan_tui`` is precisely what that timer
-      reimplements natively, so the deploy gate documented below is not
-      lifted by declaring this one; it is made explicit. Declaring both is
-      safe (a JobSpec is inert until ``ecosystem up`` installs it); ENABLING
-      both puts two restarters with INDEPENDENT debounce state on one fleet.
+      What was left was a declaration of a predecessor nobody has, which the
+      supervisor faithfully tried to spawn every ten minutes and which
+      faithfully failed — 535 times across the fleet by the morning it was
+      measured (c01 28 x exit 127, c02 166, c03 172, c04 169 spawn failures).
+
+      Repairing the path would have been the wrong repair: it would ENABLE the
+      double-supervisor hazard this very bullet warned about, two restarters
+      with independent debounce state on one fleet. The missing script was the
+      only thing preventing that, and an accident should not be load-bearing.
 
     * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
       access-token refresh for EVERY stored Claude account, including the
@@ -176,409 +177,57 @@ def provide_jobs() -> "list[JobSpec]":
     ``fleet-reconcile`` piled up fourteen concurrent instances, the oldest
     45 minutes old (2026-07-18).
 
-    Two spelling choices, both load-bearing. ``/usr/bin/timeout`` is
-    ABSOLUTE (GNU coreutils 9.4, verified on scitex-compute-04): cron's and
-    systemd's minimal PATHs both carry ``/usr/bin`` so a bare ``timeout``
-    would resolve too, but the absolute form keeps ``heal-agent-auth``'s
-    "depends on no PATH at all" property true. The INNER command stays
-    PATH-relative (``sac …``) because sac's install path VARIES BY HOST
-    (``~/.env-sac/bin/sac`` on scitex-compute-04, ``~/.env-3.11/bin/sac``
-    elsewhere), so pinning one absolute ``sac`` would break the others —
-    and the cron line has always run ``sac`` off cron's PATH anyway.
+    Both tokens are ABSOLUTE, and the second one only became so after it
+    cost a host. ``/usr/bin/timeout`` (GNU coreutils 9.4) is absolute so the
+    bound depends on no PATH at all. The PAYLOAD used to stay PATH-relative
+    (``sac …``) on the reasoning that sac's install path varies by host, so
+    pinning one absolute ``sac`` would break the others — correct about the
+    hazard, and answered rather than overridden by :mod:`._sac_bin`, which
+    derives the path from ``sys.executable`` and is therefore per-host by
+    construction with nothing hardcoded.
 
-    KNOWN CONSEQUENCE, stated rather than papered over: a wrapper prefix
-    means ``resolve_execstart`` (which absolutises only the FIRST token)
-    no longer absolutises the inner ``sac`` should these specs ever be
-    rendered as systemd units instead — the same hazard scitex-dev's own
-    lowering module documents. Not live today (``up`` writes cron, not
-    units); a future move back to a timer surface must pin the inner path
-    or declare ``venv`` at that time.
+    THE CONSEQUENCE WAS DOCUMENTED HERE AND SCOPED TOO NARROWLY. This
+    docstring used to say that a wrapper prefix stops ``resolve_execstart``
+    absolutising the inner ``sac`` "should these specs ever be rendered as
+    systemd units instead", and called it "not live today (``up`` writes cron,
+    not units)". The hazard was real and the scope was wrong: the ecosystem
+    supervisor spawns periodic jobs DIRECTLY through the same
+    ``resolve_execstart``, so the payload was already unresolved on the live
+    path. MEASURED 2026-08-20 on scitex-compute-01 — supervisor PATH without
+    the venv, ALL TEN sac jobs at exit 127, zero successes, including the
+    self-pull that would have delivered any fix. The other three hosts were
+    healthy only because their supervisor inherited a PATH that happened to
+    contain the venv.
+
+    ``executable`` is a TEST SEAM, forwarded to each group and on to
+    :func:`._sac_bin.sac_bin`. The fleet calls this with no argument and gets
+    the console script beside the interpreter that imported the plugin, which
+    is the whole point of the resolution above. A test passes a venv-shaped
+    tree it built on disk, because otherwise the rendered payload depends on
+    whether the RUNNING environment happens to have that console script — true
+    in production, false under a PYTHONPATH-only CI run — and a guard over
+    these specs would be asserting an environmental fact rather than a property
+    of the specs. MEASURED 2026-08-20: that is exactly how the population guard
+    went red in CI on three unrelated PRs while every host was behaving
+    correctly.
 
     """
-    from scitex_dev.jobs import JobSpec
-
+    from ._specs_accounts import accounts_jobs
     from ._specs_liveness import liveness_jobs
+    from ._specs_maintenance import maintenance_jobs
 
+    # Each group is one operational concern a reader checks as a unit, and
+    # each resolves its own absolute `sac` through :mod:`._sac_bin`. Spliced
+    # in THIS order to preserve the historical order of the nine specs, which
+    # `collect_cron_jobs` and every existing test still read positionally.
     return [
-        JobSpec(
-            # THE LAST NAME OFF THE LEGACY PREFIX. It was held back for
-            # months on the rule "never rename a spec ahead of its unit", and
-            # that rule was right about the hazard and wrong about the order.
-            #
-            # WHAT THE HOLD ASSUMED: that the supervised cutover renames spec
-            # and unit TOGETHER. MEASURED 2026-08-19, that is unreachable —
-            # the migration's install step delegates to scitex-dev BY THE NEW
-            # CANONICAL NAME, and scitex-dev resolves a name only if a JobSpec
-            # DECLARES it:
-            #
-            #   $ sac dev timer install scitex-agent-container-accounts-refresh
-            #   no job named 'scitex-agent-container-accounts-refresh' here
-            #
-            # So install-new cannot run until this line moves. The spec moves
-            # FIRST or the cutover never happens at all; that is not a rule
-            # violation, it is the only order the tooling admits. (Attempted
-            # in the other order 2026-08-18: stop/remove succeeded, install
-            # failed on exactly that lookup, and the fleet's sole OAuth
-            # refresher was down ~2 minutes until the old units were restored.)
-            #
-            # WHAT THE WINDOW ACTUALLY COSTS, stated plainly rather than
-            # assumed: between this rename and the host cutover,
-            # `sac dev timer status accounts-refresh` resolves to a unit name
-            # the host does not carry and reports the refresher ABSENT while
-            # `sac.accounts-refresh.timer` keeps firing every 2h. That is a
-            # MISREPORT ON ONE MANUAL VERB, not an outage — and it cannot
-            # escalate on its own: nothing in this repo installs or enables a
-            # timer automatically (`_dev_jobs_backend` declines to run
-            # systemctl; `_dev_jobs_apply` only PRINTS the enable line), so
-            # the two-racing-refreshers catastrophe still requires a human to
-            # type the install command against a host that already has the
-            # old unit.
-            #
-            # CLOSING THE WINDOW is `sac dev migrate-job-names --only
-            # accounts-refresh --include-held --yes`, run supervised, then
-            # `sac accounts status` BEFORE walking away. Ordered
-            # stop-old -> remove-old -> install-new -> verify-exactly-one, and
-            # "exactly one" means one unit FOR THIS JOB:
-            # `scitex-agent-container-accounts-keepalive` is a DIFFERENT job
-            # that must keep existing.
-            name="scitex-agent-container-accounts-refresh",
-            schedule="0 */2 * * *",  # every 2h
-            # SELF-BOUNDING (120s) — see the convention note above. The
-            # bound has to live in the command because this job lands on
-            # CRON, where `timeout_sec` cannot follow it.
-            command=(
-                "/usr/bin/timeout 120 "
-                "sac accounts refresh --all --include-active --sync-active-login"
-            ),
-            description=(
-                "Headless OAuth access-token refresh for all stored Claude "
-                "accounts including the active one (sole-refresher model), "
-                "mirroring the rotation into the live ~/.claude login."
-            ),
-            # 2026-06-11 (lead msg c5212862): scitex_dev.jobs.JobSpec kind
-            # taxonomy is {"service","timer","cron"} since scitex-dev #153.
-            # ``sac.accounts-refresh`` is a periodic systemd --user timer
-            # (token TTL ~7h, refresh every 2h) → ``kind="timer"`` with the
-            # cadence carried by ``on_unit_active_sec`` below. The legacy
-            # ``kind="systemd"`` is no longer accepted; it raises
-            # ``ValueError`` at construction time and ``scitex-dev
-            # ecosystem up`` silently drops sac's whole provider
-            # (provider-isolated, WARN-only), leaving the OAuth refresh
-            # unmanaged.
-            kind="timer",
-            on_boot_sec="15min",
-            on_unit_active_sec="2h",
-        ),
-        JobSpec(
-            name="scitex-agent-container-accounts-keepalive",
-            schedule="*/15 * * * *",  # every 15min (cron form; timer below)
-            # SELF-BOUNDING (300s). Per peer: a handful of coreutils ssh ops
-            # plus ONE outbound HTTPS verification from the peer (15s cap
-            # inside the probe). 300s covers three peers including a slow one
-            # without ever hanging forever. A pass killed here leaves the
-            # peer's previous credential intact — nothing is published
-            # unverified.
-            command=(
-                "/usr/bin/timeout 300 "
-                "sac accounts keepalive --all "
-                "--to ywata-note-win "
-                "--to scitex-compute-03 "
-                "--to scitex-compute-04"
-            ),
-            description=(
-                "The DISTRIBUTION half of the single-refresher model, and "
-                "the only thing keeping the access-only hosts alive. "
-                "sac.accounts-refresh rotates the token on the ONE host that "
-                "holds refresh material (scitex-nas-03 as of 2026-08-10); "
-                "every other host holds an ACCESS-ONLY copy that nothing on "
-                "that box can renew, so without this job those hosts simply "
-                "expire and 401 within one access-token lifetime. COPIES the "
-                "current token (never mints — minting rotates, which revokes "
-                "the token running agents hold), refuses a payload carrying "
-                "refresh material, refuses under 300s of validity, refuses "
-                "to overwrite a valid remote credential with a dead one, "
-                "backs up what it replaces, publishes 0600, and PROVES the "
-                "far side answers HTTP 200. CONVERGENT: it compares "
-                "fingerprints and rewrites a peer only when the master's "
-                "token actually changed, so most runs are cheap verified "
-                "no-ops. WORST-CASE FOLLOWER OUTAGE THE OPERATOR IS "
-                "ACCEPTING AT THIS CADENCE: 15 minutes — the moment the "
-                "master refreshes, every follower's copy is revoked, and "
-                "they stay dead until the next tick converges them. Exits "
-                "non-zero on any peer's failure. NOT armed by this "
-                "declaration."
-            ),
-            kind="timer",
-            # HOST PINNING IS NOT EXPRESSIBLE HERE. JobSpec has no host
-            # field (name/kind/schedule/command/description/on_boot_sec/
-            # on_unit_active_sec/timeout_sec/restart_policy/watchdog_sec/
-            # venv), so WHERE this runs is decided by where the operator
-            # installs it. It must run ONLY on the refresh holder. sac's
-            # own mitigation is inside the verb: `--all` resolves to the
-            # accounts THIS host holds refresh material for, and exits
-            # non-zero when that set is empty — so a keepalive installed on
-            # the wrong host fails loudly instead of pretending to work.
-            #
-            # 15min is a BOUND, not a guess. Measured 2026-08-10: Claude
-            # Code refreshes only when the token is genuinely near expiry,
-            # so the master's token changes ONCE in ~7h at an unpredictable
-            # moment — and the instant it does, every follower's copy is
-            # revoked and its agents 401. The tick therefore does not decide
-            # when work happens (the fingerprint comparison does); it decides
-            # only how long that revoked window lasts. 15min bounds the
-            # follower outage to 15min; hourly would bound it to an hour.
-            # The cost of the extra ticks is near zero because a converged
-            # peer is verified, not rewritten.
-            on_boot_sec="10min",
-            on_unit_active_sec="15min",
-        ),
-        JobSpec(
-            name="scitex-agent-container-accounts-quota-cache",
-            schedule="*/5 * * * *",  # every 5min (cron form; timer below)
-            # SELF-BOUNDING (120s). One usage read per stored account (4
-            # today), each a single HTTPS call; 120s covers all of them on a
-            # slow network and never hangs. A pass killed here leaves the
-            # PREVIOUS cache in place — stale, which is the status quo this
-            # job improves on, never wrong.
-            command="/usr/bin/timeout 120 sac accounts refresh-quota-cache",
-            description=(
-                "Keeps the per-account usage cache FRESH. Nothing else did: "
-                "sac.accounts-refresh rotates TOKENS and accounts-keepalive "
-                "COPIES tokens, so before this job every quota number the "
-                "fleet showed was as old as the last time a human happened to "
-                "run the verb by hand. Reads usage only — it neither mints nor "
-                "rotates, so it cannot revoke a credential a running agent "
-                "holds (the hazard that makes `accounts refresh` dangerous to "
-                "schedule aggressively). "
-                "MEASURED COST OF NOT HAVING IT, 2026-08-17: `sac accounts "
-                "list` rendered every bar with `! snapshot older than the "
-                "refresh window` and `(stale 1d)` — it detected its own "
-                "staleness and did not fix it. On that day-old snapshot "
-                "scitex-01 read 7d=23% and wyusuuke read 7d=100%; the truth "
-                "after a manual refresh was scitex-01 94% and wyusuuke 0% — "
-                "INVERTED. An agent was repointed at the nearly-exhausted "
-                "account on the strength of it, and the operator's own "
-                "diagnosis was that an account reaches 94% precisely because "
-                "no one is refreshing the numbers that would have shown it "
-                "climbing. A cache that reports its own staleness without "
-                "repairing it is a record, not a gate."
-            ),
-            kind="timer",
-            # 5min, at the operator's instruction — he proposed 1min and
-            # offered 5min "if that is overdoing it". Taking the 5.
-            #
-            # The cadence is chosen against the 5h window, which is the fast
-            # one: a busy account can cross from comfortable to exhausted
-            # inside a single hour, so an hourly cadence would still permit a
-            # placement decision on numbers that predate the exhaustion. The
-            # 7d window moves far too slowly to drive this.
-            #
-            # WHY NOT 1min. Staleness at 5min is already far inside any
-            # decision window — no account crosses a threshold that matters in
-            # five minutes, so 1min buys freshness nobody can act on while
-            # costing 5x the calls (4 accounts x 1440 = 5760/day against a
-            # third-party usage endpoint whose rate limits we do not control
-            # and have not measured). If a case ever appears where a 5min-old
-            # number caused a wrong decision, that is the evidence to go to
-            # 1min — and it would be evidence, not a guess.
-            on_boot_sec="2min",
-            on_unit_active_sec="5min",
-        ),
-        JobSpec(
-            name="scitex-agent-container-host-sync-check",
-            schedule="0 * * * *",  # hourly (cron form; timer cadence below)
-            # SELF-BOUNDING (600s). Sequential per-ssh probe over every peer,
-            # each capped at the verb's 120s default (an unreachable peer
-            # waits its ssh connect-timeout). 600s comfortably covers a
-            # handful of peers including a slow/unreachable one without ever
-            # hanging forever.
-            command=(
-                "/usr/bin/timeout 600 "
-                "sac host sync --check --all --alarm --exit-zero"
-            ),
-            description=(
-                "Read-only drift check of every peer's sac checkout vs the "
-                "centre; records each verdict in sac's own event log so the "
-                "shout is DURABLE. Mutates nothing on any peer — never runs "
-                "the fast-forward remedy (Stage 1). "
-                "--exit-zero because FINDING drift is not this unit being "
-                "unhealthy. MEASURED 2026-08-17: without it, drift exits 1 "
-                "and undetermined exits 2, systemd recorded the unit "
-                "`failed`, compute-04 went `degraded`, and the dotfiles sync "
-                "installer read `is-system-running: degraded` as 'systemd "
-                "absent' and silently refused to install its timer — so that "
-                "host stopped receiving dotfiles sync altogether. The verdict "
-                "still reaches its real readers: the printed report, the JSON "
-                "`exit_code`, and the --alarm event-log record."
-            ),
-            kind="timer",
-            # First check 10min after boot/login (peers reachable, listen
-            # settled), then hourly. Drift is slow-moving relative to the
-            # 2h token refresh, so hourly is ample and gentle on ssh.
-            on_boot_sec="10min",
-            on_unit_active_sec="1h",
-        ),
-        JobSpec(
-            name="scitex-agent-container-worktree-gc",
-            schedule="30 4 * * *",  # daily 04:30 (cron form; timer cadence below)
-            # SELF-BOUNDING (900s). A pass is a handful of local `git` calls
-            # per worktree plus one `gh pr list` per unmerged branch (the
-            # squash-merge leg). A repo deep in sprawl with a slow/
-            # rate-limited gh is the worst case; 900s covers the whole
-            # fleet's repos without ever hanging forever. Every gh failure
-            # already degrades to KEEP, so a timeout costs a skipped reap,
-            # never a wrong one.
-            command="/usr/bin/timeout 900 sac worktree gc --apply --all",
-            description=(
-                "Daily git-worktree GC: removes only worktrees PROVEN safe "
-                "(clean AND merged AND older than 24h AND not in use — never "
-                "--force), prunes admin refs whose directory is already gone, "
-                "and records any repo still over its worktree cap in sac's "
-                "own event log (recorded as recovered when it drops back under). "
-                "The permanent countermeasure to worktree sprawl."
-            ),
-            kind="timer",
-            # Sprawl accumulates over days, not minutes, and the age gate is
-            # 24h — so a daily pass is the natural cadence and a faster one
-            # could not remove anything a daily one would miss. 20min after
-            # boot keeps it clear of the login/auth settling window.
-            on_boot_sec="20min",
-            on_unit_active_sec="1d",
-        ),
-        JobSpec(
-            name="scitex-agent-container-spartan-sif-bake",
-            schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
-            # SELF-BOUNDING (14400s = 4h), and the one where the bound
-            # matters most: at a */10 cadence an UNBOUNDED bake outlives its
-            # own tick by design, so a wedged run would pile up against every
-            # later one. Two full bakes (base ~15-25min + scitex ~10-20min)
-            # plus a multi-GB pull on a slow link fit comfortably; the
-            # per-leg ssh timeout inside the command is 7200s, so 4h bounds
-            # the whole chain without ever killing a legitimate run.
-            command="/usr/bin/timeout 14400 sac image bake-remote --yes",
-            description=(
-                "10-minute SIF refresh with zero master CPU: bake sac-base + "
-                "sac-scitex on the standing Spartan CPU lease (srun "
-                "--overlap into the job resolved BY NAME, never sbatch), "
-                "gate at build time (.def %post symbol gate) AND on the "
-                "artifact (apptainer-exec symbol probe), keep-3 rotate the "
-                "Spartan store, then PULL via rsync-over-ssh, re-verify "
-                "here (sha256 + the same symbol probe on the received "
-                "file) and only then atomically swap both live "
-                "sac-<layer>.sif symlinks + keep-3 rotate locally. A "
-                "failed leg leaves the live image untouched and exits "
-                "non-zero; a source-unchanged run is a loud SKIPPED, not "
-                "a transfer."
-            ),
-            kind="timer",
-            # 10min: the image is a point-in-time snapshot of @develop, and at
-            # our release rate a DAY-old SIF is mostly wrong. 30min was read
-            # off the operator's 「最低でも30分に1回」 — but that was his FLOOR,
-            # not his target (「なんで三十分に一回だけなの？」; 「例えば1分に1回焼いても
-            # 全く問題ないです」), so the cadence is set to what he wants, not to
-            # the minimum he would tolerate.
-            #
-            # Cheap by construction, which is what makes a 10min tick sane: a
-            # source-unchanged run is a SKIPPED verdict (check a git ref, one
-            # ssh round-trip, no transfer), so only a real @develop change ever
-            # costs a bake. A bake takes 8-30min, so at */10 most ticks land
-            # while one is still running — the script's `flock -n` makes those
-            # exit "already-running" immediately instead of piling up, which is
-            # exactly what that lock is for. The operator has separately
-            # accepted overlap outright (the swap is an atomic symlink flip at
-            # the end). Steady state: skip, skip, skip, … one real bake when
-            # something changed, the rest of that window bouncing off the lock.
-            on_boot_sec="30min",
-            on_unit_active_sec="10min",
-        ),
-        JobSpec(
-            name="scitex-agent-container-freshness-refresh",
-            schedule="7 * * * *",  # hourly (cron form; timer cadence below)
-            # SELF-BOUNDING (300s). Generous on purpose, matching the
-            # primitive's own 30s per-source timeouts: a busy host must not
-            # be mistaken for a broken one, and a manufactured UNKNOWN is
-            # exactly the failure mode. Nothing is waiting on this run.
-            command="/usr/bin/timeout 300 sac freshness refresh",
-            description=(
-                "Publishes the version-currency verdict to the cache that "
-                "every `sac` invocation reads. Runs the real checks (PyPI, "
-                "git tags, gh release runs, systemd running-vs-installed, "
-                "symbol probes) via scitex-dev's `versioning` primitive and "
-                "writes the result atomically. This is the half that pays "
-                "the network cost, so the CLI hot path never does — without "
-                "it the startup banner has nothing to read and stays "
-                "permanently silent."
-            ),
-            kind="timer",
-            # Hourly against the primitive's 24h cache TTL: 24 consecutive
-            # misses before the banner falls silent, so a laptop that is shut
-            # most of the day still has a trustworthy answer. Faster buys
-            # nothing — releases are not more frequent than hourly — and each
-            # pass makes real network calls.
-            on_boot_sec="25min",
-            on_unit_active_sec="1h",
-        ),
+        *accounts_jobs(executable=executable),
+        *maintenance_jobs(executable=executable),
         # The two AGENT-LIVENESS enforcers live together in
         # :mod:`._specs_liveness` — each one's scope is defined by what the
         # other covers (corpses vs live-but-wedged), so they are unreadable
-        # apart. Spliced in HERE to preserve the historical order.
-        *liveness_jobs(),
-        JobSpec(
-            name="scitex-agent-container-heal-agent-auth",
-            schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
-            # ABSOLUTE by design, EVERY token. `resolve_execstart` passes a
-            # command whose head starts with "/" through VERBATIM, so this is
-            # the only form that depends on neither the ambient PATH nor which
-            # interpreter ran `ecosystem up`. A systemd --user unit gets a
-            # MINIMAL PATH, so the venv python must be named outright: the
-            # script's own `#!/usr/bin/env python3` would resolve to the SYSTEM
-            # python under systemd, not the 3.11 venv the fleet runs on.
-            #
-            # The `timeout` head is spelled ABSOLUTELY for the same reason —
-            # it keeps this command's "depends on no PATH at all" property
-            # intact, which a bare `timeout` would have quietly given up.
-            #
-            # SELF-BOUNDING (300s). A no-op tick takes ~2-8s, and the worst
-            # observed pass (a TUI restart at 15:30:04 settling by 15:32:08)
-            # ~2min. A pass killed here is SAFE — state is persisted per
-            # restart, so the next tick still honours the debounce for
-            # anything already bounced.
-            command=(
-                "/usr/bin/timeout 300 "
-                "/home/ywatanabe/.env-3.11/bin/python "
-                "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
-            ),
-            description=(
-                "Auth auto-heal for the fleet: scans each agent's session.jsonl "
-                "TAIL for a CURRENT 401/authentication_error and restarts the "
-                "agent so a fresh credential is re-mounted, plus the sibling "
-                "TUI-pane scan (2-run-corroborated) for tmux agents whose "
-                "transcript lives in the container overlay and is invisible to "
-                "the session.jsonl glob. Rate-limited (per-agent debounce, boot "
-                "grace, global cap/hour) and phones the operator instead of "
-                "looping when a restart provably did not fix it. Declared as a "
-                "JobSpec because its crontab line was swept by copy_crontab's "
-                "full-manifest install. MUTUALLY EXCLUSIVE with "
-                "sac.restart-login-expired-agents — enable exactly one."
-            ),
-            kind="timer",
-            # Same taxonomy note as the jobs above: kind must be one of
-            # {"service","timer","cron"} (scitex-dev #153); a wrong kind raises
-            # at construction and `ecosystem up` then silently drops sac's WHOLE
-            # provider.
-            #
-            # 10min preserves the incumbent cadence EXACTLY — not a guess: the
-            # live `runtime/auth-heal.log` ticks 15:20 → 15:30 → 15:40 → 15:50
-            # → 16:00 (2026-07-18), matching the `*/10` cron line. Migrating a
-            # schedule is the wrong moment to also retune it; a cadence change
-            # belongs in its own PR with its own argument.
-            on_boot_sec="5min",
-            on_unit_active_sec="10min",
-            # `Persistent=true` is emitted by scitex-dev's timer renderer for
-            # every kind="timer", so a window missed while the host was asleep
-            # fires on resume — the property a crontab line does NOT have and a
-            # laptop fleet needs most.
-        ),
+        # apart.
+        *liveness_jobs(executable=executable),
     ]
 
 

--- a/src/scitex_agent_container/_jobs/_migrate/_plan.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_plan.py
@@ -151,6 +151,7 @@ def plan_one(
     present: Iterable[str] = (),
     dropin_dirs: Iterable[str] = (),
     install_argv: Callable[[Rename], tuple[str, ...]] = default_install_argv,
+    include_held: bool = False,
 ) -> tuple[Step, ...]:
     """Build the ordered plan for ONE job.
 
@@ -159,13 +160,18 @@ def plan_one(
     the caller and passed in, so this stays pure and the plan is a
     function of observed state rather than of hope.
 
-    A held job plans nothing — see ``Rename.hold``.
+    A held job plans nothing UNLESS ``include_held`` is passed — see
+    ``Rename.hold``. The default stays refuse-by-default so a bulk run can
+    never sweep one up; the override exists because the hold text itself
+    names the supervised command that is meant to clear it, and a flag the
+    caller can set but the planner ignores is a declaration with no
+    mechanism behind it.
 
     A job whose old units are absent still gets ``install``, ``logging``
     and ``verify``: the rename may have half-completed on this host, and
     saying so is what ``verify`` is for.
     """
-    if rename.held:
+    if rename.held and not include_held:
         return ()
 
     on_host = frozenset(present)
@@ -272,8 +278,14 @@ def plan(
     present: Iterable[str] = (),
     dropin_dirs: Iterable[str] = (),
     install_argv: Callable[[Rename], tuple[str, ...]] = default_install_argv,
+    include_held: bool = False,
 ) -> tuple[Step, ...]:
-    """The full ordered plan across every non-held job in ``renames``."""
+    """The full ordered plan across ``renames``.
+
+    Held jobs contribute nothing unless ``include_held`` is set; the caller
+    that sets it is expected to have narrowed ``renames`` to the one job it
+    means (the CLI enforces ``--include-held`` requires ``--only``).
+    """
     on_host = frozenset(present)
     dirs = frozenset(dropin_dirs)
     steps: list[Step] = []
@@ -284,6 +296,7 @@ def plan(
                 present=on_host,
                 dropin_dirs=dirs,
                 install_argv=install_argv,
+                include_held=include_held,
             )
         )
     out = tuple(steps)

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -157,11 +157,6 @@ RENAMES: tuple[Rename, ...] = (
         kind="timer",
     ),
     Rename(
-        old="sac.heal-agent-auth",
-        new="scitex-agent-container-heal-agent-auth",
-        kind="timer",
-    ),
-    Rename(
         old="sac.host-sync-check",
         new="scitex-agent-container-host-sync-check",
         kind="timer",

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -122,10 +122,18 @@ RENAMES: tuple[Rename, ...] = (
             "run `sac dev migrate-job-names --only accounts-refresh "
             "--include-held --yes` in a watched window, then confirm "
             "`sac accounts status` still resolves every account BEFORE "
-            "walking away. Until then the spec keeps its legacy name ON "
-            "PURPOSE, so every CLI verb keeps naming the unit that is really "
-            "running — a spec renamed ahead of its unit would report the "
-            "refresher as absent while it refreshes."
+            "walking away. THE SPEC HAS ALREADY MOVED to the new name, and "
+            "it had to: `sac dev timer install` resolves only names a "
+            "JobSpec DECLARES, so install-new answered `no job named "
+            "'scitex-agent-container-accounts-refresh' here` while the spec "
+            "was held (measured 2026-08-19; attempted in the other order the "
+            "night before, which left the fleet with zero refreshers for ~2 "
+            "minutes). Until this cutover runs, `sac dev timer status "
+            "accounts-refresh` therefore names a unit the host does not "
+            "carry and reports the refresher ABSENT while "
+            "`sac.accounts-refresh.timer` keeps firing — a misreport on one "
+            "manual verb, which nothing automated can escalate, because "
+            "nothing in this repo installs or enables a timer by itself."
         ),
     ),
     Rename(

--- a/src/scitex_agent_container/_jobs/_migrate/_verify.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_verify.py
@@ -1,11 +1,53 @@
-"""EXACTLY ONE SUPERVISOR — the claim the migration exists to make good on.
+"""EXACTLY ONE SUPERVISOR, AND IT IS ACTUALLY SUPERVISING.
 
-"The new unit exists" is not the claim. "ONLY the new unit exists" is.
-A migration that installed the new name and left the old one behind would
-report success while doubling the supervision of the fleet's credential
-machinery, which is the precise failure this whole change is written to
-prevent. So verification counts BOTH names and treats any survivor of the
-old one as a failure, however healthy the new one looks.
+"The new unit exists" is not the claim. "ONLY the new unit exists" is not the
+whole claim either. A migration that installed the new name and left the old one
+behind would report success while doubling the supervision of the fleet's
+credential machinery, which is the precise failure this whole change is written
+to prevent. So verification counts BOTH names and treats any survivor of the old
+one as a failure, however healthy the new one looks.
+
+WHY ARMING IS PART OF THE CLAIM (measured 2026-08-19, on the real cutover)
+=========================================================================
+``sac dev migrate-job-names --only accounts-refresh --include-held --yes`` ran
+all ten steps green on scitex-compute-04 and left the fleet's OAuth refresher
+**installed and disabled**::
+
+    scitex-agent-container-accounts-keepalive.timer   enabled   enabled
+    scitex-agent-container-accounts-refresh.timer     disabled  enabled
+
+The old timer had been ``enabled`` and firing; the new one was not enabled at
+all and did not appear in ``list-timers``. For the window between the two, the
+sole-refresher host had NO refresher — and the verification pass said nothing,
+because counting unit FILES cannot see it. Zero active supervisors satisfies
+"not two supervisors" perfectly.
+
+That is §2's *a gate that cannot fail is not a gate*: the check ran, on time, in
+writing, and could not have caught the one outcome that mattered. The rule that
+does catch it is the definition of a correct rename:
+
+    **A RENAME MUST PRESERVE ARMING.** If the old unit was enabled before the
+    cutover, the new unit must be enabled after it. If it was disabled, it stays
+    disabled.
+
+Stated that way it needs no policy input and no allow-list. It reads the host's
+own pre-state as the expectation, which is why it flags accounts-refresh (old
+was enabled) and stays silent about heal-agent-auth (old was deliberately
+disabled — it is mutually exclusive with restart-login-expired-agents, and
+"enable exactly one" is its own unit description's instruction). A guard that
+demanded "every timer must be enabled" would have been wrong about the second
+one, and being wrong about a deliberate disablement is how a guard teaches
+people to ignore it.
+
+ARMING IS THREE-VALUED, and collapsing it is the bug §2 warns about
+===================================================================
+A host may not be readable, or a caller may not have measured enablement at all.
+"I could not tell" must not render as "armed correctly" — that is exactly the
+unknown-collapsed-into-a-pole failure — and it must not render as a FAILURE
+either, or every caller that does not measure starts reporting false alarms.
+So ``armed_ok`` is ``True`` / ``False`` / ``None``, and ``None`` prints as NOT
+CHECKED. ``ok`` keeps its original, narrower meaning — the installation claim —
+so a caller that never looked at arming behaves exactly as before.
 """
 
 from __future__ import annotations
@@ -17,25 +59,51 @@ from typing import Callable, Iterable
 from ._renames import Rename
 
 
+def _suffix(unit: str, name: str) -> str:
+    """The ``.service``/``.timer`` tail of ``unit`` under job ``name``."""
+    return unit[len(name) :] if unit.startswith(name) else unit
+
+
 @dataclass(frozen=True)
 class Supervisors:
-    """What is supervising one job after its cutover."""
+    """What is supervising one job after its cutover, and whether it is armed."""
 
     job: str
     expected: tuple[str, ...]
     found_new: tuple[str, ...]
     found_old: tuple[str, ...]
+    #: New units that MUST be armed, because their old counterpart was.
+    should_be_armed: tuple[str, ...] = ()
+    #: New units observed armed. ``None`` means enablement was never measured.
+    found_armed: tuple[str, ...] | None = None
 
     @property
     def ok(self) -> bool:
-        """True only when the new set is complete and NOTHING old survives."""
+        """True only when the new set is complete and NOTHING old survives.
+
+        Deliberately unchanged: this is the INSTALLATION claim. Arming is a
+        separate signal so that a caller which never measured it is not
+        silently told its migration passed a check it did not run.
+        """
         return not self.found_old and set(self.found_new) == set(self.expected)
+
+    @property
+    def unarmed(self) -> tuple[str, ...]:
+        """Units that were armed before the cutover and are not armed now."""
+        if self.found_armed is None:
+            return ()
+        return tuple(u for u in self.should_be_armed if u not in self.found_armed)
+
+    @property
+    def armed_ok(self) -> bool | None:
+        """True / False / ``None`` when enablement was not measured."""
+        if self.found_armed is None:
+            return None
+        return not self.unarmed
 
     @property
     def verdict(self) -> str:
         """One line an operator can act on, naming what was actually found."""
-        if self.ok:
-            return f"OK   {self.job}: exactly one supervisor {list(self.found_new)}"
         if self.found_old and self.found_new:
             return (
                 f"FAIL {self.job}: TWO SUPERVISORS — old {list(self.found_old)} "
@@ -46,18 +114,68 @@ class Supervisors:
                 f"FAIL {self.job}: still on the OLD name {list(self.found_old)}; "
                 "the cutover did not happen"
             )
-        missing = sorted(set(self.expected) - set(self.found_new))
-        return f"FAIL {self.job}: NO supervisor — missing {missing}"
+        if not self.ok:
+            missing = sorted(set(self.expected) - set(self.found_new))
+            return f"FAIL {self.job}: NO supervisor — missing {missing}"
+        if self.armed_ok is False:
+            units = list(self.unarmed)
+            return (
+                f"FAIL {self.job}: INSTALLED BUT NOT ARMED — {units} "
+                "was enabled before the cutover and is not now, so this job is "
+                "supervised by nothing. Fix: systemctl --user enable --now "
+                + " ".join(units)
+            )
+        if self.armed_ok is None:
+            return (
+                f"OK   {self.job}: exactly one supervisor {list(self.found_new)} "
+                "(arming NOT CHECKED — caller measured no enablement)"
+            )
+        return (
+            f"OK   {self.job}: exactly one supervisor {list(self.found_new)}, armed"
+        )
 
 
-def verify_exactly_one(rename: Rename, *, present: Iterable[str]) -> Supervisors:
-    """Count the supervisors for one job against the host's unit files."""
+def verify_exactly_one(
+    rename: Rename,
+    *,
+    present: Iterable[str],
+    armed_before: Iterable[str] | None = None,
+    armed_now: Iterable[str] | None = None,
+) -> Supervisors:
+    """Count the supervisors for one job, and check the rename preserved arming.
+
+    ``armed_before`` is the set of enabled units observed BEFORE the plan ran —
+    it has to be captured then, because the plan's own ``disable`` step destroys
+    the evidence. Passing neither set leaves arming unmeasured (``None``) rather
+    than assumed.
+    """
     on_host = frozenset(present)
+    new_units = rename.new_units()
+
+    if armed_before is None or armed_now is None:
+        should: tuple[str, ...] = ()
+        found_armed: tuple[str, ...] | None = None
+    else:
+        was = frozenset(armed_before)
+        now = frozenset(armed_now)
+        # Map old -> new by unit SUFFIX rather than by position, so the pairing
+        # survives any future change to KIND_UNIT_SUFFIXES' ordering. This is
+        # also what keeps the rule honest for a timer job: only the .timer is
+        # ever enabled (the .service is static), so only the .timer can appear
+        # here — the data decides, not a hardcoded suffix.
+        armed_suffixes = {
+            _suffix(u, rename.old) for u in rename.old_units() if u in was
+        }
+        should = tuple(u for u in new_units if _suffix(u, rename.new) in armed_suffixes)
+        found_armed = tuple(u for u in new_units if u in now)
+
     return Supervisors(
         job=rename.new,
-        expected=rename.new_units(),
-        found_new=tuple(u for u in rename.new_units() if u in on_host),
+        expected=new_units,
+        found_new=tuple(u for u in new_units if u in on_host),
         found_old=tuple(u for u in rename.old_units() if u in on_host),
+        should_be_armed=should,
+        found_armed=found_armed,
     )
 
 

--- a/src/scitex_agent_container/_jobs/_names.py
+++ b/src/scitex_agent_container/_jobs/_names.py
@@ -26,10 +26,12 @@ the same command with independent state. ``sac.accounts-refresh`` is the
 fleet's SOLE OAuth refresher against a SINGLE-USE refresh token, so two
 of it revoke each other's access token fleet-wide.
 
-The rename therefore does not ride along with a CLI-surface change; it
-ships with the migration verb that enforces stop -> remove -> install and
-makes install-before-uninstall impossible. Flipping this one constant is
-the code half of that change.
+The rename therefore does not ride along with a CLI-surface change; the
+migration verb that enforces stop -> remove -> install and makes
+install-before-uninstall impossible is what closes it on each host.
+Flipping this one constant is the code half; the verb is the host half,
+and — see below — the code half has to land FIRST for the verb to work
+at all.
 
 WHY TWO PREFIXES ARE LIVE AT ONCE, AND WHY THAT IS THE SAFE SHAPE
 =================================================================
@@ -38,16 +40,33 @@ WHY TWO PREFIXES ARE LIVE AT ONCE, AND WHY THAT IS THE SAFE SHAPE
 deliberately keeps its old name until an operator-supervised cutover:
 ``sac.accounts-refresh``, the fleet's sole OAuth refresher.
 
-The alternative — rename the SPEC now and cut the UNIT over later — is
-the one shape that must not ship. The live, enabled, actively-refreshing
-unit is ``sac.accounts-refresh.timer``; if the spec said
-``scitex-agent-container-accounts-refresh`` while that unit ran, then
-``sac dev timer status accounts-refresh`` would resolve to a name no unit
-carries and report the refresher as absent — WHILE IT IS RUNNING. A CLI
-that reports the fleet's most critical job as missing when it is healthy
-is worse than a name that does not match a convention yet.
+THE ORDER WAS INVERTED 2026-08-19, and this paragraph used to argue the
+opposite, so read the correction rather than the memory of it. The old
+rule was "rename the SPEC now and cut the UNIT over later is the one
+shape that must not ship", on the grounds that ``sac dev timer status
+accounts-refresh`` would then resolve to a name no unit carries and
+report the fleet's sole OAuth refresher as absent while it runs.
 
-So the declared name tracks the DEPLOYED unit, always. Both prefixes are
+That hazard is real and it is now ACCEPTED, because the alternative is
+not available. ``sac dev timer install`` resolves only names a JobSpec
+DECLARES, so a held spec can never be installed under its new name:
+
+    $ sac dev timer install scitex-agent-container-accounts-refresh
+    no job named 'scitex-agent-container-accounts-refresh' here
+
+"Rename both together" was therefore never reachable — attempted in the
+old order on 2026-08-18, stop and remove succeeded, install failed on
+exactly that lookup, and the fleet had zero refreshers for ~2 minutes.
+The spec leads and the unit follows, or the cutover never happens.
+
+What the accepted window costs is bounded and worth naming: a MISREPORT
+on one manual verb, which cannot escalate by itself, because nothing in
+this package installs or enables a timer automatically — the backend
+declines to run ``systemctl`` and the apply path only PRINTS the enable
+line. Two racing refreshers still require a human to type the install
+command against a host that already carries the old unit.
+
+So the declared name now LEADS the deployed unit, by necessity. Both prefixes are
 readable until :mod:`._migrate` records that cutover as done, and
 ``JOB_PREFIX`` alone is what new names are minted with.
 """

--- a/src/scitex_agent_container/_jobs/_sac_bin.py
+++ b/src/scitex_agent_container/_jobs/_sac_bin.py
@@ -1,0 +1,84 @@
+"""The absolute ``sac`` a scheduled command must name, resolved per host.
+
+WHY A JOB COMMAND MAY NOT SAY BARE ``sac``
+==========================================
+Every JobSpec here is self-bounding — its head is ``/usr/bin/timeout N`` — and
+that head is ABSOLUTE. scitex-dev's ``resolve_execstart`` absolutises only the
+FIRST token and passes a command that already starts with ``/`` through
+verbatim, so wrapping the command took the payload binary OUT of resolution.
+``timeout`` then looks ``sac`` up on whatever PATH its parent had.
+
+``_jobs_plugin``'s own docstring recorded that consequence and scoped it to a
+future in which these specs are "rendered as systemd units instead", calling it
+"not live today". MEASURED 2026-08-20, it was live: the ecosystem supervisor
+spawns periodic jobs DIRECTLY, through the same ``resolve_execstart``, so the
+payload was unresolved on that path too.
+
+THE FAILURE NEEDS TWO CONDITIONS, AND THIS FIXES ONE OF THEM. On
+scitex-compute-01, ALL TEN sac jobs sat at exit 127 with zero successes —
+self-pull included, so the host could not even fetch a fix. That took BOTH a
+relative payload AND a supervisor whose PATH lacked the venv. scitex-dev owns
+the second condition and has already closed it: ``build_supervisor_unit_text``
+emits ``Environment=PATH=<venv_bin>:...`` derived from the resolved ExecStart,
+since PR #713. compute-01 was failing because its UNIT was stale — the package
+had been upgraded and the unit was never regenerated, and installing a newer
+version does not rewrite an existing unit.
+
+So this module is not the repair for that host; regenerating its unit is (and
+that is sequenced behind a scitex-dev release, because ``ecosystem up`` on the
+older version would reinstall the cron block retired the same night). What this
+module removes is the DEPENDENCY: with an absolute payload, a stale unit, an
+unlucky manager env, or a hand-started supervisor can no longer produce this
+class of failure at all. The condition scitex-dev fixed must be re-established
+on every host after every upgrade; the one fixed here cannot regress.
+
+WHY NOT A LITERAL PATH
+======================
+The rejected option was pinning one absolute ``sac``, and the objection was
+correct: the install location VARIES BY HOST. This module answers that
+objection instead of overriding it. ``sys.executable`` is the interpreter that
+imported this plugin — the supervisor's own — and a console script installed
+with this package is by construction its sibling. The answer is therefore
+per-host by construction, with nothing hardcoded and no host list to maintain.
+
+It is also the rule scitex-dev already trusts: ``resolve_execstart``'s rule 1
+is ``Path(sys.executable).parent / head``, and its docstring explains at length
+why the parent must NOT be ``.resolve()``d (a venv's ``bin/python`` symlinks to
+an interpreter outside the venv, where no console scripts live). We inherit
+that reasoning by using the same unresolved parent.
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+__all__ = ["sac_bin"]
+
+
+def sac_bin(*, executable: str | None = None) -> str:
+    """Absolute path to the ``sac`` installed beside the running interpreter.
+
+    Returns the bare name ``"sac"`` when that sibling is absent, and WARNS when
+    it does — the same shape scitex-dev's own last-resort rule uses. That case
+    means sac is importable while its console script is not installed, which is
+    a broken install rather than a host we should paper over: the command will
+    still fail loudly at 127, but with a breadcrumb naming the reason.
+
+    ``executable`` is a test seam so a test can point at a venv-shaped tree it
+    built on disk instead of rewriting this module's globals.
+    """
+    candidate = Path(executable or sys.executable).parent / "sac"
+    if candidate.is_file():
+        return str(candidate)
+    warnings.warn(
+        f"no `sac` console script beside the running interpreter "
+        f"({candidate}); scheduled commands will fall back to a bare `sac` "
+        f"resolved against the ambient PATH, which is exactly how every sac "
+        f"job on scitex-compute-01 reached exit 127 on 2026-08-20. Install "
+        f"sac into this environment.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    return "sac"

--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -1,0 +1,229 @@
+"""The OAuth-credential beat: three jobs that keep sac able to log in.
+
+Split out of :mod:`._jobs_plugin` (at the per-file cap), following the
+convention :mod:`._specs_liveness` established for the same reason.
+
+These three belong together because they share ONE failure mode — an
+expired token — and their cadences are chosen against each other rather
+than in isolation: ``accounts-refresh`` renews on the beat the token
+lifetime dictates, ``accounts-keepalive`` covers the hosts that refresh
+cannot reach, and ``accounts-quota-cache`` publishes what both produce.
+A reader asking "why is the fleet logged out?" must see all three at
+once; asking it of any one of them gives an answer that is true and
+useless.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.jobs import JobSpec
+
+__all__ = ["accounts_jobs"]
+
+
+def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
+    """sac's OAuth-credential JobSpecs, in their historical order.
+
+    ``executable`` is the same test seam :func:`._sac_bin.sac_bin` exposes,
+    threaded through so a test can resolve the payload against a venv-shaped
+    tree it built on disk. Without it the rendered command depends on whether
+    the RUNNING environment happens to have a ``sac`` console script beside
+    its interpreter — true in production, false under a PYTHONPATH-only CI
+    run — and a population guard over these specs would then assert an
+    environmental fact rather than a property of the specs.
+    """
+    from scitex_dev.jobs import JobSpec
+
+    from ._sac_bin import sac_bin
+
+    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin` for the measurement.
+    sac = sac_bin(executable=executable)
+
+    return [
+        JobSpec(
+            # THE LAST NAME OFF THE LEGACY PREFIX. It was held back for
+            # months on the rule "never rename a spec ahead of its unit", and
+            # that rule was right about the hazard and wrong about the order.
+            #
+            # WHAT THE HOLD ASSUMED: that the supervised cutover renames spec
+            # and unit TOGETHER. MEASURED 2026-08-19, that is unreachable —
+            # the migration's install step delegates to scitex-dev BY THE NEW
+            # CANONICAL NAME, and scitex-dev resolves a name only if a JobSpec
+            # DECLARES it:
+            #
+            #   $ sac dev timer install scitex-agent-container-accounts-refresh
+            #   no job named 'scitex-agent-container-accounts-refresh' here
+            #
+            # So install-new cannot run until this line moves. The spec moves
+            # FIRST or the cutover never happens at all; that is not a rule
+            # violation, it is the only order the tooling admits. (Attempted
+            # in the other order 2026-08-18: stop/remove succeeded, install
+            # failed on exactly that lookup, and the fleet's sole OAuth
+            # refresher was down ~2 minutes until the old units were restored.)
+            #
+            # WHAT THE WINDOW ACTUALLY COSTS, stated plainly rather than
+            # assumed: between this rename and the host cutover,
+            # `sac dev timer status accounts-refresh` resolves to a unit name
+            # the host does not carry and reports the refresher ABSENT while
+            # `sac.accounts-refresh.timer` keeps firing every 2h. That is a
+            # MISREPORT ON ONE MANUAL VERB, not an outage — and it cannot
+            # escalate on its own: nothing in this repo installs or enables a
+            # timer automatically (`_dev_jobs_backend` declines to run
+            # systemctl; `_dev_jobs_apply` only PRINTS the enable line), so
+            # the two-racing-refreshers catastrophe still requires a human to
+            # type the install command against a host that already has the
+            # old unit.
+            #
+            # CLOSING THE WINDOW is `sac dev migrate-job-names --only
+            # accounts-refresh --include-held --yes`, run supervised, then
+            # `sac accounts status` BEFORE walking away. Ordered
+            # stop-old -> remove-old -> install-new -> verify-exactly-one, and
+            # "exactly one" means one unit FOR THIS JOB:
+            # `scitex-agent-container-accounts-keepalive` is a DIFFERENT job
+            # that must keep existing.
+            name="scitex-agent-container-accounts-refresh",
+            schedule="0 */2 * * *",  # every 2h
+            # SELF-BOUNDING (120s) — see the convention note above. The
+            # bound has to live in the command because this job lands on
+            # CRON, where `timeout_sec` cannot follow it.
+            command=(
+                "/usr/bin/timeout 120 "
+                f"{sac} accounts refresh --all --include-active --sync-active-login"
+            ),
+            description=(
+                "Headless OAuth access-token refresh for all stored Claude "
+                "accounts including the active one (sole-refresher model), "
+                "mirroring the rotation into the live ~/.claude login."
+            ),
+            # 2026-06-11 (lead msg c5212862): scitex_dev.jobs.JobSpec kind
+            # taxonomy is {"service","timer","cron"} since scitex-dev #153.
+            # ``sac.accounts-refresh`` is a periodic systemd --user timer
+            # (token TTL ~7h, refresh every 2h) → ``kind="timer"`` with the
+            # cadence carried by ``on_unit_active_sec`` below. The legacy
+            # ``kind="systemd"`` is no longer accepted; it raises
+            # ``ValueError`` at construction time and ``scitex-dev
+            # ecosystem up`` silently drops sac's whole provider
+            # (provider-isolated, WARN-only), leaving the OAuth refresh
+            # unmanaged.
+            kind="timer",
+            on_boot_sec="15min",
+            on_unit_active_sec="2h",
+        ),
+        JobSpec(
+            name="scitex-agent-container-accounts-keepalive",
+            schedule="*/15 * * * *",  # every 15min (cron form; timer below)
+            # SELF-BOUNDING (300s). Per peer: a handful of coreutils ssh ops
+            # plus ONE outbound HTTPS verification from the peer (15s cap
+            # inside the probe). 300s covers three peers including a slow one
+            # without ever hanging forever. A pass killed here leaves the
+            # peer's previous credential intact — nothing is published
+            # unverified.
+            command=(
+                "/usr/bin/timeout 300 "
+                f"{sac} accounts keepalive --all "
+                "--to ywata-note-win "
+                "--to scitex-compute-03 "
+                "--to scitex-compute-04"
+            ),
+            description=(
+                "The DISTRIBUTION half of the single-refresher model, and "
+                "the only thing keeping the access-only hosts alive. "
+                "sac.accounts-refresh rotates the token on the ONE host that "
+                "holds refresh material (scitex-nas-03 as of 2026-08-10); "
+                "every other host holds an ACCESS-ONLY copy that nothing on "
+                "that box can renew, so without this job those hosts simply "
+                "expire and 401 within one access-token lifetime. COPIES the "
+                "current token (never mints — minting rotates, which revokes "
+                "the token running agents hold), refuses a payload carrying "
+                "refresh material, refuses under 300s of validity, refuses "
+                "to overwrite a valid remote credential with a dead one, "
+                "backs up what it replaces, publishes 0600, and PROVES the "
+                "far side answers HTTP 200. CONVERGENT: it compares "
+                "fingerprints and rewrites a peer only when the master's "
+                "token actually changed, so most runs are cheap verified "
+                "no-ops. WORST-CASE FOLLOWER OUTAGE THE OPERATOR IS "
+                "ACCEPTING AT THIS CADENCE: 15 minutes — the moment the "
+                "master refreshes, every follower's copy is revoked, and "
+                "they stay dead until the next tick converges them. Exits "
+                "non-zero on any peer's failure. NOT armed by this "
+                "declaration."
+            ),
+            kind="timer",
+            # HOST PINNING IS NOT EXPRESSIBLE HERE. JobSpec has no host
+            # field (name/kind/schedule/command/description/on_boot_sec/
+            # on_unit_active_sec/timeout_sec/restart_policy/watchdog_sec/
+            # venv), so WHERE this runs is decided by where the operator
+            # installs it. It must run ONLY on the refresh holder. sac's
+            # own mitigation is inside the verb: `--all` resolves to the
+            # accounts THIS host holds refresh material for, and exits
+            # non-zero when that set is empty — so a keepalive installed on
+            # the wrong host fails loudly instead of pretending to work.
+            #
+            # 15min is a BOUND, not a guess. Measured 2026-08-10: Claude
+            # Code refreshes only when the token is genuinely near expiry,
+            # so the master's token changes ONCE in ~7h at an unpredictable
+            # moment — and the instant it does, every follower's copy is
+            # revoked and its agents 401. The tick therefore does not decide
+            # when work happens (the fingerprint comparison does); it decides
+            # only how long that revoked window lasts. 15min bounds the
+            # follower outage to 15min; hourly would bound it to an hour.
+            # The cost of the extra ticks is near zero because a converged
+            # peer is verified, not rewritten.
+            on_boot_sec="10min",
+            on_unit_active_sec="15min",
+        ),
+        JobSpec(
+            name="scitex-agent-container-accounts-quota-cache",
+            schedule="*/5 * * * *",  # every 5min (cron form; timer below)
+            # SELF-BOUNDING (120s). One usage read per stored account (4
+            # today), each a single HTTPS call; 120s covers all of them on a
+            # slow network and never hangs. A pass killed here leaves the
+            # PREVIOUS cache in place — stale, which is the status quo this
+            # job improves on, never wrong.
+            command=f"/usr/bin/timeout 120 {sac} accounts refresh-quota-cache",
+            description=(
+                "Keeps the per-account usage cache FRESH. Nothing else did: "
+                "sac.accounts-refresh rotates TOKENS and accounts-keepalive "
+                "COPIES tokens, so before this job every quota number the "
+                "fleet showed was as old as the last time a human happened to "
+                "run the verb by hand. Reads usage only — it neither mints nor "
+                "rotates, so it cannot revoke a credential a running agent "
+                "holds (the hazard that makes `accounts refresh` dangerous to "
+                "schedule aggressively). "
+                "MEASURED COST OF NOT HAVING IT, 2026-08-17: `sac accounts "
+                "list` rendered every bar with `! snapshot older than the "
+                "refresh window` and `(stale 1d)` — it detected its own "
+                "staleness and did not fix it. On that day-old snapshot "
+                "scitex-01 read 7d=23% and wyusuuke read 7d=100%; the truth "
+                "after a manual refresh was scitex-01 94% and wyusuuke 0% — "
+                "INVERTED. An agent was repointed at the nearly-exhausted "
+                "account on the strength of it, and the operator's own "
+                "diagnosis was that an account reaches 94% precisely because "
+                "no one is refreshing the numbers that would have shown it "
+                "climbing. A cache that reports its own staleness without "
+                "repairing it is a record, not a gate."
+            ),
+            kind="timer",
+            # 5min, at the operator's instruction — he proposed 1min and
+            # offered 5min "if that is overdoing it". Taking the 5.
+            #
+            # The cadence is chosen against the 5h window, which is the fast
+            # one: a busy account can cross from comfortable to exhausted
+            # inside a single hour, so an hourly cadence would still permit a
+            # placement decision on numbers that predate the exhaustion. The
+            # 7d window moves far too slowly to drive this.
+            #
+            # WHY NOT 1min. Staleness at 5min is already far inside any
+            # decision window — no account crosses a threshold that matters in
+            # five minutes, so 1min buys freshness nobody can act on while
+            # costing 5x the calls (4 accounts x 1440 = 5760/day against a
+            # third-party usage endpoint whose rate limits we do not control
+            # and have not measured). If a case ever appears where a 5min-old
+            # number caused a wrong decision, that is the evidence to go to
+            # 1min — and it would be evidence, not a guess.
+            on_boot_sec="2min",
+            on_unit_active_sec="5min",
+        ),
+    ]

--- a/src/scitex_agent_container/_jobs/_specs_liveness.py
+++ b/src/scitex_agent_container/_jobs/_specs_liveness.py
@@ -31,7 +31,18 @@ def liveness_jobs() -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-fleet-reconcile",
             schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
-            command="sac agents reconcile --apply",
+            # SELF-BOUNDING (300s) — the bound lives in the command because
+            # this job lands on CRON, where `timeout_sec` cannot follow it.
+            # A no-op pass takes ~seconds; this bounds the pathological one
+            # (`--limit` restarts, each a stop+settle+start). A pass killed at
+            # this timeout is SAFE: the restart history is persisted per
+            # restart, not at the end, so the next tick still honours the
+            # debounce for anything already bounced.
+            #
+            # This is the job whose UNBOUNDED cron line was measured piling
+            # up fourteen concurrent instances, the oldest 45 minutes old
+            # (2026-07-18) — the incident that motivated the guard.
+            command="/usr/bin/timeout 300 sac agents reconcile --apply",
             description=(
                 "The enforcer of 'should be running => is running'. Restarts "
                 "agents whose tmux session is GONE while their spec asks to be "
@@ -63,17 +74,18 @@ def liveness_jobs() -> "list[JobSpec]":
             # read each — cheap enough to run often.
             on_boot_sec="5min",
             on_unit_active_sec="5min",
-            # A no-op pass takes ~seconds; this bounds the pathological one
-            # (`--limit` restarts, each a stop+settle+start). A pass killed at
-            # this timeout is SAFE: the restart history is persisted per
-            # restart, not at the end, so the next tick still honours the
-            # debounce for anything already bounced.
-            timeout_sec=300,
         ),
         JobSpec(
             name="scitex-agent-container-restart-login-expired-agents",
             schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
-            command="sac agents restart-login-expired --apply",
+            # SELF-BOUNDING (300s), mirroring fleet-reconcile: bounds the
+            # pathological pass (`--limit` restarts, each a stop+settle+start)
+            # plus the ~4s capture interval. A pass killed here is SAFE —
+            # history is persisted per restart, so the next tick still honours
+            # the debounce for anything bounced.
+            command=(
+                "/usr/bin/timeout 300 sac agents restart-login-expired --apply"
+            ),
             description=(
                 "Restarts LIVE agents wedged behind a frozen 'Login expired' "
                 "banner (auth-dead but tmux-alive) — the half fleet-reconcile "
@@ -99,10 +111,5 @@ def liveness_jobs() -> "list[JobSpec]":
             # plus two pane captures ~4s apart.
             on_boot_sec="5min",
             on_unit_active_sec="5min",
-            # Mirrors fleet-reconcile: bounds the pathological pass (`--limit`
-            # restarts, each a stop+settle+start) plus the ~4s capture interval.
-            # A pass killed here is SAFE — history is persisted per restart, so
-            # the next tick still honours the debounce for anything bounced.
-            timeout_sec=300,
         ),
     ]

--- a/src/scitex_agent_container/_jobs/_specs_liveness.py
+++ b/src/scitex_agent_container/_jobs/_specs_liveness.py
@@ -23,9 +23,26 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 __all__ = ["liveness_jobs"]
 
 
-def liveness_jobs() -> "list[JobSpec]":
-    """The fleet-liveness JobSpecs, in their historical order."""
+def liveness_jobs(*, executable: str | None = None) -> "list[JobSpec]":
+    """The fleet-liveness JobSpecs, in their historical order.
+
+    ``executable`` is the same test seam :func:`._sac_bin.sac_bin` exposes,
+    threaded through so a test can resolve the payload against a venv-shaped
+    tree it built on disk. Without it the rendered command depends on whether
+    the RUNNING environment happens to have a ``sac`` console script beside
+    its interpreter — true in production, false under a PYTHONPATH-only CI
+    run — and a population guard over these specs would then assert an
+    environmental fact rather than a property of the specs.
+    """
     from scitex_dev.jobs import JobSpec
+
+    from ._sac_bin import sac_bin
+
+    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin`. A bare `sac`
+    # after the absolute `timeout` head is invisible to resolve_execstart
+    # and is looked up on the supervisor's PATH, which is how every sac
+    # job on scitex-compute-01 sat at exit 127 (measured 2026-08-20).
+    sac = sac_bin(executable=executable)
 
     return [
         JobSpec(
@@ -42,7 +59,7 @@ def liveness_jobs() -> "list[JobSpec]":
             # This is the job whose UNBOUNDED cron line was measured piling
             # up fourteen concurrent instances, the oldest 45 minutes old
             # (2026-07-18) — the incident that motivated the guard.
-            command="/usr/bin/timeout 300 sac agents reconcile --apply",
+            command=f"/usr/bin/timeout 300 {sac} agents reconcile --apply",
             description=(
                 "The enforcer of 'should be running => is running'. Restarts "
                 "agents whose tmux session is GONE while their spec asks to be "
@@ -84,7 +101,7 @@ def liveness_jobs() -> "list[JobSpec]":
             # history is persisted per restart, so the next tick still honours
             # the debounce for anything bounced.
             command=(
-                "/usr/bin/timeout 300 sac agents restart-login-expired --apply"
+                f"/usr/bin/timeout 300 {sac} agents restart-login-expired --apply"
             ),
             description=(
                 "Restarts LIVE agents wedged behind a frozen 'Login expired' "

--- a/src/scitex_agent_container/_jobs/_specs_maintenance.py
+++ b/src/scitex_agent_container/_jobs/_specs_maintenance.py
@@ -1,0 +1,177 @@
+"""The housekeeping beat: drift, worktrees, images, freshness.
+
+Split out of :mod:`._jobs_plugin` (at the per-file cap), following the
+convention :mod:`._specs_liveness` established for the same reason.
+
+Unlike the accounts group these four are INDEPENDENT — none depends on
+another's output and any one can be disabled without breaking the rest.
+What makes them one file is the shared property that every one of them
+REPORTS rather than repairs, so a finding is not the unit being
+unhealthy. That distinction is why ``host-sync-check`` carries
+``--exit-zero``; see its comment for the measurement that forced it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.jobs import JobSpec
+
+__all__ = ["maintenance_jobs"]
+
+
+def maintenance_jobs(*, executable: str | None = None) -> "list[JobSpec]":
+    """sac's housekeeping JobSpecs, in their historical order.
+
+    ``executable`` is the same test seam :func:`._sac_bin.sac_bin` exposes,
+    threaded through so a test can resolve the payload against a venv-shaped
+    tree it built on disk. Without it the rendered command depends on whether
+    the RUNNING environment happens to have a ``sac`` console script beside
+    its interpreter — true in production, false under a PYTHONPATH-only CI
+    run — and a population guard over these specs would then assert an
+    environmental fact rather than a property of the specs.
+    """
+    from scitex_dev.jobs import JobSpec
+
+    from ._sac_bin import sac_bin
+
+    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin` for the measurement.
+    sac = sac_bin(executable=executable)
+
+    return [
+        JobSpec(
+            name="scitex-agent-container-host-sync-check",
+            schedule="0 * * * *",  # hourly (cron form; timer cadence below)
+            # SELF-BOUNDING (600s). Sequential per-ssh probe over every peer,
+            # each capped at the verb's 120s default (an unreachable peer
+            # waits its ssh connect-timeout). 600s comfortably covers a
+            # handful of peers including a slow/unreachable one without ever
+            # hanging forever.
+            command=(
+                "/usr/bin/timeout 600 "
+                f"{sac} host sync --check --all --alarm --exit-zero"
+            ),
+            description=(
+                "Read-only drift check of every peer's sac checkout vs the "
+                "centre; records each verdict in sac's own event log so the "
+                "shout is DURABLE. Mutates nothing on any peer — never runs "
+                "the fast-forward remedy (Stage 1). "
+                "--exit-zero because FINDING drift is not this unit being "
+                "unhealthy. MEASURED 2026-08-17: without it, drift exits 1 "
+                "and undetermined exits 2, systemd recorded the unit "
+                "`failed`, compute-04 went `degraded`, and the dotfiles sync "
+                "installer read `is-system-running: degraded` as 'systemd "
+                "absent' and silently refused to install its timer — so that "
+                "host stopped receiving dotfiles sync altogether. The verdict "
+                "still reaches its real readers: the printed report, the JSON "
+                "`exit_code`, and the --alarm event-log record."
+            ),
+            kind="timer",
+            # First check 10min after boot/login (peers reachable, listen
+            # settled), then hourly. Drift is slow-moving relative to the
+            # 2h token refresh, so hourly is ample and gentle on ssh.
+            on_boot_sec="10min",
+            on_unit_active_sec="1h",
+        ),
+        JobSpec(
+            name="scitex-agent-container-worktree-gc",
+            schedule="30 4 * * *",  # daily 04:30 (cron form; timer cadence below)
+            # SELF-BOUNDING (900s). A pass is a handful of local `git` calls
+            # per worktree plus one `gh pr list` per unmerged branch (the
+            # squash-merge leg). A repo deep in sprawl with a slow/
+            # rate-limited gh is the worst case; 900s covers the whole
+            # fleet's repos without ever hanging forever. Every gh failure
+            # already degrades to KEEP, so a timeout costs a skipped reap,
+            # never a wrong one.
+            command=f"/usr/bin/timeout 900 {sac} worktree gc --apply --all --exit-zero",
+            description=(
+                "Daily git-worktree GC: removes only worktrees PROVEN safe "
+                "(clean AND merged AND older than 24h AND not in use — never "
+                "--force), prunes admin refs whose directory is already gone, "
+                "and records any repo still over its worktree cap in sac's "
+                "own event log (recorded as recovered when it drops back under). "
+                "The permanent countermeasure to worktree sprawl."
+            ),
+            kind="timer",
+            # Sprawl accumulates over days, not minutes, and the age gate is
+            # 24h — so a daily pass is the natural cadence and a faster one
+            # could not remove anything a daily one would miss. 20min after
+            # boot keeps it clear of the login/auth settling window.
+            on_boot_sec="20min",
+            on_unit_active_sec="1d",
+        ),
+        JobSpec(
+            name="scitex-agent-container-spartan-sif-bake",
+            schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
+            # SELF-BOUNDING (14400s = 4h), and the one where the bound
+            # matters most: at a */10 cadence an UNBOUNDED bake outlives its
+            # own tick by design, so a wedged run would pile up against every
+            # later one. Two full bakes (base ~15-25min + scitex ~10-20min)
+            # plus a multi-GB pull on a slow link fit comfortably; the
+            # per-leg ssh timeout inside the command is 7200s, so 4h bounds
+            # the whole chain without ever killing a legitimate run.
+            command=f"/usr/bin/timeout 14400 {sac} image bake-remote --yes",
+            description=(
+                "10-minute SIF refresh with zero master CPU: bake sac-base + "
+                "sac-scitex on the standing Spartan CPU lease (srun "
+                "--overlap into the job resolved BY NAME, never sbatch), "
+                "gate at build time (.def %post symbol gate) AND on the "
+                "artifact (apptainer-exec symbol probe), keep-3 rotate the "
+                "Spartan store, then PULL via rsync-over-ssh, re-verify "
+                "here (sha256 + the same symbol probe on the received "
+                "file) and only then atomically swap both live "
+                "sac-<layer>.sif symlinks + keep-3 rotate locally. A "
+                "failed leg leaves the live image untouched and exits "
+                "non-zero; a source-unchanged run is a loud SKIPPED, not "
+                "a transfer."
+            ),
+            kind="timer",
+            # 10min: the image is a point-in-time snapshot of @develop, and at
+            # our release rate a DAY-old SIF is mostly wrong. 30min was read
+            # off the operator's 「最低でも30分に1回」 — but that was his FLOOR,
+            # not his target (「なんで三十分に一回だけなの？」; 「例えば1分に1回焼いても
+            # 全く問題ないです」), so the cadence is set to what he wants, not to
+            # the minimum he would tolerate.
+            #
+            # Cheap by construction, which is what makes a 10min tick sane: a
+            # source-unchanged run is a SKIPPED verdict (check a git ref, one
+            # ssh round-trip, no transfer), so only a real @develop change ever
+            # costs a bake. A bake takes 8-30min, so at */10 most ticks land
+            # while one is still running — the script's `flock -n` makes those
+            # exit "already-running" immediately instead of piling up, which is
+            # exactly what that lock is for. The operator has separately
+            # accepted overlap outright (the swap is an atomic symlink flip at
+            # the end). Steady state: skip, skip, skip, … one real bake when
+            # something changed, the rest of that window bouncing off the lock.
+            on_boot_sec="30min",
+            on_unit_active_sec="10min",
+        ),
+        JobSpec(
+            name="scitex-agent-container-freshness-refresh",
+            schedule="7 * * * *",  # hourly (cron form; timer cadence below)
+            # SELF-BOUNDING (300s). Generous on purpose, matching the
+            # primitive's own 30s per-source timeouts: a busy host must not
+            # be mistaken for a broken one, and a manufactured UNKNOWN is
+            # exactly the failure mode. Nothing is waiting on this run.
+            command=f"/usr/bin/timeout 300 {sac} freshness refresh",
+            description=(
+                "Publishes the version-currency verdict to the cache that "
+                "every `sac` invocation reads. Runs the real checks (PyPI, "
+                "git tags, gh release runs, systemd running-vs-installed, "
+                "symbol probes) via scitex-dev's `versioning` primitive and "
+                "writes the result atomically. This is the half that pays "
+                "the network cost, so the CLI hot path never does — without "
+                "it the startup banner has nothing to read and stays "
+                "permanently silent."
+            ),
+            kind="timer",
+            # Hourly against the primitive's 24h cache TTL: 24 consecutive
+            # misses before the banner falls silent, so a laptop that is shut
+            # most of the day still has a trustworthy answer. Faster buys
+            # nothing — releases are not more frequent than hourly — and each
+            # pass makes real network calls.
+            on_boot_sec="25min",
+            on_unit_active_sec="1h",
+        ),
+    ]

--- a/src/scitex_agent_container/_lifecycle/_argv_drift.py
+++ b/src/scitex_agent_container/_lifecycle/_argv_drift.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Compare a RUNNING agent's argv against the flags its spec declares.
+
+A spec file is INTENT. A process holds the argv it was launched with.
+Nothing in the fleet compared the two, and that gap hid three separate
+defects on 2026-08-19 alone:
+
+* ``--effort low`` was added to 20 handyman specs and was present in
+  exactly ONE running process. The other agents had started before the
+  edit and were still running at default effort — the operator's cost
+  instruction was satisfied on disk and not in the fleet.
+* ``business``'s ``--env BUN_BIN=...`` was reverted in its spec and
+  stayed intact in the running process, so nothing looked wrong; it
+  would have surfaced only at the next restart, as a missing variable
+  with no obvious cause.
+* The cross-host spec guard, which compares spec against spec, is
+  structurally blind to both.
+
+All three share one shape: **the file changed and the process did not**,
+and every surface that reads only files reports green.
+
+WHY THIS COMPARES FLAGS AND NOT THE WHOLE ARGV
+----------------------------------------------
+Reconstructing the full launch argv and diffing it would be a stricter
+check and a useless one: it carries values that legitimately differ per
+launch (a2a port, session id, resume target, transcript home). Those
+would dominate the output and every agent would report DIFFERS, which
+is the fastest way to teach people to ignore a check.
+
+``spec.claude.flags`` is the honest unit. Its contract is exact — each
+element becomes ONE argv token, appended verbatim — so its presence in
+the running argv is decidable without modelling anything else.
+
+THREE VALUES, NEVER TWO
+-----------------------
+``CANNOT_DETERMINE`` is not a courtesy; it is the point. Tonight's
+failures were all instruments whose "clean" and "could not look" printed
+identically — a truncated listing read as absence, a spec-vs-spec guard
+that cannot see a process, a status probe that says "real absence" about
+another host. A drift check that answered only MATCHES/DIFFERS would
+join them: an agent with no readable process would report MATCHES and
+mean nothing by it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+MATCHES = "matches"
+DIFFERS = "differs"
+CANNOT_DETERMINE = "cannot-determine"
+
+
+@dataclass(frozen=True)
+class ArgvDrift:
+    """One agent's verdict.
+
+    ``missing`` names the spec tokens absent from the running argv, so
+    the report is actionable ("running without --effort low") rather
+    than merely negative ("differs").
+    """
+
+    agent: str
+    verdict: str
+    reason: str | None = None
+    missing: tuple[str, ...] = ()
+    pid: int | None = None
+
+    @property
+    def is_drifted(self) -> bool | None:
+        """``True``/``False``, or ``None`` when it could not be decided.
+
+        Callers must handle the ``None``. A guard that treats it as
+        falsey silently converts "I could not look" into "nothing
+        wrong", which is the defect this module exists to expose.
+        """
+        if self.verdict == CANNOT_DETERMINE:
+            return None
+        return self.verdict == DIFFERS
+
+    def describe(self) -> str:
+        if self.verdict == CANNOT_DETERMINE:
+            return f"{self.agent}: CANNOT DETERMINE — {self.reason}"
+        if self.verdict == MATCHES:
+            return f"{self.agent}: running argv carries every declared flag"
+        return (
+            f"{self.agent}: running without {' '.join(self.missing)}; "
+            f"its spec declares it. The process predates the spec edit — "
+            f"restart it to apply, or the spec is not in force."
+        )
+
+
+def _contiguous_index(haystack: Sequence[str], needle: Sequence[str]) -> int:
+    """Index of ``needle`` as a contiguous run in ``haystack``, else -1."""
+    n, m = len(haystack), len(needle)
+    if m == 0:
+        return 0
+    for i in range(n - m + 1):
+        if list(haystack[i : i + m]) == list(needle):
+            return i
+    return -1
+
+
+def compare_spec_flags_to_argv(
+    *,
+    agent: str,
+    spec_flags: Sequence[str] | None,
+    running_argv: Sequence[str] | None,
+    pid: int | None = None,
+) -> ArgvDrift:
+    """Decide whether a running process carries the flags its spec declares.
+
+    ``spec_flags`` is ``None`` when the spec could not be loaded, and
+    ``running_argv`` is ``None`` when no process was observed. Both are
+    CANNOT_DETERMINE rather than a verdict — an unreadable input cannot
+    exonerate anything.
+
+    Adjacency is checked, not just membership. ``--effort`` and ``low``
+    must appear as a contiguous run: a flag separated from its value is
+    a different command line, and the inverse error (gluing them into
+    one element, ``--effort ultracode``) left an agent unbootable for 15
+    days without the YAML ever failing to parse.
+    """
+    if spec_flags is None:
+        return ArgvDrift(
+            agent=agent,
+            verdict=CANNOT_DETERMINE,
+            reason="the spec could not be loaded, so there is nothing to compare against",
+            pid=pid,
+        )
+    if running_argv is None:
+        return ArgvDrift(
+            agent=agent,
+            verdict=CANNOT_DETERMINE,
+            reason="no running process was observed for this agent",
+            pid=pid,
+        )
+    if not spec_flags:
+        return ArgvDrift(agent=agent, verdict=MATCHES, pid=pid)
+
+    argv = list(running_argv)
+    missing = tuple(tok for tok in spec_flags if tok not in argv)
+    if missing:
+        return ArgvDrift(
+            agent=agent, verdict=DIFFERS, missing=missing, pid=pid
+        )
+
+    if _contiguous_index(argv, list(spec_flags)) < 0:
+        return ArgvDrift(
+            agent=agent,
+            verdict=DIFFERS,
+            missing=(),
+            reason=(
+                "every declared flag is present but not as one contiguous run; "
+                "a flag separated from its value is a different command line"
+            ),
+            pid=pid,
+        )
+
+    return ArgvDrift(agent=agent, verdict=MATCHES, pid=pid)
+
+
+def summarize(drifts: Sequence[ArgvDrift]) -> str:
+    """One line per agent plus a tally that keeps the three states apart.
+
+    The tally never folds CANNOT_DETERMINE into either column. A run of
+    30 agents where 29 could not be read is not "1 drifted"; it is one
+    finding and 29 unanswered questions, and the summary has to say so.
+    """
+    drifted = [d for d in drifts if d.verdict == DIFFERS]
+    unknown = [d for d in drifts if d.verdict == CANNOT_DETERMINE]
+    ok = [d for d in drifts if d.verdict == MATCHES]
+    lines = [d.describe() for d in drifts]
+    lines.append(
+        f"{len(ok)} in force, {len(drifted)} drifted, {len(unknown)} could not be determined"
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ArgvDrift",
+    "CANNOT_DETERMINE",
+    "DIFFERS",
+    "MATCHES",
+    "compare_spec_flags_to_argv",
+    "summarize",
+]

--- a/src/scitex_agent_container/_lifecycle/_birth_certificate.py
+++ b/src/scitex_agent_container/_lifecycle/_birth_certificate.py
@@ -132,16 +132,21 @@ def spec_git_sha(config_path: str | None, *, timeout_s: float = 5.0) -> str:
 def write_birth_certificate(
     config: Any,
     incarnation_id: str,
-    *,
-    db_path: Path | None = None,
 ) -> bool:
     """Record the birth certificate for ``incarnation_id``. Best-effort.
 
-    Returns True iff the row was written. A failure is LOGGED with its
+    Returns True iff the record was written. A failure is LOGGED with its
     origin and swallowed — the certificate is bookkeeping about a launch
     that already succeeded, and failing the launch over it would destroy
     the very run it documents (same contract as the sibling
     ``record_local_instance`` side-writes).
+
+    ``db_path`` was dropped on 2026-08-19 when the incarnations table moved
+    to per-host PostgreSQL. It named a SQLite file this function no longer
+    writes to, and an ignored parameter in a signature is a lie a caller
+    cannot see through: ``_instances.write_instance_records`` was still
+    threading its own state.db path in here, which would have read as
+    "the certificate lands in that file" long after it stopped being true.
     """
     try:
         spec_id = (
@@ -160,10 +165,9 @@ def write_birth_certificate(
             spec_git_sha=spec_git_sha(spec_id),
             host=None,
             compiled_spec_json=payload,
-            db_path=db_path,
         )
         return True
-    except Exception as exc:  # stx-allow: fallback (reason: the certificate documents a launch that already succeeded; failing the launch over bookkeeping would destroy the run it documents — logged with origin, never silent)
+    except Exception as exc:  # stx-allow: fallback (reason: the certificate documents a launch that already succeeded; failing the launch over bookkeeping would destroy the run it documents. SINK, measured 2026-08-20: logger.error on this module's logger, which for a listen-brokered start reaches journald via sac-listen.service (StandardOutput=journal) and for a direct CLI start reaches the caller's stderr — `journalctl --user | grep 'birth certificate NOT recorded'` is the check)
         logger.error(
             "birth certificate NOT recorded for incarnation %s (agent %s): %s "
             "(origin: _lifecycle/_birth_certificate.write_birth_certificate)",

--- a/src/scitex_agent_container/_lifecycle/_ci_deliver.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_deliver.py
@@ -138,8 +138,11 @@ def deliver_verdict(
 
         failure_streak = failures_since_last_success
 
+    # No `db_path`: the delivered-set moved to PostgreSQL via
+    # scitex_dev.store, which resolves its own target. `db_path` still
+    # reaches `ancestors` below, whose lineage table is still SQLite.
     if already_delivered(
-        repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion, db_path=db_path
+        repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion
     ):
         return {"delivered": [], "skipped": True, "reason": "already-delivered"}
 
@@ -149,14 +152,13 @@ def deliver_verdict(
     # it stall would un-cap the PR on the next tick.
     escalating = False
     if conclusion == "failure":
-        streak = failure_streak(repo=repo, pr=pr, db_path=db_path)
+        streak = failure_streak(repo=repo, pr=pr)
         if streak > CONSECUTIVE_FAILURE_CAP:
             record(
                 repo=repo,
                 pr=pr,
                 head_sha=head_sha,
                 conclusion=conclusion,
-                db_path=db_path,
             )
             return {"delivered": [], "skipped": True, "reason": "streak-capped"}
         escalating = streak == CONSECUTIVE_FAILURE_CAP
@@ -193,7 +195,7 @@ def deliver_verdict(
     # not re-delivered next tick. A total-delivery failure still records —
     # the agent picks the verdict up on its own heartbeat; re-spamming a
     # transiently-unreachable fleet every tick is worse than one miss.
-    record(repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion, db_path=db_path)
+    record(repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion)
     return {
         "delivered": delivered,
         "skipped": False,

--- a/src/scitex_agent_container/_lifecycle/_ci_owner.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_owner.py
@@ -93,8 +93,36 @@ def resolve_owner(
 #: ``gh`` call per repo per tick.
 _CANONICAL_CACHE: dict = {}
 
+#: Cache sentinel. ``None`` is now a MEANINGFUL cached value ("GitHub says this
+#: repo does not exist"), so a plain ``.get(repo)`` returning ``None`` can no
+#: longer be read as "not cached" — that would re-probe every absent repo on
+#: every tick and lose the whole saving.
+_UNCACHED = object()
 
-def _canonical_name_with_owner(repo: str) -> str:
+#: Substrings that mean GitHub ANSWERED and the answer was "no such repository".
+#: Deliberately narrow. The asymmetry is the point: a false ABSENT silently
+#: drops a real repo from the poll set and CI verdicts for it stop arriving with
+#: nothing to notice; a false UNKNOWN merely keeps polling, which is today's
+#: behaviour. So anything not clearly an absence is treated as unknown.
+#: A BARE "not found" is deliberately NOT in this list. It would match
+#: `gh: command not found` — a missing binary, which is the most UNKNOWN
+#: situation there is — and turn it into "every repo is absent", emptying the
+#: poll set on a host where gh simply is not installed. Each marker below has
+#: to name a REPOSITORY.
+_ABSENT_MARKERS = (
+    "could not resolve to a repository",
+    "no such repository",
+    "404: not found",
+)
+
+
+def _says_no_such_repo(stderr: str) -> bool:
+    """True only when gh's stderr states the repository does not exist."""
+    low = (stderr or "").lower()
+    return any(m in low for m in _ABSENT_MARKERS)
+
+
+def _canonical_name_with_owner(repo: str) -> str | None:
     """Return GitHub's canonical ``owner/name`` for ``repo``.
 
     A constructed ``<org>/<project>`` string is a GUESS about who owns the
@@ -110,19 +138,31 @@ def _canonical_name_with_owner(repo: str) -> str:
     previous behaviour, so a gh outage degrades to a guess rather than to
     an empty poll list.
     """
-    cached = _CANONICAL_CACHE.get(repo)
-    if cached is not None:
+    # NOTE the default. Plain ``.get(repo)`` returns None for a MISSING key,
+    # which is indistinguishable from the cached value None ("absent repo") —
+    # so without the sentinel default this returns None for every uncached
+    # repo and never probes at all.
+    cached = _CANONICAL_CACHE.get(repo, _UNCACHED)
+    if cached is not _UNCACHED:
         return cached
     try:
-        from ._github_ci import _run_gh
+        from ._github_ci import _run_gh_probe
 
-        raw = _run_gh(
+        probe = _run_gh_probe(
             ["repo", "view", repo, "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
         )
-    except Exception:  # stx-allow: fallback (gh missing → keep the constructed name)
-        raw = ""
-    resolved = (raw or "").strip()
-    out = resolved if "/" in resolved else repo
+    except Exception:  # stx-allow: fallback (gh missing → UNKNOWN, keep the constructed name)
+        probe = None
+    resolved = (probe.stdout if probe else "").strip()
+    if "/" in resolved:
+        out = resolved
+    elif probe is not None and _says_no_such_repo(probe.stderr):
+        # GitHub answered, and the answer was "there is no such repository".
+        out = None
+    else:
+        # UNKNOWN — network, auth, rate limit, gh missing. Keep the constructed
+        # guess, which is exactly the previous behaviour.
+        out = repo
     _CANONICAL_CACHE[repo] = out
     return out
 
@@ -164,7 +204,23 @@ def tracked_repos(
             continue
         if isinstance(project, str) and project.strip():
             projects.add(project.strip())
-    return sorted({canonicalize(f"{resolved_org}/{p}") for p in projects})
+    # DROP the ones GitHub says do not exist. Measured 2026-08-20: 22 of the 94
+    # names built from agent specs resolve to no repo in either org
+    # (SAC_PLACEHOLDER_PROJECT, <PROJECT>, handyman-01..08, canary-resume-test,
+    # …). Each cost one REST call per tick per host, forever, to be told 404 —
+    # and the poller cannot deliver a verdict for a repo that does not exist, so
+    # polling it was never doing anything but spending the shared budget.
+    #
+    # ``canonicalize`` returns None ONLY for a definite absence; an unknown
+    # answer keeps the constructed guess, so a gh outage still degrades to
+    # today's behaviour rather than to an empty poll list.
+    return sorted(
+        {
+            name
+            for name in (canonicalize(f"{resolved_org}/{p}") for p in projects)
+            if name
+        }
+    )
 
 
 __all__ = [

--- a/src/scitex_agent_container/_lifecycle/_github_ci.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Callable
+from typing import Callable, NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,39 @@ def _run_gh(args: list) -> str:
         logger.warning("_github_ci: gh invocation failed: %s", exc)
         return ""
     return proc.stdout or ""
+
+
+class GhProbe(NamedTuple):
+    """A gh invocation with its failure INTACT.
+
+    ``_run_gh`` deliberately flattens every failure to ``""`` — right for the
+    verdict path, where a missing answer and an unreadable one both mean "no
+    verdict this tick". It is wrong for any caller that must tell "GitHub says
+    this does not exist" from "I could not ask GitHub", because those two
+    warrant opposite actions and ``""`` is the same value for both.
+
+    Added BESIDE ``_run_gh`` rather than widening it: that function has several
+    callers who rely on the flattening, and changing its return shape to serve
+    one new caller would make every one of them handle a case they do not have.
+    """
+
+    stdout: str
+    returncode: int
+    stderr: str
+
+
+def _run_gh_probe(args: list) -> GhProbe:
+    """Run ``gh <args>`` and return stdout, exit code and stderr separately."""
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, check=False
+        )
+    except Exception as exc:  # stx-allow: fallback (gh missing / spawn error is UNKNOWN, not absence — see GhProbe)
+        logger.warning("_github_ci: gh probe failed to spawn: %s", exc)
+        return GhProbe("", -1, str(exc))
+    return GhProbe(proc.stdout or "", proc.returncode, proc.stderr or "")
 
 
 #: REST check-run ``conclusion`` -> the bucket vocabulary `gh pr checks`

--- a/src/scitex_agent_container/_lifecycle/_github_ci.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci.py
@@ -65,7 +65,38 @@ def _run_gh(args: list) -> str:
     return proc.stdout or ""
 
 
-def pr_ci_conclusion(repo: str, pr: int, *, run: GhRunner = _run_gh) -> str:
+#: REST check-run ``conclusion`` -> the bucket vocabulary `gh pr checks`
+#: uses, so the mapping below this stays untouched. Anything unrecognised is
+#: PENDING, never SUCCESS: an unknown state must not read as green.
+_BUCKET_FOR_CONCLUSION = {
+    "success": "pass",
+    "skipped": "skipping",
+    "neutral": "skipping",
+    "failure": "fail",
+    "timed_out": "fail",
+    "action_required": "fail",
+    "startup_failure": "fail",
+    "stale": "fail",
+    "cancelled": "cancel",
+}
+
+#: REST commit-status ``state`` -> the same vocabulary. Same rule: unknown
+#: is pending, not pass.
+_BUCKET_FOR_STATE = {
+    "success": "pass",
+    "failure": "fail",
+    "error": "fail",
+    "pending": "pending",
+}
+
+
+def pr_ci_conclusion(
+    repo: str,
+    pr: int,
+    *,
+    head_sha: str = "",
+    run: GhRunner = _run_gh,
+) -> str:
     """Return the PR's overall CI conclusion.
 
     One of :data:`CONCLUSION_SUCCESS`, :data:`CONCLUSION_FAILURE`,
@@ -77,14 +108,57 @@ def pr_ci_conclusion(repo: str, pr: int, *, run: GhRunner = _run_gh) -> str:
       * else (all ``pass``/``skipping``, non-empty) → ``success``
       * empty list or unparseable output → ``none`` (deliver nothing)
     """
-    raw = run(["pr", "checks", str(pr), "-R", repo, "--json", "bucket"])
+    # REST, not `gh pr checks --json bucket` (a GraphQL POST). See
+    # `list_open_prs` for the quota measurement that forced this.
+    #
+    # PARITY MATTERS HERE AND IS EASY TO GET WRONG. `gh pr checks` merges TWO
+    # GitHub concepts: check-runs (the Actions/App API) AND commit statuses
+    # (the older Status API that external CI still uses). Substituting only
+    # `/check-runs` would silently DROP the statuses — a green verdict that is
+    # green because it stopped looking. MEASURED 2026-08-19 on one open PR per
+    # repo: scitex-agent-container check_runs=8 statuses=0, but scitex-dev
+    # check_runs=16 statuses=1. The status arm is NOT hypothetical today, and
+    # even where it is empty the code must ask, because "no external CI right
+    # now" is a fleet fact and not a guarantee.
+    #
+    # The sha is fetched via REST (`pr_head_sha`, already REST in this
+    # module) when the caller does not supply one; the poll loop already
+    # holds it from `list_open_prs` and should pass it to save the call.
+    # `pr_head_sha` is defined BELOW this function, so it is resolved at
+    # call time rather than at import — Python looks the name up in the
+    # module globals when the call executes, by which point it exists.
+    sha = (head_sha or "").strip()
+    if not sha:
+        sha = pr_head_sha(repo, pr, run=run)
+    if not sha:
+        return CONCLUSION_NONE
+    buckets: set[str] = set()
+
+    raw = run(["api", f"repos/{repo}/commits/{sha}/check-runs?per_page=100"])
     try:
-        rows = json.loads(raw) if raw.strip() else []
+        payload = json.loads(raw) if raw.strip() else {}
     except (ValueError, TypeError):
+        payload = {}
+    for cr in (payload or {}).get("check_runs", []) or []:
+        if not isinstance(cr, dict):
+            continue
+        if str(cr.get("status", "")) != "completed":
+            buckets.add("pending")
+            continue
+        buckets.add(_BUCKET_FOR_CONCLUSION.get(str(cr.get("conclusion", "")), "pending"))
+
+    raw_st = run(["api", f"repos/{repo}/commits/{sha}/status"])
+    try:
+        st = json.loads(raw_st) if raw_st.strip() else {}
+    except (ValueError, TypeError):
+        st = {}
+    for one in (st or {}).get("statuses", []) or []:
+        if not isinstance(one, dict):
+            continue
+        buckets.add(_BUCKET_FOR_STATE.get(str(one.get("state", "")), "pending"))
+
+    if not buckets:
         return CONCLUSION_NONE
-    if not isinstance(rows, list) or not rows:
-        return CONCLUSION_NONE
-    buckets = {str(r.get("bucket", "")) for r in rows if isinstance(r, dict)}
     if buckets & _FAILING_BUCKETS:
         return CONCLUSION_FAILURE
     if "pending" in buckets:
@@ -136,16 +210,21 @@ def list_open_prs(repo: str, *, run: GhRunner = _run_gh) -> list:
     for the dedup key, body for the ``Owner:`` fallback). Unparseable /
     empty output → ``[]`` (the tick polls nothing for this repo).
     """
+    # REST, not `gh pr list --json`. MEASURED 2026-08-19: this poller ran on
+    # five hosts against one account and burned 10,634 GraphQL points/hour
+    # against a 5,000/hour pool — the account was dead for 32 minutes of every
+    # hour and every agent's PR operations failed during that window. `gh pr
+    # list --json` is a GraphQL POST; `gh api repos/<r>/pulls` is REST, and
+    # REST sat at 4,300/5,000 unused throughout. Same data, the other pool.
+    #
+    # `head_sha_for` in this same module already uses REST for exactly this
+    # reason; this call site simply had not followed it.
     raw = run(
         [
-            "pr",
-            "list",
-            "-R",
-            repo,
-            "--state",
-            "open",
-            "--json",
-            "number,headRefOid,body",
+            "api",
+            f"repos/{repo}/pulls?state=open&per_page=100",
+            "--jq",
+            "[.[] | {number: .number, headRefOid: .head.sha, body: .body}]",
         ]
     )
     try:

--- a/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
@@ -134,11 +134,21 @@ async def github_ci_poll_loop(
         # the listen server even after bind.
         for repo in list(repos_source()):
             for pr in list_prs(repo):
+                head_sha = pr.get("head_sha", "")
                 deliver(
                     repo,
                     pr["number"],
-                    pr.get("head_sha", ""),
-                    conclusion_for(repo, pr["number"]),
+                    head_sha,
+                    # PASS THE SHA WE ALREADY HAVE. ``pr_ci_conclusion`` falls
+                    # back to its own ``gh api repos/<r>/pulls/<n>`` lookup when
+                    # ``head_sha`` is empty, and ``list_open_prs`` has ALREADY
+                    # returned it in the very dict being read on this line — so
+                    # omitting it bought a third REST call per PR per tick for
+                    # a value sitting in local memory. The source comment on
+                    # ``pr_ci_conclusion`` asked for this ("the poll loop
+                    # already holds it ... and should pass it to save the
+                    # call"); it had simply never been done.
+                    conclusion_for(repo, pr["number"], head_sha=head_sha),
                     pr_body=pr.get("body", ""),
                 )
 
@@ -157,7 +167,7 @@ async def github_ci_poll_loop(
                 )
             except asyncio.CancelledError:
                 raise
-            except Exception as exc:  # stx-allow: fallback (loop must survive a transient GitHub/registry error; logged, retried next tick)
+            except Exception as exc:  # stx-allow: fallback (loop must survive a transient GitHub/registry error; retried next tick). SINK, measured 2026-08-20: logger.warning on this module's logger, which reaches journald because the poller only ever runs inside `sac listen` and sac-listen.service is a systemd user unit with the default StandardOutput=journal — `journalctl --user -u sac-listen.service | grep github_ci_poll_loop` is the check, and it is how the abandoned-tick ERRO on the line below was actually found today.
                 logger.warning(
                     "github_ci_poll_loop: tick failed (%s); retry next tick", exc
                 )

--- a/src/scitex_agent_container/_lifecycle/_instances.py
+++ b/src/scitex_agent_container/_lifecycle/_instances.py
@@ -299,7 +299,12 @@ def record_local_instance(
     # sibling side-writes above — see ``_birth_certificate``.
     from ._birth_certificate import write_birth_certificate
 
-    write_birth_certificate(config, instance_id, db_path=db_path)
+    # No ``db_path``: the certificate went to per-host PostgreSQL on
+    # 2026-08-19. This function's own ``db_path`` still names the SQLite
+    # state.db that ``record_local_instance`` above writes to — the two
+    # records now live in two different databases, which is exactly what
+    # the migration is doing, one table at a time.
+    write_birth_certificate(config, instance_id)
     return instance_id
 
 

--- a/src/scitex_agent_container/_lifecycle/_launch_fatal.py
+++ b/src/scitex_agent_container/_lifecycle/_launch_fatal.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Did apptainer refuse to create the container for THIS launch?
+
+Extracted from :mod:`._launch_verify` (512-line cap) because it answers a
+different question from the rest of that module. ``_launch_verify`` weighs
+evidence about whether an agent came up; this reads a boot log and decides
+whether apptainer said it never started. The rules here — which files to
+look at, how to tell this launch's log from the previous launch's, what
+filesystem mtime granularity does to that comparison — are self-contained
+and have nothing to do with heartbeats or poll windows.
+
+WHY THIS EXISTS AT ALL
+======================
+Operator instruction, 2026-08-20:
+
+    「アップテーナーのフェイタルを握り潰さないで、再テックスロギングで
+      つないでください。で、うるさく失敗させてください」
+
+Do not swallow apptainer's FATAL; route it through scitex-logging; fail
+loudly. The reporting half already did that — ``cli_pkg.lifecycle.
+_start_verify_report`` sends every negative verdict through ``system_msg``
+and returns False so the caller exits non-zero. What was missing was any
+path that REACHED it: the verdict loop returned ``verified-up`` the moment
+it saw a fresh heartbeat, and never looked at the boot log.
+
+WHY A FATAL OUTRANKS A HEARTBEAT
+================================
+A FATAL is positive evidence that the container was never created. A beat
+is weaker evidence of success than a FATAL is of failure, and measurably
+so: of ~118 heartbeats across the fleet on 2026-08-19, all but one were
+written by ``listen-tui-observer`` rather than by the runner itself. So a
+beat can be an observer's write about a container that does not exist,
+while a FATAL can only have been produced by apptainer refusing to make
+one.
+
+BLAST RADIUS, measured before shipping
+======================================
+50 boot logs across four hosts on 2026-08-20: ZERO contain a FATAL. So
+this check changes no start that happens today; it fires only when
+apptainer actually refuses. That measurement is why this fix shipped when
+three earlier candidates did not — they would have refused 83 of 121 bind
+sources, 29 of 29 heartbeats, and 117 of 118 launches respectively.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["FATAL_PREFIX", "MTIME_SLACK_S", "apptainer_fatal"]
+
+#: apptainer prefixes its fatal diagnostics with this, at line start.
+FATAL_PREFIX = "FATAL"
+
+#: Slack on the "was this log written by THIS launch" comparison.
+#:
+#: MEASURED, not guessed. The first version compared ``st_mtime`` against
+#: ``launched_at`` directly and the tests went red with the verdict still
+#: ``verified-up`` — a FATAL written milliseconds after launch was being
+#: skipped as stale. ``launched_at`` carries sub-second precision from
+#: ``time.time()`` while a filesystem mtime can be coarser, so the log of
+#: the very launch being verified can stamp BELOW its own launch instant.
+#:
+#: Two seconds absorbs that granularity and nothing more: a genuinely
+#: stale FATAL comes from a previous start, which is minutes or hours old,
+#: so widening the guard by two seconds does not weaken it.
+MTIME_SLACK_S = 2.0
+
+
+def apptainer_fatal(
+    state_dir: Path,
+    names: tuple[str, ...],
+    *,
+    launched_at: float,
+) -> tuple[Path, str] | None:
+    """The apptainer FATAL line from THIS launch, or ``None``.
+
+    Returns the log file and the first ``FATAL...`` line in it.
+
+    THE FRESHNESS CHECK IS NOT OPTIONAL
+    ===================================
+    ``boot.stderr.log`` is not truncated per launch, so a FATAL from a
+    start that failed yesterday is still on disk today. Without it this
+    function would fail every subsequent start of an agent that once
+    failed — converting silent success into permanent silent failure,
+    which is worse than the defect it fixes. Only a log modified at or
+    after ``launched_at`` (less :data:`MTIME_SLACK_S`) testifies about
+    this launch.
+
+    A file that cannot be read is treated as "no FATAL found", never as a
+    failure. This is one input to a verdict, and an unreadable log must
+    not manufacture a failure on its own — the caller's DEAD-process probe
+    and window expiry still decide.
+    """
+    floor = launched_at - MTIME_SLACK_S
+    for name in names:
+        candidate = state_dir / name
+        if not candidate.is_file():
+            continue
+        try:
+            if candidate.stat().st_mtime < floor:
+                continue
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+        except OSError:  # stx-allow: fallback (reason: an unreadable log is absence of evidence, never evidence of failure; the caller's DEAD probe and window expiry still decide)
+            continue
+        for line in text.splitlines():
+            if line.startswith(FATAL_PREFIX):
+                return candidate, line.strip()
+    return None

--- a/src/scitex_agent_container/_lifecycle/_launch_verify.py
+++ b/src/scitex_agent_container/_lifecycle/_launch_verify.py
@@ -224,18 +224,50 @@ def _iso(ts: float) -> str:
     return datetime.fromtimestamp(ts).astimezone().isoformat(timespec="seconds")
 
 
-def _runtime_reports_running(runtime: Any, config: Any) -> bool:
-    """The runtime's own liveness probe — a RAISING probe is UNKNOWN.
+#: Tri-state liveness readings from a runtime's own probe. ``UNKNOWN`` is
+#: the value the boolean form could not express, and its absence was a
+#: live defect: see :func:`_runtime_liveness`.
+PROBE_RUNNING = "running"
+PROBE_DEAD = "dead"
+PROBE_UNKNOWN = "unknown"
+
+
+def _runtime_liveness(runtime: Any, config: Any) -> str:
+    """The runtime's own liveness probe as THREE values, not two.
 
     A probe that could not run must not convict (the false-RED lesson of
-    :mod:`._start_verdict`): treat it as "still possibly alive" so the
-    wait continues and the window expiry reports UNVERIFIED, never a
-    fabricated death.
+    :mod:`._start_verdict`) — but it must not ACQUIT either, and the
+    boolean this replaces could only do one of those. It answered
+    ``True`` both when the runtime reported alive and when the probe
+    raised, so the two callers inherited opposite bugs from one value:
+
+    * the DEAD arm read only ``False``, so ``True`` meaning "unknown"
+      correctly declined to convict. That use was right, and is
+      unchanged.
+    * the TUI arm read ``True`` as PROOF and returned VERIFIED_UP with
+      the words "the tmux pane process is alive" — a claim about an
+      observation that never happened whenever the probe raised. That is
+      the success value doubling as the didn't-check value, on the path
+      109 of 122 fleet specs take (measured 2026-08-20: runtime tui 109,
+      claude-agent-sdk 11, apptainer 2).
+
+    Returning the third value lets each caller say what it actually saw.
     """
     try:
-        return bool(runtime.is_running(config))
-    except Exception:  # stx-allow: fallback (reason: a probe that cannot run is UNKNOWN liveness, not evidence of death — see _start_verdict's false-RED rationale)
-        return True
+        return PROBE_RUNNING if bool(runtime.is_running(config)) else PROBE_DEAD
+    except Exception:  # stx-allow: fallback (reason: a probe that cannot run is UNKNOWN liveness — neither death nor life; the tri-state is precisely so this need not masquerade as either)
+        return PROBE_UNKNOWN
+
+
+def _runtime_reports_running(runtime: Any, config: Any) -> bool:
+    """Back-compat boolean: True unless the probe positively reported DEAD.
+
+    Preserved verbatim in MEANING for the negative arm — only a definite
+    ``PROBE_DEAD`` is falsey — so the caller that convicts on ``False``
+    behaves identically. New code wanting positive evidence must call
+    :func:`_runtime_liveness` and check for ``PROBE_RUNNING``.
+    """
+    return _runtime_liveness(runtime, config) != PROBE_DEAD
 
 
 def verify_launch(
@@ -307,11 +339,29 @@ def _verify_tui(
     """
     waited = max(0.0, now_fn() - launched_at)
     log_path = _first_existing(state_dir, ("boot.stderr.log", "stdout.log"))
-    if _runtime_reports_running(runtime, config):
+    liveness = _runtime_liveness(runtime, config)
+    if liveness == PROBE_RUNNING:
         return LaunchVerdict(
             VERIFIED_UP,
             "ready: boot drain passed and the tmux pane process is alive "
             f"(probed {waited:.1f}s after launch)",
+            str(log_path) if log_path else None,
+            "",
+            waited,
+            None,
+        )
+    if liveness == PROBE_UNKNOWN:
+        # The probe RAISED. Previously this returned VERIFIED_UP with the
+        # words "the tmux pane process is alive" — asserting an
+        # observation that never happened. Report the absence of evidence
+        # instead of inventing evidence of presence; the agent may well be
+        # up, and this says exactly that.
+        return LaunchVerdict(
+            UNVERIFIED,
+            "CANNOT VERIFY: the runtime's own liveness probe could not run "
+            f"({waited:.1f}s after launch), so sac has no reading either "
+            "way. The agent may be up — confirm with `tmux ls` or "
+            "`sac agents list <name>`",
             str(log_path) if log_path else None,
             "",
             waited,

--- a/src/scitex_agent_container/_lifecycle/_launch_verify.py
+++ b/src/scitex_agent_container/_lifecycle/_launch_verify.py
@@ -66,7 +66,10 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+
 from typing import Any, Callable
+
+from ._launch_fatal import apptainer_fatal
 
 __all__ = [
     "DEFAULT_POLL_INTERVAL_S",
@@ -339,14 +342,31 @@ def _verify_by_heartbeat(
 ) -> LaunchVerdict:
     """SDK-path verdict — poll for a FRESH heartbeat from a NEW incarnation.
 
-    Per tick, in evidence order: (1) a beat stamped at/after
-    ``launched_at`` (and not the old run's ``stopping`` farewell) proves
-    the new runner booted → VERIFIED_UP; (2) the runtime's own pid probe
-    reporting the container DEAD is definitive → VERIFIED_FAILED with the
-    boot-log tail (``stdout.log`` — apptainer merges the runner's stderr
-    into it, so the Errno 98 / VenvDistributionError text lives there);
+    Per tick, in evidence order:
+
+    (0) an apptainer ``FATAL`` in a boot log written by THIS launch →
+        VERIFIED_FAILED. Checked FIRST, added 2026-08-20 on the
+        operator's instruction, because it is positive evidence the
+        container was never created and it used to be checked LAST — i.e.
+        never, since a heartbeat short-circuits the loop. See
+        :func:`._launch_fatal.apptainer_fatal`.
+    (1) a beat stamped at/after ``launched_at`` (and not the old run's
+        ``stopping`` farewell) → VERIFIED_UP. Note what this does and
+        does not prove: something wrote a beat. Fleet-wide on 2026-08-19
+        all but one of ~118 beats came from ``listen-tui-observer``, not
+        from the runner, which is why (0) must precede it.
+    (2) the runtime's own pid probe reporting the container DEAD is
+        definitive → VERIFIED_FAILED with the boot-log tail
+        (``stdout.log`` — apptainer merges the runner's stderr into it,
+        so the Errno 98 / VenvDistributionError text lives there).
     (3) window expiry with the process still standing → UNVERIFIED, which
-    is exit-nonzero but worded as "could not verify", never "failed".
+        is exit-nonzero but worded as "could not verify", never "failed".
+
+    Every negative verdict reaches the operator through
+    ``cli_pkg.lifecycle._start_verify_report``, which routes it via
+    ``system_msg`` — sac's scitex-logging surface — and returns False so
+    the caller exits non-zero. That plumbing already existed; what was
+    missing was any path that reached it when apptainer had FATAL'd.
     """
     from .._runners._session_state import read_heartbeat
 
@@ -354,6 +374,22 @@ def _verify_by_heartbeat(
     log_candidates = ("stdout.log", "boot.stderr.log")
     deadline = launched_at + window
     while True:
+        # BEFORE the heartbeat, because a FATAL is positive evidence the
+        # container was never created and a beat is not proof it was. See
+        # _apptainer_fatal for the measurement behind that ordering.
+        fatal = apptainer_fatal(state_dir, log_candidates, launched_at=launched_at)
+        if fatal is not None:
+            fatal_log, fatal_line = fatal
+            waited = max(0.0, now_fn() - launched_at)
+            return LaunchVerdict(
+                VERIFIED_FAILED,
+                f"apptainer FATAL {waited:.1f}s after launch — the container "
+                f"was never created: {fatal_line}",
+                str(fatal_log),
+                _tail(fatal_log),
+                waited,
+                str(heartbeat_path),
+            )
         beat = read_heartbeat(state_dir)
         if beat is not None:
             ts = beat.get("ts")

--- a/src/scitex_agent_container/_lifecycle/_rename_spec.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_spec.py
@@ -20,9 +20,18 @@ Touchpoints (the SSOT — :data:`SPEC_TOUCHPOINTS` documents them for
   7. ``spec.apptainer.raw_args`` ``--env K=V`` for K in :data:`ENV_RULES`
   8. ``spec.apptainer.env.<K>`` for K in :data:`ENV_RULES`
 
-``ENV_RULES`` is where the DAMAGING one lives: ``SCITEX_TODO_AGENT_ID``
-is the agent's identity ON THE BOARD. Change it without migrating the
-cards and every card the agent owns is orphaned — see ``_rename_cards``.
+``ENV_RULES`` is where the DAMAGING one lives: the agent's identity ON
+THE BOARD. Change it without migrating the cards and every card the agent
+owns is orphaned — see ``_rename_cards``. FAILING to change it is the
+mirror-image damage: the renamed agent keeps writing under its former
+name, and the board cannot say who those cards belong to.
+
+That identity is spelled ``SCITEX_CARDS_AGENT_ID`` today and
+``SCITEX_TODO_AGENT_ID`` in specs written before the rename. BOTH are in
+``ENV_RULES`` because both are live in the fleet — 108 specs and 193
+specs respectively, measured 2026-08-19. Only the old one was listed
+until then, so renaming any of the 108 silently produced exactly the
+mirror-image damage above.
 
 Why ruamel round-trip and not PyYAML load+dump: specs carry load-bearing
 operator commentary (the live ``scitex-todo`` spec is ~40% comments
@@ -59,6 +68,20 @@ from typing import Any, Iterator
 # renamed.
 ENV_RULES: dict[str, str] = {
     "SCITEX_TODO_AGENT_ID": "identity",
+    # THE CURRENT SPELLING, and it was missing. Measured 2026-08-19 on
+    # compute-04: 108 specs declare SCITEX_CARDS_AGENT_ID and 193 still
+    # declare SCITEX_TODO_AGENT_ID. Only the old name was listed here, so
+    # renaming any of those 108 agents left the board identity pointing at
+    # the agent's FORMER name — and every card it then wrote was attributed
+    # to an agent that no longer exists. Exactly the damage the module
+    # docstring above warns this dict causes when it is wrong.
+    #
+    # BOTH are listed on purpose while both populations exist. This is not a
+    # compatibility fallback to be tidied away: it is the rename tool having
+    # to recognise what is ACTUALLY IN THE SPECS. Drop the old key only when
+    # no spec declares it — the same condition _board_identity_env.py states
+    # for dropping the legacy injection, and it is the same 193 specs.
+    "SCITEX_CARDS_AGENT_ID": "identity",
     "SCITEX_TODO_AGENT": "identity",
     "SAC_NAME": "identity",
     "SCITEX_AGENT_CONTAINER_NAME": "identity",

--- a/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
+++ b/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
@@ -16,6 +16,7 @@ from typing import Any, Callable
 __all__ = [
     "_format_boot_stderr_section",
     "capture_pane_diag",
+    "fresh_retry_hint",
     "raise_start_failure",
 ]
 
@@ -54,6 +55,48 @@ def _format_boot_stderr_section(log: Path) -> str:
 
 
 _NO_PANE = "\n  (no pane diagnostics available)"
+
+
+def fresh_retry_hint(config: Any) -> str:
+    """The one-shot ``--fresh`` escape hatch, as a message section.
+
+    Operator 2026-08-18: 「フレッシュは基本的に使いません、最初の起動に必要な
+    時だけで、スタートした時に失敗したら --fresh を今回だけはつけろ的なヒント
+    をだしてください、スペックは全てレジュームで」 — every spec resumes; a
+    start failure is the one moment where a single fresh retry is the right
+    move, so the failure report is where that hint belongs.
+
+    WHY IT IS CONDITIONAL. A start that was ALREADY fresh cannot be wedged on a
+    resumed session, so naming ``--fresh`` there would be an error asserting a
+    cause it did not observe — the same disease :func:`raise_start_failure`
+    exists to kill. Emitted only when the resolved ``claude.session`` is
+    something other than ``fresh``.
+
+    WHY IT SAYS "ONCE". ``--fresh`` is a per-invocation override, not a spec
+    edit, and the difference matters: the spec must stay on resume, because a
+    fresh start DISCARDS that agent's working memory. Naming the boundary in
+    the hint is the whole point — an unqualified "try --fresh" is how a
+    one-shot recovery becomes a habit that quietly erases the fleet's memory.
+
+    Never raises: ``config`` is whatever the caller had when the start blew up,
+    and a diagnostic must not fail on a stub. An unreadable mode is treated as
+    "not fresh" — the hint is advice, and printing it needlessly costs a line
+    while withholding it costs the operator the recovery.
+    """
+    try:
+        mode = str(getattr(getattr(config, "claude", None), "session", "") or "")
+    except Exception:  # stx-allow: fallback (reason: a diagnostic must never raise over the failure it is describing)
+        mode = ""
+    if mode.strip().lower() == "fresh":
+        return ""
+    name = getattr(config, "name", "<name>")
+    return (
+        "\n  if this start was RESUMING a prior session: a session wedged on a "
+        f"queued\n  boot prompt comes back on every plain restart. Retry ONCE "
+        f"with\n    sac agents start {name} --fresh\n  ONCE — as a per-start "
+        "override, not a spec edit. The spec stays on resume;\n  a fresh start "
+        "discards this agent's working memory."
+    )
 
 
 def raise_start_failure(
@@ -102,10 +145,14 @@ def raise_start_failure(
     # a message blaming the PANE CAPTURE for a failure it never observed (it was
     # a missing directory). That is the same disease the liveness verdict next
     # door exists to kill — an error asserting a cause it did not see.
-    _persist_diag(config, diag)
+    # The recovery hint rides on the SAME suffix as the diagnostics so the
+    # persisted record and the raised error carry it identically — a remedy
+    # only the live terminal saw is lost to whoever reads the log tomorrow.
+    suffix = f"{diag}{fresh_retry_hint(config)}"
+    _persist_diag(config, suffix)
 
     raise RuntimeError(
-        f"Failed to start agent '{config.name}': runtime.start() returned False.{diag}"
+        f"Failed to start agent '{config.name}': runtime.start() returned False.{suffix}"
     )
 
 

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -301,7 +301,7 @@ def check_send_acl(
     # cross-group deny that does push.
     from .._state.state_db_blocks import has_block as _has_block
 
-    if _has_block(sender=sender, target=target, db_path=db_path):
+    if _has_block(sender=sender, target=target):
         return ("block", f"blocked: {sender!r} → {target!r}")
 
     # Phase-3 (ADR-0010 Step 2) — per-spec outbound/inbound deny layered

--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -339,16 +339,37 @@ async def agents_start(request: Request) -> JSONResponse:
             pass
 
         from .._lifecycle._start_decline import start_was_declined
+        from ._start_failure_status import classify_start_failure
 
+        # hub, 2026-08-19: a 5xx cannot distinguish "your request was
+        # wrong" from "the server is broken", and those need opposite
+        # responses from the caller. Every non-zero child exit used to
+        # answer 502, so an UNREGISTERED NAME and a broken container
+        # were the same status. Classify instead; unmatched failures
+        # still answer 502, so this narrows the opaque case rather than
+        # trading it for a guess.
+        #
+        # ``declined`` is computed ONCE and passed in rather than being
+        # re-derived inside the classifier, so the body's field and the
+        # status code can never disagree about the same output.
+        declined = start_was_declined(proc.stdout, proc.stderr)
+        failure = classify_start_failure(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            declined=declined,
+        )
         return JSONResponse(
             {
                 "name": name,
                 "returncode": proc.returncode,
                 "stdout": proc.stdout,
                 "stderr": proc.stderr,
-                "declined": start_was_declined(proc.stdout, proc.stderr),
+                "declined": declined,
+                "kind": failure.kind,
+                "hint": failure.hint,
             },
-            status_code=502,
+            status_code=failure.status,
         )
 
     # Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg

--- a/src/scitex_agent_container/_listen/_agents_list.py
+++ b/src/scitex_agent_container/_listen/_agents_list.py
@@ -188,12 +188,16 @@ async def _annotate_reachability(request: Request, rows: list[dict]) -> list[dic
     healthy agents of being deaf, and the remedy a caller reaches for on a
     false death verdict is destructive.
     """
-    from ._reachability import UNKNOWN, annotate_rows
+    from ._reachability import UNKNOWN, annotate_rows, resolve_annotation_host
 
     try:
         broker = request.app.state.inbox
         counts = await broker.subscriber_counts()
-        local_host = getattr(request.app.state, "local_host", None)
+        # NOT a bare ``app.state.local_host`` read. That is ``None`` in
+        # production (see ``resolve_annotation_host``), and reading it alone is
+        # what kept every row on THIS host annotated ``unknown`` on the very
+        # endpoint the reachability reports come from.
+        local_host = resolve_annotation_host(request.app.state)
     except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict against healthy agents)
         log.warning(
             "list_agents: could not read inbox broker (reporting reachability "

--- a/src/scitex_agent_container/_listen/_inbox_fault.py
+++ b/src/scitex_agent_container/_listen/_inbox_fault.py
@@ -93,14 +93,40 @@ _DETAIL = {
         "scitex-cards card assigned to it), or ask the operator."
     ),
     FAULT_NOT_RUNNING: (
-        "NOT RUNNING — this registry row declares an agent, but no live session "
-        "was observed for it (the probe SUCCEEDED, so this is real absence, not "
-        "a failed look). The row outlived the process. Its 0 inbox subscribers "
-        "mean 'nobody is home', NOT 'a detached adapter': nothing will "
-        "reconnect to drain its queue until someone deliberately starts it, so "
-        "waiting for a reply will never succeed."
+        "NOT RUNNING ON {host} — this registry row declares an agent, and no "
+        "live tmux session for it exists ON THIS HOST. The probe ran and "
+        "observed a real absence HERE; it says nothing about any other host, "
+        "because it can only see {host}'s sessions. If the agent is pinned "
+        "elsewhere the row outlived the process ON THIS HOST ONLY — ASK THAT "
+        "HOST before concluding it is down; `sac agents start <name>` run "
+        "there reports whether it is already running. Once that is ruled out, "
+        "the row outlived the process: its 0 inbox subscribers mean 'nobody "
+        "is home', NOT 'a detached adapter', and nothing will reconnect to "
+        "drain its queue until someone deliberately starts it."
     ),
 }
+
+#: Resolved once. ``gethostname`` is cheap, but this is formatted per ROW on a
+#: fleet-sized response and the value cannot change within a process.
+_THIS_HOST: str | None = None
+
+
+def _this_host() -> str:
+    """This daemon's hostname, for naming the population a probe covered.
+
+    Falls back to the literal ``"this host"`` so the message degrades to the
+    previous, still-honest phrasing rather than raising inside an ADVISORY
+    overlay that must never fail the status route.
+    """
+    global _THIS_HOST
+    if _THIS_HOST is None:
+        try:
+            import socket
+
+            _THIS_HOST = socket.gethostname() or "this host"
+        except Exception:  # stx-allow: fallback (reason: the fault overlay is advisory; a hostname lookup must never fail the status route)
+            _THIS_HOST = "this host"
+    return _THIS_HOST
 
 
 def session_snapshot() -> dict | None:
@@ -241,7 +267,9 @@ def annotate_faults(
         new = dict(row)
         new["fault"] = fault
         if fault is not None:
-            new["fault_detail"] = _DETAIL[fault]
+            # `.format` on a template with no placeholders is a no-op, so the
+            # DEAF entry is unaffected and needs no branch here.
+            new["fault_detail"] = _DETAIL[fault].format(host=_this_host())
         out.append(new)
     return out
 

--- a/src/scitex_agent_container/_listen/_node_channel.py
+++ b/src/scitex_agent_container/_listen/_node_channel.py
@@ -108,7 +108,8 @@ async def node_message_send(request: Request) -> Response:
     # ``metadata.from_agent`` we received, so cross-group denials
     # fire at the receiving host (handoff §4 acceptance).
     from .._state.state_db import _resolve_host as _resolve_local_host
-    from .._state.state_db_nodes import is_local_node, resolve_node_host
+    from .._state.state_db_forward import resolve_forward_target
+    from .._state.state_db_nodes import is_local_node
 
     # Prefer the per-app ``local_host`` configured at ``create_app``
     # time; fall back to the env-based resolver for callers that
@@ -118,13 +119,20 @@ async def node_message_send(request: Request) -> Response:
         None
     )
     if not is_local_node(name=name, local_host=local_host):
-        target_info = resolve_node_host(name=name)
+        # ADDRESSABILITY, not locality. `is_local_node` above answers "which
+        # host", for which a live instances row suffices with or without a
+        # port; this asks "where do I POST", for which it does not. They used
+        # to be one call, so a live row with a NULL port was handed back as
+        # the answer and 502'd here — without ever consulting comms_nodes,
+        # which may hold a working address for the same name.
+        target_info = resolve_forward_target(name=name)
         if target_info is None:
             return JSONResponse(
                 {
                     "error": (
-                        f"target {name!r} resolves to a non-local host but no "
-                        "instance row carries its address — cannot forward"
+                        f"target {name!r} resolves to a non-local host but "
+                        "neither its instance row nor the comms_nodes graph "
+                        "carries a usable address — cannot forward"
                     )
                 },
                 status_code=502,

--- a/src/scitex_agent_container/_listen/_reachability.py
+++ b/src/scitex_agent_container/_listen/_reachability.py
@@ -65,22 +65,69 @@ def _is_locally_observable(row: Mapping[str, Any], local_host: str | None) -> bo
 
     Mirrors the locality rule the publish path already uses
     (:func:`_state.state_db_nodes.is_local_node`): a node whose host we
-    cannot distinguish from our own — including one that declares no host
-    at all — is served by the LOCAL broker, so the local subscriber count
-    is authoritative for it.
+    cannot distinguish from our own is served by the LOCAL broker, so the
+    local subscriber count is authoritative for it.
 
     A row that declares a host we can see is NOT ours is served by a
     different ``sac listen`` process with a different in-memory broker.
     We have no window into it, so we must say :data:`UNKNOWN` rather than
     invent a zero — a fabricated zero would be a false accusation of
     deafness against a perfectly reachable remote agent.
+
+    A MISSING ``host`` IS NOT EVIDENCE OF LOCALITY. It used to be treated
+    as such, and that is how the false accusation above got made anyway:
+    see :func:`_host_from_turn_url` for the measured case. The row's
+    ``turn_url`` is consulted as a fallback, and only a row carrying
+    NEITHER field falls through to "local" — which is the honest reading,
+    because then there genuinely is no host evidence to weigh.
     """
-    host = row.get("host")
+    host = row.get("host") or _host_from_turn_url(row)
     if not isinstance(host, str) or not host:
-        return True  # no host declared → the local publish path serves it
+        return True  # no host evidence at all → the local publish path serves it
     if not local_host:
         return False  # we don't know who WE are → cannot claim locality
     return host == local_host
+
+
+def _host_from_turn_url(row: Mapping[str, Any]) -> str | None:
+    """Recover the row's host from ``turn_url`` when ``host`` is absent.
+
+    A row with no ``host`` key used to be treated as LOCAL outright, and
+    that is the hole: absence of a declaration is absence of INFORMATION,
+    not evidence of locality. Reading it as local lets the local broker's
+    zero subscriber count stand as authoritative for an agent living on
+    another machine — and a fabricated zero is exactly the false
+    accusation the rest of this module is written to avoid.
+
+    Measured 2026-08-19. ``agent_status paper-scitex-clew``, run on
+    compute-04, returned a row with NO ``host`` key and::
+
+        turn_url : http://ywata-note-win:19012/v1/turn
+
+    The agent was alive on compute-02 with a heartbeat 2 seconds old.
+    Because the row looked local, it was annotated ``unreachable``
+    instead of ``unknown``; ``classify_fault``'s cross-host guard
+    (``inbox_reachable == UNKNOWN -> None``) therefore never fired, and
+    the verdict read "NOT RUNNING ... the probe SUCCEEDED, so this is
+    real absence, not a failed look" about a healthy agent on a host
+    this daemon cannot see. The operator and I both believed it.
+
+    So the fix is not new evidence — the row already carried the host in
+    its ``turn_url``. It was simply not consulted.
+
+    Returns ``None`` when there is no usable hostname, which preserves
+    the original "no evidence → local" behaviour for genuinely local
+    rows that declare neither field.
+    """
+    url = row.get("turn_url")
+    if not isinstance(url, str) or not url:
+        return None
+    try:
+        from urllib.parse import urlparse
+
+        return urlparse(url).hostname or None
+    except Exception:  # stx-allow: fallback (reason: a malformed turn_url must not break annotation; falling through to None restores the prior behaviour for this row)
+        return None
 
 
 def annotate_reachability(

--- a/src/scitex_agent_container/_listen/_reachability.py
+++ b/src/scitex_agent_container/_listen/_reachability.py
@@ -57,7 +57,35 @@ __all__ = [
     "UNREACHABLE",
     "annotate_reachability",
     "annotate_rows",
+    "resolve_annotation_host",
 ]
+
+
+def resolve_annotation_host(app_state: Any) -> str | None:
+    """The host identity to weigh rows against, for BOTH annotate paths.
+
+    ``create_app`` declares ``local_host`` and defaults it to ``None``, and
+    the one production caller (``cli_pkg.listen_cmds``) never passes it. So
+    ``app.state.local_host`` is ``None`` in production, always. Read alone it
+    makes :func:`_is_locally_observable` answer ``False`` for every row that
+    carries any host evidence, and every such row is annotated ``unknown`` —
+    including rows on THIS host, whose subscriber count we can see perfectly.
+
+    The env resolver is therefore not a nicety, it is the only thing that
+    supplies an identity in production. It lives here, in one function, for a
+    measured reason: the fallback was added to the single-row path in #1174
+    and NOT to the list path, so ``GET /agents`` — the endpoint ``a2a_peers``
+    reads and the one every "nobody is reachable" report comes through — kept
+    returning ``unknown`` for the whole fleet after the fix shipped. Two call
+    sites asking one question is how half a fix looks like a whole one.
+
+    Returns ``None`` only if the resolver itself cannot answer, which
+    ``_is_locally_observable`` correctly reads as "we don't know who WE are"
+    and degrades to ``unknown`` — never to a fabricated ``unreachable``.
+    """
+    from .._state.state_db import _resolve_host
+
+    return getattr(app_state, "local_host", None) or _resolve_host(None)
 
 
 def _is_locally_observable(row: Mapping[str, Any], local_host: str | None) -> bool:

--- a/src/scitex_agent_container/_listen/_start_failure_status.py
+++ b/src/scitex_agent_container/_listen/_start_failure_status.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Map a failed ``sac agents start`` child onto an HTTP status that means something.
+
+``POST /agents`` answered **502 for every non-zero child exit**, whatever
+the cause. hub hit it standing up a scholar agent on 2026-08-19 and put
+the problem better than the code did:
+
+    a 500 cannot distinguish "your request was wrong" from "the server
+    is broken", and those need OPPOSITE responses from the caller.
+
+They could not tell whether to fix their call or wait for the daemon
+owner, so they waited, and reported a permissions bug that did not
+exist. The body carried the real reason the whole time; the status code
+threw it away.
+
+WHY THE DEFAULT STAYS 502
+-------------------------
+Every unmatched failure keeps today's behaviour. A misclassification is
+harmful in both directions and this picks the direction that is merely
+unhelpful rather than actively misleading:
+
+* a server fault reported as 4xx tells the caller to fix a call that is
+  already correct, and they stop retrying something that would have
+  recovered
+* a caller fault reported as 502 leaves them waiting — bad, but it is
+  the status quo and it does not send them to fix the wrong thing
+
+So a pattern earns a 4xx only when it is unambiguous. Silence maps to
+502, not to a guess.
+
+MATCH ON MARKERS, NOT ON SENTENCES
+----------------------------------
+The patterns below are deliberately short and structural. Matching a
+whole human-readable sentence would make this classifier break the next
+time somebody improves the wording — the message is written for a
+person, and a person's message is not a stable interface.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+SERVER_FAULT = "server-fault"
+UNREGISTERED = "unregistered-agent"
+STALE_SPEC = "stale-spec"
+DECLINED = "declined"
+
+
+@dataclass(frozen=True)
+class StartFailure:
+    """What kind of failure this was, and what the caller should do."""
+
+    status: int
+    kind: str
+    hint: str
+
+    @property
+    def is_caller_fixable(self) -> bool:
+        """``True`` when the caller can act; ``False`` when they must wait."""
+        return 400 <= self.status < 500
+
+
+# An unresolvable / unloadable spec. Both spellings are matched: the
+# resolver's own FileNotFoundError, and the refusal added when the lead
+# credential fallback was removed.
+_UNREGISTERED = re.compile(
+    r"(spec could not be loaded|Agent '[^']*' not found|no such agent)",
+    re.IGNORECASE,
+)
+
+# The drift guard refusing a spec source that is behind its remote. The
+# agent exists and the request is well-formed; the HOST needs a pull, so
+# this is a conflict rather than a bad request or a server fault.
+_STALE_SPEC = re.compile(r"(sac-drift|commit\(s\) BEHIND|STALE)", re.IGNORECASE)
+
+
+def classify_start_failure(
+    *,
+    returncode: int,
+    stdout: str = "",
+    stderr: str = "",
+    declined: bool = False,
+) -> StartFailure:
+    """Classify a failed start into an HTTP status with a reason and a hint.
+
+    ``declined`` comes from the existing
+    :func:`_lifecycle._start_decline.start_was_declined`, which already
+    recognises an agent that refused its own start. It is passed in
+    rather than re-derived so the two can never disagree.
+    """
+    blob = f"{stdout}\n{stderr}"
+
+    # A DECLINE KEEPS 502 — deliberately, and it returns early so no
+    # pattern below can reclassify it.
+    #
+    # It is tempting to call this a client error: it is not a crash, and
+    # 409 reads well. But the caller cannot fix it by changing their
+    # request — the AGENT refused its own start — so a 4xx would tell
+    # them to correct a call that was already correct, which is the
+    # precise harm this module exists to avoid. It is also an existing
+    # wire contract with its own named test
+    # (test_a_declined_brokered_start_returns_502), and narrowing the
+    # opaque 502 does not license redefining the cases that already have
+    # a decided meaning.
+    if declined:
+        return StartFailure(
+            status=502,
+            kind=DECLINED,
+            hint=(
+                "the agent declined its own start; read its stdout for the "
+                "reason rather than retrying"
+            ),
+        )
+
+    if _UNREGISTERED.search(blob):
+        return StartFailure(
+            status=404,
+            kind=UNREGISTERED,
+            hint=(
+                "no spec for this agent on the target host — check the name, "
+                "or deliver the spec there first. This is not a server fault "
+                "and retrying unchanged will not help"
+            ),
+        )
+
+    if _STALE_SPEC.search(blob):
+        return StartFailure(
+            status=409,
+            kind=STALE_SPEC,
+            hint=(
+                "the target host's spec source is behind its remote; pull the "
+                "spec repo on that host, then retry"
+            ),
+        )
+
+    return StartFailure(
+        status=502,
+        kind=SERVER_FAULT,
+        hint=(
+            f"the start subprocess exited {returncode} for a reason this "
+            "daemon does not recognise; read stderr in the body"
+        ),
+    )
+
+
+__all__ = [
+    "DECLINED",
+    "SERVER_FAULT",
+    "STALE_SPEC",
+    "UNREGISTERED",
+    "StartFailure",
+    "classify_start_failure",
+]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -191,20 +191,15 @@ async def _annotate_status_reachability(
     Degrades to ``unknown`` (never ``unreachable``) if the broker cannot be
     read — "I could not check" must not be rendered as death.
     """
-    from ._reachability import UNKNOWN, annotate_reachability
+    from ._reachability import (
+        UNKNOWN,
+        annotate_reachability,
+        resolve_annotation_host,
+    )
 
     try:
         counts = await request.app.state.inbox.subscriber_counts()
-        # Prefer the per-app ``local_host``; fall back to the env resolver —
-        # mirroring ``_node_channel`` for the identical question. The fallback
-        # is load-bearing: ``create_app`` defaults it to None and the one
-        # production caller never passes it, so without this EVERY row with a
-        # host was annotated ``unknown``, including rows on this host.
-        from .._state.state_db import _resolve_host as _resolve_local_host
-
-        local_host = getattr(request.app.state, "local_host", None) or (
-            _resolve_local_host(None)
-        )
+        local_host = resolve_annotation_host(request.app.state)
     except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict)
         import logging
 

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -195,7 +195,16 @@ async def _annotate_status_reachability(
 
     try:
         counts = await request.app.state.inbox.subscriber_counts()
-        local_host = getattr(request.app.state, "local_host", None)
+        # Prefer the per-app ``local_host``; fall back to the env resolver —
+        # mirroring ``_node_channel`` for the identical question. The fallback
+        # is load-bearing: ``create_app`` defaults it to None and the one
+        # production caller never passes it, so without this EVERY row with a
+        # host was annotated ``unknown``, including rows on this host.
+        from .._state.state_db import _resolve_host as _resolve_local_host
+
+        local_host = getattr(request.app.state, "local_host", None) or (
+            _resolve_local_host(None)
+        )
     except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict)
         import logging
 

--- a/src/scitex_agent_container/_state/event_log.py
+++ b/src/scitex_agent_container/_state/event_log.py
@@ -34,6 +34,36 @@ DEFAULT_CAP_LINES = 500
 PREVIEW_MAX_CHARS = 300
 
 
+def _redacted_preview(text: Any) -> str:
+    """Redact secret-shaped values, THEN truncate to the preview cap.
+
+    Every preview this module writes lands in a DURABLE per-agent JSONL under
+    the events root. Tool inputs and tool responses are arbitrary text an agent
+    happened to handle, so anything the agent read — a credential file, an
+    environment dump, a command that echoed a token — was being written to disk
+    in cleartext and kept.
+
+    Redaction runs BEFORE truncation so the matcher always sees the whole
+    string. Stated honestly: against the CURRENT patterns that ordering is
+    defence in depth rather than a demonstrated fix — a truncated ``sk-ant-``
+    fragment still matches its own pattern, so truncate-first would usually
+    redact too. The order is chosen because it cannot be worse and because the
+    pattern set is expected to grow: any future pattern anchored on a suffix,
+    a length, or a checksum WOULD be defeated by seeing 300 characters instead
+    of the text. Do not reorder these two steps to save a slice.
+
+    ``_redact_secrets`` is imported, never modified — it already has three
+    other consumers (interactive_login, agent_meta, config_files) and widening
+    it for this caller would change their output too.
+    """
+    from ._meta.secrets import _redact_secrets
+
+    s = text if isinstance(text, str) else str(text)
+    if not s:
+        return ""
+    return _redact_secrets(s)[:PREVIEW_MAX_CHARS]
+
+
 def _default_root() -> Path:
     """Resolve the per-agent events ring-buffer root.
 
@@ -86,7 +116,7 @@ def _preview_tool_input(tool_name: str, tool_input: dict | None) -> str:
         s = ""
     if not isinstance(s, str):
         s = str(s)
-    return s[:PREVIEW_MAX_CHARS]
+    return _redacted_preview(s)
 
 
 def append_event(
@@ -119,10 +149,10 @@ def append_event(
                         content = " ".join(
                             c.get("text", "") for c in content if isinstance(c, dict)
                         )
-                    record["result_preview"] = str(content)[:PREVIEW_MAX_CHARS]
+                    record["result_preview"] = _redacted_preview(content)
         if kind == "prompt":
             prompt = payload.get("prompt") or payload.get("user_prompt") or ""
-            record["prompt_preview"] = str(prompt)[:PREVIEW_MAX_CHARS]
+            record["prompt_preview"] = _redacted_preview(prompt)
         if kind == "stop":
             record["stop_hook_active"] = bool(payload.get("stop_hook_active"))
 

--- a/src/scitex_agent_container/_state/grant_flush.py
+++ b/src/scitex_agent_container/_state/grant_flush.py
@@ -79,7 +79,7 @@ def unblock_and_clear_pending(
 
     grant_send(sender=sender, target=target, db_path=db_path, note=note)
     unblocked = unblock_send(sender=sender, target=target, db_path=db_path)
-    cleared = clear_pending_prompt(sender=sender, target=target, db_path=db_path)
+    cleared = clear_pending_prompt(sender=sender, target=target)
     return {
         "sender": sender,
         "target": target,
@@ -124,7 +124,7 @@ def block_and_clear_pending(
     from .state_db_pending_approval import clear_pending_prompt
 
     block_send(sender=sender, target=target, db_path=db_path, note=note)
-    cleared = clear_pending_prompt(sender=sender, target=target, db_path=db_path)
+    cleared = clear_pending_prompt(sender=sender, target=target)
     return {
         "sender": sender,
         "target": target,

--- a/src/scitex_agent_container/_state/grant_flush.py
+++ b/src/scitex_agent_container/_state/grant_flush.py
@@ -78,7 +78,7 @@ def unblock_and_clear_pending(
     from .state_db_pending_approval import clear_pending_prompt
 
     grant_send(sender=sender, target=target, db_path=db_path, note=note)
-    unblocked = unblock_send(sender=sender, target=target, db_path=db_path)
+    unblocked = unblock_send(sender=sender, target=target)
     cleared = clear_pending_prompt(sender=sender, target=target)
     return {
         "sender": sender,
@@ -123,7 +123,7 @@ def block_and_clear_pending(
     from .state_db_blocks import block_send
     from .state_db_pending_approval import clear_pending_prompt
 
-    block_send(sender=sender, target=target, db_path=db_path, note=note)
+    block_send(sender=sender, target=target, note=note)
     cleared = clear_pending_prompt(sender=sender, target=target)
     return {
         "sender": sender,

--- a/src/scitex_agent_container/_state/inbound_ledger.py
+++ b/src/scitex_agent_container/_state/inbound_ledger.py
@@ -1,99 +1,218 @@
 """Inbound dispatch ledger — one row per INBOUND dispatch awaiting a
-completion report (2026-06-18).
+completion report (2026-06-18), on PostgreSQL only.
 
-The receiver-side mirror of :mod:`dispatch_ledger` (which is the SENDER's
-outbound record). It exists for the ``runtime: tui`` push-feedback loop:
-a TUI agent has no in-process turn envelope, so the requester identity
-(``from_agent`` + ``dispatch_id``) of a bus-pushed wake cannot ride the
-tmux-injected text from the host-side bridge through to the in-container
-``Stop`` hook that reports completion. This SQLite table is that bridge —
-the SAME ``state.db`` is bound into the container (``/state/<name>``), so
-the host-side writer and the in-container reader share it (WAL +
-``busy_timeout`` from :func:`state_db.open_db` make the cross-process
-access safe).
+The receiver-side mirror of :mod:`dispatch_ledger` (the SENDER's outbound
+record). It exists for the ``runtime: tui`` push-feedback loop: a TUI agent
+has no in-process turn envelope, so the requester identity (``from_agent`` +
+``dispatch_id``) of a bus-pushed wake cannot ride the tmux-injected text from
+the host-side bridge through to the in-container ``Stop`` hook that reports
+completion. This ledger is that bridge.
 
 Lifecycle of one row:
 
   * ``pending``   — the bridge recorded a requester-bearing inbound wake
     (:func:`record_inbound`); the turn is queued/running in the TUI.
-  * ``reporting`` — the Stop hook atomically CLAIMED the oldest pending
-    row (:func:`claim_oldest_pending`) to push its completion. The claim
-    is a single ``UPDATE`` so two concurrent Stop hooks (or a retry)
-    cannot double-report the same dispatch.
-  * ``reported`` / ``failed`` — terminal, set by :func:`mark_reported`
-    after the completion push to the requester succeeds / fails loud.
+  * ``reporting`` — the Stop hook atomically CLAIMED the oldest pending row
+    (:func:`claim_oldest_pending`) to push its completion.
+  * ``reported`` / ``failed`` — terminal, set by :func:`mark_reported` after
+    the completion push to the requester succeeds / fails loud.
 
 FIFO by ``ts`` + sequential TUI turn processing keeps the dispatch↔turn
 correlation correct: the Nth ``Stop`` claims the Nth recorded dispatch.
 
-Sibling-module rationale (carried from :mod:`dispatch_ledger`): the table
-+ its ``CREATE TABLE IF NOT EXISTS`` live here behind
-:func:`init_inbound_schema`, layered on top of ``state_db`` via
-``open_db``, so this feature never edits the same lines as a concurrent
-``state_db.py`` restructure.
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to
+PostgreSQL: "fail fast, fail loud, no fallbacks". This is the fourth table to
+move, after ``verdict_delivered``, ``incarnations`` and ``pending_prompts``,
+and it moves the same way — by ADOPTING :mod:`scitex_dev.store` rather than
+by sac growing a private psycopg layer. ``db_path`` is gone from every
+function; it named a SQLite file and there is no file.
+
+The old module's own rationale for the cross-process bridge — "the SAME
+state.db is bound into the container so the host-side writer and the
+in-container reader share it" — is what PostgreSQL now provides directly,
+and better: the two processes no longer need a shared mount, only a reachable
+endpoint.
+
+THE AUTOINCREMENT ID WAS NEVER PUBLIC IN EFFECT
+===============================================
+``id INTEGER PRIMARY KEY AUTOINCREMENT`` looked like the hard part: it is
+returned by ``record_inbound`` and taken by ``mark_reported``, so porting to a
+store with no counter looked like it forced a surrogate — and surrogate ids do
+not survive a store boundary, which this fleet has already paid for once.
+
+Measured 2026-08-20 before assuming it:
+
+    record_inbound's return value, consumed in PRODUCTION:  NONE
+      runtimes/_tui_outbound.py returns it from a wrapper; no caller binds it.
+    mark_reported's argument in PRODUCTION:  always claim-derived
+      row_id = int(claimed["id"])  ->  mark_reported(row_id, ...)
+
+So the id only ever ROUND-TRIPS claim -> settle inside one Stop-hook call. It
+never crosses a process boundary, is never persisted elsewhere, and is never
+compared. Its integer-ness was an artifact of how SQLite minted it, not a
+property anything depended on. The natural key replaces it outright.
+
+IDENTITY IS TOTAL, WHICH TOOK ONE DECISION
+==========================================
+``(agent, from_agent, dispatch_id, ts)``. ``dispatch_id`` is optional at the
+call site, and store IDENTITY fields must be present, so a missing one is
+stored as ``""`` — read it as "this wake carried no dispatch id", the same
+thing the SQLite ``NULL`` meant.
+
+That leaves one collision: two wakes for the same agent, from the same peer,
+with no dispatch id, in the SAME float instant. ``time.time()`` is
+microsecond-resolution and a TUI wake is a human-or-bus event, so it is not
+credible — but "not credible" is exactly the assumption that bites, and the
+SQLite counter made duplicates free. So the insert RETRIES with the timestamp
+advanced by one microsecond instead of failing or overwriting. Deterministic,
+preserves FIFO order, and needs no counter.
 """
 
 from __future__ import annotations
 
-import sqlite3
 import time
-from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-# Row lifecycle. ``record_inbound`` always writes ``pending``; the Stop
-# hook claims to ``reporting`` then settles to ``reported`` / ``failed``.
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "inbound_dispatches"
+
+#: Every write from this host is attributed to one node. The bridge that
+#: records and the Stop hook that claims both run on this host, so
+#: SINGLE_WRITER is honest rather than convenient.
+_ACTOR = "scitex-agent-container"
+
+#: Row lifecycle. ``record_inbound`` always writes ``pending``; the Stop hook
+#: claims to ``reporting`` then settles to ``reported`` / ``failed``.
 STATUS_PENDING = "pending"
 STATUS_REPORTING = "reporting"
 STATUS_REPORTED = "reported"
 STATUS_FAILED = "failed"
 VALID_STATUSES = (STATUS_PENDING, STATUS_REPORTING, STATUS_REPORTED, STATUS_FAILED)
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS inbound_dispatches (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    agent        TEXT NOT NULL,
-    from_agent   TEXT NOT NULL,
-    dispatch_id  TEXT,
-    status       TEXT NOT NULL DEFAULT 'pending',
-    ts           REAL NOT NULL,
-    reported_ts  REAL
-);
-CREATE INDEX IF NOT EXISTS idx_inbound_agent_status_ts
-    ON inbound_dispatches(agent, status, ts);
-"""
+#: The identity fields, in order. Exported because callers hand a claimed
+#: row straight back to :func:`mark_reported` and this names what that needs.
+IDENTITY_FIELDS = ("agent", "from_agent", "dispatch_id", "ts")
 
 __all__ = [
-    "STATUS_PENDING",
-    "STATUS_REPORTING",
-    "STATUS_REPORTED",
+    "IDENTITY_FIELDS",
     "STATUS_FAILED",
+    "STATUS_PENDING",
+    "STATUS_REPORTED",
+    "STATUS_REPORTING",
+    "STORE_NAME",
     "VALID_STATUSES",
-    "init_inbound_schema",
-    "record_inbound",
     "claim_oldest_pending",
-    "mark_reported",
+    "inbound_store_target",
+    "init_inbound_schema",
     "list_inbound",
+    "mark_reported",
+    "open_inbound_store",
+    "record_inbound",
 ]
 
 
-def init_inbound_schema(db_path: Path | None = None) -> Path:
-    """Create the ``inbound_dispatches`` table if missing. Idempotent.
+def _schema() -> Any:
+    """The inbound-dispatch schema.
 
-    Returns the resolved database path. Mirrors
-    :func:`dispatch_ledger.init_ledger_schema`: delegates base schema +
-    connection config to :func:`state_db.open_db`, then layers our own
-    ``CREATE TABLE IF NOT EXISTS``.
+    Built lazily so importing this module does not import scitex-dev; the old
+    module was equally lazy about ``state_db``, for the same reason.
+
+    ``status`` is LAST_WRITER_WINS because the whole point is that it moves:
+    pending -> reporting -> reported/failed. ``reported_ts`` likewise, and it
+    is not required — a row that has not settled has no settle time, and
+    inventing one would make "never reported" indistinguishable from
+    "reported at epoch".
     """
-    from .state_db import init_schema, open_db
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
 
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
-    return init_schema(db_path)
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def data(kind: Any, *, required: bool) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=required,
+            merge=MergeRule.LAST_WRITER_WINS,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "agent": ident(FieldKind.TEXT),
+            "from_agent": ident(FieldKind.TEXT),
+            "dispatch_id": ident(FieldKind.TEXT),
+            "ts": ident(FieldKind.REAL),
+            "status": data(FieldKind.TEXT, required=True),
+            "reported_ts": data(FieldKind.REAL, required=False),
+        },
+    )
 
 
-def _ensure_table(conn: sqlite3.Connection) -> None:
-    """Ensure the inbound table exists on an already-open connection."""
-    conn.executescript(_SCHEMA)
+def inbound_store_target() -> Any:
+    """Resolve WHERE the inbound ledger lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_inbound_store() -> Store:
+    """Open the ledger. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function opens and closes one per
+    call, mirroring the old ``with open_db(...)`` shape: this runs once per
+    inbound wake and once per Stop hook, not on a request path.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        inbound_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_inbound_schema() -> str:
+    """Create the ledger tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL
+    equivalent of the path the SQLite version returned, and it names WHERE
+    the state actually went so an operator can check rather than assume.
+    """
+    store = open_inbound_store()
+    try:
+        return str(inbound_store_target().locator)
+    finally:
+        store.close()
+
+
+def _key(row_or_mapping: Any) -> dict[str, Any]:
+    """The identity mapping for a row or a claimed dict.
+
+    Accepts either shape so a caller can hand back exactly what
+    :func:`claim_oldest_pending` gave them without unpacking it.
+    """
+    src = getattr(row_or_mapping, "values", None) or row_or_mapping
+    if callable(src):  # a Mapping's .values method, not a Row's field dict
+        src = row_or_mapping
+    return {field: src[field] for field in IDENTITY_FIELDS}
 
 
 def record_inbound(
@@ -101,89 +220,110 @@ def record_inbound(
     agent: str,
     from_agent: str,
     dispatch_id: Optional[str] = None,
-    ts: float | None = None,
-    db_path: Path | None = None,
-) -> int:
-    """Insert one ``pending`` inbound-dispatch row; return its ``id``.
+    ts: Optional[float] = None,
+) -> dict[str, Any]:
+    """Insert one ``pending`` inbound-dispatch row; return its identity.
 
-    Called by the bridge when an inbound wake carries a ``from_agent``
-    (the peer to report back to). A wake with no requester is NOT recorded
-    by the caller — there is nobody to report to. ``ts`` is a real-time
-    injection seam for tests.
+    Called by the bridge when an inbound wake carries a ``from_agent`` (the
+    peer to report back to). A wake with no requester is NOT recorded by the
+    caller — there is nobody to report to. ``ts`` is a real-time injection
+    seam for tests.
+
+    Returns the identity mapping rather than the old integer id. Nothing in
+    production consumed that integer (see the module docstring), and the
+    mapping is what :func:`mark_reported` now takes.
+
+    THE MICROSECOND RETRY is the collision handling described in the module
+    docstring: identical (agent, from_agent, dispatch_id, ts) means the SAME
+    record to the store, so a genuine second wake in the same instant would
+    otherwise silently overwrite the first. Advancing ``ts`` keeps both and
+    keeps them ordered.
     """
     if not agent or not from_agent:
         raise ValueError("record_inbound requires non-empty agent + from_agent")
+
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
     row_ts = float(ts) if ts is not None else time.time()
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        cur = conn.execute(
-            """
-            INSERT INTO inbound_dispatches (agent, from_agent, dispatch_id, status, ts)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (agent, from_agent, dispatch_id, STATUS_PENDING, row_ts),
+    store = open_inbound_store()
+    try:
+        for _ in range(1000):
+            key = {
+                "agent": agent,
+                "from_agent": from_agent,
+                "dispatch_id": dispatch_id or "",
+                "ts": row_ts,
+            }
+            try:
+                store.put(
+                    {**key, "status": STATUS_PENDING}, expected_revision=NEW_RECORD
+                )
+            except RevisionMismatchError:
+                row_ts += 1e-6
+                continue
+            return key
+        raise RuntimeError(
+            "record_inbound: 1000 identical timestamps for the same "
+            f"(agent={agent!r}, from_agent={from_agent!r}) — refusing to spin"
         )
-        # lastrowid is always set after a successful single-row INSERT;
-        # the ``or 0`` only satisfies the int|None type and never fires.
-        return int(cur.lastrowid or 0)
+    finally:
+        store.close()
 
 
-def claim_oldest_pending(
-    *,
-    agent: str,
-    db_path: Path | None = None,
-) -> dict[str, Any] | None:
+def claim_oldest_pending(*, agent: str) -> dict[str, Any] | None:
     """Atomically claim the OLDEST ``pending`` row for ``agent``.
 
-    Flips exactly one row ``pending → reporting`` inside a single
-    ``BEGIN IMMEDIATE`` transaction and returns it (as a dict), or
-    ``None`` when the agent has no pending dispatch (the common no-op —
-    most turns have no requester). The atomic claim means two concurrent
-    ``Stop`` hooks (or a hook retry) can never push the same completion
-    twice. The caller settles the claimed row via :func:`mark_reported`.
-    """
-    from .state_db import open_db
+    Flips exactly one row ``pending → reporting`` and returns it (identity
+    fields plus ``status``), or ``None`` when the agent has no pending
+    dispatch (the common no-op — most turns have no requester).
 
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        conn.row_factory = sqlite3.Row
-        conn.execute("BEGIN IMMEDIATE")
-        try:
-            row = conn.execute(
-                """
-                SELECT * FROM inbound_dispatches
-                WHERE agent = ? AND status = ?
-                ORDER BY ts ASC, id ASC
-                LIMIT 1
-                """,
-                (agent, STATUS_PENDING),
-            ).fetchone()
-            if row is None:
-                conn.execute("COMMIT")
-                return None
-            conn.execute(
-                "UPDATE inbound_dispatches SET status = ? WHERE id = ?",
-                (STATUS_REPORTING, row["id"]),
-            )
-            conn.execute("COMMIT")
-        except Exception:
-            conn.execute("ROLLBACK")
-            raise
-        claimed = dict(row)
-        claimed["status"] = STATUS_REPORTING
-        return claimed
+    THE ATOMIC CLAIM IS PRESERVED, and it was explicit in the SQLite version:
+    "two concurrent Stop hooks (or a hook retry) can never push the same
+    completion twice". SQLite got that from ``BEGIN IMMEDIATE``; the store has
+    no transaction, so it comes from optimistic concurrency instead. The
+    update carries ``expected_revision=<the row's seq>``, so a racing claimer
+    that already flipped this row raises ``RevisionMismatchError`` — and we
+    move to the NEXT pending row rather than failing, because a competitor
+    taking one row is not a reason to report none.
+
+    ``Row.seq`` IS the revision; there is no ``Row.revision``.
+    """
+    from scitex_dev.store import RevisionMismatchError
+
+    store = open_inbound_store()
+    try:
+        pending = [
+            row
+            for row in store.rows()
+            if row.values.get("agent") == agent
+            and row.values.get("status") == STATUS_PENDING
+        ]
+        pending.sort(key=lambda r: float(r.values["ts"]))
+        for row in pending:
+            key = _key(row.values)
+            try:
+                store.put({**key, "status": STATUS_REPORTING}, expected_revision=row.seq)
+            except RevisionMismatchError:
+                continue
+            claimed = dict(row.values)
+            claimed["status"] = STATUS_REPORTING
+            return claimed
+        return None
+    finally:
+        store.close()
 
 
 def mark_reported(
-    row_id: int,
+    handle: Any,
     *,
     status: str = STATUS_REPORTED,
-    reported_ts: float | None = None,
-    db_path: Path | None = None,
+    reported_ts: Optional[float] = None,
 ) -> bool:
     """Settle a claimed row to a terminal status. Returns True iff matched.
+
+    ``handle`` is whatever :func:`record_inbound` or
+    :func:`claim_oldest_pending` returned — the identity mapping. It replaces
+    the old integer row id, which nothing in production ever used.
 
     ``status`` must be ``reported`` (push succeeded) or ``failed`` (push
     raised) — an unknown value raises rather than writing an unqueryable
@@ -194,43 +334,39 @@ def mark_reported(
             f"mark_reported status must be {STATUS_REPORTED!r} or "
             f"{STATUS_FAILED!r}, got {status!r}"
         )
-    row_ts = float(reported_ts) if reported_ts is not None else time.time()
-    from .state_db import open_db
 
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        cur = conn.execute(
-            "UPDATE inbound_dispatches SET status = ?, reported_ts = ? WHERE id = ?",
-            (status, row_ts, row_id),
+    from scitex_dev.store import ANY_REVISION
+
+    key = _key(handle)
+    settle_ts = float(reported_ts) if reported_ts is not None else time.time()
+    store = open_inbound_store()
+    try:
+        if store.get(key) is None:
+            return False
+        store.put(
+            {**key, "status": status, "reported_ts": settle_ts},
+            expected_revision=ANY_REVISION,
         )
-        return cur.rowcount > 0
+        return True
+    finally:
+        store.close()
 
 
 def list_inbound(
     *,
-    agent: str | None = None,
-    status: str | None = None,
+    agent: Optional[str] = None,
+    status: Optional[str] = None,
     limit: int = 100,
-    db_path: Path | None = None,
 ) -> list[dict[str, Any]]:
     """Return inbound rows (newest first) — observability / tests."""
-    from .state_db import open_db
-
-    clauses: list[str] = []
-    params: list[Any] = []
+    store = open_inbound_store()
+    try:
+        rows = [dict(row.values) for row in store.rows()]
+    finally:
+        store.close()
     if agent:
-        clauses.append("agent = ?")
-        params.append(agent)
+        rows = [r for r in rows if r.get("agent") == agent]
     if status:
-        clauses.append("status = ?")
-        params.append(status)
-    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-    params.append(int(limit))
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        conn.row_factory = sqlite3.Row
-        rows = conn.execute(
-            f"SELECT * FROM inbound_dispatches{where} ORDER BY ts DESC, id DESC LIMIT ?",
-            params,
-        ).fetchall()
-        return [dict(r) for r in rows]
+        rows = [r for r in rows if r.get("status") == status]
+    rows.sort(key=lambda r: float(r.get("ts") or 0.0), reverse=True)
+    return rows[: int(limit)]

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -93,7 +93,12 @@ KNOWN_TABLES = (
     "comms_nodes",
     "node_comms_policy",
     "acl_deny_notify_log",
-    "incarnations",
+    # ``incarnations`` was here until 2026-08-19. It now lives in per-host
+    # PostgreSQL via :mod:`.state_db_incarnations`, so it is NOT queryable
+    # through `sac db query`. Removed rather than left behind: a whitelisted
+    # name with no table returns an EMPTY result, and an empty result reads
+    # as "this agent has no incarnations" when the truth is "you are asking
+    # the wrong database". An unknown-table error is the honest answer.
 )
 
 
@@ -198,14 +203,13 @@ def init_schema(db_path: Path | None = None) -> Path:
 
         conn.executescript(_pp._SCHEMA)
         conn.executescript(_blocks._SCHEMA)
-        # v4 step 5 — the ``incarnations`` birth-certificate table
-        # (compiled-spec-at-launch + exit mirror), keyed by the same
-        # incarnation id the beats and the ExitRecord carry. Lives in
-        # the EXISTING sqlite factory ON PURPOSE so the separately-
-        # carded sqlite→Postgres migration carries it along.
-        from . import state_db_incarnations as _incarn
-
-        conn.executescript(_incarn._SCHEMA_INCARNATIONS)
+        # The ``incarnations`` birth-certificate table used to be created
+        # here. It moved to per-host PostgreSQL on 2026-08-19; the promise
+        # this comment block used to make — "lives in the EXISTING sqlite
+        # factory ON PURPOSE so the separately-carded sqlite→Postgres
+        # migration carries it along" — is now kept. Its schema is created
+        # on first open by :func:`state_db_incarnations.open_incarnation_store`,
+        # so there is nothing to run here.
         # sac-comms item D (lead a2a c42b3e3c): rate-limit log for
         # synthetic ACL-deny notifications published at the target
         # receiver. One row per (sender, target) pair carrying the

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -92,7 +92,6 @@ KNOWN_TABLES = (
     "comms_grants",
     "comms_nodes",
     "node_comms_policy",
-    "acl_deny_notify_log",
     # ``incarnations`` was here until 2026-08-19. It now lives in per-host
     # PostgreSQL via :mod:`.state_db_incarnations`, so it is NOT queryable
     # through `sac db query`. Removed rather than left behind: a whitelisted
@@ -191,20 +190,13 @@ def init_schema(db_path: Path | None = None) -> Path:
         migrate_node_comms_policy_add_group_names(conn)
         conn.executescript(_SCHEMA_ATTEMPTS)
         conn.executescript(_SCHEMA_DIARY)
-        # Task #27 — ACL block/unblock flow tables. Both CREATE TABLE
-        # scripts are idempotent; running them inline here means a
-        # fresh state.db carries the tables without a separate
-        # migration step. The owning modules expose the schema
-        # strings; we pull them through the same connection so
-        # ``init_schema`` stays atomic.
-        from . import state_db_acl_deny_notify as _adn
-        from . import state_db_blocks as _blocks
-
-        # ``pending_prompts`` was created here until 2026-08-20. It moved
-        # to per-host PostgreSQL; its schema is created on first open by
-        # ``state_db_pending_approval.open_pending_prompt_store``, so there
-        # is nothing to run here.
-        conn.executescript(_blocks._SCHEMA)
+        # Task #27's two ACL tables were both created here until 2026-08-20.
+        # ``pending_prompts`` and ``comms_blocks`` have BOTH moved to per-host
+        # PostgreSQL; each store creates its own schema on first open
+        # (``state_db_pending_approval.open_pending_prompt_store`` /
+        # ``state_db_blocks.open_blocks_store``), so there is nothing to run
+        # here for either. What is left of the pair in SQLite is
+        # ``comms_grants``, which lives in ``state_db_nodes`` and has not moved.
         # The ``incarnations`` birth-certificate table used to be created
         # here. It moved to per-host PostgreSQL on 2026-08-19; the promise
         # this comment block used to make — "lives in the EXISTING sqlite
@@ -212,12 +204,10 @@ def init_schema(db_path: Path | None = None) -> Path:
         # migration carries it along" — is now kept. Its schema is created
         # on first open by :func:`state_db_incarnations.open_incarnation_store`,
         # so there is nothing to run here.
-        # sac-comms item D (lead a2a c42b3e3c): rate-limit log for
-        # synthetic ACL-deny notifications published at the target
-        # receiver. One row per (sender, target) pair carrying the
-        # last-notify timestamp; the check + update lives in
-        # :func:`state_db_acl_deny_notify.should_notify_acl_deny`.
-        conn.executescript(_adn._SCHEMA)
+        # sac-comms item D's rate-limit log (acl_deny_notify_log) was created
+        # here until 2026-08-20. It moved to per-host PostgreSQL alongside the
+        # two task-#27 tables above; its schema is created on first open by
+        # ``state_db_acl_deny_notify.open_deny_notify_store``.
         conn.commit()
     return path
 

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -199,9 +199,11 @@ def init_schema(db_path: Path | None = None) -> Path:
         # ``init_schema`` stays atomic.
         from . import state_db_acl_deny_notify as _adn
         from . import state_db_blocks as _blocks
-        from . import state_db_pending_approval as _pp
 
-        conn.executescript(_pp._SCHEMA)
+        # ``pending_prompts`` was created here until 2026-08-20. It moved
+        # to per-host PostgreSQL; its schema is created on first open by
+        # ``state_db_pending_approval.open_pending_prompt_store``, so there
+        # is nothing to run here.
         conn.executescript(_blocks._SCHEMA)
         # The ``incarnations`` birth-certificate table used to be created
         # here. It moved to per-host PostgreSQL on 2026-08-19; the promise

--- a/src/scitex_agent_container/_state/state_db_acl_deny_notify.py
+++ b/src/scitex_agent_container/_state/state_db_acl_deny_notify.py
@@ -23,24 +23,71 @@ mint + publish lives in ``_listen._node_channel`` (which calls
 :func:`should_notify_acl_deny` to decide whether to push or
 suppress the redundant frame).
 
-Schema is minimal: ``(sender, target, last_notified_at)`` with
-``(sender, target)`` PRIMARY KEY. The check-and-update is atomic
-within a single transaction so a concurrent burst of denied
-attempts publishes at most one notification per cooldown window.
+Schema is minimal: ``(sender, target)`` as the composite identity plus
+``last_notified_at``.
 
-No-mocks (PA-306) testing — real on-disk sqlite, no monkeypatch.
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to
+PostgreSQL: "fail fast, fail loud, no fallbacks". This is the fifth
+table to move, and it lands in the same PR as ``comms_blocks`` because
+the two are siblings from the same task, both empty, and both remove a
+line from the same block of ``state_db.init_schema`` — splitting them
+would only manufacture a third merge conflict in that function.
+
+``db_path`` IS GONE from every function. It named a SQLite file; there
+is no file.
+
+THE ATOMIC CHECK-AND-UPDATE IS PRESERVED, BY A DIFFERENT MECHANISM
+==================================================================
+The paragraph this replaced promised that "the check-and-update is
+atomic within a single transaction so a concurrent burst of denied
+attempts publishes at most one notification per cooldown window". That
+promise is the module's whole point — a rate-limit log that can be
+raced is not a rate limit — and the store has no transactions, so it
+would have been the easy thing to lose.
+
+It is kept with the store's OPTIMISTIC concurrency instead. The read
+returns the record's REVISION; the write passes that same revision as
+``expected_revision``. A racing writer that bumped it first makes ours
+raise ``RevisionMismatchError``, which means "someone else just
+notified this pair" — precisely the answer the transaction gave, and
+the caller is told to suppress. A first notification uses
+``NEW_RECORD`` for the same reason.
+
+This is the first table in the migration where the EXACT revision is
+load-bearing. The earlier slices could use ``ANY_REVISION`` because
+losing a race there cost nothing; here it costs a duplicate frame in a
+receiver's inbox, which is the thing being prevented.
+
+No-mocks (PA-306) testing — a real PostgreSQL via the shared
+``pg_schema`` fixture, no monkeypatch.
 """
 
 from __future__ import annotations
 
 import os
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "acl_deny_notify_log"
+
+#: Every write from this host is attributed to one node. The log is written by
+#: the listen daemon that observed the denial, so SINGLE_WRITER is honest.
+_ACTOR = "scitex-agent-container"
 
 __all__ = [
     "DEFAULT_COOLDOWN_S",
+    "STORE_NAME",
+    "deny_notify_store_target",
     "ensure_acl_deny_notify_log_table",
     "last_notified_at",
+    "open_deny_notify_store",
     "resolve_cooldown_s",
     "should_notify_acl_deny",
 ]
@@ -60,26 +107,76 @@ DEFAULT_COOLDOWN_S: float = 30.0 * 60.0
 _COOLDOWN_ENV = "SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS acl_deny_notify_log (
-    sender            TEXT NOT NULL,
-    target            TEXT NOT NULL,
-    last_notified_at  REAL NOT NULL,
-    PRIMARY KEY (sender, target)
-);
-"""
+def _schema() -> Any:
+    """The deny-notify rate-limit schema.
 
+    Built lazily so importing this module does not import scitex-dev.
 
-def ensure_acl_deny_notify_log_table(db_path: Path | None = None) -> None:
-    """Idempotent CREATE TABLE for the deny-notify rate-limit log.
-
-    Called from :func:`_state.state_db.init_schema` so a fresh
-    state.db carries the table; safe to call multiple times.
+    ``(sender, target)`` is the composite IDENTITY — the SQLite table's PRIMARY
+    KEY, unchanged. ``last_notified_at`` is LAST_WRITER_WINS: every successful
+    notification moves it forward, and that IS the rate limit.
     """
-    from .state_db import open_db
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
 
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "sender": ident(FieldKind.TEXT),
+            "target": ident(FieldKind.TEXT),
+            "last_notified_at": FieldPolicy(
+                kind=FieldKind.REAL,
+                role=FieldRole.DATA,
+                required=True,
+                merge=MergeRule.LAST_WRITER_WINS,
+                indexed=False,
+            ),
+        },
+    )
+
+
+def deny_notify_store_target() -> Any:
+    """Resolve WHERE the rate-limit log lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_deny_notify_store() -> Store:
+    """Open the rate-limit log. RAISES if PostgreSQL is unreachable."""
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        deny_notify_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def ensure_acl_deny_notify_log_table() -> str:
+    """Create the rate-limit tables if missing. Idempotent.
+
+    Kept under its original name because the name still says what it does.
+    Returns the resolved store LOCATOR as a string, so an operator can check
+    where the state went rather than assume it.
+    """
+    store = open_deny_notify_store()
+    try:
+        return str(deny_notify_store_target().locator)
+    finally:
+        store.close()
 
 
 def resolve_cooldown_s(override: float | None = None) -> float:
@@ -117,7 +214,6 @@ def should_notify_acl_deny(
     sender: str,
     target: str,
     cooldown_s: float | None = None,
-    db_path: Path | None = None,
     now: float | None = None,
 ) -> bool:
     """Atomically decide whether to publish a deny-notification frame.
@@ -142,27 +238,40 @@ def should_notify_acl_deny(
         raise ValueError("should_notify_acl_deny: sender and target must be non-empty")
     effective_cooldown = resolve_cooldown_s(cooldown_s)
     effective_now = time.time() if now is None else float(now)
-    ensure_acl_deny_notify_log_table(db_path)
-    from .state_db import open_db
 
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT last_notified_at FROM acl_deny_notify_log "
-            "WHERE sender = ? AND target = ?",
-            (sender, target),
-        ).fetchone()
-        if row is not None:
-            elapsed = effective_now - float(row["last_notified_at"])
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
+    key = {"sender": sender, "target": target}
+    store = open_deny_notify_store()
+    try:
+        existing = store.get(key)
+        if existing is not None:
+            elapsed = effective_now - float(existing.values["last_notified_at"])
             if elapsed < effective_cooldown:
                 return False
-        # First time, or cool-down elapsed — upsert + return True.
-        conn.execute(
-            "INSERT INTO acl_deny_notify_log (sender, target, last_notified_at) "
-            "VALUES (?, ?, ?) "
-            "ON CONFLICT(sender, target) DO UPDATE SET "
-            "  last_notified_at = excluded.last_notified_at",
-            (sender, target, effective_now),
-        )
+        # First time, or cool-down elapsed — write + return True.
+        #
+        # THE REVISION IS THE TRANSACTION. The SQLite version held the read and
+        # the upsert in one transaction so a burst of denied attempts published
+        # ONE notification. Here the read's own revision is passed back as
+        # ``expected_revision``: a racing writer that moved it first makes this
+        # write raise, and that raise means "someone else just notified this
+        # pair" — the same answer, reached optimistically. Passing
+        # ANY_REVISION here would compile, pass every single-threaded test, and
+        # silently delete the guarantee.
+        # ``Row.seq`` IS the revision, verified by experiment rather than by
+        # its name: writing with a STALE seq raises RevisionMismatchError,
+        # which is the only thing that makes it usable as an optimistic lock.
+        # (``Row`` has no ``.revision`` attribute — the first version of this
+        # line assumed one and died with AttributeError on the first test that
+        # reached the update path.)
+        expected = NEW_RECORD if existing is None else existing.seq
+        try:
+            store.put({**key, "last_notified_at": effective_now}, expected_revision=expected)
+        except RevisionMismatchError:
+            return False
+    finally:
+        store.close()
     return True
 
 
@@ -170,26 +279,21 @@ def last_notified_at(
     *,
     sender: str,
     target: str,
-    db_path: Path | None = None,
 ) -> float | None:
     """Return the timestamp of the most recent deny-notify for the pair.
 
     Returns ``None`` when no notification has ever been published for
     the pair. Observability / test surface — the rate-limit decision
-    itself goes through :func:`should_notify_acl_deny` so the
-    check+update is one transaction.
+    itself goes through :func:`should_notify_acl_deny`, which keeps the
+    check+write atomic against a concurrent burst.
     """
     if not sender or not target:
         return None
-    ensure_acl_deny_notify_log_table(db_path)
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT last_notified_at FROM acl_deny_notify_log "
-            "WHERE sender = ? AND target = ?",
-            (sender, target),
-        ).fetchone()
-    if row is None:
+    store = open_deny_notify_store()
+    try:
+        record = store.get({"sender": sender, "target": target})
+    finally:
+        store.close()
+    if record is None:
         return None
-    return float(row["last_notified_at"])
+    return float(record.values["last_notified_at"])

--- a/src/scitex_agent_container/_state/state_db_blocks.py
+++ b/src/scitex_agent_container/_state/state_db_blocks.py
@@ -1,149 +1,294 @@
-"""Block-list — receiver-driven persistent silencing of a sender (task #27).
+"""Block-list — receiver-driven persistent silencing of a sender, on PostgreSQL.
 
-Operator-requested via lead (2026-06-01). Lead's design amendment: the
-ACL approve-prompt flow boils down to BLOCK / UNBLOCK as the
-primitive operations, dropping the held-message + TTL +
-debounce-heuristic machinery.
+Operator-requested via lead (2026-06-01). Lead's design amendment: the ACL
+approve-prompt flow boils down to BLOCK / UNBLOCK as the primitive operations,
+dropping the held-message + TTL + debounce-heuristic machinery.
 
-* UNBLOCK is the existing :func:`state_db_nodes.grant_send` — writes
-  the ``comms_grants`` row that lets the sender's future messages
-  pass.
-* BLOCK is this module's :func:`block_send` — writes a
-  ``comms_blocks`` row that makes the sender's future ``message:send``
-  attempts SILENTLY drop (no 403 trail, no receiver push, no
-  approve-prompt re-fire). The receiver chose to silence the sender;
-  the system honours that without further surface area.
+* UNBLOCK is the existing :func:`state_db_nodes.grant_send` — writes the
+  ``comms_grants`` row that lets the sender's future messages pass.
+* BLOCK is this module's :func:`block_send` — records a block that makes the
+  sender's future ``message:send`` attempts SILENTLY drop (no 403 trail, no
+  receiver push, no approve-prompt re-fire). The receiver chose to silence the
+  sender; the system honours that without further surface area.
 
-Symmetric helpers (``unblock_send``, ``has_block``) mirror the
-``grant_send`` / ``revoke_send`` / ``has_grant`` shape in
-``state_db_nodes``.
+Symmetric helpers (``unblock_send``, ``has_block``) mirror the ``grant_send`` /
+``revoke_send`` / ``has_grant`` shape in ``state_db_nodes``.
 
-Block precedence: a (sender, target) pair with BOTH a grant and a
-block is denied (block wins). The receiver explicitly silenced the
-sender after some earlier grant — honouring the more recent veto.
+Block precedence: a (sender, target) pair with BOTH a grant and a block is
+denied (block wins). The receiver explicitly silenced the sender after some
+earlier grant — honouring the more recent veto.
 :func:`_listen._acl.check_send_acl` enforces this precedence.
+
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to PostgreSQL:
+"fail fast, fail loud, no fallbacks". This is the fourth table to move, after
+``verdict_delivered``, ``incarnations`` and ``pending_prompts``, and it moves the
+same way — by ADOPTING :mod:`scitex_dev.store` rather than by sac growing a
+private psycopg layer.
+
+``db_path`` IS GONE from every function. It named a SQLite file; there is no
+file. ``grant_flush`` and ``_listen._acl`` stop threading one in.
+
+NO MIGRATION SCRIPT, and that is measured rather than assumed. When this slice
+was scoped the prediction was the opposite — "``comms_blocks`` is a DURABLE
+decision, not a transient flag, so it almost certainly holds real rows and this
+one DOES need a migration". It holds ZERO rows: 52 SQLite databases read across
+compute-01..04 (the fleet state.db plus every per-agent shard), 0 in all of them.
+Nobody has ever blocked anyone. The prediction was reasonable and wrong, which is
+why it was checked before any code was written.
+
+A CONSEQUENCE WORTH STATING RATHER THAN DISCOVERING
+===================================================
+``has_block`` is the FIRST gate in :func:`_listen._acl.check_send_acl`, so this
+table is now read on every message send, and an unreachable PostgreSQL makes
+that read RAISE. Message delivery therefore depends on the per-host store being
+up, where before it depended only on a local file.
+
+That is the intended direction, not an oversight. The operator's ruling on this
+migration was "fail fast, fail loud, no fallbacks", and the alternative here is
+worse than downtime: a block check that cannot reach its store and answers
+"not blocked" silently delivers to a receiver who explicitly silenced the
+sender. There is no safe default for this question, which is exactly why it
+must not have one.
+
+The connection cost is unchanged in SHAPE — the SQLite version also opened and
+closed a connection per check — but a unix-socket round trip is dearer than a
+file open. If that ever shows up in send latency, the fix is a pooled or
+long-lived store handle, not a cache of the answer: a cached block is a block
+that keeps working after it was lifted.
+
+THE CLEARED-IS-NOT-ABSENT LIFECYCLE, AND WHERE IT DIFFERS FROM pending_prompts
+==============================================================================
+Like the pending-prompt flag, this table DELETEs and the store has no delete —
+it has ``hide``, which marks a record invisible to ``get``/``rows`` while keeping
+it in the oplog. That is the better primitive here for the same reason: who
+unblocked whom, and when, survives instead of being destroyed.
+
+So the same three-value branch applies, and :meth:`Store.is_hidden` is what makes
+it expressible, because it answers in THREE values where ``get`` answers in two:
+
+    None    no record at all      -> insert; this is a new block
+    True    unblocked earlier     -> unhide, and stamp a NEW created_at
+    False   present and visible   -> already blocked; leave it untouched
+
+The DIFFERENCE from ``pending_prompts`` is the middle and last lines, and it
+comes from this module's own documented idempotence: "re-blocking the same pair
+leaves the row untouched (timestamp not bumped)". So the visible branch writes
+NOTHING — not even a refreshed timestamp — while the hidden branch writes a new
+one, because an unblock followed by a block is a NEW decision by the receiver
+and dating it to the superseded block would misreport when they made it.
 """
 
 from __future__ import annotations
 
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "comms_blocks"
+
+#: Every write from this host is attributed to one node. A block is written by
+#: the listen daemon that served the receiver's decision and cleared by the same
+#: host's unblock path, so SINGLE_WRITER is honest rather than convenient.
+_ACTOR = "scitex-agent-container"
 
 __all__ = [
-    "ensure_comms_blocks_table",
+    "STORE_NAME",
     "block_send",
+    "ensure_comms_blocks_table",
     "has_block",
+    "open_blocks_store",
+    "blocks_store_target",
     "unblock_send",
 ]
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS comms_blocks (
-    sender_name TEXT NOT NULL,
-    target_name TEXT NOT NULL,
-    created_at  REAL NOT NULL,
-    note        TEXT,
-    PRIMARY KEY (sender_name, target_name)
-);
-"""
+def _schema() -> Any:
+    """The block-list schema.
 
+    Built lazily so importing this module does not import scitex-dev; the old
+    module was equally lazy about ``state_db``, for the same reason.
 
-def ensure_comms_blocks_table(db_path: Path | None = None) -> None:
-    """Idempotent CREATE TABLE for ``comms_blocks``.
+    ``(sender_name, target_name)`` is the composite IDENTITY — the SQLite
+    table's PRIMARY KEY, unchanged. Identity fields must be IMMUTABLE and the
+    store enforces it: "changing one does not update the record, it names a
+    different record", which is exactly right for a pair.
 
-    Called from :func:`_state.state_db.init_schema` so a fresh
-    state.db carries the table; safe to call multiple times.
+    ``created_at`` is LAST_WRITER_WINS rather than IMMUTABLE, and that is load
+    bearing for exactly one path: a pair that was unblocked and then blocked
+    again must carry the time of the NEW decision. The repeat-block path never
+    writes, so the "timestamp not bumped" guarantee is preserved by the caller's
+    control flow rather than by the merge rule.
+
+    ``note`` is optional — a free-form audit annotation (e.g. the prompt msg_id
+    the receiver was responding to), and ``grant_flush.block_and_clear`` passes
+    one. It is NOT required, because the CLI path blocks without one.
     """
-    from .state_db import open_db
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
 
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def fact(kind: Any, *, required: bool = False) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=required,
+            merge=MergeRule.LAST_WRITER_WINS,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "sender_name": ident(FieldKind.TEXT),
+            "target_name": ident(FieldKind.TEXT),
+            "created_at": fact(FieldKind.REAL, required=True),
+            "note": fact(FieldKind.TEXT),
+        },
+    )
 
 
-def block_send(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-    note: str | None = None,
-) -> None:
+def blocks_store_target() -> Any:
+    """Resolve WHERE the block list lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_blocks_store() -> Store:
+    """Open the block store. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function opens and closes one per
+    call, mirroring the old ``with open_db(...)`` shape: ``has_block`` runs on
+    the ACL path, but that path already crosses a process boundary, and a
+    connection per check is what the SQLite version did too.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        blocks_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def ensure_comms_blocks_table() -> str:
+    """Create the block-list tables if missing. Idempotent.
+
+    Kept under its original name because :func:`_state.state_db.init_schema`
+    calls it by that name and the name still says what it does.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL equivalent
+    of the ``None`` the SQLite version returned, and strictly more useful: it
+    names WHERE the state actually went, so an operator can check it rather than
+    assume it.
+    """
+    store = open_blocks_store()
+    try:
+        return str(blocks_store_target().locator)
+    finally:
+        store.close()
+
+
+def block_send(*, sender: str, target: str, note: str | None = None) -> None:
     """Persist a ``sender → target`` block.
 
-    Idempotent — re-blocking the same pair leaves the row untouched
-    (timestamp not bumped). The optional ``note`` is a free-form
-    audit annotation (e.g. the prompt msg_id the receiver was
-    responding to).
+    Idempotent — re-blocking the same pair leaves the record untouched
+    (timestamp not bumped, note not replaced). Blocking a pair that was
+    UNBLOCKED earlier is not a repeat: it is a new decision, and it is stamped
+    with the time it was made.
 
     Fail-loud: empty ``sender`` / ``target`` raise ``ValueError``.
+
+    CONCURRENCY. The insert carries ``expected_revision=NEW_RECORD``, so a
+    racing writer that created the record between our check and our write raises
+    ``RevisionMismatchError`` — which means "someone else blocked this pair",
+    the same end state this call wanted. Nothing else is caught: an unreachable
+    store must still be loud.
     """
     if not sender or not target:
         raise ValueError("block_send: sender and target must be non-empty")
-    from .state_db import open_db
 
-    ensure_comms_blocks_table(db_path)
-    with open_db(db_path) as conn:
-        existing = conn.execute(
-            "SELECT 1 FROM comms_blocks WHERE sender_name = ? AND target_name = ?",
-            (sender, target),
-        ).fetchone()
-        if existing is not None:
+    from scitex_dev.store import ANY_REVISION, NEW_RECORD, RevisionMismatchError
+
+    key = {"sender_name": sender, "target_name": target}
+    store = open_blocks_store()
+    try:
+        hidden = store.is_hidden(key)
+        if hidden is False:
             return
-        conn.execute(
-            "INSERT INTO comms_blocks "
-            "(sender_name, target_name, created_at, note) "
-            "VALUES (?, ?, ?, ?)",
-            (sender, target, time.time(), note),
-        )
+        record = {**key, "created_at": time.time(), "note": note}
+        if hidden is True:
+            store.unhide(key, expected_revision=ANY_REVISION)
+            store.put(record, expected_revision=ANY_REVISION)
+            return
+        try:
+            store.put(record, expected_revision=NEW_RECORD)
+        except RevisionMismatchError:
+            return
+    finally:
+        store.close()
 
 
-def unblock_send(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
-    """Remove a ``sender → target`` block. Returns ``True`` iff a row
-    was removed.
+def unblock_send(*, sender: str, target: str) -> bool:
+    """Remove a ``sender → target`` block. Returns ``True`` iff one was removed.
 
-    ``unblock_send`` only deletes the block row — it does NOT write a
-    grant. The receiver-side decision flow is "unblock = grant + clear
-    pending"; the CLI/handler stitches the two calls together (see
+    ``unblock_send`` only clears the block — it does NOT write a grant. The
+    receiver-side decision flow is "unblock = grant + clear pending"; the
+    CLI/handler stitches the two calls together (see
     ``cli_pkg/a2a_group.py::a2a_unblock``).
+
+    HIDE RATHER THAN DELETE. The store has no delete verb, and that is the
+    better fit: the unblock stays in the oplog with the actor that made it, so
+    "who let this sender back in, and when" survives — which a DELETE destroyed.
+    The read side is unchanged because ``get`` skips hidden records.
     """
     if not sender or not target:
         return False
-    from .state_db import open_db
 
-    ensure_comms_blocks_table(db_path)
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            "DELETE FROM comms_blocks WHERE sender_name = ? AND target_name = ?",
-            (sender, target),
-        )
-    return int(cur.rowcount or 0) > 0
+    from scitex_dev.store import ANY_REVISION
+
+    key = {"sender_name": sender, "target_name": target}
+    store = open_blocks_store()
+    try:
+        if store.get(key) is None:
+            return False
+        store.hide(key, expected_revision=ANY_REVISION)
+        return True
+    finally:
+        store.close()
 
 
-def has_block(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
+def has_block(*, sender: str, target: str) -> bool:
     """Return True iff ``(sender → target)`` is currently blocked.
 
-    Used by :func:`_listen._acl.check_send_acl` as the FIRST gate
-    after the trivial self-send / phase-3 checks. A blocked sender is
-    silently dropped — no 403 reason, no receiver push, no
-    approve-prompt re-fire.
+    Used by :func:`_listen._acl.check_send_acl` as the FIRST gate after the
+    trivial self-send / phase-3 checks. A blocked sender is silently dropped —
+    no 403 reason, no receiver push, no approve-prompt re-fire.
+
+    ``get`` excludes hidden records by default, so an unblocked pair reads as
+    absent here — which is precisely the SQLite DELETE semantics this replaces.
     """
     if not sender or not target:
         return False
-    from .state_db import open_db
-
-    ensure_comms_blocks_table(db_path)
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT 1 FROM comms_blocks WHERE sender_name = ? AND target_name = ?",
-            (sender, target),
-        ).fetchone()
-    return row is not None
+    store = open_blocks_store()
+    try:
+        return store.get({"sender_name": sender, "target_name": target}) is not None
+    finally:
+        store.close()

--- a/src/scitex_agent_container/_state/state_db_comms_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_comms_nodes.py
@@ -199,6 +199,37 @@ def register_comms_node(
                 f"ADR-0014: names are globally unique. Rename or "
                 f"unregister one and re-run `sac registry sync --all`."
             )
+        # Same source, but the existing row is a TOMBSTONE — the agent
+        # stopped, and ``unregister_comms_node`` recorded that. A dead
+        # row is a record of a past placement, NOT a live claim on
+        # ``(host, a2a_port)``, so it must not refuse the restart that
+        # follows it. Without this, an agent that stops and comes back
+        # on a DIFFERENT port can never re-register: the collision check
+        # below compares against the dead port, raises, and every caller
+        # swallows it best-effort — so the agent stays absent from the
+        # federated graph forever and peers only ever see
+        # ``unknown_target``. ``spec.a2a.port: auto`` makes "a different
+        # port" the NORMAL outcome of a restart, so this fires on
+        # ordinary lifecycle, not on an edge case. Reproduced on two
+        # hosts 2026-08-20: ``business`` live on 19012 behind a
+        # tombstone at 19033, and ``scitex-dev`` live on 19008 behind an
+        # 11-day-old tombstone at 19003.
+        #
+        # This is the same convergence the ``same_target`` branch above
+        # already performs ("re-activates a tombstoned row, which is the
+        # natural way a node came back sync converges") — it was simply
+        # unreachable whenever the port moved. Cross-host conflicts are
+        # deliberately NOT covered: that check runs first and still
+        # raises, because ADR-0014 name uniqueness is about WHO owns the
+        # name, which a tombstone does not answer.
+        if existing["ended_at"] is not None:
+            conn.execute(
+                "UPDATE comms_nodes SET host = ?, a2a_port = ?, "
+                "updated_at = ?, ended_at = NULL, source_host = ? "
+                "WHERE name = ?",
+                (host, a2a_port, now, source_host, name),
+            )
+            return
         # Same source, different target. PR L1 (operator directive
         # 12847) — fail loud on collision, no silent last-writer-wins.
         if not replace:

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -79,9 +79,10 @@ def _table_filter_clauses(
         # the row is upserted on every agent_start with no historical
         # tail (latest write wins).
         "node_comms_policy": ("WHERE updated_at >= ?", (since,)),
-        # acl_deny_notify_log — rate-limit ledger keyed on (sender, target);
-        # the ts-equivalent column is ``last_notified_at`` (REAL).
-        "acl_deny_notify_log": ("WHERE last_notified_at >= ?", (since,)),
+        # acl_deny_notify_log's entry lived here until 2026-08-20. The table
+        # moved to per-host PostgreSQL and left KNOWN_TABLES, so this mapping
+        # could never be selected again — and a WHERE clause naming a table
+        # SQLite no longer has reads as "sac still exports this".
         # v4 step 5 — birth certificates. A row moves when it is BORN or
         # when its death is mirrored on, so filter on either stamp (same
         # shape as ``instances``).

--- a/src/scitex_agent_container/_state/state_db_forward.py
+++ b/src/scitex_agent_container/_state/state_db_forward.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Where to SEND to a node — addressability, split from locality.
+
+``resolve_node_host`` answers LOCALITY ("which host is this agent on")
+and ``is_local_node`` consults it reading ONLY ``host``. The forwarder
+needed a different fact — an ADDRESS — and was reading the same return
+value for it. One function, two questions, and they disagree precisely
+when a live ``instances`` row carries no port:
+
+* locality      — still answerable. The row says which host, and that
+  stays true whether or not a port was recorded.
+* addressability — NOT answerable. There is nowhere to POST.
+
+Because both came from one call, the forwarder took ``{host,
+a2a_port: None}`` as its answer and ``_forward_to_remote`` 502'd on the
+falsy port, never consulting ``comms_nodes`` — which may hold a working
+address for that same name.
+
+MEASURED on ywata-note-win 2026-08-20::
+
+    instances: scitex-dev  host=scitex-compute-04
+               a2a_port=NULL  bound_port=NULL  ended_at=NULL
+
+Live, and PERMANENT: the GC never reaps cross-host rows (``AND
+remote=0``, deliberate per its own comment), and nothing back-fills the
+port — five ``UPDATE instances`` sites exist and none touches it. So the
+row cannot age out and cannot be repaired in place; the operator's
+documented repair verb writes ``comms_nodes``, the very table the
+unusable row was preventing anyone from reaching.
+
+WHY NOT JUST MAKE ``resolve_node_host`` FALL THROUGH. That one-liner was
+the obvious fix and it is wrong. Falling through on a portless row hands
+the LOCALITY decision to ``comms_nodes``, which may name a DIFFERENT
+host — so an agent that is genuinely local could start being forwarded
+away, and a routing repair would have silently redefined "local". The
+two questions get two functions instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+__all__ = ["resolve_forward_target"]
+
+
+def resolve_forward_target(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Return ``{host, a2a_port}`` usable for forwarding, else ``None``.
+
+    Resolution order matches :func:`..state_db_nodes.resolve_node_host` —
+    the live ``instances`` row first, then the ADR-0014 ``comms_nodes``
+    federated graph — with one difference that is the entire point: a row
+    that cannot supply a PORT does not end the search here.
+
+    ``a2a_port`` is preferred and ``bound_port`` is the fallback, matching
+    ``_send_resolve``; the writers populate both from one value, so a row
+    carrying only the latter is still a usable address.
+
+    ``None`` means no source could supply an address. The caller must
+    treat that as "cannot forward", never as "not registered" — the name
+    may be perfectly well known and simply unreachable.
+    """
+    if not name:
+        return None
+    from .state_db import open_db
+    from .state_db_comms_nodes import resolve_comms_node_host
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT host, a2a_port, bound_port
+              FROM instances
+             WHERE name = ? AND ended_at IS NULL
+             ORDER BY started_at DESC, id DESC
+             LIMIT 1
+            """,
+            (name,),
+        ).fetchone()
+    if row is not None:
+        port = row["a2a_port"]
+        if port is None:
+            port = row["bound_port"]
+        if port is not None:
+            return {"host": str(row["host"]), "a2a_port": int(port)}
+        # A live row recording no port is not an ADDRESS. Fall through
+        # rather than hand back a target the caller can only 502 on.
+    return resolve_comms_node_host(name=name, db_path=db_path)

--- a/src/scitex_agent_container/_state/state_db_incarnations.py
+++ b/src/scitex_agent_container/_state/state_db_incarnations.py
@@ -1,4 +1,4 @@
-"""``incarnations`` — the birth certificate (+ death mirror) table.
+"""``incarnations`` — the birth certificate (+ death mirror), on PostgreSQL only.
 
 v4 step 5, operator requirement verbatim (card sac-v4-layering-refactor-
 harness-runtime-inference-20260813, 2026-08-14): 「起動した後にコンパイル
@@ -8,7 +8,7 @@ harness-runtime-inference-20260813, 2026-08-14): 「起動した後にコンパ�
 (post-inheritance, post-defaults) as the agent's birth certificate,
 keyed by incarnation id, in the DB.
 
-One row joins the three settled identities:
+One record joins the three settled identities:
 
   * ``incarnation_id`` — one process lifetime (== ``instances.id``; the
     beat and the ExitRecord carry the same key);
@@ -22,45 +22,189 @@ serialized WITH SECRETS REDACTED — credentials are referenced by
 slot/source name (account slug, env-var NAME, credentials-file PATH),
 never by value (see ``_lifecycle._birth_certificate``).
 
-STORAGE NOTE (stated deliberately): the fleet target for running state
-is per-host Postgres :55432 (operator ruling), but sac's state layer
-today is this sqlite ``state.db`` behind :func:`state_db.open_db`'s
-central factory. The birth record therefore goes through the EXISTING
-factory — a new table beside ``instances``/``heartbeats`` — so the
-separately-carded sqlite→Postgres migration carries it along instead of
-this PR front-running it.
+THE STORAGE NOTE THIS MODULE USED TO CARRY IS NOW DISCHARGED
+============================================================
+The previous docstring said, in as many words, that the birth record went
+through the SQLite factory so that "the separately-carded sqlite→Postgres
+migration carries it along instead of this PR front-running it". This IS
+that migration. The note was a promise; this module is it being kept.
 
-Sibling-module convention (``state_db_diary`` / ``state_db_instances``):
-``state_db.init_schema`` runs :data:`_SCHEMA_INCARNATIONS`; the helpers
-here import ``open_db`` lazily to stay cycle-free.
+The move is by ADOPTING :mod:`scitex_dev.store` — the fleet's own store
+primitive — rather than by sac growing a private psycopg layer, exactly as
+:mod:`.state_db_verdict_dedup` did before it. That primitive implements the
+operator's 2026-08-19 rule ("fail fast, fail loud, no fallbacks") in its own
+``resolve_target``: exactly two steps (``SCITEX_STORE_DSN`` or the per-host
+Postgres) and deliberately NO SQLite fallback. A host whose PostgreSQL is
+unreachable raises ``StoreTargetError`` naming the DSN it could not reach.
+
+``db_path`` IS GONE from every function. It named a SQLite file; there is no
+file. Callers that used to thread it through simply stop.
+
+TWO DELIBERATE DIVERGENCES FROM THE verdict_dedup TEMPLATE
+==========================================================
+1. TIMESTAMPS STAY ISO-8601 TEXT, not the unix-seconds REAL that the dedup
+   tables use. ``born_at``/``exited_at`` are READ BY CALLERS as strings, and
+   a birth certificate is an operator-facing artifact. Switching the wire
+   format while switching the backend would be a second, silent, breaking
+   change riding along inside the first — the kind that shows up months
+   later as an unparseable timestamp. Same clock (:func:`state_db.now_iso`),
+   same format, different storage.
+
+2. THE BIRTH FIELDS ARE ``LAST_WRITER_WINS``, NOT ``IMMUTABLE``. The SQLite
+   version was ``INSERT OR REPLACE`` and its docstring said why: "a retried
+   launch that re-records the same id must refresh rather than crash".
+   ``IMMUTABLE`` would make that retry raise. This is the opposite call from
+   verdict_dedup, where a moved timestamp silently reorders a failure streak
+   — there the immutability IS the invariant; here refreshability is.
+
+THE ONE INVARIANT THAT MUST NOT BE LOST
+=======================================
+``record_incarnation_exit`` returns True iff a birth record existed, and a
+missing one is a False, NEVER an insert. The old docstring states the
+reason and it survives the port unchanged: "a death with no recorded birth
+is a real signal (a pre-artifact incarnation, or a birth write that failed)
+and fabricating a birth here would hide it."
+
+The store has no UPDATE-only verb — ``put`` writes whatever record you hand
+it — so the SQLite ``UPDATE ... WHERE`` no longer refuses on its own. The
+refusal is therefore EXPLICIT here: read first, return False on a miss, and
+only then write. Written out rather than relied upon, because the guard
+moved from the database into this function and a reader needs to see it.
+
+For the same reason the exit write sends the WHOLE merged record rather than
+the three exit fields alone: it does not depend on the store's per-field
+merge semantics to preserve the birth data, so the row cannot be hollowed
+out by a partial write. The cost is one extra read per exit, on a path that
+runs once per process lifetime.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "incarnations"
+
+#: Every write from this host is attributed to one node. A birth certificate
+#: is written by the launcher ON the host that launched it, and the death
+#: mirror by that same incarnation's runner, so SINGLE_WRITER is the honest
+#: policy rather than a convenience.
+_ACTOR = "scitex-agent-container"
 
 __all__ = [
+    "STORE_NAME",
     "get_incarnation",
+    "incarnation_store_target",
+    "init_incarnations_schema",
+    "open_incarnation_store",
     "record_incarnation_birth",
     "record_incarnation_exit",
 ]
 
-_SCHEMA_INCARNATIONS = """
-CREATE TABLE IF NOT EXISTS incarnations (
-    incarnation_id      TEXT PRIMARY KEY,
-    agent_id            TEXT NOT NULL,
-    spec_id             TEXT,
-    spec_git_sha        TEXT NOT NULL,
-    host                TEXT NOT NULL,
-    born_at             TEXT NOT NULL,
-    compiled_spec_json  TEXT NOT NULL,
-    exit_reason         TEXT,
-    exit_code           INTEGER,
-    exited_at           TEXT
-);
-CREATE INDEX IF NOT EXISTS idx_incarnations_agent
-    ON incarnations(agent_id, born_at);
-"""
+
+def _schema() -> Any:
+    """The birth-certificate schema.
+
+    Built lazily so importing this module does not import scitex-dev; the
+    old module was equally lazy about ``state_db``, for the same reason
+    (import cost off the hot path).
+
+    ``incarnation_id`` is the sole IDENTITY field and is IMMUTABLE because
+    the store enforces it on identities — "changing one does not update the
+    record, it names a different record", which is exactly right for a
+    process lifetime. Every other field is data ABOUT that lifetime and
+    takes ``LAST_WRITER_WINS`` (see the module docstring for why this
+    differs from verdict_dedup).
+
+    ``agent_id`` is indexed: the SQLite table carried
+    ``idx_incarnations_agent ON (agent_id, born_at)``, and the queries that
+    index served — "every incarnation of this agent" — are the ones a
+    future reader will write.
+    """
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
+
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def fact(kind: Any, *, required: bool = False, indexed: bool = False) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=required,
+            merge=MergeRule.LAST_WRITER_WINS,
+            indexed=indexed,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "incarnation_id": ident(FieldKind.TEXT),
+            # --- birth: written once at launch, refreshed by a retry ---
+            "agent_id": fact(FieldKind.TEXT, required=True, indexed=True),
+            "spec_id": fact(FieldKind.TEXT),
+            "spec_git_sha": fact(FieldKind.TEXT, required=True),
+            "host": fact(FieldKind.TEXT, required=True),
+            "born_at": fact(FieldKind.TEXT, required=True),
+            "compiled_spec_json": fact(FieldKind.TEXT, required=True),
+            # --- death: absent until the incarnation ends ---
+            "exit_reason": fact(FieldKind.TEXT),
+            "exit_code": fact(FieldKind.INTEGER),
+            "exited_at": fact(FieldKind.TEXT),
+        },
+    )
+
+
+def incarnation_store_target() -> Any:
+    """Resolve WHERE the birth certificates live. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_incarnation_store() -> Store:
+    """Open the incarnations store. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function here opens and closes
+    one per call, mirroring the old ``with open_db(...)`` shape: births and
+    deaths happen once per process lifetime, so the connection cost sits on
+    a launch path, never on a request path.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        incarnation_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_incarnations_schema() -> str:
+    """Create the incarnations tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL
+    equivalent of the ``Path`` the SQLite version returned, and useful in
+    exactly the same way: it names WHERE the state actually went, so an
+    operator can check it rather than assume it.
+    """
+    store = open_incarnation_store()
+    try:
+        return str(incarnation_store_target().locator)
+    finally:
+        store.close()
 
 
 def record_incarnation_birth(
@@ -71,35 +215,38 @@ def record_incarnation_birth(
     spec_git_sha: str,
     host: str | None,
     compiled_spec_json: str,
-    db_path: Path | None = None,
 ) -> str:
-    """Insert the birth certificate row for one incarnation.
+    """Write the birth certificate for one incarnation. Returns the id.
 
-    ``INSERT OR REPLACE`` on the primary key: the launch path writes
-    exactly once per incarnation, and a retried launch that re-records
-    the same id must refresh rather than crash. Returns the id.
+    Upsert, preserving the old ``INSERT OR REPLACE``: the launch path writes
+    exactly once per incarnation, and a retried launch that re-records the
+    same id must refresh rather than crash.
+
+    A retry refreshes ``born_at`` too. That matches the SQLite behaviour
+    exactly — ``INSERT OR REPLACE`` rewrote the whole row — and is the
+    correct reading: the birth being recorded is the one that took.
     """
-    from .state_db import now_iso, open_db
+    from scitex_dev.store import ANY_REVISION
+
+    from .state_db import now_iso
     from .state_db_hostname import resolve_host
 
-    with open_db(db_path) as conn:
-        conn.execute(
-            """
-            INSERT OR REPLACE INTO incarnations (
-                incarnation_id, agent_id, spec_id, spec_git_sha,
-                host, born_at, compiled_spec_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                incarnation_id,
-                agent_id,
-                spec_id,
-                spec_git_sha,
-                resolve_host(host),
-                now_iso(),
-                compiled_spec_json,
-            ),
+    store = open_incarnation_store()
+    try:
+        store.put(
+            {
+                "incarnation_id": incarnation_id,
+                "agent_id": agent_id,
+                "spec_id": spec_id,
+                "spec_git_sha": spec_git_sha,
+                "host": resolve_host(host),
+                "born_at": now_iso(),
+                "compiled_spec_json": compiled_spec_json,
+            },
+            expected_revision=ANY_REVISION,
         )
+    finally:
+        store.close()
     return incarnation_id
 
 
@@ -108,37 +255,56 @@ def record_incarnation_exit(
     *,
     reason: str,
     code: int,
-    db_path: Path | None = None,
 ) -> bool:
-    """Mirror the terminal ExitRecord onto the incarnation's row.
+    """Mirror the terminal ExitRecord onto the incarnation's record.
 
-    Returns True iff a birth row existed to update. A missing row is a
-    False, not an insert — a death with no recorded birth is a real
-    signal (a pre-artifact incarnation, or a birth write that failed)
-    and fabricating a birth here would hide it. Idempotent-by-overwrite:
-    the LAST exit write wins, matching ``exit.json`` semantics.
+    Returns True iff a birth record existed to update. A missing record is a
+    False, not an insert — a death with no recorded birth is a real signal
+    (a pre-artifact incarnation, or a birth write that failed) and
+    fabricating a birth here would hide it. Idempotent-by-overwrite: the
+    LAST exit write wins, matching ``exit.json`` semantics.
+
+    The read-then-write is not an optimisation and must not be collapsed
+    into a bare ``put``: the store has no UPDATE-only verb, so this function
+    IS the refusal that the SQLite ``UPDATE ... WHERE`` used to perform.
     """
-    from .state_db import now_iso, open_db
+    from scitex_dev.store import ANY_REVISION
 
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            "UPDATE incarnations SET exit_reason=?, exit_code=?, exited_at=? "
-            "WHERE incarnation_id=?",
-            (reason, int(code), now_iso(), incarnation_id),
+    from .state_db import now_iso
+
+    key = {"incarnation_id": incarnation_id}
+    store = open_incarnation_store()
+    try:
+        existing = store.get(key)
+        if existing is None:
+            return False
+        merged = dict(existing.values)
+        merged.update(
+            {
+                "incarnation_id": incarnation_id,
+                "exit_reason": reason,
+                "exit_code": int(code),
+                "exited_at": now_iso(),
+            }
         )
-        return cur.rowcount > 0
+        store.put(merged, expected_revision=ANY_REVISION)
+    finally:
+        store.close()
+    return True
 
 
-def get_incarnation(
-    incarnation_id: str,
-    db_path: Path | None = None,
-) -> dict | None:
-    """Return one incarnation row as a dict, or None when unknown."""
-    from .state_db import open_db
+def get_incarnation(incarnation_id: str) -> dict | None:
+    """Return one incarnation record as a dict, or None when unknown.
 
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT * FROM incarnations WHERE incarnation_id=?",
-            (incarnation_id,),
-        ).fetchone()
-        return dict(row) if row is not None else None
+    ``Row.values`` is the schema fields only — the store's own bookkeeping
+    (hlc, seq, origin, owner) hangs off sibling attributes and deliberately
+    does NOT ride along in the returned dict. The SQLite version returned
+    ``dict(sqlite3.Row)``, which was likewise exactly the table columns, so
+    callers see the same shape they always did.
+    """
+    store = open_incarnation_store()
+    try:
+        row = store.get({"incarnation_id": incarnation_id})
+    finally:
+        store.close()
+    return dict(row.values) if row is not None else None

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -416,7 +416,7 @@ def resolve_node_host(
     with open_db(db_path) as conn:
         row = conn.execute(
             """
-            SELECT host, a2a_port
+            SELECT host, a2a_port, bound_port
               FROM instances
              WHERE name = ? AND ended_at IS NULL
              ORDER BY started_at DESC, id DESC
@@ -425,11 +425,34 @@ def resolve_node_host(
             (name,),
         ).fetchone()
     if row is not None:
+        # PREFER bound_port, fall back to the legacy a2a_port. Reading only
+        # a2a_port discarded a usable address that was sitting in the same
+        # row: `_send_resolve` has preferred bound_port over the legacy
+        # column since it was introduced, and the writers populate BOTH
+        # (`record_instance_start(a2a_port=bound, bound_port=bound)`), so a
+        # row where only bound_port survived resolved to "no port" here and
+        # 502'd at the forwarder while the sibling resolver would have
+        # reached it. Same row, same moment, two answers — the asymmetry was
+        # the defect, not the null.
+        port = row["a2a_port"]
+        if port is None:
+            port = row["bound_port"]
         return {
             "host": str(row["host"]),
-            "a2a_port": int(row["a2a_port"]) if row["a2a_port"] is not None else None,
+            "a2a_port": int(port) if port is not None else None,
         }
     # Fall through to comms_nodes (ADR-0014).
+    #
+    # NOT ALSO FALLING THROUGH WHEN THE ROW EXISTS BUT CARRIES NO PORT, and
+    # the reason is that this function answers TWO questions with one value.
+    # `is_local_node` consults it and reads ONLY ``host``: a live row means
+    # "the agent is on that host", which stays true whether or not a port is
+    # recorded. Falling through on a portless row would hand the locality
+    # decision to ``comms_nodes``, which may name a DIFFERENT host — so an
+    # agent that is genuinely local could start being forwarded away, and a
+    # routing repair would have silently changed what "local" means.
+    # Splitting locality from addressability is the real fix and it is a
+    # bigger change than this one; see the a2a card.
     return resolve_comms_node_host(name=name, db_path=db_path)
 
 

--- a/src/scitex_agent_container/_state/state_db_pending_approval.py
+++ b/src/scitex_agent_container/_state/state_db_pending_approval.py
@@ -1,4 +1,4 @@
-"""Pending-prompt flag for the ACL block/unblock flow (task #27).
+"""Pending-prompt flag for the ACL block/unblock flow — on PostgreSQL only.
 
 Operator-requested via lead (2026-06-01). Lead's design amendment
 SUPERSEDED an earlier "hold the original message + replay on grant"
@@ -13,131 +13,257 @@ design in favour of a simpler BLOCK / UNBLOCK primitive:
   receiver already has the decision in front of them. This module
   owns that "is there a pending row" flag.
 * The receiver's decision (either ``unblock`` → ``grant_send`` or
-  ``block`` → ``block_send``) clears the pending row in the same
-  transaction. No held message replay — if the sender wants their
-  message delivered after unblock, they resend.
-* No TTL, no expiry sweep, no latest-wins dedupe. The original
-  spec's fragile spam-debounce logic is intentionally dropped — the
-  primitive is just "is there a pending decision yes/no".
+  ``block`` → ``block_send``) clears the pending row. No held message
+  replay — if the sender wants their message delivered after unblock,
+  they resend.
+* No TTL, no expiry sweep, no latest-wins dedupe. The primitive is
+  just "is there a pending decision yes/no".
 
-Schema is minimal: ``(sender, target, ts)``. The original message
-content is NEVER stored here (the receiver decides on identity, not
-on message content).
+The original message content is NEVER stored here (the receiver
+decides on identity, not on message content).
 
-No-mocks (PA-306) testing — real on-disk sqlite, no monkeypatch.
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to
+PostgreSQL: "fail fast, fail loud, no fallbacks". This is the third table
+to move, after ``verdict_delivered`` and ``incarnations``, and it moves
+the same way — by ADOPTING :mod:`scitex_dev.store` rather than by sac
+growing a private psycopg layer.
+
+``db_path`` IS GONE from every function. It named a SQLite file; there is
+no file. ``grant_flush`` was threading its own state.db path in here and
+stops; the two records now live in two different databases, which is what
+the migration is doing one table at a time.
+
+THE DELETE IS THE NEW GROUND, AND IT IS WHY THIS ONE NEEDED THOUGHT
+===================================================================
+The two tables that moved before this one only ever inserted. This one
+DELETES, and the store has no delete — it has ``hide``, which marks a
+record invisible to ``get``/``rows`` while keeping it in the oplog.
+
+That is the better primitive here (the decision history stays auditable),
+but it introduces a lifecycle the SQLite version did not have: a cleared
+pair is not ABSENT, it is HIDDEN. Written naively, the next denial for
+that pair would find ``get() -> None``, try to insert, collide with the
+hidden record, and return "already pending" — so the receiver would never
+be prompted again. A fix for a silent-success bug that silently suppresses
+prompts forever is worse than the bug.
+
+:meth:`Store.is_hidden` is what makes this expressible, because it answers
+in THREE values rather than two:
+
+    None    no record at all          -> insert, this is the first prompt
+    True    cleared earlier           -> unhide + refresh ts, prompt again
+    False   present and visible       -> already pending, suppress
+
+``get`` alone collapses the first two into "nothing there", and that
+collapse is exactly the bug.
+
+All times are unix-seconds (float), matching the SQLite column and the
+diary tables.
 """
 
 from __future__ import annotations
 
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "pending_prompts"
+
+#: Every write from this host is attributed to one node. The flag is
+#: written by the listen daemon that observed the denial and cleared by
+#: the same host's grant/block path, so SINGLE_WRITER is honest rather
+#: than convenient.
+_ACTOR = "scitex-agent-container"
 
 __all__ = [
-    "ensure_pending_prompts_table",
+    "STORE_NAME",
     "clear_pending_prompt",
     "has_pending_prompt",
+    "init_pending_prompts_schema",
+    "open_pending_prompt_store",
+    "pending_prompt_store_target",
     "record_pending_prompt",
 ]
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS pending_prompts (
-    sender TEXT NOT NULL,
-    target TEXT NOT NULL,
-    ts     REAL NOT NULL,
-    PRIMARY KEY (sender, target)
-);
-"""
+def _schema() -> Any:
+    """The pending-prompt schema.
 
+    Built lazily so importing this module does not import scitex-dev; the
+    old module was equally lazy about ``state_db``, for the same reason.
 
-def ensure_pending_prompts_table(db_path: Path | None = None) -> None:
-    """Idempotent CREATE TABLE for the pending-prompt flag store.
+    ``(sender, target)`` is the composite IDENTITY — the SQLite table's
+    PRIMARY KEY, unchanged. Identity fields must be IMMUTABLE and the
+    store enforces it: "changing one does not update the record, it names
+    a different record", which is exactly right for a pair.
 
-    Called from :func:`_state.state_db.init_schema` so a fresh
-    state.db carries the table; safe to call multiple times.
+    ``ts`` is LAST_WRITER_WINS rather than IMMUTABLE, and that is load
+    bearing: a pair that was cleared and then re-denied must carry the
+    time of the NEW prompt, not the old one. Nothing orders decisions on
+    this field today, so refreshing it cannot reorder anything.
     """
-    from .state_db import open_db
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
 
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "sender": ident(FieldKind.TEXT),
+            "target": ident(FieldKind.TEXT),
+            "ts": FieldPolicy(
+                kind=FieldKind.REAL,
+                role=FieldRole.DATA,
+                required=True,
+                merge=MergeRule.LAST_WRITER_WINS,
+                indexed=False,
+            ),
+        },
+    )
 
 
-def record_pending_prompt(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
+def pending_prompt_store_target() -> Any:
+    """Resolve WHERE the pending-prompt flags live. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_pending_prompt_store() -> Store:
+    """Open the flag store. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function opens and closes one
+    per call, mirroring the old ``with open_db(...)`` shape: this runs on a
+    denial and on a decision, not on a request path.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        pending_prompt_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_pending_prompts_schema() -> str:
+    """Create the flag tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL
+    equivalent of the ``None`` the SQLite version returned, and strictly
+    more useful: it names WHERE the state actually went, so an operator can
+    check it rather than assume it.
+    """
+    store = open_pending_prompt_store()
+    try:
+        return str(pending_prompt_store_target().locator)
+    finally:
+        store.close()
+
+
+def record_pending_prompt(*, sender: str, target: str) -> bool:
     """Mark ``(sender, target)`` as "prompt-emitted, awaiting decision".
 
-    Returns ``True`` iff this call is the FIRST pending-prompt for
-    the pair (caller should emit the receiver-facing push). Returns
-    ``False`` when a pending row already exists (caller suppresses
-    re-prompt). The check + insert is one atomic transaction so a
-    concurrent burst of denied attempts emits exactly one prompt.
+    Returns ``True`` iff this call is the FIRST pending-prompt for the pair
+    (caller should emit the receiver-facing push). Returns ``False`` when a
+    pending flag already exists (caller suppresses re-prompt).
 
     Fail-loud: empty ``sender`` / ``target`` raise ``ValueError``.
+
+    THE THREE-WAY BRANCH IS THE POINT — see the module docstring. A pair
+    that was CLEARED is hidden, not absent, and must be re-armed rather
+    than treated as already-pending; collapsing those two states is how
+    this becomes a prompt that never fires again.
+
+    CONCURRENCY IS PRESERVED, and it was explicit in the SQLite version:
+    "the check + insert is one atomic transaction so a concurrent burst of
+    denied attempts emits exactly one prompt". Here the insert carries
+    ``expected_revision=NEW_RECORD``, so a racing writer that created the
+    record between our check and our write raises ``RevisionMismatchError``
+    — which means "someone else prompted", the same answer the SQLite
+    transaction gave. Nothing else is caught: an unreachable store must
+    still be loud.
     """
     if not sender or not target:
         raise ValueError("record_pending_prompt: sender and target must be non-empty")
-    from .state_db import open_db
 
-    ensure_pending_prompts_table(db_path)
-    with open_db(db_path) as conn:
-        existing = conn.execute(
-            "SELECT 1 FROM pending_prompts WHERE sender = ? AND target = ?",
-            (sender, target),
-        ).fetchone()
-        if existing is not None:
+    from scitex_dev.store import ANY_REVISION, NEW_RECORD, RevisionMismatchError
+
+    key = {"sender": sender, "target": target}
+    store = open_pending_prompt_store()
+    try:
+        hidden = store.is_hidden(key)
+        if hidden is False:
             return False
-        conn.execute(
-            "INSERT INTO pending_prompts (sender, target, ts) VALUES (?, ?, ?)",
-            (sender, target, time.time()),
-        )
-    return True
+        if hidden is True:
+            store.unhide(key, expected_revision=ANY_REVISION)
+            store.put({**key, "ts": time.time()}, expected_revision=ANY_REVISION)
+            return True
+        try:
+            store.put({**key, "ts": time.time()}, expected_revision=NEW_RECORD)
+        except RevisionMismatchError:
+            return False
+        return True
+    finally:
+        store.close()
 
 
-def has_pending_prompt(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
+def has_pending_prompt(*, sender: str, target: str) -> bool:
     """Return True iff ``(sender, target)`` has a pending prompt awaiting
-    the receiver's block/unblock decision."""
-    if not sender or not target:
-        return False
-    from .state_db import open_db
+    the receiver's block/unblock decision.
 
-    ensure_pending_prompts_table(db_path)
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT 1 FROM pending_prompts WHERE sender = ? AND target = ?",
-            (sender, target),
-        ).fetchone()
-    return row is not None
-
-
-def clear_pending_prompt(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
-    """Delete the pending row for ``(sender, target)``. Returns True iff
-    a row was removed. Idempotent on absent rows.
-
-    Called from both decision paths: ``grant_send`` / ``block_send``
-    (unblock or block) clear the pending prompt in the same workflow.
+    ``get`` excludes hidden records by default, so a cleared pair reads as
+    absent here — which is precisely the SQLite DELETE semantics this
+    replaces.
     """
     if not sender or not target:
         return False
-    from .state_db import open_db
+    store = open_pending_prompt_store()
+    try:
+        return store.get({"sender": sender, "target": target}) is not None
+    finally:
+        store.close()
 
-    ensure_pending_prompts_table(db_path)
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            "DELETE FROM pending_prompts WHERE sender = ? AND target = ?",
-            (sender, target),
-        )
-    return int(cur.rowcount or 0) > 0
+
+def clear_pending_prompt(*, sender: str, target: str) -> bool:
+    """Clear the pending flag for ``(sender, target)``. Returns True iff a
+    visible flag was cleared. Idempotent on absent or already-cleared pairs.
+
+    Called from both decision paths: ``grant_send`` / ``block_send``
+    (unblock or block) clear the pending prompt in the same workflow.
+
+    HIDE RATHER THAN DELETE. The store has no delete verb, and that is the
+    better fit: the decision stays in the oplog with the actor that made
+    it, so "who cleared this, and when" survives — which a DELETE destroyed.
+    The read side is unchanged because ``get`` skips hidden records.
+    """
+    if not sender or not target:
+        return False
+
+    from scitex_dev.store import ANY_REVISION
+
+    key = {"sender": sender, "target": target}
+    store = open_pending_prompt_store()
+    try:
+        if store.get(key) is None:
+            return False
+        store.hide(key, expected_revision=ANY_REVISION)
+        return True
+    finally:
+        store.close()

--- a/src/scitex_agent_container/_state/state_db_verdict_dedup.py
+++ b/src/scitex_agent_container/_state/state_db_verdict_dedup.py
@@ -1,63 +1,186 @@
-"""CI-verdict delivery dedup — the "delivered-set" (sac #404).
+"""CI-verdict delivery dedup — the "delivered-set", on PostgreSQL only.
 
-feedback.pdf §3: sac polls GitHub CI on its OWN schedule and a2a-delivers
-each verdict to the pusher EXACTLY ONCE — deduping on
-``(repo, pr, head_sha, conclusion)`` in sac's own state so a re-poll (or a
-``sac listen`` restart) never re-delivers a verdict the agent already saw.
-This module owns that delivered-set table in ``state.db``.
+sac polls GitHub CI on its own schedule and a2a-delivers each verdict to the
+pusher EXACTLY ONCE, deduping on ``(repo, pr, head_sha, conclusion)`` so a
+re-poll or a ``sac listen`` restart never re-delivers a verdict the agent
+already saw. A re-run that flips the conclusion on the same ``head_sha`` is a
+DISTINCT key, so the flipped verdict IS delivered; a new push is likewise
+distinct. The dedup is per exact outcome, not per PR.
 
-A re-run that flips the conclusion (red→green on the same head_sha) is a
-DISTINCT key, so the flipped verdict IS delivered — the dedup is per exact
-outcome, not per PR. A new push (new ``head_sha``) is likewise distinct.
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to
+PostgreSQL: "fail fast, fail loud, no fallbacks". This is the first table to
+move, and it moves by ADOPTING :mod:`scitex_dev.store` — the fleet's own
+store primitive — rather than by sac growing a private psycopg layer.
 
-Sibling-module pattern (mirrors :mod:`dispatch_ledger`): own
-``CREATE TABLE IF NOT EXISTS`` behind :func:`init_verdict_dedup_schema`,
-layered on the shared connection from :func:`state_db.open_db`, and a
-lazy :func:`_ensure_table` so callers never need an explicit init. Kept
-out of ``state_db.py`` so this branch never collides with concurrent
-``state_db.py`` work (same rationale as the dispatch ledger).
+That primitive already implements the operator's rule, in its own words at
+``resolve_target``: "exactly two steps (``SCITEX_STORE_DSN`` or the per-host
+Postgres) and deliberately NO SQLite fallback: a host whose Postgres is down
+must fail loudly rather than start writing to a private local file that
+shares nothing."
 
-All times are ``REAL`` unix-seconds (float), matching the diary tables.
+So there is nothing here to fall back TO. A host whose PostgreSQL is
+unreachable raises ``StoreTargetError`` naming the DSN it could not reach.
+That is the intended behaviour: a verdict that cannot be recorded must not
+be silently re-delivered forever, and a dedup set written to a file nobody
+reads is worse than no dedup at all.
+
+WHAT REPLACED WHAT
+==================
+``db_path`` IS GONE from every function. It named a SQLite file; there is no
+file. The store target comes from :func:`scitex_dev.store.host_store`, which
+sac's containers reach because ``SCITEX_STORE_DSN`` is injected as a fleet
+default (see :mod:`.._fleet_env`). Callers that used to thread ``db_path``
+through simply stop.
+
+``failures_since_last_success`` was a correlated SQL aggregate. The store
+exposes ``get``/``put``/``rows``, not SQL, so the streak is now computed in
+Python. THE COST IS STATED RATHER THAN HIDDEN: ``rows()`` materialises the
+whole delivered-set, where the old query counted server-side. Measured
+2026-08-19 the largest host held 722 rows and the fleet 1,298, growing by a
+handful a day, so this is comfortable for years — but it is O(n) per call
+and if this table ever reaches six figures the streak wants an indexed
+query instead. Recorded so a future reader finds a decision, not a surprise.
+
+Writing is INSERT-OR-IGNORE, preserved exactly: a re-seen verdict must not
+move ``delivered_at``, because that timestamp is what ORDERS the streak. A
+re-poll that refreshed it would silently reorder history and the failure cap
+would stop capping, with no error anywhere.
+
+TWO INDEPENDENT GUARDS HOLD THAT INVARIANT, and I only learned there were
+two by trying to break it:
+
+  1. ``put`` is attempted only for a key that is ABSENT, with
+     ``expected_revision=NEW_RECORD``. A concurrent writer that wins the
+     race raises ``RevisionMismatchError``, which means "already recorded"
+     — the same outcome the old ``INSERT OR IGNORE`` produced. No other
+     exception is caught; an unreachable store must still be loud.
+  2. the DATA fields are ``MergeRule.IMMUTABLE`` in the schema, so the
+     store itself REFUSES a later write to them.
+
+Measured 2026-08-19, one arm at a time: breaking (1) alone (upsert with
+``ANY_REVISION``) leaves the invariant intact because (2) catches it, and
+breaking (2) alone (``LAST_WRITER_WINS``) leaves it intact because (1)
+catches it. Only with BOTH removed does the timestamp move, and the test
+then fails alone. So neither guard is redundant decoration and neither is
+load-bearing by itself — remove one and the test still passes, which is
+precisely why this note exists rather than a comment saying "idempotent".
+
+All times are unix-seconds (float), matching the diary tables.
 """
 
 from __future__ import annotations
 
-import sqlite3
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS verdict_delivered (
-    repo          TEXT NOT NULL,
-    pr            INTEGER NOT NULL,
-    head_sha      TEXT NOT NULL,
-    conclusion    TEXT NOT NULL,
-    dispatch_id   TEXT,
-    delivered_at  REAL NOT NULL,
-    PRIMARY KEY (repo, pr, head_sha, conclusion)
-);
-"""
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Row, Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "verdict_delivered"
+
+#: Every write from this host is attributed to one node. The dedup set is
+#: single-writer per host by construction — only that host's ``sac listen``
+#: polls CI for it — so SINGLE_WRITER is the honest policy rather than a
+#: convenience.
+_ACTOR = "scitex-agent-container"
 
 
-def init_verdict_dedup_schema(db_path: Path | None = None) -> Path:
-    """Create the ``verdict_delivered`` table if missing. Idempotent.
+def _schema() -> Any:
+    """The delivered-set schema.
 
-    Delegates the base schema + connection config to
-    :func:`state_db.open_db`, then layers our own
-    ``CREATE TABLE IF NOT EXISTS`` so the delivered-set lives in the same
-    ``state.db`` file as the registry + diary tables. Returns the
-    resolved database path.
+    Built lazily so importing this module does not import scitex-dev; the
+    old module was equally lazy about ``state_db``, for the same reason
+    (import cost off the hot path).
+
+    IDENTITY fields must be IMMUTABLE — the store enforces it, and the
+    reason is worth keeping: "changing one does not update the record, it
+    names a different record." The two DATA fields are IMMUTABLE too,
+    deliberately: a delivered verdict is a historical fact, and a merge that
+    could move ``delivered_at`` would silently reorder the failure streak.
     """
-    from .state_db import init_schema, open_db
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
 
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
-    return init_schema(db_path)
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def fact(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=False,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "repo": ident(FieldKind.TEXT),
+            "pr": ident(FieldKind.INTEGER),
+            "head_sha": ident(FieldKind.TEXT),
+            "conclusion": ident(FieldKind.TEXT),
+            "dispatch_id": fact(FieldKind.TEXT),
+            "delivered_at": fact(FieldKind.REAL),
+        },
+    )
 
 
-def _ensure_table(conn: sqlite3.Connection) -> None:
-    """Ensure the delivered-set table exists on an already-open connection."""
-    conn.executescript(_SCHEMA)
+def verdict_store_target() -> Any:
+    """Resolve WHERE the delivered-set lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_verdict_store() -> Store:
+    """Open the delivered-set store. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function here opens and closes
+    one per call, which mirrors the old ``with open_db(...)`` shape — the
+    connection cost was acceptable before and the call rate has not changed
+    (one CI poll tick, not a request path).
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        verdict_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_verdict_dedup_schema() -> str:
+    """Create the delivered-set tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — the PostgreSQL
+    equivalent of the ``Path`` the SQLite version returned, and useful in
+    exactly the same way: it names WHERE the state actually went, so an
+    operator can check it rather than assume it.
+
+    Opening the store is what creates the tables, so this connects. It is
+    the locator, NOT ``Store.identity`` — that is a property, and reaching
+    for it with a ``hasattr`` guard would have turned a typo into a silently
+    wrong return value instead of an error.
+    """
+    store = open_verdict_store()
+    try:
+        return str(verdict_store_target().locator)
+    finally:
+        store.close()
 
 
 def verdict_already_delivered(
@@ -66,23 +189,24 @@ def verdict_already_delivered(
     pr: int,
     head_sha: str,
     conclusion: str,
-    db_path: Path | None = None,
 ) -> bool:
     """Return ``True`` iff this exact verdict was already delivered.
 
-    The dedup key is the 4-tuple ``(repo, pr, head_sha, conclusion)``. A
-    miss — or a brand-new ``state.db`` — returns ``False`` so the caller
-    delivers. Never raises on a fresh db (the table is ensured first).
+    The dedup key is the 4-tuple ``(repo, pr, head_sha, conclusion)``. A miss
+    — or a brand-new store — returns ``False`` so the caller delivers.
     """
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        row = conn.execute(
-            "SELECT 1 FROM verdict_delivered "
-            "WHERE repo=? AND pr=? AND head_sha=? AND conclusion=?",
-            (repo, int(pr), head_sha, conclusion),
-        ).fetchone()
+    store = open_verdict_store()
+    try:
+        row = store.get(
+            {
+                "repo": repo,
+                "pr": int(pr),
+                "head_sha": head_sha,
+                "conclusion": conclusion,
+            }
+        )
+    finally:
+        store.close()
     return row is not None
 
 
@@ -94,68 +218,92 @@ def record_verdict_delivered(
     conclusion: str,
     dispatch_id: str | None = None,
     delivered_at: float | None = None,
-    db_path: Path | None = None,
 ) -> None:
     """Mark this verdict delivered. Idempotent (re-poll-safe).
 
-    Uses ``INSERT OR IGNORE`` on the 4-tuple primary key so re-seeing the
-    same verdict is a no-op rather than an ``IntegrityError`` — the loop
-    can record unconditionally after a successful delivery.
+    Re-seeing a verdict is a NO-OP rather than an overwrite: ``delivered_at``
+    orders the failure streak, so a re-poll that refreshed it would quietly
+    reorder history. This is the old ``INSERT OR IGNORE`` semantics, kept.
     """
-    from .state_db import open_db
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
 
+    key = {
+        "repo": repo,
+        "pr": int(pr),
+        "head_sha": head_sha,
+        "conclusion": conclusion,
+    }
     ts = float(delivered_at) if delivered_at is not None else time.time()
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        conn.execute(
-            "INSERT OR IGNORE INTO verdict_delivered "
-            "(repo, pr, head_sha, conclusion, dispatch_id, delivered_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (repo, int(pr), head_sha, conclusion, dispatch_id, ts),
-        )
+    store = open_verdict_store()
+    try:
+        if store.get(key) is not None:
+            return
+        try:
+            store.put(
+                {**key, "dispatch_id": dispatch_id, "delivered_at": ts},
+                expected_revision=NEW_RECORD,
+            )
+        except RevisionMismatchError:
+            # A concurrent writer created the same key between our get and
+            # our put. "Already recorded" is the outcome we wanted; this is
+            # the optimistic-concurrency contract, not a swallowed error.
+            # Deliberately narrow: nothing else is caught, so an unreachable
+            # store still raises.
+            return
+    finally:
+        store.close()
 
 
-def failures_since_last_success(
-    *,
-    repo: str,
-    pr: int,
-    db_path: Path | None = None,
-) -> int:
+def failures_since_last_success(*, repo: str, pr: int) -> int:
     """Count failure verdicts delivered for this PR since its last green.
 
     The dedup key includes ``head_sha``, so a PR whose head keeps moving
     re-fires forever — every push is a fresh key. That is correct for a
     branch someone is pushing fixes to, and wrong for a standing sync PR
-    whose head tracks its source branch: there, each unrelated merge
-    moves the head and earns another "fix-and-push" the recipient cannot
-    act on. This count is the streak the caller caps on.
+    whose head tracks its source branch: there, each unrelated merge moves
+    the head and earns another "fix-and-push" the recipient cannot act on.
+    This count is the streak the caller caps on.
 
-    Counts only rows *newer* than the most recent ``success`` for the
-    same ``(repo, pr)``, so a red→green→red sequence starts over rather
-    than staying capped forever. With no success on record the floor is
-    ``0.0``, which every real ``delivered_at`` exceeds.
+    Counts only rows NEWER than the most recent ``success`` for the same
+    ``(repo, pr)``, so a red -> green -> red sequence starts over rather than
+    staying capped forever. With no success on record the floor is ``0.0``,
+    which every real ``delivered_at`` exceeds.
 
-    Returns 0 on a fresh db (the table is ensured first).
+    Returns 0 on a brand-new store.
     """
-    from .state_db import open_db
+    store = open_verdict_store()
+    try:
+        rows: list[Row] = store.rows()
+    finally:
+        store.close()
 
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        row = conn.execute(
-            "SELECT count(*) FROM verdict_delivered "
-            "WHERE repo=? AND pr=? AND conclusion='failure' "
-            "  AND delivered_at > COALESCE(("
-            "        SELECT max(delivered_at) FROM verdict_delivered "
-            "        WHERE repo=? AND pr=? AND conclusion='success'"
-            "      ), 0.0)",
-            (repo, int(pr), repo, int(pr)),
-        ).fetchone()
-    return int(row[0]) if row else 0
+    mine = [
+        r.values
+        for r in rows
+        if r.values.get("repo") == repo and int(r.values.get("pr", -1)) == int(pr)
+    ]
+    last_success = max(
+        (
+            float(v.get("delivered_at") or 0.0)
+            for v in mine
+            if v.get("conclusion") == "success"
+        ),
+        default=0.0,
+    )
+    return sum(
+        1
+        for v in mine
+        if v.get("conclusion") == "failure"
+        and float(v.get("delivered_at") or 0.0) > last_success
+    )
 
 
 __all__ = [
+    "STORE_NAME",
+    "verdict_store_target",
     "failures_since_last_success",
     "init_verdict_dedup_schema",
+    "open_verdict_store",
     "record_verdict_delivered",
     "verdict_already_delivered",
 ]

--- a/src/scitex_agent_container/_store_plugin.py
+++ b/src/scitex_agent_container/_store_plugin.py
@@ -383,10 +383,11 @@ NEVER_SYNCED: dict[str, str] = {
         "skips or replays frames with no error anywhere"
     ),
     "acl_deny_notify_log": (
-        "a per-host rate-limit ledger (last_notified_at). Merging it "
-        "suppresses a deny-notification on a host that never sent one — "
-        "the failure is a notification that does NOT arrive, which is "
-        "invisible by construction"
+        "a per-host rate-limit ledger (last_notified_at) — since 2026-08-20 a "
+        "per-host PostgreSQL store rather than a SQLite table, which does not "
+        "change the ruling. Merging it suppresses a deny-notification on a "
+        "host that never sent one — the failure is a notification that does "
+        "NOT arrive, which is invisible by construction"
     ),
     "instance_heartbeats": (
         "the per-sample heartbeat STREAM, thousands of rows per agent per "

--- a/src/scitex_agent_container/cli_pkg/_account_keepalive.py
+++ b/src/scitex_agent_container/cli_pkg/_account_keepalive.py
@@ -76,10 +76,69 @@ def _render(record: dict[str, Any], out) -> None:
         )
 
 
-def register_keepalive_command(group: click.Group) -> None:
-    """Attach the ``keepalive`` subcommand onto ``group``."""
+def format_peer_lines(peers: "list[str]") -> list[str]:
+    """Render ``peers`` as the ``--help`` block listing what ``--to`` takes.
 
-    @group.command("keepalive")
+    Pure, so the rendering can be asserted without a host's real
+    ``config.yaml`` deciding the expected output — a test that reads the
+    live table would assert an environmental fact rather than a property
+    of this function.
+    """
+    if not peers:
+        return []
+    lines = ["Registered peers --to accepts on THIS host:"]
+    for name in sorted(peers):
+        # A wildcard row (``spartan-*``) is a TEMPLATE for per-node keys,
+        # not a name anyone can type. Printing it bare would repeat the
+        # defect this listing exists to fix: help that names something
+        # the command rejects.
+        if "*" in name:
+            lines.append(f"  {name}  (pattern — substitute a real node name)")
+        else:
+            lines.append(f"  {name}")
+    return lines
+
+
+def _registered_peer_lines() -> list[str]:
+    """The peer keys ``--to`` will actually accept, for ``--help``.
+
+    ``--to`` is documented as "a peer key from config.yaml", and the
+    shipped examples named ``compute-04`` and ``laptop`` — neither of
+    which is a key on any host. Copy-pasting the documentation therefore
+    failed. Reading the real table at render time means the help cannot
+    drift from what the command accepts.
+
+    Returns ``[]`` on ANY failure. ``--help`` must render on a machine
+    with no config, an unreadable config or a malformed one; a help
+    screen that raises is worse than a help screen that omits a hint.
+    """
+    try:
+        from .._state.host_config import load as load_host_config
+
+        peers = list(load_host_config().peers)
+    except Exception:  # stx-allow: fallback (reason: --help must never raise; an unreadable/absent config yields no hint rather than a crash)
+        return []
+    return format_peer_lines(peers)
+
+
+class _PeerListingCommand(click.Command):
+    """A command whose ``--help`` ends with the peer keys ``--to`` takes."""
+
+    def format_epilog(self, ctx, formatter) -> None:
+        super().format_epilog(ctx, formatter)
+        lines = _registered_peer_lines()
+        if not lines:
+            return
+        formatter.write_paragraph()
+        with formatter.indentation():
+            for line in lines:
+                formatter.write_text(line)
+
+
+def register_keepalive_command(group: click.Group) -> None:
+    """Attach ``send-credentials`` (and its ``keepalive`` alias) onto ``group``."""
+
+    @click.command("send-credentials", cls=_PeerListingCommand)
     @click.option(
         "--account",
         "account_labels",
@@ -109,7 +168,9 @@ def register_keepalive_command(group: click.Group) -> None:
         required=True,
         help=(
             "Peer to push ACCESS-ONLY material to (repeatable). Must be a "
-            "peer key from ~/.scitex/agent-container/config.yaml."
+            "peer key from ~/.scitex/agent-container/config.yaml — this "
+            "--help lists the ones registered here, and `sac host list` "
+            "shows them with their ssh targets."
         ),
     )
     @click.option(
@@ -205,10 +266,10 @@ def register_keepalive_command(group: click.Group) -> None:
         sha256 fingerprints.
 
         \b
-        Examples:
-          $ sac accounts keepalive --account alpha-example-com --to compute-04
-          $ sac accounts keepalive --all --to compute-04 --to laptop
-          $ sac accounts keepalive --all --to compute-04 --sweep
+        Examples (peer keys below are real; run --help to see THIS host's):
+          $ sac accounts send-credentials --account alpha-example-com --to scitex-compute-04
+          $ sac accounts send-credentials --all --to scitex-compute-04 --to ywata-note-win
+          $ sac accounts send-credentials --all --to scitex-compute-04 --sweep
         """
         import json as _json
         import sys
@@ -359,5 +420,47 @@ def register_keepalive_command(group: click.Group) -> None:
         if failed:
             sys.exit(1)
 
+    group.add_command(account_keepalive, "send-credentials")
 
-__all__ = ["register_keepalive_command"]
+    # ``keepalive`` is a PUBLISHED contract, so this is a migration, not a
+    # rename: the old name keeps WORKING and is merely hidden from --help.
+    # A redirect that printed "renamed to X" and exited would break the
+    # systemd units and operator muscle memory that already call it, which
+    # is the opposite of what a rename is for. Remove the alias only once
+    # nothing on any host invokes it.
+    legacy = click.Command(
+        name="keepalive",
+        callback=_deprecated(account_keepalive.callback),
+        params=list(account_keepalive.params),
+        help=account_keepalive.help,
+        short_help="Deprecated alias for send-credentials.",
+        epilog=account_keepalive.epilog,
+        hidden=True,
+    )
+    group.add_command(legacy, "keepalive")
+
+
+def _deprecated(callback):
+    """Wrap ``callback`` so the legacy name says so — on stderr, then runs.
+
+    stderr, not stdout: ``--json`` consumers parse stdout, and a warning
+    that lands there would turn a working script into a JSON parse error.
+    That is the whole failure this alias exists to prevent.
+    """
+    import functools
+
+    @functools.wraps(callback)
+    def _run(*args, **kwargs):
+        click.echo(
+            "warning: `sac accounts keepalive` is now "
+            "`sac accounts send-credentials` — it copies credentials to "
+            "peers, which is what the new name says. The old name still "
+            "works and will be removed once nothing calls it.",
+            err=True,
+        )
+        return callback(*args, **kwargs)
+
+    return _run
+
+
+__all__ = ["format_peer_lines", "register_keepalive_command"]

--- a/src/scitex_agent_container/cli_pkg/_completion_install.py
+++ b/src/scitex_agent_container/cli_pkg/_completion_install.py
@@ -40,6 +40,52 @@ _BINARIES = (
 _SOURCE_MAP = {"bash": "bash_source", "zsh": "zsh_source"}
 
 
+def _tracked_in_a_git_repo(path: Path) -> Path | None:
+    """The repo root when ``path`` is a TRACKED file in a git repo, else None.
+
+    MEASURED 2026-08-20, found by the dotfiles agent while building the fleet
+    git sync. On every fleet host `~/.bashrc` is a symlink:
+
+        /home/ywatanabe/.bashrc -> /home/ywatanabe/.dotfiles/src/.bashrc
+
+    so appending to it writes a TRACKED file in the dotfiles repo. Four hosts
+    ended up carrying the same "local edit" — not four humans, one installer.
+    Those checkouts are permanently dirty, an ff-only pull will not apply, and
+    that is a direct contributor to the fleet running five different dotfiles
+    heads.
+
+    The path is RESOLVED first, because the symlink is the whole mechanism: the
+    file we would open is not the file the name refers to.
+
+    `git ls-files --error-unmatch` rather than `git status`, because the
+    question is "is this file under version control", not "is it currently
+    modified" — an unmodified tracked file is exactly as wrong to append to,
+    and would silently become the modified one.
+    """
+    import subprocess
+
+    real = path.resolve()
+    try:
+        root = subprocess.run(
+            ["git", "-C", str(real.parent), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if root.returncode != 0:
+            return None
+        tracked = subprocess.run(
+            ["git", "-C", str(real.parent), "ls-files", "--error-unmatch", str(real)],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # An unusable git is not evidence that the file is untracked, but it is
+        # also not a reason to block a local install. Fall through to appending
+        # and say nothing false.
+        return None
+    if tracked.returncode != 0:
+        return None
+    return Path(root.stdout.strip())
+
+
 def _install_cached(*args, **kwargs) -> None:
     """Replacement callback for ``install-shell-completion``."""
     # Re-resolve Path.home() each call (not at attach time) so $HOME
@@ -94,6 +140,24 @@ def _install_cached(*args, **kwargs) -> None:
 
         # Add the source line in rc if not already present.
         if rc_path.is_file() and marker in rc_path.read_text():
+            continue
+        repo = _tracked_in_a_git_repo(rc_path)
+        if repo is not None:
+            # REFUSE, and say exactly what to add and where. The line belongs
+            # IN the dotfiles repo — committed once and carried to every host
+            # by the sync that already exists — not appended per host forever
+            # by an installer that makes the checkout dirty each time.
+            click.echo(
+                f"refusing to append to {rc_path}: it resolves to "
+                f"{rc_path.resolve()}, a file tracked in {repo}. Appending "
+                f"would leave that checkout permanently dirty and block an "
+                f"ff-only pull, on this host and on every host that installs "
+                f"sac.\n"
+                f"  Add this line to that file yourself and commit it, so it "
+                f"reaches every host once:\n"
+                f"    {source_line}  {marker}",
+                err=True,
+            )
             continue
         with rc_path.open("a") as fh:
             fh.write(f"\n{source_line}  {marker}\n")

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -164,7 +164,13 @@ def _kind_of(group: str) -> str:
 
 
 def _delegate(
-    kind: str, verb: str, name: str | None, yes: bool, dry_run: bool = False
+    kind: str,
+    verb: str,
+    name: str | None,
+    yes: bool,
+    dry_run: bool = False,
+    adopt: bool = False,
+    force: bool = False,
 ) -> int:
     """Resolve + run one ecosystem delegation. THE single mutation seam.
 
@@ -172,6 +178,12 @@ def _delegate(
     yes, dry_run)`` tuples a verb delegates with, rather than shelling out
     to a real ``scitex-dev`` that would rewrite the host's units and
     crontab. The delegation ARGUMENTS are what those tests are about.
+
+    ``adopt`` and ``force`` default to False and callers pass them BY
+    KEYWORD, so the positional call shape those tests capture is unchanged:
+    a five-element tuple before this parameter existed, five after. A
+    required parameter — or a positional call — would have rewritten every
+    one of those assertions to prove nothing about the behaviour that moved.
     """
     delegation = _backend.resolve(kind, verb)
     if not delegation.supported:
@@ -187,7 +199,14 @@ def _delegate(
             err=True,
         )
         raise SystemExit(4)
-    return _backend.invoke(delegation, name=name, yes=yes, dry_run=dry_run)
+    return _backend.invoke(
+        delegation,
+        name=name,
+        yes=yes,
+        dry_run=dry_run,
+        adopt=adopt,
+        force=force,
+    )
 
 
 def _resolve_one(group: str, typed: str) -> str:
@@ -239,6 +258,48 @@ def _add_list_command(grp, group: str) -> None:
             click.echo(f"  {'':24s} {j.description}")
 
 
+def _adoption_options(verb: str):
+    """``--adopt`` / ``--force``, attached ONLY to the verb that has them.
+
+    Both are real options on ``scitex-dev ecosystem timer install`` and on
+    nothing else in the group. Declaring them unconditionally would let
+    ``sac dev timer uninstall --force`` parse here and then fail downstream
+    on a command that has no such option — trading one misleading message
+    for another.
+
+    They exist at all because scitex-dev's refusal names them. MEASURED
+    2026-08-20: ``install`` on an existing unit prints "Use --adopt to keep
+    the existing supervisor (writes nothing), or --force to overwrite", and
+    following that advice returned ``Error: No such option '--force'``. The
+    wrapper forwarded the message and not the flags.
+    """
+
+    def decorate(fn):
+        if verb != "install":
+            return fn
+        fn = click.option(
+            "--force",
+            is_flag=True,
+            default=False,
+            help=(
+                "Overwrite even when another supervisor exists. Forwarded "
+                "to scitex-dev, which reports loudly what it replaced."
+            ),
+        )(fn)
+        fn = click.option(
+            "--adopt",
+            is_flag=True,
+            default=False,
+            help=(
+                "Keep an existing supervisor of ANY mechanism and write "
+                "nothing. Forwarded to scitex-dev."
+            ),
+        )(fn)
+        return fn
+
+    return decorate
+
+
 def _add_bulk_command(grp, group: str, verb: str) -> None:
     """Attach a verb that acts on every job of the kind, or one named one."""
 
@@ -258,7 +319,8 @@ def _add_bulk_command(grp, group: str, verb: str) -> None:
         default=False,
         help="Confirm. Forwarded to scitex-dev.",
     )
-    def _bulk(name, dry_run, yes, _verb=verb):
+    @_adoption_options(verb)
+    def _bulk(name, dry_run, yes, adopt=False, force=False, _verb=verb):
         _announce_deprecation(group)
         jobs = _jobs_or_degrade(group)
         if name is not None:
@@ -269,7 +331,20 @@ def _add_bulk_command(grp, group: str, verb: str) -> None:
             return
         rc = 0
         for j in jobs:
-            code = _delegate(_kind_of(group), _verb, j.name, yes, dry_run)
+            code = _delegate(
+                _kind_of(group),
+                _verb,
+                j.name,
+                yes,
+                dry_run,
+                # BY KEYWORD, and that is load-bearing. The tests replace
+                # `_delegate` with a lambda that captures `*args`, so passing
+                # these positionally would grow every captured tuple from five
+                # elements to seven and break assertions about a call shape
+                # this change does not alter.
+                adopt=adopt,
+                force=force,
+            )
             rc = rc or code
         raise SystemExit(rc)
 

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -299,6 +299,8 @@ def build_argv(
     name: str | None,
     yes: bool,
     dry_run: bool = False,
+    adopt: bool = False,
+    force: bool = False,
     exe: str = "scitex-dev",
     leaf: object | None = None,
 ) -> list[str]:
@@ -317,6 +319,20 @@ def build_argv(
     refresher; a pass-through that dropped either flag would convert a
     guarded command into an unguarded one, which is strictly worse than
     not offering the verb.
+
+    ``--adopt`` and ``--force`` are forwarded for the same reason, and the
+    argument is not hypothetical. MEASURED 2026-08-20 on scitex-compute-04:
+    ``sac dev timer install host-sync-check -y`` refused because a unit
+    already existed, and printed scitex-dev's own remedy — "Use --adopt to
+    keep the existing supervisor (writes nothing), or --force to overwrite."
+    Both flags are real options on ``scitex-dev ecosystem timer install``;
+    neither existed on the wrapper, so the command answered its own advice
+    with ``Error: No such option '--force'``.
+
+    A dropped flag is worse there than a missing verb, in the same way and
+    for a sharper reason: the reader meets that text while repairing a unit,
+    trusts it, and the failure it produces looks like a broken CLI rather
+    than a message describing a command that is not the one they ran.
 
     The job NAME follows :func:`name_style_for` — ``--name X`` or a bare
     positional, as the INSTALLED scitex-dev actually declares it. It was
@@ -339,6 +355,10 @@ def build_argv(
         argv.append("--dry-run")
     if yes:
         argv.append("--yes")
+    if adopt:
+        argv.append("--adopt")
+    if force:
+        argv.append("--force")
     return argv
 
 
@@ -348,6 +368,8 @@ def invoke(
     name: str | None,
     yes: bool,
     dry_run: bool = False,
+    adopt: bool = False,
+    force: bool = False,
 ) -> int:
     """Run the resolved ``scitex-dev ecosystem`` command; return its exit code.
 
@@ -364,7 +386,15 @@ def invoke(
             "scitex-dev to use `sac dev` job verbs"
         )
     return subprocess.call(
-        build_argv(delegation, name=name, yes=yes, dry_run=dry_run, exe=exe)
+        build_argv(
+            delegation,
+            name=name,
+            yes=yes,
+            dry_run=dry_run,
+            adopt=adopt,
+            force=force,
+            exe=exe,
+        )
     )
 
 

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
@@ -245,6 +245,7 @@ def register_migrate_command(dev_group: click.Group) -> None:
             present=present,
             dropin_dirs=dropins,
             install_argv=_install_argv_factory(),
+            include_held=include_held,
         )
 
         chosen = _migrate.selection(env=dict(__import__("os").environ), home=Path.home())

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
@@ -68,6 +68,27 @@ def _measure(unit_dir: Path) -> tuple[frozenset[str], frozenset[str]]:
     return frozenset(files), frozenset(dirs)
 
 
+def _measure_armed(unit_dir: Path) -> frozenset[str]:
+    """Which units are ARMED — i.e. enabled to fire.
+
+    Read from the same directory as :func:`_measure`, not from ``systemctl``,
+    for two reasons. It honours ``--unit-dir`` (so this is testable without a
+    live systemd), and enablement genuinely IS a filesystem fact: ``systemctl
+    --user enable`` creates a symlink under ``<target>.wants/`` and says so —
+
+        Created symlink .../timers.target.wants/foo.timer -> .../foo.timer
+
+    so the ``.wants`` entries are the enablement, not a proxy for it.
+    """
+    if not unit_dir.is_dir():
+        return frozenset()
+    armed: set[str] = set()
+    for child in unit_dir.iterdir():
+        if child.is_dir() and child.name.endswith(".wants"):
+            armed.update(entry.name for entry in child.iterdir())
+    return frozenset(armed)
+
+
 def _displace_dir(unit_dir: Path, stamp: str) -> Path:
     """``.old/<timestamp>/`` beside the units. NOTHING is ever deleted."""
     return unit_dir / ".old" / stamp
@@ -240,6 +261,10 @@ def register_migrate_command(dev_group: click.Group) -> None:
 
         renames = _select(tuple(only), include_held)
         present, dropins = _measure(directory)
+        # Captured BEFORE the plan runs, because the plan's own `disable` step
+        # destroys the evidence. Without this, "was it armed before?" becomes
+        # unanswerable the moment the migration starts.
+        armed_before = _measure_armed(directory)
         steps = _migrate.plan(
             renames,
             present=present,
@@ -284,14 +309,25 @@ def register_migrate_command(dev_group: click.Group) -> None:
         )
 
         after, _ = _measure(directory)
-        click.echo("\nVerification (exactly one supervisor per job):")
+        armed_now = _measure_armed(directory)
+        click.echo("\nVerification (exactly one supervisor per job, and armed):")
         bad = 0
         for rename in renames:
-            if rename.held:
-                continue
-            result = _migrate.verify_exactly_one(rename, present=after)
+            # NOT skipped when `rename.held`. `_select` has ALREADY decided what
+            # this invocation acts on — a held job is only in `renames` because
+            # --include-held asked for it — so re-testing `held` here silently
+            # undid the caller's decision and verified NOTHING for the one job
+            # being migrated. Measured 2026-08-19: the accounts-refresh cutover
+            # printed the "Verification" header with nothing beneath it, which
+            # reads as "nothing to report" and meant "nothing was checked".
+            result = _migrate.verify_exactly_one(
+                rename,
+                present=after,
+                armed_before=armed_before,
+                armed_now=armed_now,
+            )
             click.echo("  " + result.verdict)
-            if not result.ok:
+            if not result.ok or result.armed_ok is False:
                 bad += 1
 
         if failed:

--- a/src/scitex_agent_container/cli_pkg/_worktree_gc.py
+++ b/src/scitex_agent_container/cli_pkg/_worktree_gc.py
@@ -164,6 +164,19 @@ def _print_report(outcome: GcOutcome, *, apply: bool) -> None:
         "--apply, off on a dry run (a report stays a pure report)."
     ),
 )
+@click.option(
+    "--exit-zero",
+    "exit_zero",
+    is_flag=True,
+    default=False,
+    help=(
+        "Always exit 0. The verdict is unchanged and still printed, still in "
+        "the JSON `exit_code`, and still recorded by --alarm — only the "
+        "PROCESS status is neutralised. For unattended runners where a "
+        "non-zero status means 'this job is unhealthy', not 'this job found "
+        "something a human must decide'."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON (for cron).")
 @click.pass_context
 def worktree_gc(
@@ -175,6 +188,7 @@ def worktree_gc(
     min_age_hours: float,
     cap: int,
     alarm: bool | None,
+    exit_zero: bool,
     as_json: bool,
 ) -> None:
     """Remove worktrees that are PROVABLY safe to remove. Keep everything else.
@@ -219,7 +233,8 @@ def worktree_gc(
     \b
     Exit codes:  0 = all repos under cap.  1 = a repo is still over cap
     after the pass.  2 = a repo could not be READ (unknown outranks
-    known-bad: it is a known-bad you cannot see).
+    known-bad: it is a known-bad you cannot see).  --exit-zero keeps the
+    verdict in the report and the JSON but always exits 0.
     """
     if bool(repos) == all_repos:
         raise click.UsageError(
@@ -247,6 +262,38 @@ def worktree_gc(
         cap=cap,
     )
     code = exit_code_for(outcome)
+    # MEASURED 2026-08-20: this verb runs as
+    # scitex-agent-container-worktree-gc under the ecosystem supervisor. It
+    # exited 1 on all three of its runs, which reads as a broken job — and it
+    # was not broken. Exit 1 here means "a repo is still over cap", i.e. every
+    # kept worktree failed a safety leg and a HUMAN must decide. That is a
+    # finding, not ill health.
+    #
+    # The cost was concrete: a duplicate systemd timer for this same job could
+    # not be retired, because the rule for retiring one was "the supervisor has
+    # a recorded exit-0 for it" and this job could never produce one. A finding
+    # rendered as a failure kept a second scheduler alive.
+    #
+    # Its sibling `sac host sync --check` carries the same flag for the same
+    # reason, and its comment records where that confusion led last time: a
+    # unit marked `failed` for doing its job put the host into `degraded`, and
+    # an installer read `degraded` as "systemd is absent" and silently stopped
+    # installing dotfiles sync there.
+    #
+    # THE FINDING IS NOT DISCARDED, and that is the condition for using this
+    # flag at all. A flag that always exits 0 does destroy the distinction if
+    # the exit code is the only place the distinction lives. Here it is not:
+    # `--alarm` (on by default with --apply, which is how the scheduled job
+    # runs) records every repo's cap verdict in sac's own event log, and the
+    # verdict is still printed and still in the JSON `exit_code`. Neutralising
+    # the PROCESS status moves the signal onto the rail built for it instead of
+    # the one systemd reads as health.
+    #
+    # A job with no such rail must NOT reach for this flag — for those, the
+    # runner needs to carry "finished with findings" as its own outcome rather
+    # than folding it into ok/not-ok. That belongs in the JobSpec contract, and
+    # scitex-dev owns it.
+    status = 0 if exit_zero else code
 
     # Make the shout DURABLE: record each cap verdict in sac's own event
     # log. Defaults to riding --apply only, so a dry run stays a pure report.
@@ -271,13 +318,13 @@ def worktree_gc(
                 "failed": list(alarm_outcome.failed),
             }
         click.echo(json.dumps(payload, indent=2))
-        raise SystemExit(code)
+        raise SystemExit(status)
 
     _print_report(outcome, apply=apply)
     console.print(f"[dim]{outcome.summary_line()}[/dim]")
     if alarm_outcome is not None:
         console.print(f"[dim]{alarm_outcome.summary_line()}[/dim]")
-    raise SystemExit(code)
+    raise SystemExit(status)
 
 
 def register(worktree_group) -> None:

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -8,12 +8,37 @@ from __future__ import annotations
 
 import click
 
+from ._helpers import HelpRecursiveGroup
+
 # ---------------------------------------------------------------------------
 # account group
 # ---------------------------------------------------------------------------
 
 
-@click.group("account")
+class _AccountsGroup(HelpRecursiveGroup):
+    """Render ``sac accounts --help`` under named sections.
+
+    Fifteen verbs in one alphabetical column made ``list`` / ``status`` /
+    ``quota`` look interchangeable and hid which of them WRITE. The
+    sections say what each verb is FOR; the interface spec
+    (general/03_interface_02_cli §6) asks for this and ``sac agents``
+    already does it. Anything not listed here still renders, under
+    ``Other`` — a new verb is never silently dropped from ``--help``.
+    """
+
+    COMMAND_CATEGORIES = [
+        ("Inspect (read-only)", ["list", "status", "quota"]),
+        ("Stored accounts", ["save", "delete", "switch", "login"]),
+        (
+            "Credential material",
+            ["refresh", "mint-token", "sync-live", "sync-openai"],
+        ),
+        ("Distribute to peers", ["send-credentials"]),
+        ("Watch continuously", ["watch-live", "watch-quota", "refresh-quota-cache"]),
+    ]
+
+
+@click.group("account", cls=_AccountsGroup)
 def account() -> None:
     """Inspect provider accounts and manage Claude credential rotation."""
 

--- a/src/scitex_agent_container/cli_pkg/build_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/build_cmds.py
@@ -92,6 +92,14 @@ def check(name_or_path: str) -> None:
     # docs/adr/0001-isolation-hardening.md §D4.
     _warn_host_mirroring_bind_targets(config)
 
+    # raw_args as an APPTAINER ARGV, not merely as YAML. This check said
+    # "Ready to deploy" on a spec whose raw_args carried an env assignment
+    # with no `--env` before it, minutes before that agent failed to start
+    # (2026-08-18). Everything above validates shape and environment; this
+    # is the one that reads raw_args the way apptainer will.
+    if not _check_raw_args(config):
+        all_ok = False
+
     if all_ok:
         console.print("[green]Ready to deploy.[/green]")
     else:
@@ -99,6 +107,31 @@ def check(name_or_path: str) -> None:
             "[red]Preflight checks failed. Fix the issues above before deploying.[/red]"
         )
         sys.exit(1)
+
+
+def _check_raw_args(config) -> bool:
+    """Report whether ``spec.apptainer.raw_args`` is a well-formed argv.
+
+    FAILS the preflight rather than warning, because the failure it catches
+    is not a deviation the operator might have chosen — a positional in
+    raw_args cannot start the agent at all. Returns True when there is
+    nothing to say, so a spec with no raw_args is unaffected.
+    """
+    from ..runtimes._apptainer_argv_guard import ApptainerArgvError, validate_raw_args
+
+    ap = getattr(config, "apptainer", None)
+    raw = list(getattr(ap, "raw_args", None) or []) if ap is not None else []
+    if not raw:
+        console.print(f"  {'raw_args:':30s} [green]OK (none declared)[/green]")
+        return True
+    try:
+        validate_raw_args(raw, agent=getattr(config, "name", None))
+    except ApptainerArgvError as exc:
+        console.print(f"  {'raw_args:':30s} [red]FAIL[/red]")
+        console.print(f"[red]{exc}[/red]")
+        return False
+    console.print(f"  {'raw_args:':30s} [green]OK ({len(raw)} token(s))[/green]")
+    return True
 
 
 # Bind targets that start with these prefixes mirror host home / user

--- a/src/scitex_agent_container/cli_pkg/host_group.py
+++ b/src/scitex_agent_container/cli_pkg/host_group.py
@@ -13,6 +13,7 @@ of ``sac network probe`` / ``sac installation boot``.
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 import sys
 
@@ -187,7 +188,42 @@ def host_exec(peer: str, argv: tuple[str, ...]) -> None:
             "error: no command supplied. Try: sac host exec PEER -- <cmd>", err=True
         )
         raise SystemExit(2)
-    ssh_argv = build_ssh_argv(peer, list(argv), peers)
+    # QUOTE HERE, NOT IN build_ssh_argv. The two have different contracts and
+    # conflating them has already caused one outage.
+    #
+    # ssh word-joins every token after the host and hands the result to the
+    # remote LOGIN SHELL, which re-parses it. So `build_ssh_argv` takes an
+    # ALREADY-QUOTED remote command — callers like `_spec_handoff.ssh_runner`
+    # deliberately pass a single element such as `sh -c 'echo REACHED'`. On
+    # 2026-08-17 a `shlex.join` was added inside that function, quoted those
+    # already-quoted elements a second time, and produced rc=127 on every
+    # preamble peer ("bash: line 1: sh -c 'echo REACHED': command not found"),
+    # taking scitex-hub down and unstartable by any path.
+    #
+    # `sac host exec` is the opposite contract: `argv` is a list of ARGV WORDS
+    # typed by a human, and nothing has quoted them. Passing them raw let the
+    # remote shell re-split on metacharacters, which is silent and wrong rather
+    # than loud and wrong. Measured 2026-08-20 by scitex-cards, then reproduced
+    # here on scitex-compute-03:
+    #
+    #   sac host exec <peer> -- echo AAA-scitex-BBB '|' grep -cE 'scitex|cards'
+    #     -> bash: line 1: cards: command not found
+    #   sac host exec <peer> -- bash -lc 'echo AAA-scitex-BBB | grep -cE "..."'
+    #     -> 0        (the answer is 1)
+    #
+    # The second is the dangerous one: a mangled command returned a plausible
+    # NUMBER. They had counted 3 cron lines on that host minutes earlier, and
+    # only that contradiction made them re-check instead of reporting "no cron
+    # lines" as a measurement. This module's own `_run_peer_command` docstring
+    # already states the rule this violates — "a transport must never render
+    # 'I could not run it' identically to 'it ran and produced nothing'". This
+    # is the same rule with a number instead of an empty string.
+    #
+    # shlex.quote is a NO-OP on any word that needs no quoting, so the rendered
+    # argv is byte-identical for every invocation that was already correct.
+    # Only arguments carrying metacharacters change — exactly the broken ones.
+    quoted = [shlex.quote(word) for word in argv]
+    ssh_argv = build_ssh_argv(peer, quoted, peers)
     raise SystemExit(_run_peer_command(ssh_argv))
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_preflight_gate.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_preflight_gate.py
@@ -52,9 +52,17 @@ def make_preflight_runner(
     had lapsed, every declared pool credential was fresh, and every start
     on the host was refused anyway.
 
-    A spec that will not load is gated on the lead file, keeping the old
-    defensive default — better to ask for creds and let the dispatch loop
-    surface the real spec error than to skip the gate on a broken spec.
+    A spec that will not load is REFUSED HERE, naming the load error. It
+    is no longer gated on the lead's ``~/.claude/.credentials.json``, and
+    nothing in this path reads that file any more (operator ruling,
+    2026-08-19: 「勝手にデフォルトのクレデンシャルズを使わない」 — a silent
+    fall back to a default is exactly what the constitution forbids).
+
+    The old behaviour asked the lead file whenever a spec would not load,
+    which meant an UNREGISTERED NAME was reported as an EXPIRED TOKEN: two
+    unrelated faults printing the same sentence, and only one of them
+    fixable by the caller. Refusing early with the load error is both the
+    louder failure and the more honest one.
     """
     ran = {"done": False}
 
@@ -64,16 +72,18 @@ def make_preflight_runner(
         ran["done"] = True
         if broker_self:
             return
-        from ..._state._preflight_creds import (
-            check_oauth_token_expiry,
-            check_spec_oauth_credentials,
-        )
+        from ..._state._preflight_creds import check_spec_oauth_credentials
 
         try:
-            for cfg in _iter_target_configs(single_targets, bulk_yamls):
+            for raw, cfg, err in _iter_target_configs(single_targets, bulk_yamls):
                 if cfg is None:
-                    check_oauth_token_expiry()
-                    continue
+                    raise RuntimeError(
+                        f"cannot start {raw!r}: its spec could not be loaded "
+                        f"({type(err).__name__}: {err}). Check that the agent "
+                        "name is registered on this host and that its spec "
+                        "parses. This is NOT a credential fault — sac does not "
+                        "read ~/.claude/.credentials.json for agent starts."
+                    )
                 if getattr(getattr(cfg, "claude", None), "provider", None) is not None:
                     continue
                 check_spec_oauth_credentials(cfg)
@@ -86,12 +96,20 @@ def make_preflight_runner(
 
 def _iter_target_configs(
     single_targets: list[str], bulk_yamls: list[str]
-) -> Iterator[object | None]:
-    """Yield each target's loaded ``AgentConfig``, or ``None`` when it won't load.
+) -> Iterator[tuple[str, object | None, Exception | None]]:
+    """Yield ``(raw_target, AgentConfig | None, load error | None)`` per target.
 
     One resolve+load per target, shared by the preflight runner and
     :func:`any_target_needs_anthropic_oauth` so the two can never disagree
     about what a target's spec says.
+
+    The load error is CARRIED rather than discarded. Discarding it is what
+    made an unregistered agent name indistinguishable from a credential
+    fault: the caller received a bare ``None``, had nothing to report but
+    the lead credential's state, and so reported THAT. Measured 2026-08-19
+    — ``POST /agents`` for a name with no spec answered 502 carrying
+    "OAuth token in ~/.claude/.credentials.json expired 257594 seconds
+    ago", which is true about the file and says nothing about the request.
     """
     from ...config import load_config
     from ...config._resolve import resolve_with_prefix
@@ -99,9 +117,10 @@ def _iter_target_configs(
     for raw in list(single_targets) + list(bulk_yamls):
         try:
             cfg: object | None = load_config(resolve_with_prefix(raw))
-        except Exception:  # stx-allow: fallback (reason: defensive — an unloadable spec must not skip the gate; see make_preflight_runner)
-            cfg = None
-        yield cfg
+        except Exception as exc:  # stx-allow: fallback (reason: the error is CARRIED to the caller, not swallowed; see docstring)
+            yield raw, None, exc
+            continue
+        yield raw, cfg, None
 
 
 def any_target_needs_anthropic_oauth(
@@ -121,7 +140,7 @@ def any_target_needs_anthropic_oauth(
     actual dispatch loop than to skip the gate silently on a broken
     spec the operator hasn't noticed yet.
     """
-    for cfg in _iter_target_configs(single_targets, bulk_yamls):
+    for _raw, cfg, _err in _iter_target_configs(single_targets, bulk_yamls):
         if cfg is None:
             return True
         if getattr(getattr(cfg, "claude", None), "provider", None) is None:

--- a/src/scitex_agent_container/cli_pkg/send_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/send_cmds.py
@@ -211,6 +211,13 @@ def _refuse_uncontained_send(name: str) -> NoReturn:
     ``~/.claude/projects/`` store, so a host-side resume either finds
     nothing or resumes some unrelated host session — which is worse than
     an error, because it looks like it worked.
+
+    THIS MESSAGE IS FOR A DEFINED AGENT ONLY. A name that was never an
+    agent reaches the same dead end, and until 2026-08-20 it got this
+    same text — which describes the other cause in vocabulary that
+    presupposes the agent EXISTS ("the agent's live session", "(re)start
+    the agent"). ``_refuse_unknown_agent`` handles that case; the caller
+    decides which applies.
     """
     raise click.ClickException(
         f"agent {name!r}: no A2A port is recorded, so this turn has no "
@@ -224,6 +231,99 @@ def _refuse_uncontained_send(name: str) -> NoReturn:
         f"`sac agents start {name} -y` — then re-send. Verify with "
         f"`sac agents list {name} --json`: a2a_port must be non-null.\n"
         f"  State dir: {state_dir_for(name)}"
+    )
+
+
+def _is_known_agent(name: str) -> bool:
+    """Whether ``name`` is an agent AT ALL — a spec on disk, or any row.
+
+    DELIBERATELY BROADER than "running" and broader than "reachable". A
+    stopped agent, an agent whose row is tombstoned, and one recorded
+    with ``a2a_port=None`` are all KNOWN — they exist and the operator
+    can act on them, so the port-oriented refusal is the right advice.
+    Only a name with no spec in the agents/ cascade AND no ``instances``
+    row it has ever had is unknown.
+
+    The two halves are both needed and neither implies the other: an
+    agent defined but never started has a spec and no row, and a row can
+    outlive (or arrive without) a locally visible spec — a cross-host
+    agent's row is written into this host's store by dispatch/sync while
+    its spec lives on the peer. Checking only one half would call a real
+    agent nonexistent, which is the same class of wrong answer this
+    whole change exists to remove.
+    """
+    from ..config._resolve import enumerate_agent_names
+
+    # `enumerate_agent_names` and NOT `_discover_defined_agents`: the
+    # latter hardcodes its roots (project scope + ~/.scitex/.../agents)
+    # and does not honour SCITEX_AGENT_CONTAINER_YAML_DIRS, so an agent
+    # reachable through the operator-env cascade would be reported
+    # NONEXISTENT — the precise wrong answer this function exists to
+    # stop. It only stats `<dir>/<name>/spec.{yaml,yml}`, so the refusal
+    # path still parses no YAML on its way to refusing.
+    #
+    # It can also RAISE (AmbiguousRegistryScope: both the project-local
+    # and fleet registries exist and $SAC_AGENT_SCOPE is unset). Treat
+    # that as KNOWN, not as unknown. "I could not determine whether this
+    # agent exists" is the third value, and collapsing it into "it does
+    # not exist" would make this function assert the very kind of
+    # unestablished cause it was written to remove — and would turn a
+    # clean refusal into an unrelated crash on any host with both
+    # registries. Erring toward the port-oriented message keeps the
+    # pre-existing behaviour whenever existence is undecidable.
+    try:
+        if name in enumerate_agent_names():
+            return True
+    except Exception:  # stx-allow: fallback (reason: see comment above)
+        return True
+    from .._state.state_db import open_db
+
+    with open_db() as conn:
+        row = conn.execute(
+            "SELECT 1 FROM instances WHERE name = ? LIMIT 1", (name,)
+        ).fetchone()
+    return row is not None
+
+
+def _refuse_unknown_agent(name: str) -> NoReturn:
+    """Refuse a send to a name that was never an agent.
+
+    Delivery declines identically whether an agent is defined-but-
+    unreachable or was never defined at all, so both land at the same
+    dead end. Until 2026-08-20 both also got the SAME message —
+    ``_refuse_uncontained_send``'s — which says "no A2A port is
+    recorded" and prescribes ``sac agents start <name>``. Every word of
+    that presupposes the agent exists.
+
+    MEASURED: ``ci-watch`` dispatched to five names
+    (``proj-scitex-{stats,str,types,dict,datetime}``) 351 times, each
+    refused here, 0 successes. A peer read the text, took the named
+    cause at face value, and reported the failures as instances of an
+    unrelated port-registration defect then under active investigation.
+    The state DB showed those five with ``definitions=0`` and
+    ``instances=0`` EVER — not stopped, not tombstoned, never
+    registered. The remedy was trusted precisely because it was
+    specific, and it pointed at the wrong thing.
+
+    A refusal must not name a cause it has not established. Where two
+    states share one symptom, the message says which one was observed.
+    """
+    raise click.ClickException(
+        f"agent {name!r}: NOT DEFINED — no spec.yaml for this name under "
+        f"any agents/ tree (project-scope .scitex/agent-container/agents/ "
+        f"or ~/.scitex/agent-container/agents/).\n"
+        f"  This is NOT a missing-port problem and NOT a stopped agent: "
+        f"there is nothing to (re)start, because this name has never been "
+        f"an agent. Starting it is not the fix and will fail the same way.\n"
+        f"  Fix: check the name for a typo (`sac agents list`), or define "
+        f"the agent first (`sac agents create {name}`), then start it, "
+        f"then re-send.\n"
+        f"  If a SCHEDULED JOB is sending here, it is dispatching to a name "
+        f"that does not exist — fix the job's target list rather than this "
+        f"agent.\n"
+        f"  (There is still deliberately NO host-side fallback: every sac "
+        f"agent runs inside {CONTAINER_ENGINE}, so sac never runs the turn "
+        f"on the bare host. That guarantee holds for both causes.)"
     )
 
 
@@ -340,4 +440,11 @@ def send(
 
     # Every delivery path declined. Refuse — do NOT run the turn on the
     # bare host. See _refuse_uncontained_send for what used to happen here.
+    #
+    # Two different states land here and they need different remedies, so
+    # establish WHICH before naming a cause: an agent that exists but has
+    # no reachable port, versus a name that was never an agent at all.
+    # Telling the second to `sac agents start` is advice that cannot work.
+    if not _is_known_agent(name):
+        _refuse_unknown_agent(name)
     _refuse_uncontained_send(name)

--- a/src/scitex_agent_container/config/_container_engine.py
+++ b/src/scitex_agent_container/config/_container_engine.py
@@ -52,15 +52,53 @@ CONTAINER_ENGINE = "apptainer"
 _REMOVED_MESSAGE = (
     "spec.container.runtime has been REMOVED — "
     f"{CONTAINER_ENGINE} is the only container engine, so there is "
-    "nothing left to select. DELETE the `runtime:` line from the "
-    "`container:` block; the agent runs inside "
-    f"{CONTAINER_ENGINE} either way. No launch path ever read this "
-    "field, so deleting the line changes nothing except what the spec "
-    "claims about itself."
+    "nothing left to select. No launch path ever read this field, so "
+    "deleting it changes nothing except what the spec claims about "
+    "itself.\n"
+    "\n"
+    "  DELETE the INDENTED one, under `container:`:\n"
+    "\n"
+    "      spec:\n"
+    "        container:\n"
+    "          runtime: ...      <-- DELETE THIS LINE\n"
+    "\n"
+    "  KEEP the one directly under `spec:` — it is a DIFFERENT, LIVE "
+    "field (the harness launch mode, e.g. `tui`) that merely shares the "
+    "name:\n"
+    "\n"
+    "      spec:\n"
+    "        runtime: tui        <-- LEAVE THIS ALONE\n"
+    "\n"
+    "  So do not act on a bare `grep runtime:` — check the indentation "
+    "first."
 )
 # The message names no other engine ON PURPOSE — not even to say one is
 # gone. A removal notice that lists alternatives has rebuilt the menu it
 # was meant to close, and the reader now has a new thing to wonder about.
+#
+# BUT IT MUST NAME THE NESTING, and that is not stylistic. Measured
+# 2026-08-20 across the 122 live specs on compute-04:
+#
+#     with `spec.runtime` (LIVE)       122 / 122
+#     with `spec.container.runtime`      0 / 122
+#
+# So EVERY spec a reader could be holding contains a `runtime:` line that
+# must NOT be deleted, and the one this error is about is absent from all
+# of them. The earlier wording said only "DELETE the `runtime:` line from
+# the `container:` block". A reader who greps `runtime:` — the obvious
+# move, since the message quotes the leaf key — finds exactly one hit,
+# the live one, in 122 cases out of 122.
+#
+# That is not hypothetical. On 2026-08-20 the operator hit this error on a
+# host whose checkout still carried the removed key, ran the grep, and was
+# one keystroke from deleting `runtime: tui` from a working agent. The
+# error text was the whole cause: it was accurate about the field and
+# ambiguous about WHICH LINE, and ambiguity in a remedy is executed, not
+# puzzled over.
+#
+# A removal notice is an instruction someone will follow literally. It has
+# to be safe to follow literally on a spec that does NOT have the field,
+# because that is the spec most readers are looking at.
 
 
 def container_runtime_removed_error(spec: object) -> list[str]:

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -277,19 +277,28 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     # back-compat consumers and populated from the new homes.
     claude_spec = parse_claude(spec)
     apptainer_spec = parse_apptainer(spec)
-    # Role-based session-continuity default ("fresh by default, opt-in
-    # continue", 2026-06-22). ``claude.session`` now defaults to ``fresh``
-    # (parse_claude) so experiment capsules — which carry no coordinator
-    # role — start hermetic. But LONG-LIVED coordinator agents
-    # (lead/head/worker/telegrammer/project-maintainer/…) must keep their
-    # conversation across restarts. Those specs are hand-deployed OUTSIDE
-    # this repo and none of them set ``claude.session``, so we map an
-    # OMITTED field back to ``continue`` BY ROLE here — the one place that
-    # sees both the ``metadata.labels.role`` and the env-injected fleet
-    # role. An EXPLICIT ``session:`` (top-level or nested) is authored
-    # intent and is left untouched (so ``session: fresh`` on a coordinator
-    # stays fresh); a later CLI ``--continue`` / ``--fresh`` still wins by
-    # mutating ``config.claude.session`` after load.
+    # Session-continuity default for an OMITTED ``session:`` — ``continue``,
+    # unconditionally (operator 2026-08-18: 「スペックは全てレジュームで」).
+    #
+    # THIS USED TO BE ROLE-BASED and defaulted to ``fresh``; the polarity was
+    # inverted deliberately, so do not read the role lookup below as a gate.
+    # The old rule was an ALLOWLIST — a role had to be enumerated to keep its
+    # memory — and scitex-hub's ``product-lead-orchestrator`` matched neither
+    # the set nor any prefix, so it silently resolved to ``fresh`` and lost a
+    # day of working memory on restart. 91 of 117 live specs omit the field,
+    # so a default nobody chose was deciding the fleet's memory.
+    #
+    # ``_role`` is still resolved and still passed, because this is the one
+    # place that sees both ``metadata.labels.role`` and the env-injected fleet
+    # role, and ``default_session_for_role`` keeps the parameter for callers
+    # that ask the role question directly — but it no longer DECIDES.
+    #
+    # An EXPLICIT ``session:`` (top-level or nested) is authored intent and is
+    # left untouched (so ``session: fresh`` on a coordinator stays fresh); a
+    # later CLI ``--continue`` / ``--fresh`` still wins by mutating
+    # ``config.claude.session`` after load — that per-start override is the
+    # sanctioned escape hatch, and a failed start now says so (see
+    # ``_lifecycle/_start_failure_diag.fresh_retry_hint``).
     _session_authored = (
         spec.get("session") is not None
         or (spec.get("claude") or {}).get("session") is not None

--- a/src/scitex_agent_container/config/_session_continuity.py
+++ b/src/scitex_agent_container/config/_session_continuity.py
@@ -1,4 +1,4 @@
-"""Session-continuity resolution — ``fresh`` by default, opt-in ``continue``.
+"""Session-continuity resolution — ``continue`` by default, opt-in ``fresh``.
 
 Single source of truth for two related decisions:
 
@@ -113,13 +113,33 @@ def role_wants_continuity(role: str | None) -> bool:
 
 
 def default_session_for_role(role: str | None) -> str:
-    """Session mode for a spec that OMITTED ``claude.session``, given role.
+    """Session mode for a spec that OMITTED ``claude.session``: ``continue``.
 
-    Coordinator/long-lived role → ``"continue"``; everything else (incl. no
-    role) → ``"fresh"``. This is the role-based half of the precedence chain
-    ``CLI > explicit spec > role-default > global default (fresh)``.
+    CONTINUE FOR EVERY ROLE, INCLUDING NONE. Operator ruling 2026-08-18:
+    「フレッシュは基本的に使いません、最初の起動に必要な時だけで ... スペックは
+    全てレジュームで」 — fresh is essentially never used; only where a FIRST
+    boot needs it; every spec resumes.
+
+    This inverts the previous polarity and that is the whole point. The old
+    rule was an ALLOWLIST: a role had to appear in ``_CONTINUITY_ROLES`` or
+    match a prefix to keep its memory, and anything unenumerated silently got
+    ``fresh``. Measured 2026-08-18, that is not hypothetical — scitex-hub's
+    role is ``product-lead-orchestrator``, which matches neither the exact set
+    nor any prefix (it begins ``product-``, not ``lead-``), so it resolved to
+    ``fresh`` and lost a day of working memory on restart. 91 of 117 live
+    specs omit ``claude.session`` entirely, so the default decided the
+    fleet's memory and nobody had chosen it.
+
+    A capsule that genuinely wants a hermetic session is UNAFFECTED in
+    practice: with no prior session on disk there is nothing to continue, so
+    the first boot is fresh either way. What changes is the SECOND boot, and
+    that is exactly the case the operator is protecting.
+
+    ``role`` is retained in the signature (callers pass it) and
+    :func:`role_wants_continuity` is kept for callers that still ask the
+    role question directly, but the role no longer GATES the default.
     """
-    return SESSION_CONTINUE if role_wants_continuity(role) else SESSION_FRESH
+    return SESSION_CONTINUE
 
 
 def wants_continue(session: str | None) -> bool:

--- a/src/scitex_agent_container/runtimes/_apptainer_argv_guard.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_argv_guard.py
@@ -66,6 +66,9 @@ always printed, so the reader sees the actual argv instead of a rule.
 
 from __future__ import annotations
 
+import re
+from typing import Any, Iterable
+
 # apptainer ``exec`` options that REQUIRE a following value. A subset
 # focused on the ones sac itself emits or operators commonly pass via
 # raw_args; an unknown value-flag not listed here simply isn't guarded
@@ -239,9 +242,108 @@ def _flag_region(argv: list[str]) -> list[str]:
     return region
 
 
+#: An env assignment as raw_args can only have been meant as an ``--env``
+#: value. UPPER_SNAKE before the ``=`` is what makes this precise rather
+#: than broad: every environment variable the fleet sets is upper-snake,
+#: while the value-shaped ``k=v`` tokens that legitimately follow flags
+#: this module does NOT track (``--network-args portmap=8080:tcp``,
+#: ``--security uid:1000``) are not. Broadening it would trade a real
+#: catch for a false refusal, and this module's whole doctrine is that a
+#: guard must never block a launch it merely failed to recognise.
+_ENV_ASSIGNMENT = re.compile(r"^[A-Z][A-Z0-9_]*=")
+
+
+def find_stray_env_pair(raw_args: Iterable[Any] | None) -> tuple[int, str] | None:
+    """First ``(index, token)`` in ``raw_args`` that is a POSITIONAL env pair.
+
+    ``spec.apptainer.raw_args`` must contain ZERO positionals: sac supplies
+    the image and the inner command itself, so the first bare token the
+    operator adds becomes the token apptainer reads as the IMAGE PATH.
+
+    THE INCIDENT (2026-08-18). A bulk edit added the new board-identity
+    variable to ~100 specs and inserted only the VALUE, without the
+    ``- --env`` that has to precede it::
+
+        - --env
+        - SCITEX_TODO_AGENT_ID=business
+        - SCITEX_CARDS_AGENT_ID=business      <- positional, in flag position
+
+    apptainer resolved that bare token against the launch cwd and reported::
+
+        FATAL: While checking container encryption: could not open image
+          /home/ywatanabe/proj/business/SCITEX_CARDS_AGENT_ID=business
+
+    — a message that names an image nobody wrote, blames encryption, and
+    never mentions the missing flag. ``sac agents check`` answered "Ready to
+    deploy" on that spec minutes before the start failed, because it
+    validates raw_args as YAML and as a schema and not as an apptainer argv.
+
+    WHY THE SIBLING GUARD MISSES IT: :func:`validate_flag_argv` inspects
+    ``_flag_region(argv)``, which by construction STOPS at the first
+    positional. The stray token does not break the flag region — it ENDS
+    it, and everything after is read as the container's business. So the
+    two checks are complementary, not redundant: one finds a flag with no
+    value, this one finds a value with no flag.
+
+    Returns ``None`` for well-formed input (including ``None`` / empty).
+    """
+    tokens = [str(a) for a in (raw_args or [])]
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in VALUE_TAKING_FLAGS:
+            index += 2  # the flag CONSUMES the next token; it is not a positional
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        if _ENV_ASSIGNMENT.match(token):
+            return index, token
+        index += 1  # a bare non-env token: not ours to judge, see _ENV_ASSIGNMENT
+    return None
+
+
+def validate_raw_args(
+    raw_args: Iterable[Any] | None,
+    *,
+    agent: str | None = None,
+) -> None:
+    """Fail loud if ``raw_args`` carries an env pair with no ``--env`` flag.
+
+    A no-op for well-formed raw_args. See :func:`find_stray_env_pair` for
+    what this catches and why apptainer's own error cannot say it.
+    """
+    found = find_stray_env_pair(raw_args)
+    if found is None:
+        return
+    index, token = found
+    key = token.split("=", 1)[0]
+    who = f" for agent {agent!r}" if agent else ""
+    raise ApptainerArgvError(
+        f"spec.apptainer.raw_args[{index}]{who} is {token!r} — an environment "
+        f"assignment sitting in FLAG position with no `--env` before it.\n"
+        f"\n"
+        f"apptainer does not read that as an environment variable. It reads "
+        f"the first bare token as the IMAGE PATH, resolves it against the "
+        f"launch directory, and fails with a message that names a path "
+        f"nobody wrote:\n"
+        f"    FATAL: ... could not open image <workdir>/{token}\n"
+        f"\n"
+        f"FIX: insert `--env` immediately before it, i.e.\n"
+        f"    - --env\n"
+        f"    - {token}\n"
+        f"\n"
+        f"(If {key} was NOT meant as an environment variable, remove it: "
+        f"raw_args must contain no positionals at all — sac supplies the "
+        f"image and the inner command itself.)"
+    )
+
+
 __all__ = [
     "ApptainerArgvError",
     "VALUE_TAKING_FLAGS",
     "find_missing_value",
+    "find_stray_env_pair",
     "validate_flag_argv",
+    "validate_raw_args",
 ]

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -204,6 +204,21 @@ class ApptainerContainerRuntime(RuntimeBase):
             _write_redacted_argv(state_dir / "apptainer_run.argv.txt", argv)
             return True
 
+        # FREE-SPACE GUARANTEE — fail loud before starting a container onto a
+        # host that cannot hold its scratch, rather than letting the agent
+        # discover the shortfall mid-run as an opaque ENOSPC.
+        #
+        # HERE, past the dry_run return, for the same reason the overlay
+        # reconcile below is here: `build_run_argv` is also called by
+        # `sac agents explain` and by the dry-run path, and a read-only
+        # command must not fail on a launch-time resource condition. It used
+        # to live inside `tmpfs_workdir_flags`, which made `explain` unusable
+        # on exactly the full host it would have helped diagnose, and wired
+        # ~21 argv-building test files to ambient free disk.
+        from ._apptainer_tmpfs import verify_tmpfs_headroom
+
+        verify_tmpfs_headroom(config, state_dir)
+
         # OVERLAY VENV INVALIDATION CONTRACT — an image rebuild must invalidate
         # the `venv-sac` slice of this agent's overlay, or the overlay's stale
         # site-packages shadow the new image forever. Contract, measurement and

--- a/src/scitex_agent_container/runtimes/_apptainer_tmpfs.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_tmpfs.py
@@ -89,9 +89,38 @@ def tmpfs_workdir_flags(config, state_dir: Path) -> list[str]:
       * the operator already declared ``-W``/``--workdir`` in
         ``apptainer.raw_args`` (relaxed escape-hatch — don't duplicate).
 
-    Creates the scratch dir under ``<state_dir>/tmp-scratch`` and
-    verifies the backing filesystem has at least ``tmpfs_size`` bytes
-    free, raising :class:`TmpfsSpaceError` if not.
+    Creates the scratch dir under ``<state_dir>/tmp-scratch``.
+
+    Does NOT check free space — that is :func:`verify_tmpfs_headroom`,
+    called on the real launch path only. This function is reached by
+    ``sac agents explain`` and by ``run(dry_run=True)``, which start
+    nothing and must not fail on a host condition they do not depend on.
+    """
+    resolved = _resolve_scratch(config, state_dir)
+    if resolved is None:
+        return []
+
+    scratch, _size, _need_bytes = resolved
+    scratch.mkdir(parents=True, exist_ok=True)
+    return ["--workdir", str(scratch)]
+
+
+def _resolve_scratch(config, state_dir: Path) -> tuple[Path, str, int] | None:
+    """Resolve ``(scratch_dir, size_str, need_bytes)``, or ``None`` when sac
+    does not manage this agent's workdir (operator opt-out, or an explicit
+    ``-W``/``--workdir`` in ``raw_args``).
+
+    Shared by :func:`tmpfs_workdir_flags` and :func:`verify_tmpfs_headroom`
+    so the two can never disagree about WHICH directory is being sized —
+    the flag and the check must describe the same path or the guarantee is
+    about a directory the container does not use.
+
+    ``parse_tmpfs_size_bytes`` is called HERE, so an unparseable
+    ``tmpfs_size`` still fails loud at argv-construction time. That is
+    deliberate: a bad size string is a CONFIG error, present on every host
+    regardless of disk, and it should surface the moment the spec is read.
+    Only the free-space check — a RESOURCE condition, true on one host at
+    one moment — belongs at launch.
     """
     ap = getattr(config, "apptainer", None)
     if ap is None:
@@ -104,15 +133,43 @@ def tmpfs_workdir_flags(config, state_dir: Path) -> list[str]:
         raw_args = list(getattr(ap, "raw_args", None) or [])
 
     if not size:
-        return []
+        return None
 
     # Operator already pinned a workdir → respect it, emit nothing.
     if any(a in ("-W", "--workdir") for a in raw_args):
-        return []
+        return None
 
-    need_bytes = parse_tmpfs_size_bytes(size)
+    return state_dir.expanduser() / "tmp-scratch", size, parse_tmpfs_size_bytes(size)
 
-    scratch = state_dir.expanduser() / "tmp-scratch"
+
+def verify_tmpfs_headroom(config, state_dir: Path) -> None:
+    """Raise :class:`TmpfsSpaceError` unless the filesystem backing the
+    scratch dir has at least ``spec.apptainer.tmpfs_size`` bytes free.
+
+    CALL THIS ONLY ON A REAL LAUNCH PATH. It asks a question about the host
+    RIGHT NOW, so it is only meaningful immediately before starting a
+    container — and it is actively wrong anywhere else.
+
+    Why it is not in ``tmpfs_workdir_flags`` (which is where it used to
+    live): that function is also reached by ``sac agents explain`` and by
+    ``run(dry_run=True)``, neither of which starts anything. A full disk
+    therefore made two READ-ONLY commands fail — so an operator diagnosing
+    a full host could not run ``explain`` at exactly the moment it was
+    most useful. It also wired ~21 argv-building test files' verdicts to
+    ambient free disk they neither control nor test, which on a 91%-full
+    shared CI runner (2026-08-19) produced failures carrying unrelated
+    TEST NAMES and sent readers to their own diffs for hours.
+
+    This mirrors the placement ``_apptainer_runtime`` already chose for
+    ``reconcile_overlay_venv_for_launch`` — past the ``dry_run`` return,
+    for the same stated reason: a read-only command must not do
+    launch-time work.
+    """
+    resolved = _resolve_scratch(config, state_dir)
+    if resolved is None:
+        return
+
+    scratch, size, need_bytes = resolved
     scratch.mkdir(parents=True, exist_ok=True)
 
     usage = shutil.disk_usage(scratch)
@@ -125,7 +182,10 @@ def tmpfs_workdir_flags(config, state_dir: Path) -> list[str]:
             "lower spec.apptainer.tmpfs_size."
         )
 
-    return ["--workdir", str(scratch)]
 
-
-__all__ = ["tmpfs_workdir_flags", "parse_tmpfs_size_bytes", "TmpfsSpaceError"]
+__all__ = [
+    "tmpfs_workdir_flags",
+    "verify_tmpfs_headroom",
+    "parse_tmpfs_size_bytes",
+    "TmpfsSpaceError",
+]

--- a/src/scitex_agent_container/runtimes/_board_identity_env.py
+++ b/src/scitex_agent_container/runtimes/_board_identity_env.py
@@ -179,6 +179,7 @@ def apply_board_identity_alias(
     env: Mapping[str, Any],
     *,
     raw_args: Iterable[Any] | None = None,
+    agent_name: str | None = None,
 ) -> dict[str, str]:
     """Ensure the CANONICAL board identity is set. Returns a NEW dict.
 
@@ -226,20 +227,58 @@ def apply_board_identity_alias(
         from_raw.get(LEGACY_BOARD_ID_ENV) or merged.get(LEGACY_BOARD_ID_ENV) or ""
     ).strip()
     identity = current or legacy
+    derived_from_name = False
     if not identity:
-        return merged
+        # NEITHER SPELLING IS DECLARED. Before 2026-08-20 this returned an env
+        # with NO board identity at all, and the agent launched unable to say
+        # who it was. proj-scitex-hub reported exactly that: scitex-cards
+        # unusable, no SCITEX_CARDS_AGENT_ID, no SCITEX_CARDS_DB. The fleet
+        # baseline promises every agent that its identity "is already wired
+        # into your environment" and tells it to report a failure to resolve
+        # as a sac bug rather than work around it. This is that bug.
+        #
+        # THE AGENT'S OWN NAME IS NOT A GUESS, and that is measured rather than
+        # asserted. Across compute-03's 136 specs and compute-04's 121: 96
+        # declare an identity and it EQUALS the agent name; 9 differ, of which
+        # 6 are TEMPLATES carrying placeholders and 3 are deliberate aliases
+        # (scitex-agent-container-04 -> scitex-agent-container,
+        # scitex-hub-mobile-ux -> scitex-hub, _template_handyman ->
+        # local-coder); 16-17 declare nothing at all. Every one of the aliases
+        # DECLARES its identity, and this branch only runs when none is
+        # declared — so deriving can never override a deliberate alias. It
+        # only fills the hole the 16-17 fall into.
+        #
+        # This is the opposite of the silent default this module warns about.
+        # That warning is about substituting a value when the answer is
+        # UNKNOWN, which puts a wrong author on a card. Here the answer is
+        # known: the spec's own name is the authority sac launched the agent
+        # under. Writing nothing is what produced a wrong (empty) author.
+        if not agent_name or not str(agent_name).strip():
+            return merged
+        identity = str(agent_name).strip()
+        assert_expanded(BOARD_ID_ENV, identity)
+        derived_from_name = True
 
     if BOARD_ID_ENV in from_raw or (merged.get(BOARD_ID_ENV) or "").strip():
         return merged
 
     merged[BOARD_ID_ENV] = identity
-    logger.info(
-        "board_identity: injected %s=%s (derived from the legacy %s, which is "
-        "read but deliberately NOT written back)",
-        BOARD_ID_ENV,
-        identity,
-        LEGACY_BOARD_ID_ENV,
-    )
+    if derived_from_name:
+        logger.info(
+            "board_identity: injected %s=%s (the spec declared NEITHER "
+            "spelling, so the identity is the agent's own name — without this "
+            "the agent launches unable to say who it is)",
+            BOARD_ID_ENV,
+            identity,
+        )
+    else:
+        logger.info(
+            "board_identity: injected %s=%s (derived from the legacy %s, which "
+            "is read but deliberately NOT written back)",
+            BOARD_ID_ENV,
+            identity,
+            LEGACY_BOARD_ID_ENV,
+        )
     return merged
 
 

--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -309,7 +309,13 @@ def effective_env(
     merged = merge_fleet_env(getattr(config, "env", None), defaults=defaults)
     apptainer = getattr(config, "apptainer", None)
     raw_args = getattr(apptainer, "raw_args", None) if apptainer is not None else None
-    return apply_board_identity_alias(merged, raw_args=raw_args)
+    # The agent's own name is passed so a spec that declares NEITHER identity
+    # spelling still launches with one. See the branch in
+    # ``apply_board_identity_alias`` for why the name is the right answer and
+    # why it cannot override a deliberate alias.
+    return apply_board_identity_alias(
+        merged, raw_args=raw_args, agent_name=getattr(config, "name", None)
+    )
 
 
 def fleet_env_flags(

--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -105,14 +105,75 @@ CONFIG_SECTION = "fleet_default_env"
 # per agent until each restarts onto this cleaned environment; that is correct
 # behaviour, not a leftover. Do NOT "fix" it by reintroducing the key.
 #
-# FLEET_DEFAULT_ENV is now EMPTY, and that is a valid state — the mechanism
-# survives for operator overrides via ``config.yaml``'s ``fleet_default_env``.
-# Asserted by test_dead_read_routing_key_* in
-# tests/scitex_agent_container/runtimes/test__fleet_env.py.
+# FLEET_DEFAULT_ENV was EMPTY between 2026-07-29 and 2026-08-19, and that was
+# a valid state — the mechanism survives for operator overrides via
+# ``config.yaml``'s ``fleet_default_env``. Asserted by
+# test_an_empty_fleet_default_env_is_a_valid_state.
+#
+# SCITEX_STORE_DSN (2026-08-19, the operator's SQLite-eradication order:
+# 「sqlite 根絶をしてください」「fail fast, fail loud, no fallbacks」).
+#
+# READ THE TWO PARAGRAPHS ABOVE BEFORE ADDING ANOTHER KEY HERE. Two store
+# variables were declared here and later retired for STATING a routing policy
+# nothing enforced, and one of them cost a live diagnosis: an inert setting
+# that appears to answer the question spends the diagnostician's trust. So the
+# bar for a third store variable is not "it seems right" — it is that the
+# variable is demonstrably READ FOR BEHAVIOUR by its consumer.
+#
+# THAT BAR IS MET, AND MEASURED IN BOTH ARMS rather than argued:
+#
+#     with SCITEX_STORE_DSN set     scitex_dev.store.host_store() resolves to
+#                                   the injected DSN; Store opens; a put/get
+#                                   round trip returns typed values, and the
+#                                   row is visible in Postgres through a
+#                                   SECOND, INDEPENDENT client (raw psycopg,
+#                                   plain SQL) rather than through the library
+#                                   that chose the backend
+#     with it UNSET                 host_store() resolves to a UNIX socket and
+#                                   Store() raises StoreTargetError naming the
+#                                   missing socket path
+#
+# The unset arm is the point: the failure is LOUD and there is no SQLite path
+# to slip into. That is scitex-dev's design, in their own words at
+# ``resolve_target``: "deliberately no SQLite fallback ... a host whose
+# Postgres is down must fail loudly rather than start writing to a private
+# local file that shares nothing."
+#
+# test_store_dsn_is_read_for_behaviour_by_its_consumer asserts BOTH arms, so
+# if scitex-dev ever stops honouring the variable, sac goes RED here instead
+# of quietly injecting an inert string into every container for months. That
+# test is the guard the two retired variables never had.
+#
+# WHY THE DEFAULT IS NEEDED AT ALL — sac containers cannot use scitex-dev's
+# own default. ``host_store`` derives a socket path from ``$HOME`` and assumes
+# PostgreSQL's default port, giving
+# ``/home/agent/.scitex/pg/.s.PGSQL.5432`` inside a container. Two things are
+# wrong with that here, and only the second is sac's fault:
+#
+#   * the fleet's Postgres listens on 55432, and the port is part of the
+#     SOCKET FILENAME, so the socket that exists
+#     (``~/.scitex/pg/run/.s.PGSQL.55432``) can never be found by a resolver
+#     that has no port parameter. Reported to scitex-dev.
+#   * ``$HOME`` inside the container is ``/home/agent``, not the operator's
+#     home where the socket actually lives.
+#
+# TCP RATHER THAN THE SOCKET, deliberately: this mirrors SCITEX_CARDS_DB,
+# which is the DSN shape already proven fleet-wide in production, and the
+# same ``.pgpass`` line authenticates it — the entry wildcards the DATABASE
+# (``127.0.0.1:55432:*:scitex_cards``), so the credential is not a lucky
+# match. Following the working neighbour beats inventing a second shape.
+#
+# HOST-SPECIFIC OVERRIDES ARE THE OPERATOR'S LAYER, not a reason to compute
+# this value: a host whose Postgres is elsewhere sets
+# ``spec.fleet_default_env`` in ``config.yaml``, and a single agent that must
+# not receive it sets the key in its own ``spec.env``. A host with no
+# Postgres at all gets a loud refusal, which is the requested behaviour.
 #
 # These are opaque strings to sac. It never reads, parses or branches on them.
 # --------------------------------------------------------------------------
-FLEET_DEFAULT_ENV: dict[str, str] = {}
+FLEET_DEFAULT_ENV: dict[str, str] = {
+    "SCITEX_STORE_DSN": "postgresql://scitex_cards@127.0.0.1:55432/scitex",
+}
 
 
 def _config_path() -> Path:

--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -2,17 +2,28 @@
 
 Two classes of fleet-wide bind live here today:
 
-* **P3a-2 single-shared-store** — every agent's apptainer container
-  mounts the host's ``~/.scitex/todo/`` so scitex-todo's precedence-4
-  user-scope store resolves to the SAME global ``tasks.yaml``
-  fleet-wide. Operator directive
-  ``feedback_scitex_todo_single_shared_store``
-  (lead-learnings/22, P3a unlock). Lead a2a
-  ``214dd26d3fd24e088c75a34329895fa4``. This module is the SOLE
-  source of the bind — no fleet ``_shared/spec.yaml`` carries an
-  explicit ``~/.scitex/todo:`` line (lead audit 2026-06-13 a2a
-  ``f33cbc78c2074594b513439d93748810``), so the helper here is what
-  every sac-launched agent picks up at boot.
+* **single-shared-store** — every agent's apptainer container mounts
+  the host copy of a shared store, so a resolver keying off the
+  AGENT's ``$HOME=/home/agent`` reaches the SAME data fleet-wide.
+  Today that is ``~/.scitex/cards`` and
+  ``~/.scitex/claude-code-telegrammer``; see each entry's own note
+  for the incident that bought it.
+
+  The original member of this class, ``~/.scitex/todo``, was RETIRED
+  2026-08-19 and is archived in place at the end of the tuple rather
+  than deleted. Its P3a-2 provenance (operator directive
+  ``feedback_scitex_todo_single_shared_store``, lead-learnings/22,
+  lead a2a ``214dd26d3fd24e088c75a34329895fa4``) is recorded there.
+
+  This module remains the SOLE source of these binds — no fleet
+  ``_shared/spec.yaml`` carries them explicitly (lead audit
+  2026-06-13 a2a ``f33cbc78c2074594b513439d93748810``), so the helper
+  here is what every sac-launched agent picks up at boot. That is
+  itself under review: the operator ruled 2026-08-19 that a bind must
+  be declared in the spec rather than injected from code
+  (「必ずスペックで明示的に渡して下さい」), with sac's own wiring the
+  stated exception. See card
+  ``sac-remove-implicit-fleet-default-binds-20260819``.
 
 * **2026-06-13 SAC overlay stopgap** — bind the host's working
   ``scitex_agent_container`` source over the in-SIF install so
@@ -32,7 +43,7 @@ Mechanism — see :func:`apply_default_binds`:
     destination path REPLACES the default (operator override
     wins; we de-dupe by destination, not by full string).
   * Missing host source dir → SKIP that default silently. The
-    operator may not have a ``~/.scitex/todo/`` yet (clean
+    operator may not have a ``~/.scitex/cards/`` yet (clean
     install, fresh laptop), or a fresh deploy host may not have
     the canonical ``~/proj/scitex-agent-container/`` checkout —
     we don't create either from sac code.
@@ -57,11 +68,8 @@ __all__ = [
 # ``host:container[:mode]`` apptainer's ``--bind`` consumes.
 # ``~`` is expanded against the host's ``$HOME`` at resolution time.
 _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
-    # P3a-2 — scitex-todo single shared store (operator directive
-    # feedback_scitex_todo_single_shared_store).
-    "~/.scitex/todo:/home/agent/.scitex/todo:rw",
-    # S6 store migration (scitex-todo -> scitex-cards). Same shape and same
-    # reason as the todo bind above, and the reason is NOT obvious: the store
+    # S6 store migration (scitex-todo -> scitex-cards). The reason this bind
+    # has to exist at all is NOT obvious: the store
     # resolver keys off the AGENT's $HOME=/home/agent, so host-side reach is
     # not enough. An agent whose spec binds the operator's ENTIRE home rw
     # still cannot resolve ~/.scitex/cards — the data is present and
@@ -221,6 +229,43 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # bounded, deterministic checks and does NOT run the test suite. CI runs
     # the tests. There is no test suite in the commit path for a testmon cache
     # to accelerate.
+    #
+    # RETIRED 2026-08-19 — "~/.scitex/todo:/home/agent/.scitex/todo:rw"
+    #   (was: P3a-2, scitex-todo single shared store, operator directive
+    #    feedback_scitex_todo_single_shared_store)
+    #
+    # Archived rather than deleted, on the operator's instruction that a
+    # retired thing should stay findable: 「消すというよりアーカイブでいい
+    # んじゃないですかね。すなわち探そうと思えば探せるみたいな」. A silent
+    # absence tells the next reader nothing about why the entry went, and
+    # invites someone to "fix" its absence by adding it back.
+    #
+    # WHY IT WENT: scitex-todo was superseded by scitex-cards, and the
+    # HOME-level store the bind targets is no longer read by anything.
+    # Measured 2026-08-19 with rg --no-ignore over every checkout under
+    # ~/proj, carrying a control term in the same pass so a zero could not
+    # mean "the search did not run":
+    #     scitex-cards       0 hits in *.py (docs/logs only)
+    #     scitex-live-paper  prose in docs/research/, and a PROJECT-LOCAL
+    #                        .scitex/todo/tasks.yaml, not ~/.scitex/todo
+    #     scitex-hub         LIVE CODE at apps/workspace/todo_app/
+    #                        middleware.py:302 — but it builds
+    #                        base / project.slug / ".scitex" / "todo" /
+    #                        "tasks.yaml" where base is a WORKSPACE root, not
+    #                        $HOME, and refuses any store escaping it
+    # The host directory itself held one 4-byte board.pid naming a pid that
+    # is not running.
+    #
+    # THE TRAP, recorded because the naive check gets it backwards: the
+    # string ".scitex/todo" names TWO unrelated things — a per-project store
+    # under a workspace, and this HOME-level one. A substring search cannot
+    # tell them apart, and hub's five hits argued for keeping the bind until
+    # the paths were actually read. Matching the string is not matching the
+    # dependency.
+    #
+    # If something turns out to need it, prefer an EXPLICIT bind in that
+    # agent's spec over restoring a fleet-wide default (operator, same day:
+    # 「必ずスペックで明示的に渡して下さい」).
 )
 
 

--- a/src/scitex_agent_container/runtimes/_tui_outbound.py
+++ b/src/scitex_agent_container/runtimes/_tui_outbound.py
@@ -46,24 +46,29 @@ __all__ = [
 
 def record_dispatch(
     *,
-    db_path: Path,
     agent: str,
     from_agent: str,
     dispatch_id: Optional[str] = None,
-) -> int | None:
+) -> dict[str, Any] | None:
     """Record a requester-bearing inbound wake into the inbound ledger.
 
     No-op (returns ``None``) when ``from_agent`` is empty — an operator
     ``sac agents send`` without a peer, or a boot turn, has nobody to
-    report back to. Returns the ledger row id otherwise. Called by the
-    bridge with the agent's host-side ``state.db`` path.
+    report back to. Returns the ledger row's IDENTITY otherwise.
+
+    ``db_path`` is gone: the ledger moved to PostgreSQL, so there is no
+    state.db to point at. The bridge no longer needs the agent's host-side
+    file bound into the container for this to work — an endpoint suffices.
+
+    The return type changed from ``int`` to the identity mapping, and that is
+    safe here rather than merely tolerable: measured 2026-08-20, no caller in
+    this repo binds this function's return value at all.
     """
     if not from_agent:
         return None
     from .._state.inbound_ledger import record_inbound
 
     return record_inbound(
-        db_path=db_path,
         agent=agent,
         from_agent=from_agent,
         dispatch_id=dispatch_id,
@@ -147,7 +152,6 @@ def _assistant_text(rec: Any) -> str:
 
 def flush_one_completion(
     *,
-    db_path: Path,
     agent: str,
     transcript_path: Path | None,
     listen_url: str,
@@ -174,10 +178,13 @@ def flush_one_completion(
         mark_reported,
     )
 
-    claimed = claim_oldest_pending(agent=agent, db_path=db_path)
+    claimed = claim_oldest_pending(agent=agent)
     if claimed is None:
         return False
-    row_id = int(claimed["id"])
+    # The claimed mapping IS the handle now — the ledger's autoincrement id
+    # is gone, and nothing here needed it to be a number. See
+    # `_state.inbound_ledger` for the measurement behind that.
+    handle = claimed
     requester = str(claimed.get("from_agent") or "").strip()
     dispatch_id = claimed.get("dispatch_id")
     did = dispatch_id if isinstance(dispatch_id, str) and dispatch_id else None
@@ -213,9 +220,9 @@ def flush_one_completion(
             dispatch_id=did,
         )
     except Exception:
-        mark_reported(row_id, status=STATUS_FAILED, db_path=db_path)
+        mark_reported(handle, status=STATUS_FAILED)
         raise
-    mark_reported(row_id, status=STATUS_REPORTED, db_path=db_path)
+    mark_reported(handle, status=STATUS_REPORTED)
     log.info(
         "tui-outbound: completion report pushed to %s (dispatch_id=%s, status=%s)",
         requester,
@@ -260,21 +267,28 @@ def main(argv: list[str] | None = None) -> int:
             transcript_path = None
 
     agent = os.environ.get("SCITEX_AGENT_CONTAINER_AGENT", "").strip()
-    db_path_s = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB", "").strip()
     listen_url = os.environ.get("SAC_LISTEN_BASE_URL", "").strip()
     bearer = os.environ.get("SAC_LISTEN_BEARER", "").strip() or None
-    if not agent or not db_path_s or not listen_url:
+    # SCITEX_AGENT_CONTAINER_STATE_DB IS NO LONGER PART OF THIS GATE, and
+    # dropping it is the point rather than tidying. It named the SQLite file
+    # the ledger used to live in; the ledger is PostgreSQL now and this path
+    # reads nothing from it. Left in place, an agent without that variable
+    # would silently stop reporting completions — the gate would be refusing
+    # on a fact that no longer bears on whether the work can be done.
+    #
+    # The two that remain are the two this path actually needs: who to report
+    # AS, and where the bus is.
+    if not agent or not listen_url:
         # Not a wired sac TUI agent context (or no bus) — nothing to report.
         return 0
     try:
         flush_one_completion(
-            db_path=Path(db_path_s),
             agent=agent,
             transcript_path=transcript_path,
             listen_url=listen_url,
             bearer=bearer,
         )
-    except Exception as exc:  # stx-allow: fallback (reason: a completion-push failure must not wedge the agent's turn loop; the row is already marked failed + this logs loud — the requester can fall back to the agent's logs)
+    except Exception as exc:  # stx-allow: fallback (reason: a completion-push failure must not wedge the agent's turn loop; the row is already marked failed + this logs loud at WARNING to stderr and the rotating ~/.scitex/logging/runtime/scitex-<date>.log via scitex-logging, so the requester can read it there)
         log.warning("tui-outbound: completion flush failed: %s", exc)
     return 0
 

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -332,15 +332,18 @@ def _build_on_turn(
         if from_agent:
             try:
                 from ._tui_outbound import record_dispatch
-                from .tui_session import state_dir_for_config
 
+                # No state.db path any more: the inbound ledger is PostgreSQL.
+                # `state_dir_for_config` is no longer imported here because it
+                # was imported ONLY to build that path — and an import kept for
+                # a vanished use is how a module keeps a dependency nobody can
+                # see the reason for.
                 record_dispatch(
-                    db_path=state_dir_for_config(config) / "state.db",
                     agent=config.name,
                     from_agent=from_agent,
                     dispatch_id=dispatch_id,
                 )
-            except Exception as exc:  # stx-allow: fallback (reason: a ledger-write failure must not block delivering the wake — the agent still processes the turn; only the auto-completion-report is lost, logged for the operator)
+            except Exception as exc:  # stx-allow: fallback (reason: a ledger-write failure must not block delivering the wake — the agent still processes the turn; only the auto-completion-report is lost, logged at WARNING to stderr and the rotating ~/.scitex/logging/runtime/scitex-<date>.log via scitex-logging)
                 logging.getLogger(__name__).warning(
                     "tui-outbound: failed to record inbound dispatch for %s: %s",
                     config.name,

--- a/tests/_store_isolation.py
+++ b/tests/_store_isolation.py
@@ -1,0 +1,189 @@
+"""PostgreSQL store isolation, loaded as a PLUGIN so no directory escapes it.
+
+WHY A PLUGIN AND NOT A CONFTEST. This lived in
+``tests/scitex_agent_container/conftest.py`` until 2026-08-20, and that
+placement is what let the incident described below happen a second time.
+``tests/smoke/``, ``tests/develop/``, ``tests/integration/`` and
+``tests/examples/`` are SIBLINGS of that directory, not children, so the
+autouse guard never reached them. When ``acl_deny_notify`` moved to
+PostgreSQL, the smoke suite began writing fixture rows — ``alpha``,
+``beta``, ``gamma`` — into the live per-host store, exactly as the lifecycle
+tests had under #1154.
+
+A whole-suite run was protected only by accident: collecting the
+``scitex_agent_container`` package imports its conftest, and the
+module-level assignment below is process-wide. Running ``tests/smoke/``
+ALONE was not protected at all. Protection by import order is not
+protection.
+
+Registered from ``pyproject.toml`` (``addopts = "... -p
+tests._store_isolation"``) rather than from ``tests/conftest.py``, because
+that conftest is already over the per-file line cap and this file has no
+business making it worse. ``-p`` also loads earlier and unconditionally —
+it does not depend on which directory the run happens to collect.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+
+
+# ----------------------------------------------------------------------
+# PostgreSQL isolation for the sqlite -> Postgres migration (2026-08-19)
+# ----------------------------------------------------------------------
+
+#: The per-host store. Loopback only — every fleet PostgreSQL refuses
+#: non-local connections at pg_hba, measured 2026-08-19.
+PG_BASE_DSN = os.environ.get(
+    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
+)
+
+#: The password file, resolved AT IMPORT and pinned for the fixture below.
+#:
+#: MEASURED 2026-08-20. `tests/.../_listen/test__acl_approve_flow.py` sandboxes
+#: `HOME` to a tmp_path — correctly, it is testing host-file behaviour. libpq
+#: finds its password file via `~/.pgpass`, so under that sandbox the lookup
+#: lands in an empty directory and the fixture's own CREATE SCHEMA fails with
+#: `fe_sendauth: no password supplied`. The same fixture works everywhere else,
+#: which is what made it look like a fixture bug rather than an interaction.
+#:
+#: Resolving here — while HOME is still the real one, before any test can move
+#: it — and passing it explicitly makes the fixture independent of a variable
+#: tests are entitled to change. `PGPASSFILE` is libpq's own override and takes
+#: precedence over the HOME lookup.
+_PGPASS_AT_IMPORT = os.environ.get("PGPASSFILE") or os.path.expanduser("~/.pgpass")
+
+#: A DSN that cannot reach anything, on purpose. Port 1 refuses instantly, and
+#: the database name is written to be legible in the error a stray write
+#: produces — the message itself states the rule it just enforced.
+_UNREACHABLE_DSN = (
+    "postgresql://sac_tests@127.0.0.1:1/tests_must_not_write_to_the_fleet_store"
+)
+
+# SET AT IMPORT, NOT ONLY IN A FIXTURE, and the difference is measured.
+#
+# The first version of this guard was function-scoped only. Re-running the full
+# package suite with it dropped the pollution from 46 rows to 4 — better, and
+# still not zero. Every targeted re-run (six lifecycle modules, four whole
+# directories, five store-touching modules) then wrote ZERO rows, so the
+# remaining four were not any single module: they came from writes that happen
+# OUTSIDE a function-scoped fixture's window — collection, and module- or
+# session-scoped fixtures, which are set up before the first function fixture
+# runs and torn down after the last one ends.
+#
+# A conftest is imported before anything under its directory is collected, so
+# assigning here covers the whole pytest process, including those windows. The
+# fixture below stays: it re-asserts the value per test, so a test that changes
+# the variable cannot leak the change into its neighbours.
+os.environ["SCITEX_STORE_DSN"] = _UNREACHABLE_DSN
+
+
+@pytest.fixture(autouse=True)
+def _no_accidental_fleet_store_writes() -> Iterator[None]:
+    """Point every test at a store that cannot exist, unless it asks otherwise.
+
+    MEASURED INCIDENT, 2026-08-20. When the birth certificate moved to
+    PostgreSQL (#1154), ``write_birth_certificate`` lost its ``db_path``. Tests
+    that had been threading a ``tmp_path`` SQLite file were suddenly resolving
+    the FLEET DSN instead, and one full-suite run on scitex-compute-04 wrote
+    **46 rows into the live incarnations store** — ``alpha``, ``zombie``,
+    ``born-1``..``born-4``, ``pid-*``, ``rec-*``, ``screen-*``, every one a
+    fixture name. They were removed with the store's own ``hide`` verb.
+
+    The rows were the small half of the problem. sac's CI runs on SELF-HOSTED
+    runners that sit on the fleet hosts, so every future CI run would have
+    written its fixtures into whichever machine it landed on — a test suite
+    quietly editing production state, on a schedule.
+
+    WHY AN UNREACHABLE DSN RATHER THAN A THROWAWAY SCHEMA. A schema per test
+    would CONNECT, which makes every test in this package depend on PostgreSQL
+    being up — hundreds of tests that never touch a store would start failing
+    on a database outage. This costs nothing and cannot be skipped: there is no
+    server on port 1, so a stray write raises immediately.
+
+    WHY THE LIVE DSN IS NOT SIMPLY LEFT IN PLACE FOR "HARMLESS" WRITES. It was,
+    and that IS the incident. A best-effort caller swallows the failure, so a
+    test that writes to the fleet store looks identical to one that does not —
+    right up until someone counts the rows.
+
+    Tests that need a REAL store take ``pg_schema``, which depends on this
+    fixture and overwrites the variable afterwards, so the ordering is
+    guaranteed by the dependency rather than by pytest's autouse rules.
+    """
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = _UNREACHABLE_DSN
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+@pytest.fixture()
+def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
+    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
+
+    Yields the schema name. Anything a module-under-test writes through
+    ``scitex_dev.store`` lands here and is dropped afterwards, so the live
+    fleet state is never touched.
+
+    NOT AUTOUSE, and the two fixtures above are: this one is opt-in because
+    it CONNECTS, and a test that does not need PostgreSQL must not fail
+    because PostgreSQL is down.
+
+    A SCHEMA rather than a database, deliberately: creating a database needs
+    ``CREATEDB`` and the fleet is not uniform there (compute-03's
+    ``scitex_cards`` role has ``rolcreatedb=False``), so a create-a-database
+    fixture would pass on three runners and fail on the fourth — a flake
+    that looks like the code. The name carries a uuid because the three-way
+    python matrix can put concurrent jobs on ONE runner.
+
+    ``psycopg`` is imported INSIDE the fixture, not at module scope. A
+    top-level import here would make it a hard dependency of every test in
+    this package, so a missing psycopg would turn into a collection error
+    for hundreds of tests that never touch a database.
+
+    Real ``os.environ`` save/restore, not ``monkeypatch`` — PA-306 forbids
+    mocks, and the point is that the REAL resolver reads the REAL variable.
+
+    (``_state/test_state_db_verdict_dedup.py`` still carries its own copy of
+    this fixture, written before this shared one existed. It is the same
+    code; consolidating it is a tidy-up for a PR that already touches that
+    file, not for this one.)
+    """
+    import uuid
+
+    import psycopg
+
+    # Pin PGPASSFILE for the whole fixture: a test that sandboxes HOME (several
+    # legitimately do) would otherwise strand libpq's ~/.pgpass lookup.
+    pgpass_key = "PGPASSFILE"
+    saved_pgpass = os.environ.get(pgpass_key)
+    os.environ[pgpass_key] = _PGPASS_AT_IMPORT
+
+    schema = "sac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = f"{PG_BASE_DSN}?options=-csearch_path%3D{schema}"
+    try:
+        yield schema
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        if saved_pgpass is None:
+            os.environ.pop(pgpass_key, None)
+        else:
+            os.environ[pgpass_key] = saved_pgpass

--- a/tests/develop/test_audit.py
+++ b/tests/develop/test_audit.py
@@ -52,8 +52,9 @@ this — drift goes silent.
 
 from __future__ import annotations
 
+import importlib.util
 import inspect
-import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -98,10 +99,41 @@ def _verified_repo_root() -> Path:
 
 @pytest.fixture
 def scitex_dev_audit():
-    if shutil.which("scitex-dev") is None:
+    # PROBE WHAT THE AUDITOR ACTUALLY RUNS, NOT A CONSOLE SCRIPT IT IGNORES.
+    #
+    # This used to be `shutil.which("scitex-dev") is None -> skip`. The
+    # auditor never invokes that binary. `_audit_conformance.py` builds its
+    # argv as `[sys.executable, "-m", "scitex_dev", ...]`, with the comment
+    # "`sys.executable -m` binds the auditor to the interpreter running the
+    # tests" — so what matters is whether THIS interpreter can import
+    # scitex_dev, and the console script's presence on $PATH is unrelated.
+    #
+    # The two disagree in the common case and the gate lost. Measured
+    # 2026-08-20 on scitex-compute-04: scitex-dev is installed in
+    # ~/.venv/bin, which is not on the $PATH the test process inherits, so
+    # `which` returned None and this gate SKIPPED — while the same
+    # interpreter ran `python -m scitex_dev ecosystem audit-all` to
+    # completion, exit 0. Re-running the suite with that directory on $PATH
+    # turned "1 passed, 1 skipped" into "2 passed in 83s".
+    #
+    # THE COST WAS PAID THE SAME DAY. PR #1155 added a test file in a
+    # location PS-204 rejects. Local runs of tests/develop/ reported
+    # "1 passed, 1 skipped" three times and looked like coverage; the
+    # skipped one WAS the gate. CI caught it, and the message told me
+    # scitex-dev was "not installed" — false, and it points at a fix that
+    # changes nothing.
+    #
+    # So: skip only when the MODULE is genuinely unavailable, which is the
+    # condition the auditor cannot survive. importlib rather than a bare
+    # try/import so that an ImportError raised from INSIDE scitex_dev — a
+    # real breakage — still propagates instead of being read as absence.
+    if importlib.util.find_spec("scitex_dev") is None:
         pytest.skip(
-            "scitex-dev not installed — add `scitex-dev[cli-audit]` "
-            "to [project.optional-dependencies.dev]"
+            "scitex_dev is not importable by this interpreter "
+            f"({sys.executable}) — add `scitex-dev[cli-audit]` to "
+            "[project.optional-dependencies.dev]. Note this is about the "
+            "MODULE, not the `scitex-dev` console script: the auditor runs "
+            "`sys.executable -m scitex_dev` and never looks at $PATH."
         )
     from scitex_dev.testing import audit_all_for_package
 

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -133,7 +133,13 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         "scitex_agent_container/_agentstate/_journal.py:226",
         "scitex_agent_container/_authheal/_pass.py:283",
         "scitex_agent_container/_authheal/_pass.py:431",
-        "scitex_agent_container/_lifecycle/_birth_certificate.py:166",
+        # _birth_certificate.py LEFT THIS SET 2026-08-20 — the reason now
+        # names its sink (journald via sac-listen.service for a brokered
+        # start, the caller's stderr for a direct one) and carries the
+        # journalctl invocation that checks it. Measured before writing:
+        # sac-listen.service is StandardOutput=journal, and per-agent logs
+        # live under runtime/logs/<agent>/ — asserted rather than assumed,
+        # because a NAMED sink that is wrong is worse than an unnamed one.
         "scitex_agent_container/_lifecycle/_github_ci_poll_loop.py:160",
         "scitex_agent_container/_lifecycle/_in_sif_http_client.py:141",
         "scitex_agent_container/_lifecycle/_instances.py:263",

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -190,14 +190,22 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         "scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py:272",
         "scitex_agent_container/cli_pkg/build_cmds.py:198",
         "scitex_agent_container/cli_pkg/hook_cmds.py:46",
+        # _tui_outbound.py and _tui_turn_bridge.py LEFT THIS SET 2026-08-20 —
+        # both reasons now name their sink. MEASURED before writing it, because
+        # a NAMED sink that is wrong is worse than an unnamed one:
+        # _logging/__init__.py documents scitex-logging fanning out to stderr
+        # AND a rotating file under ~/.scitex/logging/runtime/, and that
+        # directory holds live scitex-<date>.log files (plus .1/.2 rotations)
+        # on both this container and its host. It is NOT
+        # ~/.scitex/agent-container/runtime/logs/ — that one holds
+        # shell-redirect logs (creds-watch.log, host_exec.log, build logs) and
+        # is the directory I would have named had I guessed from the tree.
         "scitex_agent_container/runtimes/_apptainer_auth_bind.py:296",
         "scitex_agent_container/runtimes/_cct_rail_alarm.py:198",
         "scitex_agent_container/runtimes/_cct_rail_verdict.py:242",
         "scitex_agent_container/runtimes/_openai_sdk_common.py:179",
         "scitex_agent_container/runtimes/_tui_bridge_seam.py:40",
         "scitex_agent_container/runtimes/_tui_inject.py:92",
-        "scitex_agent_container/runtimes/_tui_outbound.py:277",
-        "scitex_agent_container/runtimes/_tui_turn_bridge.py:343",
         "scitex_agent_container/runtimes/_tui_turn_bridge_lifecycle.py:196",
     }
 )

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -140,7 +140,14 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         # sac-listen.service is StandardOutput=journal, and per-agent logs
         # live under runtime/logs/<agent>/ — asserted rather than assumed,
         # because a NAMED sink that is wrong is worse than an unnamed one.
-        "scitex_agent_container/_lifecycle/_github_ci_poll_loop.py:160",
+        # _github_ci_poll_loop.py:160 LEFT THIS LIST 2026-08-20. Its sink is now
+        # named in the reason itself (journald via sac-listen.service). It came
+        # off the list the hard way: this change shifted the claim from line 160
+        # to 170, which rotted the entry AND made the same claim reappear as a
+        # NEW unnamed one — two failures from one insertion, and green locally
+        # because the frozen list is keyed on a line number that only moves when
+        # the file is edited. That is the guard working, not misfiring: an entry
+        # pinned by line is a claim about a LOCATION, and the location changed.
         "scitex_agent_container/_lifecycle/_in_sif_http_client.py:141",
         "scitex_agent_container/_lifecycle/_instances.py:263",
         "scitex_agent_container/_lifecycle/_listen_client_resolve.py:178",

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A `stx-allow` reason that claims delivery must NAME the sink.
+
+WHY THIS GATE EXISTS
+====================
+2026-08-19: three of the operator's Telegram messages were delivered to the
+WRONG agent's session over several hours, and nobody noticed. The guard that
+should have prevented it existed and FIRED CORRECTLY — `ensure_port_free_or_raise`
+refused to bind a port another agent held, naming the port and the holder's
+pid. The exception was then caught here:
+
+    runtimes/_tui_bridge_seam.py
+        except Exception as exc:  # stx-allow: fallback (reason: ... ; logged
+                                  # for the operator)
+            logging.getLogger(__name__).warning(...)
+
+"logged for the operator" is a CHECKABLE CLAIM, and it was false: a full-text
+search of the runtime tree found that warning in no log at all.
+
+WHAT THIS GATE CHECKS, AND WHAT IT DELIBERATELY DOES NOT
+========================================================
+The repo already has TWO working layers here, and neither is the gap:
+  1. a lint rule that flags fallbacks — it fires;
+  2. an escape hatch that DEMANDS a written reason — it is obeyed, 1244 times.
+The missing third question is whether the stated reason is TRUE. In general
+that is not machine-checkable. But one subset is: a claim that something
+REACHES SOMEWHERE can name where, and a named path can be opened.
+
+So: if a `stx-allow` reason says the failure is logged / alerted / reported /
+notified / surfaced / told, it must also name a sink — a path, a log file, a
+channel, a card. Prose stays free; only the delivery promise is constrained.
+
+THE PREDICATE IS "CLAIMS SOMETHING REACHES SOMEWHERE", not "contains the word
+logged". cct's own near-miss on the same night read "silence becomes
+impossible" — a delivery guarantee that no logging-verb filter would catch.
+The vocabulary below is therefore deliberately wider than logging verbs, and
+widening it further is a correct change, not a scope creep.
+
+WHY A NAMED PATH AND NOT AN HONEST VERB
+=======================================
+"logged for the operator" was plausibly TRUE when written. The defect is
+DRIFT: the claim outlived the sink it described, and nothing could notice
+because "logged" has no referent to re-check. `runtime/logs/turn-bridge.log`
+has one. That is the entire difference this gate buys.
+
+THIS GATE DOES NOT DEPEND ON THE LOGGING MIGRATION
+==================================================
+src/ imports stdlib `logging` in 154 files and `scitex_logging` in 13. A
+check built on scitex_logging would see 8% of the codebase today. This one
+reads COMMENT TEXT, so it covers all 361 files with `stx-allow` regardless of
+which library they use — and it must NOT later be "improved" into a
+scitex_logging-based check, which would silently shrink its coverage twelve-fold.
+
+IT DOES NOT TRY TO REDUCE 1244
+==============================
+Whether a swallow-if-you-explain hatch should exist at all is a larger and
+separate argument. Mixing it in would sink both. This gate freezes the
+falsifiable subset and stops.
+
+SHRINKING IS TWO LINES; GROWING IS IMPOSSIBLE
+=============================================
+Name the sink in the comment, delete the entry here. A 70th unnamed claim
+fails. Same asymmetry as tests/develop/test_sqlite_footprint_frozen.py, for
+the same reason: a list that can only shrink is an inventory; one that can
+grow is a wish.
+
+WHAT A PASS DOES **NOT** PROVE — READ THIS BEFORE TRUSTING A GREEN
+==================================================================
+This gate checks the FORM of the claim, not its TRUTH. A reason that names
+`runtime/logs/turn-bridge.log` passes even if nothing has ever written one
+byte there. So `_tui_bridge_seam.py` — the site that motivated this entire
+gate — would pass the moment someone appends a plausible path, and would then
+carry a GREEN CHECK beside a claim that is still false. That is worse than
+the original in one specific way, and it is the reason this paragraph exists.
+
+Raised by claude-code-telegrammer while reviewing the gate, and it is the
+same shape one turn further in: "documented and justified" was not "does
+anything enforce it", and "names a sink" is not "the sink receives".
+
+Closure, cheapest first, none of it done here:
+  1. assert the named path sits under a known log root — grep-level, catches
+     inventions and typos. NOT DONE: the 69 frozen reasons use several roots
+     and enumerating them honestly needs a survey, not a guess.
+  2. assert something in the tree actually writes to that path.
+  3. the only one that proves delivery: emit a line there in a test and read
+     it back. Same shape as the two-ended probe agreed for the turn bridge —
+     a claim about ARRIVAL can only be settled at the receiving end.
+
+SCOPE, STATED SO THE SUMMARY CANNOT DRIFT
+=========================================
+1244 `stx-allow` escape hatches exist. 73 claim delivery; 69 of those name no
+sink and are frozen here. THE OTHER 1175 ARE NOT CLEAN — they are merely
+making claims that are not falsifiable, and this gate says nothing whatever
+about them. "The fallback problem is fixed" is the sentence this will collapse
+into if the scope is not written down, and it would be false.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+
+#: Claims that SOMETHING REACHES SOMEWHERE. Wider than logging verbs on
+#: purpose — see the module docstring.
+_CLAIMS_DELIVERY = re.compile(
+    r"\b(logged|logs|logging|alerted|alarm|reported|notified|notify|surfaced|"
+    r"raised as a card|the operator will see|reaches the operator|told)\b",
+    re.I,
+)
+
+#: A NAMED sink: a path, a log file, a channel, a card, a stream.
+_NAMES_A_SINK = re.compile(
+    r"(runtime/logs/|\.log\b|~/\.scitex/|\$HOME/|/var/log/|telegram|"
+    r"scitex-cards|a2a|journald|journalctl|stderr|stdout|card\b)",
+    re.I,
+)
+
+_ESCAPE_HATCH = re.compile(r"stx-allow:")
+
+#: MEASURED 2026-08-19. Every `stx-allow` line whose reason claims delivery
+#: and names no sink. 73 lines claimed delivery; 4 already named a sink.
+FROZEN_UNNAMED_CLAIMS = frozenset(
+    {
+        "scitex_agent_container/_account/claude_usage.py:381",
+        "scitex_agent_container/_account/claude_usage.py:540",
+        "scitex_agent_container/_account/interactive_login.py:262",
+        "scitex_agent_container/_account/openai_usage.py:333",
+        "scitex_agent_container/_account/openai_usage.py:407",
+        "scitex_agent_container/_account/refresh_alarm.py:75",
+        "scitex_agent_container/_agentstate/_journal.py:226",
+        "scitex_agent_container/_authheal/_pass.py:283",
+        "scitex_agent_container/_authheal/_pass.py:431",
+        "scitex_agent_container/_lifecycle/_birth_certificate.py:166",
+        "scitex_agent_container/_lifecycle/_github_ci_poll_loop.py:160",
+        "scitex_agent_container/_lifecycle/_in_sif_http_client.py:141",
+        "scitex_agent_container/_lifecycle/_instances.py:263",
+        "scitex_agent_container/_lifecycle/_listen_client_resolve.py:178",
+        "scitex_agent_container/_lifecycle/_orphan_mcp_cleanup.py:227",
+        "scitex_agent_container/_lifecycle/_prune_runtime.py:80",
+        "scitex_agent_container/_lifecycle/_relocate_transcript.py:172",
+        "scitex_agent_container/_lifecycle/_restart_client.py:142",
+        "scitex_agent_container/_lifecycle/_sdk_heartbeat_loop.py:188",
+        "scitex_agent_container/_lifecycle/_sdk_heartbeat_loop.py:289",
+        "scitex_agent_container/_lifecycle/_sdk_heartbeat_loop.py:328",
+        "scitex_agent_container/_lifecycle/_tui_bridge_supervisor.py:206",
+        "scitex_agent_container/_lifecycle/_tui_bridge_supervisor.py:230",
+        "scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py:230",
+        "scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py:346",
+        "scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py:375",
+        "scitex_agent_container/_listen/_deploy_freshness.py:227",
+        "scitex_agent_container/_listen/_liveness_tick.py:123",
+        "scitex_agent_container/_listen/_node_channel_forwarders.py:177",
+        "scitex_agent_container/_maintenance/_install_integrity_pointers.py:193",
+        "scitex_agent_container/_maintenance/_install_integrity_pointers.py:226",
+        "scitex_agent_container/_maintenance/_venv_dist_assertion.py:120",
+        "scitex_agent_container/_mcp/_channel_post_deliver.py:120",
+        "scitex_agent_container/_mcp/_channel_post_deliver.py:99",
+        "scitex_agent_container/_mcp/_channel_reaction_ack.py:107",
+        "scitex_agent_container/_mcp/channel.py:329",
+        "scitex_agent_container/_network/_peer_dispatch.py:46",
+        "scitex_agent_container/_network/_peer_dispatch.py:59",
+        "scitex_agent_container/_network/probe.py:457",
+        "scitex_agent_container/_reconcile/_budget.py:164",
+        "scitex_agent_container/_reconcile/_pass.py:370",
+        "scitex_agent_container/_reconcile/_pass.py:428",
+        "scitex_agent_container/_reconcile/_perform.py:96",
+        "scitex_agent_container/_runners/_codex_turn_driver.py:169",
+        "scitex_agent_container/_runners/_openai_turn_driver.py:240",
+        "scitex_agent_container/_runners/_session_completion.py:183",
+        "scitex_agent_container/_runners/_session_conversation.py:262",
+        "scitex_agent_container/_runners/_session_hooks.py:225",
+        "scitex_agent_container/_runners/_session_http.py:244",
+        "scitex_agent_container/_runners/_tmux/claude_code.py:516",
+        "scitex_agent_container/_state/_acl_broker_client.py:130",
+        "scitex_agent_container/_state/snapshot/_io.py:411",
+        "scitex_agent_container/a2a/executors/_base.py:97",
+        "scitex_agent_container/cli_pkg/_account_refresh_push.py:99",
+        "scitex_agent_container/cli_pkg/_agents_cct_audit.py:101",
+        "scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py:157",
+        "scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py:186",
+        "scitex_agent_container/cli_pkg/_helpers/_agent_list_fleet_probe.py:272",
+        "scitex_agent_container/cli_pkg/build_cmds.py:198",
+        "scitex_agent_container/cli_pkg/hook_cmds.py:46",
+        "scitex_agent_container/runtimes/_apptainer_auth_bind.py:296",
+        "scitex_agent_container/runtimes/_cct_rail_alarm.py:198",
+        "scitex_agent_container/runtimes/_cct_rail_verdict.py:242",
+        "scitex_agent_container/runtimes/_openai_sdk_common.py:179",
+        "scitex_agent_container/runtimes/_tui_bridge_seam.py:40",
+        "scitex_agent_container/runtimes/_tui_inject.py:92",
+        "scitex_agent_container/runtimes/_tui_outbound.py:277",
+        "scitex_agent_container/runtimes/_tui_turn_bridge.py:343",
+        "scitex_agent_container/runtimes/_tui_turn_bridge_lifecycle.py:196",
+    }
+)
+
+
+def _unnamed_delivery_claims() -> set[str]:
+    """Every `stx-allow` line claiming delivery without naming a sink."""
+    found: set[str] = set()
+    for path in sorted(SRC.rglob("*.py")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if not _ESCAPE_HATCH.search(line):
+                continue
+            if not _CLAIMS_DELIVERY.search(line):
+                continue
+            if _NAMES_A_SINK.search(line):
+                continue
+            found.add(f"{path.relative_to(SRC)}:{lineno}")
+    return found
+
+
+def test_the_scanner_still_detects_the_incident_that_motivated_it():
+    """POSITIVE CONTROL. Without this, an empty result reads as compliance.
+
+    The regexes are the whole gate. If a refactor breaks one, every other
+    test here passes vacuously and the gate reports a clean codebase. So
+    assert on a line we KNOW is a delivery claim with no sink.
+    """
+    # Arrange
+    known_bad = 'except Exception:  # stx-allow: fallback (reason: x; logged for the operator)'
+    # Act
+    claims = bool(_CLAIMS_DELIVERY.search(known_bad))
+    names = bool(_NAMES_A_SINK.search(known_bad))
+    # Assert
+    assert claims and not names
+
+
+def test_a_named_sink_satisfies_the_gate():
+    """The other half of the control: a compliant line must PASS.
+
+    A predicate that rejects everything would also make the frozen set
+    unshrinkable, and the failure would look like diligence.
+    """
+    # Arrange
+    good = 'except Exception:  # stx-allow: fallback (reason: x; logged to runtime/logs/turn-bridge.log)'
+    # Act
+    claims = bool(_CLAIMS_DELIVERY.search(good))
+    names = bool(_NAMES_A_SINK.search(good))
+    # Assert
+    assert claims and names
+
+
+def test_no_new_unnamed_delivery_claim():
+    """A 70th unnamed claim fails. This is the operator-facing rule."""
+    # Arrange
+    frozen = FROZEN_UNNAMED_CLAIMS
+    # Act
+    current = _unnamed_delivery_claims()
+    # Assert
+    new = current - frozen
+    assert not new, (
+        "These `stx-allow` reasons claim the failure is logged/alerted/"
+        "reported but name no sink. Name the path or channel in the comment "
+        "(e.g. 'logged to runtime/logs/<name>.log') so the claim can be "
+        f"re-checked later:\n  " + "\n  ".join(sorted(new))
+    )
+
+
+def test_the_frozen_list_does_not_rot():
+    """An entry that no longer matches must be REMOVED from the list.
+
+    Line numbers move. A stale entry silently grants permission to whatever
+    line drifts into that position, which is how an allowlist becomes a set
+    of blessed coordinates rather than an inventory. Removing it is the same
+    two-line change as fixing one.
+    """
+    # Arrange
+    frozen = FROZEN_UNNAMED_CLAIMS
+    # Act
+    current = _unnamed_delivery_claims()
+    # Assert
+    stale = frozen - current
+    assert not stale, (
+        "These entries no longer match — the claim was fixed, or the line "
+        "moved. Delete them from FROZEN_UNNAMED_CLAIMS:\n  "
+        + "\n  ".join(sorted(stale))
+    )
+
+
+# EOF

--- a/tests/develop/test_fastmcp_floor.py
+++ b/tests/develop/test_fastmcp_floor.py
@@ -1,0 +1,168 @@
+"""The `mcp` upper bound is the gate — an unpinned one makes CI a coin flip.
+
+2026-08-18. Three pytest-matrix runs of the SAME workflow on the same py3.11,
+minutes apart, with nothing in the repo changed between them::
+
+    run 32184153812   fastmcp==3.4.7     mcp==1.29.0   ->   17094 passed
+    run 32185071483   fastmcp==2.14.1    mcp==2.0.0    ->      29 failed
+    run 32185515xxx   fastmcp==4.0.0b3   mcp==2.0.0    ->      26 failed
+
+EVERY failure is ``AttributeError: 'Server' object has no attribute
+'list_tools'`` (plus ``TypeError: 'types.UnionType' object is not callable``).
+Neither message names a package, let alone a version, so each run reads as a
+code regression on whichever branch happened to draw it.
+
+READ THE TABLE BY WHAT VARIES WITH THE OUTCOME. ``fastmcp`` moves DOWN then UP
+across those rows and the result does not follow it. ``mcp`` does: 1.29.0
+passes, 2.0.0 fails, twice. ``Server`` is an ``mcp`` python-sdk class and
+``list_tools`` is its API — mcp 2.0.0 (released 2026-07-28) removed it, and
+fastmcp only pulls mcp transitively.
+
+THE FIRST VERSION OF THIS FILE PINNED THE WRONG PACKAGE. It floored
+``fastmcp>=3.0`` on the theory that 2.x was too old. The very next CI run
+resolved ``fastmcp==4.0.0b3`` — satisfying that floor, reaching for a
+PRE-RELEASE — and failed identically, because mcp was still 2.0.0. A bound
+that admits the failure is not a gate; it is a comment.
+
+So the pins are now: ``mcp>=1.29,<2`` (the bound the code is written against)
+and ``fastmcp>=3.0,<4`` in [dev] / ``fastmcp>=2.0,<4`` in [mcp] (keeping the
+observed pre-release out). The [dev] fastmcp FLOOR is higher than [mcp]'s
+because the TESTS call ``server.list_tools()`` outright while the SOURCE
+tolerates more — ``cli_pkg/mcp_group._list_tools`` branches on ``hasattr``.
+
+There is no lockfile, so ``uv pip install -e .[dev]`` re-resolves every run;
+these bounds are the only thing standing between the suite and the index.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+#: The lowest fastmcp the _mcp suite has ever been observed to pass on.
+#: Not a guess: 3.4.7 is what run 32184153812 resolved and passed with.
+MINIMUM_TESTED_MAJOR = 3
+
+#: The first mcp major that REMOVES ``Server.list_tools``. Every red run
+#: above carried it; the one green run did not.
+FIRST_BREAKING_MCP_MAJOR = 2
+
+
+def _pyproject() -> dict:
+    root = Path(__file__).resolve().parents[2]
+    path = root / "pyproject.toml"
+    assert path.is_file(), f"pyproject.toml not found at {path}"
+    return tomllib.loads(path.read_text())
+
+
+def _specs(extra: str, dist: str) -> list[str]:
+    extras = _pyproject()["project"]["optional-dependencies"]
+    assert extra in extras, f"[{extra}] extra is gone; this gate is now blind"
+    out = []
+    for d in extras[extra]:
+        name = d.split(">")[0].split("<")[0].split("=")[0].split("[")[0].strip()
+        if name == dist:
+            out.append(d)
+    return out
+
+
+def _fastmcp_specs(extra: str) -> list[str]:
+    return _specs(extra, "fastmcp")
+
+
+def _mcp_specs(extra: str) -> list[str]:
+    return _specs(extra, "mcp")
+
+
+def _sole_mcp_spec(extra: str) -> str:
+    """The ONE mcp requirement in ``extra``.
+
+    The exactly-once check lives here rather than in the test body because
+    STX-TQ007 allows a test one assertion, and because a second mcp
+    requirement would make the bound below ambiguous for EVERY caller — a
+    gate that reads whichever spec it happened to see first is not a gate.
+    """
+    specs = _mcp_specs(extra)
+    assert len(specs) == 1, f"[{extra}] must pin mcp exactly once, got {specs}"
+    return specs[0]
+
+
+def _ceiling_major(spec: str) -> int:
+    """The major version from a ``pkg<X`` upper bound."""
+    _, _, rest = spec.partition("<")
+    assert rest, f"expected a < ceiling, got {spec!r}"
+    return int(rest.split(".")[0])
+
+
+def _floor_major(spec: str) -> int:
+    """The major version from a ``fastmcp>=X.Y`` spec."""
+    _, _, rest = spec.partition(">=")
+    assert rest, f"expected a >= floor, got {spec!r}"
+    return int(rest.split(".")[0])
+
+
+def test_the_dev_extra_declares_exactly_one_fastmcp_requirement():
+    # Arrange — two specs would make the floor below ambiguous, and this
+    # gate would then pass while reading the permissive one.
+    specs = _fastmcp_specs("dev")
+    # Act
+    count = len(specs)
+    # Assert
+    assert count == 1
+
+
+def test_the_dev_fastmcp_floor_excludes_the_untestable_api_line():
+    # Arrange — THE GATE. Below 3.0 the _mcp suite cannot run at all.
+    spec = _fastmcp_specs("dev")[0]
+    # Act
+    major = _floor_major(spec)
+    # Assert
+    assert major >= MINIMUM_TESTED_MAJOR
+
+
+def test_the_runtime_extra_keeps_the_wider_floor():
+    # Arrange — POSITIVE CONTROL for the asymmetry. If someone "fixes the
+    # inconsistency" by raising [mcp] too, the 2.x support the shim exists
+    # for is dropped from consumers who never asked for the test surface.
+    spec = _fastmcp_specs("mcp")[0]
+    # Act
+    major = _floor_major(spec)
+    # Assert
+    assert major == 2
+
+
+@pytest.mark.parametrize("extra", ["dev", "mcp"])
+def test_neither_floor_is_removed_entirely(extra: str):
+    # Arrange — an absent requirement is not a permissive one; it is a
+    # suite that silently collection-skips. Pair the bound checks above
+    # with the presence check they both assume.
+    specs = _fastmcp_specs(extra)
+    # Act
+    present = bool(specs)
+    # Assert
+    assert present is True
+
+
+@pytest.mark.parametrize("extra", ["dev", "mcp"])
+def test_the_mcp_bound_excludes_the_release_that_removed_list_tools(extra: str):
+    # Arrange — THE GATE, and the one the first version of this file
+    # missed. mcp 2.0.0 removed `Server.list_tools`; every red run above
+    # carried it and the one green run did not.
+    spec = _sole_mcp_spec(extra)
+    # Act
+    ceiling = _ceiling_major(spec)
+    # Assert
+    assert ceiling <= FIRST_BREAKING_MCP_MAJOR
+
+
+@pytest.mark.parametrize("extra", ["dev", "mcp"])
+def test_fastmcp_has_a_ceiling_so_a_prerelease_cannot_be_drawn(extra: str):
+    # Arrange — run 32185515xxx resolved fastmcp==4.0.0b3 under a
+    # floor-only spec. A bound that admits the failure is not a gate.
+    spec = _fastmcp_specs(extra)[0]
+    # Act
+    has_ceiling = "<" in spec
+    # Assert
+    assert has_ceiling is True

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -141,7 +141,12 @@ FROZEN_SQLITE_DDL = frozenset(
         "_state/state_db_acl_deny_notify.py",
         "_state/state_db_acl_policy.py",
         "_state/state_db_blocks.py",
-        "_state/state_db_pending_approval.py",
+        # _state/state_db_pending_approval.py LEFT THIS SET 2026-08-20 — the
+        # THIRD table to move to PostgreSQL, and the first whose SQLite verb
+        # had no store equivalent: it DELETEd, and the store only hides. That
+        # turned out to be the better primitive (the decision stays in the
+        # oplog with its actor) but it introduced a lifecycle the SQLite
+        # version did not have, and the module documents it.
         "_state/state_db_schema.py",
         # _state/state_db_incarnations.py LEFT THIS SET 2026-08-19 — the
         # SECOND table to move to PostgreSQL, and the first to leave via

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -66,6 +66,13 @@ they hand their DDL to `state_db.open_db` to execute —
     _state/state_db_acl_policy.py        _state/state_db_acl_deny_notify.py
     _state/state_db_pending_approval.py
 
+(That enumeration is the original 2026-08-19 measurement, kept as written
+because it is what motivated the second list. ``state_db_incarnations.py``
+left the set later the same day when the birth certificate moved to
+PostgreSQL — the live set is always ``FROZEN_SQLITE_DDL`` below, never this
+prose, which is exactly why the gate reads the constant and not the
+docstring.)
+
 So the shape "add a new SQLite table without appearing in FROZEN_SQLITE" is
 not hypothetical — it is the IDIOMATIC way tables are added in this package,
 with five existing examples. A new `state_db_<thing>.py` written that way
@@ -134,9 +141,14 @@ FROZEN_SQLITE_DDL = frozenset(
         "_state/state_db_acl_deny_notify.py",
         "_state/state_db_acl_policy.py",
         "_state/state_db_blocks.py",
-        "_state/state_db_incarnations.py",
         "_state/state_db_pending_approval.py",
         "_state/state_db_schema.py",
+        # _state/state_db_incarnations.py LEFT THIS SET 2026-08-19 — the
+        # SECOND table to move to PostgreSQL, and the first to leave via
+        # THIS list rather than FROZEN_SQLITE (it never imported sqlite3;
+        # it handed its DDL to state_db.open_db, which is exactly the hole
+        # this second list was added to close). The birth certificate now
+        # lives in per-host PostgreSQL via scitex_dev.store.
     }
 )
 

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -38,7 +38,11 @@ entry) and growing is a conversation. That asymmetry is the point.
 
 WHAT THIS GATE DOES NOT CLAIM
 =============================
-It does not say the 13 modules below are correct, or that they should stay.
+It does not say the modules listed below are correct, or that they should
+stay. The prose deliberately carries NO COUNT: the lists shrink as the
+migration lands, and a number written here is a fact no test checks, so it
+would go stale silently — which is the exact failure this file exists to
+prevent, one level up. Count the sets if you want a number.
 They are the measured footprint on 2026-08-19, recorded so the migration has
 a definite scope instead of an estimate. Every one of them is per-host state
 under ~/.scitex/agent-container/runtime/state.db; the fleet-shared store
@@ -47,6 +51,37 @@ under ~/.scitex/agent-container/runtime/state.db; the fleet-shared store
 It also does not police test code or third-party reads. A test using
 `:memory:` creates nothing durable, and reading someone else's .db file is
 not sac choosing a storage engine.
+
+THE IMPORT CHECK HAD A HOLE, AND THE HOLE IS THE ONE THE OPERATOR ASKED ABOUT
+============================================================================
+`import sqlite3` is a good proxy for "somebody OPENED a database". It is not
+a proxy for "somebody DEFINED a table". Measured 2026-08-19: SIX modules
+under src/ carry `CREATE TABLE` DDL and import no sqlite3 at all, because
+they hand their DDL to `state_db.open_db` to execute —
+
+    _state/state_db_schema.py            15 CREATE TABLE statements, and it
+                                         owns seven of the twelve tables that
+                                         currently hold rows
+    _state/state_db_incarnations.py      _state/state_db_blocks.py
+    _state/state_db_acl_policy.py        _state/state_db_acl_deny_notify.py
+    _state/state_db_pending_approval.py
+
+So the shape "add a new SQLite table without appearing in FROZEN_SQLITE" is
+not hypothetical — it is the IDIOMATIC way tables are added in this package,
+with five existing examples. A new `state_db_<thing>.py` written that way
+grows SQLite back and the gate stays green, which is exactly the six-months-
+later outcome the instruction above is meant to prevent.
+
+FROZEN_SQLITE_DDL closes it, with the same two-directional asymmetry: a new
+DDL-bearing module fails, and an entry that stops carrying DDL also fails.
+
+WHY TWO SETS RATHER THAN ONE MERGED LIST: they answer different questions and
+a single number would answer neither honestly. FROZEN_SQLITE counts modules
+that OPEN SQLite; FROZEN_SQLITE_DDL counts modules that DEFINE SQLite tables.
+The migration shrinks the second faster than the first, and a reader watching
+only the first would conclude SQLite was gone from sac while fifteen table
+definitions remained. Keeping them separate is what stops one number being
+read as an answer to the other question.
 """
 
 from __future__ import annotations
@@ -89,6 +124,38 @@ FROZEN_SQLITE = frozenset(
 _IMPORTS_SQLITE = re.compile(
     r"^\s*(?:import\s+sqlite3\b|from\s+sqlite3\s+import\b)", re.M
 )
+
+
+#: Modules that DEFINE SQLite tables without opening a connection themselves —
+#: they hand their DDL to ``state_db.open_db``. Invisible to FROZEN_SQLITE by
+#: construction; see the module docstring. THIS LIST MAY ONLY SHRINK.
+FROZEN_SQLITE_DDL = frozenset(
+    {
+        "_state/state_db_acl_deny_notify.py",
+        "_state/state_db_acl_policy.py",
+        "_state/state_db_blocks.py",
+        "_state/state_db_incarnations.py",
+        "_state/state_db_pending_approval.py",
+        "_state/state_db_schema.py",
+    }
+)
+
+# `CREATE TABLE` / `CREATE TABLE IF NOT EXISTS`, any case, any indentation.
+_DEFINES_A_TABLE = re.compile(r"\bCREATE\s+TABLE\b", re.I)
+
+
+def _modules_defining_tables() -> set[str]:
+    """Every module under src/ carrying CREATE TABLE DDL, as relative paths.
+
+    Deliberately NOT excluding modules that also import sqlite3 — a module can
+    legitimately be in both sets, and subtracting one from the other would
+    make each list depend on the other's accuracy.
+    """
+    found: set[str] = set()
+    for path in SRC.rglob("*.py"):
+        if _DEFINES_A_TABLE.search(path.read_text(encoding="utf-8", errors="replace")):
+            found.add(path.relative_to(SRC).as_posix())
+    return found
 
 
 def _modules_importing_sqlite() -> set[str]:
@@ -151,4 +218,62 @@ def test_the_frozen_list_has_no_stale_entries() -> None:
         f"{stale}. Good news — the footprint shrank. Delete these entries so "
         "the list keeps describing reality; a stale allowlist re-opens the "
         "door it was written to close."
+    )
+
+
+# ----------------------------------------------------------------------
+# The DDL footprint — the hole the import check could not see.
+# ----------------------------------------------------------------------
+
+
+def test_the_ddl_scan_actually_finds_something() -> None:
+    """POSITIVE CONTROL — a zero here would make both DDL gates vacuous.
+
+    Same reasoning as the import scan's control: an empty result and a
+    SQLite-free codebase produce the same PASS below, so without this the
+    whole section could go green because the glob broke.
+    """
+    # Arrange
+    scanned_root = SRC
+    # Act
+    found = _modules_defining_tables()
+    # Assert
+    assert found, f"no CREATE TABLE found anywhere under {scanned_root}"
+
+
+def test_no_module_defines_a_new_sqlite_table() -> None:
+    """A module may not DEFINE a SQLite table without being frozen.
+
+    This is the case `import sqlite3` cannot see, and it is the idiomatic way
+    tables are added here — five existing modules do exactly this. Without
+    this gate, `state_db_<newthing>.py` grows SQLite back on a green build.
+    """
+    # Arrange
+    frozen = FROZEN_SQLITE_DDL | FROZEN_SQLITE
+    # Act
+    new = sorted(_modules_defining_tables() - frozen)
+    # Assert
+    assert not new, (
+        "these modules define SQLite tables and are not frozen: "
+        f"{new}. sac is migrating state to PostgreSQL via scitex_dev.store; "
+        "a new SQLite table is a decision to raise, not a line to add to "
+        "FROZEN_SQLITE_DDL."
+    )
+
+
+def test_the_ddl_freeze_list_has_no_stale_entries() -> None:
+    """An entry that no longer defines a table must leave the list.
+
+    Same asymmetry as the import list: shrinking is two lines, and a stale
+    allowlist rots into blessed filenames that a future module inherits.
+    """
+    # Arrange
+    defining = _modules_defining_tables()
+    # Act
+    stale = sorted(FROZEN_SQLITE_DDL - defining)
+    # Assert
+    assert not stale, (
+        "FROZEN_SQLITE_DDL lists modules that no longer define a table: "
+        f"{stale}. Delete the entries — the list is an inventory, not a "
+        "set of blessed filenames."
     )

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -1,0 +1,149 @@
+"""SQLite must not spread. The footprint is FROZEN and may only shrink.
+
+WHY THIS GATE EXISTS
+====================
+The operator's instruction, 2026-08-18, when he ranked the fleet's four most
+important pieces of work:
+
+    「特に重要なのは移行そのものより、SQLite を新しく作れないようにする監査
+      ルールです。これを入れないと半年後にまた SQLite が生えます」
+
+    (What matters is not the migration itself but the audit rule that makes
+     new SQLite impossible. Without it, SQLite grows back in six months.)
+
+That is the whole reasoning. A migration moves the databases that exist today;
+only a gate stops the next one being written. sac, scitex-cards and scitex-dev
+have each grown the same mixed SQLite/PostgreSQL problem independently, which
+is the evidence that intent alone does not hold this line.
+
+THE PREDICATE, WRITTEN AS WHAT MUST BE TRUE
+===========================================
+    Every module under src/ that imports sqlite3 appears in FROZEN_SQLITE.
+
+Stated positively on purpose. "No new SQLite" is unfalsifiable prose; "this
+set is a subset of that set" is a thing a machine can check on every push.
+
+TWO DIRECTIONS, AND WHY BOTH ARE TESTED
+=======================================
+* A module importing sqlite3 that is NOT in the list -> FAIL. This is the
+  case the operator asked for: SQLite growing back.
+* An entry in the list that NO LONGER imports sqlite3 -> FAIL. This one is
+  less obvious and matters more over time. A stale allowlist rots into a set
+  of blessed filenames, and a future module reusing a retired name inherits
+  permission nobody granted it. Making removal update the list is what keeps
+  the list an inventory rather than a wish.
+
+Shrinking is therefore a two-line change (delete the import, delete the
+entry) and growing is a conversation. That asymmetry is the point.
+
+WHAT THIS GATE DOES NOT CLAIM
+=============================
+It does not say the 13 modules below are correct, or that they should stay.
+They are the measured footprint on 2026-08-19, recorded so the migration has
+a definite scope instead of an estimate. Every one of them is per-host state
+under ~/.scitex/agent-container/runtime/state.db; the fleet-shared store
+(scitex-cards) is already on PostgreSQL at 127.0.0.1:55432.
+
+It also does not police test code or third-party reads. A test using
+`:memory:` creates nothing durable, and reading someone else's .db file is
+not sac choosing a storage engine.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "scitex_agent_container"
+
+#: The measured SQLite footprint on 2026-08-19, as repo-relative paths under
+#: ``src/scitex_agent_container/``. THIS LIST MAY ONLY SHRINK.
+#:
+#: Adding an entry means a new SQLite database in a fleet that is trying to
+#: standardise on PostgreSQL — raise it as a decision, not a diff.
+FROZEN_SQLITE = frozenset(
+    {
+        "_authheal/_specimen.py",
+        "_lifecycle/_rename_db.py",
+        "_lifecycle/_rename_plan.py",
+        "_state/auth_state.py",
+        "_state/dispatch_ledger.py",
+        "_state/inbound_ledger.py",
+        "_state/port_allocator.py",
+        "_state/state_db.py",
+        "_state/state_db_health.py",
+        "_state/state_db_heartbeats.py",
+        "_state/state_db_migrations.py",
+        "_state/state_db_relocation.py",
+        "_state/state_db_verdict_dedup.py",
+    }
+)
+
+# `import sqlite3` / `import sqlite3 as x` / `from sqlite3 import ...`, at any
+# indentation (several of these imports are function-local, deliberately).
+_IMPORTS_SQLITE = re.compile(
+    r"^\s*(?:import\s+sqlite3\b|from\s+sqlite3\s+import\b)", re.M
+)
+
+
+def _modules_importing_sqlite() -> set[str]:
+    """Every module under src/ that imports sqlite3, as relative paths."""
+    found: set[str] = set()
+    for path in SRC.rglob("*.py"):
+        if _IMPORTS_SQLITE.search(path.read_text(encoding="utf-8", errors="replace")):
+            found.add(path.relative_to(SRC).as_posix())
+    return found
+
+
+def test_the_scan_actually_finds_something() -> None:
+    """POSITIVE CONTROL — a zero here would make both gates below vacuous.
+
+    An empty result and a healthy codebase produce the same PASS in the two
+    tests that follow, so without this the whole file could go green because
+    the glob broke rather than because the rule holds.
+    """
+    # Arrange
+    scanned_root = SRC
+    # Act
+    found = _modules_importing_sqlite()
+    # Assert
+    assert found, (
+        f"scanned {scanned_root} for sqlite3 imports and found NONE. Either every "
+        "SQLite user was removed (delete this file and FROZEN_SQLITE with it) "
+        "or the scan is broken. Do not assume the former."
+    )
+
+
+def test_no_module_outside_the_frozen_list_imports_sqlite() -> None:
+    """The operator's rule: SQLite must not grow back."""
+    # Arrange
+    found = _modules_importing_sqlite()
+    # Act
+    new = sorted(found - FROZEN_SQLITE)
+    # Assert
+    assert not new, (
+        "NEW SQLITE. These modules import sqlite3 and are not in the frozen "
+        f"footprint: {new}. The fleet is standardising on PostgreSQL "
+        "(scitex-cards already runs on 127.0.0.1:55432). If this module "
+        "genuinely needs local per-host state, that is a decision to raise "
+        "rather than a line to add to FROZEN_SQLITE."
+    )
+
+
+def test_the_frozen_list_has_no_stale_entries() -> None:
+    """The list must stay an inventory, not a set of blessed filenames.
+
+    Without this, removing a SQLite user leaves its path permitted forever,
+    and a later module reusing that path inherits permission silently.
+    """
+    # Arrange
+    found = _modules_importing_sqlite()
+    # Act
+    stale = sorted(FROZEN_SQLITE - found)
+    # Assert
+    assert not stale, (
+        "FROZEN_SQLITE lists modules that no longer import sqlite3: "
+        f"{stale}. Good news — the footprint shrank. Delete these entries so "
+        "the list keeps describing reality; a stale allowlist re-opens the "
+        "door it was written to close."
+    )

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -138,9 +138,29 @@ _IMPORTS_SQLITE = re.compile(
 #: construction; see the module docstring. THIS LIST MAY ONLY SHRINK.
 FROZEN_SQLITE_DDL = frozenset(
     {
-        "_state/state_db_acl_deny_notify.py",
+        # _state/state_db_acl_deny_notify.py LEFT THIS SET 2026-08-20 — the
+        # FIFTH table, moved in the same PR as comms_blocks because the two are
+        # siblings that both lose a line from one block of init_schema.
+        #
+        # It is also the first table whose move had a SECOND SITE: it was in
+        # KNOWN_TABLES, so state_db_export would have queried a table SQLite no
+        # longer has. comms_blocks was not, which is exactly why the pair had
+        # to be checked separately rather than assumed symmetric.
+        #
+        # And this list's OWN staleness gate is what caught the omission: the
+        # DDL left the module in one commit and the entry stayed here, which
+        # `test_the_ddl_freeze_list_has_no_stale_entries` reported. A ratchet
+        # that only checks one direction would have gone green on a half-done
+        # migration.
         "_state/state_db_acl_policy.py",
-        "_state/state_db_blocks.py",
+        # _state/state_db_blocks.py LEFT THIS SET 2026-08-20 — the FOURTH table
+        # to move to PostgreSQL, and the first where the migration's own
+        # PREDICTION was wrong in the safe direction. It was scoped as "a
+        # DURABLE decision, not a transient flag, so it almost certainly holds
+        # real rows and DOES need a migration". It holds zero: 52 SQLite
+        # databases read across compute-01..04 (the fleet state.db plus every
+        # per-agent shard), zero rows in all of them. Nobody has ever blocked
+        # anyone. Checking beat carrying the previous slice's conclusion over.
         # _state/state_db_pending_approval.py LEFT THIS SET 2026-08-20 — the
         # THIRD table to move to PostgreSQL, and the first whose SQLite verb
         # had no store equivalent: it DELETEd, and the store only hides. That

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -75,7 +75,12 @@ FROZEN_SQLITE = frozenset(
         "_state/state_db_heartbeats.py",
         "_state/state_db_migrations.py",
         "_state/state_db_relocation.py",
-        "_state/state_db_verdict_dedup.py",
+        # _state/state_db_verdict_dedup.py LEFT THIS SET 2026-08-19 — the
+        # first table to move to PostgreSQL, by adopting
+        # scitex_dev.store rather than by sac growing its own psycopg
+        # layer. The ratchet is the point: this file FAILS if a module
+        # is listed here but no longer imports sqlite3, so a port that
+        # forgets to shrink the set is caught, not merely uncelebrated.
     }
 )
 

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -110,7 +110,17 @@ FROZEN_SQLITE = frozenset(
         "_lifecycle/_rename_plan.py",
         "_state/auth_state.py",
         "_state/dispatch_ledger.py",
-        "_state/inbound_ledger.py",
+        # _state/inbound_ledger.py LEFT THIS SET 2026-08-20 — the FOURTH table
+        # to move to PostgreSQL. Its obstacle was neither a missing verb nor a
+        # missing endpoint but an AUTOINCREMENT id that looked public: returned
+        # by record_inbound, taken by mark_reported. Measured before assuming —
+        # no caller in this repo binds that return value, and mark_reported is
+        # always handed a claim-derived id — so the integer only ever
+        # round-tripped claim -> settle inside one Stop hook. The natural key
+        # replaced it with no surrogate, which matters because surrogate ids do
+        # not survive a store boundary and this fleet has already paid for that
+        # once. The atomic BEGIN IMMEDIATE claim became an optimistic loop on
+        # Row.seq, preserving "two concurrent Stop hooks never double-report".
         "_state/port_allocator.py",
         "_state/state_db.py",
         "_state/state_db_health.py",

--- a/tests/scitex_agent_container/_jobs/_jobspec_helpers.py
+++ b/tests/scitex_agent_container/_jobs/_jobspec_helpers.py
@@ -1,0 +1,42 @@
+"""Shared readers for the JobSpec assertions in this package.
+
+Both helpers were defined in ``test__jobs_plugin.py`` until that file was split
+into per-group modules. They live here rather than being imported from one test
+module into another: a test module that reaches into a sibling's private helper
+breaks the moment either file is reorganised, which is exactly what happened to
+produce this file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
+
+
+def _split_command(command: str) -> tuple[str, str, str]:
+    """``(bound, payload, rest)`` — the three things a job command can get wrong.
+
+    The whole-command assertions below used to pin a literal ``sac``. They
+    cannot any more: the payload is now the ABSOLUTE console script beside the
+    running interpreter (:mod:`._sac_bin`), so its text differs per machine and
+    a literal would pin the developer's venv into CI.
+
+    Splitting keeps every property those assertions were protecting — the bound
+    and the full argument list stay pinned character-for-character, so dropping
+    a ``--to`` or an ``--apply`` is still a red test — while the one token that
+    is legitimately machine-specific is checked by SHAPE instead. Asserting it
+    equals ``sac_bin()`` would be no test at all: a check parameterised by the
+    value it is checking cannot fail.
+    """
+    tokens = command.split()
+    return " ".join(tokens[:2]), tokens[2], " ".join(tokens[3:])
+
+def _job(name: str):
+    (match,) = [j for j in provide_jobs() if j.name == name]
+    return match

--- a/tests/scitex_agent_container/_jobs/_migrate/test__plan.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__plan.py
@@ -316,3 +316,40 @@ def test_a_step_renders_its_argv_for_the_dry_run() -> None:
     rendered = step.render()
     # Assert
     assert "systemctl stop x" in rendered
+
+
+def test_a_held_job_plans_the_cutover_when_include_held_is_set() -> None:
+    # Arrange — the hold text itself names the supervised command meant to
+    # clear it, so the override has to actually reach the planner.
+    held = [r for r in _renames.RENAMES if r.held][0]
+    # Act
+    steps = _plan.plan_one(
+        held, present=frozenset(held.old_units()), include_held=True
+    )
+    # Assert
+    assert steps != ()
+
+
+def test_include_held_does_not_bypass_stop_before_install() -> None:
+    # Arrange — the override must not buy its way past the ordering this
+    # module exists to guarantee: installing the new unit before displacing
+    # the old one leaves BOTH supervising the same command.
+    held = [r for r in _renames.RENAMES if r.held][0]
+    steps = _plan.plan_one(
+        held, present=frozenset(held.old_units()), include_held=True
+    )
+    actions = _actions(steps)
+    # Act
+    stopped_before_installed = actions.index("stop") < actions.index("install")
+    # Assert
+    assert stopped_before_installed
+
+
+def test_the_full_plan_honours_include_held_for_the_named_job() -> None:
+    # Arrange — the CLI narrows `renames` to one job before setting the
+    # flag, so plan() must thread it through rather than drop it.
+    held = [r for r in _renames.RENAMES if r.held][0]
+    # Act
+    steps = _plan.plan((held,), present=frozenset(held.old_units()), include_held=True)
+    # Assert
+    assert held.new in {s.target for s in steps if s.action == "install"}

--- a/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
@@ -36,16 +36,11 @@ def _declared_names() -> frozenset[str]:
 
 
 def test_no_tabled_row_names_an_undeclared_job() -> None:
-    # Arrange — a row's DECLARED name is `old` while it is held and `new`
-    # once it has been cut over. A row naming neither is a row that
-    # migrates something no provider offers.
+    # Arrange — every row's DECLARED name is `new`, held or not. A row
+    # naming a job no provider offers is a row that migrates nothing.
     declared = _declared_names()
     # Act
-    orphans = [
-        r.local
-        for r in _renames.RENAMES
-        if (r.old if r.held else r.new) not in declared
-    ]
+    orphans = [r.local for r in _renames.RENAMES if r.new not in declared]
     # Assert
     assert orphans == []
 
@@ -61,25 +56,34 @@ def test_every_declared_job_has_a_row() -> None:
     assert uncovered == frozenset()
 
 
-def test_a_held_job_still_declares_its_legacy_name() -> None:
-    # Arrange — the invariant stopping the CLI from reporting a running
-    # refresher as absent: a held spec must keep the name its unit has.
+def test_a_held_row_declares_its_new_name_so_install_can_resolve_it() -> None:
+    # Arrange — THIS INVARIANT WAS INVERTED 2026-08-19, deliberately. It
+    # used to say a HELD row must still declare its LEGACY name, to stop
+    # the CLI reporting a running refresher as absent. That protected a
+    # real hazard and made the cutover unreachable: the migration's
+    # install step delegates BY THE NEW CANONICAL NAME, and scitex-dev
+    # resolves only names a JobSpec DECLARES —
+    #     $ sac dev timer install scitex-agent-container-accounts-refresh
+    #     no job named 'scitex-agent-container-accounts-refresh' here
+    # so install-new could never run while the spec was held. The spec
+    # leads and the unit follows; `hold` still gates the HOST cutover.
     held = [r for r in _renames.RENAMES if r.held]
     declared = _declared_names()
     # Act
-    mismatched = [r.local for r in held if r.old not in declared]
+    unresolvable = [r.local for r in held if r.new not in declared]
     # Assert
-    assert mismatched == []
+    assert unresolvable == []
 
 
-def test_a_held_job_does_not_yet_declare_its_new_name() -> None:
-    # Arrange
-    held = [r for r in _renames.RENAMES if r.held]
+def test_no_row_still_declares_its_legacy_name() -> None:
+    # Arrange — the guard the inversion above must not lose: nothing may
+    # regress to the legacy `sac.*` prefix, whose dot becomes a dot in the
+    # derived unit filename (PS-226).
     declared = _declared_names()
     # Act
-    premature = [r.local for r in held if r.new in declared]
+    regressed = [r.local for r in _renames.RENAMES if r.old in declared]
     # Assert
-    assert premature == []
+    assert regressed == []
 
 
 def test_every_tabled_kind_is_one_the_real_validator_accepts() -> None:
@@ -96,11 +100,7 @@ def test_the_tabled_kind_matches_what_the_spec_declares() -> None:
     # Arrange
     by_name = {j.name: j for j in provide_jobs()}
     # Act
-    wrong = [
-        r.local
-        for r in _renames.RENAMES
-        if by_name[r.old if r.held else r.new].kind != r.kind
-    ]
+    wrong = [r.local for r in _renames.RENAMES if by_name[r.new].kind != r.kind]
     # Assert
     assert wrong == []
 

--- a/tests/scitex_agent_container/_jobs/_migrate/test__verify.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__verify.py
@@ -145,3 +145,119 @@ def test_a_host_without_systemctl_cannot_supervise_units() -> None:
     got = _verify.systemd_user_available(which=which)
     # Assert
     assert got is False
+
+
+# ---------------------------------------------------------------------------
+# ARMING — a rename must preserve it
+#
+# Measured 2026-08-19 on the real accounts-refresh cutover: every step ran
+# green and left the fleet's sole OAuth refresher INSTALLED AND DISABLED. Unit
+# files were counted; enablement was not. Zero active supervisors satisfies
+# "not two supervisors" perfectly, so the check could not have caught the one
+# outcome that mattered.
+# ---------------------------------------------------------------------------
+
+#: Only the .timer is ever enabled — a timer job's .service is `static`.
+ARMED_OLD = frozenset({WORKTREE_GC.old + ".timer"})
+ARMED_NEW = frozenset({WORKTREE_GC.new + ".timer"})
+NOTHING_ARMED: frozenset[str] = frozenset()
+
+
+def test_a_rename_that_disarms_the_job_is_not_armed_ok() -> None:
+    # Arrange — THE incident: armed before, installed disabled after.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=ARMED_OLD,
+        armed_now=NOTHING_ARMED,
+    ).armed_ok
+    # Assert
+    assert got is False
+
+
+def test_the_installation_claim_alone_cannot_see_a_disarmed_rename() -> None:
+    # Arrange — the regression documented: this is the OLD check's verdict on
+    # the incident. It passes, which is exactly why arming needed its own
+    # signal rather than being folded into `ok`.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=ARMED_OLD,
+        armed_now=NOTHING_ARMED,
+    ).ok
+    # Assert
+    assert got is True
+
+
+def test_a_deliberately_disabled_job_stays_a_non_finding() -> None:
+    # Arrange — heal-agent-auth's shape: disabled BEFORE the cutover on
+    # purpose (it is mutually exclusive with restart-login-expired-agents,
+    # "enable exactly one"). A guard demanding every timer be enabled would
+    # cry wolf here, and a guard that cries wolf gets ignored.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=NOTHING_ARMED,
+        armed_now=NOTHING_ARMED,
+    ).armed_ok
+    # Assert
+    assert got is True
+
+
+def test_arming_preserved_across_the_rename_is_armed_ok() -> None:
+    # Arrange — the correct cutover.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=ARMED_OLD,
+        armed_now=ARMED_NEW,
+    ).armed_ok
+    # Assert
+    assert got is True
+
+
+def test_unmeasured_arming_is_unknown_not_a_pass() -> None:
+    # Arrange — a caller that never looked. Collapsing this into True is the
+    # unknown-into-a-pole bug; collapsing it into False makes every such
+    # caller report a false alarm.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(WORKTREE_GC, present=present).armed_ok
+    # Assert
+    assert got is None
+
+
+def test_the_unarmed_verdict_carries_the_command_that_fixes_it() -> None:
+    # Arrange — an operator reading "FAIL" must not have to re-derive the fix.
+    # Asserting on the UNIT NAME would be vacuous: every verdict lists the new
+    # units, so such a test passes even when the unarmed branch is dead. A
+    # sabotage control caught exactly that, so this asserts on something only
+    # the unarmed branch emits.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    verdict = _verify.verify_exactly_one(
+        WORKTREE_GC,
+        present=present,
+        armed_before=ARMED_OLD,
+        armed_now=NOTHING_ARMED,
+    ).verdict
+    # Assert
+    assert "systemctl --user enable --now" in verdict
+
+
+def test_the_unmeasured_verdict_says_arming_was_not_checked() -> None:
+    # Arrange — an OK line that silently omits an unrun check is how a
+    # migration gets believed for a property nobody verified.
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    verdict = _verify.verify_exactly_one(WORKTREE_GC, present=present).verdict
+    # Assert
+    assert "NOT CHECKED" in verdict

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -40,6 +40,8 @@ the provider import is lazy, so an old scitex-dev must not fail CI here.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 jobs_mod = pytest.importorskip(
@@ -116,6 +118,7 @@ def test_provider_job_command_includes_active_account() -> None:
     job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert job.command == (
+        "/usr/bin/timeout 120 "
         "sac accounts refresh --all --include-active --sync-active-login"
     )
 
@@ -207,6 +210,7 @@ def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert job.command == (
+        "/usr/bin/timeout 300 "
         "sac accounts keepalive --all "
         "--to ywata-note-win "
         "--to scitex-compute-03 "
@@ -222,10 +226,13 @@ def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() ->
     # turn a keepalive into a fleet-wide logout every 15 minutes, so pin the
     # verb itself rather than trusting the full-command assertion above to be
     # re-read whenever someone edits the peer list.
+    #
+    # Indexed PAST the self-bounding `/usr/bin/timeout <N>` prefix (tokens 0
+    # and 1), so this still pins the VERB rather than the wrapper.
     # Act
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
-    assert job.command.split()[:3] == ["sac", "accounts", "keepalive"]
+    assert job.command.split()[2:5] == ["sac", "accounts", "keepalive"]
 
 
 def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
@@ -256,10 +263,13 @@ def test_accounts_keepalive_timeout_outlives_a_three_peer_pass() -> None:
     # verification (15s cap inside the probe). 300s covers three peers
     # including a slow one. A pass killed here is SAFE — nothing is published
     # unverified, so the peer keeps its previous credential.
+    #
+    # The bound is asserted on the COMMAND, not on `timeout_sec`, because
+    # this job is deployed to cron and a cron line cannot carry that field.
     # Act
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
-    assert job.timeout_sec == 300
+    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
 def test_accounts_keepalive_constructs_as_a_real_jobspec() -> None:
@@ -360,7 +370,9 @@ def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
     # Act
     job = _job("scitex-agent-container-host-sync-check")
     # Assert — the command is precisely the read-only check+alarm form.
-    assert job.command == "sac host sync --check --all --alarm --exit-zero"
+    assert job.command == (
+        "/usr/bin/timeout 600 sac host sync --check --all --alarm --exit-zero"
+    )
 
 
 def test_host_sync_check_cadence_is_hourly() -> None:
@@ -398,7 +410,7 @@ def test_worktree_gc_command_is_the_apply_form() -> None:
     # Act
     job = _job("scitex-agent-container-worktree-gc")
     # Assert
-    assert job.command == "sac worktree gc --apply --all"
+    assert job.command == "/usr/bin/timeout 900 sac worktree gc --apply --all"
 
 
 def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
@@ -448,7 +460,7 @@ def test_fleet_reconcile_command_is_the_applying_form() -> None:
     # Act
     job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
-    assert job.command == "sac agents reconcile --apply"
+    assert job.command == "/usr/bin/timeout 300 sac agents reconcile --apply"
 
 
 def test_fleet_reconcile_cadence_is_five_minutes() -> None:
@@ -466,10 +478,16 @@ def test_fleet_reconcile_timeout_outlives_a_capped_pass() -> None:
     # stop+settle+start. A pass killed at this timeout is SAFE (the restart
     # history is persisted per restart, not at the end), but the timeout must
     # still comfortably exceed a normal pass or the enforcer never finishes.
+    #
+    # THIS is the job whose unbounded cron line was measured accumulating
+    # fourteen concurrent instances, the oldest 45 minutes old (2026-07-18).
+    # A `timeout_sec` assertion would have passed throughout that incident,
+    # because the field was set and the deployed cron line was still
+    # unbounded — so the bound is pinned where it actually runs.
     # Act
     job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
-    assert job.timeout_sec == 300
+    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
 def test_spartan_sif_bake_job_name_is_package_prefixed() -> None:
@@ -528,7 +546,7 @@ def test_spartan_sif_bake_command_is_the_confirmed_form() -> None:
     # Act
     job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
-    assert job.command == "sac image bake-remote --yes"
+    assert job.command == "/usr/bin/timeout 14400 sac image bake-remote --yes"
 
 
 def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
@@ -547,13 +565,19 @@ def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
 
 def test_spartan_sif_bake_timeout_outlives_two_bakes_and_a_pull() -> None:
     # Arrange — two full bakes (base + scitex) plus a multi-GB pull on a
-    # slow link must fit; the per-leg ssh timeout is 7200s, so the unit
-    # cap must exceed the worst legitimate chain or the timer kills its
+    # slow link must fit; the per-leg ssh timeout is 7200s, so the cap
+    # must exceed the worst legitimate chain or the timer kills its
     # own successful runs.
+    #
+    # This job needs a REAL bound more than any sibling: at a */10 cadence
+    # an unbounded bake outlives its own tick by construction, so a wedged
+    # run piles up against every later one. The bound therefore has to be
+    # in the command — cron, the surface this is deployed to, cannot carry
+    # `timeout_sec` at all.
     # Act
     job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
-    assert job.timeout_sec == 14_400
+    assert job.command.startswith("/usr/bin/timeout 14400 ")
 
 
 def test_restart_login_expired_command_is_the_applying_form() -> None:
@@ -563,7 +587,9 @@ def test_restart_login_expired_command_is_the_applying_form() -> None:
     # Act
     job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
-    assert job.command == "sac agents restart-login-expired --apply"
+    assert job.command == (
+        "/usr/bin/timeout 300 sac agents restart-login-expired --apply"
+    )
 
 
 def test_restart_login_expired_cadence_is_five_minutes() -> None:
@@ -646,20 +672,36 @@ def test_heal_agent_auth_interpreter_token_is_absolute() -> None:
     # Arrange — scitex-dev's `resolve_execstart` passes a head starting with "/"
     # through VERBATIM. An absolute head is therefore the only form that depends
     # on neither the ambient PATH nor which interpreter ran `ecosystem up`.
+    #
+    # The interpreter is token 2 now, after the `/usr/bin/timeout <N>` prefix.
     # Act
     job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.command.split()[0].startswith("/")
+    assert job.command.split()[2].startswith("/")
+
+
+def test_heal_agent_auth_command_head_is_still_absolute() -> None:
+    # Arrange — the self-bounding prefix must not cost this job its
+    # PATH-independence. `/usr/bin/timeout` is spelled absolutely precisely so
+    # the HEAD keeps starting with "/" and `resolve_execstart` keeps passing
+    # the whole command through verbatim. A bare `timeout` would have quietly
+    # made this the one command that needs an ambient PATH.
+    # Act
+    job = _job("scitex-agent-container-heal-agent-auth")
+    # Assert
+    assert job.command.split()[0] == "/usr/bin/timeout"
 
 
 def test_heal_agent_auth_script_token_is_absolute() -> None:
     # Arrange — a systemd --user unit gets a MINIMAL PATH and no meaningful cwd,
     # so the script argument must be absolute too; a relative path would exec
     # fine under cron's $HOME cwd and fail as status=127 under systemd.
+    #
+    # The script is token 3 now, after the `/usr/bin/timeout <N>` prefix.
     # Act
     job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.command.split()[1].startswith("/")
+    assert job.command.split()[3].startswith("/")
 
 
 def test_heal_agent_auth_runs_the_venv_python_not_the_system_one() -> None:
@@ -670,7 +712,9 @@ def test_heal_agent_auth_runs_the_venv_python_not_the_system_one() -> None:
     # Act
     job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.command.startswith("/home/ywatanabe/.env-3.11/bin/python ")
+    assert job.command.startswith(
+        "/usr/bin/timeout 300 /home/ywatanabe/.env-3.11/bin/python "
+    )
 
 
 def test_heal_agent_auth_targets_the_real_auth_heal_entrypoint() -> None:
@@ -691,10 +735,13 @@ def test_heal_agent_auth_timeout_outlives_a_restarting_pass() -> None:
     # Arrange — a no-op tick takes ~2-8s; the worst observed pass (a TUI restart
     # at 15:30:04 settling by 15:32:08) ~2min. A pass killed here is SAFE (state
     # is persisted per restart), but the timeout must still outlive a real one.
+    #
+    # Pinned on the COMMAND: this job is lowered onto cron, and a cron line
+    # has no field a `timeout_sec` could ride in.
     # Act
     job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.timeout_sec == 300
+    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
 def test_heal_agent_auth_constructs_as_a_real_jobspec() -> None:
@@ -718,3 +765,158 @@ def test_heal_agent_auth_and_restart_login_expired_are_both_declared() -> None:
     names = {job.name for job in provide_jobs()}
     # Assert
     assert {"scitex-agent-container-heal-agent-auth", "scitex-agent-container-restart-login-expired-agents"} <= names
+
+
+# ---------------------------------------------------------------------------
+# THE POPULATION INVARIANT — what lets these JobSpecs land on cron at all.
+#
+# The per-job pins above are pinned by name; these are pinned over EVERY job,
+# because the way this contract breaks is by OMISSION in a job added later,
+# which no name-based test would notice.
+#
+# The mechanism: `scitex-dev ecosystem up` lowers every kind="timer" JobSpec
+# onto the managed crontab block (operator policy 2026-06-14), and a cron line
+# is `<schedule> <command> # marker` and nothing else — there is no field a
+# `timeout_sec` could ride in. scitex-dev's guard therefore REFUSES to lower a
+# timer declaring one, and because `up` is all-or-nothing, ONE such job blocks
+# every provider on the host. Measured 2026-08-17 on scitex-compute-04: nine
+# sac jobs declared `timeout_sec`, `up` aborted, nothing could be armed.
+#
+# So the bound lives in the COMMAND, and the field that cannot travel is gone.
+# ---------------------------------------------------------------------------
+
+#: A self-bounding command: the coreutils binary, a whole-second bound, and a
+#: non-empty payload after it.
+_SELF_BOUNDING = re.compile(r"^/usr/bin/timeout (\d+) (\S.*)$")
+
+
+def test_every_command_is_self_bounding() -> None:
+    # Arrange — the bound must live in the COMMAND, the only part of a JobSpec
+    # a cron line carries. Asserted over every job rather than an enumerated
+    # set: a job added later without a bound is exactly the regression this
+    # pins, and a list would not catch it.
+    # Act
+    unbounded = [
+        job.name for job in provide_jobs() if not _SELF_BOUNDING.match(job.command)
+    ]
+    # Assert
+    assert unbounded == []
+
+
+def test_no_job_declares_timeout_sec() -> None:
+    # Arrange — NOT a style rule. scitex-dev's lowering guard fires on
+    # `timeout_sec is not None` and never inspects whether the command is
+    # actually bounded, so a job carrying BOTH a literal `timeout` and this
+    # field still refuses to lower and still aborts `ecosystem up` for the
+    # whole host. The field is therefore dropped, not kept alongside.
+    # Act
+    declaring = [job.name for job in provide_jobs() if job.timeout_sec is not None]
+    # Assert
+    assert declaring == []
+
+
+def test_no_command_is_double_bounded() -> None:
+    # Arrange — the payload after the prefix must not itself be a `timeout`
+    # invocation. Two nested bounds are not a stricter bound; they are a
+    # second number nobody maintains, and the inner one silently wins.
+    # Act
+    doubled = [
+        job.name
+        for job in provide_jobs()
+        if (m := _SELF_BOUNDING.match(job.command))
+        and m.group(2).split()[0].endswith("timeout")
+    ]
+    # Assert
+    assert doubled == []
+
+
+def test_declared_bound_is_a_positive_number_of_seconds() -> None:
+    # Arrange — `timeout 0 <cmd>` means "no timeout at all" in coreutils, so a
+    # zero would read as a bound while removing one. Guard the value, not just
+    # the shape.
+    # Act
+    bounds = {
+        job.name: int(m.group(1))
+        for job in provide_jobs()
+        if (m := _SELF_BOUNDING.match(job.command))
+    }
+    # Assert
+    assert all(seconds > 0 for seconds in bounds.values()), bounds
+
+
+def test_the_prefix_wraps_something_in_every_job() -> None:
+    # Arrange — a positive control on the regex above: prove it matches a real
+    # payload in EVERY job, not merely in some. Anchoring on the job count (an
+    # identity) rather than on `> 0` (a quantity) keeps this honest when the
+    # provider list changes.
+    # Act
+    payloads = [
+        m.group(2)
+        for job in provide_jobs()
+        if (m := _SELF_BOUNDING.match(job.command))
+    ]
+    # Assert
+    assert len(payloads) == len(provide_jobs())
+
+
+# ---------------------------------------------------------------------------
+# The operator-facing outcome, measured through scitex-dev's OWN guard rather
+# than restated in our words. Skips cleanly on a scitex-dev predating the
+# lowering module, so CI never reddens on a version lag.
+# ---------------------------------------------------------------------------
+
+
+def _lowering():
+    return pytest.importorskip(
+        "scitex_dev._cli.ecosystem._cmds._up_timer_lowering",
+        reason="installed scitex-dev predates the timer-lowering guard",
+    )
+
+
+def test_no_job_degrades_when_lowered_onto_cron() -> None:
+    # Arrange — `degraded_job_names` is the exact predicate `ecosystem up`
+    # reports under --allow-lossy-timer-lowering. Nine sac jobs were listed
+    # there on 2026-08-17; the target is none.
+    low = _lowering()
+    # Act
+    degraded = low.degraded_job_names(provide_jobs())
+    # Assert
+    assert degraded == []
+
+
+def test_strict_lowering_does_not_abort_the_ecosystem() -> None:
+    # Arrange — this is THE blocker being fixed. `ecosystem up` calls
+    # `collect_cron_jobs` WITHOUT allow_lossy first; one raising job aborts the
+    # run before anything is written, for every provider on the host.
+    low = _lowering()
+    jobs = provide_jobs()
+    # Act — must not raise TimerLoweringError.
+    _merged, _native, lowered = low.collect_cron_jobs(jobs, allow_lossy=False)
+    # Assert
+    assert lowered == len([job for job in jobs if job.kind == "timer"])
+
+
+def test_strict_lowering_installs_every_declared_job() -> None:
+    # Arrange — the companion to the abort check: proceeding is only the right
+    # outcome if nothing was quietly dropped on the way through.
+    low = _lowering()
+    jobs = provide_jobs()
+    # Act
+    merged, _native, _lowered = low.collect_cron_jobs(jobs, allow_lossy=False)
+    # Assert
+    assert len(merged) == len(jobs)
+
+
+def test_the_cron_line_that_lands_on_the_host_carries_the_bound() -> None:
+    # Arrange — the end-to-end check, and the one that would have caught the
+    # original defect: assert on the ARTIFACT (the crontab line) rather than on
+    # the declaration. A `timeout_sec` assertion passed throughout the
+    # 2026-07-18 incident while the deployed line was unbounded.
+    low = _lowering()
+    from scitex_dev.jobs import _cron_block as cron_block
+
+    merged, _native, _lowered = low.collect_cron_jobs(provide_jobs(), allow_lossy=False)
+    # Act
+    lines = [cron_block.build_cron_line(spec) for spec in merged]
+    # Assert
+    assert all(" /usr/bin/timeout " in line for line in lines), lines

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -3,7 +3,7 @@
 Verifies the JobSpecs sac registers under the ``scitex_dev.jobs``
 entry-point group match the federated contract:
 
-* ``sac.accounts-refresh`` — a periodic systemd timer job that runs
+* ``scitex-agent-container-accounts-refresh`` — a periodic systemd timer job that runs
   ``--all --include-active --sync-active-login`` every 2h (the SOLE
   refresher; see the ``--skip-active`` note below).
 * ``sac.accounts-keepalive`` — the DISTRIBUTION half of that same
@@ -69,7 +69,7 @@ def test_provider_returns_every_expected_job() -> None:
     names = {job.name for job in provide_jobs()}
     # Assert
     assert names == {
-        "sac.accounts-refresh",
+        "scitex-agent-container-accounts-refresh",
         "scitex-agent-container-accounts-keepalive",
         # The usage-cache refresher. Nothing else reads usage: accounts-refresh
         # rotates tokens and accounts-keepalive copies them, so before this job
@@ -96,9 +96,9 @@ def test_provider_jobs_are_real_jobspecs() -> None:
 def test_provider_job_name_is_package_prefixed() -> None:
     # Arrange — call the registered provider.
     # Act
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
-    assert job.name == "sac.accounts-refresh"
+    assert job.name == "scitex-agent-container-accounts-refresh"
 
 
 def test_provider_job_command_includes_active_account() -> None:
@@ -113,7 +113,7 @@ def test_provider_job_command_includes_active_account() -> None:
     # Act — by NAME, not by index: this provider now returns two jobs, so
     # provide_jobs()[0] would silently start asserting against the wrong
     # JobSpec the day the list order changes.
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert job.command == (
         "sac accounts refresh --all --include-active --sync-active-login"
@@ -124,7 +124,7 @@ def test_provider_job_command_never_skips_active() -> None:
     # Arrange — a belt-and-braces guard: --skip-active must never
     # reappear in the sole-refresher timer, however the command is spelled.
     # Act
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert "--skip-active" not in job.command
 
@@ -132,11 +132,11 @@ def test_provider_job_command_never_skips_active() -> None:
 def test_provider_job_kind_is_timer() -> None:
     # Arrange — call the registered provider. The legacy ``kind=
     # "systemd"`` is no longer accepted by JobSpec.validate() since
-    # scitex-dev #153; ``sac.accounts-refresh`` is a periodic
+    # scitex-dev #153; ``scitex-agent-container-accounts-refresh`` is a periodic
     # systemd --user timer (token TTL ~7h, refresh every 2h) so the
     # canonical kind is ``"timer"`` (lead msg c5212862, 2026-06-11).
     # Act
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert job.kind == "timer"
 
@@ -154,14 +154,14 @@ def test_every_provided_job_uses_an_allowed_kind() -> None:
 def test_provider_job_cadence_is_two_hours() -> None:
     # Arrange — call the registered provider.
     # Act
-    job = _job("sac.accounts-refresh")
+    job = _job("scitex-agent-container-accounts-refresh")
     # Assert
     assert job.on_unit_active_sec == "2h"
 
 
 # ---------------------------------------------------------------------------
 # sac.accounts-keepalive — the DISTRIBUTION half of the single-refresher
-# model, and the SIBLING of sac.accounts-refresh above. That job rotates the
+# model, and the SIBLING of scitex-agent-container-accounts-refresh above. That job rotates the
 # token on the ONE host holding refresh material; this one copies the result
 # out to the access-only hosts and proves each of them accepts it. Refreshing
 # the master is not enough on its own: every other host holds a copy nothing
@@ -280,7 +280,7 @@ def test_accounts_keepalive_and_accounts_refresh_are_both_declared() -> None:
     # Act
     names = {job.name for job in provide_jobs()}
     # Assert
-    assert {"sac.accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names
+    assert {"scitex-agent-container-accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names
 
 
 def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -> None:

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -51,40 +51,14 @@ jobs_mod = pytest.importorskip(
 
 from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
 
-
-def _job(name: str):
-    (match,) = [j for j in provide_jobs() if j.name == name]
-    return match
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
 
 
-def test_provider_returns_every_expected_job() -> None:
-    # Arrange — pinned by NAME, not by count. An exact-count assertion goes
-    # red on every legitimate addition while saying nothing about WHICH job
-    # moved, so the number gets bumped reflexively and the pin quietly stops
-    # meaning anything. Membership names what actually changed.
-    #
-    # accounts-keepalive is the newest: the DISTRIBUTION half of the
-    # single-refresher model, paired with accounts-refresh below. `sac
-    # listen` is still NOT federated (see the module docstring and the
-    # absence-pin below).
-    # Act
-    names = {job.name for job in provide_jobs()}
-    # Assert
-    assert names == {
-        "scitex-agent-container-accounts-refresh",
-        "scitex-agent-container-accounts-keepalive",
-        # The usage-cache refresher. Nothing else reads usage: accounts-refresh
-        # rotates tokens and accounts-keepalive copies them, so before this job
-        # every quota number the fleet showed was as old as the last manual run.
-        "scitex-agent-container-accounts-quota-cache",
-        "scitex-agent-container-host-sync-check",
-        "scitex-agent-container-worktree-gc",
-        "scitex-agent-container-spartan-sif-bake",
-        "scitex-agent-container-fleet-reconcile",
-        "scitex-agent-container-restart-login-expired-agents",
-        "scitex-agent-container-heal-agent-auth",
-        "scitex-agent-container-freshness-refresh",
-    }
+
+
+
+
+
 
 
 def test_provider_jobs_are_real_jobspecs() -> None:
@@ -117,10 +91,8 @@ def test_provider_job_command_includes_active_account() -> None:
     # JobSpec the day the list order changes.
     job = _job("scitex-agent-container-accounts-refresh")
     # Assert
-    assert job.command == (
-        "/usr/bin/timeout 120 "
-        "sac accounts refresh --all --include-active --sync-active-login"
-    )
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 120", "accounts refresh --all --include-active --sync-active-login")
 
 
 def test_provider_job_command_never_skips_active() -> None:
@@ -180,117 +152,22 @@ def test_provider_job_cadence_is_two_hours() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_accounts_keepalive_job_name_is_package_prefixed() -> None:
-    # Arrange — the distribution half of the single-refresher model.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.name == "scitex-agent-container-accounts-keepalive"
 
 
-def test_accounts_keepalive_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer, so kind="timer". A kind
-    # outside JobSpec.ALLOWED_KINDS raises at construction, and `ecosystem up`
-    # then silently DROPS sac's WHOLE provider (provider-isolated, WARN-only)
-    # — taking the OAuth refresh, the drift check, the worktree GC and both
-    # heal enforcers down with it.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
-    # Arrange — the peer list IS the job. A keepalive that reaches two of the
-    # three access-only hosts looks healthy (exit 0, verified peers) while the
-    # third silently expires, which is the exact failure this job exists to
-    # end. Pin the whole command so dropping a `--to` is a red test, not a
-    # host nobody notices is dead.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.command == (
-        "/usr/bin/timeout 300 "
-        "sac accounts keepalive --all "
-        "--to ywata-note-win "
-        "--to scitex-compute-03 "
-        "--to scitex-compute-04"
-    )
 
 
-def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() -> None:
-    # Arrange — belt-and-braces, the counterpart of accounts-refresh's
-    # --skip-active guard. This job COPIES the master's current token; minting
-    # rotates it, and a rotation revokes the token every running agent is
-    # holding. Scheduling `accounts refresh` or `accounts login` here would
-    # turn a keepalive into a fleet-wide logout every 15 minutes, so pin the
-    # verb itself rather than trusting the full-command assertion above to be
-    # re-read whenever someone edits the peer list.
-    #
-    # Indexed PAST the self-bounding `/usr/bin/timeout <N>` prefix (tokens 0
-    # and 1), so this still pins the VERB rather than the wrapper.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.command.split()[2:5] == ["sac", "accounts", "keepalive"]
 
 
-def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
-    # Arrange — the cadence IS the worst-case follower outage, not a guess at
-    # when work is needed. The master's token changes once in ~7h at an
-    # unpredictable moment, and the instant it does every follower's copy is
-    # revoked; the tick only decides how long that revoked window lasts. A
-    # converged peer is verified rather than rewritten, so the extra ticks are
-    # near free — which is what makes 15min affordable.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.on_unit_active_sec == "15min"
 
 
-def test_accounts_keepalive_schedule_mirrors_the_timer_cadence() -> None:
-    # Arrange — the cron form is kept alongside the timer cadence (as every
-    # sibling does) so `ecosystem cron` could derive an equivalent line, and
-    # so the two spellings cannot silently disagree about how often this runs.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.schedule == "*/15 * * * *"
 
 
-def test_accounts_keepalive_timeout_outlives_a_three_peer_pass() -> None:
-    # Arrange — per peer: a handful of ssh ops plus ONE outbound HTTPS
-    # verification (15s cap inside the probe). 300s covers three peers
-    # including a slow one. A pass killed here is SAFE — nothing is published
-    # unverified, so the peer keeps its previous credential.
-    #
-    # The bound is asserted on the COMMAND, not on `timeout_sec`, because
-    # this job is deployed to cron and a cron line cannot carry that field.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
-def test_accounts_keepalive_constructs_as_a_real_jobspec() -> None:
-    # Arrange — construction must not raise (a bad field would drop the whole
-    # provider). Assert it is the canonical contract type, not a look-alike.
-    # Act
-    job = _job("scitex-agent-container-accounts-keepalive")
-    # Assert
-    assert isinstance(job, jobs_mod.JobSpec)
 
 
-def test_accounts_keepalive_and_accounts_refresh_are_both_declared() -> None:
-    # Arrange — unlike the heal pair below, these two are NOT alternatives:
-    # they are the two halves of one model and BOTH must be enabled. Refresh
-    # without keepalive leaves the followers holding a revoked copy; keepalive
-    # without refresh distributes a token nothing renews. Deleting either one
-    # breaks the fleet in a way that looks like the other half working.
-    # Act
-    names = {job.name for job in provide_jobs()}
-    # Assert
-    assert {"scitex-agent-container-accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names
 
 
 def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -> None:
@@ -317,195 +194,40 @@ def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -
     assert "sac.listen" not in names
 
 
-def test_host_sync_check_job_name_is_package_prefixed() -> None:
-    # Arrange — the drift-alarm timer that makes the Stage-0 detector run.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert job.name == "scitex-agent-container-host-sync-check"
 
 
-def test_host_sync_check_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer (hourly), so kind="timer".
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_host_sync_check_command_is_the_readonly_check() -> None:
-    # Arrange — the scheduled command MUST carry --check. A timer that could
-    # fast-forward a peer unattended is Stage 1, explicitly out of scope.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert "--check" in job.command
 
 
-def test_host_sync_check_command_routes_to_a_seen_card() -> None:
-    # Arrange — --alarm is what turns the exit code into a SEEN board card
-    # instead of a journald line nobody reads.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert "--alarm" in job.command
 
 
-def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
-    # Arrange — belt-and-braces: the exact mutating form `sac host sync
-    # <peer>` (no --check) must never be what this timer runs. The command
-    # is the read-only detector, full stop.
-    #
-    # `--exit-zero` was added 2026-08-17 and does NOT weaken that intent: it
-    # touches only this process's exit status, never a peer. It is here
-    # because the tri-state verdict (1 = drift found, 2 = undetermined) was
-    # being read by systemd as unit failure, which put the host into
-    # `degraded`, which made the dotfiles sync installer conclude systemd
-    # was absent and silently stop installing its timer.
-    #
-    # Kept as EXACT EQUALITY on purpose. This assertion is the reason that
-    # change could not land unnoticed — a substring check would have let it
-    # through silently, and the next edit to this command deserves the same
-    # scrutiny. Update the literal deliberately; do not relax the operator.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert — the command is precisely the read-only check+alarm form.
-    assert job.command == (
-        "/usr/bin/timeout 600 sac host sync --check --all --alarm --exit-zero"
-    )
 
 
-def test_host_sync_check_cadence_is_hourly() -> None:
-    # Arrange — drift is slow-moving; hourly is ample and gentle on ssh.
-    # Act
-    job = _job("scitex-agent-container-host-sync-check")
-    # Assert
-    assert job.on_unit_active_sec == "1h"
 
 
-def test_worktree_gc_job_name_is_package_prefixed() -> None:
-    # Arrange — the daily GC that makes the worktree-sprawl countermeasure
-    # PERIODIC. A GC nobody schedules is a script, not a countermeasure —
-    # which is exactly how one repo reached 105 worktrees.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert job.name == "scitex-agent-container-worktree-gc"
 
 
-def test_worktree_gc_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer (daily), so kind="timer".
-    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_worktree_gc_command_is_the_apply_form() -> None:
-    # Arrange — the scheduled job must ACT, not just report: a timer that
-    # only dry-runs would print a nightly report nobody reads while the
-    # sprawl kept growing. The safety lives in the predicate, not in
-    # withholding --apply.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert job.command == "/usr/bin/timeout 900 sac worktree gc --apply --all"
 
 
-def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
-    # Arrange — --all is only correct because it HAS a clean source (every
-    # agent spec.workdir that is a local git repo toplevel). If that source
-    # ever disappears, this command silently sweeps nothing.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert "--all" in job.command
 
 
-def test_worktree_gc_cadence_is_daily() -> None:
-    # Arrange — sprawl accumulates over days and the age gate is 24h, so a
-    # faster pass could not remove anything a daily one would miss.
-    # Act
-    job = _job("scitex-agent-container-worktree-gc")
-    # Assert
-    assert job.on_unit_active_sec == "1d"
 
 
-def test_fleet_reconcile_job_name_is_package_prefixed() -> None:
-    # Arrange — the enforcer of "should be running => is running".
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.name == "scitex-agent-container-fleet-reconcile"
 
 
-def test_fleet_reconcile_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong
-    # kind raises at construction and `ecosystem up` then silently DROPS
-    # sac's whole provider (provider-isolated, WARN-only) — taking the OAuth
-    # refresh, the drift check and the worktree GC down with it.
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_fleet_reconcile_command_is_the_applying_form() -> None:
-    # Arrange — THIS JOB IS THE MECHANISM. `restart.policy` in ~93 specs is
-    # dead code without it: `_lifecycle/_start.py` runs the loop that reads
-    # it on a daemon thread inside the short-lived `sac agents start` CLI, so
-    # the supervisor dies with the process that promised it. A scheduled
-    # DRY-RUN would restore nothing — the whole point is `--apply`.
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.command == "/usr/bin/timeout 300 sac agents reconcile --apply"
 
 
-def test_fleet_reconcile_cadence_is_five_minutes() -> None:
-    # Arrange — the cadence IS the window a dead agent stays dead. A no-op
-    # pass is one batched `tmux list-sessions` plus a spec read each, so it
-    # is cheap enough to run often.
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.on_unit_active_sec == "5min"
 
 
-def test_fleet_reconcile_timeout_outlives_a_capped_pass() -> None:
-    # Arrange — the pathological pass restarts `--limit` agents, each a
-    # stop+settle+start. A pass killed at this timeout is SAFE (the restart
-    # history is persisted per restart, not at the end), but the timeout must
-    # still comfortably exceed a normal pass or the enforcer never finishes.
-    #
-    # THIS is the job whose unbounded cron line was measured accumulating
-    # fourteen concurrent instances, the oldest 45 minutes old (2026-07-18).
-    # A `timeout_sec` assertion would have passed throughout that incident,
-    # because the field was set and the deployed cron line was still
-    # unbounded — so the bound is pinned where it actually runs.
-    # Act
-    job = _job("scitex-agent-container-fleet-reconcile")
-    # Assert
-    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
-def test_spartan_sif_bake_job_name_is_package_prefixed() -> None:
-    # Arrange — the daily remote SIF bake (operator directive 2026-07-17:
-    # bake on Spartan, rsync to the master, zero master CPU).
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.name == "scitex-agent-container-spartan-sif-bake"
 
 
-def test_spartan_sif_bake_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer (*/10), so kind="timer".
-    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.kind == "timer"
 
 
 # ---------------------------------------------------------------------------
@@ -519,95 +241,20 @@ def test_spartan_sif_bake_job_kind_is_timer() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_restart_login_expired_job_name_is_package_prefixed() -> None:
-    # Arrange — the auto-restarter for auth-dead-but-live agents.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert job.name == "scitex-agent-container-restart-login-expired-agents"
 
 
-def test_restart_login_expired_job_kind_is_timer() -> None:
-    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong kind
-    # raises at construction and `ecosystem up` then silently DROPS sac's whole
-    # provider (provider-isolated, WARN-only) — taking the OAuth refresh, the
-    # drift check, the worktree GC AND the fleet-reconcile enforcer down too.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_spartan_sif_bake_command_is_the_confirmed_form() -> None:
-    # Arrange — `sac image bake-remote` REFUSES to run without --yes
-    # (exit 2), mirroring `sac image build`'s non-interactive gate. A
-    # scheduled command missing --yes would fail every single night —
-    # a timer that fires and does nothing, the inert-feature shape.
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.command == "/usr/bin/timeout 14400 sac image bake-remote --yes"
 
 
-def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
-    # Arrange — the SIF is a point-in-time snapshot of @develop, and at our
-    # release rate a day-old one is mostly wrong. 30min was the operator's
-    # stated FLOOR (「最低でも30分に1回」), not his target — he asked why it was
-    # only every 30 and said even 1min would be fine — so this pins the
-    # cadence he wants. skip-if-unchanged keeps a no-change tick at one ssh
-    # round-trip instead of a multi-GB transfer, and the script's `flock -n`
-    # single-flights the overlaps a 10min interval necessarily causes.
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.on_unit_active_sec == "10min"
 
 
-def test_spartan_sif_bake_timeout_outlives_two_bakes_and_a_pull() -> None:
-    # Arrange — two full bakes (base + scitex) plus a multi-GB pull on a
-    # slow link must fit; the per-leg ssh timeout is 7200s, so the cap
-    # must exceed the worst legitimate chain or the timer kills its
-    # own successful runs.
-    #
-    # This job needs a REAL bound more than any sibling: at a */10 cadence
-    # an unbounded bake outlives its own tick by construction, so a wedged
-    # run piles up against every later one. The bound therefore has to be
-    # in the command — cron, the surface this is deployed to, cannot carry
-    # `timeout_sec` at all.
-    # Act
-    job = _job("scitex-agent-container-spartan-sif-bake")
-    # Assert
-    assert job.command.startswith("/usr/bin/timeout 14400 ")
 
 
-def test_restart_login_expired_command_is_the_applying_form() -> None:
-    # Arrange — a scheduled DRY-RUN would detect wedged agents and heal none.
-    # The whole point is `--apply`. Detection stays read-only; the restart is
-    # the only mutation.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert job.command == (
-        "/usr/bin/timeout 300 sac agents restart-login-expired --apply"
-    )
 
 
-def test_restart_login_expired_cadence_is_five_minutes() -> None:
-    # Arrange — the cadence IS the window a login-expired agent stays wedged,
-    # matched to fleet-reconcile so the two enforcers sweep on the same beat.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert job.on_unit_active_sec == "5min"
 
 
-def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
-    # Arrange — construction must not raise (a bad field would drop the whole
-    # provider). Assert it is the canonical contract type, not a look-alike.
-    # Act
-    job = _job("scitex-agent-container-restart-login-expired-agents")
-    # Assert
-    assert isinstance(job, jobs_mod.JobSpec)
 
 
 # ---------------------------------------------------------------------------
@@ -628,143 +275,28 @@ def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_heal_agent_auth_job_name_is_package_prefixed() -> None:
-    # Arrange — the incumbent auth healer, now declared rather than hand-cronned.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.name == "scitex-agent-container-heal-agent-auth"
 
 
-def test_heal_agent_auth_job_kind_is_timer() -> None:
-    # Arrange — kind="timer" is what buys `Persistent=true` from scitex-dev's
-    # renderer (a missed window fires on resume — the property the swept crontab
-    # line never had). kind="cron" would materialise the very crontab line this
-    # job exists to escape, and a kind outside {"service","timer","cron"} raises
-    # at construction, silently dropping sac's WHOLE provider.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.kind == "timer"
 
 
-def test_heal_agent_auth_cadence_preserves_the_incumbent_ten_minutes() -> None:
-    # Arrange — 10min is the LIVE cadence, not a new choice: runtime/auth-heal.log
-    # ticks 15:20 → 15:30 → 15:40 → 15:50 → 16:00, matching the `*/10` cron line.
-    # Migrating a schedule is the wrong moment to also retune it.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.on_unit_active_sec == "10min"
 
 
-def test_heal_agent_auth_schedule_mirrors_the_retired_cron_expression() -> None:
-    # Arrange — the cron form is kept alongside the timer cadence (as every
-    # sibling does) so the expression the crontab line used stays legible in the
-    # spec, and so `ecosystem cron` could still derive an equivalent line.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.schedule == "*/10 * * * *"
 
 
-def test_heal_agent_auth_interpreter_token_is_absolute() -> None:
-    # Arrange — scitex-dev's `resolve_execstart` passes a head starting with "/"
-    # through VERBATIM. An absolute head is therefore the only form that depends
-    # on neither the ambient PATH nor which interpreter ran `ecosystem up`.
-    #
-    # The interpreter is token 2 now, after the `/usr/bin/timeout <N>` prefix.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.split()[2].startswith("/")
 
 
-def test_heal_agent_auth_command_head_is_still_absolute() -> None:
-    # Arrange — the self-bounding prefix must not cost this job its
-    # PATH-independence. `/usr/bin/timeout` is spelled absolutely precisely so
-    # the HEAD keeps starting with "/" and `resolve_execstart` keeps passing
-    # the whole command through verbatim. A bare `timeout` would have quietly
-    # made this the one command that needs an ambient PATH.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.split()[0] == "/usr/bin/timeout"
 
 
-def test_heal_agent_auth_script_token_is_absolute() -> None:
-    # Arrange — a systemd --user unit gets a MINIMAL PATH and no meaningful cwd,
-    # so the script argument must be absolute too; a relative path would exec
-    # fine under cron's $HOME cwd and fail as status=127 under systemd.
-    #
-    # The script is token 3 now, after the `/usr/bin/timeout <N>` prefix.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.split()[3].startswith("/")
 
 
-def test_heal_agent_auth_runs_the_venv_python_not_the_system_one() -> None:
-    # Arrange — the script's own `#!/usr/bin/env python3` would resolve to the
-    # SYSTEM python under systemd's minimal PATH, not the 3.11 venv the fleet
-    # runs on. Naming the venv interpreter outright is what carries the "PATH
-    # prefixed with .env-3.11/bin" requirement into a unit that has no PATH.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.startswith(
-        "/usr/bin/timeout 300 /home/ywatanabe/.env-3.11/bin/python "
-    )
 
 
-def test_heal_agent_auth_targets_the_real_auth_heal_entrypoint() -> None:
-    # Arrange — the entrypoint the cron line actually invokes, per the tracked
-    # `~/.scitex/agent-container/bin/README.md` ("run from cron; cron lines live
-    # in ~/.dotfiles/.crontab_list") and corroborated by the live state/log files
-    # that script writes. It takes no arguments — its `main()` has no argparse,
-    # only a `--selftest` branch — so the bare script path is the whole command.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.endswith(
-        "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
-    )
 
 
-def test_heal_agent_auth_timeout_outlives_a_restarting_pass() -> None:
-    # Arrange — a no-op tick takes ~2-8s; the worst observed pass (a TUI restart
-    # at 15:30:04 settling by 15:32:08) ~2min. A pass killed here is SAFE (state
-    # is persisted per restart), but the timeout must still outlive a real one.
-    #
-    # Pinned on the COMMAND: this job is lowered onto cron, and a cron line
-    # has no field a `timeout_sec` could ride in.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert job.command.startswith("/usr/bin/timeout 300 ")
 
 
-def test_heal_agent_auth_constructs_as_a_real_jobspec() -> None:
-    # Arrange — construction must not raise (a bad field would drop the whole
-    # provider). Assert it is the canonical contract type, not a look-alike.
-    # Act
-    job = _job("scitex-agent-container-heal-agent-auth")
-    # Assert
-    assert isinstance(job, jobs_mod.JobSpec)
 
 
-def test_heal_agent_auth_and_restart_login_expired_are_both_declared() -> None:
-    # Arrange — declaring both is SAFE and deliberate: a JobSpec is inert until
-    # `ecosystem up` installs it, so version-controlling the incumbent does not
-    # enable it. What must never happen is both being ENABLED — they are the two
-    # implementations of the same TUI heal, with INDEPENDENT debounce state, and
-    # two restarters on one fleet is the documented double-supervisor hazard.
-    # This pins that the choice stays an operator deploy decision rather than
-    # being silently foreclosed by deleting one of them.
-    # Act
-    names = {job.name for job in provide_jobs()}
-    # Assert
-    assert {"scitex-agent-container-heal-agent-auth", "scitex-agent-container-restart-login-expired-agents"} <= names
 
 
 # ---------------------------------------------------------------------------
@@ -920,3 +452,9 @@ def test_the_cron_line_that_lands_on_the_host_carries_the_bound() -> None:
     lines = [cron_block.build_cron_line(spec) for spec in merged]
     # Assert
     assert all(" /usr/bin/timeout " in line for line in lines), lines
+
+
+# The POPULATION guard over these jobs' payloads — the one that catches a
+# JobSpec added tomorrow rather than any named above — lives in
+# `test__specs_payload.py`. It needs the `executable` seam to resolve
+# deterministically, which is a different setup from every test here.

--- a/tests/scitex_agent_container/_jobs/test__names.py
+++ b/tests/scitex_agent_container/_jobs/test__names.py
@@ -141,12 +141,15 @@ def test_is_ours_rejects_a_foreign_job() -> None:
 
 
 def test_resolve_finds_a_real_declared_job_by_local_name() -> None:
-    # Arrange — against the REAL declarations, not a hand-picked list.
+    # Arrange — against the REAL declarations, not a hand-picked list. The
+    # literals elsewhere in this file stay on the legacy dotted shape ON
+    # PURPOSE: they pin that the PARSER still handles it, which is what a
+    # host mid-cutover types.
     declared = [j.name for j in provide_jobs()]
     # Act
     got = _names.resolve("accounts-refresh", declared)
     # Assert
-    assert got == "sac.accounts-refresh"
+    assert got == "scitex-agent-container-accounts-refresh"
 
 
 def test_resolve_raises_on_an_unknown_name() -> None:

--- a/tests/scitex_agent_container/_jobs/test__sac_bin.py
+++ b/tests/scitex_agent_container/_jobs/test__sac_bin.py
@@ -1,0 +1,256 @@
+"""``sac_bin`` — the payload path a scheduled command must name.
+
+The defect these guard against is not hypothetical. On 2026-08-20 every sac
+JobSpec said a bare ``sac`` after an absolute ``/usr/bin/timeout`` head, which
+takes the payload OUT of ``resolve_execstart`` (it absolutises only the first
+token). On scitex-compute-01 the supervisor's PATH held no venv and all ten sac
+jobs sat at exit 127 with zero successes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs
+from scitex_agent_container._jobs._sac_bin import sac_bin
+
+from ._jobspec_helpers import _split_command
+
+
+def _venv_shaped(tmp_path: Path, *, with_sac: bool) -> Path:
+    """A real venv-shaped tree on disk: ``bin/python`` symlinked OUT of it.
+
+    Not a mock — the property under test is how a SYMLINK is treated, so the
+    test must build a real one. This mirrors how uv (the mandated installer)
+    lays a venv out.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True)
+    (bindir / "python").symlink_to(Path(os.path.realpath("/usr/bin/python3")))
+    if with_sac:
+        (bindir / "sac").write_text("#!/bin/sh\nexit 0\n")
+    return bindir
+
+
+def test_returns_the_console_script_beside_the_interpreter(tmp_path: Path) -> None:
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    resolved = sac_bin(executable=str(bindir / "python"))
+    # Assert
+    assert resolved == str(bindir / "sac")
+
+
+def test_does_not_follow_the_interpreter_symlink_out_of_the_venv(tmp_path: Path) -> None:
+    """The property scitex-dev's ``resolve_execstart`` docstring insists on.
+
+    Falsifiable, and that is the point: change the implementation to
+    ``Path(executable).resolve().parent`` and this goes RED, because the
+    resolved parent is ``/usr/bin`` — a directory that structurally cannot hold
+    this venv's console scripts.
+    """
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    resolved = sac_bin(executable=str(bindir / "python"))
+    # Assert
+    assert not resolved.startswith("/usr/bin/")
+
+
+def test_absent_console_script_warns(tmp_path: Path) -> None:
+    """A silent fallback is how the original defect stayed invisible."""
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=False)
+    # Act
+    executable = str(bindir / "python")
+    # Assert
+    with pytest.warns(RuntimeWarning, match="no `sac` console script"):
+        sac_bin(executable=executable)
+
+
+def test_absent_console_script_still_yields_a_usable_command(tmp_path: Path) -> None:
+    """The warning does not replace a return value — the job must still render."""
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=False)
+    # Act
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        resolved = sac_bin(executable=str(bindir / "python"))
+    # Assert
+    assert resolved == "sac"
+
+
+def test_resolves_against_this_interpreter_by_default() -> None:
+    """No argument means ``sys.executable`` — the supervisor's own interpreter.
+
+    Either an absolute sibling, or the loud bare-name fallback. What it must
+    never be is a relative path WITH a directory in it, which would depend on
+    the child's working directory as well as its PATH.
+    """
+    # Arrange
+    acceptable_bare = "sac"
+    # Act
+    resolved = sac_bin()
+    # Assert
+    assert resolved == acceptable_bare or Path(resolved).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# THE POPULATION GUARD: sac_bin's resolution must REACH the rendered specs.
+#
+# The tests above pin `sac_bin` in isolation. These pin the thing the module
+# exists for -- that every JobSpec the provider returns names the resolved
+# payload rather than a bare `sac` the ambient PATH has to find.
+#
+# They live in this file rather than a `test__specs_payload.py` of their own
+# because the repo mirrors tests onto source modules one-to-one (PS-204 §2),
+# and their subject IS this module: `_sac_bin`'s whole docstring is the
+# argument for why a job command may not say bare `sac`.
+#
+# WHY THEY TAKE THE `executable` SEAM. `sac_bin` returns the bare name and
+# warns when no console script sits beside the running interpreter -- correct
+# for a broken install, and also exactly what a PYTHONPATH-only CI run looks
+# like. Calling `provide_jobs()` with no seam and asserting the payload is
+# absolute therefore asserts a fact about the RUNNING ENVIRONMENT, not about
+# the specs. MEASURED 2026-08-20: that is why this guard was red in CI on
+# three unrelated PRs while every host behaved correctly.
+#
+# WHY NOT "absolute OR a warning fired". A warning ALWAYS fires under CI, so
+# every job -- including one that hardcoded a literal `sac` -- would satisfy
+# that vacuously, in the one environment where the guard actually runs.
+# ---------------------------------------------------------------------------
+
+
+def _payload(command: str) -> str:
+    """The token after the ``/usr/bin/timeout N`` head — the binary that runs.
+
+    Reads it through the shared ``_split_command`` rather than re-slicing the
+    string here, so a change to what counts as the head reaches this file too.
+    See that helper for why the payload is checked by SHAPE and never against
+    ``sac_bin()``'s own return value.
+    """
+    return _split_command(command)[1]
+
+
+def test_every_job_names_an_absolute_payload_not_a_bare_sac(tmp_path: Path) -> None:
+    """The whole-fleet guard, and the one that would have caught compute-01.
+
+    Each per-job assertion elsewhere pins ONE job, so a JobSpec added tomorrow
+    with a bare ``sac`` would pass every one of them. This covers the
+    population instead.
+    """
+    # Arrange — a tree that DOES hold a console script, so resolution is the
+    # test's choice rather than the runner's accident.
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    relative = [
+        (job.name, job.command)
+        for job in provide_jobs(executable=str(bindir / "python"))
+        if not Path(_payload(job.command)).is_absolute()
+    ]
+    # Assert
+    assert relative == [], (
+        f"these commands name a payload that must be found on the ambient "
+        f"PATH: {relative}. `resolve_execstart` absolutises only the FIRST "
+        f"token, and that token is already `/usr/bin/timeout`, so nothing "
+        f"downstream will fix this."
+    )
+
+
+def test_the_payload_guard_has_something_to_guard(tmp_path: Path) -> None:
+    """Non-vacuity: an empty provider would pass the check above silently."""
+    # Arrange
+    expected_minimum = 1
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    jobs = provide_jobs(executable=str(bindir / "python"))
+    # Assert
+    assert len(jobs) >= expected_minimum
+
+
+def test_every_payload_comes_from_the_tree_the_seam_named(tmp_path: Path) -> None:
+    """The seam is REACHED, not merely accepted.
+
+    Absoluteness alone cannot tell those apart: if ``provide_jobs`` ignored
+    ``executable`` and resolved against the running interpreter, the payload
+    would still be absolute on a developer's machine and the guard above would
+    still pass. This pins the payload to the tree the test built, so a seam
+    that is accepted and never threaded down goes red — the
+    accepted-but-never-applied shape that lets a flag exist while the
+    behaviour behind it is absent.
+    """
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=True)
+    # Act
+    jobs = provide_jobs(executable=str(bindir / "python"))
+    # Assert
+    elsewhere = [
+        (job.name, _payload(job.command))
+        for job in jobs
+        if _payload(job.command) != str(bindir / "sac")
+    ]
+    assert elsewhere == [], (
+        f"these payloads did not come from the tree the seam named "
+        f"({bindir / 'sac'}): {elsewhere}. `executable` was accepted but not "
+        f"threaded through to `sac_bin`."
+    )
+
+
+def test_specs_built_without_a_console_script_warn(tmp_path: Path) -> None:
+    """What does NOT go red, made to go red — half one, the noise.
+
+    The guard above is only meaningful while the fallback it guards against
+    stays AUDIBLE. If the warning ever stopped, a silently degraded fleet
+    would look identical to a healthy one.
+    """
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=False)
+    # Act
+    executable = str(bindir / "python")
+    # Assert
+    with pytest.warns(RuntimeWarning):
+        provide_jobs(executable=executable)
+
+
+def test_specs_built_without_a_console_script_carry_the_bare_name(
+    tmp_path: Path,
+) -> None:
+    """What does NOT go red, made to go red — half two, the value.
+
+    The fallback returns the bare name rather than inventing a path. If it
+    ever started synthesising one, the population guard would pass against a
+    payload no host can execute — a green test describing a fleet at exit 127.
+    """
+    # Arrange
+    bindir = _venv_shaped(tmp_path, with_sac=False)
+    # Act
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        jobs = provide_jobs(executable=str(bindir / "python"))
+    # Assert
+    assert {_payload(job.command) for job in jobs} == {"sac"}
+
+
+def test_the_default_seam_still_resolves_against_this_interpreter() -> None:
+    """Omitting the seam must keep production behaviour, not become a no-op.
+
+    The fleet calls ``provide_jobs()`` with no arguments and must still get the
+    console script beside the interpreter that imported the plugin. Asserting
+    the exact path would parameterise the test by the value under test, so this
+    asserts the RELATIONSHIP: whatever the default resolves to is what the seam
+    produces when handed this interpreter.
+    """
+    # Arrange
+    interpreter = sys.executable
+    # Act
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        defaulted = [_payload(job.command) for job in provide_jobs()]
+        seamed = [_payload(job.command) for job in provide_jobs(executable=interpreter)]
+    # Assert
+    assert defaulted == seamed

--- a/tests/scitex_agent_container/_jobs/test__specs_accounts.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_accounts.py
@@ -1,0 +1,127 @@
+"""The accounts-keepalive JobSpec — the DISTRIBUTION half of the token model.
+
+Split out of ``test__jobs_plugin.py`` (at the per-file cap), mirroring the
+split of :mod:`scitex_agent_container._jobs._specs_accounts` on the source
+side, so the tests for a group sit beside the module that defines it.
+
+``accounts-refresh`` rotates the token on the ONE host holding refresh
+material; this job copies the result out to the access-only hosts and proves
+each accepts it. The two are a pair, and the pair is why a fresh token on the
+master does not by itself keep the followers alive — which is why these
+assertions pin the peer list and the copying verb, not just the cadence.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
+
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
+
+
+def test_accounts_keepalive_job_name_is_package_prefixed() -> None:
+    # Arrange — the distribution half of the single-refresher model.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.name == "scitex-agent-container-accounts-keepalive"
+
+def test_accounts_keepalive_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer, so kind="timer". A kind
+    # outside JobSpec.ALLOWED_KINDS raises at construction, and `ecosystem up`
+    # then silently DROPS sac's WHOLE provider (provider-isolated, WARN-only)
+    # — taking the OAuth refresh, the drift check, the worktree GC and both
+    # heal enforcers down with it.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.kind == "timer"
+
+def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
+    # Arrange — the peer list IS the job. A keepalive that reaches two of the
+    # three access-only hosts looks healthy (exit 0, verified peers) while the
+    # third silently expires, which is the exact failure this job exists to
+    # end. Pin the whole command so dropping a `--to` is a red test, not a
+    # host nobody notices is dead.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "accounts keepalive --all --to ywata-note-win --to scitex-compute-03 --to scitex-compute-04")
+
+def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() -> None:
+    # Arrange — belt-and-braces, the counterpart of accounts-refresh's
+    # --skip-active guard. This job COPIES the master's current token; minting
+    # rotates it, and a rotation revokes the token every running agent is
+    # holding. Scheduling `accounts refresh` or `accounts login` here would
+    # turn a keepalive into a fleet-wide logout every 15 minutes, so pin the
+    # verb itself rather than trusting the full-command assertion above to be
+    # re-read whenever someone edits the peer list.
+    #
+    # Indexed PAST the self-bounding `/usr/bin/timeout <N>` prefix (tokens 0
+    # and 1), so this still pins the VERB rather than the wrapper.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    _bound, _payload, rest = _split_command(job.command)
+    assert rest.split()[:2] == ["accounts", "keepalive"]
+
+def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
+    # Arrange — the cadence IS the worst-case follower outage, not a guess at
+    # when work is needed. The master's token changes once in ~7h at an
+    # unpredictable moment, and the instant it does every follower's copy is
+    # revoked; the tick only decides how long that revoked window lasts. A
+    # converged peer is verified rather than rewritten, so the extra ticks are
+    # near free — which is what makes 15min affordable.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.on_unit_active_sec == "15min"
+
+def test_accounts_keepalive_schedule_mirrors_the_timer_cadence() -> None:
+    # Arrange — the cron form is kept alongside the timer cadence (as every
+    # sibling does) so `ecosystem cron` could derive an equivalent line, and
+    # so the two spellings cannot silently disagree about how often this runs.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.schedule == "*/15 * * * *"
+
+def test_accounts_keepalive_timeout_outlives_a_three_peer_pass() -> None:
+    # Arrange — per peer: a handful of ssh ops plus ONE outbound HTTPS
+    # verification (15s cap inside the probe). 300s covers three peers
+    # including a slow one. A pass killed here is SAFE — nothing is published
+    # unverified, so the peer keeps its previous credential.
+    #
+    # The bound is asserted on the COMMAND, not on `timeout_sec`, because
+    # this job is deployed to cron and a cron line cannot carry that field.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert job.command.startswith("/usr/bin/timeout 300 ")
+
+def test_accounts_keepalive_constructs_as_a_real_jobspec() -> None:
+    # Arrange — construction must not raise (a bad field would drop the whole
+    # provider). Assert it is the canonical contract type, not a look-alike.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    # Assert
+    assert isinstance(job, jobs_mod.JobSpec)
+
+def test_accounts_keepalive_and_accounts_refresh_are_both_declared() -> None:
+    # Arrange — unlike the heal pair below, these two are NOT alternatives:
+    # they are the two halves of one model and BOTH must be enabled. Refresh
+    # without keepalive leaves the followers holding a revoked copy; keepalive
+    # without refresh distributes a token nothing renews. Deleting either one
+    # breaks the fleet in a way that looks like the other half working.
+    # Act
+    names = {job.name for job in provide_jobs()}
+    # Assert
+    assert {"scitex-agent-container-accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names

--- a/tests/scitex_agent_container/_jobs/test__specs_liveness.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_liveness.py
@@ -1,0 +1,126 @@
+"""The two AGENT-LIVENESS enforcers, tested side by side.
+
+Split out of ``test__jobs_plugin.py`` (at the per-file cap), mirroring the
+split of :mod:`scitex_agent_container._jobs._specs_liveness` on the source
+side — a file that already argued these two are unreadable apart, because each
+one's scope is defined by what the other handles:
+
+* ``fleet-reconcile`` restarts CORPSES — no tmux session, so no context to lose.
+* ``restart-login-expired-agents`` restarts the LIVE-BUT-WEDGED half, which
+  fleet-reconcile deliberately will not touch.
+
+``fleet-reconcile``'s pins matter more than most: ``restart.policy`` in ~93
+specs is DEAD CODE without that timer, so a wrong ``kind`` or a command that
+lost ``--apply`` would put the fleet back to dying unnoticed.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
+
+
+def test_fleet_reconcile_job_name_is_package_prefixed() -> None:
+    # Arrange — the enforcer of "should be running => is running".
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    assert job.name == "scitex-agent-container-fleet-reconcile"
+
+def test_fleet_reconcile_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong
+    # kind raises at construction and `ecosystem up` then silently DROPS
+    # sac's whole provider (provider-isolated, WARN-only) — taking the OAuth
+    # refresh, the drift check and the worktree GC down with it.
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    assert job.kind == "timer"
+
+def test_fleet_reconcile_command_is_the_applying_form() -> None:
+    # Arrange — THIS JOB IS THE MECHANISM. `restart.policy` in ~93 specs is
+    # dead code without it: `_lifecycle/_start.py` runs the loop that reads
+    # it on a daemon thread inside the short-lived `sac agents start` CLI, so
+    # the supervisor dies with the process that promised it. A scheduled
+    # DRY-RUN would restore nothing — the whole point is `--apply`.
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "agents reconcile --apply")
+
+def test_fleet_reconcile_cadence_is_five_minutes() -> None:
+    # Arrange — the cadence IS the window a dead agent stays dead. A no-op
+    # pass is one batched `tmux list-sessions` plus a spec read each, so it
+    # is cheap enough to run often.
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    assert job.on_unit_active_sec == "5min"
+
+def test_fleet_reconcile_timeout_outlives_a_capped_pass() -> None:
+    # Arrange — the pathological pass restarts `--limit` agents, each a
+    # stop+settle+start. A pass killed at this timeout is SAFE (the restart
+    # history is persisted per restart, not at the end), but the timeout must
+    # still comfortably exceed a normal pass or the enforcer never finishes.
+    #
+    # THIS is the job whose unbounded cron line was measured accumulating
+    # fourteen concurrent instances, the oldest 45 minutes old (2026-07-18).
+    # A `timeout_sec` assertion would have passed throughout that incident,
+    # because the field was set and the deployed cron line was still
+    # unbounded — so the bound is pinned where it actually runs.
+    # Act
+    job = _job("scitex-agent-container-fleet-reconcile")
+    # Assert
+    assert job.command.startswith("/usr/bin/timeout 300 ")
+
+def test_restart_login_expired_job_name_is_package_prefixed() -> None:
+    # Arrange — the auto-restarter for auth-dead-but-live agents.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    assert job.name == "scitex-agent-container-restart-login-expired-agents"
+
+def test_restart_login_expired_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong kind
+    # raises at construction and `ecosystem up` then silently DROPS sac's whole
+    # provider (provider-isolated, WARN-only) — taking the OAuth refresh, the
+    # drift check, the worktree GC AND the fleet-reconcile enforcer down too.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    assert job.kind == "timer"
+
+def test_restart_login_expired_command_is_the_applying_form() -> None:
+    # Arrange — a scheduled DRY-RUN would detect wedged agents and heal none.
+    # The whole point is `--apply`. Detection stays read-only; the restart is
+    # the only mutation.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 300", "agents restart-login-expired --apply")
+
+def test_restart_login_expired_cadence_is_five_minutes() -> None:
+    # Arrange — the cadence IS the window a login-expired agent stays wedged,
+    # matched to fleet-reconcile so the two enforcers sweep on the same beat.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    assert job.on_unit_active_sec == "5min"
+
+def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
+    # Arrange — construction must not raise (a bad field would drop the whole
+    # provider). Assert it is the canonical contract type, not a look-alike.
+    # Act
+    job = _job("scitex-agent-container-restart-login-expired-agents")
+    # Assert
+    assert isinstance(job, jobs_mod.JobSpec)

--- a/tests/scitex_agent_container/_jobs/test__specs_maintenance.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_maintenance.py
@@ -1,0 +1,195 @@
+"""The housekeeping JobSpecs: drift, worktrees, images.
+
+Split out of ``test__jobs_plugin.py`` (at the per-file cap), mirroring the
+split of :mod:`scitex_agent_container._jobs._specs_maintenance` on the source
+side.
+
+These three are INDEPENDENT of each other — none consumes another's output —
+and what they share is that every one of them REPORTS rather than repairs. The
+assertions here protect that: ``host-sync-check`` must stay read-only and must
+never acquire the mutating remedy, ``worktree-gc`` must keep ``--apply`` and
+its every-repo sweep, and ``spartan-sif-bake`` must stay in its confirmed form.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
+
+
+def test_host_sync_check_job_name_is_package_prefixed() -> None:
+    # Arrange — the drift-alarm timer that makes the Stage-0 detector run.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert job.name == "scitex-agent-container-host-sync-check"
+
+def test_host_sync_check_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer (hourly), so kind="timer".
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert job.kind == "timer"
+
+def test_host_sync_check_command_is_the_readonly_check() -> None:
+    # Arrange — the scheduled command MUST carry --check. A timer that could
+    # fast-forward a peer unattended is Stage 1, explicitly out of scope.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert "--check" in job.command
+
+def test_host_sync_check_command_routes_to_a_seen_card() -> None:
+    # Arrange — --alarm is what turns the exit code into a SEEN board card
+    # instead of a journald line nobody reads.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert "--alarm" in job.command
+
+def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
+    # Arrange — belt-and-braces: the exact mutating form `sac host sync
+    # <peer>` (no --check) must never be what this timer runs. The command
+    # is the read-only detector, full stop.
+    #
+    # `--exit-zero` was added 2026-08-17 and does NOT weaken that intent: it
+    # touches only this process's exit status, never a peer. It is here
+    # because the tri-state verdict (1 = drift found, 2 = undetermined) was
+    # being read by systemd as unit failure, which put the host into
+    # `degraded`, which made the dotfiles sync installer conclude systemd
+    # was absent and silently stop installing its timer.
+    #
+    # Kept as EXACT EQUALITY on purpose. This assertion is the reason that
+    # change could not land unnoticed — a substring check would have let it
+    # through silently, and the next edit to this command deserves the same
+    # scrutiny. Update the literal deliberately; do not relax the operator.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert — the command is precisely the read-only check+alarm form.
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 600", "host sync --check --all --alarm --exit-zero")
+
+def test_host_sync_check_cadence_is_hourly() -> None:
+    # Arrange — drift is slow-moving; hourly is ample and gentle on ssh.
+    # Act
+    job = _job("scitex-agent-container-host-sync-check")
+    # Assert
+    assert job.on_unit_active_sec == "1h"
+
+def test_worktree_gc_job_name_is_package_prefixed() -> None:
+    # Arrange — the daily GC that makes the worktree-sprawl countermeasure
+    # PERIODIC. A GC nobody schedules is a script, not a countermeasure —
+    # which is exactly how one repo reached 105 worktrees.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    assert job.name == "scitex-agent-container-worktree-gc"
+
+def test_worktree_gc_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer (daily), so kind="timer".
+    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    assert job.kind == "timer"
+
+def test_worktree_gc_command_is_the_apply_form() -> None:
+    # Arrange — the scheduled job must ACT, not just report: a timer that
+    # only dry-runs would print a nightly report nobody reads while the
+    # sprawl kept growing. The safety lives in the predicate, not in
+    # withholding --apply.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == (
+        "/usr/bin/timeout 900",
+        # --exit-zero is LOAD-BEARING and pinned here on purpose. Exit 1 from
+        # this verb means "a repo is over cap, a human decides" — a finding,
+        # not ill health. Without the flag the supervisor records the job as
+        # failed, and the rule for retiring its duplicate systemd timer was
+        # "the supervisor has a recorded exit-0", which this job could then
+        # never produce. Dropping the flag silently re-creates that deadlock.
+        "worktree gc --apply --all --exit-zero",
+    )
+
+def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
+    # Arrange — --all is only correct because it HAS a clean source (every
+    # agent spec.workdir that is a local git repo toplevel). If that source
+    # ever disappears, this command silently sweeps nothing.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    assert "--all" in job.command
+
+def test_worktree_gc_cadence_is_daily() -> None:
+    # Arrange — sprawl accumulates over days and the age gate is 24h, so a
+    # faster pass could not remove anything a daily one would miss.
+    # Act
+    job = _job("scitex-agent-container-worktree-gc")
+    # Assert
+    assert job.on_unit_active_sec == "1d"
+
+def test_spartan_sif_bake_job_name_is_package_prefixed() -> None:
+    # Arrange — the daily remote SIF bake (operator directive 2026-07-17:
+    # bake on Spartan, rsync to the master, zero master CPU).
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    assert job.name == "scitex-agent-container-spartan-sif-bake"
+
+def test_spartan_sif_bake_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer (*/10), so kind="timer".
+    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    assert job.kind == "timer"
+
+def test_spartan_sif_bake_command_is_the_confirmed_form() -> None:
+    # Arrange — `sac image bake-remote` REFUSES to run without --yes
+    # (exit 2), mirroring `sac image build`'s non-interactive gate. A
+    # scheduled command missing --yes would fail every single night —
+    # a timer that fires and does nothing, the inert-feature shape.
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == ("/usr/bin/timeout 14400", "image bake-remote --yes")
+
+def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
+    # Arrange — the SIF is a point-in-time snapshot of @develop, and at our
+    # release rate a day-old one is mostly wrong. 30min was the operator's
+    # stated FLOOR (「最低でも30分に1回」), not his target — he asked why it was
+    # only every 30 and said even 1min would be fine — so this pins the
+    # cadence he wants. skip-if-unchanged keeps a no-change tick at one ssh
+    # round-trip instead of a multi-GB transfer, and the script's `flock -n`
+    # single-flights the overlaps a 10min interval necessarily causes.
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    assert job.on_unit_active_sec == "10min"
+
+def test_spartan_sif_bake_timeout_outlives_two_bakes_and_a_pull() -> None:
+    # Arrange — two full bakes (base + scitex) plus a multi-GB pull on a
+    # slow link must fit; the per-leg ssh timeout is 7200s, so the cap
+    # must exceed the worst legitimate chain or the timer kills its
+    # own successful runs.
+    #
+    # This job needs a REAL bound more than any sibling: at a */10 cadence
+    # an unbounded bake outlives its own tick by construction, so a wedged
+    # run piles up against every later one. The bound therefore has to be
+    # in the command — cron, the surface this is deployed to, cannot carry
+    # `timeout_sec` at all.
+    # Act
+    job = _job("scitex-agent-container-spartan-sif-bake")
+    # Assert
+    assert job.command.startswith("/usr/bin/timeout 14400 ")

--- a/tests/scitex_agent_container/_lifecycle/test__argv_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__argv_drift.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A spec is intent; a process holds its launch argv. Nothing compared them.
+
+Measured 2026-08-19 on compute-04, reading ``/proc/<pid>/cmdline`` for
+each running handyman:
+
+    handyman-01   up 1d02h   NO --effort
+    handyman-02   up 07h27m  --effort low
+    handyman-03   up 22h     NO --effort
+
+``--effort low`` was in TWENTY spec files and in ONE running process.
+The two that lacked it had started before the edit. Every file-reading
+surface reported the operator's cost instruction as applied.
+
+These tests pin the comparison, and above all pin that "I could not
+look" is a THIRD answer. Every instrument that failed us that night —
+a truncated listing read as absence, a spec-vs-spec guard blind to
+processes, a status probe asserting "real absence" about another host —
+failed by printing its could-not-look as a clean result.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._argv_drift import (
+    CANNOT_DETERMINE,
+    DIFFERS,
+    MATCHES,
+    ArgvDrift,
+    compare_spec_flags_to_argv,
+    summarize,
+)
+
+_ARGV_WITH = ["claude", "--model", "qwen38-27b", "--effort", "low", "--resume", "abc"]
+_ARGV_WITHOUT = ["claude", "--model", "qwen38-27b", "--resume", "abc"]
+
+
+def test_an_unloadable_spec_cannot_be_decided():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=None, running_argv=_ARGV_WITH
+    )
+    # Assert
+    assert result.verdict == CANNOT_DETERMINE
+
+
+def test_an_unobserved_process_cannot_be_decided():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=None
+    )
+    # Assert
+    assert result.verdict == CANNOT_DETERMINE
+
+
+def test_an_unobserved_process_is_not_reported_as_matching():
+    # Arrange: the regression — silence must not read as compliance.
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=None
+    )
+    # Assert
+    assert result.verdict != MATCHES
+
+
+def test_the_undecided_reason_names_the_missing_process():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=None
+    )
+    # Assert
+    assert "no running process" in (result.reason or "")
+
+
+def test_the_undecided_reason_names_the_unloadable_spec():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=None, running_argv=_ARGV_WITH
+    )
+    # Assert
+    assert "spec could not be loaded" in (result.reason or "")
+
+
+def test_is_drifted_is_none_when_undecided():
+    # Arrange: a caller treating this as falsey turns "did not look" into "fine".
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=None
+    )
+    # Assert
+    assert result.is_drifted is None
+
+
+def test_a_process_carrying_every_declared_flag_matches():
+    # Arrange
+    agent = "handyman-02"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=_ARGV_WITH
+    )
+    # Assert
+    assert result.verdict == MATCHES
+
+
+def test_the_measured_handyman_incident_is_reported_as_drift():
+    # Arrange: handyman-01, spec says --effort low, process predates the edit.
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=_ARGV_WITHOUT
+    )
+    # Assert
+    assert result.verdict == DIFFERS
+
+
+def test_the_drift_names_the_flag_that_is_missing():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=_ARGV_WITHOUT
+    )
+    # Assert
+    assert result.missing == ("--effort", "low")
+
+
+def test_the_drift_message_names_the_remedy():
+    # Arrange
+    agent = "handyman-01"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=_ARGV_WITHOUT
+    )
+    # Assert
+    assert "restart it" in result.describe()
+
+
+def test_flags_present_but_not_adjacent_are_drift():
+    # Arrange: --effort separated from its value is a different command line.
+    agent = "handyman-03"
+    argv = ["claude", "--effort", "--model", "qwen38-27b", "low"]
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=argv
+    )
+    # Assert
+    assert result.verdict == DIFFERS
+
+
+def test_the_non_adjacent_drift_explains_itself():
+    # Arrange
+    agent = "handyman-03"
+    argv = ["claude", "--effort", "--model", "qwen38-27b", "low"]
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=["--effort", "low"], running_argv=argv
+    )
+    # Assert
+    assert "contiguous" in (result.reason or "")
+
+
+def test_a_spec_declaring_no_flags_matches_any_process():
+    # Arrange
+    agent = "scitex-cards"
+    # Act
+    result = compare_spec_flags_to_argv(
+        agent=agent, spec_flags=[], running_argv=_ARGV_WITHOUT
+    )
+    # Assert
+    assert result.verdict == MATCHES
+
+
+def test_the_summary_counts_undetermined_separately_from_matching():
+    # Arrange: 1 ok, 1 drifted, 1 unknown must never render as 2 ok.
+    drifts = [
+        ArgvDrift(agent="a", verdict=MATCHES),
+        ArgvDrift(agent="b", verdict=DIFFERS, missing=("--effort", "low")),
+        ArgvDrift(agent="c", verdict=CANNOT_DETERMINE, reason="no running process"),
+    ]
+    # Act
+    text = summarize(drifts)
+    # Assert
+    assert "1 in force, 1 drifted, 1 could not be determined" in text

--- a/tests/scitex_agent_container/_lifecycle/test__birth_certificate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__birth_certificate.py
@@ -4,9 +4,11 @@ Operator requirement (2026-08-14): record the COMPILED final spec as
 "this agent was born like this", keyed by incarnation id, in the DB —
 and reference credentials by slot/source NAME, never by value.
 
-Real AgentConfigs, a real on-disk SQLite via explicit ``db_path``, and a
-REAL git repo for the sha tests (git invoked as a subprocess with -C,
-signing disabled per-invocation). No mocks.
+Real AgentConfigs, a REAL PostgreSQL via the ``pg_schema`` fixture (the
+certificate moved off SQLite on 2026-08-19; the fixture gives each test a
+throwaway schema so the live fleet state is never touched), and a REAL git
+repo for the sha tests (git invoked as a subprocess with -C, signing
+disabled per-invocation). No mocks.
 """
 
 from __future__ import annotations
@@ -15,7 +17,6 @@ import json
 import subprocess
 from pathlib import Path
 
-import pytest
 
 from scitex_agent_container._lifecycle._birth_certificate import (
     SPEC_SHA_UNRESOLVABLE,
@@ -152,62 +153,57 @@ def test_sha_resolves_head_in_a_real_repo(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def db(tmp_path: Path) -> Path:
-    return tmp_path / "state.db"
-
-
-def test_certificate_row_lands_keyed_by_incarnation(db: Path) -> None:
+def test_certificate_row_lands_keyed_by_incarnation(pg_schema: str) -> None:
     # Arrange
     cfg = AgentConfig(name="alpha")
     # Act
-    ok = write_birth_certificate(cfg, "inc-b1", db_path=db)
+    ok = write_birth_certificate(cfg, "inc-b1")
     # Assert
-    assert ok is True and get_incarnation("inc-b1", db_path=db) is not None
+    assert ok is True and get_incarnation("inc-b1") is not None
 
 
-def test_certificate_names_the_agent_identity(db: Path) -> None:
+def test_certificate_names_the_agent_identity(pg_schema: str) -> None:
     # Arrange
     cfg = AgentConfig(name="alpha")
     # Act
-    write_birth_certificate(cfg, "inc-b2", db_path=db)
+    write_birth_certificate(cfg, "inc-b2")
     # Assert
-    assert get_incarnation("inc-b2", db_path=db)["agent_id"] == "alpha"
+    assert get_incarnation("inc-b2")["agent_id"] == "alpha"
 
 
-def test_certificate_records_unresolvable_sha_honestly(db: Path) -> None:
+def test_certificate_records_unresolvable_sha_honestly(pg_schema: str) -> None:
     # Arrange: no config_path at all — nothing to fake a sha from.
     cfg = AgentConfig(name="alpha")
     # Act
-    write_birth_certificate(cfg, "inc-b3", db_path=db)
+    write_birth_certificate(cfg, "inc-b3")
     # Assert
-    assert get_incarnation("inc-b3", db_path=db)["spec_git_sha"] == (
+    assert get_incarnation("inc-b3")["spec_git_sha"] == (
         SPEC_SHA_UNRESOLVABLE
     )
 
 
-def test_certificate_records_the_spec_repo_head(db: Path, tmp_path: Path) -> None:
+def test_certificate_records_the_spec_repo_head(pg_schema: str, tmp_path: Path) -> None:
     # Arrange: a spec tracked in a real git repo.
     repo = tmp_path / "specs"
     head = _git_repo_with_commit(repo)
     cfg = AgentConfig(name="alpha", config_path=str(repo / "spec.yaml"))
     # Act
-    write_birth_certificate(cfg, "inc-b4", db_path=db)
+    write_birth_certificate(cfg, "inc-b4")
     # Assert
-    assert get_incarnation("inc-b4", db_path=db)["spec_git_sha"] == head
+    assert get_incarnation("inc-b4")["spec_git_sha"] == head
 
 
-def test_certificate_compiled_spec_is_redacted_json(db: Path) -> None:
+def test_certificate_compiled_spec_is_redacted_json(pg_schema: str) -> None:
     # Arrange
     cfg = AgentConfig(name="alpha", env={"API_KEY": "sk-live"})
     # Act
-    write_birth_certificate(cfg, "inc-b5", db_path=db)
-    stored = json.loads(get_incarnation("inc-b5", db_path=db)["compiled_spec_json"])
+    write_birth_certificate(cfg, "inc-b5")
+    stored = json.loads(get_incarnation("inc-b5")["compiled_spec_json"])
     # Assert: no secret material in the record.
     assert stored["env"]["API_KEY"] == "<redacted:API_KEY>"
 
 
-def test_certificate_compiled_spec_carries_residency(db: Path, tmp_path: Path) -> None:
+def test_certificate_compiled_spec_carries_residency(pg_schema: str, tmp_path: Path) -> None:
     # Arrange: a compiled config declaring the v4 residency axis — the
     # birth certificate must record it (provenance for "why did this
     # incarnation end at oneshot-complete?").
@@ -215,16 +211,16 @@ def test_certificate_compiled_spec_carries_residency(db: Path, tmp_path: Path) -
 
     cfg = AgentConfig(name="alpha", residency=ONE_SHOT)
     # Act
-    write_birth_certificate(cfg, "inc-b7", db_path=db)
-    stored = json.loads(get_incarnation("inc-b7", db_path=db)["compiled_spec_json"])
+    write_birth_certificate(cfg, "inc-b7")
+    stored = json.loads(get_incarnation("inc-b7")["compiled_spec_json"])
     # Assert
     assert stored["residency"] == ONE_SHOT
 
 
-def test_certificate_failure_is_false_not_raise(db: Path) -> None:
+def test_certificate_failure_is_false_not_raise(pg_schema: str) -> None:
     # Arrange: a config whose serialization cannot work (not a dataclass).
     broken = object()
     # Act
-    ok = write_birth_certificate(broken, "inc-b6", db_path=db)
+    ok = write_birth_certificate(broken, "inc-b6")
     # Assert: best-effort — the launch it documents must not die over it.
     assert ok is False

--- a/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
+import contextlib
 from pathlib import Path
 
 from scitex_agent_container._lifecycle._ci_owner import resolve_owner, tracked_repos
@@ -160,43 +161,117 @@ def test_tracked_repos_collapses_two_projects_that_resolve_to_one_repo(
     assert repos == ["an-org/new-name"]
 
 
+def _probe_seam(stdout="", returncode=0, stderr="", calls=None):
+    """Build a fake ``_run_gh_probe``. Returns the real GhProbe shape."""
+    from scitex_agent_container._lifecycle._github_ci import GhProbe
+
+    def fake(args):
+        if calls is not None:
+            calls.append(args)
+        return GhProbe(stdout, returncode, stderr)
+
+    return fake
+
+
+@contextlib.contextmanager
+def _seamed_probe(**kw):
+    """Swap ``_github_ci._run_gh_probe`` and clear the canonical cache.
+
+    The cache MUST be cleared on both sides: it is module-global and now
+    caches ``None`` as a meaningful value, so a leaked entry would make the
+    next test read a verdict it never produced.
+    """
+    from scitex_agent_container._lifecycle import _ci_owner as mod
+    import scitex_agent_container._lifecycle._github_ci as ghmod
+
+    mod._CANONICAL_CACHE.clear()
+    real = ghmod._run_gh_probe
+    ghmod._run_gh_probe = _probe_seam(**kw)
+    try:
+        yield mod
+    finally:
+        ghmod._run_gh_probe = real
+        mod._CANONICAL_CACHE.clear()
+
+
 def test_canonical_lookup_falls_back_to_the_guess_when_gh_gives_nothing():
     # Arrange — a gh outage must degrade to the previous behaviour (a
     # guess), never to an empty poll list that silently watches nothing.
-    from scitex_agent_container._lifecycle import _ci_owner as mod
-
-    mod._CANONICAL_CACHE.clear()
-    saved = mod._run_gh if hasattr(mod, "_run_gh") else None
-    import scitex_agent_container._lifecycle._github_ci as ghmod
-
-    real = ghmod._run_gh
-    ghmod._run_gh = lambda args: ""
-    try:
+    with _seamed_probe(stdout="", returncode=1, stderr="dial tcp: i/o timeout") as mod:
         # Act
         out = mod._canonical_name_with_owner("an-org/a-repo")
-    finally:
-        ghmod._run_gh = real
-        mod._CANONICAL_CACHE.clear()
     # Assert
     assert out == "an-org/a-repo"
+
+
+def test_canonical_lookup_returns_none_when_github_says_no_such_repo():
+    # Arrange — GitHub ANSWERED, and the answer was that it does not exist.
+    # This is the case worth one REST call per tick per host, forever.
+    with _seamed_probe(
+        stdout="",
+        returncode=1,
+        stderr="GraphQL: Could not resolve to a Repository with the name 'an-org/nope'. (repository)",
+    ) as mod:
+        # Act
+        out = mod._canonical_name_with_owner("an-org/nope")
+    # Assert
+    assert out is None
+
+
+def test_a_rate_limited_probe_is_unknown_and_keeps_the_repo():
+    # Arrange — THE ASYMMETRY THIS FIX TURNS ON. A 403 is GitHub declining to
+    # answer, not GitHub saying the repo is absent. Treating it as absence
+    # would drop the whole poll set during exactly the rate-limit incident
+    # this change exists to relieve — and it would do so silently.
+    with _seamed_probe(
+        stdout="",
+        returncode=1,
+        stderr="HTTP 403: API rate limit exceeded for user ID 1234 (https://api.github.com/...)",
+    ) as mod:
+        # Act
+        out = mod._canonical_name_with_owner("an-org/a-repo")
+    # Assert
+    assert out == "an-org/a-repo"
+
+
+def test_tracked_repos_drops_a_repo_github_says_does_not_exist(tmp_path: Path):
+    # Arrange — the end-to-end consequence: an absent name must not reach the
+    # poll set, because the loop spends a REST call on every member of it.
+    agents = tmp_path / "agents"
+    _write_spec(agents, "proj-real", "real-repo")
+    _write_spec(agents, "proj-ghost", "ghost-repo")
+    # Act
+    repos = tracked_repos(
+        agents_dir=agents,
+        org="an-org",
+        canonicalize=lambda repo: None if "ghost" in repo else repo,
+    )
+    # Assert
+    assert repos == ["an-org/real-repo"]
 
 
 def test_canonical_lookup_is_cached_so_a_tick_costs_one_call_per_repo():
     # Arrange — without a cache the poll loop spends one gh call per repo
     # per tick, forever.
-    from scitex_agent_container._lifecycle import _ci_owner as mod
-    import scitex_agent_container._lifecycle._github_ci as ghmod
-
-    mod._CANONICAL_CACHE.clear()
     calls: list = []
-    real = ghmod._run_gh
-    ghmod._run_gh = lambda args: calls.append(args) or "an-org/canonical"
-    try:
+    with _seamed_probe(stdout="an-org/canonical", calls=calls) as mod:
         # Act
         mod._canonical_name_with_owner("an-org/a-repo")
         mod._canonical_name_with_owner("an-org/a-repo")
-    finally:
-        ghmod._run_gh = real
-        mod._CANONICAL_CACHE.clear()
+    # Assert
+    assert len(calls) == 1
+
+
+def test_an_absent_verdict_is_cached_too():
+    # Arrange — None is now a MEANINGFUL cached value. If the cache treated it
+    # as "not cached", every absent repo would be re-probed every tick and the
+    # saving this change exists for would be exactly zero.
+    calls: list = []
+    with _seamed_probe(
+        stdout="", returncode=1, stderr="Could not resolve to a Repository", calls=calls
+    ) as mod:
+        # Act
+        mod._canonical_name_with_owner("an-org/nope")
+        mod._canonical_name_with_owner("an-org/nope")
     # Assert
     assert len(calls) == 1

--- a/tests/scitex_agent_container/_lifecycle/test__github_ci.py
+++ b/tests/scitex_agent_container/_lifecycle/test__github_ci.py
@@ -22,44 +22,81 @@ from scitex_agent_container._lifecycle._github_ci import (
 )
 
 
+
+
+def _rest(check_runs=None, statuses=None, sha="deadbeef"):
+    """A ``run`` double speaking the REST shapes ``pr_ci_conclusion`` now reads.
+
+    The function used to make ONE call (`gh pr checks --json bucket`) and the
+    tests could answer with a single string. It now makes up to three REST
+    calls — head sha, check-runs, commit statuses — because `gh pr checks`
+    merged check-runs AND commit statuses and dropping the second would have
+    made a green verdict green by stopping looking (measured 2026-08-19:
+    scitex-dev had check_runs=16 statuses=1 on a live PR).
+
+    So the double DISPATCHES ON THE URL rather than returning one blob. Each
+    test below still asserts exactly the property it asserted before; only
+    the wire shape moved.
+    """
+    import json as _json
+
+    def run(args):
+        url = args[1] if len(args) > 1 else ""
+        if "/check-runs" in url:
+            return _json.dumps({"check_runs": check_runs or []})
+        if url.endswith("/status"):
+            return _json.dumps({"statuses": statuses or []})
+        return sha
+
+    return run
+
+
+def _completed(conclusion):
+    return {"status": "completed", "conclusion": conclusion}
+
+
 def test_all_pass_buckets_yield_success_conclusion():
-    # Arrange
-    out = json.dumps([{"bucket": "pass"}, {"bucket": "skipping"}])
+    # Arrange — every check completed green or skipped.
+    run = _rest(check_runs=[_completed("success"), _completed("skipped")])
     # Act
-    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
     # Assert
     assert conclusion == "success"
 
 
 def test_any_fail_bucket_yields_failure_conclusion():
-    # Arrange
-    out = json.dumps([{"bucket": "pass"}, {"bucket": "fail"}])
+    # Arrange — one red among greens must dominate.
+    run = _rest(check_runs=[_completed("success"), _completed("failure")])
     # Act
-    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
     # Assert
     assert conclusion == "failure"
 
 
 def test_cancel_bucket_yields_failure_conclusion():
-    # Arrange
-    out = json.dumps([{"bucket": "pass"}, {"bucket": "cancel"}])
+    # Arrange — a cancelled run is NOT a pass; it is unfinished work whose
+    # verdict nobody has. It counted as failure before and must still.
+    run = _rest(check_runs=[_completed("success"), _completed("cancelled")])
     # Act
-    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
     # Assert
     assert conclusion == "failure"
 
 
 def test_pending_without_fail_yields_pending_conclusion():
-    # Arrange
-    out = json.dumps([{"bucket": "pass"}, {"bucket": "pending"}])
+    # Arrange — an in-flight run (status != completed) with no red.
+    run = _rest(
+        check_runs=[_completed("success"), {"status": "in_progress"}]
+    )
     # Act
-    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
     # Assert
     assert conclusion == "pending"
 
 
 def test_empty_checks_list_yields_none_conclusion():
-    # Arrange
+    # Arrange — no check-runs AND no statuses: nothing to report, and the
+    # poller must deliver nothing rather than invent a verdict.
     out = json.dumps([])
     # Act
     conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
@@ -177,3 +214,62 @@ def test_failing_check_names_dedupes_and_sorts():
     names = failing_check_names("o/r", 1, run=lambda args: payload)
     # Assert
     assert names == ["alpha", "zeta"]
+
+def test_a_commit_status_is_not_dropped():
+    """`gh pr checks` merged check-runs AND commit statuses; REST does not.
+
+    Substituting only /check-runs would silently ignore external CI that
+    reports through the older Status API — a green verdict produced by
+    looking at less. scitex-dev had exactly one such status on a live PR
+    when this was measured, so it is not hypothetical.
+    """
+    # Arrange — all check-runs green, one commit status red.
+    run = _rest(
+        check_runs=[_completed("success")],
+        statuses=[{"state": "failure"}],
+    )
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
+    # Assert
+    assert conclusion == "failure"
+
+
+def test_an_unknown_conclusion_is_pending_not_success():
+    """A conclusion GitHub adds later must never read as green.
+
+    The mapping is explicit and closed; anything outside it falls to
+    pending. Defaulting the other way would make a future GitHub release
+    turn unknown states into passes, silently, everywhere.
+    """
+    # Arrange
+    run = _rest(check_runs=[_completed("some_new_state_github_added")])
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=run)
+    # Assert
+    assert conclusion == "pending"
+
+
+def test_the_caller_can_supply_the_head_sha_and_save_a_call():
+    """The poll loop already has the sha from `list_open_prs`.
+
+    Passing it removes one REST call per PR per tick — the whole point of
+    this change being about call VOLUME, not just which pool it spends.
+    """
+    # Arrange
+    seen: list = []
+
+    def run(args):
+        seen.append(args[1] if len(args) > 1 else "")
+        if "/check-runs" in (args[1] if len(args) > 1 else ""):
+            return json.dumps({"check_runs": [_completed("success")]})
+        return json.dumps({"statuses": []})
+
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, head_sha="cafe1234", run=run)
+    # Assert
+    assert conclusion == "success" and not any(
+        u.endswith("/pulls/1") for u in seen
+    )
+
+
+# EOF

--- a/tests/scitex_agent_container/_lifecycle/test__github_ci_poll_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__github_ci_poll_loop.py
@@ -28,7 +28,7 @@ async def test_loop_disabled_when_gh_not_ready_delivers_nothing():
         ready_check=lambda: False,
         repos_source=lambda: ["o/r"],
         list_prs=lambda repo: [{"number": 1, "head_sha": "s", "body": ""}],
-        conclusion_for=lambda repo, pr: "success",
+        conclusion_for=lambda repo, pr, *, head_sha="": "success",
         deliver=lambda *a, **k: calls.append(a),
     )
     # Assert
@@ -50,7 +50,7 @@ async def test_loop_disabled_via_env_var_delivers_nothing():
             ready_check=lambda: True,
             repos_source=lambda: ["o/r"],
             list_prs=lambda repo: [{"number": 1, "head_sha": "s", "body": ""}],
-            conclusion_for=lambda repo, pr: "success",
+            conclusion_for=lambda repo, pr, *, head_sha="": "success",
             deliver=lambda *a, **k: calls.append(a),
         )
     finally:
@@ -72,7 +72,7 @@ async def test_loop_delivers_open_pr_verdict_in_one_tick():
             ready_check=lambda: True,
             repos_source=lambda: ["o/r"],
             list_prs=lambda repo: [{"number": 7, "head_sha": "abc", "body": ""}],
-            conclusion_for=lambda repo, pr: "success",
+            conclusion_for=lambda repo, pr, *, head_sha="": "success",
             deliver=lambda repo, pr, head_sha, conclusion, **k: calls.append(
                 (repo, pr, head_sha, conclusion)
             ),
@@ -101,7 +101,7 @@ async def test_loop_survives_a_tick_exception_then_cancels_cleanly():
             ready_check=lambda: True,
             repos_source=lambda: ["o/r"],
             list_prs=boom,
-            conclusion_for=lambda repo, pr: "success",
+            conclusion_for=lambda repo, pr, *, head_sha="": "success",
             deliver=lambda *a, **k: None,
         )
     )
@@ -123,7 +123,7 @@ async def test_loop_honours_cancellation_cleanly():
             ready_check=lambda: True,
             repos_source=lambda: [],
             list_prs=lambda repo: [],
-            conclusion_for=lambda repo, pr: "none",
+            conclusion_for=lambda repo, pr, *, head_sha="": "none",
             deliver=lambda *a, **k: None,
         )
     )
@@ -133,6 +133,52 @@ async def test_loop_honours_cancellation_cleanly():
     # Assert — the finally must re-raise CancelledError, not swallow it.
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+# --- the tick must not re-fetch a sha it is already holding ------------
+# ``list_open_prs`` returns head_sha, and ``pr_ci_conclusion`` falls back to
+# its own `gh api repos/<r>/pulls/<n>` REST call when head_sha is empty. So
+# omitting it costs one extra REST call PER PR PER TICK for a value already
+# in local memory — measured 2026-08-20 as ~1,560 wasted calls/hour against
+# a 5,000/hour budget, on a pool that was fully exhausted at the time.
+#
+# WHY THIS ASSERTS THE SHA AND NOT "the call happened". A test that merely
+# accepted a `head_sha` keyword would pass against a loop that forwards the
+# empty string — which is precisely the bug, since empty is what triggers
+# the fallback fetch. The captured VALUE is the only thing that separates
+# "wired" from "wired to nothing".
+
+
+@pytest.mark.asyncio
+async def test_tick_forwards_the_head_sha_it_already_has_to_the_conclusion_call():
+    # Arrange — capture what the loop hands the conclusion seam.
+    seen: list = []
+
+    def conclusion_for(repo, pr, *, head_sha=""):
+        seen.append(head_sha)
+        return "success"
+
+    task = asyncio.create_task(
+        github_ci_poll_loop(
+            poll_interval_s=0.05,
+            ready_check=lambda: True,
+            repos_source=lambda: ["o/r"],
+            list_prs=lambda repo: [
+                {"number": 7, "head_sha": "deadbeef", "body": ""}
+            ],
+            conclusion_for=conclusion_for,
+            deliver=lambda *a, **k: None,
+        )
+    )
+    # Act
+    await asyncio.sleep(0.08)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    # Assert — the sha from list_prs, not "" (which would re-fetch it).
+    assert "deadbeef" in seen
 
 
 # --- the post budget must fit inside the tick that starts it -----------

--- a/tests/scitex_agent_container/_lifecycle/test__instances_birth.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_birth.py
@@ -4,8 +4,14 @@ The launch path is the ONE place the compiled config and the freshly
 minted incarnation id are both in hand; the certificate must land there
 as an intrinsic side-effect, keyed by the same id the ``instances`` row,
 the beats and the ExitRecord carry. Same no-mocks arrangement as
-``test__instances.py`` — a real on-disk state.db via explicit
-``db_path`` and the honest runtime stub.
+``test__instances.py`` — the honest runtime stub, a real on-disk state.db
+via explicit ``db_path`` for the ``instances`` row, and a REAL PostgreSQL
+via ``pg_schema`` for the certificate.
+
+The two databases in one test are the migration in miniature: the
+``instances`` row is still SQLite, the birth certificate moved to per-host
+PostgreSQL on 2026-08-19, and this file asserts they still agree on the
+incarnation id that joins them.
 """
 
 from __future__ import annotations
@@ -29,39 +35,39 @@ class _RuntimeStub:
         return self._root / config.name
 
 
-def test_local_start_records_a_birth_certificate(tmp_path: Path) -> None:
+def test_local_start_records_a_birth_certificate(pg_schema: str, tmp_path: Path) -> None:
     # Arrange
     db = tmp_path / "state.db"
     cfg = AgentConfig(name="born-1", runtime="apptainer")
     # Act
     incarnation = record_local_instance(cfg, _RuntimeStub(tmp_path), db_path=db)
     # Assert: the row exists under the SAME id the instances row minted.
-    assert get_incarnation(incarnation, db_path=db) is not None
+    assert get_incarnation(incarnation) is not None
 
 
-def test_birth_certificate_names_the_agent(tmp_path: Path) -> None:
+def test_birth_certificate_names_the_agent(pg_schema: str, tmp_path: Path) -> None:
     # Arrange
     db = tmp_path / "state.db"
     cfg = AgentConfig(name="born-2", runtime="apptainer")
     # Act
     incarnation = record_local_instance(cfg, _RuntimeStub(tmp_path), db_path=db)
     # Assert
-    assert get_incarnation(incarnation, db_path=db)["agent_id"] == "born-2"
+    assert get_incarnation(incarnation)["agent_id"] == "born-2"
 
 
-def test_birth_certificate_carries_the_compiled_spec(tmp_path: Path) -> None:
+def test_birth_certificate_carries_the_compiled_spec(pg_schema: str, tmp_path: Path) -> None:
     # Arrange: a resolved value that only exists post-compile (the model
     # default) must be readable straight off the record.
     db = tmp_path / "state.db"
     cfg = AgentConfig(name="born-3", runtime="apptainer")
     # Act
     incarnation = record_local_instance(cfg, _RuntimeStub(tmp_path), db_path=db)
-    stored = json.loads(get_incarnation(incarnation, db_path=db)["compiled_spec_json"])
+    stored = json.loads(get_incarnation(incarnation)["compiled_spec_json"])
     # Assert
     assert stored["model"] == cfg.model
 
 
-def test_birth_certificate_redacts_env_secrets(tmp_path: Path) -> None:
+def test_birth_certificate_redacts_env_secrets(pg_schema: str, tmp_path: Path) -> None:
     # Arrange
     db = tmp_path / "state.db"
     cfg = AgentConfig(
@@ -69,6 +75,6 @@ def test_birth_certificate_redacts_env_secrets(tmp_path: Path) -> None:
     )
     # Act
     incarnation = record_local_instance(cfg, _RuntimeStub(tmp_path), db_path=db)
-    stored = json.loads(get_incarnation(incarnation, db_path=db)["compiled_spec_json"])
+    stored = json.loads(get_incarnation(incarnation)["compiled_spec_json"])
     # Assert: slot name kept, value never recorded.
     assert stored["env"]["MY_API_KEY"] == "<redacted:MY_API_KEY>"

--- a/tests/scitex_agent_container/_lifecycle/test__launch_verify.py
+++ b/tests/scitex_agent_container/_lifecycle/test__launch_verify.py
@@ -316,3 +316,168 @@ def test_malformed_env_window_fails_loud(clean_window_env) -> None:
     # Assert
     with raiser:
         resolve_verify_window()
+
+
+# ---------------------------------------------------------------------------
+# apptainer FATAL must not be swallowed (operator instruction, 2026-08-20)
+# ---------------------------------------------------------------------------
+
+_APPTAINER_FATAL = (
+    "INFO:    Converting SIF file to temporary sandbox...\n"
+    "FATAL:   container creation failed: mount hook function failure: "
+    "mount /home/ywatanabe/absent -> /absent error: "
+    "while mounting /home/ywatanabe/absent: stat /home/ywatanabe/absent: "
+    "no such file or directory\n"
+)
+
+
+def _write_boot_log(state_dir: Path, text: str, *, mtime: float | None = None) -> Path:
+    """A real boot.stderr.log, optionally back-dated to a prior launch."""
+    path = state_dir / "boot.stderr.log"
+    path.write_text(text, encoding="utf-8")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_apptainer_fatal_outranks_a_fresh_heartbeat(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """THE DEFECT THIS FIXES, in one test.
+
+    Both signals are present: a beat stamped after launch AND a FATAL
+    saying the container was never created. Before 2026-08-20 the beat
+    won and `sac agents start` printed SUCC over a dead launch. A FATAL
+    is positive evidence of failure; a beat is not proof of success —
+    fleet-wide, all but one of ~118 beats were written by an OBSERVER,
+    not by the runner.
+    """
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    _write_boot_log(tmp_path, _APPTAINER_FATAL)
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == VERIFIED_FAILED
+
+
+def test_apptainer_fatal_verdict_is_not_ok(clean_window_env, tmp_path: Path) -> None:
+    """It must flip the caller exit code, which is what "fail loudly" means."""
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    _write_boot_log(tmp_path, _APPTAINER_FATAL)
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.ok is False
+
+
+def test_apptainer_fatal_evidence_quotes_the_fatal_line(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """The operator gets the CAUSE, not just a verdict word."""
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    _write_boot_log(tmp_path, _APPTAINER_FATAL)
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert "mount hook function failure" in verdict.evidence
+
+
+def test_apptainer_fatal_names_the_log_it_was_read_from(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """Naming the FILE is what lets someone go deeper than the tail."""
+    # Arrange
+    launched_at = time.time()
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    log = _write_boot_log(tmp_path, _APPTAINER_FATAL)
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.log_path == str(log)
+
+
+def test_a_stale_fatal_from_a_previous_launch_is_ignored(
+    clean_window_env, tmp_path: Path
+) -> None:
+    """THE GUARD THAT KEEPS THIS FIX FROM BECOMING WORSE THAN THE DEFECT.
+
+    boot.stderr.log is not truncated per launch, so a FATAL from a start
+    that failed yesterday is still on disk today. Without the mtime
+    check, every subsequent start of that agent would fail forever —
+    converting silent success into permanent silent failure. Only a log
+    modified at or after ``launched_at`` testifies about THIS launch.
+    """
+    # Arrange
+    launched_at = time.time()
+    _write_boot_log(tmp_path, _APPTAINER_FATAL, mtime=launched_at - 3600.0)
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == VERIFIED_UP
+
+
+def test_a_clean_boot_log_still_verifies_up(clean_window_env, tmp_path: Path) -> None:
+    """POSITIVE CONTROL — the check must not fail launches that are fine.
+
+    Without this, a function that returned FATAL for every boot log would
+    satisfy every test above and break every start in the fleet. Measured
+    2026-08-20 before shipping: 50 boot logs across four hosts, ZERO
+    containing a FATAL, so this is the arm that carries the whole fleet.
+    """
+    # Arrange
+    launched_at = time.time()
+    _write_boot_log(tmp_path, "INFO:    Converting SIF file to temporary sandbox...\n")
+    write_heartbeat(tmp_path, pid=4242, state="ready")
+    # Act
+    verdict = verify_launch(
+        _config(),
+        _AliveRuntime(),
+        launched_at=launched_at,
+        window_s=2.0,
+        poll_interval_s=0.05,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert verdict.status == VERIFIED_UP

--- a/tests/scitex_agent_container/_lifecycle/test__launch_verify_probe_unknown.py
+++ b/tests/scitex_agent_container/_lifecycle/test__launch_verify_probe_unknown.py
@@ -1,0 +1,197 @@
+"""A liveness probe that could not RUN must not report the pane as alive.
+
+`_verify_tui` asked `_runtime_reports_running`, which returned True BOTH when
+the runtime reported alive and when the probe raised — then returned
+VERIFIED_UP with the words "the tmux pane process is alive". So whenever the
+probe raised, sac asserted an observation that never happened, on the path 109
+of 122 fleet specs take (measured 2026-08-20: tui 109, claude-agent-sdk 11,
+apptainer 2). The success value doubled as the didn't-check value.
+
+The boolean could not express the difference: refusing to convict on a raising
+probe (correct, and what the DEAD arm needs) and refusing to acquit on one
+(also correct, and what this arm needs) are opposite requirements on one value.
+Hence three values.
+
+The controls carry the weight: a fix that returned UNVERIFIED for everything
+would satisfy the defect test and break every start in the fleet.
+
+Separate file — `test__launch_verify.py` is 483 lines against a 512 cap.
+PA-306: no mocks; hand-written runtime doubles matching the seam shape the
+existing suite already uses.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._launch_verify import (
+    PROBE_DEAD,
+    PROBE_RUNNING,
+    PROBE_UNKNOWN,
+    UNVERIFIED,
+    VERIFIED_FAILED,
+    VERIFIED_UP,
+    _runtime_liveness,
+    _runtime_reports_running,
+    _verify_tui,
+)
+
+
+class _AliveRuntime:
+    def is_running(self, config) -> bool:  # noqa: ARG002 - runtime seam shape
+        return True
+
+
+class _DeadRuntime:
+    def is_running(self, config) -> bool:  # noqa: ARG002 - runtime seam shape
+        return False
+
+
+class _RaisingRuntime:
+    """A probe that cannot RUN — neither alive nor dead is observed."""
+
+    def is_running(self, config):  # noqa: ARG002 - runtime seam shape
+        raise OSError("tmux server not reachable")
+
+
+def _config(name: str = "probe-x") -> SimpleNamespace:
+    return SimpleNamespace(name=name)
+
+
+@pytest.fixture
+def clean_window() -> Iterator[None]:
+    """Unset the real env var and restore it — no fixture rewrites internals."""
+    # Arrange
+    key = "SAC_VERIFY_WINDOW_S"
+    saved = os.environ.pop(key, None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ[key] = saved
+
+
+def _verdict(runtime, tmp_path: Path):
+    """Exercise `_verify_tui` DIRECTLY — the function that changed.
+
+    Going through `verify_launch` would not reach it: dispatch is
+    `isinstance(runtime, TuiSessionRuntime)`, so a hand-written double
+    falls to the generic heartbeat path instead. That path ALSO returns
+    UNVERIFIED when no beat arrives, which would have made these tests
+    pass without touching the code under test — green for a reason
+    unrelated to the fix. Calling the function directly is what makes
+    the assertions mean what they say.
+    """
+    return _verify_tui(
+        _config(),
+        runtime,
+        tmp_path,
+        time.time(),
+        time.time,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The tri-state itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_raising_probe_reads_unknown(clean_window) -> None:
+    # Arrange
+    runtime = _RaisingRuntime()
+    # Act
+    reading = _runtime_liveness(runtime, _config())
+    # Assert
+    assert reading == PROBE_UNKNOWN
+
+
+def test_a_live_probe_reads_running(clean_window) -> None:
+    # Arrange
+    runtime = _AliveRuntime()
+    # Act
+    reading = _runtime_liveness(runtime, _config())
+    # Assert
+    assert reading == PROBE_RUNNING
+
+
+def test_a_false_probe_reads_dead(clean_window) -> None:
+    # Arrange
+    runtime = _DeadRuntime()
+    # Act
+    reading = _runtime_liveness(runtime, _config())
+    # Assert
+    assert reading == PROBE_DEAD
+
+
+# ---------------------------------------------------------------------------
+# The defect: an unobserved pane was reported alive
+# ---------------------------------------------------------------------------
+
+
+def test_a_raising_probe_does_not_report_the_pane_alive(
+    clean_window, tmp_path: Path
+) -> None:
+    # Arrange
+    runtime = _RaisingRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert — returned VERIFIED_UP before the fix
+    assert verdict.status != VERIFIED_UP, verdict.evidence
+
+
+def test_a_raising_probe_says_it_cannot_verify(clean_window, tmp_path: Path) -> None:
+    # Arrange
+    runtime = _RaisingRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert
+    assert verdict.status == UNVERIFIED, verdict.evidence
+
+
+def test_a_raising_probe_is_not_reported_as_death_either(
+    clean_window, tmp_path: Path
+) -> None:
+    # Arrange — the false-RED lesson: unknown must not convict
+    runtime = _RaisingRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert
+    assert verdict.status != VERIFIED_FAILED, verdict.evidence
+
+
+# ---------------------------------------------------------------------------
+# Controls — the fleet must keep starting
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_runtime_still_verifies_up(clean_window, tmp_path: Path) -> None:
+    # Arrange — the arm that carries every healthy start
+    runtime = _AliveRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert
+    assert verdict.status == VERIFIED_UP, verdict.evidence
+
+
+def test_a_dead_runtime_still_verifies_failed(clean_window, tmp_path: Path) -> None:
+    # Arrange — the arm that catches a stillborn container
+    runtime = _DeadRuntime()
+    # Act
+    verdict = _verdict(runtime, tmp_path)
+    # Assert
+    assert verdict.status == VERIFIED_FAILED, verdict.evidence
+
+
+def test_the_boolean_shim_still_declines_to_convict_on_unknown(clean_window) -> None:
+    # Arrange — the DEAD arm reads this and must behave exactly as before
+    runtime = _RaisingRuntime()
+    # Act
+    reports_running = _runtime_reports_running(runtime, _config())
+    # Assert — only a definite DEAD is falsey
+    assert reports_running is True

--- a/tests/scitex_agent_container/_lifecycle/test__rename_spec.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_spec.py
@@ -105,6 +105,39 @@ def test_sub_env_value_rewrites_the_board_identity():
     assert result == NEW
 
 
+def test_sub_env_value_rewrites_the_CURRENT_board_identity():
+    """The spelling 108 specs already use, and it was not in ENV_RULES.
+
+    Measured 2026-08-19 on compute-04: 108 specs declare
+    ``SCITEX_CARDS_AGENT_ID`` and 193 still declare the old
+    ``SCITEX_TODO_AGENT_ID``. Only the old key was listed, so renaming any of
+    those 108 agents left the board identity pointing at the agent's FORMER
+    name, and every card it then wrote was attributed to an agent that no
+    longer exists -- the damage this module's own docstring warns about.
+    """
+    # Arrange
+    key = "SCITEX_CARDS_AGENT_ID"
+    # Act
+    result = sub_env_value(key, OLD, OLD, NEW)
+    # Assert
+    assert result == NEW
+
+
+def test_sub_env_value_still_rewrites_the_legacy_board_identity():
+    """Both spellings, on purpose, while both populations exist.
+
+    Not a compatibility fallback to be tidied away: the rename tool has to
+    recognise what is ACTUALLY IN THE SPECS. Dropping this one early breaks
+    renames for the 193 specs that still carry it.
+    """
+    # Arrange
+    key = "SCITEX_TODO_AGENT_ID"
+    # Act
+    result = sub_env_value(key, OLD, OLD, NEW)
+    # Assert
+    assert result == NEW
+
+
 def test_sub_env_value_rewrites_the_state_db_path_component():
     # Arrange
     key = "SCITEX_AGENT_CONTAINER_STATE_DB"

--- a/tests/scitex_agent_container/_lifecycle/test__start_failure_fresh_hint.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_failure_fresh_hint.py
@@ -1,0 +1,201 @@
+"""A failed start must name the ONE-SHOT ``--fresh`` escape hatch — and only there.
+
+WHY THIS FILE EXISTS (operator, 2026-08-18). 「フレッシュは基本的に使いません、
+最初の起動に必要な時だけで、スタートした時に失敗したら --fresh を今回だけは
+つけろ的なヒントをだしてください、スペックは全てレジュームで」 — every spec
+resumes; a start failure is the one moment where a single fresh retry is the
+right move. The failure report is where the operator is actually standing when
+that moment arrives, so that is where the hint has to be.
+
+THE TWO WAYS THIS GOES WRONG, and both are covered below:
+
+  * MISSING — the report says the start failed and nothing about recovering.
+    The operator's own instruction, unimplemented.
+  * OVER-EAGER — the report names ``--fresh`` on a start that was ALREADY
+    fresh. A fresh start cannot be wedged on a resumed session, so that is an
+    error asserting a cause it never observed — the exact disease the sibling
+    file next door documents. The negative test is paired with a positive
+    control on the same message, so a blank or truncated report cannot pass it
+    by accident.
+
+  * And a third, quieter one: the hint reaching only the terminal. A
+    false-negative start leaves no registry row, so whoever reads
+    ``start_failure_diag.log`` tomorrow is often the only reader there is.
+
+NO MOCKS (repo doctrine): the configs below are real objects driven through the
+production entry point, and the exploding-config case is a real object whose
+attribute access genuinely raises.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._lifecycle._start_failure_diag import (
+    fresh_retry_hint,
+    raise_start_failure,
+)
+
+
+class _Claude:
+    """The resolved ``spec.claude`` slice the hint reads."""
+
+    def __init__(self, session: str) -> None:
+        self.session = session
+
+
+class _Cfg:
+    """A real minimal config carrying a resolved session mode."""
+
+    def __init__(self, name: str, session: str, runtime: str = "apptainer") -> None:
+        self.name = name
+        self.runtime = runtime
+        self.claude = _Claude(session)
+
+
+class _ExplodingCfg:
+    """A config whose ``claude`` access genuinely raises.
+
+    Not a hypothetical: ``raise_start_failure`` runs on whatever the caller was
+    holding when the start blew up, and a diagnostic that raises over the
+    failure it is describing destroys the report.
+    """
+
+    name = "exploding"
+
+    @property
+    def claude(self) -> Any:
+        raise RuntimeError("resolved config was never populated")
+
+
+def _unique(session: str) -> _Cfg:
+    """An agent NOBODY else has started — its state dir cannot pre-exist.
+
+    Same reason as the sibling file: sharing a name silently borrows another
+    test's directory and makes these assertions depend on the schedule.
+    """
+    return _Cfg(name=f"freshhint-{uuid.uuid4().hex[:12]}", session=session)
+
+
+def _diag_log(config: _Cfg) -> Path:
+    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
+
+    return state_dir_for_config(config) / "start_failure_diag.log"
+
+
+def _message(config: Any) -> str:
+    """Drive the real failure path and return the operator-visible message."""
+    with pytest.raises(RuntimeError) as excinfo:
+        raise_start_failure(config)
+    return str(excinfo.value)
+
+
+def test_a_resuming_start_is_told_to_retry_with_fresh():
+    """THE OPERATOR'S ASK. A resuming start that failed must name the escape hatch."""
+    # Arrange
+    config = _unique("continue")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "--fresh" in message
+
+
+def test_the_hint_names_the_agent_so_the_command_is_runnable():
+    """A hint the operator has to assemble by hand is a hint they will mistype."""
+    # Arrange
+    config = _unique("continue")
+    # Act
+    message = _message(config)
+    # Assert
+    assert f"sac agents start {config.name} --fresh" in message
+
+
+def test_the_hint_bounds_itself_to_one_retry():
+    """``--fresh`` is a per-start override; making it the habit erases memory.
+
+    The whole point of the operator's wording is the boundary — 「今回だけは」.
+    An unqualified "try --fresh" is how a one-shot recovery becomes a spec edit.
+    """
+    # Arrange
+    config = _unique("continue")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "ONCE" in message
+
+
+def test_the_hint_says_the_spec_stays_on_resume():
+    """State the invariant positively, so the reader knows what NOT to change."""
+    # Arrange
+    config = _unique("continue")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "spec stays on resume" in message
+
+
+def test_an_already_fresh_start_still_reports_the_real_cause():
+    """POSITIVE CONTROL for the negative test below.
+
+    Without this, an empty or truncated message would satisfy "does not mention
+    --fresh" while proving nothing at all.
+    """
+    # Arrange
+    config = _unique("fresh")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "runtime.start() returned False" in message
+
+
+def test_an_already_fresh_start_is_not_told_to_retry_with_fresh():
+    """A fresh start cannot be wedged on a resumed session.
+
+    Naming ``--fresh`` here would be the report asserting a cause it never
+    observed. Paired with the positive control directly above.
+    """
+    # Arrange
+    config = _unique("fresh")
+    # Act
+    message = _message(config)
+    # Assert
+    assert "--fresh" not in message
+
+
+def test_the_hint_reaches_the_persisted_record_too():
+    """A remedy only the live terminal saw is lost to tomorrow's reader.
+
+    The start that failed left no registry row; this log is often all there is.
+    """
+    # Arrange
+    config = _unique("continue")
+    log = _diag_log(config)
+    # Act
+    _message(config)
+    # Assert
+    assert "--fresh" in log.read_text()
+
+
+def test_the_hint_never_raises_over_the_failure_it_describes():
+    """A diagnostic that explodes destroys the report it exists to produce."""
+    # Arrange
+    config = _ExplodingCfg()
+    # Act
+    hint = fresh_retry_hint(config)
+    # Assert
+    assert isinstance(hint, str)
+
+
+def test_an_unreadable_session_mode_still_offers_the_recovery():
+    """Fail toward HELPING. Printing the hint needlessly costs a line;
+    withholding it costs the operator the recovery."""
+    # Arrange
+    config = _ExplodingCfg()
+    # Act
+    hint = fresh_retry_hint(config)
+    # Assert
+    assert "--fresh" in hint

--- a/tests/scitex_agent_container/_lifecycle/test__start_retracts_marker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_retracts_marker.py
@@ -106,6 +106,49 @@ class FakeRuntime:
         return ""
 
 
+class FakeThread:
+    """Hand-rolled stand-in for ``threading.Thread`` that NEVER runs.
+
+    ``_write_spec`` enables ``health``, so ``agent_start`` reaches
+    ``_start_supervision``, which does::
+
+        thread = thread_factory(target=health_monitor, ..., daemon=True)
+        thread.start()
+
+    With the real ``threading.Thread`` that daemon thread OUTLIVES the test
+    and keeps looping ``health_monitor -> restart_and_record ->
+    write_birth_certificate`` for the rest of the worker process. Its
+    ``logger.error`` then lands in whatever capture buffer happens to be open
+    -- an unrelated test's ``CliRunner`` -- ahead of that command's own
+    output, which is how a PASSING test here turns a stranger's assertion red
+    three files later. Measured on develop 2026-08-21: 31 stray certificates
+    in one run, plus ``ValueError: I/O operation on closed file`` from writing
+    into a stream pytest had already torn down.
+
+    Recording ``start()`` rather than swallowing it keeps the seam honest: a
+    test that wants to assert the monitor was launched still can. Same shape
+    as ``_RecordingThread`` in ``test__start_supervision.py`` and
+    ``_CapturingThread`` in ``test__instances_auto_grant.py``.
+
+    PA-306: a hand-written stand-in, not a mock.
+    """
+
+    def __init__(self, *, target=None, args=(), daemon=False, **_kw) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self, timeout=None) -> None:
+        return None
+
+    def is_alive(self) -> bool:
+        return False
+
+
 class FakeHandover:
     def ensure_instance_uuid(self, config: AgentConfig) -> str:
         return "fake-uuid"
@@ -150,6 +193,7 @@ def test_the_already_running_noop_returns_the_already_running_outcome(
     # Act
     ok = agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -171,6 +215,7 @@ def test_the_already_running_noop_retracts_an_existing_marker(
     # Act
     agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -192,6 +237,7 @@ def test_the_already_running_noop_leaves_the_retracted_copy(
     # Act
     agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -213,6 +259,7 @@ def test_the_already_running_noop_with_no_marker_does_not_raise(
     # Act
     ok = agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -244,6 +291,7 @@ def test_a_launch_that_merely_returned_keeps_the_marker(
     # Act
     agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -271,6 +319,7 @@ def test_a_dry_run_on_an_alive_agent_keeps_the_marker(
     # Act
     agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -299,6 +348,7 @@ def test_a_failed_start_keeps_the_marker(
     try:
         agent_start(
             str(spec),
+            thread_factory=FakeThread,
             registry=registry,
             runtime_factory=lambda _c: runtime,
             handover_mod=FakeHandover(),

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -82,7 +82,7 @@ def test_acl_allows_self_send(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_acl_allows_intra_group_parent_to_child(db_path: Path) -> None:
+def test_acl_allows_intra_group_parent_to_child(db_path: Path, pg_schema: str) -> None:
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     # Act
@@ -96,7 +96,7 @@ def test_acl_allows_intra_group_parent_to_child(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_acl_allows_intra_group_sibling_to_sibling(db_path: Path) -> None:
+def test_acl_allows_intra_group_sibling_to_sibling(db_path: Path, pg_schema: str) -> None:
     """Handoff §4: 'parent↔child *and* sibling↔sibling, bidirectional'."""
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
@@ -112,7 +112,7 @@ def test_acl_allows_intra_group_sibling_to_sibling(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_acl_allows_cross_group_by_default(db_path: Path) -> None:
+def test_acl_allows_cross_group_by_default(db_path: Path, pg_schema: str) -> None:
     """Messaging default-allow (operator 2026-07-03): two unrelated
     lineage families, no grant → ALLOW."""
     # Arrange — two unrelated families
@@ -129,13 +129,13 @@ def test_acl_allows_cross_group_by_default(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_acl_blocked_sender_is_blocked(db_path: Path) -> None:
+def test_acl_blocked_sender_is_blocked(db_path: Path, pg_schema: str) -> None:
     """Override preserved: an explicit block still yields a "block"
     decision even under the cross-group default-allow."""
     # Arrange — two unrelated families + an explicit block
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
-    block_send(sender="child-1", target="child-2", db_path=db_path)
+    block_send(sender="child-1", target="child-2")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="child-1",
@@ -147,7 +147,7 @@ def test_acl_blocked_sender_is_blocked(db_path: Path) -> None:
     assert decision == "block"
 
 
-def test_acl_allows_cross_group_with_explicit_grant(db_path: Path) -> None:
+def test_acl_allows_cross_group_with_explicit_grant(db_path: Path, pg_schema: str) -> None:
     """Explicit cross-group grant flips a deny to allow."""
     # Arrange — two unrelated families + grant child-1 → child-2
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
@@ -197,7 +197,7 @@ def test_acl_spoof_deny_reason_names_both_identities(db_path: Path) -> None:
     assert reason is not None and "alice" in reason and "bob" in reason
 
 
-def test_acl_admin_caller_honors_claimed_from_agent(db_path: Path) -> None:
+def test_acl_admin_caller_honors_claimed_from_agent(db_path: Path, pg_schema: str) -> None:
     """Host-wide bearer + ``metadata.from_agent`` set → admin path
     (cross-host forwarder). The metadata claim is honoured verbatim.
     """
@@ -340,7 +340,7 @@ def _payload(sender: str, content: str = "x") -> dict:
 
 
 def test_http_node_message_send_allows_cross_group_by_default(
-    isolated_listen_env, db_path: Path
+    isolated_listen_env, db_path: Path, pg_schema: str
 ) -> None:
     """End-to-end: messaging default-allow — a cross-group sender (two
     unrelated lineage families) now lands (< 400)."""
@@ -360,7 +360,7 @@ def test_http_node_message_send_allows_cross_group_by_default(
 
 
 def test_http_node_message_send_403_body_carries_per_spec_reason(
-    isolated_listen_env, db_path: Path
+    isolated_listen_env, db_path: Path, pg_schema: str
 ) -> None:
     """A per-spec ``inbound.siblings=deny`` override still 403s and the
     body explains the denial (the deny path survives default-allow)."""
@@ -382,7 +382,7 @@ def test_http_node_message_send_403_body_carries_per_spec_reason(
 
 
 def test_http_node_message_send_allows_intra_group(
-    isolated_listen_env, db_path: Path
+    isolated_listen_env, db_path: Path, pg_schema: str
 ) -> None:
     """Intra-group send (sibling-to-sibling) lands."""
     # Arrange
@@ -401,7 +401,7 @@ def test_http_node_message_send_allows_intra_group(
 
 
 def test_http_node_message_send_allows_after_explicit_grant(
-    isolated_listen_env, db_path: Path
+    isolated_listen_env, db_path: Path, pg_schema: str
 ) -> None:
     """A cross-group grant flips the deny to an allow."""
     # Arrange
@@ -427,7 +427,7 @@ def test_http_node_message_send_allows_after_explicit_grant(
 
 
 def test_http_per_node_bearer_allows_matching_from_agent(
-    isolated_listen_env, db_path: Path
+    isolated_listen_env, db_path: Path, pg_schema: str
 ) -> None:
     """Per-node bearer for worker-a + ``metadata.from_agent=worker-a``
     + intra-group target → allow.
@@ -449,7 +449,7 @@ def test_http_per_node_bearer_allows_matching_from_agent(
 
 
 def test_http_per_node_bearer_denies_spoofed_from_agent_with_403(
-    isolated_listen_env, db_path: Path
+    isolated_listen_env, db_path: Path, pg_schema: str
 ) -> None:
     """Per-node bearer for worker-a + ``metadata.from_agent=worker-b``
     → 403 identity spoof (the acceptance criterion).
@@ -472,7 +472,7 @@ def test_http_per_node_bearer_denies_spoofed_from_agent_with_403(
 
 
 def test_http_per_node_bearer_403_body_explains_spoof(
-    isolated_listen_env, db_path: Path
+    isolated_listen_env, db_path: Path, pg_schema: str
 ) -> None:
     """The 403 body identifies the resolved name vs the claimed
     name so the operator can see which identity tried to spoof."""
@@ -568,7 +568,7 @@ def _denied_attempt_rows(target: str, db_path: Path) -> list[dict]:
 
 
 @pytest.fixture
-def cross_group_deny_scenario(isolated_listen_env, db_path: Path) -> dict:
+def cross_group_deny_scenario(isolated_listen_env, db_path: Path, pg_schema: str) -> dict:
     """A denied send via host bearer (admin caller path).
 
     Since messaging is now DEFAULT-ALLOW cross-group (operator
@@ -590,7 +590,7 @@ def cross_group_deny_scenario(isolated_listen_env, db_path: Path) -> dict:
     return {"resp": resp, "notifs": notifs, "db_path": db_path}
 
 
-def test_cross_group_deny_returns_403_to_sender(cross_group_deny_scenario) -> None:
+def test_cross_group_deny_returns_403_to_sender(cross_group_deny_scenario, pg_schema: str) -> None:
     # Arrange
     resp = cross_group_deny_scenario["resp"]
     # Act
@@ -600,7 +600,7 @@ def test_cross_group_deny_returns_403_to_sender(cross_group_deny_scenario) -> No
 
 
 def test_cross_group_deny_publishes_one_denied_attempt_to_target_inbox(
-    cross_group_deny_scenario,
+    cross_group_deny_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     notifs = cross_group_deny_scenario["notifs"]
@@ -611,7 +611,7 @@ def test_cross_group_deny_publishes_one_denied_attempt_to_target_inbox(
 
 
 def test_cross_group_deny_notification_identifies_the_sender(
-    cross_group_deny_scenario,
+    cross_group_deny_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     event = cross_group_deny_scenario["notifs"][0]["event"]
@@ -622,7 +622,7 @@ def test_cross_group_deny_notification_identifies_the_sender(
 
 
 def test_cross_group_deny_notification_identifies_the_receiver(
-    cross_group_deny_scenario,
+    cross_group_deny_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     event = cross_group_deny_scenario["notifs"][0]["event"]
@@ -633,7 +633,7 @@ def test_cross_group_deny_notification_identifies_the_receiver(
 
 
 def test_cross_group_deny_notification_carries_reason(
-    cross_group_deny_scenario,
+    cross_group_deny_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     event = cross_group_deny_scenario["notifs"][0]["event"]
@@ -644,7 +644,7 @@ def test_cross_group_deny_notification_carries_reason(
 
 
 def test_cross_group_deny_notification_carries_positive_timestamp(
-    cross_group_deny_scenario,
+    cross_group_deny_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     event = cross_group_deny_scenario["notifs"][0]["event"]
@@ -661,7 +661,7 @@ _SECRET = "PII / credentials / anything the sender shoved in here"
 
 
 @pytest.fixture
-def body_leak_scenario(isolated_listen_env, db_path: Path) -> dict:
+def body_leak_scenario(isolated_listen_env, db_path: Path, pg_schema: str) -> dict:
     """Denied send carrying a secret in its body — must not leak. Denial
     is triggered by a per-spec ``inbound.siblings=deny`` (the surviving
     deny path under messaging default-allow)."""
@@ -679,7 +679,7 @@ def body_leak_scenario(isolated_listen_env, db_path: Path) -> dict:
     return {"resp": resp, "notifs": notifs}
 
 
-def test_body_leak_scenario_denies_with_403(body_leak_scenario) -> None:
+def test_body_leak_scenario_denies_with_403(body_leak_scenario, pg_schema: str) -> None:
     # Arrange
     resp = body_leak_scenario["resp"]
     # Act
@@ -689,7 +689,7 @@ def test_body_leak_scenario_denies_with_403(body_leak_scenario) -> None:
 
 
 def test_body_leak_scenario_notification_content_is_empty(
-    body_leak_scenario,
+    body_leak_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     event = body_leak_scenario["notifs"][0]["event"]
@@ -700,7 +700,7 @@ def test_body_leak_scenario_notification_content_is_empty(
 
 
 def test_body_leak_scenario_secret_absent_from_serialized_notification(
-    body_leak_scenario,
+    body_leak_scenario, pg_schema: str,
 ) -> None:
     """Defence-in-depth: the entire stored frame (round-tripped JSON)
     must not contain the secret — guards against a future accidental
@@ -720,7 +720,7 @@ def test_body_leak_scenario_secret_absent_from_serialized_notification(
 
 
 @pytest.fixture
-def fanout_scope_scenario(isolated_listen_env, db_path: Path) -> dict:
+def fanout_scope_scenario(isolated_listen_env, db_path: Path, pg_schema: str) -> dict:
     """A per-spec denied send — only the *real* target's inbox should
     carry a notif; bystander targets and the empty-name inbox stay
     untouched. Denial via ``inbound.siblings=deny`` on child-2 (siblings
@@ -746,7 +746,7 @@ def fanout_scope_scenario(isolated_listen_env, db_path: Path) -> dict:
 
 
 def test_fanout_scope_scenario_target_inbox_has_exactly_one_notif(
-    fanout_scope_scenario,
+    fanout_scope_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     notifs = fanout_scope_scenario["target_notifs"]
@@ -757,7 +757,7 @@ def test_fanout_scope_scenario_target_inbox_has_exactly_one_notif(
 
 
 def test_fanout_scope_scenario_bystander_inbox_is_empty(
-    fanout_scope_scenario,
+    fanout_scope_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     notifs = fanout_scope_scenario["bystander_notifs"]
@@ -768,7 +768,7 @@ def test_fanout_scope_scenario_bystander_inbox_is_empty(
 
 
 def test_fanout_scope_scenario_empty_name_inbox_is_empty(
-    fanout_scope_scenario,
+    fanout_scope_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     notifs = fanout_scope_scenario["empty_notifs"]
@@ -782,7 +782,7 @@ def test_fanout_scope_scenario_empty_name_inbox_is_empty(
 
 
 @pytest.fixture
-def spoof_deny_scenario(isolated_listen_env, db_path: Path) -> dict:
+def spoof_deny_scenario(isolated_listen_env, db_path: Path, pg_schema: str) -> dict:
     """Per-node bearer for worker-a claims to be worker-b. ACL denies
     as spoof; the notification on worker-b's inbox must name the
     AUTHENTICATED identity (worker-a), not the spoofed claim
@@ -803,7 +803,7 @@ def spoof_deny_scenario(isolated_listen_env, db_path: Path) -> dict:
     return {"resp": resp, "notifs": notifs}
 
 
-def test_spoof_deny_returns_403(spoof_deny_scenario) -> None:
+def test_spoof_deny_returns_403(spoof_deny_scenario, pg_schema: str) -> None:
     # Arrange
     resp = spoof_deny_scenario["resp"]
     # Act
@@ -813,7 +813,7 @@ def test_spoof_deny_returns_403(spoof_deny_scenario) -> None:
 
 
 def test_spoof_deny_notification_names_authenticated_identity(
-    spoof_deny_scenario,
+    spoof_deny_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     event = spoof_deny_scenario["notifs"][0]["event"]
@@ -824,7 +824,7 @@ def test_spoof_deny_notification_names_authenticated_identity(
 
 
 def test_spoof_deny_notification_reason_mentions_spoof(
-    spoof_deny_scenario,
+    spoof_deny_scenario, pg_schema: str,
 ) -> None:
     # Arrange
     event = spoof_deny_scenario["notifs"][0]["event"]
@@ -838,7 +838,7 @@ def test_spoof_deny_notification_reason_mentions_spoof(
 
 
 @pytest.fixture
-def live_broker_event(isolated_listen_env, db_path: Path) -> dict:
+def live_broker_event(isolated_listen_env, db_path: Path, pg_schema: str) -> dict:
     """End-to-end on the broker fast path: a live subscriber on the
     target's inbox receives the denied-attempt event the moment the
     denial happens (not just on next reconnect / replay). Uses
@@ -881,7 +881,7 @@ def live_broker_event(isolated_listen_env, db_path: Path) -> dict:
     return asyncio.run(driver())
 
 
-def test_live_broker_event_kind_is_denied_attempt(live_broker_event) -> None:
+def test_live_broker_event_kind_is_denied_attempt(live_broker_event, pg_schema: str) -> None:
     # Arrange
     event = live_broker_event
     # Act
@@ -890,7 +890,7 @@ def test_live_broker_event_kind_is_denied_attempt(live_broker_event) -> None:
     assert kind == "denied_attempt"
 
 
-def test_live_broker_event_names_the_sender(live_broker_event) -> None:
+def test_live_broker_event_names_the_sender(live_broker_event, pg_schema: str) -> None:
     # Arrange
     event = live_broker_event
     # Act
@@ -899,7 +899,7 @@ def test_live_broker_event_names_the_sender(live_broker_event) -> None:
     assert sender == "child-1"
 
 
-def test_live_broker_event_names_the_receiver(live_broker_event) -> None:
+def test_live_broker_event_names_the_receiver(live_broker_event, pg_schema: str) -> None:
     # Arrange
     event = live_broker_event
     # Act
@@ -908,7 +908,7 @@ def test_live_broker_event_names_the_receiver(live_broker_event) -> None:
     assert receiver == "child-2"
 
 
-def test_live_broker_event_content_is_empty(live_broker_event) -> None:
+def test_live_broker_event_content_is_empty(live_broker_event, pg_schema: str) -> None:
     # Arrange
     event = live_broker_event
     # Act
@@ -917,7 +917,7 @@ def test_live_broker_event_content_is_empty(live_broker_event) -> None:
     assert content == ""
 
 
-def test_live_broker_event_carries_deny_reason(live_broker_event) -> None:
+def test_live_broker_event_carries_deny_reason(live_broker_event, pg_schema: str) -> None:
     # Arrange
     event = live_broker_event
     # Act
@@ -926,7 +926,7 @@ def test_live_broker_event_carries_deny_reason(live_broker_event) -> None:
     assert "inbound deny" in reason
 
 
-def test_live_broker_event_does_not_leak_body(live_broker_event) -> None:
+def test_live_broker_event_does_not_leak_body(live_broker_event, pg_schema: str) -> None:
     import json as _json
 
     # Arrange

--- a/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
+++ b/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
@@ -109,7 +109,7 @@ def _send_payload(sender: str, content: str = "hi") -> dict:
 
 
 def test_record_pending_prompt_first_call_returns_true(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange
     from scitex_agent_container._state.state_db_pending_approval import (
@@ -118,24 +118,24 @@ def test_record_pending_prompt_first_call_returns_true(
 
     # Act
     first = record_pending_prompt(
-        sender="worker-a", target="lead", db_path=isolated_state
+        sender="worker-a", target="lead"
     )
     # Assert
     assert first is True
 
 
 def test_record_pending_prompt_dedupes_second_call(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — the second record for the same pair must NOT re-prompt.
     from scitex_agent_container._state.state_db_pending_approval import (
         record_pending_prompt,
     )
 
-    record_pending_prompt(sender="worker-a", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="worker-a", target="lead")
     # Act
     second = record_pending_prompt(
-        sender="worker-a", target="lead", db_path=isolated_state
+        sender="worker-a", target="lead"
     )
     # Assert
     assert second is False
@@ -182,7 +182,7 @@ def test_approval_prompt_body_does_not_leak_message_content() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_unblock_writes_comms_grants_row(isolated_state: Path) -> None:
+def test_unblock_writes_comms_grants_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     from scitex_agent_container._state.grant_flush import (
         unblock_and_clear_pending,
@@ -194,7 +194,7 @@ def test_unblock_writes_comms_grants_row(isolated_state: Path) -> None:
     assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
 
 
-def test_unblock_clears_the_pending_prompt(isolated_state: Path) -> None:
+def test_unblock_clears_the_pending_prompt(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — seed a pending row directly, then unblock.
     from scitex_agent_container._state.grant_flush import (
         unblock_and_clear_pending,
@@ -203,16 +203,16 @@ def test_unblock_clears_the_pending_prompt(isolated_state: Path) -> None:
         record_pending_prompt,
     )
 
-    record_pending_prompt(sender="worker-a", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="worker-a", target="lead")
     # Act
     unblock_and_clear_pending(sender="worker-a", target="lead")
     # Assert
     assert not has_pending_prompt(
-        sender="worker-a", target="lead", db_path=isolated_state
+        sender="worker-a", target="lead"
     )
 
 
-def test_unblock_removes_existing_block_row(isolated_state: Path) -> None:
+def test_unblock_removes_existing_block_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — block first, then unblock. The unblock MUST remove
     # the block row (otherwise the block-precedence rule in
     # ``check_send_acl`` would still silently drop sends post-
@@ -234,7 +234,7 @@ def test_unblock_removes_existing_block_row(isolated_state: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_block_writes_comms_blocks_row(isolated_state: Path) -> None:
+def test_block_writes_comms_blocks_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     from scitex_agent_container._state.grant_flush import (
         block_and_clear_pending,
@@ -246,7 +246,7 @@ def test_block_writes_comms_blocks_row(isolated_state: Path) -> None:
     assert has_block(sender="worker-a", target="lead", db_path=isolated_state)
 
 
-def test_block_clears_the_pending_prompt(isolated_state: Path) -> None:
+def test_block_clears_the_pending_prompt(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — seed a pending row directly, then block.
     from scitex_agent_container._state.grant_flush import (
         block_and_clear_pending,
@@ -255,16 +255,16 @@ def test_block_clears_the_pending_prompt(isolated_state: Path) -> None:
         record_pending_prompt,
     )
 
-    record_pending_prompt(sender="worker-a", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="worker-a", target="lead")
     # Act
     block_and_clear_pending(sender="worker-a", target="lead")
     # Assert
     assert not has_pending_prompt(
-        sender="worker-a", target="lead", db_path=isolated_state
+        sender="worker-a", target="lead"
     )
 
 
-def test_blocked_send_emits_no_receiver_push(isolated_state: Path) -> None:
+def test_blocked_send_emits_no_receiver_push(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — block first, then attempt a send. The receiver
     # MUST see NOTHING (no denied_attempt, no approve-prompt, no
     # new prompt re-fire). The sender still gets 403 (next test).
@@ -287,7 +287,7 @@ def test_blocked_send_emits_no_receiver_push(isolated_state: Path) -> None:
 
 
 def test_blocked_send_still_returns_403_to_sender(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — sender side learns their send did not land. The
     # silence is receiver-only; we are not in the business of
@@ -314,7 +314,7 @@ def test_blocked_send_still_returns_403_to_sender(
 # ---------------------------------------------------------------------------
 
 
-def test_cli_unblock_writes_comms_grants(isolated_state: Path) -> None:
+def test_cli_unblock_writes_comms_grants(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     from scitex_agent_container.cli_pkg.a2a_group import a2a
 
@@ -324,7 +324,7 @@ def test_cli_unblock_writes_comms_grants(isolated_state: Path) -> None:
     assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
 
 
-def test_cli_block_writes_comms_blocks(isolated_state: Path) -> None:
+def test_cli_block_writes_comms_blocks(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     from scitex_agent_container.cli_pkg.a2a_group import a2a
 
@@ -334,7 +334,7 @@ def test_cli_block_writes_comms_blocks(isolated_state: Path) -> None:
     assert has_block(sender="worker-a", target="lead", db_path=isolated_state)
 
 
-def test_cli_grant_alias_still_unblocks(isolated_state: Path) -> None:
+def test_cli_grant_alias_still_unblocks(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — legacy `sac a2a grant` MUST behave like unblock so
     # operator muscle memory keeps working.
     from scitex_agent_container.cli_pkg.a2a_group import a2a

--- a/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
+++ b/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
@@ -226,7 +226,7 @@ def test_unblock_removes_existing_block_row(isolated_state: Path, pg_schema: str
     # Act
     unblock_and_clear_pending(sender="worker-a", target="lead")
     # Assert
-    assert not has_block(sender="worker-a", target="lead", db_path=isolated_state)
+    assert not has_block(sender="worker-a", target="lead")
 
 
 # ---------------------------------------------------------------------------
@@ -243,7 +243,7 @@ def test_block_writes_comms_blocks_row(isolated_state: Path, pg_schema: str) -> 
     # Act
     block_and_clear_pending(sender="worker-a", target="lead")
     # Assert
-    assert has_block(sender="worker-a", target="lead", db_path=isolated_state)
+    assert has_block(sender="worker-a", target="lead")
 
 
 def test_block_clears_the_pending_prompt(isolated_state: Path, pg_schema: str) -> None:
@@ -331,7 +331,7 @@ def test_cli_block_writes_comms_blocks(isolated_state: Path, pg_schema: str) -> 
     # Act
     CliRunner().invoke(a2a, ["block", "worker-a", "lead"])
     # Assert
-    assert has_block(sender="worker-a", target="lead", db_path=isolated_state)
+    assert has_block(sender="worker-a", target="lead")
 
 
 def test_cli_grant_alias_still_unblocks(isolated_state: Path, pg_schema: str) -> None:

--- a/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
+++ b/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
@@ -122,7 +122,7 @@ def _synthetic_rows(target: str, db_path: Path) -> list[dict]:
 
 
 def test_cross_group_deny_publishes_synthetic_notification(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
@@ -139,7 +139,7 @@ def test_cross_group_deny_publishes_synthetic_notification(
 
 
 def test_synthetic_notification_sender_is_daemon(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — the frame must not appear to come from the sender
     # (that would impersonate a granted peer at the receiver). As a sac
@@ -162,7 +162,7 @@ def test_synthetic_notification_sender_is_daemon(
 
 
 def test_synthetic_notification_sender_literal_is_daemon(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — pin the literal wire value so a rename of the constant
     # can't silently drift the on-the-wire sender the operator's bracket
@@ -181,7 +181,7 @@ def test_synthetic_notification_sender_literal_is_daemon(
 
 
 def test_synthetic_notification_embeds_grant_command(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — operator-actionable: the content MUST embed the exact
     # CLI to grant if the attempt was intended.
@@ -200,7 +200,7 @@ def test_synthetic_notification_embeds_grant_command(
 
 
 def test_synthetic_notification_does_not_leak_message_body(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — receiver decides on identity; the synthetic frame
     # MUST NOT reveal the denied body pre-decision.
@@ -219,7 +219,7 @@ def test_synthetic_notification_does_not_leak_message_body(
 
 
 def test_synthetic_notification_extra_carries_grant_command(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — structured field for richer clients.
     app = create_app(token=_TOKEN)
@@ -242,7 +242,7 @@ def test_synthetic_notification_extra_carries_grant_command(
 
 
 def test_deny_records_rate_limit_log_timestamp(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
@@ -253,7 +253,7 @@ def test_deny_records_rate_limit_log_timestamp(
             json=_send_payload("worker-a"),
             headers={"authorization": f"Bearer {_TOKEN}"},
         )
-    stamp = last_notified_at(sender="worker-a", target="lead", db_path=isolated_state)
+    stamp = last_notified_at(sender="worker-a", target="lead")
     # Assert — admit MUST have written a row to the rate-limit log.
     assert stamp is not None
 
@@ -266,7 +266,7 @@ def test_deny_records_rate_limit_log_timestamp(
 
 
 def test_second_deny_inside_cooldown_publishes_no_extra_synthetic(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange — set a long cool-down so the second post is throttled.
     os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "3600"

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -104,7 +104,7 @@ def db_path(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_send_allowed_within_same_named_group(db_path: Path) -> None:
+def test_send_allowed_within_same_named_group(db_path: Path, pg_schema: str) -> None:
     """Same named group, no lineage edge, no grant → allow (full mesh)."""
     # Arrange
     record_comms_policy(name="alice", group_name="developer", db_path=db_path)
@@ -120,7 +120,7 @@ def test_send_allowed_within_same_named_group(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_send_allowed_cross_group_by_default(db_path: Path) -> None:
+def test_send_allowed_cross_group_by_default(db_path: Path, pg_schema: str) -> None:
     """Messaging default-allow (operator 2026-07-03): different named
     groups, no lineage, no grant → ALLOW. Cross-group messaging is
     collaboration, not a security boundary."""
@@ -138,13 +138,13 @@ def test_send_allowed_cross_group_by_default(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_send_blocked_sender_still_denied_cross_group(db_path: Path) -> None:
+def test_send_blocked_sender_still_denied_cross_group(db_path: Path, pg_schema: str) -> None:
     """Override preserved: an explicit block still denies even though the
     cross-group default is now allow."""
     # Arrange
     record_comms_policy(name="alice", group_name="developer", db_path=db_path)
     record_comms_policy(name="carol", group_name="analysts", db_path=db_path)
-    block_send(sender="alice", target="carol", db_path=db_path)
+    block_send(sender="alice", target="carol")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="alice",
@@ -156,7 +156,7 @@ def test_send_blocked_sender_still_denied_cross_group(db_path: Path) -> None:
     assert decision == "block"
 
 
-def test_send_allowed_cross_group_with_explicit_grant(db_path: Path) -> None:
+def test_send_allowed_cross_group_with_explicit_grant(db_path: Path, pg_schema: str) -> None:
     """An explicit grant still flips a cross-group deny to allow."""
     # Arrange
     record_comms_policy(name="alice", group_name="developer", db_path=db_path)
@@ -173,7 +173,7 @@ def test_send_allowed_cross_group_with_explicit_grant(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_ungrouped_pair_allowed_by_default(db_path: Path) -> None:
+def test_ungrouped_pair_allowed_by_default(db_path: Path, pg_schema: str) -> None:
     """Messaging default-allow: two ungrouped agents in unrelated lineage
     families may now message each other with no grant."""
     # Arrange — no group_name on either; unrelated lineage families.
@@ -196,7 +196,7 @@ def test_ungrouped_pair_allowed_by_default(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_send_allowed_developer_to_researcher(db_path: Path) -> None:
+def test_send_allowed_developer_to_researcher(db_path: Path, pg_schema: str) -> None:
     """Cross-group mesh: developer → researcher, no grant → allow."""
     # Arrange
     record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
@@ -212,7 +212,7 @@ def test_send_allowed_developer_to_researcher(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_send_allowed_researcher_to_generalist(db_path: Path) -> None:
+def test_send_allowed_researcher_to_generalist(db_path: Path, pg_schema: str) -> None:
     """Cross-group mesh: researcher → generalist, no grant → allow."""
     # Arrange
     record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
@@ -228,7 +228,7 @@ def test_send_allowed_researcher_to_generalist(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_send_allowed_generalist_to_developer_all_directions(db_path: Path) -> None:
+def test_send_allowed_generalist_to_developer_all_directions(db_path: Path, pg_schema: str) -> None:
     """Mesh is bidirectional: generalist → developer, no grant → allow."""
     # Arrange
     record_comms_policy(name="gen-1", group_name="generalist", db_path=db_path)
@@ -244,7 +244,7 @@ def test_send_allowed_generalist_to_developer_all_directions(db_path: Path) -> N
     assert decision == "allow"
 
 
-def test_send_allowed_mesh_group_to_non_mesh_group(db_path: Path) -> None:
+def test_send_allowed_mesh_group_to_non_mesh_group(db_path: Path, pg_schema: str) -> None:
     """Messaging default-allow: a non-mesh group is no longer a MESSAGING
     boundary — developer → solver-group now ALLOWS. (Group-based isolation
     still gates PRIVILEGED actions via check_lineage_acl; a solver that must
@@ -263,7 +263,7 @@ def test_send_allowed_mesh_group_to_non_mesh_group(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_send_allowed_non_mesh_group_to_mesh_group(db_path: Path) -> None:
+def test_send_allowed_non_mesh_group_to_mesh_group(db_path: Path, pg_schema: str) -> None:
     """Messaging default-allow, both directions: solver-group → researcher
     now ALLOWS (the exact cross-group case PR #12/#524's mesh could not
     cover for paper-group agents a2a-ing developer agents)."""

--- a/tests/scitex_agent_container/_listen/test__acl_phase3.py
+++ b/tests/scitex_agent_container/_listen/test__acl_phase3.py
@@ -47,7 +47,7 @@ def db_path(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_outbound_siblings_deny_blocks_sibling_send(db_path: Path) -> None:
+def test_outbound_siblings_deny_blocks_sibling_send(db_path: Path, pg_schema: str) -> None:
     """Gap-1: sender with outbound.siblings=deny cannot address a sibling
     even though they share the same parent (group ACL would allow)."""
     # Arrange
@@ -65,7 +65,7 @@ def test_outbound_siblings_deny_blocks_sibling_send(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_outbound_parent_deny_blocks_send_to_parent(db_path: Path) -> None:
+def test_outbound_parent_deny_blocks_send_to_parent(db_path: Path, pg_schema: str) -> None:
     """Gap-1: child with outbound.parent=deny cannot send to its parent."""
     # Arrange
     record_lineage(child="cap-a", parent="root", db_path=db_path)
@@ -81,7 +81,7 @@ def test_outbound_parent_deny_blocks_send_to_parent(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_outbound_default_allows_sibling_send(db_path: Path) -> None:
+def test_outbound_default_allows_sibling_send(db_path: Path, pg_schema: str) -> None:
     """Default-preservation: with no comms policy row, the legacy
     intra-group sibling allow continues to fire (Phase-3 is opt-in)."""
     # Arrange
@@ -103,7 +103,7 @@ def test_outbound_default_allows_sibling_send(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_inbound_siblings_deny_rejects_sibling_inbound(db_path: Path) -> None:
+def test_inbound_siblings_deny_rejects_sibling_inbound(db_path: Path, pg_schema: str) -> None:
     """Gap-2: target with inbound.siblings=deny rejects a sibling sender
     even when the sender's outbound policy permits."""
     # Arrange
@@ -121,7 +121,7 @@ def test_inbound_siblings_deny_rejects_sibling_inbound(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_inbound_parent_deny_rejects_send_from_parent(db_path: Path) -> None:
+def test_inbound_parent_deny_rejects_send_from_parent(db_path: Path, pg_schema: str) -> None:
     """Gap-2: target with inbound.parent=deny rejects its own parent's
     send (the parent appears as ``rel='child'`` from sender's POV)."""
     # Arrange

--- a/tests/scitex_agent_container/_listen/test__acl_routes.py
+++ b/tests/scitex_agent_container/_listen/test__acl_routes.py
@@ -55,7 +55,7 @@ def _auth() -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def test_unblock_route_writes_comms_grants_row(isolated_state: Path) -> None:
+def test_unblock_route_writes_comms_grants_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -69,7 +69,7 @@ def test_unblock_route_writes_comms_grants_row(isolated_state: Path) -> None:
     assert has_grant(sender="alice", target="lead", db_path=isolated_state)
 
 
-def test_unblock_route_returns_200(isolated_state: Path) -> None:
+def test_unblock_route_returns_200(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -84,7 +84,7 @@ def test_unblock_route_returns_200(isolated_state: Path) -> None:
 
 
 def test_unblock_route_response_envelope_carries_decision_fields(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
@@ -105,7 +105,7 @@ def test_unblock_route_response_envelope_carries_decision_fields(
 # ---------------------------------------------------------------------------
 
 
-def test_block_route_writes_comms_blocks_row(isolated_state: Path) -> None:
+def test_block_route_writes_comms_blocks_row(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -125,7 +125,7 @@ def test_block_route_writes_comms_blocks_row(isolated_state: Path) -> None:
 
 
 def test_grant_route_writes_comms_grants_like_unblock(
-    isolated_state: Path,
+    isolated_state: Path, pg_schema: str,
 ) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
@@ -145,7 +145,7 @@ def test_grant_route_writes_comms_grants_like_unblock(
 # ---------------------------------------------------------------------------
 
 
-def test_missing_sender_returns_400(isolated_state: Path) -> None:
+def test_missing_sender_returns_400(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -159,7 +159,7 @@ def test_missing_sender_returns_400(isolated_state: Path) -> None:
     assert r.status_code == 400
 
 
-def test_missing_target_returns_400(isolated_state: Path) -> None:
+def test_missing_target_returns_400(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -173,7 +173,7 @@ def test_missing_target_returns_400(isolated_state: Path) -> None:
     assert r.status_code == 400
 
 
-def test_malformed_body_returns_400(isolated_state: Path) -> None:
+def test_malformed_body_returns_400(isolated_state: Path, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=_TOKEN)
     # Act
@@ -187,7 +187,7 @@ def test_malformed_body_returns_400(isolated_state: Path) -> None:
     assert r.status_code == 400
 
 
-def test_missing_bearer_returns_401_or_403(isolated_state: Path) -> None:
+def test_missing_bearer_returns_401_or_403(isolated_state: Path, pg_schema: str) -> None:
     # Arrange — no Authorization header.
     app = create_app(token=_TOKEN)
     # Act

--- a/tests/scitex_agent_container/_listen/test__acl_routes.py
+++ b/tests/scitex_agent_container/_listen/test__acl_routes.py
@@ -116,7 +116,7 @@ def test_block_route_writes_comms_blocks_row(isolated_state: Path, pg_schema: st
             headers=_auth(),
         )
     # Assert
-    assert has_block(sender="alice", target="lead", db_path=isolated_state)
+    assert has_block(sender="alice", target="lead")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_listen/test__agents_list_reachability_local_host.py
+++ b/tests/scitex_agent_container/_listen/test__agents_list_reachability_local_host.py
@@ -1,0 +1,197 @@
+"""The LIST endpoint must resolve its own host, exactly as the single-row one does.
+
+WHY THIS FILE EXISTS, and why the sibling test was not enough. #1174 added the
+env fallback to ``server._annotate_status_reachability`` — the SINGLE-row path
+— and its test (``test_server_reachability_local_host.py``) proved that path
+correct. It shipped, and the reported symptom did not move: ``a2a_peers`` still
+returned ``inbox_reachable: "unknown"`` for all eleven peers.
+
+Because ``a2a_peers`` reads ``GET /agents``, and that route annotates through
+``_agents_list._annotate_reachability``, which kept the bare
+``getattr(request.app.state, "local_host", None)``. ``create_app`` defaults
+that to ``None`` and ``cli_pkg/listen_cmds.py`` never passes it, so
+``_is_locally_observable`` hit ``if not local_host: return False`` for every
+row carrying host evidence and annotated the whole fleet ``unknown``.
+
+MEASURED on scitex-compute-04 2026-08-20T21:35Z, with the daemon restarted and
+verifiably running the #1174 code: 11 of 11 rows ``unknown``, every one of them
+with a ``turn_url`` naming this very host.
+
+So the lesson this file encodes is not "add a fallback". It is that a fix
+verified on the call site it PATCHED says nothing about the call site the
+SYMPTOM arrives through, and both existed here.
+
+PA-306: no mocks. The stand-ins below are hand-written objects holding exactly
+the attributes the function reads — the same "configuration, not mocking"
+pattern the sibling file documents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from scitex_agent_container._listen._agents_list import _annotate_reachability
+from scitex_agent_container._listen._reachability import (
+    REACHABLE,
+    UNKNOWN,
+    UNREACHABLE,
+)
+from scitex_agent_container._state.state_db import _resolve_host
+
+
+class _Inbox:
+    """The broker seam: returns a real subscriber-count mapping."""
+
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    async def subscriber_counts(self) -> dict[str, int]:
+        return dict(self._counts)
+
+
+class _BrokenInbox:
+    """A broker that cannot be read — the degrade-safely control."""
+
+    async def subscriber_counts(self) -> dict[str, int]:
+        raise RuntimeError("broker unreadable")
+
+
+class _State:
+    def __init__(self, inbox: object, local_host: str | None) -> None:
+        self.inbox = inbox
+        self.local_host = local_host
+
+
+class _App:
+    def __init__(self, state: _State) -> None:
+        self.state = state
+
+
+class _Req:
+    def __init__(self, app: _App) -> None:
+        self.app = app
+
+
+def _annotate(
+    rows: list[dict],
+    *,
+    counts: dict[str, int] | None = None,
+    local_host: str | None = None,
+    inbox: object | None = None,
+) -> list[dict]:
+    box = inbox if inbox is not None else _Inbox(counts or {})
+    req = _Req(_App(_State(box, local_host)))
+    return asyncio.run(_annotate_reachability(req, rows))
+
+
+def _local_row() -> dict:
+    """A row shaped like production: no ``host`` key, host named by turn_url."""
+    return {"name": "peer", "turn_url": f"http://{_resolve_host(None)}:19001/v1/turn"}
+
+
+# ---------------------------------------------------------------------------
+# The defect: production has local_host=None, and the list path read it bare
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_row_is_reachable_when_app_state_has_no_host() -> None:
+    # Arrange
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, counts={"peer": 1}, local_host=None)
+    # Assert — was UNKNOWN for all 11 peers on the live fleet
+    assert out[0]["inbox_reachable"] == REACHABLE
+
+
+def test_a_local_row_reports_its_subscriber_count() -> None:
+    # Arrange
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, counts={"peer": 1}, local_host=None)
+    # Assert — the count was None alongside the unknown verdict
+    assert out[0]["inbox_subscribers"] == 1
+
+
+def test_a_local_row_with_no_subscribers_is_unreachable() -> None:
+    # Arrange — an OBSERVED zero on a bus we can see is the one case
+    # that earns UNREACHABLE rather than UNKNOWN.
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, counts={}, local_host=None)
+    # Assert — the field must be able to reach its third value too
+    assert out[0]["inbox_reachable"] == UNREACHABLE
+
+
+def test_a_local_row_with_no_subscribers_reports_zero() -> None:
+    # Arrange
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, counts={}, local_host=None)
+    # Assert
+    assert out[0]["inbox_subscribers"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Controls — the fix must not buy reachability by fabricating locality
+# ---------------------------------------------------------------------------
+
+
+def test_a_remote_row_stays_unknown() -> None:
+    # Arrange — a row on a DIFFERENT host, served by a different broker whose
+    # subscriber table we cannot see.
+    rows = [{"name": "peer", "host": "some-other-host-entirely"}]
+    # Act
+    out = _annotate(rows, counts={}, local_host=None)
+    # Assert — a fabricated zero here is a false accusation of deafness
+    assert out[0]["inbox_reachable"] == UNKNOWN
+
+
+def test_a_remote_row_reports_no_subscriber_count() -> None:
+    # Arrange
+    rows = [{"name": "peer", "host": "some-other-host-entirely"}]
+    # Act
+    out = _annotate(rows, counts={}, local_host=None)
+    # Assert — None, not 0: we did not observe, we declined to guess
+    assert out[0]["inbox_subscribers"] is None
+
+
+def test_an_explicit_app_state_host_still_wins() -> None:
+    # Arrange — when create_app IS given a host, that declaration is
+    # authoritative and the env resolver must not override it.
+    rows = [{"name": "peer", "host": "declared-host"}]
+    # Act
+    out = _annotate(rows, counts={"peer": 2}, local_host="declared-host")
+    # Assert — the fallback is a fallback, not a replacement
+    assert out[0]["inbox_reachable"] == REACHABLE
+
+
+def test_an_unreadable_broker_degrades_to_unknown() -> None:
+    # Arrange — the safe-direction guarantee this route is written around
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, inbox=_BrokenInbox(), local_host=None)
+    # Assert — "could not check" must never render as death
+    assert out[0]["inbox_reachable"] == UNKNOWN
+
+
+def test_an_unreadable_broker_reports_no_count() -> None:
+    # Arrange
+    rows = [_local_row()]
+    # Act
+    out = _annotate(rows, inbox=_BrokenInbox(), local_host=None)
+    # Assert
+    assert out[0]["inbox_subscribers"] is None
+
+
+def test_every_row_is_annotated_not_just_the_first() -> None:
+    # Arrange — the list path's own responsibility: it maps over N rows
+    here = _resolve_host(None)
+    rows = [
+        {"name": "a", "turn_url": f"http://{here}:19001/v1/turn"},
+        {"name": "b", "turn_url": f"http://{here}:19002/v1/turn"},
+        {"name": "c", "host": "elsewhere"},
+    ]
+    # Act
+    out = _annotate(rows, counts={"a": 1}, local_host=None)
+    # Assert
+    assert [r["inbox_reachable"] for r in out] == [REACHABLE, UNREACHABLE, UNKNOWN]

--- a/tests/scitex_agent_container/_listen/test__inbox_fault.py
+++ b/tests/scitex_agent_container/_listen/test__inbox_fault.py
@@ -257,3 +257,78 @@ def test_annotate_does_not_mutate_the_input_row():
     annotate_faults([row], snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
     # Assert
     assert "fault" not in row
+
+
+# ---------------------------------------------------------------------------
+# The NOT_RUNNING verdict must name the POPULATION its probe covered.
+#
+# Three independent reproductions, 2026-08-17..19 (hub twice, then
+# paper-scitex-clew). The message said "the probe SUCCEEDED, so this is real
+# absence, not a failed look" about agents alive on ANOTHER host — clew with a
+# 2-second-old heartbeat on compute-02, hub eight minutes into a live PR poll
+# on compute-03. It then told the reader "waiting for a reply will never
+# succeed", which is an instruction to restart a healthy agent.
+#
+# The sentence pre-empts the exact objection a careful reader would raise,
+# which is why it was believed. On the clew reading the OPERATOR and I agreed
+# on the false fact; nothing broke only because I tried starting it on the
+# other host rather than acting on the verdict.
+#
+# A probe of THIS host's tmux sessions can only speak for THIS host.
+# ---------------------------------------------------------------------------
+
+
+def _stopped_detail() -> str:
+    """The rendered NOT_RUNNING detail — empty snapshot means no session here."""
+    return annotate_faults([_row()], snapshot={}, runtime_is_tui_fn=TUI)[0][
+        "fault_detail"
+    ]
+
+
+def test_the_not_running_verdict_names_the_host_it_observed():
+    # Arrange
+    import socket
+
+    expected = socket.gethostname()
+    # Act
+    detail = _stopped_detail()
+    # Assert
+    assert expected in detail
+
+
+def test_the_not_running_verdict_no_longer_claims_unqualified_absence():
+    # Arrange: the exact phrase that was believed three times.
+    forbidden = "real absence, not a failed look"
+    # Act
+    detail = _stopped_detail()
+    # Assert
+    assert forbidden not in detail
+
+
+def test_the_not_running_verdict_says_it_cannot_speak_for_other_hosts():
+    # Arrange
+    expected = "says nothing about any other host"
+    # Act
+    detail = _stopped_detail()
+    # Assert
+    assert expected in detail
+
+
+def test_the_not_running_verdict_tells_the_reader_to_ask_the_pinned_host():
+    # Arrange: the remedy, so the message ends in the right ACTION rather than
+    # in a restart of a live agent.
+    expected = "ASK THAT HOST"
+    # Act
+    detail = _stopped_detail()
+    # Assert
+    assert expected in detail
+
+
+def test_the_deaf_verdict_survives_the_host_formatting():
+    # Arrange: the DEAF template carries no placeholder, so .format must be a
+    # no-op on it rather than raising or mangling it.
+    rows = [_row()]
+    # Act
+    out = annotate_faults(rows, snapshot={"tui-alpha": 1}, runtime_is_tui_fn=TUI)
+    # Assert
+    assert out[0]["fault_detail"].startswith("RUNNING BUT DEAF")

--- a/tests/scitex_agent_container/_listen/test__node_channel.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel.py
@@ -89,7 +89,7 @@ def _send(client: TestClient, *, kind, headers) -> object:
     return client.post("/agents/lead/message:send", json=body, headers=headers)
 
 
-def test_string_kind_lands_on_persisted_event(kind_env) -> None:
+def test_string_kind_lands_on_persisted_event(kind_env, pg_schema: str) -> None:
     # Arrange — real app, real state.db; same-group ACL was set up.
     app = create_app(token=TOKEN, local_host="127.0.0.1")
     headers = {"authorization": f"Bearer {TOKEN}"}
@@ -101,7 +101,7 @@ def test_string_kind_lands_on_persisted_event(kind_env) -> None:
     assert rows and rows[0]["event"].get("kind") == "done"
 
 
-def test_string_kind_round_trips_status(kind_env) -> None:
+def test_string_kind_round_trips_status(kind_env, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=TOKEN, local_host="127.0.0.1")
     headers = {"authorization": f"Bearer {TOKEN}"}
@@ -113,7 +113,7 @@ def test_string_kind_round_trips_status(kind_env) -> None:
     assert rows and rows[0]["event"].get("kind") == "status"
 
 
-def test_missing_kind_yields_no_kind_field(kind_env) -> None:
+def test_missing_kind_yields_no_kind_field(kind_env, pg_schema: str) -> None:
     # Arrange — the receiver only stamps ``kind`` when the sender sends
     # one; absence must stay absent so legacy callers (auto-ack, dispatch
     # ledger, ...) are unchanged.
@@ -140,7 +140,7 @@ def test_missing_kind_yields_no_kind_field(kind_env) -> None:
     assert rows and "kind" not in rows[0]["event"]
 
 
-def test_non_string_kind_is_loud_400(kind_env) -> None:
+def test_non_string_kind_is_loud_400(kind_env, pg_schema: str) -> None:
     # Arrange — a numeric ``kind`` would silently round-trip as JSON
     # if the receiver coerced; refuse it loudly so bad senders cannot
     # poison the inbox shape.
@@ -166,7 +166,7 @@ def test_non_string_kind_is_loud_400(kind_env) -> None:
     assert resp.status_code == 400
 
 
-def test_non_string_kind_400_names_metadata_field(kind_env) -> None:
+def test_non_string_kind_400_names_metadata_field(kind_env, pg_schema: str) -> None:
     # Arrange — the 400 body must say where the bad value came from
     # so an operator chasing a failed push sees what to fix.
     app = create_app(token=TOKEN, local_host="127.0.0.1")
@@ -203,7 +203,7 @@ def test_non_string_kind_400_names_metadata_field(kind_env) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_extra_dict_round_trips_onto_event(kind_env) -> None:
+def test_extra_dict_round_trips_onto_event(kind_env, pg_schema: str) -> None:
     # Arrange
     app = create_app(token=TOKEN, local_host="127.0.0.1")
     headers = {"authorization": f"Bearer {TOKEN}"}
@@ -233,7 +233,7 @@ def test_extra_dict_round_trips_onto_event(kind_env) -> None:
     assert extra.get("reacted_dispatch_id") == "did-abc"
 
 
-def test_empty_extra_does_not_land_on_event(kind_env) -> None:
+def test_empty_extra_does_not_land_on_event(kind_env, pg_schema: str) -> None:
     # Arrange — an empty ``extra`` dict is morally absent; the receiver
     # MUST keep the persisted envelope compact (no empty placeholder key).
     app = create_app(token=TOKEN, local_host="127.0.0.1")

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -126,7 +126,7 @@ def auth_headers():
 # ---------------------------------------------------------------------------
 
 
-def test_message_send_to_external_node_returns_2xx(client, auth_headers) -> None:
+def test_message_send_to_external_node_returns_2xx(client, auth_headers, pg_schema: str) -> None:
     """An external node has no YAML and is not in the local registry,
     but ``message:send`` must still accept the POST and route it to
     the inbox bus. The implicit-registration semantics (handoff §4)
@@ -157,7 +157,7 @@ def test_message_send_to_external_node_returns_2xx(client, auth_headers) -> None
 
 
 def test_message_send_to_external_node_response_carries_msg_id(
-    client, auth_headers
+    client, auth_headers, pg_schema: str
 ) -> None:
     """The published event must include the broker-minted ``msg_id`` so
     the sender can correlate. This is the same envelope shape the
@@ -284,7 +284,7 @@ def _make_payload(text: str = "hello external", **meta: object) -> dict:
     }
 
 
-def test_external_inbox_stream_delivers_posted_event(isolated_env) -> None:
+def test_external_inbox_stream_delivers_posted_event(isolated_env, pg_schema: str) -> None:
     """End-to-end: subscribe to inbox/stream, POST a ``message:send``
     to the same name, observe the SSE frame.
 
@@ -299,7 +299,7 @@ def test_external_inbox_stream_delivers_posted_event(isolated_env) -> None:
     assert event.get("content") == "hello external"
 
 
-def test_external_inbox_stream_event_preserves_from_agent(isolated_env) -> None:
+def test_external_inbox_stream_event_preserves_from_agent(isolated_env, pg_schema: str) -> None:
     """The publisher's ``from_agent`` metadata reaches the receiver."""
     # Arrange
     payload = _make_payload(text="x")
@@ -315,7 +315,7 @@ def test_external_inbox_stream_event_preserves_from_agent(isolated_env) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_external_node_agent_card_returns_200(client, auth_headers) -> None:
+def test_external_node_agent_card_returns_200(client, auth_headers, pg_schema: str) -> None:
     """The AgentCard route must succeed for a registered external node.
     Currently returns 404 because the lookup goes through ``resolve_config``
     which only knows YAML-backed names.
@@ -349,7 +349,7 @@ def test_external_node_agent_card_returns_200(client, auth_headers) -> None:
 
 
 def test_external_node_agent_card_advertises_node_kind_external(
-    client, auth_headers
+    client, auth_headers, pg_schema: str
 ) -> None:
     """The synthesised card carries
     ``x-scitex-agent-container.node_kind == "external"`` so consumers
@@ -387,7 +387,7 @@ def test_external_node_agent_card_advertises_node_kind_external(
 
 
 def test_external_node_agent_card_supportedinterfaces_url_targets_inbox(
-    client, auth_headers
+    client, auth_headers, pg_schema: str
 ) -> None:
     """The card's supportedInterfaces URL is the agent's inbox base —
     that's what an A2A v1 client uses to send messages.

--- a/tests/scitex_agent_container/_listen/test__reachability.py
+++ b/tests/scitex_agent_container/_listen/test__reachability.py
@@ -201,3 +201,88 @@ def test_annotate_rows_separates_reachable_from_deaf_peers():
     deaf = [r["name"] for r in out if r["inbox_reachable"] == UNREACHABLE]
     # Assert
     assert deaf == ["claude-code-telegrammer", "scitex-dev"]
+
+
+# ---------------------------------------------------------------------------
+# A hostless row is not automatically LOCAL — turn_url still names its host.
+#
+# Measured 2026-08-19. `agent_status paper-scitex-clew`, run on compute-04,
+# returned a row with NO `host` key and turn_url http://ywata-note-win:19012/…
+# while the agent was alive on compute-02 with a 2-second-old heartbeat.
+# The hostless row was treated as local, so the local broker's zero stood as a
+# real observation, `inbox_reachable` became UNREACHABLE instead of UNKNOWN,
+# and classify_fault's cross-host guard (UNKNOWN -> no fault) never fired. The
+# verdict read "the probe SUCCEEDED, so this is real absence, not a failed
+# look" about a healthy agent on a machine this daemon cannot see.
+#
+# The row already carried the host. Nothing consulted it.
+# ---------------------------------------------------------------------------
+
+
+def test_hostless_row_whose_turn_url_is_remote_is_unknown():
+    """The measured clew case: no host key, turn_url on another machine."""
+    # Arrange
+    row = {"name": "paper-scitex-clew", "turn_url": "http://elsewhere:19012/v1/turn"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNKNOWN
+
+
+def test_hostless_remote_row_reports_null_subscribers_not_a_fabricated_zero():
+    """A zero we did not observe is a false accusation, not a reading."""
+    # Arrange
+    row = {"name": "paper-scitex-clew", "turn_url": "http://elsewhere:19012/v1/turn"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_subscribers"] is None
+
+
+def test_hostless_row_whose_turn_url_is_local_is_still_observed_locally():
+    """The fix must not make every hostless row unknown — that would lose
+    genuine deaf-inbox detection for local agents."""
+    # Arrange
+    row = {"name": "local-agent", "turn_url": f"http://{LOCAL}:19001/v1/turn"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_an_explicit_host_still_wins_over_the_turn_url():
+    """turn_url is a FALLBACK. A declared host is the stronger statement and
+    must not be second-guessed by a URL that may be stale."""
+    # Arrange
+    row = {
+        "name": "declared",
+        "host": LOCAL,
+        "turn_url": "http://elsewhere:19012/v1/turn",
+    }
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_a_malformed_turn_url_falls_back_to_the_previous_behaviour():
+    """An unparseable URL yields no host evidence, so the row is treated as
+    local exactly as it was before this fix — the change adds a reading, it
+    does not introduce a new way to fail."""
+    # Arrange
+    row = {"name": "hostless", "turn_url": "::::not a url::::"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_a_non_string_turn_url_does_not_raise():
+    """Registry rows are not schema-guaranteed here; a wrong type must not
+    take down GET /agents for every other row in the same response."""
+    # Arrange
+    row = {"name": "hostless", "turn_url": 19012}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE

--- a/tests/scitex_agent_container/_listen/test__start_failure_status.py
+++ b/tests/scitex_agent_container/_listen/test__start_failure_status.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A refusal must name its reason; 5xx is for genuine server faults.
+
+``POST /agents`` answered 502 for EVERY non-zero child exit. hub hit it
+on 2026-08-19 standing up a scholar agent, and stated the defect better
+than the code did:
+
+    a 500 cannot distinguish "your request was wrong" from "the server
+    is broken", and those need OPPOSITE responses from the caller.
+
+They waited for the daemon owner and reported a permissions bug that did
+not exist. The response BODY carried the real reason throughout — an
+expired-credential message that was true about a file and silent about
+the request. The status code was what threw the distinction away.
+
+These tests pin that unambiguous, caller-fixable failures get a 4xx that
+says which, and that everything else still gets 502. The default matters
+as much as the classification: a server fault misreported as 4xx sends
+someone to fix a call that was already correct.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._listen._start_failure_status import (
+    DECLINED,
+    SERVER_FAULT,
+    STALE_SPEC,
+    UNREGISTERED,
+    classify_start_failure,
+)
+
+_MEASURED_CREDENTIAL_STDERR = (
+    "Error: OAuth token in /home/ywatanabe/.claude/.credentials.json "
+    "expired 257594 seconds ago. Run `claude login` to refresh."
+)
+_MEASURED_DRIFT_STDERR = (
+    "sac-drift ERROR for agent 'business': the spec source is 3 commit(s) "
+    "BEHIND origin/develop — you may be launching a STALE spec."
+)
+
+
+def test_an_unresolvable_agent_is_a_client_error():
+    # Arrange
+    stderr = "Error: cannot start 'scitex-scholar': its spec could not be loaded"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.status == 404
+
+
+def test_an_unresolvable_agent_is_named_as_such():
+    # Arrange
+    stderr = "FileNotFoundError: Agent 'scitex-scholar' not found"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.kind == UNREGISTERED
+
+
+def test_an_unresolvable_agent_is_reported_as_caller_fixable():
+    # Arrange
+    stderr = "Error: cannot start 'scitex-scholar': its spec could not be loaded"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.is_caller_fixable is True
+
+
+def test_the_unregistered_hint_says_retrying_will_not_help():
+    # Arrange
+    stderr = "no such agent"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert "retrying unchanged will not help" in result.hint
+
+
+def test_a_stale_spec_source_is_a_conflict_not_a_bad_request():
+    # Arrange: the agent exists and the call is well-formed; the HOST is behind.
+    stderr = _MEASURED_DRIFT_STDERR
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.status == 409
+
+
+def test_a_stale_spec_source_is_named_as_such():
+    # Arrange
+    stderr = _MEASURED_DRIFT_STDERR
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.kind == STALE_SPEC
+
+
+def test_the_stale_spec_hint_names_the_remedy():
+    # Arrange
+    stderr = _MEASURED_DRIFT_STDERR
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert "pull the spec repo" in result.hint
+
+
+def test_a_self_declined_start_keeps_its_existing_status():
+    # Arrange: an existing wire contract, and not caller-fixable — the
+    # AGENT refused itself, so a 4xx would tell the caller to correct a
+    # call that was already correct.
+    # Act
+    result = classify_start_failure(returncode=1, stderr="", declined=True)
+    # Assert
+    assert result.status == 502
+
+
+def test_a_self_declined_start_is_named_as_such():
+    # Arrange
+    # Act
+    result = classify_start_failure(returncode=1, stderr="", declined=True)
+    # Assert
+    assert result.kind == DECLINED
+
+
+def test_an_unrecognised_failure_keeps_the_existing_status():
+    # Arrange: the conservative default — unmatched must not become a guess.
+    stderr = "apptainer: FATAL: while extracting image: root filesystem missing"
+    # Act
+    result = classify_start_failure(returncode=255, stderr=stderr)
+    # Assert
+    assert result.status == 502
+
+
+def test_an_unrecognised_failure_is_named_a_server_fault():
+    # Arrange
+    stderr = "apptainer: FATAL: while extracting image"
+    # Act
+    result = classify_start_failure(returncode=255, stderr=stderr)
+    # Assert
+    assert result.kind == SERVER_FAULT
+
+
+def test_a_server_fault_is_not_reported_as_caller_fixable():
+    # Arrange: the harmful direction — never tell someone to fix a correct call.
+    stderr = "apptainer: FATAL: while extracting image"
+    # Act
+    result = classify_start_failure(returncode=255, stderr=stderr)
+    # Assert
+    assert result.is_caller_fixable is False
+
+
+def test_an_empty_stderr_falls_back_to_a_server_fault():
+    # Arrange: silence must not be classified as a caller error.
+    # Act
+    result = classify_start_failure(returncode=1, stdout="", stderr="")
+    # Assert
+    assert result.status == 502
+
+
+def test_the_measured_credential_failure_is_no_longer_a_bare_server_fault():
+    # Arrange: hub's actual 502. Post-#1135 the child names the spec fault,
+    # so the SAME start now classifies as unregistered rather than opaque.
+    stderr = (
+        "Error: cannot start 'scitex-scholar': its spec could not be loaded "
+        "(FileNotFoundError: Agent 'scitex-scholar' not found)"
+    )
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr)
+    # Assert
+    assert result.status == 404
+
+
+def test_the_pre_fix_credential_message_alone_stays_a_server_fault():
+    # Arrange: on its own the old message says nothing about the request,
+    # so it must NOT be promoted to a caller error by pattern-matching hope.
+    # Act
+    result = classify_start_failure(
+        returncode=1, stderr=_MEASURED_CREDENTIAL_STDERR
+    )
+    # Assert
+    assert result.status == 502
+
+
+def test_a_declined_start_outranks_a_matching_spec_pattern():
+    # Arrange: an agent that declined, whose output also mentions a spec.
+    stderr = "no such agent mentioned in passing"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr, declined=True)
+    # Assert
+    assert result.kind == DECLINED
+
+
+def test_a_declined_start_is_not_promoted_to_a_client_error_by_a_stray_match():
+    # Arrange: the early return is what stops the 404 pattern firing here.
+    stderr = "no such agent mentioned in passing"
+    # Act
+    result = classify_start_failure(returncode=1, stderr=stderr, declined=True)
+    # Assert
+    assert result.is_caller_fixable is False

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -879,7 +879,7 @@ def _send_payload(text: str, *, from_agent: str) -> dict:
     }
 
 
-def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
+def test_cross_host_send_forwards_to_target_host(cross_host_env, pg_schema: str) -> None:
     """End-to-end: a POST to host B's ``message:send`` for a target
     pinned to host A arrives on host A's broker.
     """
@@ -961,7 +961,7 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
     assert event.get("content") == "hi from b"
 
 
-def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env) -> None:
+def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env, pg_schema: str) -> None:
     """The forwarded event keeps the original ``from_agent`` so
     host A's ACL can gate on the real sender, not the forwarding
     host's identity.
@@ -1271,7 +1271,7 @@ def _drive_ssh_cross_host_send(
 
 
 def test_cross_host_send_via_ssh_shim_delivers_to_remote_inbox(
-    cross_host_ssh_env,
+    cross_host_ssh_env, pg_schema: str,
 ) -> None:
     """End-to-end ssh-transport: a POST to host B's ``message:send`` for
     a target pinned to host A arrives on host A's broker through the
@@ -1290,7 +1290,7 @@ def test_cross_host_send_via_ssh_shim_delivers_to_remote_inbox(
 
 
 def test_cross_host_send_via_ssh_shim_preserves_from_agent_metadata(
-    cross_host_ssh_env,
+    cross_host_ssh_env, pg_schema: str,
 ) -> None:
     """The forwarded event keeps the original ``from_agent`` across the
     ssh transport so host A's ACL gates on the real sender, not the
@@ -1309,7 +1309,7 @@ def test_cross_host_send_via_ssh_shim_preserves_from_agent_metadata(
 
 
 def test_cross_host_send_with_explicit_grant_unblocks_cross_group_push(
-    cross_host_ssh_env,
+    cross_host_ssh_env, pg_schema: str,
 ) -> None:
     """A cross-group send delivered across the ssh transport lands at the
     destination. (Under messaging DEFAULT-ALLOW, operator 2026-07-03, the
@@ -1338,7 +1338,7 @@ def test_cross_host_send_with_explicit_grant_unblocks_cross_group_push(
 
 
 def test_cross_host_send_without_grant_returns_403_from_target_listen(
-    cross_host_ssh_env,
+    cross_host_ssh_env, pg_schema: str,
 ) -> None:
     """A receiver-side ACL deny must surface across the ssh transport as
     a non-2xx response to the originating sender (loud failure, no silent
@@ -1381,7 +1381,7 @@ def test_cross_host_send_without_grant_returns_403_from_target_listen(
 
 
 def test_cross_host_send_via_ssh_shim_uses_peer_token_bearer_header(
-    cross_host_ssh_env,
+    cross_host_ssh_env, pg_schema: str,
 ) -> None:
     """The shim's captured Authorization header matches the destination
     host's bearer (``peer-tokens/host-a.token``) — proves the forwarder
@@ -1481,7 +1481,7 @@ def _roundtrip_local_send(cross_host_env, *, metadata: dict) -> dict:
 
 
 def test_message_send_with_ack_metadata_yields_ack_true_event(
-    cross_host_env,
+    cross_host_env, pg_schema: str,
 ) -> None:
     # Arrange
     metadata = {"from_agent": "bob", "ack": True}
@@ -1492,7 +1492,7 @@ def test_message_send_with_ack_metadata_yields_ack_true_event(
 
 
 def test_message_send_without_ack_metadata_yields_falsey_ack_event(
-    cross_host_env,
+    cross_host_env, pg_schema: str,
 ) -> None:
     # Arrange
     metadata = {"from_agent": "bob"}
@@ -1503,7 +1503,7 @@ def test_message_send_without_ack_metadata_yields_falsey_ack_event(
 
 
 def test_message_send_threads_dispatch_id_into_published_event(
-    cross_host_env,
+    cross_host_env, pg_schema: str,
 ) -> None:
     # Arrange
     # The sender-minted dispatch_id must ride from metadata onto the

--- a/tests/scitex_agent_container/_listen/test_server_reachability_local_host.py
+++ b/tests/scitex_agent_container/_listen/test_server_reachability_local_host.py
@@ -1,0 +1,107 @@
+"""``_annotate_status_reachability`` must resolve its own host.
+
+WHY THIS FILE EXISTS. ``create_app`` defaults ``local_host=None`` and the one
+production caller (``cli_pkg/listen_cmds.py``) does not pass it. So
+``app.state.local_host`` was None on every running daemon,
+``_reachability._is_locally_observable`` hit its ``if not local_host: return
+False``, and EVERY row carrying a host was annotated ``unknown`` — including
+rows on the very host answering the request. Reported by scitex-dev as all 11
+a2a peers reading ``unknown``.
+
+That made ``inbox_reachable`` a three-valued field that could only ever return
+one of its values, while its own tool description tells callers to check it
+before sending. The sibling ``_node_channel`` path already carried the env
+fallback for the identical question; this one did not.
+
+A SEPARATE FILE, not an addition to ``test_server.py``: that mirror is already
+1,647 lines against a 512-line cap, and the package convention is focused
+``test_server_<topic>.py`` files (``test_server_lineage_acl.py``,
+``test_server_agent_card_path.py``, …).
+
+PA-306: no mocks. ``_Req`` is a hand-written stand-in holding exactly the two
+attributes the function reads — the same "configuration, not mocking" pattern
+``test_server.py`` documents for its module-attribute re-pointing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from scitex_agent_container._listen.server import _annotate_status_reachability
+from scitex_agent_container._state.state_db import _resolve_host
+
+
+class _Inbox:
+    """The broker seam: returns a real subscriber-count mapping."""
+
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    async def subscriber_counts(self) -> dict[str, int]:
+        return dict(self._counts)
+
+
+class _State:
+    def __init__(self, inbox: _Inbox, local_host: str | None) -> None:
+        self.inbox = inbox
+        self.local_host = local_host
+
+
+class _App:
+    def __init__(self, state: _State) -> None:
+        self.state = state
+
+
+class _Req:
+    def __init__(self, app: _App) -> None:
+        self.app = app
+
+
+def _annotate(row: dict, *, counts: dict[str, int], local_host: str | None) -> dict:
+    req = _Req(_App(_State(_Inbox(counts), local_host)))
+    return asyncio.run(_annotate_status_reachability(req, row))
+
+
+def test_local_row_is_reachable_when_app_state_local_host_is_unset():
+    # Arrange — reproduces production exactly: create_app was called without
+    # local_host, so app.state.local_host is None, and the row names THIS host.
+    host = _resolve_host(None)
+    row = {"name": "alpha", "host": host}
+    # Act
+    out = _annotate(row, counts={"alpha": 1}, local_host=None)
+    # Assert — before the fix this was "unknown" for every host-carrying row.
+    assert out["inbox_reachable"] == "reachable"
+
+
+def test_local_row_reports_its_subscriber_count_when_local_host_is_unset():
+    # Arrange — the count is the other half: an "unknown" verdict also nulls
+    # inbox_subscribers, so asserting only the verdict leaves that unpinned.
+    host = _resolve_host(None)
+    row = {"name": "alpha", "host": host}
+    # Act
+    out = _annotate(row, counts={"alpha": 3}, local_host=None)
+    # Assert
+    assert out["inbox_subscribers"] == 3
+
+
+def test_a_row_on_another_host_stays_unknown():
+    # Arrange — POSITIVE CONTROL for the assertions above. They check that a
+    # value is NOT "unknown", which a function that always said "reachable"
+    # would also satisfy. A remote row must still be unknown: this daemon has
+    # no window into another host's broker, and inventing a zero there would
+    # be a false accusation of deafness.
+    row = {"name": "beta", "host": "some-other-host-that-is-not-us"}
+    # Act
+    out = _annotate(row, counts={}, local_host=None)
+    # Assert
+    assert out["inbox_reachable"] == "unknown"
+
+
+def test_an_explicit_local_host_still_wins():
+    # Arrange — the fallback must not shadow a caller that DID pin the host,
+    # which is what in-process multi-host tests rely on.
+    row = {"name": "alpha", "host": "pinned-host"}
+    # Act
+    out = _annotate(row, counts={"alpha": 1}, local_host="pinned-host")
+    # Assert
+    assert out["inbox_reachable"] == "reachable"

--- a/tests/scitex_agent_container/_state/test_event_log.py
+++ b/tests/scitex_agent_container/_state/test_event_log.py
@@ -721,3 +721,86 @@ class TestOpenAgentCalls:
         out = summarize("ag-e", root=tmp_root)
         # Assert
         assert out["open_agent_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# secret redaction in the on-disk previews
+#
+# Every preview below lands in a DURABLE per-agent JSONL. Before this, an
+# agent that happened to read a credential file, or run a command that echoed
+# a token, wrote that value to disk in cleartext and kept it.
+#
+# EVERY SECRET IN THIS BLOCK IS SYNTHETIC. Never put a real credential in a
+# test: the fixture would then be the leak it exists to prevent.
+# ---------------------------------------------------------------------------
+
+# Shaped to match the third pattern in _state/_meta/secrets.py —
+# (token|secret|api_key|password|bearer) followed by = or : — with a value
+# distinctive enough that an assertion on its absence cannot pass by accident.
+FAKE_SECRET_LINE = "declare -x GITHUB_TOKEN=ZZZsyntheticNotARealTokenZZZ"
+FAKE_SECRET_VALUE = "ZZZsyntheticNotARealTokenZZZ"
+
+
+class TestPreviewsRedactSecrets:
+    def test_result_preview_masks_a_secret_value(self, tmp_root: Path):
+        # Arrange — a posttool response carrying a secret-shaped line.
+        append_event(
+            "ag-redact-1",
+            "posttool",
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "env"},
+                "tool_response": {"output": FAKE_SECRET_LINE},
+            },
+            root=tmp_root,
+        )
+        # Act
+        events = read_recent("ag-redact-1", root=tmp_root)
+        # Assert
+        assert FAKE_SECRET_VALUE not in events[-1]["result_preview"]
+
+    def test_result_preview_still_records_something(self, tmp_root: Path):
+        # Arrange — redaction must MASK, not blank the record; a preview that
+        # became empty would silently destroy the diagnostic value the log
+        # exists for, and would also pass the assertion above.
+        append_event(
+            "ag-redact-2",
+            "posttool",
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "env"},
+                "tool_response": {"output": FAKE_SECRET_LINE},
+            },
+            root=tmp_root,
+        )
+        # Act
+        preview = read_recent("ag-redact-2", root=tmp_root)[-1]["result_preview"]
+        # Assert
+        assert "GITHUB_TOKEN" in preview
+
+    def test_prompt_preview_masks_a_secret_value(self, tmp_root: Path):
+        # Arrange
+        append_event(
+            "ag-redact-3", "prompt", {"prompt": FAKE_SECRET_LINE}, root=tmp_root
+        )
+        # Act
+        events = read_recent("ag-redact-3", root=tmp_root)
+        # Assert
+        assert FAKE_SECRET_VALUE not in events[-1]["prompt_preview"]
+
+    def test_input_preview_masks_a_secret_value(self):
+        # Arrange — the tool-input path has its own preview builder.
+        # Act
+        preview = _preview_tool_input("Bash", {"command": FAKE_SECRET_LINE})
+        # Assert
+        assert FAKE_SECRET_VALUE not in preview
+
+    def test_a_benign_preview_is_left_alone(self):
+        # Arrange — POSITIVE CONTROL for the assertions above: they check for
+        # ABSENCE, which is also what a redactor that blanks everything, or a
+        # preview builder that silently returns "", would produce. This pins
+        # that ordinary text survives untouched.
+        # Act
+        preview = _preview_tool_input("Bash", {"command": "ls -la /tmp"})
+        # Assert
+        assert preview == "ls -la /tmp"

--- a/tests/scitex_agent_container/_state/test_inbound_ledger.py
+++ b/tests/scitex_agent_container/_state/test_inbound_ledger.py
@@ -1,109 +1,171 @@
 """Tests for the receiver-side inbound dispatch ledger
-(``_state.inbound_ledger``) — the DB-backed bridge that carries a TUI
-wake's requester identity from the host-side turn-bridge to the
-in-container Stop hook that reports completion.
+(``_state.inbound_ledger``) — the bridge that carries a TUI wake's requester
+identity from the host-side turn-bridge to the in-container Stop hook that
+reports completion.
 
-Real SQLite (a tmp ``state.db`` path, no mocks). Covers the
-pending→reporting→reported lifecycle, FIFO claim order, the atomic
-single-claim guarantee, and fail-loud validation. STX-TQ002 AAA markers
-+ STX-TQ007 one assert + STX-TQ003 descriptive names.
+Real PostgreSQL via ``scitex_dev.store``, isolated per test by the
+``pg_schema`` fixture (no mocks). Covers the pending→reporting→reported
+lifecycle, FIFO claim order, the atomic single-claim guarantee, the identity
+collision the SQLite autoincrement used to absorb, and fail-loud validation.
+STX-TQ002 AAA markers + STX-TQ007 one assert + STX-TQ003 descriptive names.
+
+``db_path`` IS GONE from every call. It named a SQLite file and there is no
+file; every test that used to thread ``tmp_path / "state.db"`` now takes
+``pg_schema`` instead, which is the seam that keeps one test's rows out of
+another's — and out of the live fleet store.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 
 from scitex_agent_container._state import inbound_ledger as ledger
 
 
-def test_record_inbound_inserts_a_pending_row(tmp_path: Path) -> None:
+def test_record_inbound_inserts_a_pending_row(pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
-    ledger.record_inbound(
-        db_path=db, agent="figrecipe", from_agent="lead", dispatch_id="d1"
-    )
+    ledger.record_inbound(agent="figrecipe", from_agent="lead", dispatch_id="d1")
     # Assert
-    rows = ledger.list_inbound(agent="figrecipe", db_path=db)
+    rows = ledger.list_inbound(agent="figrecipe")
     assert len(rows) == 1 and rows[0]["status"] == ledger.STATUS_PENDING
 
 
-def test_record_inbound_rejects_empty_from_agent(tmp_path: Path) -> None:
+def test_record_inbound_rejects_empty_from_agent(pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
     # Assert
     with pytest.raises(ValueError):
-        ledger.record_inbound(db_path=db, agent="figrecipe", from_agent="")
+        ledger.record_inbound(agent="figrecipe", from_agent="")
 
 
-def test_claim_oldest_pending_returns_the_fifo_oldest(tmp_path: Path) -> None:
-    # Arrange — two dispatches, oldest first by ts.
-    db = tmp_path / "state.db"
-    ledger.record_inbound(
-        db_path=db, agent="a", from_agent="lead", dispatch_id="old", ts=100.0
-    )
-    ledger.record_inbound(
-        db_path=db, agent="a", from_agent="peer", dispatch_id="new", ts=200.0
-    )
+def test_record_inbound_returns_the_identity_not_a_counter(pg_schema: str) -> None:
+    """The autoincrement id is gone; the handle is the natural key.
+
+    Pins the SHAPE rather than a value, because the whole point of the port is
+    that nothing downstream may depend on the handle being a number.
+    """
+    # Arrange
     # Act
-    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    handle = ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    # Assert
+    assert set(handle) == set(ledger.IDENTITY_FIELDS)
+
+
+def test_claim_oldest_pending_returns_the_fifo_oldest(pg_schema: str) -> None:
+    # Arrange — two dispatches, oldest first by ts.
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="old", ts=100.0)
+    ledger.record_inbound(agent="a", from_agent="peer", dispatch_id="new", ts=200.0)
+    # Act
+    claimed = ledger.claim_oldest_pending(agent="a")
     # Assert
     assert claimed is not None and claimed["dispatch_id"] == "old"
 
 
-def test_claim_oldest_pending_flips_row_to_reporting(tmp_path: Path) -> None:
+def test_claim_oldest_pending_flips_row_to_reporting(pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
-    ledger.record_inbound(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
     # Act
-    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    claimed = ledger.claim_oldest_pending(agent="a")
     # Assert
     assert claimed is not None and claimed["status"] == ledger.STATUS_REPORTING
 
 
-def test_claim_oldest_pending_none_when_queue_empty(tmp_path: Path) -> None:
+def test_claim_oldest_pending_none_when_queue_empty(pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
-    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    claimed = ledger.claim_oldest_pending(agent="a")
     # Assert
     assert claimed is None
 
 
-def test_claim_is_atomic_so_one_row_is_claimed_once(tmp_path: Path) -> None:
+def test_claim_oldest_pending_ignores_another_agents_row(pg_schema: str) -> None:
+    """CONTROL — the claim must be scoped, or one agent settles another's work.
+
+    Without this, a claim that ignored ``agent`` would satisfy every other
+    test in this file: they each use a single agent.
+    """
+    # Arrange
+    ledger.record_inbound(agent="other", from_agent="lead", dispatch_id="d1")
+    # Act
+    claimed = ledger.claim_oldest_pending(agent="a")
+    # Assert
+    assert claimed is None
+
+
+def test_claim_is_atomic_so_one_row_is_claimed_once(pg_schema: str) -> None:
     # Arrange — a single pending row, claimed once already.
-    db = tmp_path / "state.db"
-    ledger.record_inbound(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
-    ledger.claim_oldest_pending(agent="a", db_path=db)
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    ledger.claim_oldest_pending(agent="a")
     # Act — a second claim finds nothing pending (no double-report).
-    second = ledger.claim_oldest_pending(agent="a", db_path=db)
+    second = ledger.claim_oldest_pending(agent="a")
     # Assert
     assert second is None
 
 
-def test_mark_reported_settles_a_claimed_row(tmp_path: Path) -> None:
-    # Arrange
-    db = tmp_path / "state.db"
-    row_id = ledger.record_inbound(
-        db_path=db, agent="a", from_agent="lead", dispatch_id="d1"
-    )
-    ledger.claim_oldest_pending(agent="a", db_path=db)
+def test_two_wakes_in_the_same_instant_are_both_kept(pg_schema: str) -> None:
+    """The collision the SQLite autoincrement used to absorb for free.
+
+    Identity is ``(agent, from_agent, dispatch_id, ts)``. Two requester-bearing
+    wakes with no dispatch id, from the same peer, at the SAME float instant
+    name the same record — so without the microsecond retry the second would
+    silently overwrite the first and one completion report would never be sent.
+
+    Not credible in production (``time.time()`` is microsecond-resolution and a
+    wake is a bus event) — which is exactly why it is pinned here rather than
+    reasoned about: the SQLite version made duplicates free and the port must
+    not quietly withdraw that.
+    """
+    # Arrange — same everything, including ts.
+    ledger.record_inbound(agent="a", from_agent="lead", ts=100.0)
+    ledger.record_inbound(agent="a", from_agent="lead", ts=100.0)
     # Act
-    settled = ledger.mark_reported(row_id, status=ledger.STATUS_REPORTED, db_path=db)
+    rows = ledger.list_inbound(agent="a")
+    # Assert
+    assert len(rows) == 2
+
+
+def test_mark_reported_settles_a_claimed_row(pg_schema: str) -> None:
+    # Arrange
+    handle = ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    ledger.claim_oldest_pending(agent="a")
+    # Act
+    settled = ledger.mark_reported(handle, status=ledger.STATUS_REPORTED)
     # Assert
     assert settled is True
 
 
-def test_mark_reported_rejects_a_non_terminal_status(tmp_path: Path) -> None:
+def test_mark_reported_accepts_the_claimed_row_itself(pg_schema: str) -> None:
+    """Production hands back the CLAIM, not the record. Both must work.
+
+    ``flush_one_completion`` never sees ``record_inbound``'s return value — it
+    settles whatever ``claim_oldest_pending`` gave it, which carries the data
+    fields too. If the handle had to be exactly the identity mapping, the real
+    call path would be the one that breaks.
+    """
     # Arrange
-    db = tmp_path / "state.db"
-    row_id = ledger.record_inbound(
-        db_path=db, agent="a", from_agent="lead", dispatch_id="d1"
-    )
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    claimed = ledger.claim_oldest_pending(agent="a")
+    # Act
+    settled = ledger.mark_reported(claimed, status=ledger.STATUS_REPORTED)
+    # Assert
+    assert settled is True
+
+
+def test_mark_reported_is_false_for_an_unknown_row(pg_schema: str) -> None:
+    """CONTROL — settling must report whether it matched, not always True."""
+    # Arrange — a well-formed handle for a record that was never written.
+    handle = {"agent": "a", "from_agent": "lead", "dispatch_id": "ghost", "ts": 1.0}
+    # Act
+    settled = ledger.mark_reported(handle, status=ledger.STATUS_REPORTED)
+    # Assert
+    assert settled is False
+
+
+def test_mark_reported_rejects_a_non_terminal_status(pg_schema: str) -> None:
+    # Arrange
+    handle = ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
     # Act
     # Assert
     with pytest.raises(ValueError):
-        ledger.mark_reported(row_id, status="pending", db_path=db)
+        ledger.mark_reported(handle, status="pending")

--- a/tests/scitex_agent_container/_state/test_lead_inbox.py
+++ b/tests/scitex_agent_container/_state/test_lead_inbox.py
@@ -329,7 +329,7 @@ def _push_kind(lead_env, *, kind: str, summary: str, from_agent: str) -> dict:
         )
 
 
-def test_push_to_lead_returns_server_msg_id(lead_env) -> None:
+def test_push_to_lead_returns_server_msg_id(lead_env, pg_schema: str) -> None:
     # Arrange
     kind = "done"
     # Act
@@ -340,7 +340,7 @@ def test_push_to_lead_returns_server_msg_id(lead_env) -> None:
     assert isinstance(out.get("msg_id"), str) and out["msg_id"]
 
 
-def test_push_to_lead_persists_event_with_kind(lead_env) -> None:
+def test_push_to_lead_persists_event_with_kind(lead_env, pg_schema: str) -> None:
     # Arrange — push then read back from the durable table.
     kind = "blocker"
     # Act
@@ -353,7 +353,7 @@ def test_push_to_lead_persists_event_with_kind(lead_env) -> None:
     assert rows and rows[0]["event"].get("kind") == "blocker"
 
 
-def test_push_to_lead_persists_summary_as_content(lead_env) -> None:
+def test_push_to_lead_persists_summary_as_content(lead_env, pg_schema: str) -> None:
     # Arrange
     summary = "phase 2/4"
     # Act
@@ -363,7 +363,7 @@ def test_push_to_lead_persists_summary_as_content(lead_env) -> None:
     assert rows and rows[0]["event"].get("content") == "phase 2/4"
 
 
-def test_push_to_lead_persists_from_agent(lead_env) -> None:
+def test_push_to_lead_persists_from_agent(lead_env, pg_schema: str) -> None:
     # Arrange
     sender = "bob"
     # Act
@@ -424,7 +424,7 @@ def test_push_to_lead_loud_on_unreachable_lead(lead_env) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_regression_agent_completion_event_lands_in_lead_inbox(lead_env) -> None:
+def test_regression_agent_completion_event_lands_in_lead_inbox(lead_env, pg_schema: str) -> None:
     # Arrange — real lead listen on a free port; real peer-token; real
     # same-group lineage so the ACL admits the send. The agent identity
     # is ``alice``; the lead identity is ``lead`` (matches lead_env's

--- a/tests/scitex_agent_container/_state/test_state_db_acl_deny_notify.py
+++ b/tests/scitex_agent_container/_state/test_state_db_acl_deny_notify.py
@@ -62,14 +62,13 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
 # ---------------------------------------------------------------------------
 
 
-def test_first_call_returns_true(isolated_state: Path) -> None:
+def test_first_call_returns_true(pg_schema: str) -> None:
     # Arrange — fresh DB, no prior row for the pair.
     # Act
     admitted = should_notify_acl_deny(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1000.0,
     )
     # Assert — first denied attempt MUST emit the synthetic notification.
@@ -77,14 +76,13 @@ def test_first_call_returns_true(isolated_state: Path) -> None:
 
 
 def test_second_call_within_cooldown_returns_false(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — record an admit at t=1000, cool-down=60s.
     should_notify_acl_deny(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1000.0,
     )
     # Act — second attempt only 30s later (inside the window).
@@ -92,7 +90,6 @@ def test_second_call_within_cooldown_returns_false(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1030.0,
     )
     # Assert — duplicate inside cool-down MUST suppress (no flood).
@@ -100,14 +97,13 @@ def test_second_call_within_cooldown_returns_false(
 
 
 def test_call_after_cooldown_elapses_returns_true(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — cool-down=60s; second attempt 61s later (just past).
     should_notify_acl_deny(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1000.0,
     )
     # Act
@@ -115,7 +111,6 @@ def test_call_after_cooldown_elapses_returns_true(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1061.0,
     )
     # Assert — past the window, re-emit so the operator who missed
@@ -124,7 +119,7 @@ def test_call_after_cooldown_elapses_returns_true(
 
 
 def test_different_pair_not_throttled_by_unrelated(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — throttle is per (sender, target). One pair's emit
     # MUST NOT silence a different pair.
@@ -132,7 +127,6 @@ def test_different_pair_not_throttled_by_unrelated(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1000.0,
     )
     # Act — different sender, same target.
@@ -140,7 +134,6 @@ def test_different_pair_not_throttled_by_unrelated(
         sender="bob",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1005.0,
     )
     # Assert
@@ -148,14 +141,13 @@ def test_different_pair_not_throttled_by_unrelated(
 
 
 def test_same_sender_different_target_admitted(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — same sender, different target — independent key.
     should_notify_acl_deny(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1000.0,
     )
     # Act
@@ -163,53 +155,49 @@ def test_same_sender_different_target_admitted(
         sender="alice",
         target="other",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1005.0,
     )
     # Assert
     assert admitted is True
 
 
-def test_admit_updates_last_notified_at(isolated_state: Path) -> None:
+def test_admit_updates_last_notified_at(pg_schema: str) -> None:
     # Arrange — capture the stamp the admit recorded.
     should_notify_acl_deny(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1234.5,
     )
     # Act
-    stamp = last_notified_at(sender="alice", target="lead", db_path=isolated_state)
+    stamp = last_notified_at(sender="alice", target="lead")
     # Assert — observability surface MUST round-trip the recorded ts.
     assert stamp == 1234.5
 
 
-def test_re_admit_overwrites_last_notified_at(isolated_state: Path) -> None:
+def test_re_admit_overwrites_last_notified_at(pg_schema: str) -> None:
     # Arrange — first admit at t=1000, second (past cool-down) at t=2000.
     should_notify_acl_deny(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1000.0,
     )
     should_notify_acl_deny(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=2000.0,
     )
     # Act
-    stamp = last_notified_at(sender="alice", target="lead", db_path=isolated_state)
+    stamp = last_notified_at(sender="alice", target="lead")
     # Assert — the second admit MUST bump the stamp forward so the
     # next cool-down is measured from the most recent emit.
     assert stamp == 2000.0
 
 
 def test_suppressed_call_does_not_bump_last_notified_at(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — a suppressed (inside-window) attempt MUST NOT slide
     # the cool-down forward. Otherwise a sender attempting every
@@ -218,18 +206,16 @@ def test_suppressed_call_does_not_bump_last_notified_at(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1000.0,
     )
     should_notify_acl_deny(
         sender="alice",
         target="lead",
         cooldown_s=60.0,
-        db_path=isolated_state,
         now=1030.0,
     )
     # Act
-    stamp = last_notified_at(sender="alice", target="lead", db_path=isolated_state)
+    stamp = last_notified_at(sender="alice", target="lead")
     # Assert
     assert stamp == 1000.0
 
@@ -239,7 +225,7 @@ def test_suppressed_call_does_not_bump_last_notified_at(
 # ---------------------------------------------------------------------------
 
 
-def test_empty_sender_raises(isolated_state: Path) -> None:
+def test_empty_sender_raises(pg_schema: str) -> None:
     # Arrange
     # Act
     # Assert
@@ -248,11 +234,10 @@ def test_empty_sender_raises(isolated_state: Path) -> None:
             sender="",
             target="lead",
             cooldown_s=60.0,
-            db_path=isolated_state,
         )
 
 
-def test_empty_target_raises(isolated_state: Path) -> None:
+def test_empty_target_raises(pg_schema: str) -> None:
     # Arrange
     # Act
     # Assert
@@ -261,16 +246,15 @@ def test_empty_target_raises(isolated_state: Path) -> None:
             sender="alice",
             target="",
             cooldown_s=60.0,
-            db_path=isolated_state,
         )
 
 
 def test_last_notified_at_absent_pair_returns_none(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — no admit calls for this pair.
     # Act
-    stamp = last_notified_at(sender="ghost", target="lead", db_path=isolated_state)
+    stamp = last_notified_at(sender="ghost", target="lead")
     # Assert
     assert stamp is None
 
@@ -280,7 +264,7 @@ def test_last_notified_at_absent_pair_returns_none(
 # ---------------------------------------------------------------------------
 
 
-def test_default_cooldown_is_thirty_minutes(isolated_state: Path) -> None:
+def test_default_cooldown_is_thirty_minutes(pg_schema: str) -> None:
     # Arrange — no env, no override.
     os.environ.pop("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S", None)
     # Act
@@ -289,7 +273,7 @@ def test_default_cooldown_is_thirty_minutes(isolated_state: Path) -> None:
     assert effective == DEFAULT_COOLDOWN_S
 
 
-def test_env_overrides_default(isolated_state: Path) -> None:
+def test_env_overrides_default(pg_schema: str) -> None:
     # Arrange — operator sets a custom window.
     os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "5"
     # Act
@@ -298,7 +282,7 @@ def test_env_overrides_default(isolated_state: Path) -> None:
     assert effective == 5.0
 
 
-def test_explicit_override_beats_env(isolated_state: Path) -> None:
+def test_explicit_override_beats_env(pg_schema: str) -> None:
     # Arrange — test seam: explicit arg wins over env wins over default.
     os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "999"
     # Act
@@ -307,7 +291,7 @@ def test_explicit_override_beats_env(isolated_state: Path) -> None:
     assert effective == 0.5
 
 
-def test_malformed_env_falls_back_to_default(isolated_state: Path) -> None:
+def test_malformed_env_falls_back_to_default(pg_schema: str) -> None:
     # Arrange — operator typo (non-float) MUST NOT silently disable
     # the rate-limit; fall back to the safe default.
     os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "not-a-number"
@@ -317,7 +301,7 @@ def test_malformed_env_falls_back_to_default(isolated_state: Path) -> None:
     assert effective == DEFAULT_COOLDOWN_S
 
 
-def test_negative_env_falls_back_to_default(isolated_state: Path) -> None:
+def test_negative_env_falls_back_to_default(pg_schema: str) -> None:
     # Arrange — "-1" would disable the rate-limit (every attempt
     # past, since elapsed >= -1 always). Safe fallback per spec.
     os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "-1"

--- a/tests/scitex_agent_container/_state/test_state_db_blocks.py
+++ b/tests/scitex_agent_container/_state/test_state_db_blocks.py
@@ -11,36 +11,18 @@ assertion per test.
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from typing import Iterator
+import time
+
 
 import pytest
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_blocks import (
     block_send,
+    ensure_comms_blocks_table,
     has_block,
+    open_blocks_store,
     unblock_send,
 )
-
-
-@pytest.fixture
-def isolated_state(tmp_path: Path) -> Iterator[Path]:
-    db = tmp_path / "state.db"
-    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
-    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
-    try:
-        yield db
-    finally:
-        state_db.DEFAULT_DB_PATH = saved_default
-        if saved_env is None:
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
-        else:
-            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
 
 
 # ---------------------------------------------------------------------------
@@ -48,43 +30,42 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
 # ---------------------------------------------------------------------------
 
 
-def test_block_then_has_block_returns_true(isolated_state: Path) -> None:
+def test_block_then_has_block_returns_true(pg_schema: str) -> None:
     # Arrange
-    block_send(sender="alice", target="lead", db_path=isolated_state)
+    block_send(sender="alice", target="lead")
     # Act
-    flag = has_block(sender="alice", target="lead", db_path=isolated_state)
+    flag = has_block(sender="alice", target="lead")
     # Assert
     assert flag is True
 
 
-def test_has_block_returns_false_for_absent_pair(isolated_state: Path) -> None:
+def test_has_block_returns_false_for_absent_pair(pg_schema: str) -> None:
     # Arrange — no block_send.
     # Act
-    flag = has_block(sender="ghost", target="lead", db_path=isolated_state)
+    flag = has_block(sender="ghost", target="lead")
     # Assert
     assert flag is False
 
 
-def test_block_is_directional(isolated_state: Path) -> None:
+def test_block_is_directional(pg_schema: str) -> None:
     # Arrange — block alice → lead. The REVERSE direction
     # (lead → alice) must be unaffected.
-    block_send(sender="alice", target="lead", db_path=isolated_state)
+    block_send(sender="alice", target="lead")
     # Act
-    reverse_flag = has_block(sender="lead", target="alice", db_path=isolated_state)
+    reverse_flag = has_block(sender="lead", target="alice")
     # Assert
     assert reverse_flag is False
 
 
-def test_block_is_idempotent(isolated_state: Path) -> None:
-    # Arrange — block twice. The row's timestamp must not bump on
-    # the second call (mirrors grant_send semantics).
-    block_send(sender="alice", target="lead", note="first", db_path=isolated_state)
+def test_block_is_idempotent(pg_schema: str) -> None:
+    # Arrange
+    block_send(sender="alice", target="lead", note="first")
     # Act
-    block_send(sender="alice", target="lead", note="second", db_path=isolated_state)
-    # Assert — still exactly one row's worth of state visible via
-    # has_block; the test pins the public observable, not the row
-    # count (idempotency is the contract).
-    assert has_block(sender="alice", target="lead", db_path=isolated_state)
+    block_send(sender="alice", target="lead", note="second")
+    # Assert — still blocked. The TIMESTAMP half of idempotence, which this
+    # test's comment used to claim and never checked, is pinned separately
+    # below where it can actually fail.
+    assert has_block(sender="alice", target="lead")
 
 
 # ---------------------------------------------------------------------------
@@ -92,29 +73,29 @@ def test_block_is_idempotent(isolated_state: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_unblock_removes_the_block_row(isolated_state: Path) -> None:
+def test_unblock_removes_the_block_row(pg_schema: str) -> None:
     # Arrange
-    block_send(sender="alice", target="lead", db_path=isolated_state)
-    unblock_send(sender="alice", target="lead", db_path=isolated_state)
+    block_send(sender="alice", target="lead")
+    unblock_send(sender="alice", target="lead")
     # Act
-    flag = has_block(sender="alice", target="lead", db_path=isolated_state)
+    flag = has_block(sender="alice", target="lead")
     # Assert
     assert flag is False
 
 
-def test_unblock_returns_true_when_row_existed(isolated_state: Path) -> None:
+def test_unblock_returns_true_when_row_existed(pg_schema: str) -> None:
     # Arrange
-    block_send(sender="alice", target="lead", db_path=isolated_state)
+    block_send(sender="alice", target="lead")
     # Act
-    removed = unblock_send(sender="alice", target="lead", db_path=isolated_state)
+    removed = unblock_send(sender="alice", target="lead")
     # Assert
     assert removed is True
 
 
-def test_unblock_returns_false_when_row_absent(isolated_state: Path) -> None:
+def test_unblock_returns_false_when_row_absent(pg_schema: str) -> None:
     # Arrange — no prior block.
     # Act
-    removed = unblock_send(sender="ghost", target="lead", db_path=isolated_state)
+    removed = unblock_send(sender="ghost", target="lead")
     # Assert
     assert removed is False
 
@@ -124,17 +105,97 @@ def test_unblock_returns_false_when_row_absent(isolated_state: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_block_empty_sender_raises(isolated_state: Path) -> None:
+def test_block_empty_sender_raises(pg_schema: str) -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError, match="non-empty"):
-        block_send(sender="", target="lead", db_path=isolated_state)
+        block_send(sender="", target="lead")
 
 
-def test_block_empty_target_raises(isolated_state: Path) -> None:
+def test_block_empty_target_raises(pg_schema: str) -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError, match="non-empty"):
-        block_send(sender="alice", target="", db_path=isolated_state)
+        block_send(sender="alice", target="")
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL semantics (2026-08-20): the store hides, it does not delete
+# ---------------------------------------------------------------------------
+#
+# `unblock_send` used to DELETE. The store has no delete — it has `hide`, which
+# is the better primitive here (who unblocked whom, and when, survives) but
+# introduces a state SQLite did not have: a cleared pair is HIDDEN, not ABSENT.
+# These pin the three-value branch that distinguishes them.
+
+
+def _created_at(sender: str, target: str) -> float:
+    """The stored timestamp, read back through the store the module writes to."""
+    store = open_blocks_store()
+    try:
+        record = store.get({"sender_name": sender, "target_name": target})
+        return float(record.values["created_at"])
+    finally:
+        store.close()
+
+
+def test_reblocking_does_not_bump_the_timestamp(pg_schema: str) -> None:
+    """The documented idempotence: "re-blocking leaves the row untouched".
+
+    Falsifiable, and it is the one the old test only claimed: make the visible
+    branch write instead of returning early and this goes RED.
+    """
+    # Arrange
+    block_send(sender="alice", target="lead")
+    first = _created_at("alice", "lead")
+    time.sleep(0.01)
+    # Act
+    block_send(sender="alice", target="lead")
+    # Assert
+    assert _created_at("alice", "lead") == first
+
+
+def test_reblocking_after_an_unblock_does_bump_the_timestamp(pg_schema: str) -> None:
+    """An unblock followed by a block is a NEW decision, not a repeat.
+
+    Dating it to the superseded block would misreport when the receiver made
+    it. This is the case that separates "hidden" from "visible": collapse the
+    two and one of these two tests must fail.
+    """
+    # Arrange
+    block_send(sender="alice", target="lead")
+    first = _created_at("alice", "lead")
+    unblock_send(sender="alice", target="lead")
+    time.sleep(0.01)
+    # Act
+    block_send(sender="alice", target="lead")
+    # Assert
+    assert _created_at("alice", "lead") > first
+
+
+def test_unblocking_hides_the_record_rather_than_destroying_it(pg_schema: str) -> None:
+    """The audit trail a DELETE destroyed."""
+    # Arrange
+    block_send(sender="alice", target="lead")
+    unblock_send(sender="alice", target="lead")
+    # Act
+    store = open_blocks_store()
+    try:
+        hidden = store.is_hidden({"sender_name": "alice", "target_name": "lead"})
+    finally:
+        store.close()
+    # Assert — True means "present but hidden"; None would mean it was erased.
+    assert hidden is True
+
+
+def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> None:
+    """The SQLite version returned None. Naming where the state went is more
+    useful: an operator can check it instead of assuming it."""
+    # Arrange
+    expected_scheme = "postgres"
+    # Act
+    locator = ensure_comms_blocks_table()
+    # Assert
+    assert expected_scheme in locator

--- a/tests/scitex_agent_container/_state/test_state_db_comms_nodes_tombstone_reregister.py
+++ b/tests/scitex_agent_container/_state/test_state_db_comms_nodes_tombstone_reregister.py
@@ -1,0 +1,148 @@
+"""A tombstoned ``comms_nodes`` row must not refuse the restart after it.
+
+``unregister_comms_node`` tombstones a row (``ended_at`` set) when an agent
+stops. Until this fix, ``register_comms_node``'s collision check compared the
+incoming target against that DEAD row, so an agent that came back on a
+different port raised :class:`CommsNodeConflictError` and — because every
+production caller swallows it best-effort — vanished from the federated graph
+permanently, surfacing only as ``unknown_target`` at the far end.
+
+``spec.a2a.port: auto`` makes "a different port" the normal outcome of a
+restart, so this was ordinary lifecycle rather than an edge case. Reproduced
+independently on two hosts 2026-08-20: ``business`` live on 19012 behind a
+tombstone pinned at 19033 (ywata-note-win, 19 live / 132 tombstoned), and
+``scitex-dev`` live on 19008 behind an 11-day-old tombstone at 19003
+(compute-04, 3 live / 29 tombstoned).
+
+The revival assertions matter as much as the "does not raise" ones: fixing the
+SELECT makes the re-activation UPDATE three lines below it reachable for the
+first time, so a registration could stop raising and still leave a row that
+readers filter out.
+
+Separate file because ``test_state_db_comms_nodes.py`` is already 625 lines
+against a 512-line cap. PA-306: no mocks; real on-disk SQLite under
+``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    CommsNodeConflictError,
+    lookup_comms_node,
+    register_comms_node,
+    unregister_comms_node,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    # Arrange
+    p = tmp_path / "state.db"
+    state_db.init_schema(p)
+    return p
+
+
+def _stopped_agent(db_path: Path, *, port: int = 19033) -> None:
+    """Register an agent, then stop it — leaving a tombstone at ``port``."""
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=port, db_path=db_path
+    )
+    unregister_comms_node(name="business", db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# The defect: a dead row blocked the restart that followed it
+# ---------------------------------------------------------------------------
+
+
+def test_restart_on_a_new_port_is_visible_to_peers_again(db_path: Path) -> None:
+    # Arrange — stopped at 19033, comes back on 19012 (port: auto moved it)
+    _stopped_agent(db_path)
+    # Act — raised CommsNodeConflictError before the fix
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=19012, db_path=db_path
+    )
+    # Assert — lookup filters tombstones, so a non-None row proves both that
+    # the call was accepted AND that ended_at was cleared.
+    assert lookup_comms_node(name="business", db_path=db_path) is not None
+
+
+def test_the_revived_row_carries_the_new_port(db_path: Path) -> None:
+    # Arrange
+    _stopped_agent(db_path)
+    # Act
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=19012, db_path=db_path
+    )
+    # Assert — peers must route to where the agent actually listens
+    row = lookup_comms_node(name="business", db_path=db_path)
+    assert row is not None and int(row["a2a_port"]) == 19012
+
+
+# ---------------------------------------------------------------------------
+# Controls — the fix must not become "the guard is disabled"
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_row_on_a_different_port_still_refuses(db_path: Path) -> None:
+    # Arrange — LIVE registration, never unregistered
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=19033, db_path=db_path
+    )
+
+    # Act
+    def _reregister() -> None:
+        register_comms_node(
+            name="business", host="ywata-note-win", a2a_port=19012, db_path=db_path
+        )
+
+    # Assert — the collision this guard exists for must still fire
+    with pytest.raises(CommsNodeConflictError):
+        _reregister()
+
+
+def test_a_cross_host_tombstone_still_refuses(db_path: Path) -> None:
+    # Arrange — tombstone owned by one source_host
+    register_comms_node(
+        name="business",
+        host="ywata-note-win",
+        a2a_port=19033,
+        source_host="ywata-note-win",
+        db_path=db_path,
+    )
+    unregister_comms_node(name="business", db_path=db_path)
+
+    # Act
+    def _claim_from_another_host() -> None:
+        register_comms_node(
+            name="business",
+            host="scitex-compute-04",
+            a2a_port=19012,
+            source_host="scitex-compute-04",
+            db_path=db_path,
+        )
+
+    # Assert — another host claiming the name is an ADR-0014 uniqueness
+    # question, which a tombstone does not answer.
+    with pytest.raises(CommsNodeConflictError):
+        _claim_from_another_host()
+
+
+def test_an_unrelated_live_name_is_untouched_by_the_revival(db_path: Path) -> None:
+    # Arrange — a neighbour holding a port of its own
+    _stopped_agent(db_path)
+    register_comms_node(
+        name="scitex-hpc", host="ywata-note-win", a2a_port=19012, db_path=db_path
+    )
+    # Act — business revives onto a different port than the neighbour's
+    register_comms_node(
+        name="business", host="ywata-note-win", a2a_port=19099, db_path=db_path
+    )
+    # Assert — reviving one name must not disturb another's row
+    row = lookup_comms_node(name="scitex-hpc", db_path=db_path)
+    assert row is not None and int(row["a2a_port"]) == 19012

--- a/tests/scitex_agent_container/_state/test_state_db_forward.py
+++ b/tests/scitex_agent_container/_state/test_state_db_forward.py
@@ -1,0 +1,136 @@
+"""A live row with no port must not end the search for an ADDRESS.
+
+`resolve_node_host` answers LOCALITY ("which host"), and `is_local_node` reads
+only its `host`. The forwarder needed ADDRESSABILITY ("where do I POST") and was
+reading the same value, so a live `instances` row with a NULL port was returned
+as the answer, the forwarder took it, and `_forward_to_remote` 502'd on the
+falsy port — never consulting `comms_nodes`, which may hold a working address
+for that same name.
+
+MEASURED on ywata-note-win 2026-08-20: `scitex-dev host=scitex-compute-04
+a2a_port=NULL bound_port=NULL ended_at=NULL`. Live and PERMANENT — the GC never
+reaps cross-host rows (`AND remote=0`, deliberate) and nothing back-fills the
+port, so it can neither age out nor be repaired in place.
+
+The controls are the weight-bearing half: locality must NOT move. A "fix" that
+made `resolve_node_host` fall through would hand the locality decision to
+`comms_nodes`, which may name a different host — silently redefining "local".
+
+PA-306: no mocks; real on-disk SQLite under `tmp_path`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_forward import resolve_forward_target
+from scitex_agent_container._state.state_db_nodes import (
+    is_local_node,
+    register_comms_node,
+    resolve_node_host,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    # Arrange
+    p = tmp_path / "state.db"
+    state_db.init_schema(p)
+    return p
+
+
+def _live_row(db_path: Path, *, a2a_port, bound_port, host: str = "host-a") -> None:
+    """One live instances row for 'peer' with the given port columns."""
+    with state_db.open_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO instances (id, name, host, scope, a2a_port, "
+            " bound_port, started_at, ended_at) "
+            "VALUES ('id-1', 'peer', ?, 'global', ?, ?, "
+            "        '2026-08-20T00:00:00Z', NULL)",
+            (host, a2a_port, bound_port),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The defect: a portless live row ended the search
+# ---------------------------------------------------------------------------
+
+
+def test_a_portless_live_row_falls_through_to_comms_nodes(db_path: Path) -> None:
+    # Arrange — the exact fleet state: live row, both ports NULL, and a
+    # comms_nodes entry that DOES carry an address.
+    _live_row(db_path, a2a_port=None, bound_port=None)
+    register_comms_node(
+        name="peer", host="host-b", a2a_port=19099, db_path=db_path
+    )
+    # Act
+    target = resolve_forward_target(name="peer", db_path=db_path)
+    # Assert — resolved to {host-a, None} before, and 502'd downstream
+    assert target is not None and target["a2a_port"] == 19099
+
+
+def test_no_address_anywhere_returns_none(db_path: Path) -> None:
+    # Arrange — live row with no port, and nothing in comms_nodes either
+    _live_row(db_path, a2a_port=None, bound_port=None)
+    # Act
+    target = resolve_forward_target(name="peer", db_path=db_path)
+    # Assert — "cannot forward", not a fabricated target
+    assert target is None
+
+
+# ---------------------------------------------------------------------------
+# Controls — the instances row still WINS when it can answer
+# ---------------------------------------------------------------------------
+
+
+def test_a_usable_instances_row_wins_over_comms_nodes(db_path: Path) -> None:
+    # Arrange — both sources have an address; instances is authoritative
+    _live_row(db_path, a2a_port=19001, bound_port=None)
+    register_comms_node(
+        name="peer", host="host-b", a2a_port=19099, db_path=db_path
+    )
+    # Act
+    target = resolve_forward_target(name="peer", db_path=db_path)
+    # Assert — the fall-through must not become a preference for comms_nodes
+    assert target is not None and target["a2a_port"] == 19001
+
+
+def test_bound_port_counts_as_a_usable_address(db_path: Path) -> None:
+    # Arrange — only bound_port survived on the row
+    _live_row(db_path, a2a_port=None, bound_port=19012)
+    register_comms_node(
+        name="peer", host="host-b", a2a_port=19099, db_path=db_path
+    )
+    # Act
+    target = resolve_forward_target(name="peer", db_path=db_path)
+    # Assert — still the instances row, via the fallback column
+    assert target is not None and target["a2a_port"] == 19012
+
+
+# ---------------------------------------------------------------------------
+# Controls — LOCALITY must be untouched by all of this
+# ---------------------------------------------------------------------------
+
+
+def test_locality_still_comes_from_the_instances_row(db_path: Path) -> None:
+    # Arrange — portless local row, with comms_nodes naming a DIFFERENT host
+    _live_row(db_path, a2a_port=None, bound_port=None, host="host-a")
+    register_comms_node(
+        name="peer", host="host-b", a2a_port=19099, db_path=db_path
+    )
+    # Act
+    local = is_local_node(name="peer", local_host="host-a", db_path=db_path)
+    # Assert — the agent IS on host-a; forwarding must not redefine that
+    assert local is True
+
+
+def test_resolve_node_host_still_reports_the_portless_row(db_path: Path) -> None:
+    # Arrange
+    _live_row(db_path, a2a_port=None, bound_port=None)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert — unchanged: it answers locality, port or no port
+    assert info is not None and info["host"] == "host-a"

--- a/tests/scitex_agent_container/_state/test_state_db_incarnations.py
+++ b/tests/scitex_agent_container/_state/test_state_db_incarnations.py
@@ -48,6 +48,7 @@ import pytest
 from scitex_agent_container._state.state_db_incarnations import (
     STORE_NAME,
     get_incarnation,
+    incarnation_store_target,
     init_incarnations_schema,
     record_incarnation_birth,
     record_incarnation_exit,
@@ -334,3 +335,110 @@ def test_incarnations_is_no_longer_a_sqlite_known_table() -> None:
     known = set(KNOWN_TABLES)
     # Assert
     assert "incarnations" not in known
+
+
+# ----------------------------------------------------------------------
+# A test must not be able to write into the live fleet store
+# ----------------------------------------------------------------------
+#
+# REGRESSION GUARD for a measured incident, 2026-08-20. PR #1154 dropped
+# `db_path` from `write_birth_certificate`; tests that had been threading a
+# tmp_path SQLite file silently began resolving the FLEET DSN, and one
+# full-suite run on scitex-compute-04 wrote 46 rows into the live
+# `incarnations` store — alpha, zombie, born-1..4, pid-*, rec-*, grant-*,
+# screen-*, every one a fixture name. Removed afterwards with the store's
+# own `hide` verb.
+#
+# The rows were the small half. sac's CI runs on SELF-HOSTED runners sitting
+# on the fleet hosts, so this was a test suite scheduled to edit production
+# state on every push. And it was invisible: write_birth_certificate is
+# best-effort, so a test that wrote to the fleet store passed exactly like
+# one that did not.
+#
+# THESE LIVE HERE, in the incarnations mirror, rather than in a file of
+# their own: a standalone tests/scitex_agent_container/test_*.py has no src
+# counterpart and the ecosystem audit rejects it (PS-204 orphan-test-file,
+# measured in CI on 2026-08-20). tests/develop/ would satisfy the audit but
+# is OUTSIDE the conftest whose guard these tests verify, so the guard would
+# not be armed there — the tests would pass by not being covered. This is
+# the table the incident polluted, so the mirror it belongs to is this one.
+
+#: The fleet's real store. If a test ever resolves this, the guard is gone.
+_FLEET_HOST_PORT = "127.0.0.1:55432"
+
+
+def test_the_store_dsn_is_not_the_fleet_store_during_a_test() -> None:
+    # Arrange: the autouse conftest guard has already run for this test.
+    dsn = os.environ.get("SCITEX_STORE_DSN", "")
+    # Act
+    points_at_fleet = _FLEET_HOST_PORT in dsn
+    # Assert
+    assert not points_at_fleet
+
+
+def test_the_resolved_target_is_not_the_fleet_store() -> None:
+    """The variable being set is not the same as the resolver honouring it.
+
+    Checked separately because ``host_store`` is a two-step resolution: a
+    future change that stopped reading ``SCITEX_STORE_DSN`` would leave the
+    assertion above green while sending writes back to the fleet.
+    """
+    # Arrange
+    target = incarnation_store_target()
+    # Act
+    locator = str(target.locator)
+    # Assert
+    assert _FLEET_HOST_PORT not in locator
+
+
+def test_a_birth_certificate_written_during_a_test_does_not_land() -> None:
+    """The behavioural assertion: the write must not reach a real store.
+
+    Uses the best-effort launch path, which is exactly how the 46 rows were
+    written — not the store API directly, because the incident came through
+    a caller that swallows failures rather than through a deliberate write.
+
+    ASSERTS ON THE RETURN VALUE, and the first draft did not. It asserted
+    ``get_incarnation(...) is None``, which cannot hold: with no store to
+    reach, the READ raises exactly as the write did, so the test failed
+    while the guard was working perfectly. "Nothing was written" and
+    "reading finds nothing" are different claims, and only the first one is
+    observable when the store is deliberately absent.
+    """
+    # Arrange
+    from scitex_agent_container._lifecycle._birth_certificate import (
+        write_birth_certificate,
+    )
+    from scitex_agent_container.config import AgentConfig
+
+    cfg = AgentConfig(name="guard-must-not-persist")
+    # Act
+    landed = write_birth_certificate(cfg, "inc-guard-must-not-persist")
+    # Assert: the launch path reports the record did not land.
+    assert landed is False
+
+
+def test_the_guard_lets_a_test_opt_in_to_a_real_store(pg_schema: str) -> None:
+    """POSITIVE CONTROL — without it the three tests above are unfalsifiable.
+
+    A guard that blocked EVERY store access would satisfy all of them and
+    also break every legitimate PostgreSQL test in the suite. This proves
+    the opt-in path still reaches a real database, just not the fleet's.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db_incarnations import (
+        record_incarnation_birth,
+    )
+
+    record_incarnation_birth(
+        "inc-guard-opt-in",
+        agent_id="guard",
+        spec_id=None,
+        spec_git_sha="unresolvable",
+        host="h",
+        compiled_spec_json="{}",
+    )
+    # Act
+    row = get_incarnation("inc-guard-opt-in")
+    # Assert
+    assert row is not None

--- a/tests/scitex_agent_container/_state/test_state_db_incarnations.py
+++ b/tests/scitex_agent_container/_state/test_state_db_incarnations.py
@@ -141,13 +141,32 @@ def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> 
     scitex'``. Pinned as discovered rather than quietly weakened: an
     operator following this string reaches the right server, and still has
     to know which schema to look in.
+
+    ASSERTS ON THE PARTS, NOT THE PUNCTUATION, and that is the fix for how
+    this test broke. The quotation in the paragraph above is the locator as
+    scitex-dev 0.56.0 rendered it — ``postgres://127.0.0.1:55432/scitex`` —
+    and the old assertion spliced the tail off ``_BASE_DSN`` and looked for
+    that substring verbatim. 0.56.1 renders the same endpoint as
+    ``postgres[host=127.0.0.1 db=scitex port=55432]``.
+
+    Nothing about where the state goes changed. A developer machine pinned
+    to 0.56.0 stayed green while CI, which resolves the newest, went red —
+    so this was invisible to every local run and only a full CI
+    reproduction found it.
+
+    The locator is a REDACTED DISPLAY FORM, deliberately: the real
+    connection string is ``target.dsn``. A display form is not a contract
+    and must not be asserted on as if it were. What this test means is "the
+    locator names this host, this port and this database", which survives
+    any reformatting that still names them — including both forms above.
     """
     # Arrange: the endpoint the fixture routed this test's writes through.
-    endpoint = _BASE_DSN.split("@", 1)[-1]
+    host_port, _, database = _BASE_DSN.split("@", 1)[-1].partition("/")
+    host, _, port = host_port.partition(":")
     # Act
     locator = init_incarnations_schema()
     # Assert
-    assert endpoint in locator
+    assert all(part in locator for part in (host, port, database))
 
 
 # ----------------------------------------------------------------------

--- a/tests/scitex_agent_container/_state/test_state_db_incarnations.py
+++ b/tests/scitex_agent_container/_state/test_state_db_incarnations.py
@@ -1,130 +1,336 @@
-"""``incarnations`` — the birth-certificate table (v4 step 5).
+"""``incarnations`` — the birth certificate, on a REAL PostgreSQL.
 
-One row joins the three settled identities (spec / agent / incarnation)
+Mirrors ``src/scitex_agent_container/_state/state_db_incarnations.py``.
+
+One record joins the three settled identities (spec / agent / incarnation)
 plus the compiled-spec snapshot at launch; the exit mirror completes the
-life-and-death record. Real on-disk SQLite via explicit ``db_path`` —
-no env juggling, no mocks.
+life-and-death record.
+
+WHY THESE TESTS TALK TO A REAL DATABASE
+=======================================
+The module under test is PostgreSQL-only by the operator's 2026-08-19 order
+("fail fast, fail loud, no fallbacks"), and it reaches PostgreSQL through
+``scitex_dev.store``. A suite that exercised the store's SQLite dialect
+instead would be testing a code path production can never take — the exact
+defect scitex-dev 0.49.0 shipped, where the PostgreSQL backend could be
+WRITTEN to and never READ from.
+
+AND WHY THEY MUST NOT SKIP
+==========================
+There is deliberately NO ``skipif`` on database availability. A skip that
+reads as a pass is the defect this migration exists to remove (same shape as
+the ``importorskip`` bug fixed in #1108). Every runner in the gate pool has a
+PostgreSQL on 127.0.0.1:55432, so an unreachable store is a broken fleet,
+not a test-environment quirk, and the red is correct.
+
+ISOLATION WITHOUT PRIVILEGE
+===========================
+Each test gets its own PostgreSQL SCHEMA inside the existing ``scitex``
+database, selected through ``search_path`` in the DSN, and dropped with
+``CASCADE`` afterwards — a schema and not a database because creating a
+database needs ``CREATEDB`` and the fleet is not uniform there (compute-03's
+``scitex_cards`` role has ``rolcreatedb=False``), which would make the suite
+pass on three runners and fail on the fourth.
+
+Real ``os.environ`` save/restore, not ``monkeypatch`` — PA-306 forbids mocks,
+and the point is that the REAL resolver reads the REAL variable.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
+import uuid
+from typing import Iterator
 
+import psycopg
 import pytest
 
 from scitex_agent_container._state.state_db_incarnations import (
+    STORE_NAME,
     get_incarnation,
+    init_incarnations_schema,
     record_incarnation_birth,
     record_incarnation_exit,
 )
 
+#: The per-host store. Loopback only — every fleet PostgreSQL refuses
+#: non-local connections at pg_hba, measured 2026-08-19.
+_BASE_DSN = os.environ.get(
+    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
+)
 
-@pytest.fixture
-def db(tmp_path: Path) -> Path:
-    return tmp_path / "state.db"
+
+@pytest.fixture()
+def pg_schema() -> Iterator[str]:
+    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
+
+    Yields the schema name. Anything the module writes lands here and is
+    dropped afterwards, so the live birth-certificate store is never
+    touched.
+    """
+    schema = "sac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = f"{_BASE_DSN}?options=-csearch_path%3D{schema}"
+    try:
+        yield schema
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
 
 
-def _birth(db: Path, incarnation: str = "inc-1") -> str:
+def _tables_in(schema: str) -> set[str]:
+    """The table names PostgreSQL actually holds in ``schema``."""
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
+            (schema,),
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _birth(incarnation: str = "inc-1", *, sha: str = "abc123") -> str:
     return record_incarnation_birth(
         incarnation,
         agent_id="alpha",
         spec_id="/specs/alpha/spec.yaml",
-        spec_git_sha="abc123",
+        spec_git_sha=sha,
         host="h1",
         compiled_spec_json='{"name": "alpha"}',
-        db_path=db,
     )
 
 
-def test_birth_row_is_readable_by_incarnation_id(db: Path) -> None:
-    # Arrange
-    _birth(db)
+# ----------------------------------------------------------------------
+# The store exists, and it is PostgreSQL.
+# ----------------------------------------------------------------------
+
+
+def test_init_creates_the_incarnations_store_in_postgres(pg_schema: str) -> None:
+    """POSITIVE CONTROL for every test below.
+
+    Read through a SECOND, INDEPENDENT client (raw psycopg, plain SQL): if
+    this passes, the rows the other tests assert on are demonstrably in
+    PostgreSQL and not in some in-process stand-in. Without it, a suite that
+    silently wrote nowhere would still be green.
+    """
+    # Arrange: the fixture created an empty schema and pointed the resolver
+    # at it. Captured so the assertion below reads a TRANSITION rather than
+    # a snapshot — a table that had always been there would pass a bare
+    # membership check without this module having done anything.
+    before = _tables_in(pg_schema)
     # Act
-    row = get_incarnation("inc-1", db_path=db)
+    init_incarnations_schema()
+    # Assert
+    assert f"{STORE_NAME}_rows" in _tables_in(pg_schema) - before
+
+
+def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> None:
+    """The return value names WHERE the state went, so it can be checked.
+
+    It names the DATABASE and not the ``search_path`` schema layered on top
+    — measured 2026-08-19, when this test was first written asserting the
+    schema and failed with ``'sac_test_...' in 'postgres://127.0.0.1:55432/
+    scitex'``. Pinned as discovered rather than quietly weakened: an
+    operator following this string reaches the right server, and still has
+    to know which schema to look in.
+    """
+    # Arrange: the endpoint the fixture routed this test's writes through.
+    endpoint = _BASE_DSN.split("@", 1)[-1]
+    # Act
+    locator = init_incarnations_schema()
+    # Assert
+    assert endpoint in locator
+
+
+# ----------------------------------------------------------------------
+# Birth
+# ----------------------------------------------------------------------
+
+
+def test_birth_record_is_readable_by_incarnation_id(pg_schema: str) -> None:
+    # Arrange
+    _birth()
+    # Act
+    row = get_incarnation("inc-1")
     # Assert
     assert row is not None and row["agent_id"] == "alpha"
 
 
-def test_birth_row_carries_the_spec_git_sha(db: Path) -> None:
+def test_birth_record_carries_the_spec_git_sha(pg_schema: str) -> None:
     # Arrange
-    _birth(db)
+    _birth()
     # Act
-    row = get_incarnation("inc-1", db_path=db)
+    row = get_incarnation("inc-1")
     # Assert
     assert row["spec_git_sha"] == "abc123"
 
 
-def test_birth_row_carries_the_compiled_spec_json(db: Path) -> None:
+def test_birth_record_carries_the_compiled_spec_json(pg_schema: str) -> None:
     # Arrange
-    _birth(db)
+    _birth()
     # Act
-    row = get_incarnation("inc-1", db_path=db)
+    row = get_incarnation("inc-1")
     # Assert
     assert row["compiled_spec_json"] == '{"name": "alpha"}'
 
 
-def test_birth_is_upsert_on_the_incarnation_key(db: Path) -> None:
+def test_birth_is_upsert_on_the_incarnation_key(pg_schema: str) -> None:
     # Arrange: a retried launch re-records the same incarnation.
-    _birth(db)
-    record_incarnation_birth(
-        "inc-1",
-        agent_id="alpha",
-        spec_id="/specs/alpha/spec.yaml",
-        spec_git_sha="def456",
-        host="h1",
-        compiled_spec_json='{"name": "alpha"}',
-        db_path=db,
-    )
+    _birth()
+    _birth(sha="def456")
     # Act
-    row = get_incarnation("inc-1", db_path=db)
+    row = get_incarnation("inc-1")
     # Assert: refreshed, not duplicated / not crashed.
     assert row["spec_git_sha"] == "def456"
 
 
-def test_exit_mirror_updates_the_birth_row(db: Path) -> None:
+def test_birth_returns_the_incarnation_id(pg_schema: str) -> None:
     # Arrange
-    _birth(db)
+    incarnation = "inc-returns"
     # Act
-    record_incarnation_exit("inc-1", reason="harness-returned", code=1, db_path=db)
-    row = get_incarnation("inc-1", db_path=db)
+    returned = _birth(incarnation)
+    # Assert
+    assert returned == incarnation
+
+
+# ----------------------------------------------------------------------
+# Death
+# ----------------------------------------------------------------------
+
+
+def test_exit_mirror_updates_the_birth_record(pg_schema: str) -> None:
+    # Arrange
+    _birth()
+    # Act
+    record_incarnation_exit("inc-1", reason="harness-returned", code=1)
+    row = get_incarnation("inc-1")
     # Assert
     assert (row["exit_reason"], row["exit_code"]) == ("harness-returned", 1)
 
 
-def test_exit_mirror_stamps_exited_at(db: Path) -> None:
+def test_exit_mirror_stamps_exited_at(pg_schema: str) -> None:
     # Arrange
-    _birth(db)
+    _birth()
     # Act
-    record_incarnation_exit("inc-1", reason="stopped-by-signal", code=0, db_path=db)
-    row = get_incarnation("inc-1", db_path=db)
+    record_incarnation_exit("inc-1", reason="stopped-by-signal", code=0)
+    row = get_incarnation("inc-1")
     # Assert
     assert row["exited_at"] is not None
 
 
-def test_exit_without_birth_reports_false_not_insert(db: Path) -> None:
-    # Arrange: no birth row for this id.
-    _birth(db, "inc-other")
+def test_exit_does_not_hollow_out_the_birth_fields(pg_schema: str) -> None:
+    """The exit write must not blank the certificate it is completing.
+
+    The store has no UPDATE-only verb, so the exit path READS the record and
+    writes the whole thing back. If that ever collapses into a bare ``put``
+    of the three exit fields, the birth data would depend on the store's
+    per-field merge to survive — this asserts it survives outright.
+    """
+    # Arrange
+    _birth()
     # Act
-    updated = record_incarnation_exit("inc-ghost", reason="crashed", code=1, db_path=db)
+    record_incarnation_exit("inc-1", reason="harness-returned", code=1)
+    row = get_incarnation("inc-1")
+    # Assert
+    assert row["compiled_spec_json"] == '{"name": "alpha"}'
+
+
+def test_exit_without_birth_reports_false_not_insert(pg_schema: str) -> None:
+    # Arrange: no birth record for this id.
+    _birth("inc-other")
+    # Act
+    updated = record_incarnation_exit("inc-ghost", reason="crashed", code=1)
     # Assert: a death with no recorded birth is a real signal, not an
     # excuse to fabricate one.
     assert updated is False
 
 
-def test_unknown_incarnation_reads_none(db: Path) -> None:
+def test_exit_without_birth_writes_nothing(pg_schema: str) -> None:
+    """The False above must mean "wrote nothing", not "wrote and said no"."""
     # Arrange
-    _birth(db)
+    _birth("inc-other")
     # Act
-    row = get_incarnation("inc-nope", db_path=db)
+    record_incarnation_exit("inc-ghost", reason="crashed", code=1)
+    # Assert
+    assert get_incarnation("inc-ghost") is None
+
+
+def test_last_exit_write_wins(pg_schema: str) -> None:
+    # Arrange: exit.json semantics — the LAST write is the record.
+    _birth()
+    record_incarnation_exit("inc-1", reason="first", code=1)
+    # Act
+    record_incarnation_exit("inc-1", reason="second", code=2)
+    row = get_incarnation("inc-1")
+    # Assert
+    assert (row["exit_reason"], row["exit_code"]) == ("second", 2)
+
+
+# ----------------------------------------------------------------------
+# Reads
+# ----------------------------------------------------------------------
+
+
+def test_unknown_incarnation_reads_none(pg_schema: str) -> None:
+    # Arrange
+    _birth()
+    # Act
+    row = get_incarnation("inc-nope")
     # Assert
     assert row is None
 
 
-def test_incarnations_is_a_known_table(db: Path) -> None:
+def test_returned_dict_carries_no_store_bookkeeping(pg_schema: str) -> None:
+    """Callers see the schema fields, the same shape ``sqlite3.Row`` gave.
+
+    The store hangs hlc / seq / origin / owner off sibling attributes rather
+    than the values mapping, and this pins that: a caller iterating the dict
+    must not suddenly meet store internals it never asked for.
+    """
+    # Arrange
+    _birth()
+    # Act
+    row = get_incarnation("inc-1")
+    # Assert
+    assert set(row) == {
+        "incarnation_id",
+        "agent_id",
+        "spec_id",
+        "spec_git_sha",
+        "host",
+        "born_at",
+        "compiled_spec_json",
+        "exit_reason",
+        "exit_code",
+        "exited_at",
+    }
+
+
+# ----------------------------------------------------------------------
+# The SQLite table is gone, and asking for it must SAY so.
+# ----------------------------------------------------------------------
+
+
+def test_incarnations_is_no_longer_a_sqlite_known_table() -> None:
+    """Inverted on 2026-08-19, and the inversion is the point.
+
+    While ``incarnations`` stayed whitelisted, ``sac db query
+    --table=incarnations`` would open state.db, find no such table, and
+    return an EMPTY result — which reads as "this agent has no
+    incarnations" when the truth is "you are asking the wrong database".
+    Removing the name turns that silent lie into an unknown-table error.
+    """
     # Arrange
     from scitex_agent_container._state.state_db import KNOWN_TABLES
 
     # Act
     known = set(KNOWN_TABLES)
-    # Assert: `sac db query --table=incarnations` can reach the record.
-    assert "incarnations" in known
+    # Assert
+    assert "incarnations" not in known

--- a/tests/scitex_agent_container/_state/test_state_db_nodes_bound_port_fallback.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes_bound_port_fallback.py
@@ -1,0 +1,119 @@
+"""``resolve_node_host`` must not discard a usable port sitting in its own row.
+
+The instances row carries BOTH ``a2a_port`` and ``bound_port`` — the writers
+populate them together (``record_instance_start(a2a_port=b, bound_port=b)``).
+``resolve_node_host`` selected only ``a2a_port``, so a row where just
+``bound_port`` survived resolved to "no port" and 502'd at the forwarder, while
+the sibling resolver ``_send_resolve`` — which has preferred ``bound_port`` over
+the legacy column since it was introduced — would have reached the same agent
+from the same row. Two resolvers, one row, one moment, two answers.
+
+The controls matter more than the fix here: preferring bound_port must not
+change WHICH HOST a name resolves to, and must not disturb the tombstone and
+fallback semantics that ``is_local_node`` and the comms_nodes fall-through
+depend on.
+
+PA-306: no mocks; real on-disk SQLite under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    is_local_node,
+    resolve_node_host,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    # Arrange
+    p = tmp_path / "state.db"
+    state_db.init_schema(p)
+    return p
+
+
+def _row(db_path: Path, *, a2a_port, bound_port) -> None:
+    """Insert one live instances row with the given port columns.
+
+    Written directly rather than through ``record_instance_start`` on
+    purpose: that writer sets ``a2a_port`` and ``bound_port`` from ONE
+    argument, so it cannot express the very state under test — a row
+    where only ``bound_port`` survives.
+    """
+    with state_db.open_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO instances (id, name, host, scope, a2a_port, "
+            " bound_port, started_at, ended_at) "
+            "VALUES ('id-1', 'peer', 'host-a', 'global', ?, ?, "
+            "        '2026-08-20T00:00:00Z', NULL)",
+            (a2a_port, bound_port),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The defect: a usable bound_port was thrown away
+# ---------------------------------------------------------------------------
+
+
+def test_bound_port_is_used_when_a2a_port_is_null(db_path: Path) -> None:
+    # Arrange — only bound_port survived on this row
+    _row(db_path, a2a_port=None, bound_port=19012)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert — resolved to 'no port' before the fix, then 502'd downstream
+    assert info is not None and info["a2a_port"] == 19012
+
+
+# ---------------------------------------------------------------------------
+# Controls — the preference must change the PORT and nothing else
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_port_still_wins_when_both_are_set(db_path: Path) -> None:
+    # Arrange — both populated and deliberately different
+    _row(db_path, a2a_port=19001, bound_port=19999)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert — the legacy column keeps precedence; this is a fallback, not a swap
+    assert info is not None and info["a2a_port"] == 19001
+
+
+def test_a_row_with_neither_port_still_resolves_to_none_port(db_path: Path) -> None:
+    # Arrange — the state that 502s; still reported, not invented
+    _row(db_path, a2a_port=None, bound_port=None)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert
+    assert info is not None and info["a2a_port"] is None
+
+
+def test_the_host_is_unchanged_by_the_port_preference(db_path: Path) -> None:
+    # Arrange
+    _row(db_path, a2a_port=None, bound_port=19012)
+    # Act
+    info = resolve_node_host(name="peer", db_path=db_path)
+    # Assert — locality must not move when only the port source changes
+    assert info is not None and info["host"] == "host-a"
+
+
+def test_locality_is_unchanged_for_a_portless_row(db_path: Path) -> None:
+    # Arrange — the case deliberately NOT given a fall-through
+    _row(db_path, a2a_port=None, bound_port=None)
+    # Act
+    local = is_local_node(name="peer", local_host="host-a", db_path=db_path)
+    # Assert — a live row still means "the agent is on that host"
+    assert local is True
+
+
+def test_an_unknown_name_still_resolves_to_none(db_path: Path) -> None:
+    # Arrange — no row at all
+    unknown = "never-registered"
+    # Act
+    info = resolve_node_host(name=unknown, db_path=db_path)
+    # Assert — the fall-through must still return None, not a fabricated host
+    assert info is None

--- a/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
+++ b/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
@@ -7,20 +7,19 @@ identity, not on content. This module covers the flag CRUD in
 isolation; the integration (denied send records the flag, the CLI
 decision clears it) lives in its own test file.
 
-No-mocks (PA-306): real on-disk state.db, env + module constant
-save/restore. Each test: AAA markers (TQ002), one assertion (TQ007),
-3+-word name.
+No-mocks (PA-306): a REAL PostgreSQL via the shared ``pg_schema``
+fixture, which gives each test a throwaway schema so the live fleet
+store is never touched. The flag moved off SQLite on 2026-08-20; there
+is deliberately NO skipif on database availability, because a skip that
+reads as a pass is the defect this migration exists to remove.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
 """
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from typing import Iterator
-
 import pytest
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_pending_approval import (
     clear_pending_prompt,
     has_pending_prompt,
@@ -28,57 +27,39 @@ from scitex_agent_container._state.state_db_pending_approval import (
 )
 
 
-@pytest.fixture
-def isolated_state(tmp_path: Path) -> Iterator[Path]:
-    db = tmp_path / "state.db"
-    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
-    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
-    try:
-        yield db
-    finally:
-        state_db.DEFAULT_DB_PATH = saved_default
-        if saved_env is None:
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
-        else:
-            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
-
-
 # ---------------------------------------------------------------------------
 # record_pending_prompt — first-wins flag semantics
 # ---------------------------------------------------------------------------
 
 
-def test_first_record_returns_true(isolated_state: Path) -> None:
+def test_first_record_returns_true(pg_schema: str) -> None:
     # Arrange — fresh DB, no prior row.
     # Act
-    first = record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    first = record_pending_prompt(sender="alice", target="lead")
     # Assert — caller uses this signal to "emit the receiver-facing
     # push exactly once per pair until a decision".
     assert first is True
 
 
 def test_second_record_returns_false_no_duplicate_push(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — a pending row already exists.
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
     # Act
     second = record_pending_prompt(
-        sender="alice", target="lead", db_path=isolated_state
+        sender="alice", target="lead"
     )
     # Assert — duplicate denied attempts MUST NOT re-prompt.
     assert second is False
 
 
-def test_different_sender_target_pairs_both_emit(isolated_state: Path) -> None:
+def test_different_sender_target_pairs_both_emit(pg_schema: str) -> None:
     # Arrange — dedupe is per-pair, not global.
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
     # Act
     second_pair = record_pending_prompt(
-        sender="bob", target="lead", db_path=isolated_state
+        sender="bob", target="lead"
     )
     # Assert
     assert second_pair is True
@@ -90,22 +71,22 @@ def test_different_sender_target_pairs_both_emit(isolated_state: Path) -> None:
 
 
 def test_has_pending_prompt_returns_true_after_record(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
     # Act
-    flag = has_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    flag = has_pending_prompt(sender="alice", target="lead")
     # Assert
     assert flag is True
 
 
 def test_has_pending_prompt_returns_false_for_absent_pair(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — no record_pending_prompt call.
     # Act
-    flag = has_pending_prompt(sender="ghost", target="lead", db_path=isolated_state)
+    flag = has_pending_prompt(sender="ghost", target="lead")
     # Assert
     assert flag is False
 
@@ -115,48 +96,48 @@ def test_has_pending_prompt_returns_false_for_absent_pair(
 # ---------------------------------------------------------------------------
 
 
-def test_clear_removes_pending_row(isolated_state: Path) -> None:
+def test_clear_removes_pending_row(pg_schema: str) -> None:
     # Arrange
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
-    clear_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
+    clear_pending_prompt(sender="alice", target="lead")
     # Act
-    flag = has_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    flag = has_pending_prompt(sender="alice", target="lead")
     # Assert
     assert flag is False
 
 
-def test_clear_returns_true_when_row_existed(isolated_state: Path) -> None:
+def test_clear_returns_true_when_row_existed(pg_schema: str) -> None:
     # Arrange
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
     # Act
     removed = clear_pending_prompt(
-        sender="alice", target="lead", db_path=isolated_state
+        sender="alice", target="lead"
     )
     # Assert
     assert removed is True
 
 
-def test_clear_returns_false_when_row_absent(isolated_state: Path) -> None:
+def test_clear_returns_false_when_row_absent(pg_schema: str) -> None:
     # Arrange — no prior record.
     # Act
     removed = clear_pending_prompt(
-        sender="ghost", target="lead", db_path=isolated_state
+        sender="ghost", target="lead"
     )
     # Assert
     assert removed is False
 
 
 def test_after_clear_next_record_returns_true_again(
-    isolated_state: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — record + clear + record again. The second record
     # MUST return True (i.e. emit the prompt) because the prior
     # decision was already made.
-    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
-    clear_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    record_pending_prompt(sender="alice", target="lead")
+    clear_pending_prompt(sender="alice", target="lead")
     # Act
     second = record_pending_prompt(
-        sender="alice", target="lead", db_path=isolated_state
+        sender="alice", target="lead"
     )
     # Assert
     assert second is True
@@ -167,17 +148,101 @@ def test_after_clear_next_record_returns_true_again(
 # ---------------------------------------------------------------------------
 
 
-def test_empty_sender_raises(isolated_state: Path) -> None:
+def test_empty_sender_raises(pg_schema: str) -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError, match="non-empty"):
-        record_pending_prompt(sender="", target="lead", db_path=isolated_state)
+        record_pending_prompt(sender="", target="lead")
 
 
-def test_empty_target_raises(isolated_state: Path) -> None:
+def test_empty_target_raises(pg_schema: str) -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError, match="non-empty"):
-        record_pending_prompt(sender="alice", target="", db_path=isolated_state)
+        record_pending_prompt(sender="alice", target="")
+
+
+# ---------------------------------------------------------------------------
+# What the PostgreSQL move CHANGED — clearing hides, it does not delete
+# ---------------------------------------------------------------------------
+
+
+def test_clearing_hides_the_record_rather_than_destroying_it(pg_schema: str) -> None:
+    """The decision survives the clear, which the SQLite DELETE destroyed.
+
+    ``clear_pending_prompt`` maps to the store's ``hide``, so the record
+    stays in the oplog with the actor that cleared it. Reads are
+    unaffected — ``get`` skips hidden records — but "who cleared this
+    pair, and when" is now answerable, and under DELETE it was not.
+
+    Asserted through the store's own ``is_hidden`` rather than by peeking
+    at a physical table: the claim is about the RECORD's state, and a raw
+    table read would be a true statement about a different artifact.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db_pending_approval import (
+        open_pending_prompt_store,
+    )
+
+    record_pending_prompt(sender="alice", target="lead")
+    clear_pending_prompt(sender="alice", target="lead")
+    # Act
+    store = open_pending_prompt_store()
+    try:
+        hidden = store.is_hidden({"sender": "alice", "target": "lead"})
+    finally:
+        store.close()
+    # Assert — True means "record exists and is hidden", not "absent".
+    assert hidden is True
+
+
+def test_re_recording_after_a_clear_refreshes_the_timestamp(pg_schema: str) -> None:
+    """A re-armed pair carries the NEW prompt's time, not the old one.
+
+    This is why ``ts`` is LAST_WRITER_WINS rather than IMMUTABLE. Nothing
+    orders decisions on this field today, so the refresh cannot reorder
+    anything — but a stale timestamp on a live prompt would misreport when
+    the receiver was actually asked.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db_pending_approval import (
+        open_pending_prompt_store,
+    )
+
+    record_pending_prompt(sender="alice", target="lead")
+    store = open_pending_prompt_store()
+    try:
+        first_ts = store.get({"sender": "alice", "target": "lead"}).values["ts"]
+    finally:
+        store.close()
+    clear_pending_prompt(sender="alice", target="lead")
+    record_pending_prompt(sender="alice", target="lead")
+    # Act
+    store = open_pending_prompt_store()
+    try:
+        second_ts = store.get({"sender": "alice", "target": "lead"}).values["ts"]
+    finally:
+        store.close()
+    # Assert
+    assert second_ts >= first_ts
+
+
+def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> None:
+    """The return value names WHERE the state went, so it can be checked.
+
+    The SQLite version returned None. The locator names the DATABASE and
+    not the search_path schema layered on top — the same shape the
+    incarnations store has, pinned here so the two do not drift apart.
+    """
+    # Arrange
+    from scitex_agent_container._state.state_db_pending_approval import (
+        init_pending_prompts_schema,
+    )
+
+    expected = "55432"
+    # Act
+    locator = init_pending_prompts_schema()
+    # Assert
+    assert expected in locator

--- a/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
+++ b/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
@@ -1,277 +1,311 @@
-"""Tests for the CI-verdict delivery dedup table (sac #404).
+"""CI-verdict delivered-set — on a REAL PostgreSQL, never SQLite, never a mock.
 
-The CI-feedback ring (feedback.pdf §3) requires sac to deliver each
-GitHub CI verdict to the pusher EXACTLY ONCE, even though it polls
-GitHub repeatedly. Dedup key is ``(repo, pr, head_sha, conclusion)`` —
-sac's own ``delivered-set`` (the PDF's term), kept in ``state.db`` so it
-survives a ``sac listen`` restart.
+Mirrors ``src/scitex_agent_container/_state/state_db_verdict_dedup.py``.
 
-Conventions (mirroring test_dispatch_ledger.py):
+WHY THESE TESTS TALK TO A REAL DATABASE
+=======================================
+The module under test is PostgreSQL-only by the operator's 2026-08-19 order
+("fail fast, fail loud, no fallbacks"), and it reaches PostgreSQL through
+``scitex_dev.store``. A suite that exercised the store's SQLite dialect
+instead would be testing a code path production can never take.
 
-  * One assertion per test (STX-TQ007); related invariants via
-    ``pytest.parametrize``.
-  * AAA markers (Arrange / Act / Assert).
-  * No mocks / monkeypatch (STX-NM); real sqlite under ``tmp_path``,
-    isolated via the ``db_path`` env fixture (explicit save/restore).
+That is not a hypothetical. scitex-dev 0.49.0 shipped a PostgreSQL backend
+that could be WRITTEN to and never READ from — writes bind parameters and
+survived, reads addressed columns by name against a dialect that set no row
+factory. It shipped precisely because the PostgreSQL path had been written
+to and never read from. Any suite that proves this module works must
+therefore read back through the same dialect production uses.
+
+AND WHY THEY MUST NOT SKIP
+==========================
+There is deliberately NO ``skipif`` on database availability. A skip that
+reads as a pass is the defect this whole migration exists to remove, and it
+is the same shape as the ``importorskip`` bug fixed in #1108, where a
+missing submodule turned "cannot test" into a green run. If PostgreSQL is
+unreachable these tests FAIL, and that red is correct: every runner in the
+gate pool (measured 2026-08-19: scitex-01..04-org-cpu-01 sit on
+scitex-compute-01..04) has a PostgreSQL on 127.0.0.1:55432, so an
+unreachable store is a broken fleet, not a test-environment quirk.
+
+ISOLATION WITHOUT PRIVILEGE
+===========================
+Each test gets its own PostgreSQL SCHEMA inside the existing ``scitex``
+database, selected through ``search_path`` in the DSN, and dropped with
+``CASCADE`` afterwards. Deliberately a schema and not a database:
+
+  * creating a database needs ``CREATEDB``, and the fleet is NOT uniform —
+    compute-03's ``scitex_cards`` role has ``rolcreatedb=False``, so a
+    create-a-database fixture would pass on three runners and fail on the
+    fourth, which is the worst possible flake (it looks like the code).
+  * the three-way python matrix can put concurrent jobs on ONE runner, so
+    the name carries a uuid; two legs get two schemas and never collide.
+  * ``DROP SCHEMA ... CASCADE`` leaves nothing behind, verified in this
+    file's own teardown assertion rather than assumed.
+
+Real ``os.environ`` save/restore, not ``monkeypatch`` — PA-306 forbids mocks,
+and the point is that the REAL resolver reads the REAL variable.
 """
 
 from __future__ import annotations
 
-import importlib
 import os
-import sqlite3
-from pathlib import Path
+import uuid
+from typing import Iterator
 
+import psycopg
 import pytest
 
+from scitex_agent_container._state.state_db_verdict_dedup import (
+    failures_since_last_success,
+    init_verdict_dedup_schema,
+    record_verdict_delivered,
+    verdict_already_delivered,
+)
 
-@pytest.fixture
-def db_path(tmp_path: Path):
-    """Isolated state.db location, exported via env so callers pick it up.
+#: The per-host store. Loopback only — every fleet PostgreSQL refuses
+#: non-local connections at pg_hba, measured 2026-08-19.
+_BASE_DSN = os.environ.get(
+    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
+)
 
-    Explicit env save/restore (no monkeypatch fixture, PA-306).
+
+@pytest.fixture()
+def pg_schema() -> Iterator[str]:
+    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
+
+    Yields the schema name. Anything the module writes lands here and is
+    dropped afterwards, so the live delivered-set is never touched.
     """
-    p = tmp_path / "state.db"
-    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
-    saved = os.environ.get(key)
-    os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
+    schema = "sac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema}"')
 
-    importlib.reload(mod)
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = f"{_BASE_DSN}?options=-csearch_path%3D{schema}"
     try:
-        yield p
+        yield schema
     finally:
         if saved is None:
             os.environ.pop(key, None)
         else:
             os.environ[key] = saved
-        importlib.reload(mod)
+        with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
 
 
-# ---------------------------------------------------------------------------
-# Schema
-# ---------------------------------------------------------------------------
+def _tables_in(schema: str) -> set[str]:
+    """The table names PostgreSQL actually holds in ``schema``."""
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
+            (schema,),
+        ).fetchall()
+    return {r[0] for r in rows}
 
 
-def test_init_schema_creates_verdict_delivered_table(db_path: Path):
+# ----------------------------------------------------------------------
+# The store exists, and it is PostgreSQL.
+# ----------------------------------------------------------------------
+
+
+def test_init_creates_the_delivered_set_in_postgres(pg_schema: str) -> None:
+    """POSITIVE CONTROL for every test below.
+
+    Read through a SECOND, INDEPENDENT client (raw psycopg, plain SQL)
+    rather than through the store that created them. Asking a library
+    whether its own write landed cannot distinguish "wrote to PostgreSQL"
+    from "wrote somewhere else" — which is exactly how a store can look
+    healthy while sharing nothing.
+    """
     # Arrange
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        init_verdict_dedup_schema,
-    )
-
+    expected = "verdict_delivered_rows"
     # Act
     init_verdict_dedup_schema()
-    with sqlite3.connect(db_path) as conn:
-        names = {
-            r[0]
-            for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
-        }
     # Assert
-    assert "verdict_delivered" in names
+    assert expected in _tables_in(pg_schema)
 
 
-def test_record_creates_table_lazily_without_explicit_init(db_path: Path):
-    # Arrange — never call init; record must ensure the table itself.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
+def test_init_reports_where_the_state_went(pg_schema: str) -> None:
+    """The return value NAMES the target, so a caller can check it.
 
+    The SQLite version returned a Path for the same reason. A store that
+    cannot say where it is is a store nobody can verify.
+    """
+    # Arrange
+    expected_fragment = "55432"
+    # Act
+    locator = init_verdict_dedup_schema()
+    # Assert
+    assert expected_fragment in locator
+
+
+def test_record_creates_the_store_lazily_without_an_explicit_init(
+    pg_schema: str,
+) -> None:
+    """Callers never have to remember to initialise first."""
+    # Arrange
+    expected = "verdict_delivered_rows"
     # Act
     record_verdict_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=1, head_sha="abc", conclusion="success"
+        repo="o/r", pr=1, head_sha="abc", conclusion="success", delivered_at=1.0
     )
     # Assert
-    assert verdict_already_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=1, head_sha="abc", conclusion="success"
-    )
+    assert expected in _tables_in(pg_schema)
 
 
-# ---------------------------------------------------------------------------
-# Dedup semantics
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# The dedup key.
+# ----------------------------------------------------------------------
 
 
-def test_fresh_key_is_not_delivered(db_path: Path):
+def test_a_fresh_key_is_not_delivered(pg_schema: str) -> None:
+    """A miss must return False so the caller DELIVERS rather than swallows."""
     # Arrange
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        verdict_already_delivered,
-    )
+    key = dict(repo="o/r", pr=7, head_sha="abc", conclusion="success")
+    # Act
+    seen = verdict_already_delivered(**key)
+    # Assert
+    assert seen is False
 
+
+def test_a_recorded_key_is_delivered(pg_schema: str) -> None:
+    """The whole point: a re-poll must not re-deliver."""
+    # Arrange
+    key = dict(repo="o/r", pr=7, head_sha="abc", conclusion="success")
+    record_verdict_delivered(**key, delivered_at=1.0)
+    # Act
+    seen = verdict_already_delivered(**key)
+    # Assert
+    assert seen is True
+
+
+def test_a_different_conclusion_is_a_distinct_key(pg_schema: str) -> None:
+    """A re-run that flips red->green on the SAME head MUST be delivered."""
+    # Arrange
+    record_verdict_delivered(
+        repo="o/r", pr=7, head_sha="abc", conclusion="failure", delivered_at=1.0
+    )
     # Act
     seen = verdict_already_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="success"
+        repo="o/r", pr=7, head_sha="abc", conclusion="success"
     )
     # Assert
     assert seen is False
 
 
-def test_recorded_key_is_delivered(db_path: Path):
+def test_a_different_head_sha_is_a_distinct_key(pg_schema: str) -> None:
+    """A new push is a new verdict, even with the same conclusion."""
     # Arrange
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
-
-    # Act
     record_verdict_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="failure"
+        repo="o/r", pr=7, head_sha="abc", conclusion="failure", delivered_at=1.0
     )
-    # Assert
-    assert verdict_already_delivered(
-        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="failure"
-    )
-
-
-def test_different_conclusion_is_a_distinct_key(db_path: Path):
-    # Arrange — a re-run flipping red→green is a NEW verdict to deliver.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
-
-    record_verdict_delivered(repo="r", pr=3, head_sha="sha1", conclusion="failure")
     # Act
-    seen_success = verdict_already_delivered(
-        repo="r", pr=3, head_sha="sha1", conclusion="success"
+    seen = verdict_already_delivered(
+        repo="o/r", pr=7, head_sha="def", conclusion="failure"
     )
     # Assert
-    assert seen_success is False
+    assert seen is False
 
 
-def test_different_head_sha_is_a_distinct_key(db_path: Path):
-    # Arrange — a new push (new head_sha) is a new verdict.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
+def test_recording_twice_does_not_move_the_timestamp(pg_schema: str) -> None:
+    """INSERT-OR-IGNORE semantics, and this is the one that would rot silently.
 
-    record_verdict_delivered(repo="r", pr=3, head_sha="sha1", conclusion="success")
-    # Act
-    seen_other = verdict_already_delivered(
-        repo="r", pr=3, head_sha="sha2", conclusion="success"
-    )
-    # Assert
-    assert seen_other is False
-
-
-def test_record_is_idempotent(db_path: Path):
-    # Arrange — re-seeing the same verdict (re-poll) must not raise.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        record_verdict_delivered,
-        verdict_already_delivered,
-    )
-
-    record_verdict_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
-    # Act
-    record_verdict_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
-    # Assert
-    assert verdict_already_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
-
-
-# ---------------------------------------------------------------------------
-# Failure streak — the consecutive-failure cap's counter
-#
-# `delivered_at` is passed explicitly throughout: the streak is defined by
-# comparison against the last green's timestamp, and two records written in
-# the same float tick would make the ordering ambiguous. Production ticks are
-# minutes apart, so this is a test-determinism concern, not a live one.
-# ---------------------------------------------------------------------------
-
-
-def test_failure_streak_counts_reds_for_this_pr(db_path: Path):
+    ``delivered_at`` ORDERS the failure streak. If a re-poll refreshed it,
+    every re-poll would quietly reorder history and the streak cap would
+    stop capping — with no error anywhere. So the second write must be a
+    no-op, not an upsert.
+    """
     # Arrange
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-        record_verdict_delivered,
-    )
+    key = dict(repo="o/r", pr=7, head_sha="abc", conclusion="failure")
+    record_verdict_delivered(**key, dispatch_id="first", delivered_at=100.0)
+    # Act
+    record_verdict_delivered(**key, dispatch_id="second", delivered_at=999.0)
+    # Assert
+    assert _delivered_at_of(pg_schema, **key) == 100.0
 
+
+def _delivered_at_of(schema: str, *, repo: str, pr: int, head_sha: str,
+                     conclusion: str) -> float:
+    """Read ``delivered_at`` straight out of PostgreSQL, bypassing the store."""
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        row = conn.execute(
+            f'SELECT delivered_at FROM "{schema}".verdict_delivered_rows '
+            "WHERE repo = %s AND pr = %s AND head_sha = %s AND conclusion = %s",
+            (repo, pr, head_sha, conclusion),
+        ).fetchone()
+    return float(row[0])
+
+
+# ----------------------------------------------------------------------
+# The failure streak.
+# ----------------------------------------------------------------------
+
+
+def test_the_streak_counts_reds_for_this_pr(pg_schema: str) -> None:
+    """Three reds on three pushes is a streak of three."""
+    # Arrange
     for i, sha in enumerate(("a", "b", "c")):
         record_verdict_delivered(
-            repo="o/r", pr=1, head_sha=sha, conclusion="failure", delivered_at=100.0 + i
+            repo="o/r", pr=7, head_sha=sha, conclusion="failure",
+            delivered_at=float(i + 1),
         )
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
     assert streak == 3
 
 
-def test_failure_streak_resets_after_a_green(db_path: Path):
-    # Arrange — two reds, a green, then one more red.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-        record_verdict_delivered,
-    )
-
-    record_verdict_delivered(
-        repo="o/r", pr=1, head_sha="a", conclusion="failure", delivered_at=100.0
-    )
-    record_verdict_delivered(
-        repo="o/r", pr=1, head_sha="b", conclusion="failure", delivered_at=101.0
-    )
-    record_verdict_delivered(
-        repo="o/r", pr=1, head_sha="g", conclusion="success", delivered_at=102.0
-    )
-    record_verdict_delivered(
-        repo="o/r", pr=1, head_sha="d", conclusion="failure", delivered_at=103.0
-    )
+def test_the_streak_resets_after_a_green(pg_schema: str) -> None:
+    """red -> green -> red starts over, so a fixed PR is not capped forever."""
+    # Arrange
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="a",
+                             conclusion="failure", delivered_at=1.0)
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="b",
+                             conclusion="success", delivered_at=2.0)
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="c",
+                             conclusion="failure", delivered_at=3.0)
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
     assert streak == 1
 
 
-def test_failure_streak_ignores_another_prs_reds(db_path: Path):
-    # Arrange — a noisy neighbour must not cap this PR.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-        record_verdict_delivered,
-    )
-
-    for i, sha in enumerate(("a", "b", "c", "d", "e")):
-        record_verdict_delivered(
-            repo="o/r",
-            pr=999,
-            head_sha=sha,
-            conclusion="failure",
-            delivered_at=100.0 + i,
-        )
+def test_the_streak_ignores_another_prs_reds(pg_schema: str) -> None:
+    """One noisy PR must not cap a quiet one."""
+    # Arrange
+    record_verdict_delivered(repo="o/r", pr=8, head_sha="a",
+                             conclusion="failure", delivered_at=1.0)
+    record_verdict_delivered(repo="o/r", pr=8, head_sha="b",
+                             conclusion="failure", delivered_at=2.0)
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="c",
+                             conclusion="failure", delivered_at=3.0)
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
-    assert streak == 0
+    assert streak == 1
 
 
-def test_failure_streak_ignores_another_repos_reds(db_path: Path):
-    # Arrange — same PR number in a different repo is a different PR.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-        record_verdict_delivered,
-    )
-
-    for i, sha in enumerate(("a", "b", "c", "d")):
-        record_verdict_delivered(
-            repo="other/repo",
-            pr=1,
-            head_sha=sha,
-            conclusion="failure",
-            delivered_at=100.0 + i,
-        )
+def test_the_streak_ignores_another_repos_reds(pg_schema: str) -> None:
+    """PR numbers collide across repos; the repo is part of the identity."""
+    # Arrange
+    record_verdict_delivered(repo="o/other", pr=7, head_sha="a",
+                             conclusion="failure", delivered_at=1.0)
+    record_verdict_delivered(repo="o/other", pr=7, head_sha="b",
+                             conclusion="failure", delivered_at=2.0)
+    record_verdict_delivered(repo="o/r", pr=7, head_sha="c",
+                             conclusion="failure", delivered_at=3.0)
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
-    assert streak == 0
+    assert streak == 1
 
 
-def test_failure_streak_is_zero_on_a_fresh_db(db_path: Path):
-    # Arrange — never written; the table must be ensured lazily, not raise.
-    from scitex_agent_container._state.state_db_verdict_dedup import (
-        failures_since_last_success,
-    )
-
+def test_the_streak_is_zero_on_a_fresh_store(pg_schema: str) -> None:
+    """A brand-new store must not look like a capped PR."""
+    # Arrange
+    expected = 0
     # Act
-    streak = failures_since_last_success(repo="o/r", pr=1)
+    streak = failures_since_last_success(repo="o/r", pr=7)
     # Assert
-    assert streak == 0
+    assert streak == expected

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_force_clears_session.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_force_clears_session.py
@@ -112,6 +112,49 @@ class FakeRuntime:
         return ""
 
 
+class FakeThread:
+    """Hand-rolled stand-in for ``threading.Thread`` that NEVER runs.
+
+    ``_write_spec`` enables ``health``, so ``agent_start`` reaches
+    ``_start_supervision``, which does::
+
+        thread = thread_factory(target=health_monitor, ..., daemon=True)
+        thread.start()
+
+    With the real ``threading.Thread`` that daemon thread OUTLIVES the test
+    and keeps looping ``health_monitor -> restart_and_record ->
+    write_birth_certificate`` for the rest of the worker process. Its
+    ``logger.error`` then lands in whatever capture buffer happens to be open
+    -- an unrelated test's ``CliRunner`` -- ahead of that command's own
+    output, which is how a PASSING test here turns a stranger's assertion red
+    three files later. Measured on develop 2026-08-21: 31 stray certificates
+    in one run, plus ``ValueError: I/O operation on closed file`` from writing
+    into a stream pytest had already torn down.
+
+    Recording ``start()`` rather than swallowing it keeps the seam honest: a
+    test that wants to assert the monitor was launched still can. Same shape
+    as ``_RecordingThread`` in ``test__start_supervision.py`` and
+    ``_CapturingThread`` in ``test__instances_auto_grant.py``.
+
+    PA-306: a hand-written stand-in, not a mock.
+    """
+
+    def __init__(self, *, target=None, args=(), daemon=False, **_kw) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self, timeout=None) -> None:
+        return None
+
+    def is_alive(self) -> bool:
+        return False
+
+
 class FakeHandover:
     """Real collaborator implementing the handover module surface."""
 
@@ -201,6 +244,7 @@ def test_force_removes_persisted_session_id_file(
     # Act
     lc.agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -233,6 +277,7 @@ def test_force_leaves_other_runtime_state_alone(
     # Act
     lc.agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -260,6 +305,7 @@ def test_no_force_leaves_session_id(
     # Act
     lc.agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
@@ -282,6 +328,7 @@ def test_missing_session_id_file_under_force_is_no_op(
     # Act
     ok = lc.agent_start(
         str(spec),
+        thread_factory=FakeThread,
         registry=registry,
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight.py
@@ -108,9 +108,22 @@ class TestArgumentValidationExitsBeforePreflight:
 
 
 class TestExpiredCredsBlocksDispatch:
-    """When the lead's OAuth token is expired and a real target is
-    being dispatched, the CLI must exit 1 with the expiry message on
-    stderr — no traceback bubbling up."""
+    """An UNRESOLVABLE target must exit 1 cleanly, naming the spec fault.
+
+    Note what these targets actually are: ``any-target-name`` does not
+    resolve to anything on disk. So this class never exercised "a real
+    target with an expired token" — it exercised the path where the spec
+    would not load and the gate fell back to the lead's
+    ``~/.claude/.credentials.json``. That fallback is gone (operator,
+    2026-08-19: 「勝手にデフォルトのクレデンシャルズを使わない」), so the
+    message now names the spec fault instead of the credential.
+
+    The genuine expired-credential contract is unchanged and is covered
+    by ``test_anthropic_backed_spec_still_runs_preflight`` below, which
+    uses a spec that RESOLVES and declares expired credentials.
+
+    Exit code 1 and "no traceback" are unchanged either way, which is why
+    the sibling tests here still pass without modification."""
 
     def test_expired_creds_exits_one_for_single_target(
         self, tmp_path: Path, env_save_restore
@@ -126,7 +139,7 @@ class TestExpiredCredsBlocksDispatch:
         # Assert
         assert result.exit_code == 1
 
-    def test_expired_creds_error_message_mentions_claude_login(
+    def test_unresolvable_target_message_names_the_spec_fault(
         self, tmp_path: Path, env_save_restore
     ) -> None:
         # Arrange
@@ -138,7 +151,21 @@ class TestExpiredCredsBlocksDispatch:
         # Act
         result = runner.invoke(start, ["any-target-name"], catch_exceptions=False)
         # Assert
-        assert "claude login" in result.output
+        assert "spec could not be loaded" in result.output
+
+    def test_unresolvable_target_does_not_blame_the_lead_credential(
+        self, tmp_path: Path, env_save_restore
+    ) -> None:
+        # Arrange — the lead token IS expired here; it must stay irrelevant.
+        env_save_restore.set("HOME", str(tmp_path))
+        env_save_restore.delete("ANTHROPIC_API_KEY")
+        env_save_restore.delete("SAC_ANTHROPIC_API_KEY")
+        _install_expired_creds(tmp_path)
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, ["any-target-name"], catch_exceptions=False)
+        # Assert
+        assert "claude login" not in result.output
 
     def test_expired_creds_does_not_raise_unhandled_traceback(
         self, tmp_path: Path, env_save_restore
@@ -319,12 +346,15 @@ class TestProviderBackedSpecBypassesPreflight:
         # Assert — preflight DID fire (the existing Anthropic path is unchanged).
         assert "claude login" in result.output
 
-    def test_unresolvable_target_defaults_to_running_oauth_preflight(
+    def test_unresolvable_target_is_refused_by_name_not_by_credential(
         self, tmp_path: Path, env_save_restore
     ) -> None:
-        # Arrange — defensive default: if a spec can't be loaded,
-        # the preflight still fires (better to surface the OAuth
-        # state than to silently skip on a broken spec).
+        # Arrange — the old "defensive default" ran the OAuth preflight
+        # when a spec would not load, so an UNREGISTERED NAME was
+        # reported as an EXPIRED TOKEN. Measured 2026-08-19: a spawn for
+        # a name with no spec answered 502 carrying "OAuth token ...
+        # expired 257594 seconds ago", and the caller spent the interval
+        # chasing a permissions bug that did not exist.
         env_save_restore.set("HOME", str(tmp_path))
         env_save_restore.delete("ANTHROPIC_API_KEY")
         env_save_restore.delete("SAC_ANTHROPIC_API_KEY")
@@ -332,6 +362,5 @@ class TestProviderBackedSpecBypassesPreflight:
         runner = CliRunner()
         # Act — target name doesn't resolve to anything on disk.
         result = runner.invoke(start, ["nonexistent-target-9c4f7a"])
-        # Assert — preflight fired (defensive); operator sees the
-        # OAuth message before they get the spec-resolve error.
-        assert "claude login" in result.output
+        # Assert — the refusal names the target, not the lead credential.
+        assert "nonexistent-target-9c4f7a" in result.output

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight_gate.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight_gate.py
@@ -1,203 +1,226 @@
-"""CLI-seam tests for the ``sac agents start`` credential preflight gate.
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""An unloadable spec must be refused by NAME, never by the lead credential.
 
-These drive the REAL click entry point (``cli_pkg.lifecycle._start.start``)
-rather than the resolver alone, because the seam is where the last defect
-of this class hid: PR #949 shipped a click default the resolver read as
-"be lenient", silently disabling a gate on every CLI start, and every
-unit test passed because none crossed click → gate → resolver.
+Measured 2026-08-19. ``POST /agents`` for an agent name with no spec on
+this host answered::
 
-The gate itself is unit-tested in
-``tests/scitex_agent_container/_state/test__preflight_creds_spec.py``.
-What is proved HERE is only that the CLI reaches it, with the target's
-own spec, and honours its verdict in both directions.
+    HTTP 502
+    {"returncode": 1, "stdout": "",
+     "stderr": "Error: OAuth token in /home/ywatanabe/.claude/.credentials.json
+                expired 257594 seconds ago. Run `claude login` to refresh."}
 
-Style: one assert per test, AAA markers, no monkeypatch fixture params.
+Every word of that is true about the FILE and none of it is about the
+REQUEST. The caller (hub, trying to stand up a scholar agent) could not
+tell whether to fix their call or wait for the daemon owner, and spent
+the interval reporting a permissions bug that did not exist.
+
+Cause: ``_iter_target_configs`` swallowed the spec load error and yielded
+a bare ``None``; the gate then asked the only question it had left — is
+the lead's ``~/.claude/.credentials.json`` fresh? — and reported THAT.
+Two unrelated faults printed the same sentence, and only one of them was
+fixable by the caller.
+
+Operator ruling, 2026-08-19: 「勝手にデフォルトのクレデンシャルズを使わない」
+— a silent fall back to a default is what the constitution forbids, and
+the requirement is to fail loudly and early instead.
+
+These tests pin both halves: the refusal NAMES the load error, and the
+lead credential file is not consulted on any path through this gate.
+
+PA-306: no ``unittest.mock`` / ``monkeypatch``. Production collaborators
+are swapped at the module namespace with an explicit save/restore
+``_swap``, matching ``test__restart_noop_reports_false.py``.
 """
 
 from __future__ import annotations
 
-import json
-import os
-from pathlib import Path
-from typing import Iterator
+from contextlib import contextmanager
+from typing import Callable, Iterator
 
-import pytest
-import yaml
-from click.testing import CliRunner
+import scitex_agent_container._state._preflight_creds as creds_mod
+import scitex_agent_container.config as config_mod
+import scitex_agent_container.config._resolve as resolve_mod
+from scitex_agent_container.cli_pkg.lifecycle._start_preflight_gate import (
+    any_target_needs_anthropic_oauth,
+    make_preflight_runner,
+)
 
-from scitex_agent_container.cli_pkg.lifecycle._start import start
-from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
-
-_ONE_HOUR_S = 3600
-
-
-def _write_creds(path: Path, expires_at_ms: int) -> Path:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(
-            {
-                "claudeAiOauth": {
-                    "accessToken": "sk-ant-oat-fake",
-                    "refreshToken": "sk-ant-ort-fake",
-                    "expiresAt": expires_at_ms,
-                    "scopes": ["user:inference"],
-                    "subscriptionType": "max",
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-    return path
+_MISSING_SPEC = "spec file is absent on this host"
 
 
-def _fresh(path: Path) -> Path:
-    import time
-
-    return _write_creds(path, int((time.time() + _ONE_HOUR_S) * 1000))
-
-
-def _stale(path: Path) -> Path:
-    import time
-
-    return _write_creds(path, int((time.time() - _ONE_HOUR_S) * 1000))
-
-
-@pytest.fixture
-def isolated_home(tmp_path: Path) -> Iterator[Path]:
-    """Pin ``$HOME`` to a tmp dir and strip the API-key opt-out env vars."""
-    # Arrange
-    saved = {
-        "HOME": os.environ.get("HOME"),
-        "ANTHROPIC_API_KEY": os.environ.pop("ANTHROPIC_API_KEY", None),
-        "SAC_ANTHROPIC_API_KEY": os.environ.pop("SAC_ANTHROPIC_API_KEY", None),
-    }
-    os.environ["HOME"] = str(tmp_path)
+@contextmanager
+def _swap(module: object, name: str, fn: Callable) -> Iterator[None]:
+    saved = getattr(module, name)
+    setattr(module, name, fn)
     try:
-        yield tmp_path
+        yield
     finally:
-        for key, value in saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
+        setattr(module, name, saved)
 
 
-def _write_spec(home: Path, name: str, pool: list[Path]) -> Path:
-    """Materialise a loadable v3 spec declaring ``pool`` as its account pool.
+class _Claude:
+    def __init__(self, provider=None):
+        self.provider = provider
 
-    ``host`` names a peer that is deliberately NOT registered, so the run
-    stops at the cross-host dispatch guard immediately after the preflight
-    — the gate's verdict is observed without launching anything.
-    """
-    doc = explicit_doc(
-        {
-            "host": "sac-test-unregistered-peer",
-            "workdir": str(home),
-            "claude": {"credentials_files": [str(p) for p in pool]},
-        }
+
+class _Cfg:
+    def __init__(self, name="agent", provider=None):
+        self.name = name
+        self.claude = _Claude(provider)
+
+
+def _runner(target: str):
+    return make_preflight_runner(
+        single_targets=[target],
+        bulk_yamls=[],
+        no_redispatch=False,
+        broker_self=False,
     )
-    spec_dir = home / "agents" / name
-    spec_dir.mkdir(parents=True, exist_ok=True)
-    spec_path = spec_dir / f"{name}.yaml"
-    spec_path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
-    return spec_path
 
 
-class TestStartHonoursTheSpecsOwnCredentials:
-    def test_start_is_not_refused_when_a_declared_pool_entry_is_fresh(
-        self, isolated_home: Path
-    ) -> None:
-        # Arrange — the 2026-08-10 outage shape: lead token dead, pool fresh.
-        _stale(isolated_home / ".claude" / ".credentials.json")
-        good = _fresh(isolated_home / "accounts" / "alpha" / ".credentials.json")
-        spec = _write_spec(isolated_home, "poolagent", [good])
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(start, [str(spec), "-y"])
-        # Assert — the lead file is never even named; it is not this agent's.
-        assert ".claude/.credentials.json expired" not in result.output
+@contextmanager
+def _spec_that_will_not_load(message: str) -> Iterator[None]:
+    def _boom(_resolved):
+        raise FileNotFoundError(message)
 
-    def test_start_is_refused_when_every_declared_entry_is_expired(
-        self, isolated_home: Path
-    ) -> None:
-        # Arrange — inverse control: lead token FRESH (the old gate would
-        # have waved this through), every declared credential dead.
-        _fresh(isolated_home / ".claude" / ".credentials.json")
-        dead_a = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
-        dead_b = _stale(isolated_home / "accounts" / "beta" / ".credentials.json")
-        spec = _write_spec(isolated_home, "deadpool", [dead_a, dead_b])
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(start, [str(spec), "-y"])
-        # Assert
-        assert "every credential its spec declares is unusable" in result.output
-
-    def test_refusal_exits_nonzero(self, isolated_home: Path) -> None:
-        # Arrange — the gate is an ERROR, never a warning: a refusal must
-        # cost the caller a non-zero exit, not just a line of output.
-        _fresh(isolated_home / ".claude" / ".credentials.json")
-        dead = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
-        spec = _write_spec(isolated_home, "deadpool", [dead])
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(start, [str(spec), "-y"])
-        # Assert
-        assert result.exit_code == 1
-
-    def test_refusal_happens_before_any_dispatch_attempt(
-        self, isolated_home: Path
-    ) -> None:
-        # Arrange — the spec pins an unregistered peer, so reaching the
-        # dispatch stage is loudly visible. The gate must fire first.
-        _fresh(isolated_home / ".claude" / ".credentials.json")
-        dead = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
-        spec = _write_spec(isolated_home, "deadpool", [dead])
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(start, [str(spec), "-y"])
-        # Assert
-        assert "registered peer" not in result.output
-
-    def test_refusal_names_every_declared_candidate(self, isolated_home: Path) -> None:
-        # Arrange
-        _fresh(isolated_home / ".claude" / ".credentials.json")
-        dead_a = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
-        dead_b = _stale(isolated_home / "accounts" / "beta" / ".credentials.json")
-        spec = _write_spec(isolated_home, "deadpool", [dead_a, dead_b])
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(start, [str(spec), "-y"])
-        # Assert
-        assert str(dead_a) in result.output and str(dead_b) in result.output
-
-    def test_api_key_env_skips_the_gate_at_the_cli_seam(
-        self, isolated_home: Path
-    ) -> None:
-        # Arrange — every credential dead, but the operator opted into the
-        # API-key auth path, so the OAuth gate must not fire at all.
-        _stale(isolated_home / ".claude" / ".credentials.json")
-        dead = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
-        spec = _write_spec(isolated_home, "keyagent", [dead])
-        os.environ["ANTHROPIC_API_KEY"] = "sk-ant-fake"
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(start, [str(spec), "-y"])
-        # Assert
-        assert "every credential its spec declares is unusable" not in result.output
+    with _swap(resolve_mod, "resolve_with_prefix", lambda raw: raw):
+        with _swap(config_mod, "load_config", _boom):
+            yield
 
 
-class TestUndeclaredSpecKeepsTheLeadFileGate:
-    def test_unloadable_spec_still_gates_on_the_expired_lead_file(
-        self, isolated_home: Path
-    ) -> None:
-        # Arrange — a spec that will not parse keeps the defensive default:
-        # gate on the lead file rather than skip the check.
-        _stale(isolated_home / ".claude" / ".credentials.json")
-        agents_dir = isolated_home / "agents"
-        (agents_dir / "broken").mkdir(parents=True)
-        (agents_dir / "broken" / "broken.yaml").write_text("{{{ not yaml")
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(start, [str(agents_dir), "-y"])
-        # Assert
-        assert "expired" in result.output
+@contextmanager
+def _spec_that_loads(cfg: _Cfg) -> Iterator[None]:
+    with _swap(resolve_mod, "resolve_with_prefix", lambda raw: raw):
+        with _swap(config_mod, "load_config", lambda _r: cfg):
+            yield
+
+
+def _refuse(target: str = "scitex-scholar", message: str = _MISSING_SPEC) -> str:
+    """Run the gate against an unloadable spec; return its exit status word.
+
+    Swallows the ``SystemExit`` here so each test spends its single
+    permitted assertion on the BEHAVIOUR rather than on the raise.
+    """
+    run = _runner(target)
+    with _spec_that_will_not_load(message):
+        with _swap(creds_mod, "check_spec_oauth_credentials", lambda *a, **k: None):
+            try:
+                run()
+            except SystemExit:
+                return "refused"
+    return "dispatched"
+
+
+def _refusal_stderr(capsys, message: str = _MISSING_SPEC) -> str:
+    _refuse(message=message)
+    return capsys.readouterr().err
+
+
+def _lead_check_calls() -> list[int]:
+    calls: list[int] = []
+    run = _runner("scitex-scholar")
+    with _spec_that_will_not_load(_MISSING_SPEC):
+        with _swap(creds_mod, "check_oauth_token_expiry", lambda *a, **k: calls.append(1)):
+            with _swap(creds_mod, "check_spec_oauth_credentials", lambda *a, **k: None):
+                try:
+                    run()
+                except SystemExit:
+                    pass
+    return calls
+
+
+def _spec_checked_with(cfg: _Cfg) -> list[object]:
+    seen: list[object] = []
+    run = _runner(cfg.name)
+    with _spec_that_loads(cfg):
+        with _swap(
+            creds_mod,
+            "check_spec_oauth_credentials",
+            lambda c, *a, **k: seen.append(c),
+        ):
+            run()
+    return seen
+
+
+def test_an_unloadable_spec_is_refused_rather_than_dispatched():
+    # Arrange
+    target = "scitex-scholar"
+    # Act
+    outcome = _refuse(target)
+    # Assert
+    assert outcome == "refused"
+
+
+def test_the_refusal_names_the_target(capsys):
+    # Arrange
+    expected = "scitex-scholar"
+    # Act
+    err = _refusal_stderr(capsys)
+    # Assert
+    assert expected in err
+
+
+def test_the_refusal_carries_the_underlying_load_error(capsys):
+    # Arrange
+    expected = _MISSING_SPEC
+    # Act
+    err = _refusal_stderr(capsys, message=expected)
+    # Assert
+    assert expected in err
+
+
+def test_the_refusal_does_not_blame_an_expired_credential(capsys):
+    # Arrange: the old gate reported the lead file's expiry here.
+    forbidden = "expired"
+    # Act
+    err = _refusal_stderr(capsys)
+    # Assert
+    assert forbidden not in err
+
+
+def test_the_lead_credential_check_is_never_called_for_an_unloadable_spec():
+    # Arrange: a tripwire on the exact function the old gate called.
+    expected: list[int] = []
+    # Act
+    calls = _lead_check_calls()
+    # Assert
+    assert calls == expected
+
+
+def test_a_loadable_spec_still_reaches_the_spec_credential_check():
+    # Arrange
+    cfg = _Cfg(name="paper-scitex-clew")
+    # Act
+    seen = _spec_checked_with(cfg)
+    # Assert
+    assert seen == [cfg]
+
+
+def test_a_provider_backed_spec_skips_the_credential_check():
+    # Arrange
+    cfg = _Cfg(name="handyman-01", provider="qwen38")
+    # Act
+    seen = _spec_checked_with(cfg)
+    # Assert
+    assert seen == []
+
+
+def test_an_unloadable_spec_still_counts_as_needing_oauth():
+    # Arrange
+    target = "scitex-scholar"
+    # Act
+    with _spec_that_will_not_load(_MISSING_SPEC):
+        result = any_target_needs_anthropic_oauth([target], [])
+    # Assert
+    assert result is True
+
+
+def test_a_provider_backed_spec_does_not_need_oauth():
+    # Arrange
+    cfg = _Cfg(name="handyman-01", provider="qwen38")
+    # Act
+    with _spec_that_loads(cfg):
+        result = any_target_needs_anthropic_oauth([cfg.name], [])
+    # Assert
+    assert result is False

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
@@ -41,6 +41,28 @@ def _swap(name: str, fn: Callable) -> Iterator[None]:
         setattr(stop_mod, name, saved)
 
 
+#: Fixture agent names. The prefix is LOAD-BEARING — do not shorten these.
+#:
+#: They used to be "a" and "b", and that reached the REAL FLEET. Measured
+#: 2026-08-19: `_stop` resolves each target name through
+#: `config._resolve.resolve_with_prefix`, which PREFIX-MATCHED "b" to the
+#: live agent "business", decided it was REMOTE, and issued
+#:
+#:     ssh ywata-note-win-net -- 'sac agents stop b --json'
+#:
+#: The `_swap("agent_stop", ...)` above does not cover that path — a remote
+#: target never calls the local function — so the swap gave the APPEARANCE
+#: of isolation while a production stop went out over SSH. It failed only
+#: because this container could not resolve that hostname; anywhere DNS
+#: works, the test would have stopped a real agent AND THEN PASSED, since
+#: `exit_code == 0` is what it asserts.
+#:
+#: A `tmp_path` fixture bounds what the test SETS UP, never what the code
+#: under test REACHES FOR. These names are chosen so that no real agent can
+#: ever be a prefix-extension of them.
+FIXTURE_AGENTS = ("pytest-fixture-a", "pytest-fixture-b")
+
+
 def _seed(tmp_path: Path, names) -> Path:
     """Seed a directory with N agents (each <name>/<name>.yaml)."""
     root = tmp_path / "agents"
@@ -64,7 +86,7 @@ class _FakeCfg:
 @pytest.fixture
 def dry_run_result(tmp_path):
     # Arrange
-    root = _seed(tmp_path, ["a", "b"])
+    root = _seed(tmp_path, FIXTURE_AGENTS)
     runner = CliRunner()
     # Act
     result = runner.invoke(stop, [str(root), "extra", "--dry-run"])
@@ -107,7 +129,7 @@ def test_dry_run_lists_targets_mentions_bulk_yaml(dry_run_result):
 @pytest.fixture
 def bulk_no_yes_result(tmp_path):
     # Arrange
-    root = _seed(tmp_path, ["a", "b"])
+    root = _seed(tmp_path, FIXTURE_AGENTS)
     runner = CliRunner()
     # Act
     result = runner.invoke(stop, [str(root)])
@@ -141,7 +163,7 @@ def test_bulk_without_yes_refuses_prints_message(bulk_no_yes_result):
 @pytest.fixture
 def bulk_with_yes_run(tmp_path):
     # Arrange
-    root = _seed(tmp_path, ["a", "b"])
+    root = _seed(tmp_path, FIXTURE_AGENTS)
     stopped: list = []
     # Act
     with (
@@ -172,7 +194,7 @@ def test_bulk_with_yes_stops_all_invokes_agent_stop_per_agent(bulk_with_yes_run)
     # Act
     names = sorted(s[0] for s in stopped)
     # Assert
-    assert names == ["a", "b"]
+    assert names == sorted(FIXTURE_AGENTS)
 
 
 # ---------------------------------------------------------------------------
@@ -186,7 +208,7 @@ def bulk_failure_result(tmp_path):
     def _boom(_name, _force, *, prune_runtime=False):
         raise RuntimeError("boom")
 
-    root = _seed(tmp_path, ["a", "b"])
+    root = _seed(tmp_path, FIXTURE_AGENTS)
     # Act
     with (
         _swap("load_config", lambda p: _FakeCfg(Path(p).stem)),

--- a/tests/scitex_agent_container/cli_pkg/test__account_keepalive_cli_surface.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_keepalive_cli_surface.py
@@ -1,0 +1,187 @@
+"""``sac accounts send-credentials``: a real peer list, and a live legacy alias.
+
+Two of the three defects the operator found reading the shipped ``--help``:
+
+1. The examples named peers that exist on no host (``compute-04``, ``laptop``),
+   while ``--to`` requires a key from ``config.yaml``. Copying the
+   documentation therefore failed.
+2. ``keepalive`` needs a paragraph to say it copies credentials to peers - and
+   the constitution's rule is that when a name needs restating as something
+   else, that something else IS the name.
+
+The alias tests are the load-bearing ones: ``keepalive`` is a PUBLISHED
+contract with a scitex-dev JobSpec calling it every 15 minutes, so a rename
+that stopped at renaming would take the fleet's credential distribution down.
+
+(The ``--help`` SECTIONS are the third defect and live beside their own module,
+in ``test_account_group_categories.py``.)
+"""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._account_keepalive import (
+    _registered_peer_lines,
+    format_peer_lines,
+    register_keepalive_command,
+)
+
+
+def _group() -> click.Group:
+    """A bare group carrying only the commands under test."""
+    group = click.Group("accounts")
+    register_keepalive_command(group)
+    return group
+
+
+# --- the peer listing ------------------------------------------------------
+
+
+def test_peer_lines_are_empty_when_no_peers_are_registered():
+    # Arrange
+    peers: list[str] = []
+
+    # Act
+    lines = format_peer_lines(peers)
+
+    # Assert — a host with no peers gets no hint, never a bare header
+    assert lines == []
+
+
+def test_peer_lines_name_every_registered_peer():
+    # Arrange
+    peers = ["ywata-note-win", "scitex-compute-04"]
+
+    # Act
+    rendered = "\n".join(format_peer_lines(peers))
+
+    # Assert
+    assert "ywata-note-win" in rendered and "scitex-compute-04" in rendered
+
+
+def test_peer_lines_mark_a_wildcard_row_as_a_pattern():
+    # Arrange — `spartan-*` is a template for per-node keys, not a typable name
+    peers = ["spartan-*"]
+
+    # Act
+    rendered = "\n".join(format_peer_lines(peers))
+
+    # Assert
+    assert "pattern" in rendered
+
+
+def test_help_lists_the_peers_exactly_when_this_host_has_them():
+    # Arrange — asserting `"Registered peers" in stdout` outright would be an
+    # ENVIRONMENTAL fact, not a property of the code: the block renders from the
+    # live config, so it is absent on any host with no peers registered (a CI
+    # runner, a fresh checkout) and the test would fail there for being right.
+    # The invariant that holds everywhere is that the two AGREE.
+    group = _group()
+    host_has_peers = bool(_registered_peer_lines())
+
+    # Act
+    result = CliRunner().invoke(group, ["send-credentials", "--help"])
+
+    # Assert — wiring is present; what it renders is the host's business
+    assert ("Registered peers" in result.stdout) == host_has_peers
+
+
+# --- the examples ----------------------------------------------------------
+
+
+def test_examples_do_not_name_the_peer_that_exists_nowhere():
+    # Arrange
+    group = _group()
+
+    # Act
+    result = CliRunner().invoke(group, ["send-credentials", "--help"])
+
+    # Assert — `--to laptop` was in the shipped examples and is not a key
+    assert "--to laptop" not in result.stdout
+
+
+# --- the rename, which must not break the JobSpec that calls it ------------
+
+
+def test_the_new_name_is_registered():
+    # Arrange
+    group = _group()
+
+    # Act
+    cmd = group.get_command(click.Context(group), "send-credentials")
+
+    # Assert
+    assert cmd is not None
+
+
+def test_the_legacy_name_still_resolves():
+    # Arrange — a JobSpec runs `accounts keepalive --all` every 15 minutes
+    group = _group()
+
+    # Act
+    cmd = group.get_command(click.Context(group), "keepalive")
+
+    # Assert
+    assert cmd is not None
+
+
+def test_the_legacy_name_still_accepts_the_same_options():
+    # Arrange
+    group = _group()
+    ctx = click.Context(group)
+
+    # Act
+    legacy = group.get_command(ctx, "keepalive")
+    current = group.get_command(ctx, "send-credentials")
+
+    # Assert — same params, so the scheduled command line keeps parsing
+    assert [p.name for p in legacy.params] == [p.name for p in current.params]
+
+
+def test_the_legacy_name_is_hidden_from_help():
+    # Arrange
+    group = _group()
+
+    # Act
+    result = CliRunner().invoke(group, ["--help"])
+
+    # Assert — deprecated, so it must not be advertised to new readers
+    assert "keepalive" not in result.stdout
+
+
+def test_the_legacy_name_warns_that_it_was_renamed():
+    # Arrange — args that reach the callback, then fail on their own merits
+    group = _group()
+    args = ["keepalive", "--account", "no-such-account", "--to", "no-such-peer"]
+
+    # Act
+    result = CliRunner().invoke(group, args)
+
+    # Assert
+    assert "send-credentials" in result.stderr
+
+
+def test_the_legacy_warning_never_lands_on_stdout():
+    # Arrange — `--json` consumers parse stdout; a warning there breaks them
+    group = _group()
+    args = ["keepalive", "--account", "no-such-account", "--to", "no-such-peer"]
+
+    # Act
+    result = CliRunner().invoke(group, args)
+
+    # Assert
+    assert "renamed" not in result.stdout
+
+
+def test_the_new_name_does_not_warn():
+    # Arrange — the control: proves the warning is bound to the alias only
+    group = _group()
+    args = ["send-credentials", "--account", "no-such-account", "--to", "no-such"]
+
+    # Act
+    result = CliRunner().invoke(group, args)
+
+    # Assert
+    assert "is now" not in result.stderr

--- a/tests/scitex_agent_container/cli_pkg/test__completion_install.py
+++ b/tests/scitex_agent_container/cli_pkg/test__completion_install.py
@@ -1,0 +1,101 @@
+"""The completion installer must not write into a git-tracked rc file.
+
+MEASURED 2026-08-20, found by the dotfiles agent while building the fleet git
+sync. On every fleet host `~/.bashrc` is a SYMLINK:
+
+    /home/ywatanabe/.bashrc -> /home/ywatanabe/.dotfiles/src/.bashrc
+
+so appending to it modified a TRACKED file in the dotfiles repo. Four hosts
+carried the same "local edit" — not four humans, one installer. Those checkouts
+were permanently dirty, an ff-only pull would not apply, and that was a direct
+contributor to the fleet running five different dotfiles heads.
+
+No-mocks (PA-306): every test builds a REAL git repository on disk. The property
+under test is how a SYMLINK into a repo is treated, and a fake cannot exhibit
+that — it is exactly the thing the production code got wrong.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scitex_agent_container.cli_pkg._completion_install import _tracked_in_a_git_repo
+
+
+def _repo_with(tmp_path: Path, *, filename: str, tracked: bool) -> Path:
+    """A real git repo containing ``filename``, committed or not."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run = lambda *a: subprocess.run(  # noqa: E731 - local, one line, one use
+        ["git", "-C", str(repo), *a], capture_output=True, check=True
+    )
+    run("init", "-q")
+    run("config", "user.email", "t@example.invalid")
+    run("config", "user.name", "t")
+    (repo / filename).write_text("# rc\n")
+    if tracked:
+        run("add", filename)
+        run("commit", "-qm", "add rc")
+    return repo
+
+
+def test_a_tracked_file_reports_its_repo_root(tmp_path: Path) -> None:
+    # Arrange
+    repo = _repo_with(tmp_path, filename=".bashrc", tracked=True)
+    # Act
+    found = _tracked_in_a_git_repo(repo / ".bashrc")
+    # Assert
+    assert found == repo
+
+
+def test_a_symlink_into_a_repo_reports_the_repo_root(tmp_path: Path) -> None:
+    """THE ACTUAL BUG SHAPE — the file opened is not the file named.
+
+    Falsifiable, and it is the one that matters: drop the `.resolve()` from the
+    implementation and this goes RED while every other test here stays green,
+    because only this one names the file from outside the repo.
+    """
+    # Arrange
+    repo = _repo_with(tmp_path, filename=".bashrc", tracked=True)
+    link = tmp_path / "home-bashrc"
+    link.symlink_to(repo / ".bashrc")
+    # Act
+    found = _tracked_in_a_git_repo(link)
+    # Assert
+    assert found == repo
+
+
+def test_an_untracked_file_in_a_repo_is_not_refused(tmp_path: Path) -> None:
+    """Being INSIDE a repo is not the condition — being tracked is.
+
+    A user whose rc file merely sits in a repo directory, unversioned, has
+    nothing to lose from an append, and refusing there would be a false alarm
+    that sends them looking for a commit that does not exist.
+    """
+    # Arrange
+    repo = _repo_with(tmp_path, filename=".bashrc", tracked=False)
+    # Act
+    found = _tracked_in_a_git_repo(repo / ".bashrc")
+    # Assert
+    assert found is None
+
+
+def test_a_file_outside_any_repo_is_not_refused(tmp_path: Path) -> None:
+    # Arrange
+    plain = tmp_path / ".bashrc"
+    plain.write_text("# rc\n")
+    # Act
+    found = _tracked_in_a_git_repo(plain)
+    # Assert
+    assert found is None
+
+
+def test_a_missing_file_is_not_refused(tmp_path: Path) -> None:
+    """The installer creates the rc file when absent; that path must stay open."""
+    # Arrange
+    absent = tmp_path / "never-created"
+    # Act
+    found = _tracked_in_a_git_repo(absent)
+    # Assert
+    assert found is None

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -544,7 +544,7 @@ def test_install_accepts_the_short_local_name() -> None:
         # Act
         runner.invoke(dev_group, ["timer", "install", "accounts-refresh", "-y"])
     # Assert
-    assert [a[2] for a in captured] == ["sac.accounts-refresh"]
+    assert [a[2] for a in captured] == ["scitex-agent-container-accounts-refresh"]
 
 
 def test_install_accepts_the_canonical_name_too() -> None:
@@ -552,9 +552,12 @@ def test_install_accepts_the_canonical_name_too() -> None:
     with _captured_delegations() as captured:
         runner = CliRunner()
         # Act
-        runner.invoke(dev_group, ["timer", "install", "sac.accounts-refresh", "-y"])
+        runner.invoke(
+            dev_group,
+            ["timer", "install", "scitex-agent-container-accounts-refresh", "-y"],
+        )
     # Assert
-    assert [a[2] for a in captured] == ["sac.accounts-refresh"]
+    assert [a[2] for a in captured] == ["scitex-agent-container-accounts-refresh"]
 
 
 def test_install_forwards_dry_run_to_the_delegation() -> None:
@@ -733,7 +736,7 @@ def test_a_refusal_offers_the_manual_command() -> None:
     result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
     # Assert
     assert (
-        "systemctl --user status sac.accounts-refresh.timer" in result.stderr
+        f"systemctl --user status {'scitex-agent-container-accounts-refresh'}.timer" in result.stderr
     ) is (not delegation.supported), (
         f"probe says supported={delegation.supported}. When sac refuses it "
         "must hand the operator the manual command; when it delegates it "

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
@@ -80,14 +80,25 @@ def _declared_timers() -> list[str]:
 
 
 class _Recorder:
-    """Capture every ``(kind, verb, name, yes, dry_run)`` delegation."""
+    """Capture every ``(kind, verb, name, yes, dry_run)`` delegation.
+
+    ``**passed`` absorbs the seam's OPTIONAL keyword arguments — ``adopt``
+    and ``force`` today — and keeps them out of ``calls``, so the five-element
+    tuple every assertion below reads is unchanged by a parameter being added
+    upstream. Without it a new keyword raises TypeError inside the Click
+    callback, which surfaces as a non-zero exit and an EMPTY ``calls`` list:
+    the tests then fail saying the verb delegated for no jobs, which is true
+    and describes the recorder rather than the code.
+    """
 
     def __init__(self, rc: int = 0) -> None:
         self.calls: list[tuple] = []
+        self.passed: list[dict] = []
         self._rc = rc
 
-    def __call__(self, kind, verb, name, yes, dry_run=False) -> int:
+    def __call__(self, kind, verb, name, yes, dry_run=False, **passed) -> int:
         self.calls.append((kind, verb, name, yes, dry_run))
+        self.passed.append(passed)
         return self._rc
 
     def names_for(self, verb: str) -> list[str]:
@@ -474,3 +485,27 @@ def test_every_rendered_service_has_an_execstart(rendered_units) -> None:
     without = [n for n, (_t, service) in rendered_units.items() if "ExecStart=" not in service]
     # Assert
     assert without == []
+
+
+def test_install_forwards_force_to_the_delegation_seam() -> None:
+    """The end-to-end shape of the defect: install's refusal names --force."""
+    # Arrange
+    recorder = _Recorder()
+    # Act
+    with _delegating_to(recorder):
+        CliRunner().invoke(
+            dj._make_group("timer"), ["install", "host-sync-check", "--yes", "--force"]
+        )
+    # Assert
+    assert recorder.passed and recorder.passed[0].get("force") is True
+
+
+def test_uninstall_rejects_force_because_upstream_has_no_such_option() -> None:
+    """Forwarding a flag the target verb lacks trades one wrong message for another."""
+    # Arrange
+    argv = ["uninstall", "host-sync-check", "--yes", "--force"]
+    # Act
+    with _delegating_to(_Recorder()):
+        result = CliRunner().invoke(dj._make_group("timer"), argv)
+    # Assert
+    assert result.exit_code != 0

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_apply.py
@@ -336,7 +336,7 @@ def test_bulk_enable_still_accepts_one_name() -> None:
             dj._make_group("timer"), ["enable", "accounts-refresh", "--yes"]
         )
     # Assert
-    assert recorder.names_for("enable") == ["sac.accounts-refresh"]
+    assert recorder.names_for("enable") == ["scitex-agent-container-accounts-refresh"]
 
 
 def test_disable_has_no_bulk_form() -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -468,3 +468,41 @@ def test_an_unreadable_tree_refuses_a_verb_that_never_shipped() -> None:
         backend.reset_capability_cache()
     # Assert
     assert got.supported is False
+
+
+def _install_delegation() -> "backend.Delegation":
+    """`timer install` — the only verb upstream carrying --adopt/--force."""
+    return backend.Delegation(
+        path=("timer",), verb="install", supported=True, evidence="fixture"
+    )
+
+
+def test_the_pass_through_forwards_adopt() -> None:
+    """MEASURED 2026-08-20: install's refusal names --adopt; the wrapper had no
+    such option, so following its own advice errored."""
+    # Arrange
+    delegation = _install_delegation()
+    # Act
+    argv = backend.build_argv(delegation, name="sac.x", yes=True, adopt=True, exe="sd")
+    # Assert
+    assert "--adopt" in argv
+
+
+def test_the_pass_through_forwards_force() -> None:
+    """The other half of that same refusal message."""
+    # Arrange
+    delegation = _install_delegation()
+    # Act
+    argv = backend.build_argv(delegation, name="sac.x", yes=True, force=True, exe="sd")
+    # Assert
+    assert "--force" in argv
+
+
+def test_neither_flag_appears_unless_asked() -> None:
+    """Non-vacuity: one that always appended both would pass the two above."""
+    # Arrange
+    delegation = _install_delegation()
+    # Act
+    argv = backend.build_argv(delegation, name="sac.x", yes=True, exe="sd")
+    # Assert
+    assert not {"--adopt", "--force"} & set(argv)

--- a/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
@@ -620,7 +620,7 @@ def isolated_state_db(tmp_path: Path, env_save_restore) -> Iterator[Path]:
         importlib.reload(_sdb)
 
 
-def test_grant_exit_zero_on_happy_path(isolated_state_db: Path) -> None:
+def test_grant_exit_zero_on_happy_path(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     # Act
@@ -629,7 +629,7 @@ def test_grant_exit_zero_on_happy_path(isolated_state_db: Path) -> None:
     assert res.exit_code == 0
 
 
-def test_grant_persists_row_into_comms_grants(isolated_state_db: Path) -> None:
+def test_grant_persists_row_into_comms_grants(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
@@ -641,7 +641,7 @@ def test_grant_persists_row_into_comms_grants(isolated_state_db: Path) -> None:
     assert any(r["sender"] == "worker-a" and r["target"] == "worker-b" for r in rows)
 
 
-def test_grant_stores_optional_note(isolated_state_db: Path) -> None:
+def test_grant_stores_optional_note(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b", "--note", "ticket-PA-512"])
@@ -653,7 +653,7 @@ def test_grant_stores_optional_note(isolated_state_db: Path) -> None:
     assert "ticket-PA-512" in notes
 
 
-def test_grant_idempotent_no_duplicate_rows(isolated_state_db: Path) -> None:
+def test_grant_idempotent_no_duplicate_rows(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange: grant twice with the same pair
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
@@ -670,7 +670,7 @@ def test_grant_idempotent_no_duplicate_rows(isolated_state_db: Path) -> None:
     assert len(rows) == 1
 
 
-def test_grant_empty_sender_exits_two(isolated_state_db: Path) -> None:
+def test_grant_empty_sender_exits_two(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     # Act
@@ -681,6 +681,7 @@ def test_grant_empty_sender_exits_two(isolated_state_db: Path) -> None:
 
 def test_grant_empty_sender_writes_error_to_stderr(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -692,6 +693,7 @@ def test_grant_empty_sender_writes_error_to_stderr(
 
 def test_grant_human_output_announces_direction(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -704,7 +706,7 @@ def test_grant_human_output_announces_direction(
 # --- revoke -----------------------------------------------------------------
 
 
-def test_revoke_existing_grant_exits_zero(isolated_state_db: Path) -> None:
+def test_revoke_existing_grant_exits_zero(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
@@ -714,7 +716,7 @@ def test_revoke_existing_grant_exits_zero(isolated_state_db: Path) -> None:
     assert res.exit_code == 0
 
 
-def test_revoke_removes_row_from_comms_grants(isolated_state_db: Path) -> None:
+def test_revoke_removes_row_from_comms_grants(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
@@ -731,7 +733,7 @@ def test_revoke_removes_row_from_comms_grants(isolated_state_db: Path) -> None:
     assert rows == []
 
 
-def test_revoke_missing_grant_is_noop_zero_exit(isolated_state_db: Path) -> None:
+def test_revoke_missing_grant_is_noop_zero_exit(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange: no grant exists
     runner = CliRunner()
     # Act
@@ -742,6 +744,7 @@ def test_revoke_missing_grant_is_noop_zero_exit(isolated_state_db: Path) -> None
 
 def test_revoke_missing_grant_emits_noop_marker(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -751,7 +754,7 @@ def test_revoke_missing_grant_emits_noop_marker(
     assert "no-op" in res.output
 
 
-def test_revoke_empty_sender_exits_two(isolated_state_db: Path) -> None:
+def test_revoke_empty_sender_exits_two(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     # Act
@@ -762,6 +765,7 @@ def test_revoke_empty_sender_exits_two(isolated_state_db: Path) -> None:
 
 def test_revoke_empty_target_writes_error_to_stderr(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -796,7 +800,7 @@ def test_grants_json_empty_table_is_empty_array(
     assert json.loads(res.output) == []
 
 
-def test_grants_json_lists_inserted_grant(isolated_state_db: Path) -> None:
+def test_grants_json_lists_inserted_grant(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "worker-a", "worker-b", "--note", "demo"])
@@ -812,6 +816,7 @@ def test_grants_json_lists_inserted_grant(isolated_state_db: Path) -> None:
 
 def test_grants_rich_table_shows_sender_and_target(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -822,7 +827,7 @@ def test_grants_rich_table_shows_sender_and_target(
     assert "alpha" in res.output and "beta" in res.output
 
 
-def test_grants_json_orders_by_insertion(isolated_state_db: Path) -> None:
+def test_grants_json_orders_by_insertion(isolated_state_db: Path, pg_schema: str) -> None:
     # Arrange
     runner = CliRunner()
     runner.invoke(a2a, ["grant", "first-sender", "first-target"])
@@ -838,6 +843,7 @@ def test_grants_json_orders_by_insertion(isolated_state_db: Path) -> None:
 
 def test_grants_json_after_revoke_drops_the_row(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -849,7 +855,7 @@ def test_grants_json_after_revoke_drops_the_row(
     assert json.loads(res.output) == []
 
 
-def test_grant_direction_is_one_way(isolated_state_db: Path) -> None:
+def test_grant_direction_is_one_way(isolated_state_db: Path, pg_schema: str) -> None:
     """Granting A→B must NOT auto-grant B→A (the ACL is directional)."""
     # Arrange
     runner = CliRunner()

--- a/tests/scitex_agent_container/cli_pkg/test_account_group_categories.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group_categories.py
@@ -1,0 +1,65 @@
+"""``sac accounts --help`` renders its verbs under named sections.
+
+Fifteen verbs in one flat alphabetical column made ``list`` / ``status`` /
+``quota`` look interchangeable and hid which of them WRITE. The interface spec
+(general/03_interface_02_cli §6) asks for sections and ``sac agents`` already
+renders them.
+
+The two population guards matter more than the rendering test: a category that
+names a verb which no longer exists renders nothing and fails silently, and a
+verb nobody categorised disappears into ``Other`` unnoticed.
+"""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.account_group import _AccountsGroup, account
+
+
+# --- the sections ----------------------------------------------------------
+
+
+def test_accounts_help_renders_named_sections():
+    # Arrange
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(account, ["--help"])
+
+    # Assert
+    assert "Distribute to peers:" in result.stdout
+
+
+def test_every_categorised_name_is_a_real_command():
+    # Arrange — a category naming a verb that does not exist would silently
+    # render nothing, which is how a section quietly goes empty after a rename
+    ctx = click.Context(account)
+    listed = {n for _, names in _AccountsGroup.COMMAND_CATEGORIES for n in names}
+
+    # Act
+    missing = sorted(n for n in listed if account.get_command(ctx, n) is None)
+
+    # Assert
+    assert missing == []
+
+
+def test_no_visible_command_falls_through_to_other():
+    # Arrange — `Other` is the catch-all; a VISIBLE verb landing there is one
+    # somebody forgot to categorise. Hidden verbs (the `keepalive` alias) are
+    # excluded on the same predicate the formatter itself uses, so this tracks
+    # what a reader actually sees rather than what the group happens to hold.
+    ctx = click.Context(account)
+    categorised = {n for _, names in _AccountsGroup.COMMAND_CATEGORIES for n in names}
+    visible = {
+        n
+        for n in account.list_commands(ctx)
+        if not getattr(account.get_command(ctx, n), "hidden", False)
+    }
+
+    # Act
+    uncategorised = sorted(visible - categorised)
+
+    # Assert
+    assert uncategorised == []

--- a/tests/scitex_agent_container/cli_pkg/test_guard_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_guard_group.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import traceback
 from pathlib import Path
 
 import pytest
@@ -85,6 +86,63 @@ def _run(*args: str):
     return CliRunner().invoke(main, ["guard", "deletions", *args])
 
 
+def _run_json(*args: str) -> dict:
+    """Parse the command's JSON stdout, or fail with everything the runner saw.
+
+    TWO defects, both measured on click 8.4.2 on 2026-08-20.
+
+    ONE — the wrong stream. ``result.output`` INTERLEAVES stdout and stderr.
+    Measured with a positive control (write to ``sys.stderr`` at call time, so
+    it reaches the stream CliRunner actually swapped in)::
+
+        .output -> '{"ok": true}\nSTDERR-MARKER\n'   json.loads FAILS
+        .stdout -> '{"ok": true}\n'                  json.loads OK
+
+    A control matters here because the obvious experiment does NOT work: a
+    logging handler created at import time holds the PRE-SWAP stderr, so its
+    output never enters the capture and ``.output`` looks stdout-clean. That
+    run cannot fail for any input.
+
+    The CLI's contract is JSON *on stdout*; any log line from any module on
+    stderr is not part of it. So parse ``.stdout``.
+
+    TWO — the silent report. When parsing did fail on develop, the entire
+    diagnostic was::
+
+        json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
+
+    `char 0` does NOT distinguish "stdout was empty" from "something non-JSON
+    came first" — both land there. So the message below prints all three
+    streams, the exit code, and the swallowed traceback, and lets the reader
+    tell those apart instead of guessing.
+
+    This does NOT tolerate the failure: an unparseable payload still fails the
+    test. It only makes the failure say something.
+    """
+    result = _run(*args)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        try:
+            stderr = result.stderr
+        except (ValueError, AttributeError):  # stx-allow: fallback (reason: click does not always capture stderr separately; a missing stderr must not replace the real failure with an error about reading it. SINK: the assertion message below, which pytest prints on failure)
+            stderr = "<not captured separately>"
+        detail = [
+            "guard deletions --json produced no parseable JSON on stdout.",
+            f"  json error : {exc}",
+            f"  exit_code  : {result.exit_code}",
+            f"  stdout     : {result.output!r}",
+            f"  stderr     : {stderr!r}",
+            f"  exception  : {result.exception!r}",
+        ]
+        if result.exc_info is not None:
+            detail.append(
+                "  traceback  :\n"
+                + "".join(traceback.format_exception(*result.exc_info))
+            )
+        raise AssertionError("\n".join(detail)) from exc
+
+
 def test_incident_exits_with_the_violations_code(incident_repo: Path) -> None:
     """3 — the declared domain code, never 1."""
     # Arrange
@@ -132,7 +190,7 @@ def test_json_still_lists_every_deleted_method(incident_repo: Path) -> None:
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert "transforms.py::class:Scaler.apply" in {
         d["key"] for d in payload["deletions"]
@@ -220,7 +278,7 @@ def test_missing_baseline_json_verdict_is_undetermined(repo: Path) -> None:
     # Arrange
     args = ("--repo", str(repo), "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert payload["verdict"] == "could-not-determine"
 
@@ -242,7 +300,7 @@ def test_json_verdict_is_violations_on_the_incident(
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert payload["verdict"] == "violations"
 
@@ -252,7 +310,7 @@ def test_json_carries_the_declared_exit_code(incident_repo: Path) -> None:
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert payload["exit_code"] == 3
 
@@ -262,7 +320,7 @@ def test_json_top_level_keys_are_stable(incident_repo: Path) -> None:
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert set(payload) == {
         "verdict", "exit_code", "baseline", "target", "files_compared",
@@ -278,7 +336,7 @@ def test_json_deletion_entry_carries_its_allow_key(
     # Arrange
     args = ("--repo", str(incident_repo), "--base", "HEAD", "--json")
     # Act
-    payload = json.loads(_run(*args).output)
+    payload = _run_json(*args)
     # Assert
     assert "transforms.py::class:Scaler" in {
         d["key"] for d in payload["deletions"]

--- a/tests/scitex_agent_container/cli_pkg/test_host_group_exec_captures_output.py
+++ b/tests/scitex_agent_container/cli_pkg/test_host_group_exec_captures_output.py
@@ -29,6 +29,9 @@ PA-306: no mocks. Real `subprocess`, real child processes, real CliRunner.
 
 from __future__ import annotations
 
+import shlex
+import subprocess
+
 import click
 import pytest
 from click.testing import CliRunner
@@ -140,3 +143,79 @@ def test_stdout_and_stderr_are_not_merged_into_one_stream():
     result = _run(*argv)
     # Assert
     assert "DIAGNOSTIC" not in result.stdout
+
+
+# ----------------------------------------------------------------------
+# ARGUMENT BOUNDARIES MUST SURVIVE THE TRANSPORT
+#
+# The same rule as the top of this file, with a NUMBER instead of an empty
+# string. ssh word-joins every token after the host and hands the result to
+# the remote LOGIN SHELL, which re-parses it — so `host exec` must quote the
+# user's argv words or the remote shell re-splits them.
+#
+# Measured 2026-08-20 by scitex-cards, reproduced here on compute-03:
+#
+#   host exec <peer> -- echo AAA-scitex-BBB '|' grep -cE 'scitex|cards'
+#     -> bash: line 1: cards: command not found
+#   host exec <peer> -- bash -lc 'echo AAA-scitex-BBB | grep -cE "scitex|cards"'
+#     -> 0                                            (the answer is 1)
+#
+# The second is the dangerous one: a mangled command returned a plausible
+# number, and only a contradiction with an earlier count stopped it being
+# reported as a measurement.
+#
+# The quoting belongs in `host_exec`, NOT in `build_ssh_argv`: that function's
+# contract is an ALREADY-QUOTED remote command, and adding a join there on
+# 2026-08-17 double-quoted callers that pre-quote correctly and produced
+# rc=127 on every preamble peer, taking scitex-hub down.
+# ----------------------------------------------------------------------
+
+
+def _as_ssh_would_join(words: list[str]) -> str:
+    """What the remote login shell actually receives, per OpenSSH's word-join."""
+    return " ".join(shlex.quote(w) for w in words)
+
+
+@pytest.mark.parametrize(
+    "words",
+    [
+        ["hostname"],
+        ["sac", "db", "export"],
+        ["agent", "list", "--json"],
+    ],
+)
+def test_ordinary_words_render_byte_identically(words):
+    """Quoting must not perturb any invocation that was already correct."""
+    # Arrange — words carrying no shell metacharacters.
+    # Act
+    rendered = [shlex.quote(w) for w in words]
+    # Assert
+    assert rendered == words
+
+
+def test_a_metacharacter_argument_survives_the_remote_reparse():
+    """The exact shape that returned a wrong NUMBER against the live fleet."""
+    # Arrange — a pipe as its own word, and a regex alternation inside one.
+    words = ["echo", "AAA-scitex-BBB", "|", "grep", "-cE", "scitex|cards"]
+    # Act — join as ssh does, then let a REAL shell re-parse it (no mocks).
+    recovered = shlex.split(_as_ssh_would_join(words))
+    # Assert
+    assert recovered == words
+
+
+def test_the_remote_shell_runs_the_command_the_caller_wrote():
+    """End to end through a real child: the pipe must NOT take effect here.
+
+    With the words quoted, `|` is an ARGUMENT to echo, so echo prints it and
+    nothing is piped. Unquoted, the remote shell would treat it as a pipeline
+    and hunt for a command named `cards` — which is exactly what compute-03
+    reported before the fix.
+    """
+    # Arrange
+    joined = _as_ssh_would_join(["echo", "a", "|", "b"])
+    # Act
+    out = subprocess.run(
+        ["bash", "-c", joined], capture_output=True, text=True
+    ).stdout.strip()
+    # Assert
+    assert out == "a | b"

--- a/tests/scitex_agent_container/cli_pkg/test_send_cmds_unknown_agent.py
+++ b/tests/scitex_agent_container/cli_pkg/test_send_cmds_unknown_agent.py
@@ -1,0 +1,172 @@
+"""A send to a name that was never an agent must say so, not blame the port.
+
+Delivery declines identically for "defined agent, no reachable port" and for
+"this name was never an agent", so both reach the same refusal. Until
+2026-08-20 both also got the SAME text — "no A2A port is recorded", prescribing
+`sac agents start <name>` — which presupposes the agent exists.
+
+MEASURED: ci-watch dispatched to five names that had never been registered
+(definitions=0, instances=0 EVER), 351 times, 0 successes. A peer read this
+refusal, took the named cause at face value, and reported the failures as
+instances of an unrelated port-registration defect. The remedy was trusted
+because it was specific, and it pointed at the wrong thing.
+
+The controls here carry the weight: it is easy to write a "not defined" branch
+that fires for everything, and the resulting message would still look correct
+in the one case you tested.
+
+Separate file because ``test_send_cmds.py`` is 566 lines against a 512 cap.
+PA-306: no mocks — real spec files under ``tmp_path`` and a real isolated
+SQLite state db.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.send_cmds import send
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+_YAML_DIRS = "SCITEX_AGENT_CONTAINER_YAML_DIRS"
+_STATE_DB = "SCITEX_AGENT_CONTAINER_STATE_DB"
+
+
+def _write_spec(yaml_root: Path, name: str) -> None:
+    agent_dir = yaml_root / name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "spec.yaml").write_text(
+        explicitize_yaml(f"""apiVersion: scitex-agent-container/v3
+kind: Agent
+spec:
+  runtime: apptainer
+  host: ${{HOSTNAME}}
+  workdir: {yaml_root.parent / "workdir"}
+  apptainer:
+    image: /x.sif
+    binds: []
+  claude:
+    model: sonnet
+""")
+    )
+
+
+@contextmanager
+def _env(key: str, value: str) -> Iterator[None]:
+    saved = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+@pytest.fixture
+def only_alpha_defined(tmp_path: Path) -> Iterator[Path]:
+    """Exactly one agent (``alpha``) exists; the state db is empty.
+
+    So ``alpha`` is defined-but-unreachable and any other name is unknown —
+    the two states this refusal must tell apart.
+    """
+    import importlib
+
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    yaml_root = tmp_path / "agents"
+    yaml_root.mkdir()
+    _write_spec(yaml_root, "alpha")
+    (tmp_path / "workdir").mkdir()
+    with _env(_YAML_DIRS, str(yaml_root)), _env(
+        _STATE_DB, str(tmp_path / "isolated-state.db")
+    ):
+        importlib.reload(_state_db_mod)
+        try:
+            yield tmp_path
+        finally:
+            importlib.reload(_state_db_mod)
+
+
+def _refuse(name: str) -> str:
+    return CliRunner().invoke(send, [name, "hi"]).output
+
+
+# ---------------------------------------------------------------------------
+# The defect: an unknown name was told its port was missing
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_name_is_reported_as_not_defined(only_alpha_defined: Path) -> None:
+    # Arrange
+    unknown = "proj-scitex-stats"
+    # Act
+    out = _refuse(unknown)
+    # Assert
+    assert "NOT DEFINED" in out, out
+
+
+def test_an_unknown_name_is_not_told_to_start_the_agent(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange
+    unknown = "proj-scitex-stats"
+    # Act
+    out = _refuse(unknown)
+    # Assert — the remedy that sent a reader to the wrong cause
+    assert "sac agents start proj-scitex-stats" not in out, out
+
+
+def test_an_unknown_name_does_not_claim_a_missing_port(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange
+    unknown = "proj-scitex-stats"
+    # Act
+    out = _refuse(unknown)
+    # Assert — naming an unestablished cause is the whole defect
+    assert "no A2A port is recorded" not in out, out
+
+
+# ---------------------------------------------------------------------------
+# Controls — the branch must DISCRIMINATE, not fire for everything
+# ---------------------------------------------------------------------------
+
+
+def test_a_defined_agent_still_gets_the_missing_port_message(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange — alpha has a spec and no reachable port
+    defined = "alpha"
+    # Act
+    out = _refuse(defined)
+    # Assert
+    assert "no A2A port is recorded" in out, out
+
+
+def test_a_defined_agent_is_never_called_not_defined(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange
+    defined = "alpha"
+    # Act
+    out = _refuse(defined)
+    # Assert — the false negative that would break every real send
+    assert "NOT DEFINED" not in out, out
+
+
+def test_both_refusals_keep_the_containment_guarantee(
+    only_alpha_defined: Path,
+) -> None:
+    # Arrange
+    both = ("alpha", "proj-scitex-stats")
+    # Act
+    outs = [_refuse(name) for name in both]
+    # Assert — sac never runs the turn on the bare host, either way
+    assert all("apptainer" in out for out in outs), outs

--- a/tests/scitex_agent_container/config/test__container_engine.py
+++ b/tests/scitex_agent_container/config/test__container_engine.py
@@ -441,3 +441,48 @@ def test_a_scaffolded_spec_cannot_reproduce_the_key():
         "the required/paste-ready block still emits container.runtime — a "
         "spec scaffolded from it would be born failing validation"
     )
+
+
+# ----------------------------------------------------------------------
+# The remedy must be SAFE TO FOLLOW LITERALLY
+#
+# `spec.runtime` (the harness launch mode) and `spec.container.runtime`
+# (removed) share a leaf name and nothing else. Measured 2026-08-20 over
+# the 122 live specs on compute-04:
+#
+#     with spec.runtime            122 / 122
+#     with spec.container.runtime    0 / 122
+#
+# So a reader who hits this error and greps `runtime:` finds exactly one
+# line — the LIVE one — in every spec they could be holding. On
+# 2026-08-20 the operator did exactly that and was one keystroke from
+# deleting `runtime: tui` from a working agent. An ambiguous remedy is
+# executed, not puzzled over, so the disambiguation is pinned here.
+# ----------------------------------------------------------------------
+
+
+def test_the_remedy_tells_the_reader_which_runtime_to_keep():
+    # Arrange — naming only the doomed line is what made this dangerous.
+    message = _runtime_errors({"runtime": "none"})[0]
+    # Act
+    protects_the_live_field = "KEEP" in message
+    # Assert
+    assert protects_the_live_field, message
+
+
+def test_the_remedy_shows_the_nesting_rather_than_the_leaf_name():
+    # Arrange — `container:` alone names a block, not a line.
+    message = _runtime_errors({"runtime": "none"})[0]
+    # Act
+    shows_the_parent_path = "spec:" in message
+    # Assert
+    assert shows_the_parent_path, message
+
+
+def test_the_remedy_warns_against_acting_on_a_bare_grep():
+    # Arrange — the grep is the obvious move and it finds the wrong line.
+    message = _runtime_errors({"runtime": "none"})[0]
+    # Act
+    warns = "grep" in message.lower()
+    # Assert
+    assert warns, message

--- a/tests/scitex_agent_container/config/test__explicit_validation.py
+++ b/tests/scitex_agent_container/config/test__explicit_validation.py
@@ -322,13 +322,18 @@ def test_paste_ready_hint_round_trips_to_green(
 def test_paste_ready_hint_preserves_omission_behaviour(
     tmp_path: Path, _round_trip_healed: dict
 ) -> None:
-    # Arrange — pasted claude.session must reproduce what omission meant:
-    # role-less agent -> 'fresh' (null keeps the role-derived default).
+    # Arrange — THE INVARIANT IS UNCHANGED: a pasted explicit
+    # `session: null` must resolve to whatever OMISSION resolves to, so a
+    # round-tripped spec never silently changes an agent's memory. Only the
+    # value moved: omission now means 'continue' for every role (operator,
+    # 2026-08-18, 「スペックは全てレジュームで」). Asserted as a literal rather
+    # than by calling default_session_for_role() — a test parameterised by
+    # the implementation it checks cannot fail.
     healed_path = _write_doc(tmp_path, _round_trip_healed, "healed-session")
     # Act
     cfg = load_config(healed_path)
     # Assert
-    assert cfg.claude.session == "fresh"
+    assert cfg.claude.session == "continue"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/config/test__session_continuity.py
+++ b/tests/scitex_agent_container/config/test__session_continuity.py
@@ -114,13 +114,16 @@ def test_default_session_for_coordinator_role_is_continue():
     assert result == "continue"
 
 
-def test_default_session_for_absent_role_is_fresh():
-    # Arrange
+def test_default_session_for_absent_role_is_continue():
+    # Arrange — operator ruling 2026-08-18: 「スペックは全てレジュームで」, so a
+    # spec that omits claude.session continues REGARDLESS of role. The old
+    # allowlist silently gave `fresh` to any role nobody had enumerated, which
+    # is how scitex-hub (role `product-lead-orchestrator`) lost a day.
     candidate = None
     # Act
     result = default_session_for_role(candidate)
     # Assert
-    assert result == "fresh"
+    assert result == "continue"
 
 
 # ---------------------------------------------------------------------------
@@ -273,13 +276,28 @@ def test_loader_coordinator_role_defaults_omitted_session_to_continue(tmp_path):
     assert cfg.claude.session == "continue"
 
 
-def test_loader_absent_role_keeps_omitted_session_fresh(tmp_path):
-    # Arrange
+def test_loader_absent_role_gets_continue_not_fresh(tmp_path):
+    # Arrange — a roleless spec is the case that used to fall through to
+    # `fresh`. 91 of 117 live specs omit claude.session, so this default
+    # decided the fleet's memory and nobody had chosen it.
     spec = _write_spec(tmp_path, _OMIT_SESSION_NO_ROLE)
     # Act
     cfg = load_config(str(spec))
     # Assert
-    assert cfg.claude.session == "fresh"
+    assert cfg.claude.session == "continue"
+
+
+def test_an_unenumerated_coordinator_role_still_continues(tmp_path):
+    # Arrange — the regression that motivated the change: `product-lead-
+    # orchestrator` matches neither _CONTINUITY_ROLES nor any prefix (it
+    # begins `product-`, not `lead-`), so under the allowlist it resolved to
+    # `fresh`. Pinned by ROLE STRING, not by the set, so re-adding an
+    # allowlist cannot make this pass again.
+    role = "product-lead-orchestrator"
+    # Act
+    result = default_session_for_role(role)
+    # Assert
+    assert result == "continue"
 
 
 def test_loader_explicit_fresh_on_coordinator_is_not_overridden(tmp_path):

--- a/tests/scitex_agent_container/conftest.py
+++ b/tests/scitex_agent_container/conftest.py
@@ -92,6 +92,21 @@ PG_BASE_DSN = os.environ.get(
     "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
 )
 
+#: The password file, resolved AT IMPORT and pinned for the fixture below.
+#:
+#: MEASURED 2026-08-20. `tests/.../_listen/test__acl_approve_flow.py` sandboxes
+#: `HOME` to a tmp_path — correctly, it is testing host-file behaviour. libpq
+#: finds its password file via `~/.pgpass`, so under that sandbox the lookup
+#: lands in an empty directory and the fixture's own CREATE SCHEMA fails with
+#: `fe_sendauth: no password supplied`. The same fixture works everywhere else,
+#: which is what made it look like a fixture bug rather than an interaction.
+#:
+#: Resolving here — while HOME is still the real one, before any test can move
+#: it — and passing it explicitly makes the fixture independent of a variable
+#: tests are entitled to change. `PGPASSFILE` is libpq's own override and takes
+#: precedence over the HOME lookup.
+_PGPASS_AT_IMPORT = os.environ.get("PGPASSFILE") or os.path.expanduser("~/.pgpass")
+
 #: A DSN that cannot reach anything, on purpose. Port 1 refuses instantly, and
 #: the database name is written to be legible in the error a stray write
 #: produces — the message itself states the rule it just enforced.
@@ -197,6 +212,12 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
 
     import psycopg
 
+    # Pin PGPASSFILE for the whole fixture: a test that sandboxes HOME (several
+    # legitimately do) would otherwise strand libpq's ~/.pgpass lookup.
+    pgpass_key = "PGPASSFILE"
+    saved_pgpass = os.environ.get(pgpass_key)
+    os.environ[pgpass_key] = _PGPASS_AT_IMPORT
+
     schema = "sac_test_" + uuid.uuid4().hex[:12]
     with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
         conn.execute(f'CREATE SCHEMA "{schema}"')
@@ -213,3 +234,7 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
             os.environ[key] = saved
         with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
             conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        if saved_pgpass is None:
+            os.environ.pop(pgpass_key, None)
+        else:
+            os.environ[pgpass_key] = saved_pgpass

--- a/tests/scitex_agent_container/conftest.py
+++ b/tests/scitex_agent_container/conftest.py
@@ -92,9 +92,77 @@ PG_BASE_DSN = os.environ.get(
     "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
 )
 
+#: A DSN that cannot reach anything, on purpose. Port 1 refuses instantly, and
+#: the database name is written to be legible in the error a stray write
+#: produces — the message itself states the rule it just enforced.
+_UNREACHABLE_DSN = (
+    "postgresql://sac_tests@127.0.0.1:1/tests_must_not_write_to_the_fleet_store"
+)
+
+# SET AT IMPORT, NOT ONLY IN A FIXTURE, and the difference is measured.
+#
+# The first version of this guard was function-scoped only. Re-running the full
+# package suite with it dropped the pollution from 46 rows to 4 — better, and
+# still not zero. Every targeted re-run (six lifecycle modules, four whole
+# directories, five store-touching modules) then wrote ZERO rows, so the
+# remaining four were not any single module: they came from writes that happen
+# OUTSIDE a function-scoped fixture's window — collection, and module- or
+# session-scoped fixtures, which are set up before the first function fixture
+# runs and torn down after the last one ends.
+#
+# A conftest is imported before anything under its directory is collected, so
+# assigning here covers the whole pytest process, including those windows. The
+# fixture below stays: it re-asserts the value per test, so a test that changes
+# the variable cannot leak the change into its neighbours.
+os.environ["SCITEX_STORE_DSN"] = _UNREACHABLE_DSN
+
+
+@pytest.fixture(autouse=True)
+def _no_accidental_fleet_store_writes() -> Iterator[None]:
+    """Point every test at a store that cannot exist, unless it asks otherwise.
+
+    MEASURED INCIDENT, 2026-08-20. When the birth certificate moved to
+    PostgreSQL (#1154), ``write_birth_certificate`` lost its ``db_path``. Tests
+    that had been threading a ``tmp_path`` SQLite file were suddenly resolving
+    the FLEET DSN instead, and one full-suite run on scitex-compute-04 wrote
+    **46 rows into the live incarnations store** — ``alpha``, ``zombie``,
+    ``born-1``..``born-4``, ``pid-*``, ``rec-*``, ``screen-*``, every one a
+    fixture name. They were removed with the store's own ``hide`` verb.
+
+    The rows were the small half of the problem. sac's CI runs on SELF-HOSTED
+    runners that sit on the fleet hosts, so every future CI run would have
+    written its fixtures into whichever machine it landed on — a test suite
+    quietly editing production state, on a schedule.
+
+    WHY AN UNREACHABLE DSN RATHER THAN A THROWAWAY SCHEMA. A schema per test
+    would CONNECT, which makes every test in this package depend on PostgreSQL
+    being up — hundreds of tests that never touch a store would start failing
+    on a database outage. This costs nothing and cannot be skipped: there is no
+    server on port 1, so a stray write raises immediately.
+
+    WHY THE LIVE DSN IS NOT SIMPLY LEFT IN PLACE FOR "HARMLESS" WRITES. It was,
+    and that IS the incident. A best-effort caller swallows the failure, so a
+    test that writes to the fleet store looks identical to one that does not —
+    right up until someone counts the rows.
+
+    Tests that need a REAL store take ``pg_schema``, which depends on this
+    fixture and overwrites the variable afterwards, so the ordering is
+    guaranteed by the dependency rather than by pytest's autouse rules.
+    """
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = _UNREACHABLE_DSN
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
 
 @pytest.fixture()
-def pg_schema() -> Iterator[str]:
+def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
     """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
 
     Yields the schema name. Anything a module-under-test writes through

--- a/tests/scitex_agent_container/conftest.py
+++ b/tests/scitex_agent_container/conftest.py
@@ -82,159 +82,27 @@ def _clear_agent_identity() -> Iterator[None]:
     yield from _save_restore_yield(_AGENT_IDENTITY_KEYS)
 
 
+
 # ----------------------------------------------------------------------
-# PostgreSQL isolation for the sqlite -> Postgres migration (2026-08-19)
+# The PostgreSQL store isolation MOVED UP to tests/conftest.py on
+# 2026-08-20, and the move is the fix for a recurrence of the incident its
+# own docstring describes.
+#
+# It lived here, and this directory is `tests/scitex_agent_container/`.
+# `tests/smoke/`, `tests/develop/`, `tests/integration/` and
+# `tests/examples/` are its SIBLINGS, not its children, so none of them was
+# covered. When `acl_deny_notify` moved to PostgreSQL, the smoke suite began
+# writing fixture rows (`alpha`, `beta`, `gamma`) into the live per-host
+# store exactly as the lifecycle tests had done under #1154 — the same
+# failure, one directory over.
+#
+# A whole-suite run happened to be protected, because collecting this
+# package imports this file and the assignment is process-wide. Running
+# `tests/smoke/` ALONE was not. Protection by import order is not
+# protection; the guard now sits at the root of the test tree, where being
+# imported first is structural.
+#
+# `pg_schema` went up with it: a test that needs a REAL store must be able
+# to ask for one from any directory, and leaving it here would have made
+# the isolated-store escape hatch reachable from only one subtree.
 # ----------------------------------------------------------------------
-
-#: The per-host store. Loopback only — every fleet PostgreSQL refuses
-#: non-local connections at pg_hba, measured 2026-08-19.
-PG_BASE_DSN = os.environ.get(
-    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
-)
-
-#: The password file, resolved AT IMPORT and pinned for the fixture below.
-#:
-#: MEASURED 2026-08-20. `tests/.../_listen/test__acl_approve_flow.py` sandboxes
-#: `HOME` to a tmp_path — correctly, it is testing host-file behaviour. libpq
-#: finds its password file via `~/.pgpass`, so under that sandbox the lookup
-#: lands in an empty directory and the fixture's own CREATE SCHEMA fails with
-#: `fe_sendauth: no password supplied`. The same fixture works everywhere else,
-#: which is what made it look like a fixture bug rather than an interaction.
-#:
-#: Resolving here — while HOME is still the real one, before any test can move
-#: it — and passing it explicitly makes the fixture independent of a variable
-#: tests are entitled to change. `PGPASSFILE` is libpq's own override and takes
-#: precedence over the HOME lookup.
-_PGPASS_AT_IMPORT = os.environ.get("PGPASSFILE") or os.path.expanduser("~/.pgpass")
-
-#: A DSN that cannot reach anything, on purpose. Port 1 refuses instantly, and
-#: the database name is written to be legible in the error a stray write
-#: produces — the message itself states the rule it just enforced.
-_UNREACHABLE_DSN = (
-    "postgresql://sac_tests@127.0.0.1:1/tests_must_not_write_to_the_fleet_store"
-)
-
-# SET AT IMPORT, NOT ONLY IN A FIXTURE, and the difference is measured.
-#
-# The first version of this guard was function-scoped only. Re-running the full
-# package suite with it dropped the pollution from 46 rows to 4 — better, and
-# still not zero. Every targeted re-run (six lifecycle modules, four whole
-# directories, five store-touching modules) then wrote ZERO rows, so the
-# remaining four were not any single module: they came from writes that happen
-# OUTSIDE a function-scoped fixture's window — collection, and module- or
-# session-scoped fixtures, which are set up before the first function fixture
-# runs and torn down after the last one ends.
-#
-# A conftest is imported before anything under its directory is collected, so
-# assigning here covers the whole pytest process, including those windows. The
-# fixture below stays: it re-asserts the value per test, so a test that changes
-# the variable cannot leak the change into its neighbours.
-os.environ["SCITEX_STORE_DSN"] = _UNREACHABLE_DSN
-
-
-@pytest.fixture(autouse=True)
-def _no_accidental_fleet_store_writes() -> Iterator[None]:
-    """Point every test at a store that cannot exist, unless it asks otherwise.
-
-    MEASURED INCIDENT, 2026-08-20. When the birth certificate moved to
-    PostgreSQL (#1154), ``write_birth_certificate`` lost its ``db_path``. Tests
-    that had been threading a ``tmp_path`` SQLite file were suddenly resolving
-    the FLEET DSN instead, and one full-suite run on scitex-compute-04 wrote
-    **46 rows into the live incarnations store** — ``alpha``, ``zombie``,
-    ``born-1``..``born-4``, ``pid-*``, ``rec-*``, ``screen-*``, every one a
-    fixture name. They were removed with the store's own ``hide`` verb.
-
-    The rows were the small half of the problem. sac's CI runs on SELF-HOSTED
-    runners that sit on the fleet hosts, so every future CI run would have
-    written its fixtures into whichever machine it landed on — a test suite
-    quietly editing production state, on a schedule.
-
-    WHY AN UNREACHABLE DSN RATHER THAN A THROWAWAY SCHEMA. A schema per test
-    would CONNECT, which makes every test in this package depend on PostgreSQL
-    being up — hundreds of tests that never touch a store would start failing
-    on a database outage. This costs nothing and cannot be skipped: there is no
-    server on port 1, so a stray write raises immediately.
-
-    WHY THE LIVE DSN IS NOT SIMPLY LEFT IN PLACE FOR "HARMLESS" WRITES. It was,
-    and that IS the incident. A best-effort caller swallows the failure, so a
-    test that writes to the fleet store looks identical to one that does not —
-    right up until someone counts the rows.
-
-    Tests that need a REAL store take ``pg_schema``, which depends on this
-    fixture and overwrites the variable afterwards, so the ordering is
-    guaranteed by the dependency rather than by pytest's autouse rules.
-    """
-    key = "SCITEX_STORE_DSN"
-    saved = os.environ.get(key)
-    os.environ[key] = _UNREACHABLE_DSN
-    try:
-        yield
-    finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
-
-
-@pytest.fixture()
-def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
-    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
-
-    Yields the schema name. Anything a module-under-test writes through
-    ``scitex_dev.store`` lands here and is dropped afterwards, so the live
-    fleet state is never touched.
-
-    NOT AUTOUSE, and the two fixtures above are: this one is opt-in because
-    it CONNECTS, and a test that does not need PostgreSQL must not fail
-    because PostgreSQL is down.
-
-    A SCHEMA rather than a database, deliberately: creating a database needs
-    ``CREATEDB`` and the fleet is not uniform there (compute-03's
-    ``scitex_cards`` role has ``rolcreatedb=False``), so a create-a-database
-    fixture would pass on three runners and fail on the fourth — a flake
-    that looks like the code. The name carries a uuid because the three-way
-    python matrix can put concurrent jobs on ONE runner.
-
-    ``psycopg`` is imported INSIDE the fixture, not at module scope. A
-    top-level import here would make it a hard dependency of every test in
-    this package, so a missing psycopg would turn into a collection error
-    for hundreds of tests that never touch a database.
-
-    Real ``os.environ`` save/restore, not ``monkeypatch`` — PA-306 forbids
-    mocks, and the point is that the REAL resolver reads the REAL variable.
-
-    (``_state/test_state_db_verdict_dedup.py`` still carries its own copy of
-    this fixture, written before this shared one existed. It is the same
-    code; consolidating it is a tidy-up for a PR that already touches that
-    file, not for this one.)
-    """
-    import uuid
-
-    import psycopg
-
-    # Pin PGPASSFILE for the whole fixture: a test that sandboxes HOME (several
-    # legitimately do) would otherwise strand libpq's ~/.pgpass lookup.
-    pgpass_key = "PGPASSFILE"
-    saved_pgpass = os.environ.get(pgpass_key)
-    os.environ[pgpass_key] = _PGPASS_AT_IMPORT
-
-    schema = "sac_test_" + uuid.uuid4().hex[:12]
-    with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
-        conn.execute(f'CREATE SCHEMA "{schema}"')
-
-    key = "SCITEX_STORE_DSN"
-    saved = os.environ.get(key)
-    os.environ[key] = f"{PG_BASE_DSN}?options=-csearch_path%3D{schema}"
-    try:
-        yield schema
-    finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
-        with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
-            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
-        if saved_pgpass is None:
-            os.environ.pop(pgpass_key, None)
-        else:
-            os.environ[pgpass_key] = saved_pgpass

--- a/tests/scitex_agent_container/conftest.py
+++ b/tests/scitex_agent_container/conftest.py
@@ -80,3 +80,68 @@ def _clear_agent_identity() -> Iterator[None]:
     agent's value would otherwise win over test-controlled overrides.
     """
     yield from _save_restore_yield(_AGENT_IDENTITY_KEYS)
+
+
+# ----------------------------------------------------------------------
+# PostgreSQL isolation for the sqlite -> Postgres migration (2026-08-19)
+# ----------------------------------------------------------------------
+
+#: The per-host store. Loopback only — every fleet PostgreSQL refuses
+#: non-local connections at pg_hba, measured 2026-08-19.
+PG_BASE_DSN = os.environ.get(
+    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
+)
+
+
+@pytest.fixture()
+def pg_schema() -> Iterator[str]:
+    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
+
+    Yields the schema name. Anything a module-under-test writes through
+    ``scitex_dev.store`` lands here and is dropped afterwards, so the live
+    fleet state is never touched.
+
+    NOT AUTOUSE, and the two fixtures above are: this one is opt-in because
+    it CONNECTS, and a test that does not need PostgreSQL must not fail
+    because PostgreSQL is down.
+
+    A SCHEMA rather than a database, deliberately: creating a database needs
+    ``CREATEDB`` and the fleet is not uniform there (compute-03's
+    ``scitex_cards`` role has ``rolcreatedb=False``), so a create-a-database
+    fixture would pass on three runners and fail on the fourth — a flake
+    that looks like the code. The name carries a uuid because the three-way
+    python matrix can put concurrent jobs on ONE runner.
+
+    ``psycopg`` is imported INSIDE the fixture, not at module scope. A
+    top-level import here would make it a hard dependency of every test in
+    this package, so a missing psycopg would turn into a collection error
+    for hundreds of tests that never touch a database.
+
+    Real ``os.environ`` save/restore, not ``monkeypatch`` — PA-306 forbids
+    mocks, and the point is that the REAL resolver reads the REAL variable.
+
+    (``_state/test_state_db_verdict_dedup.py`` still carries its own copy of
+    this fixture, written before this shared one existed. It is the same
+    code; consolidating it is a tidy-up for a PR that already touches that
+    file, not for this one.)
+    """
+    import uuid
+
+    import psycopg
+
+    schema = "sac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = f"{PG_BASE_DSN}?options=-csearch_path%3D{schema}"
+    try:
+        yield schema
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')

--- a/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard_stray_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard_stray_env.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""An env pair with no ``--env`` is a POSITIONAL, and apptainer calls it the image.
+
+2026-08-18 incident. A bulk edit added the new board-identity variable to ~100
+specs' ``raw_args`` and inserted only the VALUE, without the ``- --env`` that
+has to precede it::
+
+    - --env
+    - SCITEX_TODO_AGENT_ID=business
+    - SCITEX_CARDS_AGENT_ID=business      <- positional, in flag position
+
+apptainer resolved that bare token against the launch directory and reported::
+
+    FATAL: While checking container encryption: could not open image
+      /home/ywatanabe/proj/business/SCITEX_CARDS_AGENT_ID=business
+
+The message names an image nobody wrote, blames encryption, and never mentions
+the missing flag. ``sac agents check`` had answered "Ready to deploy" on that
+spec minutes earlier, because it validated ``raw_args`` as YAML and as a schema
+and never as an apptainer argv.
+
+WHY THE SIBLING GUARD CANNOT CATCH IT: :func:`validate_flag_argv` inspects
+``_flag_region(argv)``, which by construction STOPS at the first positional. The
+stray token does not break the flag region — it ENDS it. One guard finds a flag
+with no value; this one finds a value with no flag.
+
+WHY THE MATCH IS NARROW, and why that is the point: the detector fires only on
+UPPER_SNAKE ``KEY=`` tokens. Value-shaped tokens legitimately follow flags this
+module does not track (``--network-args portmap=8080:tcp``, ``--security
+uid:1000``), and a broader rule would refuse launches it merely failed to
+recognise — the failure mode this module's own doctrine forbids. Both of those
+shapes are pinned below, so a later broadening trips a test.
+
+Measured before shipping: across 117 live specs on compute-04, 103 declare
+``raw_args`` and the detector flags NONE of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.runtimes._apptainer_argv_guard import (
+    ApptainerArgvError,
+    find_stray_env_pair,
+    validate_raw_args,
+)
+
+#: The exact shape that took the agent down, reproduced verbatim.
+INCIDENT = [
+    "--env",
+    "SCITEX_TODO_AGENT_ID=business",
+    "SCITEX_CARDS_AGENT_ID=business",
+    "--env",
+    "SCITEX_AGENT_CONTAINER_STATE_DB=/state/business/state.db",
+]
+
+#: The same spec after the missing flag is restored.
+REPAIRED = [
+    "--env",
+    "SCITEX_TODO_AGENT_ID=business",
+    "--env",
+    "SCITEX_CARDS_AGENT_ID=business",
+    "--env",
+    "SCITEX_AGENT_CONTAINER_STATE_DB=/state/business/state.db",
+]
+
+
+def _message_for(raw_args, **kw) -> str:
+    """The refusal text for ``raw_args``. Fails loudly if it does NOT refuse.
+
+    Exists because STX-TQ007 counts a ``pytest.raises`` block as an assertion,
+    so a test that raises and then inspects the message would carry two. The
+    raise belongs here; what the message SAYS is what each test asserts.
+    """
+    with pytest.raises(ApptainerArgvError) as excinfo:
+        validate_raw_args(raw_args, **kw)
+    return str(excinfo.value)
+
+
+def test_the_incident_shape_is_detected():
+    # Arrange — THE REGRESSION.
+    raw_args = INCIDENT
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is not None
+
+
+def test_the_detector_names_the_offending_token():
+    # Arrange — a guard that says "something is wrong" makes the reader
+    # re-derive what. Name the token.
+    raw_args = INCIDENT
+    # Act
+    _, token = find_stray_env_pair(raw_args)
+    # Assert
+    assert token == "SCITEX_CARDS_AGENT_ID=business"
+
+
+def test_the_detector_names_the_index_so_the_line_is_findable():
+    # Arrange — raw_args is a YAML list; the index IS the line to open.
+    raw_args = INCIDENT
+    # Act
+    index, _ = find_stray_env_pair(raw_args)
+    # Assert
+    assert index == 2
+
+
+def test_the_repaired_spec_is_silent():
+    # Arrange — POSITIVE CONTROL for every negative below: the detector
+    # must go quiet once the flag is restored, or "silent" proves nothing.
+    raw_args = REPAIRED
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is None
+
+
+@pytest.mark.parametrize(
+    "raw_args",
+    [
+        pytest.param(["--network-args", "portmap=8080:tcp"], id="network-args-value"),
+        pytest.param(["--security", "uid:1000"], id="security-value"),
+        pytest.param(["--app", "myapp"], id="app-value"),
+        pytest.param(["--hostname", "box=1"], id="hostname-value-with-equals"),
+    ],
+)
+def test_no_false_positive_on_values_of_untracked_flags(raw_args):
+    # Arrange — VALUE_TAKING_FLAGS is a deliberate SUBSET, so values of
+    # flags outside it look like positionals. Refusing those would block
+    # launches the guard merely failed to recognise.
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is None
+
+
+def test_an_empty_raw_args_is_silent():
+    # Arrange — most specs declare none at all.
+    raw_args = []
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is None
+
+
+def test_a_none_raw_args_is_silent():
+    # Arrange — the field is optional; absent must not be an error.
+    raw_args = None
+    # Act
+    found = find_stray_env_pair(raw_args)
+    # Assert
+    assert found is None
+
+
+def test_validate_raises_on_the_incident_shape():
+    # Arrange — the callable the CLI and the launch path use. Bound as a
+    # closure so Act and Assert stay separable: STX-TQ002 wants each marker
+    # on its own line, and a raises-block wrapped directly around the call
+    # fuses the two. Same shape the repo already uses in
+    # tests/_jobs/test__names.py.
+    raw_args = INCIDENT
+
+    def _call():
+        return validate_raw_args(raw_args)
+
+    # Act
+    call = _call
+    # Assert
+    with pytest.raises(ApptainerArgvError):
+        call()
+
+
+def test_validate_is_a_no_op_on_the_repaired_shape():
+    # Arrange — POSITIVE CONTROL for the raise above.
+    raw_args = REPAIRED
+    # Act
+    result = validate_raw_args(raw_args)
+    # Assert
+    assert result is None
+
+
+def test_the_message_shows_the_exact_two_yaml_lines_to_write():
+    # Arrange — the operator is looking at a YAML list. Hand them the
+    # lines, not a rule to apply.
+    raw_args = INCIDENT
+    # Act
+    message = _message_for(raw_args)
+    # Assert
+    assert "- --env\n    - SCITEX_CARDS_AGENT_ID=business" in message
+
+
+def test_the_message_explains_what_apptainer_does_with_it():
+    # Arrange — the real FATAL blames encryption and names a path nobody
+    # wrote. Say what actually happens, or the reader chases the path.
+    raw_args = INCIDENT
+    # Act
+    message = _message_for(raw_args)
+    # Assert
+    assert "IMAGE PATH" in message
+
+
+def test_the_message_names_the_agent_when_it_is_known():
+    # Arrange — the sibling guard's own documented lesson: an operator
+    # opened the wrong spec because the message never named the file.
+    raw_args = INCIDENT
+    # Act
+    message = _message_for(raw_args, agent="business")
+    # Assert
+    assert "'business'" in message

--- a/tests/scitex_agent_container/runtimes/test__apptainer_preflight.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_preflight.py
@@ -6,6 +6,7 @@ See docs/adr/0001-isolation-hardening.md (D2 + D4).
 from __future__ import annotations
 
 import shlex
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,30 @@ from scitex_agent_container.runtimes._apptainer_runtime import (
 
 
 def _cfg(workdir: Path, **kw) -> AgentConfig:
+    # tmpfs_size="" is DECLARED here, never inherited.
+    #
+    # Every test in this file asserts on the INNER argv (everything
+    # after the SIF path). ``--workdir`` is an OUTER flag and no
+    # assertion here reads it. But building the argv calls
+    # ``tmpfs_workdir_flags``, which runs ``shutil.disk_usage`` against
+    # the real filesystem and raises ``TmpfsSpaceError`` when free space
+    # is below ``tmpfs_size``. Under the 2G default that makes these
+    # verdicts depend on ambient free disk the tests neither control nor
+    # are about.
+    #
+    # 2026-08-19: a shared CI runner at 91% full turned that dependency
+    # into named, code-shaped failures here — test_preflight_wrapper_*
+    # and test_preflight_script_* all went red on a full disk, which
+    # sends readers to their own diff for a condition no diff caused.
+    #
+    # The guard itself is correct and stays. It is covered
+    # deterministically in ``test__apptainer_tmpfs.py``, which requests
+    # 10 EiB so it fires on any host rather than only on a full one.
+    #
+    # Normalise on EVERY path, including callers that pass their own
+    # spec — a setdefault would leave those reinheriting the 2G default.
+    ap = kw.pop("apptainer", None) or ApptainerSpec()
+    kw["apptainer"] = replace(ap, tmpfs_size="")
     return AgentConfig(
         name=kw.pop("name", "iso"),
         runtime="apptainer",

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -48,6 +48,7 @@ from scitex_agent_container.runtimes._apptainer_runtime import (
     ApptainerContainerRuntime,
     _safe_image_tag,
 )
+from scitex_agent_container.runtimes._apptainer_tmpfs import TmpfsSpaceError
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1481,6 +1482,55 @@ def test_start_returns_false_when_sif_cannot_be_resolved(
     started = rt.start(cfg)
     # Assert
     assert started is False
+
+
+def test_start_dry_run_succeeds_on_a_host_too_full_to_launch(
+    state_root: Path, tmp_path: Path, apptainer_on_path: Path
+) -> None:
+    # Arrange — an impossible headroom request (10 EiB), which NO host can
+    # satisfy. A dry run starts nothing, so it must not consult the disk.
+    # While the free-space check lived inside ``tmpfs_workdir_flags`` this
+    # raised TmpfsSpaceError, making ``sac agents start --dry-run`` and
+    # ``sac agents explain`` fail on exactly the full host they would have
+    # been most useful for diagnosing.
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(image=str(sif), tmpfs_size="10737418240G"),
+    )
+
+    # Act
+    ok = rt.start(cfg, dry_run=True)
+
+    # Assert
+    assert ok is True
+
+
+def test_start_refuses_a_real_launch_when_headroom_is_insufficient(
+    state_root: Path, tmp_path: Path, apptainer_on_path: Path
+) -> None:
+    # Arrange — SABOTAGE CONTROL. This is the one test of the pair that must
+    # never be deleted or weakened. Moving the free-space check off the argv
+    # path is only correct if it STILL FIRES on a real launch; a guard that
+    # was silently dropped instead of moved passes every other test in this
+    # suite, including the dry-run case directly above. Same impossible size,
+    # so the only difference between the two tests is dry_run.
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(image=str(sif), tmpfs_size="10737418240G"),
+    )
+
+    # Act
+    ctx = pytest.raises(TmpfsSpaceError)
+
+    # Assert
+    with ctx:
+        rt.start(cfg)
 
 
 def test_start_dry_run_returns_true(

--- a/tests/scitex_agent_container/runtimes/test__apptainer_tmpfs.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_tmpfs.py
@@ -11,6 +11,7 @@ from scitex_agent_container.runtimes._apptainer_tmpfs import (
     TmpfsSpaceError,
     parse_tmpfs_size_bytes,
     tmpfs_workdir_flags,
+    verify_tmpfs_headroom,
 )
 
 # ---------------------------------------------------------------------------
@@ -131,22 +132,50 @@ def test_flags_skips_when_operator_declares_short_workdir(tmp_path: Path) -> Non
     assert flags == []
 
 
-def test_flags_fail_loud_when_space_insufficient(tmp_path: Path) -> None:
+def test_verify_headroom_fails_loud_when_space_insufficient(tmp_path: Path) -> None:
     # Arrange — request more than any real filesystem can offer so the
     # free-space guard fires deterministically (10 EiB exceeds every disk).
+    # This is the GUARD-IS-ALIVE control: if it ever stops raising, the
+    # launch-time guarantee has been silently removed.
     cfg = _Cfg(ApptainerSpec(tmpfs_size="10737418240G"))
     # Act
     ctx = pytest.raises(TmpfsSpaceError)
     # Assert
     with ctx:
-        tmpfs_workdir_flags(cfg, tmp_path)
+        verify_tmpfs_headroom(cfg, tmp_path)
+
+
+def test_flags_do_not_check_space_even_when_it_is_insufficient(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the SAME impossible size that makes verify_tmpfs_headroom
+    # raise above. Building argv must not consult the disk at all: this
+    # function is reached by `sac agents explain` and by run(dry_run=True),
+    # which start nothing.
+    cfg = _Cfg(ApptainerSpec(tmpfs_size="10737418240G"))
+    # Act
+    flags = tmpfs_workdir_flags(cfg, tmp_path)
+    # Assert — emits the workdir, raises nothing
+    assert flags == ["--workdir", str(tmp_path / "tmp-scratch")]
 
 
 def test_flags_propagates_parse_error_on_bad_size(tmp_path: Path) -> None:
-    # Arrange
+    # Arrange — an unparseable size is a CONFIG error, not a resource
+    # condition: it is wrong on every host regardless of disk, so it must
+    # still surface at argv-construction time rather than at launch.
     cfg = _Cfg(ApptainerSpec(tmpfs_size="garbage"))
     # Act
     ctx = pytest.raises(ValueError)
     # Assert
     with ctx:
         tmpfs_workdir_flags(cfg, tmp_path)
+
+
+def test_verify_headroom_is_a_noop_when_operator_opted_out(tmp_path: Path) -> None:
+    # Arrange — tmpfs_size="" means the operator declined sac's workdir, so
+    # there is no scratch dir to size and nothing to guarantee.
+    cfg = _Cfg(ApptainerSpec(tmpfs_size=""))
+    # Act
+    result = verify_tmpfs_headroom(cfg, tmp_path)
+    # Assert
+    assert result is None

--- a/tests/scitex_agent_container/runtimes/test__board_identity_env.py
+++ b/tests/scitex_agent_container/runtimes/test__board_identity_env.py
@@ -393,3 +393,77 @@ def test_the_legacy_name_reaches_the_rendered_env_flags() -> None:
     flags = fleet_env_flags(config, defaults={})
     # Assert
     assert f"{LEGACY_BOARD_ID_ENV}=scitex-agent-container" in flags
+
+
+# ----------------------------------------------------------------------
+# Deriving the identity from the agent's own name (2026-08-20)
+# ----------------------------------------------------------------------
+#
+# proj-scitex-hub launched with NEITHER identity spelling declared and could
+# not use scitex-cards at all. Measured across the fleet's specs that day: 96
+# declare an identity equal to the agent name, 9 differ (6 templates carrying
+# placeholders, 3 deliberate aliases), and 16-17 declare nothing. Every alias
+# DECLARES its identity, so filling in from the name cannot override one.
+
+
+def test_absent_identity_is_filled_in_from_the_agent_name() -> None:
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="proj-scitex-hub")
+    # Assert
+    assert result[BOARD_ID_ENV] == "proj-scitex-hub"
+
+
+def test_a_declared_identity_beats_the_agent_name() -> None:
+    """The deliberate-alias case: scitex-agent-container-04 -> scitex-agent-container.
+
+    Falsifiable, and it is the one that matters: make the derivation
+    unconditional and this goes RED, because three real specs on the fleet
+    declare an identity that is NOT their directory name on purpose.
+    """
+    # Arrange
+    env = {BOARD_ID_ENV: "scitex-agent-container"}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="scitex-agent-container-04")
+    # Assert
+    assert result[BOARD_ID_ENV] == "scitex-agent-container"
+
+
+def test_a_legacy_declared_identity_also_beats_the_agent_name() -> None:
+    # Arrange
+    env = {LEGACY_BOARD_ID_ENV: "scitex-hub"}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="scitex-hub-mobile-ux")
+    # Assert
+    assert result[BOARD_ID_ENV] == "scitex-hub"
+
+
+def test_no_name_and_no_declaration_still_injects_nothing() -> None:
+    """Without a name there IS no answer, and inventing one is the bug this
+    module exists to prevent — a wrong author is worse than an absent launch."""
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    result = apply_board_identity_alias(env, agent_name=None)
+    # Assert
+    assert BOARD_ID_ENV not in result
+
+
+def test_a_blank_agent_name_is_not_an_identity() -> None:
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="   ")
+    # Assert
+    assert BOARD_ID_ENV not in result
+
+
+def test_the_legacy_name_is_still_never_written_back() -> None:
+    """Deriving must not undo the migration this module's docstring describes."""
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    result = apply_board_identity_alias(env, agent_name="proj-scitex-hub")
+    # Assert
+    assert LEGACY_BOARD_ID_ENV not in result

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -132,13 +132,38 @@ def test_without_the_injection_the_resolver_goes_somewhere_else() -> None:
     container, and opening a Store against it raises StoreTargetError naming
     the missing path. That loud refusal — with no SQLite to slip into — is
     scitex-dev's stated design and the behaviour the operator asked for.
+
+    THE DISCRIMINATOR WAS A RENDERING DETAIL, and a dependency bump exposed
+    it. This asserted ``"55432" not in locator`` — reading the ABSENCE of a
+    port as proof the unset arm went elsewhere. Measured on both versions:
+
+        scitex-dev 0.56.0   set: postgres://127.0.0.1:55432/scitex
+                          unset: postgres://?/scitex            <- no port
+        scitex-dev 0.56.1 unset: postgres[... port=55432]       <- port
+
+    The behaviour never changed; only ``__str__`` did. That is the whole
+    reason this ran green on a developer machine pinned to 0.56.0 and red in
+    CI, which resolves the newest — and why it took a full CI reproduction,
+    not a local run, to see it. Both failing tests on develop shared this
+    single cause, and between them they blocked every open PR, including
+    ones touching no state code at all.
+
+    The locator is a DISPLAY FORM (the real connection string is
+    ``target.dsn``, redacted here deliberately). A display form is not a
+    contract. So state the predicate this docstring already describes: the
+    two arms must DIFFER. That is exactly what "the variable is not inert"
+    means, it needs no knowledge of WHICH field carries the difference, and
+    no reformatting on either side can defeat it.
+
+    Mutation-checked: pointing the unset arm at the injected DSN makes the
+    two identical and this test fails, so it still discriminates.
     """
     # Arrange
-    expected_absent = "55432"
+    with_injection = _resolved_store_locator(FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"])
     # Act
-    locator = _resolved_store_locator(None)
+    without_injection = _resolved_store_locator(None)
     # Assert
-    assert expected_absent not in locator
+    assert without_injection != with_injection
 
 
 def test_declared_defaults_do_not_mutate_the_module_constant(tmp_path: Path) -> None:

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -43,20 +43,102 @@ def _write_config_yaml(path: Path, mapping: dict) -> Path:
 # ----------------------------------------------------------------------
 
 
-def test_sac_declares_no_fleet_defaults_of_its_own() -> None:
-    """Replaces test_fleet_defaults_seeded_with_the_cards_sqlite_read_backend.
+def test_sac_declares_the_store_dsn_and_nothing_else() -> None:
+    """Replaces test_sac_declares_no_fleet_defaults_of_its_own.
 
-    sac used to seed SCITEX_CARDS_READ_BACKEND=sqlite. Dropped 2026-07-29 on the
-    store owner's ruling — nothing reads it, and it actively misled a diagnosis
-    by stating a read policy that was never enforced. sac now declares nothing;
-    the cascade exists purely for operator overrides.
+    sac declared NOTHING between 2026-07-29 and 2026-08-19, after two store
+    variables were retired for stating a routing policy nothing enforced.
+    SCITEX_STORE_DSN is the third store variable declared here, and the
+    similarity is the reason this test pins the whole mapping rather than
+    just asserting the new key is present: an EXACT match is what makes a
+    fourth key someone adds casually show up as a failing test instead of as
+    another line in a container's environment that nobody chose.
     """
     # Arrange
     absent = Path("/nonexistent/config.yaml")
     # Act
     defaults = declared_fleet_defaults(absent)
     # Assert
-    assert defaults == {}
+    assert defaults == {
+        "SCITEX_STORE_DSN": "postgresql://scitex_cards@127.0.0.1:55432/scitex",
+    }
+
+
+def _resolved_store_locator(dsn: str | None) -> str:
+    """The locator scitex-dev resolves for sac, with SCITEX_STORE_DSN set or not.
+
+    Real ``os.environ`` with save/restore, the idiom this repo already uses
+    (``test__provider_common.py``, ``test_tui_session_settings_delivery.py``)
+    — NOT ``monkeypatch``. PA-306 forbids mocks here, and the point of these
+    two tests is that the REAL consumer reads the REAL variable, so a patched
+    environment would test the patch.
+
+    Resolution is PURE — it computes a target, it does not connect — so this
+    needs no Postgres. That is deliberate: a test that required a live
+    database would SKIP in CI, and a skip that reads as a pass is the defect
+    fixed in #1108.
+    """
+    import os
+
+    from scitex_dev.store import host_store  # HARD import; see the note below.
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    try:
+        if dsn is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = dsn
+        return str(host_store(pkg="scitex_agent_container", name="state").locator)
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+def test_the_injected_store_dsn_reaches_scitex_devs_resolver() -> None:
+    """Half of the guard the two RETIRED store variables never had.
+
+    SCITEX_CARDS_READ_BACKEND was injected into every container for months
+    while nothing read it. It was not merely useless: it STATED a read policy,
+    so an operator diagnosing an outage read that line, concluded the read
+    target was configured, and looked elsewhere. Nothing caught it, because no
+    test ever asked whether the consumer honoured the variable.
+
+    This asks. The import of ``scitex_dev.store`` is HARD rather than
+    ``importorskip`` for the same reason — scitex-dev is a [dev] dependency,
+    so an ImportError is a real breakage sac must see, and importorskip on a
+    dotted path is exactly the bug fixed in #1108.
+    """
+    # Arrange
+    dsn = FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"]
+    # Act
+    locator = _resolved_store_locator(dsn)
+    # Assert
+    assert "55432" in locator
+
+
+def test_without_the_injection_the_resolver_goes_somewhere_else() -> None:
+    """The other half: the two arms must DIFFER, or the variable is inert.
+
+    A test that only checked the "set" arm could pass even if scitex-dev
+    resolved to 55432 for its own reasons and ignored the variable entirely —
+    which is precisely the inert-but-plausible state that cost the live
+    diagnosis above. Requiring the UNSET arm to land elsewhere is what makes
+    "read for behaviour" an observation rather than an assumption.
+
+    The unset arm resolves to a UNIX socket that does not exist in a
+    container, and opening a Store against it raises StoreTargetError naming
+    the missing path. That loud refusal — with no SQLite to slip into — is
+    scitex-dev's stated design and the behaviour the operator asked for.
+    """
+    # Arrange
+    expected_absent = "55432"
+    # Act
+    locator = _resolved_store_locator(None)
+    # Assert
+    assert expected_absent not in locator
 
 
 def test_declared_defaults_do_not_mutate_the_module_constant(tmp_path: Path) -> None:

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -559,3 +559,19 @@ def test_an_empty_fleet_default_env_is_a_valid_state() -> None:
     flags = fleet_env_flags(config, defaults={})
     # Assert
     assert flags == []
+
+
+def test_effective_env_gives_an_unlabelled_spec_its_own_name() -> None:
+    """The end-to-end path proj-scitex-hub fell through on 2026-08-20.
+
+    The unit test above covers the alias function; this covers the WIRING —
+    that ``effective_env`` actually hands the agent's name down. Drop the
+    ``agent_name=`` argument at the call site and the unit tests stay green
+    while this one goes red, which is the point of having both.
+    """
+    # Arrange
+    config = SimpleNamespace(name="proj-scitex-hub", env={})
+    # Act
+    env = effective_env(config)
+    # Assert
+    assert env["SCITEX_CARDS_AGENT_ID"] == "proj-scitex-hub"

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -50,18 +50,20 @@ def fake_home(tmp_path: Path) -> Iterator[Path]:
 # ---------------------------------------------------------------------------
 
 
-def test_default_binds_for_host_returns_todo_bind_when_host_dir_exists(
+def test_default_binds_for_host_returns_cards_bind_when_host_dir_exists(
     fake_home: Path,
 ) -> None:
-    # Arrange
-    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    # Arrange — retargeted from the retired todo bind. The cards store had
+    # NO coverage of its own, so this closes a real gap rather than merely
+    # relocating an assertion.
+    (fake_home / ".scitex" / "cards").mkdir(parents=True)
     # Act
     binds = default_binds_for_host()
     # Assert
-    assert any("/.scitex/todo:" in b for b in binds)
+    assert any("/.scitex/cards:" in b for b in binds)
 
 
-def test_default_binds_for_host_skips_todo_bind_when_host_dir_missing(
+def test_default_binds_for_host_skips_cards_bind_when_host_dir_missing(
     fake_home: Path,
 ) -> None:
     # Arrange — fake_home (tmp_path) is freshly created with no .scitex
@@ -69,7 +71,7 @@ def test_default_binds_for_host_skips_todo_bind_when_host_dir_missing(
     # Act
     binds = default_binds_for_host()
     # Assert
-    assert not any("/.scitex/todo:" in b for b in binds)
+    assert not any("/.scitex/cards:" in b for b in binds)
 
 
 def test_default_binds_for_host_returns_telegrammer_bind_when_host_dir_exists(
@@ -141,12 +143,14 @@ def test_apply_default_binds_prepends_defaults_when_spec_has_no_overlap(
     fake_home: Path,
 ) -> None:
     # Arrange
-    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    (fake_home / ".scitex" / "cards").mkdir(parents=True)
     spec_binds = ["~/proj:/home/agent/proj:ro"]
     # Act
     result = apply_default_binds(spec_binds)
-    # Assert — first entry is the P3a-2 default, second is the spec entry.
-    assert "/.scitex/todo:" in result[0] and result[-1] == "~/proj:/home/agent/proj:ro"
+    # Assert — defaults come first, the spec entry last. (Was pinned on the
+    # todo bind purely because it happened to head the tuple; cards heads it
+    # now, and the ORDERING is what this test is actually about.)
+    assert "/.scitex/cards:" in result[0] and result[-1] == "~/proj:/home/agent/proj:ro"
 
 
 def test_apply_default_binds_lets_explicit_spec_entry_override_default(
@@ -154,13 +158,13 @@ def test_apply_default_binds_lets_explicit_spec_entry_override_default(
 ) -> None:
     # Arrange — spec carries the SAME destination as the default; the
     # spec wins (de-dup by destination).
-    (fake_home / ".scitex" / "todo").mkdir(parents=True)
-    spec_binds = ["/tmp/operator-todo:/home/agent/.scitex/todo:rw"]
+    (fake_home / ".scitex" / "cards").mkdir(parents=True)
+    spec_binds = ["/tmp/operator-cards:/home/agent/.scitex/cards:rw"]
     # Act
     result = apply_default_binds(spec_binds)
-    # Assert — exactly one entry whose destination is /home/agent/.scitex/todo.
-    todo_entries = [b for b in result if "/home/agent/.scitex/todo" in b]
-    assert todo_entries == ["/tmp/operator-todo:/home/agent/.scitex/todo:rw"]
+    # Assert — exactly one entry whose destination is /home/agent/.scitex/cards.
+    cards_entries = [b for b in result if "/home/agent/.scitex/cards" in b]
+    assert cards_entries == ["/tmp/operator-cards:/home/agent/.scitex/cards:rw"]
 
 
 def test_apply_default_binds_returns_spec_only_when_host_dir_missing(
@@ -180,11 +184,11 @@ def test_apply_default_binds_returns_spec_only_when_host_dir_missing(
 
 def test_apply_default_binds_handles_empty_spec_binds(fake_home: Path) -> None:
     # Arrange
-    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    (fake_home / ".scitex" / "cards").mkdir(parents=True)
     # Act
     result = apply_default_binds([])
     # Assert
-    assert any("/.scitex/todo:" in b for b in result)
+    assert any("/.scitex/cards:" in b for b in result)
 
 
 def test_apply_default_binds_accepts_iterable_of_strings(fake_home: Path) -> None:
@@ -430,6 +434,37 @@ def test_fleet_defaults_include_host_tmp_handoff_bind_read_only() -> None:
 # sac never used testmon itself. The assertion is INVERTED so that re-adding the
 # plumbing fails loudly rather than quietly reappearing on every agent.
 # ---------------------------------------------------------------------------
+
+
+def test_fleet_defaults_carry_no_todo_bind() -> None:
+    # Arrange — read the static fleet-default tuple directly.
+    from scitex_agent_container.runtimes._p3a_default_binds import (
+        _FLEET_DEFAULT_BINDS,
+    )
+
+    # Act
+    todo = [b for b in _FLEET_DEFAULT_BINDS if "/.scitex/todo" in b]
+    # Assert — scitex-todo was superseded by scitex-cards and nothing in the
+    # fleet reads the HOME-level store. Measured 2026-08-19 across every
+    # checkout under ~/proj with a control term: cards has 0 hits in *.py,
+    # live-paper's are prose, and hub's todo_app builds a WORKSPACE-scoped
+    # path (base / slug / .scitex / todo / tasks.yaml), never ~/.scitex/todo.
+    assert todo == []
+
+
+def test_the_retired_todo_bind_stays_findable_in_the_source() -> None:
+    # Arrange — the operator asked for retirement by ARCHIVE, not deletion:
+    # 「消すというよりアーカイブでいいんじゃないですかね。すなわち探そうと
+    # 思えば探せるみたいな」. A bare removal satisfies the test above and
+    # loses the reason, which is what invites someone to add it back.
+    from pathlib import Path
+
+    import scitex_agent_container.runtimes._p3a_default_binds as mod
+
+    # Act
+    source = Path(mod.__file__).read_text(encoding="utf-8")
+    # Assert
+    assert "RETIRED 2026-08-19" in source
 
 
 def test_fleet_defaults_carry_no_testmon_cache_bind() -> None:

--- a/tests/scitex_agent_container/runtimes/test__tui_outbound.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_outbound.py
@@ -26,24 +26,22 @@ def _write_transcript(path: Path, *records: dict) -> None:
     path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
 
 
-def test_record_dispatch_noop_without_from_agent(tmp_path: Path) -> None:
+def test_record_dispatch_noop_without_from_agent(tmp_path: Path, pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
     row_id = outbound.record_dispatch(
-        db_path=db, agent="a", from_agent="", dispatch_id="d1"
+        agent="a", from_agent="", dispatch_id="d1"
     )
     # Assert
     assert row_id is None
 
 
-def test_record_dispatch_records_pending_inbound(tmp_path: Path) -> None:
+def test_record_dispatch_records_pending_inbound(tmp_path: Path, pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
     # Act
-    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    outbound.record_dispatch(agent="a", from_agent="lead", dispatch_id="d1")
     # Assert
-    assert len(ledger.list_inbound(agent="a", db_path=db)) == 1
+    assert len(ledger.list_inbound(agent="a")) == 1
 
 
 def test_summarize_transcript_returns_last_assistant_text(tmp_path: Path) -> None:
@@ -77,12 +75,10 @@ def test_summarize_transcript_unknown_when_no_assistant_reply(tmp_path: Path) ->
     assert status == "unknown"
 
 
-def test_flush_one_completion_false_when_queue_empty(tmp_path: Path) -> None:
+def test_flush_one_completion_false_when_queue_empty(tmp_path: Path, pg_schema: str) -> None:
     # Arrange — nothing recorded.
-    db = tmp_path / "state.db"
     # Act
     flushed = outbound.flush_one_completion(
-        db_path=db,
         agent="a",
         transcript_path=None,
         listen_url="http://127.0.0.1:7878",
@@ -93,10 +89,9 @@ def test_flush_one_completion_false_when_queue_empty(tmp_path: Path) -> None:
     assert flushed is False
 
 
-def test_flush_one_completion_pushes_to_requester(tmp_path: Path) -> None:
+def test_flush_one_completion_pushes_to_requester(tmp_path: Path, pg_schema: str) -> None:
     # Arrange — one queued dispatch + a transcript with a reply.
-    db = tmp_path / "state.db"
-    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    outbound.record_dispatch(agent="a", from_agent="lead", dispatch_id="d1")
     transcript = tmp_path / "t.jsonl"
     _write_transcript(
         transcript,
@@ -112,7 +107,6 @@ def test_flush_one_completion_pushes_to_requester(tmp_path: Path) -> None:
 
     # Act
     outbound.flush_one_completion(
-        db_path=db,
         agent="a",
         transcript_path=transcript,
         listen_url="http://127.0.0.1:7878",
@@ -123,13 +117,11 @@ def test_flush_one_completion_pushes_to_requester(tmp_path: Path) -> None:
     assert captured["requester"] == "lead"
 
 
-def test_flush_one_completion_marks_reported_on_success(tmp_path: Path) -> None:
+def test_flush_one_completion_marks_reported_on_success(tmp_path: Path, pg_schema: str) -> None:
     # Arrange
-    db = tmp_path / "state.db"
-    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    outbound.record_dispatch(agent="a", from_agent="lead", dispatch_id="d1")
     # Act
     outbound.flush_one_completion(
-        db_path=db,
         agent="a",
         transcript_path=None,
         listen_url="http://127.0.0.1:7878",
@@ -137,16 +129,16 @@ def test_flush_one_completion_marks_reported_on_success(tmp_path: Path) -> None:
         push_fn=lambda **_kw: None,
     )
     # Assert
-    rows = ledger.list_inbound(agent="a", db_path=db)
+    rows = ledger.list_inbound(agent="a")
     assert rows[0]["status"] == ledger.STATUS_REPORTED
 
 
 def test_flush_one_completion_marks_failed_and_raises_on_push_error(
     tmp_path: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange — a push that fails loud (no live subscriber).
-    db = tmp_path / "state.db"
-    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    outbound.record_dispatch(agent="a", from_agent="lead", dispatch_id="d1")
 
     def boom(**_kw: Any) -> None:
         raise RuntimeError("no live subscriber")
@@ -155,8 +147,7 @@ def test_flush_one_completion_marks_failed_and_raises_on_push_error(
     # Assert
     with pytest.raises(RuntimeError):
         outbound.flush_one_completion(
-            db_path=db,
-            agent="a",
+                agent="a",
             transcript_path=None,
             listen_url="http://127.0.0.1:7878",
             bearer=None,
@@ -219,18 +210,51 @@ def _run_main_with(env: dict[str, str], stdin_text: str) -> int:
                 os.environ[k] = v
 
 
-def test_main_returns_zero_when_queue_empty(tmp_path: Path) -> None:
-    # Arrange — wired env, empty ledger, a transcript path on stdin.
-    db = tmp_path / "state.db"
+def test_main_returns_zero_when_queue_empty(tmp_path: Path, pg_schema: str) -> None:
+    """Wired env, empty ledger, a transcript path on stdin.
+
+    ``SCITEX_AGENT_CONTAINER_STATE_DB`` IS DELIBERATELY ABSENT, and its absence
+    is now the interesting half — see the sibling test below. The two env vars
+    here are the two ``main`` still needs: who to report as, and where the bus
+    is.
+    """
+    # Arrange
     env = {
         "SCITEX_AGENT_CONTAINER_AGENT": "a",
-        "SCITEX_AGENT_CONTAINER_STATE_DB": str(db),
         "SAC_LISTEN_BASE_URL": "http://127.0.0.1:7878",
     }
     # Act
     rc = _run_main_with(env, json.dumps({"transcript_path": str(tmp_path / "x.jsonl")}))
     # Assert
     assert rc == 0
+
+
+def test_main_still_flushes_without_the_retired_state_db_env(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The ledger moved to PostgreSQL, so a SQLite path must not gate the flush.
+
+    ``main`` used to refuse unless ``SCITEX_AGENT_CONTAINER_STATE_DB`` was set,
+    which was right while the ledger was a file and became a trap the moment it
+    was not: an agent without that variable would have silently stopped
+    reporting completions, with the refusal resting on a fact that no longer
+    bears on whether the work can be done.
+
+    Pinned as a POSITIVE outcome rather than "does not crash": a pending row is
+    recorded first, so a `main` that still gated on the retired variable would
+    return before flushing it and leave the row pending.
+    """
+    # Arrange — one pending dispatch, and no STATE_DB anywhere in the env.
+    ledger.record_inbound(agent="a", from_agent="lead", dispatch_id="d1")
+    env = {
+        "SCITEX_AGENT_CONTAINER_AGENT": "a",
+        "SAC_LISTEN_BASE_URL": "http://127.0.0.1:7878",
+    }
+    _run_main_with(env, json.dumps({"transcript_path": str(tmp_path / "x.jsonl")}))
+    # Act
+    rows = ledger.list_inbound(agent="a")
+    # Assert
+    assert rows and rows[0]["status"] != ledger.STATUS_PENDING
 
 
 def test_main_noop_when_agent_env_absent(tmp_path: Path) -> None:

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -65,8 +65,23 @@ def disk_tmp(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
 
 
 @pytest.fixture
-def comms_env(disk_tmp: Path) -> Iterator[dict[str, Any]]:
-    """Isolated state.db + HOME + registry + runtime roots.
+def comms_env(pg_schema: str, disk_tmp: Path) -> Iterator[dict[str, Any]]:
+    """Isolated state.db + HOME + registry + runtime roots + PostgreSQL schema.
+
+    ``pg_schema`` FIRST, and it is not decoration. When this fixture was
+    written the comms state lived entirely in the ``state.db`` below, so
+    isolating a tmp SQLite file and HOME was the whole job. The ACL tables
+    have since moved to the per-host PostgreSQL store, and without this
+    dependency the deny path writes its rate-limit rows into the LIVE fleet
+    store — measured 2026-08-20, ``alpha``/``beta``/``gamma`` rows in
+    production, and a 30-minute cool-down that then made
+    ``test_listen_denied_send_persists_two_channel_events_rows`` fail on
+    every re-run within the window.
+
+    Ordered before ``disk_tmp`` deliberately: ``pg_schema`` connects while
+    HOME is still real, and this fixture goes on to sandbox HOME. libpq
+    finds its password file under HOME, so the reverse order strands the
+    schema's own CREATE.
 
     Touches every read-path the comms code may consult (env var,
     module-level constant) so neither code path leaks into the


### PR DESCRIPTION
## Why

`main` is RED. Four tests in `_mcp/test__channel_send_errors.py` fail identically on py3.11, py3.12 and py3.13:

```
AttributeError: 'Server' object has no attribute 'list_tools'
```

**It is not our code.** `main` declares no upper bound on the `mcp` SDK — it arrives transitively via `fastmcp>=2.0`, and there is no lockfile, so CI re-resolves from the index every run. It drew **mcp 2.0.0** (released 2026-07-28), a breaking rewrite that deleted the decorator-registration API.

Measured, not inferred:

| | |
|---|---|
| mcp 1.29.0 (installed locally) | `Server` has `list_tools`, `call_tool`, `request_handlers` |
| mcp 2.0.0 (wheel downloaded, **not** installed) | none of them — handlers are constructor-injected, `_request_handlers` is private |
| same source, mcp 1.29.0 | **31 passed in 1.60s** |

And the source is **byte-identical** between main and develop for both the failing test and `_mcp/_channel_tools.py` — `git diff --stat` returns empty for each. Control: the same command on `pyproject.toml` returns `1 file changed, 100 insertions(+)`. So the empties are real absences, and the code is not the variable.

Why only this one file goes red: the other `_mcp` test modules pass a local `_ToolRecorder` fake that defines its own `list_tools()`. This file deliberately drives a **real** `mcp.server.lowlevel.Server` ("No mocks" — its own docstring). The honest test is the one that broke.

## What this ships

The fix already exists on develop and simply never reached main — `ff590594`, which added the pin **and** a 168-line guard test (`tests/develop/test_fastmcp_floor.py`, absent on main):

```toml
"fastmcp>=2.0,<4"      "mcp>=1.29,<2"      # [mcp]
"fastmcp>=3.0,<4"      "mcp>=1.29,<2"      # [dev]
```

`mcp>=1.29,<2` is the load-bearing half. The fastmcp bounds keep an observed 4.0.0b3 pre-release out of resolution — a floor alone is not a gate, which this file records learning the expensive way.

## Safety

- `merge-base --is-ancestor origin/main develop` → **true**; develop contains all of main
- develop HEAD `38ddef04` is **green on all five workflows** (import-smoke, lint, no-hosted-runners, docs, tests); control: 20 runs visible to the query
- the pin describes the version already installed and already passing — it removes a possibility, it does not change a state

## Not fixed by this

Porting to mcp 2.x. `_channel_tools.py:310` uses `@server.list_tools()` on the **live** a2a channel registration path, so this is a production break under 2.x, not merely a red test. Pinning is the correct emergency fix and the wrong permanent one — a compatibility window with no closing date is a gate that cannot fail. The port is carded separately with a date.
