### PR TITLE
feat(doctor): one Telegram poller per bot token, or say so — the 409 storm had no instrument

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ sac fleet sync                            # cross-host spec audit (fails loud on
 
 # Diagnostics / introspection
 sac doctor [--fleet]                      # diagnose agent-spec source drift
+sac doctor --pollers                      # >1 live Telegram poller per bot token?
 sac subagent get-state                    # Claude Code Agent-tool subagent state
 sac mcp list-tools                        # MCP introspection
 sac skills list / get                     # bundled agent-facing skills

--- a/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
@@ -116,7 +116,8 @@ sac image switch X
 
 | Command | Purpose |
 |---|---|
-| `sac doctor [--fleet]` | Diagnose agent-spec source drift (locally, or `--fleet` across peers). |
+| `sac doctor [--fleet]` | Diagnose agent-spec source drift (locally, or `--fleet` across peers). Also runs the poller-singleton check. |
+| `sac doctor --pollers` | Is more than one live Telegram poller holding the same bot token on this host? Read-only; `ok` / `violation` / `unknown`, never a token value. |
 | `sac subagent get-state` | Pure state data for every matching Claude Code Agent-tool subagent (Type 2). |
 | `sac mcp list-tools` | Local MCP introspection (no MCP server bundled — sac agents spawn their own via `to_home/.mcp.json`). |
 | `sac skills list / get` | Bundled agent-facing skills. |

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -259,7 +259,7 @@ class _MainGroup(LazyGroup):
         "list-python-apis": "List all public Python APIs of scitex-agent-container.",
         "installation": "Bootstrap and install helpers for a new fleet host.",
         "fleet": "Peer-aware multi-agent orchestration across hosts.",
-        "doctor": "Diagnose agent-spec source drift (local, or --fleet across hosts).",
+        "doctor": "Diagnose spec-source drift and duplicate Telegram pollers.",
         "provenance": "Prove which code is actually loaded (commit, origin, fossil installs).",
         "ci": "Read WHY CI is red as cheaply as its status (extract the real failure).",
         "guard": "Mechanical gates a delegated change must pass.",

--- a/src/scitex_agent_container/cli_pkg/doctor_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/doctor_cmds.py
@@ -36,6 +36,7 @@ from ..runtimes._cct_poller_singleton import (
     POLLER_OK,
     POLLER_UNKNOWN,
     POLLER_VIOLATION,
+    SCOPE_NOTE,
     PollerSingletonVerdict,
     check_poller_singleton,
 )
@@ -92,8 +93,15 @@ def _render_pollers_human(verdict: PollerSingletonVerdict) -> None:
     )
     for poller in verdict.pollers:
         owner = poller.agent or "(agent unknown)"
-        fingerprint = poller.token_fp or "(token unreadable)"
-        console.print(f"  pid {poller.pid:<8} {fingerprint}  {owner}")
+        if poller.token_fp:
+            mark = poller.token_fp
+        elif poller.disabled:
+            mark = "(no token — by design)"
+        else:
+            mark = "(token unreadable)"
+        console.print(f"  pid {poller.pid:<8} {mark:<24}  {owner}")
+    console.print(f"  [dim]{verdict.population()}[/dim]")
+    console.print(f"  [dim]{SCOPE_NOTE}[/dim]")
     if verdict.is_alarming:
         console.print(f"  [{style}]{verdict.detail}[/{style}]")
         console.print(f"  [bold]hint[/bold]  {verdict.hint()}")

--- a/src/scitex_agent_container/cli_pkg/doctor_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/doctor_cmds.py
@@ -1,16 +1,27 @@
 """``sac doctor`` — drift + health diagnostics.
 
-Today the doctor surfaces spec-source git drift:
+Two local checks and one fleet check:
 
 * ``sac doctor`` — check THIS host's agent-spec source repo against its
-  remote (the same comparison the launch-time guard runs) and print the
-  verdict.
+  remote (the same comparison the launch-time guard runs) AND assert that
+  no two live Telegram pollers share a bot token, then print both verdicts.
+* ``sac doctor --pollers`` — the poller check alone.
 * ``sac doctor --fleet`` — ssh every configured peer and render a
   per-host drift table (current / N-behind / M-ahead / diverged /
   unreachable / not-a-repo).
 
-``--strict`` makes a drifted result a non-zero exit (CI gate). Both
-surfaces are resilient: an unreachable peer is reported, never crashed.
+``--strict`` makes a drifted result — or an alarming poller verdict — a
+non-zero exit (CI gate). Both surfaces are resilient: an unreachable peer
+is reported, never crashed.
+
+WHY THE POLLER CHECK LIVES HERE, and why it is on by default: it observes a
+fault that has never had an instrument. An orphaned ``telegram-server.ts``
+survives its agent's container restart, the next start adds a second poller
+for the same bot token, and Telegram 409s them both — dropping the operator's
+inbound messages with no error anywhere. See
+:mod:`..runtimes._cct_poller_singleton`. Every previous sighting came from an
+agent happening to read its own log mid-incident; a check nobody has to
+remember to run is the difference between that and a measurement.
 """
 
 from __future__ import annotations
@@ -19,8 +30,15 @@ import json
 
 import click
 
-from .._drift import DriftState, check_spec_source_drift
+from .._drift import DriftState, DriftStatus, check_spec_source_drift
 from .._drift._fleet import HostDrift, check_fleet_drift
+from ..runtimes._cct_poller_singleton import (
+    POLLER_OK,
+    POLLER_UNKNOWN,
+    POLLER_VIOLATION,
+    PollerSingletonVerdict,
+    check_poller_singleton,
+)
 from ._helpers import _json_flag, console
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -33,6 +51,14 @@ _STATE_STYLE = {
     DriftState.DIVERGED: "red",
     DriftState.NOT_A_REPO: "dim",
     DriftState.UNREACHABLE: "dim",
+}
+
+# Rich style per poller state. UNKNOWN is yellow, never green: an unread
+# instrument must not look like an all-clear.
+_POLLER_STYLE = {
+    POLLER_OK: "green",
+    POLLER_VIOLATION: "red",
+    POLLER_UNKNOWN: "yellow",
 }
 
 
@@ -48,21 +74,29 @@ def _local_agents_spec_dir() -> str:
     return str(Path("~/.scitex/agent-container/agents").expanduser())
 
 
-def _render_local(ctx: click.Context, as_json: bool, strict: bool) -> int:
-    """Run + render the local spec-source drift check. Returns exit code."""
-    status = check_spec_source_drift(_local_agents_spec_dir())
-    if _json_flag(ctx, as_json):
-        click.echo(json.dumps({"local": status.to_dict()}, indent=2))
-    else:
-        style = _STATE_STYLE.get(status.state, "white")
-        console.print(
-            f"[bold]local spec-source[/bold]  [{style}]{status.summary()}[/{style}]"
-        )
-        if status.repo:
-            console.print(f"  repo  {status.repo}")
-    if strict and status.is_drifted:
-        return 1
-    return 0
+def _render_local_human(status: DriftStatus) -> None:
+    """Print the local spec-source drift verdict."""
+    style = _STATE_STYLE.get(status.state, "white")
+    console.print(
+        f"[bold]local spec-source[/bold]  [{style}]{status.summary()}[/{style}]"
+    )
+    if status.repo:
+        console.print(f"  repo  {status.repo}")
+
+
+def _render_pollers_human(verdict: PollerSingletonVerdict) -> None:
+    """Print the poller-singleton verdict, and its remedy when alarming."""
+    style = _POLLER_STYLE.get(verdict.state, "white")
+    console.print(
+        f"[bold]telegram pollers[/bold]  [{style}]{verdict.summary()}[/{style}]"
+    )
+    for poller in verdict.pollers:
+        owner = poller.agent or "(agent unknown)"
+        fingerprint = poller.token_fp or "(token unreadable)"
+        console.print(f"  pid {poller.pid:<8} {fingerprint}  {owner}")
+    if verdict.is_alarming:
+        console.print(f"  [{style}]{verdict.detail}[/{style}]")
+        console.print(f"  [bold]hint[/bold]  {verdict.hint()}")
 
 
 def _render_fleet(ctx: click.Context, as_json: bool, strict: bool, timeout: int) -> int:
@@ -100,6 +134,44 @@ def _render_fleet(ctx: click.Context, as_json: bool, strict: bool, timeout: int)
     return 0
 
 
+def _render_local(
+    ctx: click.Context,
+    as_json: bool,
+    strict: bool,
+    *,
+    with_drift: bool = True,
+    with_pollers: bool = True,
+) -> int:
+    """Run + render the requested local checks. Returns exit code.
+
+    ``--strict`` fails on a drifted spec source OR an alarming poller verdict
+    — which includes UNKNOWN, matching ``sac agents cct-audit``: an invariant
+    sac could not assert is not an invariant that held.
+    """
+    payload: dict = {}
+    failed = False
+
+    status = check_spec_source_drift(_local_agents_spec_dir()) if with_drift else None
+    verdict = check_poller_singleton() if with_pollers else None
+
+    if status is not None:
+        payload["local"] = status.to_dict()
+        failed = failed or status.is_drifted
+    if verdict is not None:
+        payload["pollers"] = verdict.to_dict()
+        failed = failed or verdict.is_alarming
+
+    if _json_flag(ctx, as_json):
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        if status is not None:
+            _render_local_human(status)
+        if verdict is not None:
+            _render_pollers_human(verdict)
+
+    return 1 if (strict and failed) else 0
+
+
 @click.command("doctor", context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--fleet",
@@ -109,11 +181,24 @@ def _render_fleet(ctx: click.Context, as_json: bool, strict: bool, timeout: int)
     help="ssh every configured peer and report each host's spec-source drift.",
 )
 @click.option(
+    "--pollers",
+    "pollers",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run ONLY the poller-singleton check: is more than one live Telegram "
+        "poller holding the same bot token on this host?"
+    ),
+)
+@click.option(
     "--strict",
     "strict",
     is_flag=True,
     default=False,
-    help="Exit non-zero when any checked source is drifted (CI gate).",
+    help=(
+        "Exit non-zero when any checked source is drifted, or the poller "
+        "verdict is violation/unknown (CI gate)."
+    ),
 )
 @click.option(
     "--timeout",
@@ -127,21 +212,32 @@ def _render_fleet(ctx: click.Context, as_json: bool, strict: bool, timeout: int)
 def doctor(
     ctx: click.Context,
     fleet: bool,
+    pollers: bool,
     strict: bool,
     timeout: int,
     as_json: bool,
 ) -> None:
-    """Diagnose agent-spec source drift (local, or --fleet across hosts).
+    """Diagnose spec-source drift and duplicate Telegram pollers.
 
     \b
     Examples:
-      $ sac doctor                 # this host's spec source vs its remote
+      $ sac doctor                 # spec source vs remote + poller singleton
+      $ sac doctor --pollers       # only: one live poller per bot token?
       $ sac doctor --fleet         # per-host drift table for every peer
       $ sac doctor --fleet --json
       $ sac doctor --fleet --strict   # exit 1 if any host drifted
+
+    \b
+    The poller check is READ-ONLY and three-valued — ok / violation /
+    unknown. It reports duplicates; it does not kill, lock or prevent them,
+    and an unreadable /proc/<pid>/environ is reported as unknown rather than
+    quietly counted as fine. No bot token VALUE is ever read out: only an
+    opaque sha256:<12hex> fingerprint appears anywhere in the output.
     """
     if fleet:
         code = _render_fleet(ctx, as_json, strict, timeout)
+    elif pollers:
+        code = _render_local(ctx, as_json, strict, with_drift=False)
     else:
         code = _render_local(ctx, as_json, strict)
     if code:

--- a/src/scitex_agent_container/runtimes/_cct_poller_scan.py
+++ b/src/scitex_agent_container/runtimes/_cct_poller_scan.py
@@ -1,0 +1,283 @@
+"""OBSERVATION half of the poller-singleton detector: who is polling, on what?
+
+This module answers only "which live processes on this host are Telegram
+pollers, and what is the opaque fingerprint of the bot token each one holds?".
+The VERDICT — whether that population violates one-poller-per-token — lives in
+:mod:`._cct_poller_singleton`, which imports this. Splitting them keeps the
+thing that touches ``/proc`` separate from the thing that decides, so the
+decision can be tested without a process and the reader without a rule.
+
+Read-only, stdlib-only. Nothing here signals, kills or reaps anything.
+
+TOKEN VALUES NEVER LEAVE THIS MODULE
+    A value is read from a process environment, handed straight to
+    :func:`.._account._rotation_audit.fingerprint_token`, and dropped. Only the
+    opaque ``sha256:<12hex>`` prefix is stored or returned — the same contract
+    ``_host_push_config`` states as "Only sha256 digests (12 chars) are ever
+    printed", and the reason this reuses that helper rather than growing a
+    second one.
+
+    :class:`LivePoller` deliberately carries NO cmdline either. sac never puts
+    a token on an argv (see :mod:`._cct_token_pool`), but a poller someone
+    started by hand might, and a detector that leaks the secret it is
+    protecting is worse than no detector.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from .._account._rotation_audit import fingerprint_token
+from ._cct_token_pool import _AGENT_ID_VAR, _TOKEN_VAR
+
+#: Substrings identifying the poller SCRIPT in an argv token. The poller is a
+#: bun/TypeScript process, not a Python module — matching the script name
+#: rather than the interpreter keeps this true if the runner changes. Same
+#: string :mod:`..cli_pkg._helpers._agent_list_inbound_rail` matches for its
+#: own, different question (is THIS agent's claude the parent of one?).
+POLLER_SCRIPT_MARKERS: tuple[str, ...] = (
+    "telegram-server.ts",
+    "telegram-server.js",
+)
+
+#: argv[0] basenames that MENTION the poller script without BEING one.
+#:
+#: THE NAMED TRAP: a plain ``pgrep -f telegram-server`` matches the searching
+#: shell itself, and a detector that counts its own search as a poller invents
+#: the very duplicate it exists to find. Excluding the current pid is not
+#: enough — ``pgrep``/``rg`` run as CHILDREN carry the pattern in their argv
+#: too. So the match is anchored on argv[0]: a poller is a process that RUNS
+#: the script, not one that talks about it.
+_SEARCH_TOOLS = frozenset(
+    {
+        "ack",
+        "ag",
+        "awk",
+        "egrep",
+        "fgrep",
+        "find",
+        "grep",
+        "less",
+        "pgrep",
+        "pkill",
+        "ps",
+        "rg",
+        "ripgrep",
+        "sed",
+        "tail",
+        "xargs",
+    }
+)
+
+#: Env keys naming the agent that owns a poller, most specific first.
+#: ``CCT_AGENT_ID`` is the telegram identity sac writes per agent (see
+#: :func:`._cct_token_pool._default_agent_id`); the two ``*_NAME`` keys are the
+#: runtime's own agent-name vars, inherited by every stdio child (see
+#: :mod:`..._lifecycle._orphan_mcp_cleanup`).
+_OWNER_ENV_KEYS: tuple[str, ...] = (
+    _AGENT_ID_VAR,
+    "SCITEX_AGENT_CONTAINER_NAME",
+    "SAC_NAME",
+)
+
+#: WHY a poller yielded no fingerprint. Both are UNKNOWN, and they need
+#: DIFFERENT remedies — one is a vantage problem (run as the owning uid), the
+#: other is a process that was never started through sac. A single "could not
+#: resolve" would send the reader to the wrong fix half the time.
+UNRESOLVED_ENVIRON = "environ-unreadable"
+UNRESOLVED_NO_TOKEN = "no-token-in-env"
+
+
+@dataclass(frozen=True)
+class LivePoller:
+    """One live poller process. Carries a fingerprint, never a token."""
+
+    pid: int
+    #: Opaque ``sha256:<12hex>`` of the bot token this process is polling with,
+    #: or ``None`` when sac could not read it. ``None`` is what drives UNKNOWN.
+    token_fp: str | None = None
+    #: Owning agent where determinable, else ``""``. Best-effort: an orphan
+    #: from a previous incarnation still carries its old env, which is exactly
+    #: what makes it nameable.
+    agent: str = ""
+    #: Why the token is unresolved. Operator-facing, never a value.
+    detail: str = ""
+    #: :data:`UNRESOLVED_ENVIRON` / :data:`UNRESOLVED_NO_TOKEN` when
+    #: unresolved, ``""`` when resolved. Machine-readable so the remedy can
+    #: branch without parsing prose.
+    reason: str = ""
+
+    @property
+    def resolved(self) -> bool:
+        """True iff a token fingerprint was obtained for this process."""
+        return bool(self.token_fp)
+
+    def to_dict(self) -> dict:
+        """JSON-friendly projection (for ``--json`` surfaces)."""
+        return {
+            "pid": self.pid,
+            "token_fp": self.token_fp,
+            "agent": self.agent,
+            "reason": self.reason,
+            "detail": self.detail,
+        }
+
+
+def is_poller_argv(argv: Sequence[str]) -> bool:
+    """True iff ``argv`` is a process RUNNING the telegram poller script.
+
+    Anchored on argv[0] so a ``pgrep``/``rg`` that merely carries the pattern
+    is not counted as a poller — see :data:`_SEARCH_TOOLS` for why that trap is
+    worth spending a constant on. Pure and total over its input: the seam the
+    tests drive without inventing a ``/proc``.
+
+    KNOWN LIMIT, stated rather than hidden: ``sh``/``bash`` are NOT excluded,
+    because ``sh -c "exec bun run …/telegram-server.ts"`` is a shape the SDK
+    channel config really emits — dropping it would lose real pollers. So a
+    shell running ``rg telegram-server.ts`` is counted. It then carries no
+    ``CCT_BOT_TOKEN``, which surfaces as UNKNOWN with a hint pointing at the
+    pid — a mild, self-explaining false alarm, and the right side to err on
+    when the alternative is missing a live 409.
+    """
+    tokens = [str(a) for a in argv if str(a)]
+    if not tokens:
+        return False
+    if os.path.basename(tokens[0]) in _SEARCH_TOOLS:
+        return False
+    return any(marker in tok for tok in tokens for marker in POLLER_SCRIPT_MARKERS)
+
+
+def _read_argv(pid_dir: Path) -> list[str]:
+    """``/proc/<pid>/cmdline`` as an argv list; ``[]`` when unreadable.
+
+    A process that exits mid-scan is normal, and its absence is not evidence
+    about any other process — so an empty argv simply drops it from the
+    population rather than making the whole verdict unknown.
+    """
+    # stx-allow: fallback (reason: a pid that exits between iterdir() and the
+    # read is a normal race; it is not a poller we failed to measure, it is a
+    # process that is no longer live, so dropping it is the correct answer.)
+    try:
+        raw = (pid_dir / "cmdline").read_bytes()
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return []
+    return [tok for tok in raw.decode("utf-8", "replace").split("\0") if tok]
+
+
+def read_process_env(pid_dir: Path) -> dict[str, str] | None:
+    """``/proc/<pid>/environ`` as a dict, or ``None`` when it cannot be read.
+
+    ``None`` is a REAL answer and must stay distinguishable from ``{}``: the
+    file is mode 0400 owned by the process user, so an unreadable environ is
+    the routine cross-uid case that drives UNKNOWN. Returning ``{}`` for it
+    would silently claim the process has no token.
+    """
+    # stx-allow: fallback (reason: environ is owner-only; PermissionError is
+    # the ORDINARY cross-uid case and must reach the caller as "could not
+    # read", never as "no token present".)
+    try:
+        raw = (pid_dir / "environ").read_bytes()
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    env: dict[str, str] = {}
+    for entry in raw.decode("utf-8", "replace").split("\0"):
+        key, sep, value = entry.partition("=")
+        if sep and key:
+            env[key] = value
+    return env
+
+
+def _owner_from_env(env: dict[str, str]) -> str:
+    """The agent that owns this poller, or ``""`` when nothing names it."""
+    for key in _OWNER_ENV_KEYS:
+        value = str(env.get(key, "") or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def poller_from_pid(pid: int, pid_dir: Path) -> LivePoller:
+    """Fingerprint one already-identified poller process.
+
+    The token is read from the PROCESS's own environment and nowhere else. The
+    agent's materialised ``.env`` is deliberately NOT consulted as a fallback:
+    that file says which token the agent WOULD get on its next start, while an
+    orphan is by definition running on the token of a PREVIOUS one. Answering
+    the second question with the first is how a detector reports a duplicate
+    where there is none, and misses the one there is.
+    """
+    env = read_process_env(pid_dir)
+    if env is None:
+        return LivePoller(
+            pid=pid,
+            reason=UNRESOLVED_ENVIRON,
+            detail=(
+                f"/proc/{pid}/environ could not be read (it is owner-only), so "
+                f"this poller's {_TOKEN_VAR} was never seen. sac cannot say "
+                "which bot it polls — this is NOT a report that it has none."
+            ),
+        )
+    token = str(env.get(_TOKEN_VAR, "") or "").strip()
+    agent = _owner_from_env(env)
+    if not token:
+        return LivePoller(
+            pid=pid,
+            agent=agent,
+            reason=UNRESOLVED_NO_TOKEN,
+            detail=(
+                f"the process environment is readable but carries no "
+                f"{_TOKEN_VAR}, so this poller cannot be matched against the "
+                "others. It was started outside sac's env."
+            ),
+        )
+    return LivePoller(pid=pid, token_fp=fingerprint_token(token), agent=agent)
+
+
+def _numeric_pid_dirs(proc_root: Path) -> Iterable[Path]:
+    """Every ``<proc_root>/<pid>`` directory, in ascending pid order."""
+    entries = [e for e in proc_root.iterdir() if e.name.isdigit()]
+    return sorted(entries, key=lambda e: int(e.name))
+
+
+def scan_live_pollers(
+    *,
+    proc_root: Path | None = None,
+    self_pid: int | None = None,
+) -> tuple[LivePoller, ...]:
+    """Every live telegram poller visible under ``proc_root``.
+
+    ``self_pid`` (default: this process) is excluded — belt to
+    :func:`is_poller_argv`'s braces, because the caller of a detector must
+    never be able to appear in its own population.
+
+    Raises ``OSError`` when ``proc_root`` itself cannot be enumerated. That is
+    the "the scan did not run" case, and
+    :func:`._cct_poller_singleton.check_poller_singleton` turns it into UNKNOWN
+    rather than an empty — and falsely reassuring — result.
+    """
+    root = Path(proc_root) if proc_root is not None else Path("/proc")
+    me = self_pid if self_pid is not None else os.getpid()
+    found: list[LivePoller] = []
+    for pid_dir in _numeric_pid_dirs(root):
+        pid = int(pid_dir.name)
+        if pid == me:
+            continue
+        if not is_poller_argv(_read_argv(pid_dir)):
+            continue
+        found.append(poller_from_pid(pid, pid_dir))
+    return tuple(found)
+
+
+__all__ = [
+    "POLLER_SCRIPT_MARKERS",
+    "UNRESOLVED_ENVIRON",
+    "UNRESOLVED_NO_TOKEN",
+    "LivePoller",
+    "is_poller_argv",
+    "poller_from_pid",
+    "read_process_env",
+    "scan_live_pollers",
+]

--- a/src/scitex_agent_container/runtimes/_cct_poller_scan.py
+++ b/src/scitex_agent_container/runtimes/_cct_poller_scan.py
@@ -72,23 +72,55 @@ _SEARCH_TOOLS = frozenset(
     }
 )
 
-#: Env keys naming the agent that owns a poller, most specific first.
-#: ``CCT_AGENT_ID`` is the telegram identity sac writes per agent (see
-#: :func:`._cct_token_pool._default_agent_id`); the two ``*_NAME`` keys are the
-#: runtime's own agent-name vars, inherited by every stdio child (see
-#: :mod:`..._lifecycle._orphan_mcp_cleanup`).
+#: Env keys naming the agent that owns a poller, MOST AUTHORITATIVE FIRST.
+#:
+#: ``SAC_NAME`` leads, and the order is not cosmetic — it was measured. On
+#: compute-04, 2026-08-22 17:02Z, this process::
+#:
+#:     pid 574160   CCT_AGENT_ID=handyman-01   SAC_NAME=handyman-06
+#:
+#: A ``CCT_AGENT_ID``-first order named it handyman-01, and a VIOLATION report
+#: that names the wrong agent sends the remediation to an innocent one — worse
+#: than naming nobody, because the rest of the row (pid, fingerprint) is right
+#: and gives the reader no reason to doubt it.
+#:
+#: Note what the same measurement rules OUT: reading the PARENT instead would
+#: not have helped. The parent claude process carried the SAME
+#: ``CCT_AGENT_ID=handyman-01`` alongside ``SAC_NAME=handyman-06``, so the
+#: defect is which KEY is trusted, not which process is read. ``CCT_AGENT_ID``
+#: is a TELEGRAM identity — it can be, and here is, a different thing from the
+#: agent — so it is kept last, as a name of last resort. ``SAC_NAME`` and
+#: ``SCITEX_AGENT_CONTAINER_NAME`` are the runtime's own agent-name vars,
+#: inherited by every stdio child (see :mod:`..._lifecycle._orphan_mcp_cleanup`),
+#: and they agreed with the parent on all ten live servers measured.
 _OWNER_ENV_KEYS: tuple[str, ...] = (
-    _AGENT_ID_VAR,
-    "SCITEX_AGENT_CONTAINER_NAME",
     "SAC_NAME",
+    "SCITEX_AGENT_CONTAINER_NAME",
+    _AGENT_ID_VAR,
 )
 
-#: WHY a poller yielded no fingerprint. Both are UNKNOWN, and they need
-#: DIFFERENT remedies — one is a vantage problem (run as the owning uid), the
-#: other is a process that was never started through sac. A single "could not
-#: resolve" would send the reader to the wrong fix half the time.
+#: WHY a poller yielded no fingerprint. THREE different facts wearing one
+#: shape, and they need three different responses:
+#:
+#: * ``UNRESOLVED_ENVIRON`` — sac could not READ the environment. Vantage
+#:   problem; re-run as the owning uid. UNKNOWN.
+#: * ``UNRESOLVED_NO_TOKEN`` — the environment is readable and the variable is
+#:   ABSENT. The process was started outside sac's env, so sac cannot tell
+#:   whether it polls some token by another route. UNKNOWN.
+#: * ``TOKEN_DISABLED`` — the variable is PRESENT and EMPTY. Somebody set it
+#:   to nothing on purpose (the handyman family's spec does exactly this, to
+#:   stop several agents sharing one bot). An empty string is not a bot token,
+#:   so this process cannot collide with anything: it is excluded from the
+#:   invariant rather than clouding it. NOT unknown.
+#:
+#: Measured on compute-04, 2026-08-22: of 10 live servers, 4 carried real and
+#: distinct tokens, 6 were EMPTY by design, 1 was ABSENT. Folding EMPTY into
+#: UNKNOWN made a perfectly healthy host report UNKNOWN on every single run —
+#: a check that is never green gets muted, which is the gate-that-cannot-fail
+#: arriving from the other direction.
 UNRESOLVED_ENVIRON = "environ-unreadable"
 UNRESOLVED_NO_TOKEN = "no-token-in-env"
+TOKEN_DISABLED = "token-empty"
 
 
 @dataclass(frozen=True)
@@ -105,15 +137,25 @@ class LivePoller:
     agent: str = ""
     #: Why the token is unresolved. Operator-facing, never a value.
     detail: str = ""
-    #: :data:`UNRESOLVED_ENVIRON` / :data:`UNRESOLVED_NO_TOKEN` when
-    #: unresolved, ``""`` when resolved. Machine-readable so the remedy can
-    #: branch without parsing prose.
+    #: :data:`UNRESOLVED_ENVIRON` / :data:`UNRESOLVED_NO_TOKEN` /
+    #: :data:`TOKEN_DISABLED` when there is no fingerprint, ``""`` when
+    #: resolved. Machine-readable so the remedy can branch without parsing
+    #: prose.
     reason: str = ""
 
     @property
     def resolved(self) -> bool:
         """True iff a token fingerprint was obtained for this process."""
         return bool(self.token_fp)
+
+    @property
+    def disabled(self) -> bool:
+        """True iff this process was deliberately given an EMPTY bot token.
+
+        It holds no token, so it cannot be the second consumer of anyone's.
+        Excluded from the invariant — see :data:`TOKEN_DISABLED`.
+        """
+        return self.reason == TOKEN_DISABLED
 
     def to_dict(self) -> dict:
         """JSON-friendly projection (for ``--json`` surfaces)."""
@@ -220,17 +262,33 @@ def poller_from_pid(pid: int, pid_dir: Path) -> LivePoller:
                 "which bot it polls — this is NOT a report that it has none."
             ),
         )
-    token = str(env.get(_TOKEN_VAR, "") or "").strip()
     agent = _owner_from_env(env)
+    present = _TOKEN_VAR in env
+    token = str(env.get(_TOKEN_VAR, "") or "").strip()
+
+    if present and not token:
+        return LivePoller(
+            pid=pid,
+            agent=agent,
+            reason=TOKEN_DISABLED,
+            detail=(
+                f"{_TOKEN_VAR} is present and DELIBERATELY EMPTY, so this "
+                "process holds no bot token and cannot be a second consumer "
+                "of anyone's. Excluded from the one-poller-per-token "
+                "invariant. Nothing to fix — the handyman family's spec "
+                "empties it on purpose to stop several agents sharing a bot."
+            ),
+        )
     if not token:
         return LivePoller(
             pid=pid,
             agent=agent,
             reason=UNRESOLVED_NO_TOKEN,
             detail=(
-                f"the process environment is readable but carries no "
-                f"{_TOKEN_VAR}, so this poller cannot be matched against the "
-                "others. It was started outside sac's env."
+                f"the process environment is readable and {_TOKEN_VAR} is "
+                "ABSENT from it, so this process was started outside sac's "
+                "env and sac cannot tell whether it polls some token by "
+                "another route."
             ),
         )
     return LivePoller(pid=pid, token_fp=fingerprint_token(token), agent=agent)
@@ -273,6 +331,7 @@ def scan_live_pollers(
 
 __all__ = [
     "POLLER_SCRIPT_MARKERS",
+    "TOKEN_DISABLED",
     "UNRESOLVED_ENVIRON",
     "UNRESOLVED_NO_TOKEN",
     "LivePoller",

--- a/src/scitex_agent_container/runtimes/_cct_poller_singleton.py
+++ b/src/scitex_agent_container/runtimes/_cct_poller_singleton.py
@@ -29,10 +29,21 @@ this makes verifiable. A fix without a detector cannot be shown to have worked.
 
 THE INVARIANT
 -------------
-``count(distinct token fingerprints) == count(live pollers)``
+``count(distinct token fingerprints) == count(token-holding servers)``
 
 One fingerprint carried by two live pids IS the fault, and is the only thing
 reported as :data:`POLLER_VIOLATION`.
+
+The population is the SERVER (``telegram-server.ts``), not a poller process,
+and that choice is load-bearing: measured 2026-08-22, a host with a live
+token conflict had NO poller process at all — the rival holding the contended
+token was a server. A server holding a real token is a poller-in-waiting, so a
+poller census sees the fault only AFTER it becomes one.
+
+A server carrying a DELIBERATELY EMPTY token holds no token at all and is
+excluded from the invariant rather than clouding it — see
+:data:`.._cct_poller_scan.TOKEN_DISABLED` for the measurement that forced
+that distinction.
 
 THREE-VALUED, AND THE THIRD VALUE IS LOAD-BEARING
 -------------------------------------------------
@@ -74,6 +85,25 @@ POLLER_VIOLATION = "violation"
 #: the process scan itself could not run. NOT a soft OK.
 POLLER_UNKNOWN = "unknown"
 
+#: The limit of this check, stated in every result rather than left to be
+#: discovered. Telegram permits one ``getUpdates`` consumer per token
+#: GLOBALLY, and this reads ONE host's ``/proc``. A cross-host duplicate is
+#: real and this cannot see it: measured 2026-08-22, fingerprint
+#: ``00ec09b9ad73`` was held on compute-04 AND compute-03 at once, and a
+#: per-host probe returned OK on both while the fault was live across them.
+#:
+#: The PID namespace is the same trap one level down: run inside an apptainer
+#: container with ``--containall``, ``/proc`` shows only that container's
+#: processes — one server where the host has ten — and the small number reads
+#: exactly like a clean host. Run it on the HOST.
+SCOPE_NOTE = (
+    "HOST-SCOPED, and Telegram's one-consumer-per-token rule is GLOBAL: a "
+    "duplicate split across two hosts is invisible here and an ok on one host "
+    "is not a fleet all-clear. Run this on the HOST, not inside a container — "
+    "a --containall PID namespace shows only its own processes, which reads "
+    "like a clean host."
+)
+
 
 @dataclass(frozen=True)
 class DuplicatePollers:
@@ -100,6 +130,9 @@ class PollerSingletonVerdict:
     pollers: tuple[LivePoller, ...] = ()
     duplicates: tuple[DuplicatePollers, ...] = ()
     unresolved_pids: tuple[int, ...] = ()
+    #: Live servers deliberately given an EMPTY token. Reported, never counted
+    #: against the invariant — see :data:`.._cct_poller_scan.TOKEN_DISABLED`.
+    disabled_pids: tuple[int, ...] = ()
     #: False when the process scan itself could not run — the reason a zero
     #: count must not read as OK.
     scanned: bool = True
@@ -130,6 +163,22 @@ class PollerSingletonVerdict:
             if not p.resolved and p.reason == UNRESOLVED_ENVIRON
         )
 
+    def population(self) -> str:
+        """What was actually examined. Never let a clean count stand alone.
+
+        "0 violations" means nothing until the same reading says how much was
+        looked at: ``0 across 0 examined`` and ``0 across 10`` are different
+        facts and must not render the same. scitex-hub's rule, adopted after
+        it caught itself reporting "0 x 409 Conflict" over a window in which
+        nothing at all had happened.
+        """
+        return (
+            f"{len(self.pollers)} live server(s) examined, "
+            f"{self.distinct_fingerprints} real token(s), "
+            f"{len(self.disabled_pids)} deliberately tokenless, "
+            f"{len(self.unresolved_pids)} unreadable"
+        )
+
     def summary(self) -> str:
         """One-line human summary of the verdict."""
         live = len(self.pollers)
@@ -146,7 +195,15 @@ class PollerSingletonVerdict:
                 f"unknown — {len(self.unresolved_pids)} of {live} live "
                 "poller(s) would not yield a token"
             )
-        return f"{live} live poller(s), {self.distinct_fingerprints} distinct token(s)"
+        disabled = (
+            f", {len(self.disabled_pids)} deliberately tokenless"
+            if self.disabled_pids
+            else ""
+        )
+        return (
+            f"{live} live server(s) on this host, "
+            f"{self.distinct_fingerprints} distinct token(s){disabled}"
+        )
 
     def hint(self) -> str:
         """What to DO. Empty for OK — an all-clear needs no remedy.
@@ -207,15 +264,20 @@ class PollerSingletonVerdict:
         (:meth:`.._drift.DriftStatus.to_dict`) — ``state`` / ``detail`` /
         ``summary`` plus this check's own fields — with ``hint`` added because
         a failing check that does not say what to do is a check people learn
-        to scroll past.
+        to scroll past, and ``scope_note`` because an unstated limit is the
+        same defect as a wrong hint.
         """
         return {
             "state": self.state,
+            "scope": "host",
+            "scope_note": SCOPE_NOTE,
             "live_pollers": len(self.pollers),
             "distinct_fingerprints": self.distinct_fingerprints,
+            "population": self.population(),
             "pollers": [p.to_dict() for p in self.pollers],
             "duplicates": [d.to_dict() for d in self.duplicates],
             "unresolved_pids": list(self.unresolved_pids),
+            "disabled_pids": list(self.disabled_pids),
             "scanned": self.scanned,
             "proc_root": self.proc_root,
             "detail": self.detail,
@@ -259,7 +321,8 @@ def verdict_for(
     """
     pollers = tuple(pollers)
     duplicates = group_duplicates(pollers)
-    unresolved = tuple(p.pid for p in pollers if not p.resolved)
+    disabled = tuple(p.pid for p in pollers if p.disabled)
+    unresolved = tuple(p.pid for p in pollers if not p.resolved and not p.disabled)
     distinct = len({p.token_fp for p in pollers if p.token_fp})
 
     if duplicates:
@@ -268,6 +331,7 @@ def verdict_for(
             pollers=pollers,
             duplicates=duplicates,
             unresolved_pids=unresolved,
+            disabled_pids=disabled,
             proc_root=proc_root,
             detail=(
                 f"{len(pollers)} live poller(s) under {proc_root} resolve to "
@@ -279,17 +343,19 @@ def verdict_for(
         )
 
     if unresolved:
-        why = "; ".join(f"pid {p.pid}: {p.detail}" for p in pollers if not p.resolved)
+        blind = [p for p in pollers if not p.resolved and not p.disabled]
+        why = "; ".join(f"pid {p.pid}: {p.detail}" for p in blind)
         return PollerSingletonVerdict(
             state=POLLER_UNKNOWN,
             pollers=pollers,
             unresolved_pids=unresolved,
+            disabled_pids=disabled,
             proc_root=proc_root,
             detail=(
-                f"{len(unresolved)} of {len(pollers)} live poller(s) yielded no "
+                f"{len(unresolved)} of {len(pollers)} live server(s) yielded no "
                 f"{_TOKEN_VAR}, so the one-poller-per-token invariant cannot be "
-                "asserted: an unread poller could hold the same token as a read "
-                f"one. {why}"
+                "asserted: an unread server could hold the same token as a read "
+                f"one. {why} ({SCOPE_NOTE})"
             ),
         )
 
@@ -299,18 +365,21 @@ def verdict_for(
             proc_root=proc_root,
             detail=(
                 f"the scan ran against {proc_root} and found no live Telegram "
-                "poller. Nothing can conflict with nothing."
+                f"server. Nothing can conflict with nothing. ({SCOPE_NOTE})"
             ),
         )
 
     return PollerSingletonVerdict(
         state=POLLER_OK,
         pollers=pollers,
+        disabled_pids=disabled,
         proc_root=proc_root,
         detail=(
-            f"{len(pollers)} live poller(s) under {proc_root}, each holding a "
-            "distinct bot token. count(distinct fingerprints) == "
-            "count(live pollers)."
+            f"{len(pollers)} live server(s) under {proc_root}; "
+            f"{distinct} hold a real bot token and no two hold the same one "
+            f"({len(disabled)} carry a deliberately EMPTY token and hold none, "
+            "so they cannot collide with anything). count(distinct "
+            f"fingerprints) == count(token-holding servers). ({SCOPE_NOTE})"
         ),
     )
 
@@ -360,6 +429,7 @@ __all__ = [
     "POLLER_OK",
     "POLLER_UNKNOWN",
     "POLLER_VIOLATION",
+    "SCOPE_NOTE",
     "DuplicatePollers",
     "PollerSingletonVerdict",
     "check_poller_singleton",

--- a/src/scitex_agent_container/runtimes/_cct_poller_singleton.py
+++ b/src/scitex_agent_container/runtimes/_cct_poller_singleton.py
@@ -1,0 +1,368 @@
+"""ONE live Telegram poller per bot token — or say so. Three answers, never two.
+
+THE FAULT THIS OBSERVES
+-----------------------
+Restarting an agent's container does NOT reliably kill the previous
+``bun run …/telegram-server.ts`` poller: the container runtime leaves it
+orphaned, attached to the HOST. The next start spawns a SECOND poller for the
+SAME bot token. Telegram's ``getUpdates`` admits exactly ONE consumer per
+token, so the pair enters a 409 conflict loop and the operator's messages are
+dropped — silently, from the only side that matters.
+
+This is documented in claude-code-telegrammer's ``ts/lib/takeover.ts`` and has
+been since 2026-06-07, and it has never been instrumented. Every time the fleet
+learned of a 409 storm it learned because ONE agent happened to read its own
+log during an incident. That is a coincidence, not a measurement.
+
+Operator, 2026-08-22 (Telegram 13379):
+「ポーラーが ophan になってしまうことがあるんですかね。sac が持って置くべきで、
+sac のプロセスとかならず１対１対応するように制限しなくてはいけないような。」
+— approved as 「１トークン１ポーラーですか、はい、お願いします。」
+
+WHAT THIS IS, AND WHAT IT IS NOT
+--------------------------------
+A DETECTOR. It reads ``/proc`` and returns a verdict. It never kills, signals,
+locks, reaps or otherwise touches a process, and it changes NOTHING about the
+start/stop path. It answers one question — *is the 1:1 invariant holding on
+this host right now?* — and the eventual enforcement is a separate change that
+this makes verifiable. A fix without a detector cannot be shown to have worked.
+
+THE INVARIANT
+-------------
+``count(distinct token fingerprints) == count(live pollers)``
+
+One fingerprint carried by two live pids IS the fault, and is the only thing
+reported as :data:`POLLER_VIOLATION`.
+
+THREE-VALUED, AND THE THIRD VALUE IS LOAD-BEARING
+-------------------------------------------------
+``/proc/<pid>/environ`` is OWNER-ONLY. A poller belonging to another uid is a
+poller whose token sac cannot read, and "I could not read it" is not "there is
+no duplicate" — the unread one could be the twin of a read one. So a live
+poller with no resolvable token yields :data:`POLLER_UNKNOWN`, never
+:data:`POLLER_OK`. Folding that into OK would make the detector quietest
+exactly when it is blindest, which is the most common bug we ship.
+
+A scan that could not run at all (no readable ``/proc``) is UNKNOWN for the
+same reason: zero pollers found because nobody looked is not zero pollers.
+
+The observation half — which processes are pollers, and what token fingerprint
+each holds — lives in :mod:`._cct_poller_scan`, including the contract that no
+token VALUE is ever stored, returned or printed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from ._cct_poller_scan import (
+    UNRESOLVED_ENVIRON,
+    LivePoller,
+    scan_live_pollers,
+)
+from ._cct_token_pool import _TOKEN_VAR
+
+#: The invariant holds: every live poller resolved a token, and no two of them
+#: resolved the same one. Zero live pollers is OK — nothing can conflict.
+POLLER_OK = "ok"
+#: Two or more live pollers share a bot-token fingerprint. This is the 409
+#: conflict loop, observed rather than inferred.
+POLLER_VIOLATION = "violation"
+#: sac could not assert the invariant: a live poller's token was unreadable, or
+#: the process scan itself could not run. NOT a soft OK.
+POLLER_UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class DuplicatePollers:
+    """Two or more live pids polling the SAME bot token. The fault itself."""
+
+    token_fp: str
+    pids: tuple[int, ...]
+    agents: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        """JSON-friendly projection (for ``--json`` surfaces)."""
+        return {
+            "token_fp": self.token_fp,
+            "pids": list(self.pids),
+            "agents": list(self.agents),
+        }
+
+
+@dataclass(frozen=True)
+class PollerSingletonVerdict:
+    """The host-wide verdict. ``state`` is OK / VIOLATION / UNKNOWN."""
+
+    state: str
+    pollers: tuple[LivePoller, ...] = ()
+    duplicates: tuple[DuplicatePollers, ...] = ()
+    unresolved_pids: tuple[int, ...] = ()
+    #: False when the process scan itself could not run — the reason a zero
+    #: count must not read as OK.
+    scanned: bool = True
+    proc_root: str = "/proc"
+    detail: str = ""
+
+    @property
+    def is_alarming(self) -> bool:
+        """True for the two states a human must be told about."""
+        return self.state in (POLLER_VIOLATION, POLLER_UNKNOWN)
+
+    @property
+    def distinct_fingerprints(self) -> int:
+        """How many distinct bot tokens the live pollers resolved to."""
+        return len({p.token_fp for p in self.pollers if p.token_fp})
+
+    @property
+    def blind_pids(self) -> tuple[int, ...]:
+        """Unresolved pids whose ``environ`` sac could not READ at all.
+
+        The subset of :attr:`unresolved_pids` that is a VANTAGE problem rather
+        than a process started outside sac's env. The two need different
+        remedies, so :meth:`hint` branches on this rather than on prose.
+        """
+        return tuple(
+            p.pid
+            for p in self.pollers
+            if not p.resolved and p.reason == UNRESOLVED_ENVIRON
+        )
+
+    def summary(self) -> str:
+        """One-line human summary of the verdict."""
+        live = len(self.pollers)
+        if self.state == POLLER_VIOLATION:
+            worst = ", ".join(
+                f"{d.token_fp} held by pids {'+'.join(str(p) for p in d.pids)}"
+                for d in self.duplicates
+            )
+            return f"{len(self.duplicates)} duplicated bot token(s): {worst}"
+        if self.state == POLLER_UNKNOWN:
+            if not self.scanned:
+                return "unknown — the process scan could not run"
+            return (
+                f"unknown — {len(self.unresolved_pids)} of {live} live "
+                "poller(s) would not yield a token"
+            )
+        return f"{live} live poller(s), {self.distinct_fingerprints} distinct token(s)"
+
+    def hint(self) -> str:
+        """What to DO. Empty for OK — an all-clear needs no remedy.
+
+        The two alarming states need DIFFERENT actions: a violation is a live
+        outage to end by hand, an unknown is an unread instrument whose vantage
+        point must be fixed first. Handing out one sentence for both is how a
+        hint stops being read.
+        """
+        if self.state == POLLER_VIOLATION:
+            offenders = sorted({p for d in self.duplicates for p in d.pids})
+            pids = ", ".join(str(p) for p in offenders)
+            return (
+                "Two or more pollers hold the same bot token, so Telegram is "
+                "409-ing both and the operator's inbound messages are being "
+                "dropped. To end it NOW: for each duplicated fingerprint, find "
+                f"which of pids {pids} is a CHILD of that agent's current "
+                "`claude` process (`ps -o pid,ppid,lstart,args -p <pid>`; the "
+                "orphan is the one whose parent is 1, or an exited container), "
+                "then SIGKILL the orphan(s), leaving exactly one. Confirm by "
+                "re-running this check: it must read `ok`. sac does NOT do this "
+                "for you — this is a detector; the reaper is a separate change."
+            )
+        if self.state == POLLER_UNKNOWN:
+            if not self.scanned:
+                return (
+                    f"The process scan could not run against {self.proc_root}, "
+                    "so NOTHING was learned — this is not an all-clear. Re-run "
+                    "on a Linux host with a readable /proc."
+                )
+            pids = ", ".join(str(p) for p in self.unresolved_pids)
+            head = (
+                f"A live poller yielded no {_TOKEN_VAR}, so sac cannot assert "
+                "one-poller-per-token: the unread process could be the twin of "
+                f"a read one. Affected pid(s): {pids}. "
+            )
+            if self.blind_pids:
+                return head + (
+                    "`/proc/<pid>/environ` is OWNER-ONLY, so the cause here is "
+                    "VANTAGE — pids "
+                    + ", ".join(str(p) for p in self.blind_pids)
+                    + " belong to another uid. Re-run as the user that owns "
+                    "those processes (or as root) before believing any row."
+                )
+            return head + (
+                "Their environments ARE readable and simply carry no "
+                f"{_TOKEN_VAR}: these pollers were started outside sac's env, "
+                "so sac has nothing to match them on. Identify them by hand "
+                "(`ps -o pid,ppid,lstart,args -p <pid>`) and either restart "
+                "them through sac or stop them."
+            )
+        return ""
+
+    def to_dict(self) -> dict:
+        """JSON-friendly projection (for ``--json`` surfaces).
+
+        Same shape as the doctor's neighbouring drift check
+        (:meth:`.._drift.DriftStatus.to_dict`) — ``state`` / ``detail`` /
+        ``summary`` plus this check's own fields — with ``hint`` added because
+        a failing check that does not say what to do is a check people learn
+        to scroll past.
+        """
+        return {
+            "state": self.state,
+            "live_pollers": len(self.pollers),
+            "distinct_fingerprints": self.distinct_fingerprints,
+            "pollers": [p.to_dict() for p in self.pollers],
+            "duplicates": [d.to_dict() for d in self.duplicates],
+            "unresolved_pids": list(self.unresolved_pids),
+            "scanned": self.scanned,
+            "proc_root": self.proc_root,
+            "detail": self.detail,
+            "summary": self.summary(),
+            "hint": self.hint(),
+        }
+
+
+def group_duplicates(pollers: Sequence[LivePoller]) -> tuple[DuplicatePollers, ...]:
+    """Fingerprints held by two or more live pids, in fingerprint order.
+
+    Pure over its input — the seam that lets the duplicate condition be
+    constructed and asserted without a process, next to the test that
+    constructs it with two real ones.
+    """
+    by_fp: dict[str, list[LivePoller]] = {}
+    for poller in pollers:
+        if poller.token_fp:
+            by_fp.setdefault(poller.token_fp, []).append(poller)
+    return tuple(
+        DuplicatePollers(
+            token_fp=fp,
+            pids=tuple(p.pid for p in group),
+            agents=tuple(dict.fromkeys(p.agent for p in group if p.agent)),
+        )
+        for fp, group in sorted(by_fp.items())
+        if len(group) > 1
+    )
+
+
+def verdict_for(
+    pollers: Sequence[LivePoller],
+    *,
+    proc_root: str = "/proc",
+) -> PollerSingletonVerdict:
+    """Decide OK / VIOLATION / UNKNOWN for an already-observed population.
+
+    A VIOLATION outranks an UNKNOWN: a duplicate that HAS been observed is a
+    fact, and an unread third process does not make it less true. The reverse
+    ordering would let one unreadable poller mute a live outage.
+    """
+    pollers = tuple(pollers)
+    duplicates = group_duplicates(pollers)
+    unresolved = tuple(p.pid for p in pollers if not p.resolved)
+    distinct = len({p.token_fp for p in pollers if p.token_fp})
+
+    if duplicates:
+        return PollerSingletonVerdict(
+            state=POLLER_VIOLATION,
+            pollers=pollers,
+            duplicates=duplicates,
+            unresolved_pids=unresolved,
+            proc_root=proc_root,
+            detail=(
+                f"{len(pollers)} live poller(s) under {proc_root} resolve to "
+                f"only {distinct} distinct bot token(s). Telegram's getUpdates "
+                "admits ONE consumer per token, so every duplicated "
+                "fingerprint below is a live 409 conflict loop in which the "
+                "operator's inbound messages are dropped."
+            ),
+        )
+
+    if unresolved:
+        why = "; ".join(f"pid {p.pid}: {p.detail}" for p in pollers if not p.resolved)
+        return PollerSingletonVerdict(
+            state=POLLER_UNKNOWN,
+            pollers=pollers,
+            unresolved_pids=unresolved,
+            proc_root=proc_root,
+            detail=(
+                f"{len(unresolved)} of {len(pollers)} live poller(s) yielded no "
+                f"{_TOKEN_VAR}, so the one-poller-per-token invariant cannot be "
+                "asserted: an unread poller could hold the same token as a read "
+                f"one. {why}"
+            ),
+        )
+
+    if not pollers:
+        return PollerSingletonVerdict(
+            state=POLLER_OK,
+            proc_root=proc_root,
+            detail=(
+                f"the scan ran against {proc_root} and found no live Telegram "
+                "poller. Nothing can conflict with nothing."
+            ),
+        )
+
+    return PollerSingletonVerdict(
+        state=POLLER_OK,
+        pollers=pollers,
+        proc_root=proc_root,
+        detail=(
+            f"{len(pollers)} live poller(s) under {proc_root}, each holding a "
+            "distinct bot token. count(distinct fingerprints) == "
+            "count(live pollers)."
+        ),
+    )
+
+
+def check_poller_singleton(
+    *,
+    proc_root: Path | None = None,
+    self_pid: int | None = None,
+) -> PollerSingletonVerdict:
+    """Is there MORE THAN ONE live Telegram poller per bot token on this host?
+
+    Returns a three-valued verdict:
+
+    * :data:`POLLER_OK` — every live poller resolved a token and no two share
+      one, i.e. ``count(distinct fingerprints) == count(live pollers)``. Zero
+      live pollers is OK: nothing can conflict.
+    * :data:`POLLER_VIOLATION` — at least one fingerprint is held by two or
+      more live pids. Both pids, the fingerprint, and the owning agents where
+      determinable are reported.
+    * :data:`POLLER_UNKNOWN` — the scan could not run, or a live poller's token
+      could not be read. Never folded into OK.
+
+    Read-only. Enumerates ``proc_root`` and returns; touches no process.
+    """
+    root = Path(proc_root) if proc_root is not None else Path("/proc")
+    # stx-allow: fallback (reason: a proc root that cannot be enumerated is the
+    # UNKNOWN verdict this function exists to be able to give — reporting zero
+    # pollers because nobody looked is the exact collapse this detector
+    # refuses, so the failure must become a state, not an exception.)
+    try:
+        pollers = scan_live_pollers(proc_root=root, self_pid=self_pid)
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        return PollerSingletonVerdict(
+            state=POLLER_UNKNOWN,
+            scanned=False,
+            proc_root=str(root),
+            detail=(
+                f"{root} could not be enumerated ({exc}), so no poller was "
+                "observed at all. Nothing was learned; this is not an "
+                "all-clear."
+            ),
+        )
+    return verdict_for(pollers, proc_root=str(root))
+
+
+__all__ = [
+    "POLLER_OK",
+    "POLLER_UNKNOWN",
+    "POLLER_VIOLATION",
+    "DuplicatePollers",
+    "PollerSingletonVerdict",
+    "check_poller_singleton",
+    "group_duplicates",
+    "verdict_for",
+]

--- a/tests/scitex_agent_container/cli_pkg/test_doctor_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_doctor_cmds.py
@@ -180,3 +180,63 @@ def test_local_json_carries_state_field(local_drifted_source):
     payload = json.loads(result.stdout)
     # Assert
     assert payload["local"]["state"] == "behind"
+
+
+# ---------------------------------------------------------------------------
+# sac doctor --pollers  (one live Telegram poller per bot token?)
+# ---------------------------------------------------------------------------
+#
+# These drive the REAL host /proc, so the STATE is whatever this machine is
+# actually doing right now and must NOT be asserted. What IS deterministic --
+# and what these pin -- is that the check runs, reports one of exactly three
+# values, and rides along by default. The state TRANSITIONS are measured
+# against real spawned processes in
+# tests/.../runtimes/test__cct_poller_singleton.py, where the population is
+# controlled.
+
+_POLLER_STATES = {"ok", "violation", "unknown"}
+
+
+def test_pollers_json_carries_a_three_valued_state():
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--pollers", "--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["pollers"]["state"] in _POLLER_STATES
+
+
+def test_pollers_only_omits_the_drift_check():
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--pollers", "--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert "local" not in payload
+
+
+def test_pollers_human_output_names_the_check():
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--pollers"])
+    # Assert
+    assert "telegram pollers" in result.output
+
+
+def test_default_doctor_runs_the_poller_check_too(local_drifted_source):
+    # Arrange -- a check nobody remembers to run is how a 409 storm survives
+    # for weeks, so the poller verdict must appear without being asked for.
+    # Act
+    result = CliRunner().invoke(doctor, ["--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["pollers"]["state"] in _POLLER_STATES
+
+
+def test_default_doctor_still_carries_the_drift_verdict(local_drifted_source):
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["local"]["state"] == "behind"

--- a/tests/scitex_agent_container/runtimes/test__cct_poller_scan.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_poller_scan.py
@@ -152,6 +152,58 @@ def test_the_owning_agent_comes_from_the_process_env(tmp_path):
     assert poller.agent == "scitex-agent-container"
 
 
+def test_sac_name_beats_a_disagreeing_cct_agent_id(tmp_path):
+    # Arrange — MEASURED, compute-04 2026-08-22 17:02Z, pid 574160 exactly:
+    # CCT_AGENT_ID said handyman-01 while SAC_NAME said handyman-06, and the
+    # PARENT carried the same wrong CCT_AGENT_ID — so trusting the telegram
+    # identity named an innocent agent as the offender.
+    pid_dir = _write_proc(
+        tmp_path,
+        574160,
+        _BUN_POLLER,
+        {
+            "CCT_BOT_TOKEN": "t",
+            "CCT_AGENT_ID": "handyman-01",
+            "SAC_NAME": "handyman-06",
+        },
+    )
+    # Act
+    poller = poller_from_pid(574160, pid_dir)
+    # Assert
+    assert poller.agent == "handyman-06"
+
+
+def test_an_empty_token_is_disabled_not_unresolved(tmp_path):
+    # Arrange — the handyman family sets CCT_BOT_TOKEN="" on purpose. An empty
+    # string is not a bot token, so this process cannot be anyone's second
+    # consumer.
+    pid_dir = _write_proc(tmp_path, 4242, _BUN_POLLER, {"CCT_BOT_TOKEN": ""})
+    # Act
+    poller = poller_from_pid(4242, pid_dir)
+    # Assert
+    assert poller.disabled is True
+
+
+def test_an_absent_token_is_not_disabled(tmp_path):
+    # Arrange — THE DISTINCTION: absent means started outside sac's env, and
+    # sac cannot tell whether it polls something by another route.
+    pid_dir = _write_proc(tmp_path, 4242, _BUN_POLLER, {"PATH": "/usr/bin"})
+    # Act
+    poller = poller_from_pid(4242, pid_dir)
+    # Assert
+    assert poller.disabled is False
+
+
+def test_the_disabled_detail_does_not_blame_sac_provisioning(tmp_path):
+    # Arrange — the old wording said "started outside sac's env", which is
+    # FALSE for these: sac started them, from a sac spec, emptied on purpose.
+    pid_dir = _write_proc(tmp_path, 4242, _BUN_POLLER, {"CCT_BOT_TOKEN": ""})
+    # Act
+    poller = poller_from_pid(4242, pid_dir)
+    # Assert
+    assert "outside sac's env" not in poller.detail
+
+
 def test_the_scan_excludes_the_calling_process(tmp_path):
     # Arrange — a poller-shaped argv written under OUR OWN pid. A detector
     # that can appear in its own population is not measuring the host.

--- a/tests/scitex_agent_container/runtimes/test__cct_poller_scan.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_poller_scan.py
@@ -1,0 +1,172 @@
+"""The poller SCAN must find pollers and must not find its own search.
+
+The named trap this pins: ``pgrep -f telegram-server`` matches the searching
+shell itself. A detector that counts its own search as a poller manufactures
+the exact duplicate it exists to find — and would then report VIOLATION on a
+perfectly healthy host, which is how a detector gets ignored.
+
+No mocks. ``is_poller_argv`` is pure over an argv list, and the ``/proc``
+readers are driven against a real directory tree written by the test.
+
+PA-307 / STX-TQ002 / STX-TQ007 — one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+import os
+
+from scitex_agent_container.runtimes._cct_poller_scan import (
+    is_poller_argv,
+    poller_from_pid,
+    read_process_env,
+    scan_live_pollers,
+)
+
+_BUN_POLLER = [
+    "/home/ywatanabe/.bun/bin/bun",
+    "run",
+    "/home/y/proj/cct/ts/telegram-server.ts",
+]
+_SH_WRAPPED = ["/bin/sh", "-c", "exec bun run /tg/telegram-server.ts"]
+_UNRELATED = ["/opt/venv-sac/bin/python", "/opt/venv-sac/bin/sac", "mcp", "start"]
+
+
+def _write_proc(root, pid: int, argv: list[str], env: dict[str, str] | None = None):
+    """Write a minimal ``/proc/<pid>`` with cmdline (+ environ when given)."""
+    pid_dir = root / str(pid)
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    (pid_dir / "cmdline").write_bytes(("\0".join(argv) + "\0").encode())
+    if env is not None:
+        blob = "\0".join(f"{k}={v}" for k, v in env.items()) + "\0"
+        (pid_dir / "environ").write_bytes(blob.encode())
+    return pid_dir
+
+
+def test_a_bun_run_poller_is_recognised():
+    # Arrange
+    argv = _BUN_POLLER
+    # Act
+    verdict = is_poller_argv(argv)
+    # Assert
+    assert verdict is True
+
+
+def test_a_shell_wrapped_poller_is_recognised():
+    # Arrange — the shape the SDK channel config actually emits.
+    argv = _SH_WRAPPED
+    # Act
+    verdict = is_poller_argv(argv)
+    # Assert
+    assert verdict is True
+
+
+def test_a_pgrep_searching_for_the_poller_is_not_one():
+    # Arrange — THE LOAD-BEARING CASE. This argv carries the pattern and runs
+    # nothing; counting it would invent a duplicate on a healthy host.
+    argv = ["pgrep", "-f", "telegram-server.ts"]
+    # Act
+    verdict = is_poller_argv(argv)
+    # Assert
+    assert verdict is False
+
+
+def test_a_ripgrep_over_the_source_is_not_a_poller():
+    # Arrange
+    argv = ["/usr/bin/rg", "-n", "telegram-server.ts", "/home/y/proj/cct"]
+    # Act
+    verdict = is_poller_argv(argv)
+    # Assert
+    assert verdict is False
+
+
+def test_an_unrelated_mcp_child_is_not_a_poller():
+    # Arrange
+    argv = _UNRELATED
+    # Act
+    verdict = is_poller_argv(argv)
+    # Assert
+    assert verdict is False
+
+
+def test_an_empty_argv_is_not_a_poller():
+    # Arrange — a kernel thread has an empty cmdline.
+    argv: list[str] = []
+    # Act
+    verdict = is_poller_argv(argv)
+    # Assert
+    assert verdict is False
+
+
+def test_an_unreadable_environ_reads_as_none_not_empty(tmp_path):
+    # Arrange — the cross-uid case: cmdline present, environ absent. ``{}``
+    # here would silently claim the process carries no token.
+    pid_dir = _write_proc(tmp_path, 4242, _BUN_POLLER)
+    # Act
+    env = read_process_env(pid_dir)
+    # Assert
+    assert env is None
+
+
+def test_an_unreadable_environ_yields_no_fingerprint(tmp_path):
+    # Arrange
+    pid_dir = _write_proc(tmp_path, 4242, _BUN_POLLER)
+    # Act
+    poller = poller_from_pid(4242, pid_dir)
+    # Assert
+    assert poller.token_fp is None
+
+
+def test_a_readable_token_yields_an_opaque_fingerprint(tmp_path):
+    # Arrange
+    pid_dir = _write_proc(
+        tmp_path, 4242, _BUN_POLLER, {"CCT_BOT_TOKEN": "123456:SECRET-VALUE"}
+    )
+    # Act
+    poller = poller_from_pid(4242, pid_dir)
+    # Assert
+    assert poller.token_fp.startswith("sha256:") and len(poller.token_fp) == 19
+
+
+def test_the_fingerprint_contains_no_part_of_the_token(tmp_path):
+    # Arrange
+    pid_dir = _write_proc(
+        tmp_path, 4242, _BUN_POLLER, {"CCT_BOT_TOKEN": "123456:SECRET-VALUE"}
+    )
+    # Act
+    poller = poller_from_pid(4242, pid_dir)
+    # Assert
+    assert "SECRET" not in repr(poller) and "123456" not in repr(poller)
+
+
+def test_the_owning_agent_comes_from_the_process_env(tmp_path):
+    # Arrange
+    pid_dir = _write_proc(
+        tmp_path,
+        4242,
+        _BUN_POLLER,
+        {"CCT_BOT_TOKEN": "t", "CCT_AGENT_ID": "scitex-agent-container"},
+    )
+    # Act
+    poller = poller_from_pid(4242, pid_dir)
+    # Assert
+    assert poller.agent == "scitex-agent-container"
+
+
+def test_the_scan_excludes_the_calling_process(tmp_path):
+    # Arrange — a poller-shaped argv written under OUR OWN pid. A detector
+    # that can appear in its own population is not measuring the host.
+    _write_proc(tmp_path, os.getpid(), _BUN_POLLER, {"CCT_BOT_TOKEN": "t"})
+    # Act
+    found = scan_live_pollers(proc_root=tmp_path)
+    # Assert
+    assert found == ()
+
+
+def test_the_scan_skips_non_numeric_proc_entries(tmp_path):
+    # Arrange — /proc holds self, sys, meminfo … alongside the pid dirs.
+    (tmp_path / "sys").mkdir()
+    _write_proc(tmp_path, 4242, _BUN_POLLER, {"CCT_BOT_TOKEN": "t"})
+    # Act
+    found = scan_live_pollers(proc_root=tmp_path, self_pid=1)
+    # Assert
+    assert [p.pid for p in found] == [4242]

--- a/tests/scitex_agent_container/runtimes/test__cct_poller_singleton.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_poller_singleton.py
@@ -19,6 +19,13 @@ THE THIRD VALUE IS TESTED TOO. A live poller whose token cannot be read must
 come back UNKNOWN, never OK — an unread process could be the twin of a read
 one, and collapsing that into an all-clear is the bug this fleet ships most.
 
+AND THE OPPOSITE FAILURE, which a live run found after the first commit: a
+server whose ``CCT_BOT_TOKEN`` is DELIBERATELY EMPTY holds no token and cannot
+collide with anything, so it must NOT drag the host into UNKNOWN. Measured on
+compute-04, 2026-08-22: 10 live servers, 4 real tokens, 6 empty by design —
+i.e. the fleet's healthy steady state returned UNKNOWN on every run. A check
+that is never green is muted, and a muted check is not a check.
+
 PA-307 / STX-TQ002 / STX-TQ007 — one assert per test, full AAA markers.
 """
 
@@ -74,11 +81,18 @@ class _PollerFarm:
         self._procs: list[subprocess.Popen] = []
 
     def spawn(self, *, token: str | None, agent: str = "") -> int:
-        """Start one live poller; return its pid once /proc shows it."""
+        """Start one live poller; return its pid once /proc shows it.
+
+        ``token=None`` leaves ``CCT_BOT_TOKEN`` ABSENT (a server started
+        outside sac's env); ``token=""`` sets it PRESENT AND EMPTY (the
+        handyman family's deliberate no-bot shape). The two are different
+        facts and the detector must not conflate them.
+        """
         env = {"PATH": "/usr/bin:/bin"}
         if token is not None:
             env["CCT_BOT_TOKEN"] = token
         if agent:
+            env["SAC_NAME"] = agent
             env["CCT_AGENT_ID"] = agent
         proc = subprocess.Popen(
             [str(self.bun), "run", str(self.script)],
@@ -268,6 +282,66 @@ def test_an_unreadable_environ_hint_names_the_vantage():
     verdict = verdict_for(pollers)
     # Assert
     assert "OWNER-ONLY" in verdict.hint()
+
+
+def test_a_deliberately_tokenless_server_does_not_make_the_host_unknown(farm):
+    # Arrange — THE HEALTHY FLEET STEADY STATE, reproduced from the compute-04
+    # census of 2026-08-22: real tokens alongside servers whose CCT_BOT_TOKEN
+    # is EMPTY on purpose. Reporting unknown here would mean this check is
+    # never green on a healthy host, and a check that is never green is muted.
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token="", agent="handyman-01")
+    farm.spawn(token="", agent="handyman-02")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.state == POLLER_OK
+
+
+def test_the_tokenless_servers_are_still_reported(farm):
+    # Arrange — excluded from the invariant, NOT hidden from the reader.
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    first = farm.spawn(token="", agent="handyman-01")
+    second = farm.spawn(token="", agent="handyman-02")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert sorted(verdict.disabled_pids) == sorted([first, second])
+
+
+def test_two_tokenless_servers_are_not_a_duplicate(farm):
+    # Arrange — THE COLLISION THIS AVOIDS: grouping on a field that is
+    # deliberately empty manufactures a duplicate out of two agents that
+    # simply have no bot. Six empty strings are not one agent with six
+    # servers.
+    farm.spawn(token="", agent="handyman-01")
+    farm.spawn(token="", agent="handyman-02")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.duplicates == ()
+
+
+def test_the_population_examined_is_reported_beside_the_count(farm):
+    # Arrange — "0 violations across 0 examined" and "across 3" must not
+    # render the same.
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token="", agent="handyman-01")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert "2 live server(s) examined" in verdict.population()
+
+
+def test_every_verdict_states_that_it_is_host_scoped(farm):
+    # Arrange — a per-host ok is not a fleet all-clear: measured 2026-08-22,
+    # one fingerprint was live on compute-04 AND compute-03 at once and a
+    # per-host probe returned ok on both. An unstated limit is a defect.
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    # Act
+    payload = check_poller_singleton(proc_root=farm.proc_root).to_dict()
+    # Assert
+    assert payload["scope"] == "host" and "GLOBAL" in payload["scope_note"]
 
 
 def test_an_unscannable_proc_root_is_unknown(tmp_path):

--- a/tests/scitex_agent_container/runtimes/test__cct_poller_singleton.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_poller_singleton.py
@@ -1,0 +1,327 @@
+"""The poller-singleton detector must FIRE on a duplicate it can actually see.
+
+THE POSITIVE CONTROL IS THE POINT. A detector that has never returned a known
+answer is not a measurement, so the load-bearing tests here CONSTRUCT the
+fault: two REAL live processes, spawned by the test, whose argv names
+``telegram-server.ts`` and whose environment carries the SAME
+``CCT_BOT_TOKEN``. That is the 409 condition, and the check must call it a
+VIOLATION. "Returns ok on a healthy host" would pass for a function that
+returns the string "ok" unconditionally.
+
+NO MOCKS ANYWHERE. The processes are real, ``/proc`` is the real ``/proc``,
+and the reader is the real reader. The only thing the test controls is the
+POPULATION: it builds a scan root of symlinks pointing at exactly the pids it
+spawned, so a live poller belonging to some other agent on this host can
+neither hide a duplicate nor invent one. Scoping the population is not faking
+the instrument.
+
+THE THIRD VALUE IS TESTED TOO. A live poller whose token cannot be read must
+come back UNKNOWN, never OK — an unread process could be the twin of a read
+one, and collapsing that into an all-clear is the bug this fleet ships most.
+
+PA-307 / STX-TQ002 / STX-TQ007 — one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.runtimes._cct_poller_scan import (
+    UNRESOLVED_ENVIRON,
+    LivePoller,
+    is_poller_argv,
+)
+from scitex_agent_container.runtimes._cct_poller_singleton import (
+    POLLER_OK,
+    POLLER_UNKNOWN,
+    POLLER_VIOLATION,
+    check_poller_singleton,
+    verdict_for,
+)
+
+#: A token-shaped string that must never appear in any output.
+_TOKEN_A = "8123456789:AAHduplicate-bot-token-value-A"
+_TOKEN_B = "9987654321:AAHdistinct-bot-token-value-B"
+
+
+class _PollerFarm:
+    """Spawns REAL poller-shaped processes and scopes a /proc view onto them.
+
+    The child is a shell script named ``telegram-server.ts`` invoked through a
+    stand-in ``bun``, i.e. exactly the argv shape the real launcher produces.
+    It blocks on ``read`` from its stdin pipe, so it holds its cmdline and its
+    environment for as long as the test needs and dies on its own the moment
+    the pipe closes — no forked ``sleep`` to leak.
+    """
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.proc_root = tmp_path / "proc"
+        self.proc_root.mkdir()
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        self.bun = bin_dir / "bun"
+        self.bun.write_text("#!/bin/sh\nread line\n")
+        self.bun.chmod(0o755)
+        ts_dir = tmp_path / "ts"
+        ts_dir.mkdir()
+        self.script = ts_dir / "telegram-server.ts"
+        self.script.write_text("// stand-in for the real poller\n")
+        self._procs: list[subprocess.Popen] = []
+
+    def spawn(self, *, token: str | None, agent: str = "") -> int:
+        """Start one live poller; return its pid once /proc shows it."""
+        env = {"PATH": "/usr/bin:/bin"}
+        if token is not None:
+            env["CCT_BOT_TOKEN"] = token
+        if agent:
+            env["CCT_AGENT_ID"] = agent
+        proc = subprocess.Popen(
+            [str(self.bun), "run", str(self.script)],
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self._procs.append(proc)
+        self._await_exec(proc.pid)
+        (self.proc_root / str(proc.pid)).symlink_to(f"/proc/{proc.pid}")
+        return proc.pid
+
+    @staticmethod
+    def _await_exec(pid: int, timeout: float = 10.0) -> None:
+        """Block until the child's real cmdline names the poller script."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+            argv = [t for t in raw.decode("utf-8", "replace").split("\0") if t]
+            if is_poller_argv(argv):
+                return
+            time.sleep(0.02)
+        raise AssertionError(f"pid {pid} never exec'd into a poller-shaped argv")
+
+    def close(self) -> None:
+        for proc in self._procs:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+@pytest.fixture
+def farm(tmp_path):
+    """A live poller farm, torn down after the test."""
+    made = _PollerFarm(tmp_path)
+    try:
+        yield made
+    finally:
+        made.close()
+
+
+# ---------------------------------------------------------------------------
+# POSITIVE CONTROL — the fault, constructed with real processes
+# ---------------------------------------------------------------------------
+
+
+def test_two_real_pollers_on_one_token_is_a_violation(farm):
+    # Arrange — THE FAULT: a restart left the old poller alive and the new one
+    # started anyway, both on the same bot token.
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.state == POLLER_VIOLATION
+
+
+def test_the_violation_names_both_offending_pids(farm):
+    # Arrange
+    first = farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    second = farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert sorted(verdict.duplicates[0].pids) == sorted([first, second])
+
+
+def test_the_violation_names_the_shared_fingerprint(farm):
+    # Arrange
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.duplicates[0].token_fp.startswith("sha256:")
+
+
+def test_the_violation_names_the_owning_agent(farm):
+    # Arrange
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.duplicates[0].agents == ("scitex-agent-container",)
+
+
+def test_the_violation_carries_an_actionable_hint(farm):
+    # Arrange
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert "SIGKILL" in verdict.hint()
+
+
+def test_no_token_value_appears_in_the_violation_report(farm):
+    # Arrange — the whole report is serialised and searched for the secret.
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    # Act
+    blob = json.dumps(check_poller_singleton(proc_root=farm.proc_root).to_dict())
+    # Assert
+    assert _TOKEN_A not in blob and "AAHduplicate" not in blob
+
+
+# ---------------------------------------------------------------------------
+# The other three answers
+# ---------------------------------------------------------------------------
+
+
+def test_one_live_poller_is_ok(farm):
+    # Arrange
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.state == POLLER_OK
+
+
+def test_two_pollers_on_distinct_tokens_is_ok(farm):
+    # Arrange — two agents, two bots. The invariant is per TOKEN, not per host.
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token=_TOKEN_B, agent="scitex-cards")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.state == POLLER_OK
+
+
+def test_zero_live_pollers_is_ok(farm):
+    # Arrange — nothing spawned; the scan RAN and found none.
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.state == POLLER_OK
+
+
+def test_a_poller_with_no_readable_token_is_unknown(farm):
+    # Arrange — THE LOAD-BEARING NEGATIVE: a live poller sac cannot read a
+    # token for. Reporting OK here would be an all-clear from a blind check.
+    farm.spawn(token=None, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.state == POLLER_UNKNOWN
+
+
+def test_an_unresolved_poller_is_not_folded_into_ok(farm):
+    # Arrange — one readable poller alongside one unreadable one. The readable
+    # one alone would satisfy the invariant; the unreadable one could be its
+    # twin, so the honest answer is still unknown.
+    farm.spawn(token=_TOKEN_A, agent="scitex-agent-container")
+    farm.spawn(token=None, agent="")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.state == POLLER_UNKNOWN
+
+
+def test_the_unknown_verdict_names_the_unresolved_pid(farm):
+    # Arrange
+    blind = farm.spawn(token=None, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert verdict.unresolved_pids == (blind,)
+
+
+def test_the_unknown_verdict_carries_an_actionable_hint(farm):
+    # Arrange — this poller's environ IS readable and simply has no token, so
+    # the remedy is "find the process", NOT "re-run as another user".
+    farm.spawn(token=None, agent="scitex-agent-container")
+    # Act
+    verdict = check_poller_singleton(proc_root=farm.proc_root)
+    # Assert
+    assert "outside sac's env" in verdict.hint()
+
+
+def test_an_unreadable_environ_hint_names_the_vantage():
+    # Arrange — the OTHER unresolved reason. Sending a reader who hit a
+    # cross-uid /proc to "restart it through sac" wastes the one action they
+    # could have taken, so the two hints must differ.
+    pollers = [LivePoller(pid=7, token_fp=None, reason=UNRESOLVED_ENVIRON)]
+    # Act
+    verdict = verdict_for(pollers)
+    # Assert
+    assert "OWNER-ONLY" in verdict.hint()
+
+
+def test_an_unscannable_proc_root_is_unknown(tmp_path):
+    # Arrange — nobody looked. Zero pollers found this way is not zero pollers.
+    missing = tmp_path / "no-such-proc"
+    # Act
+    verdict = check_poller_singleton(proc_root=missing)
+    # Assert
+    assert verdict.state == POLLER_UNKNOWN
+
+
+def test_an_unscannable_proc_root_records_that_it_did_not_scan(tmp_path):
+    # Arrange
+    missing = tmp_path / "no-such-proc"
+    # Act
+    verdict = check_poller_singleton(proc_root=missing)
+    # Assert
+    assert verdict.scanned is False
+
+
+# ---------------------------------------------------------------------------
+# The decision, without a process
+# ---------------------------------------------------------------------------
+
+
+def test_a_violation_outranks_an_unresolved_poller():
+    # Arrange — an unread third process must not mute an observed duplicate.
+    pollers = [
+        LivePoller(pid=1, token_fp="sha256:aaaaaaaaaaaa"),
+        LivePoller(pid=2, token_fp="sha256:aaaaaaaaaaaa"),
+        LivePoller(pid=3, token_fp=None, detail="environ unreadable"),
+    ]
+    # Act
+    verdict = verdict_for(pollers)
+    # Assert
+    assert verdict.state == POLLER_VIOLATION
+
+
+def test_the_ok_verdict_carries_no_hint():
+    # Arrange
+    pollers = [LivePoller(pid=1, token_fp="sha256:aaaaaaaaaaaa")]
+    # Act
+    verdict = verdict_for(pollers)
+    # Assert
+    assert verdict.hint() == ""
+
+
+def test_the_invariant_is_stated_in_the_ok_detail():
+    # Arrange
+    pollers = [
+        LivePoller(pid=1, token_fp="sha256:aaaaaaaaaaaa"),
+        LivePoller(pid=2, token_fp="sha256:bbbbbbbbbbbb"),
+    ]
+    # Act
+    verdict = verdict_for(pollers)
+    # Assert
+    assert verdict.distinct_fingerprints == len(verdict.pollers)


### PR DESCRIPTION
## What this detects

**Is there more than one live Telegram poller per bot token on this host?**

`sac doctor --pollers` (and the default `sac doctor`, which now runs it
alongside the spec-source drift check):

1. enumerates the live poller processes — `bun run …/telegram-server.ts` —
   from `/proc`;
2. reads each one's `CCT_BOT_TOKEN` **from that process's own environment**
   and fingerprints it with the existing
   `_account._rotation_audit.fingerprint_token`;
3. asserts `count(distinct fingerprints) == count(live pollers)`.

A fingerprint held by two live pids is the fault. The report names both pids,
the fingerprint, and the owning agent where determinable.

The population is the **server** (`telegram-server.ts`), not a poller process,
and that is load-bearing: measured 2026-08-22, a host with a live token
conflict had *no poller process at all* — the rival holding the contended
token was a server. A server holding a real token is a poller-in-waiting, so a
poller census sees the fault only after it becomes one.

Measured on compute-04 (host vantage), reproducing an independently
hand-measured baseline exactly:

```
STATE: ok
POPULATION: 10 live server(s) examined, 4 real token(s),
            6 deliberately tokenless, 0 unreadable
  pid=122857   fp=sha256:00ec09b9ad73   agent=scitex-hub
  pid=227846   fp=sha256:dab4bf7b5a7a   agent=dotfiles
  pid=536543   fp=sha256:573dae4d4f5f   agent=scitex-agent-container
  pid=574160   fp=sha256:59680301e109   agent=handyman-06
  pid=17759 30738 35425 38132 49751 54322  reason=token-empty
```

Two independent probes agreeing on the same population validates the method,
not just the answer.

## Four defects a live run found, after the first commit

Reading the code did not surface these; running it on the host did.

1. **It returned `unknown` on a perfectly healthy host.** Six of the ten
   servers carry a `CCT_BOT_TOKEN` that is *present and empty* — the handyman
   family's spec empties it on purpose so several agents do not share one bot.
   Treating empty as absent made the fleet's healthy steady state report
   `unknown` every single run. A check that is never green gets muted, which
   is the gate-that-cannot-fail arriving from the other direction. An empty
   string is not a bot token, so such a process holds none and cannot be
   anyone's second consumer: it is excluded from the invariant and *reported*
   alongside it. The host verdict stays three-valued — `disabled` is a fact
   about a process, not about the host; with six disabled and a duplicate, the
   host is still in violation.
2. **A hint that was factually wrong.** Those six were described as "started
   outside sac's env". They were started *by* sac, from a sac spec — the hint
   sent the reader hunting a provisioning fault that does not exist. Empty and
   absent now say different, true things.
3. **It named the wrong agent** — the worst of the four, because a violation
   report exists to send someone to the offending agent:
   `pid 574160  CCT_AGENT_ID=handyman-01  SAC_NAME=handyman-06`. The same
   measurement rules out the obvious fix: the parent `claude` process carries
   the *same* wrong `CCT_AGENT_ID`, so reading the parent would have given the
   same wrong answer. The defect is which **key** is trusted. `CCT_AGENT_ID`
   is a Telegram identity and can differ from the agent; `SAC_NAME` is the
   agent, and agreed with the parent on all ten servers. `SAC_NAME` now leads.
4. **An unstated limit** — see the scope section below.

A zero also no longer stands alone: every verdict reports the population it
examined, so "0 violations across 0 examined" and "across 10" cannot render
the same.

## What this does NOT do

**It fixes and prevents nothing.** It never kills, signals, locks or reaps a
process, and it changes nothing about the start/stop path. There is no
singleton lock and no orphan reaper in this PR.

That is deliberate. The constitution requires a detector before a fix — *a fix
without a detector cannot be shown to have worked* — and the reaper is a
separate change that this makes verifiable. The detector also earns its place
alone: until now, the only way anyone learned of a 409 storm was an agent
happening to read its own log during an incident.

## The fault it observes

Restarting an agent's container does not reliably kill the previous
`bun run …/telegram-server.ts` poller — the container runtime leaves it
orphaned on the host. The next start spawns a second poller for the same bot
token. Telegram's `getUpdates` admits exactly one consumer per token, so both
enter a 409 conflict loop and the operator's inbound messages are dropped,
silently, from the only side that matters. Documented in
claude-code-telegrammer's `ts/lib/takeover.ts` since 2026-06-07 and never
instrumented.

## Three-valued, not boolean

| state | meaning |
|---|---|
| `ok` | every token-holding server holds a distinct token. Zero servers is `ok` — nothing can conflict. |
| `violation` | a fingerprint is held by two or more live pids. |
| `unknown` | a live server's token could not be read, **or** the scan itself could not run. |

Per **process** there is a fourth fact, `token-empty` (*disabled*): the
variable is present and deliberately blank, so that process holds no token,
cannot collide, and is excluded from the invariant while still being listed.
That is a property of a process, not of the host, which is why it does not
become a fourth host state.

`unknown` is never folded into `ok`. `/proc/<pid>/environ` is owner-only, so a
poller belonging to another uid is one whose token sac cannot read — and "I
could not read it" is not "there is no duplicate": the unread one could be the
twin of a read one. Likewise, zero pollers found because nobody looked is not
zero pollers. A `violation` outranks an `unknown`, so a single unreadable
process cannot mute an observed outage.

The two alarming states carry **different** hints, because they need different
actions: a violation is a live outage to end by hand (`ps` to find which pid is
the orphan, then SIGKILL it and re-run the check), an unknown is an unread
instrument whose vantage point must be fixed first (re-run as the uid owning
those pids). And the `unknown` hint splits further on *why* the token was
unresolved — an unreadable `environ` is a vantage problem, a readable one with
no `CCT_BOT_TOKEN` is a poller started outside sac's env.

## No token value, anywhere

The value goes straight from the process environment into the existing
`fingerprint_token` helper and is dropped. Only the opaque `sha256:<12hex>`
prefix is stored, returned, logged or printed — reusing the module
`_host_push_config` describes as "Only sha256 digests (12 chars) are ever
printed", rather than growing a second fingerprint function.

The verdict deliberately carries **no cmdline** either. sac never puts a token
on an argv, but a poller someone started by hand might, and a detector that
leaks the secret it is protecting is worse than none. A test serialises the
whole violation report and asserts the token string does not appear in it.

## Scope, stated in every result

This reads **one host's** `/proc`, and Telegram's one-consumer-per-token rule
is **global**. Measured 2026-08-22, fingerprint `00ec09b9ad73` was live on
compute-04 *and* compute-03 at once, and a per-host probe returned `ok` on
both while the fault was live across them. Fleet-wide scanning stays out of
scope for this PR (the brief is explicitly host-scoped), so every result
carries `scope: "host"` and a note saying so — an unstated limit is the same
defect as a wrong hint.

The PID-namespace version of the same trap is named in that note: run inside
an apptainer container with `--containall`, `/proc` shows only that
container's processes — one server where the host has ten — and the small
number reads exactly like a clean host. **Run it on the host.**

## The named trap

A plain `pgrep -f telegram-server` matches the searching shell itself, and a
detector that counts its own search as a poller invents the very duplicate it
exists to find. Excluding the current pid is not enough, since `pgrep`/`rg` run
as children carry the pattern too. So the match is anchored on `argv[0]`: a
poller *runs* the script, it does not talk about it. Both cases are pinned by
tests.

## Tests — including a real positive control

The load-bearing tests **construct the fault with real processes**: two live
processes spawned by the test, whose argv names `telegram-server.ts` and whose
environment carries the same `CCT_BOT_TOKEN`. That is the 409 condition, and
the check returns `violation` on it. A detector that has never returned a known
answer is not a measurement.

No mocks anywhere: real processes, the real `/proc`, the real reader. The only
thing the test controls is the *population* — it builds a scan root of symlinks
onto exactly the pids it spawned, so a live poller belonging to some other
agent on the host can neither hide a duplicate nor invent one. Scoping the
population is not faking the instrument.

Also covered against real spawned processes: one poller → `ok`; two pollers on
distinct tokens → `ok`; zero pollers → `ok`; a poller whose token cannot be
resolved → `unknown`, **not** `ok`; a readable poller alongside an unreadable
one → still `unknown`; a real token beside two deliberately-empty ones → `ok`
with both listed as disabled, **not** `unknown`; two empty-token servers →
**not** a duplicate (grouping on a deliberately blank field manufactures
collisions — six empty strings are six agents with no bot, not one agent with
six servers).

And the misattribution is pinned with the exact measured row:
`CCT_AGENT_ID=handyman-01` + `SAC_NAME=handyman-06` must resolve to
handyman-06.

## Operator directive this answers

Telegram 13379, 2026-08-22:

> ポーラーが ophan になってしまうことがあるんですかね。sac が持って置くべきで、
> sac のプロセスとかならず１対１対応するように制限しなくてはいけないような。

approved as 「１トークン１ポーラーですか、はい、お願いします。」

This PR delivers the *measurement* half of that directive. The ownership /
enforcement half is the follow-up.

## Behaviour change to flag

`sac doctor` with no flags now prints a second verdict and its `--json` output
gains a `pollers` key alongside the existing `local` key (additive; the `local`
shape is untouched). `--strict` now also exits non-zero on a `violation` or
`unknown` poller verdict — matching `sac agents cct-audit`, where an invariant
sac could not assert is not an invariant that held. Nothing in this repo's CI,
cron or systemd invokes `sac doctor --strict` today, so the blast radius of
that is a human running it by hand.

Card: `sac-poller-singleton-detector-20260822`
