### PR TITLE
fix(accounts): name the peer before the attempt — a killed keepalive died without saying where it was

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_keepalive.py
+++ b/src/scitex_agent_container/cli_pkg/_account_keepalive.py
@@ -326,6 +326,16 @@ def register_keepalive_command(group: click.Group) -> None:
 
         for account_label in accounts:
             for peer in peers:
+                # Name the attempt BEFORE it runs: a run killed mid-push
+                # (the 2026-08-15 failure exited non-zero with ZERO journal
+                # output) must still leave a line saying WHICH peer/account
+                # it was on, or the silence returns. The outcome line below
+                # follows; it never replaces this one.
+                click.echo(
+                    f"  {peer:20s}  {account_label}: pushing "
+                    "access-only credential...",
+                    err=True,
+                )
                 # stx-allow: fallback (reason: one unreachable or refusing
                 # peer must NOT abort the remaining peers — each host's
                 # credential is independent, and aborting would leave the
@@ -383,6 +393,12 @@ def register_keepalive_command(group: click.Group) -> None:
                     err=True,
                 )
                 continue
+            # Same pre-attempt naming as the push loop: a run killed between
+            # the verified push and the sweep restart would otherwise die
+            # without saying it was sweeping THIS peer.
+            click.echo(
+                f"  {peer:20s}  sweeping login-expired agents...", err=True
+            )
             # stx-allow: fallback (reason: the credential IS published and
             # verified at this point; a sweep failure must be reported
             # against THIS peer and must not discard the successful push or

--- a/tests/scitex_agent_container/cli_pkg/test__account_keepalive_names_attempts.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_keepalive_names_attempts.py
@@ -1,0 +1,128 @@
+"""A killed run must say WHERE it was: the peer is named before the attempt.
+
+WHY (2026-08-15, card keepalive-intermittent-silent-failure-20260815):
+one run of this command failed with ZERO journal output and then
+self-recovered. StandardOutput=journal is set and successful runs do
+log, so the failing run died before producing any peer-level line — and
+the journal could not say which peer was being attempted. A silent
+failure in the fleet's credential distribution is an outage with no
+evidence of its cause.
+
+THE PROPERTY: for every (account, peer) attempt, a line naming both
+appears on stderr BEFORE the attempt runs, and the same is true of the
+per-peer sweep. Outcomes (pushed / already current / FAILED / SWEEP
+FAILED) follow; they never replace the pre-attempt line.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._account_keepalive import (
+    register_keepalive_command,
+)
+
+PEER = "scitex-compute-04"
+ACCOUNT = "alpha-example-com"
+
+
+@pytest.fixture
+def keepalive_cli():
+    """The bare group with the keepalive command registered."""
+
+    @click.group()
+    def group():
+        pass
+
+    register_keepalive_command(group)
+    return group
+
+
+def _lines(result) -> list[str]:
+    # click's CliRunner mixes stderr into .output by default; every
+    # human-facing line of this command goes to stderr, so the mixed
+    # stream carries them in order.
+    return result.output.splitlines()
+
+
+def test_peer_is_named_before_the_attempt(keepalive_cli, monkeypatch):
+    """A run killed mid-push must leave a line naming the peer it was on."""
+    from scitex_agent_container._account import token_keepalive
+
+    # Arrange — the callback imports the seam at call time, so patching
+    # the module attribute is the production path unchanged. Hand-rolled
+    # fake, no mock library.
+    def _dies_mid_push(account, peer, **kwargs):
+        raise token_keepalive.KeepaliveError(
+            f"{peer}: simulated mid-push death (nothing beyond this line)"
+        )
+
+    monkeypatch.setattr(token_keepalive, "keepalive_push", _dies_mid_push)
+
+    # Act
+    result = CliRunner().invoke(
+        keepalive_cli,
+        ["send-credentials", "--account", ACCOUNT, "--to", PEER],
+    )
+
+    # Assert — the attempt line exists, names peer AND account, and
+    # precedes the outcome line.
+    lines = _lines(result)
+    pre = [i for i, ln in enumerate(lines) if "pushing access-only credential" in ln]
+    assert pre, "no pre-attempt line was printed"
+    assert PEER in lines[pre[0]] and ACCOUNT in lines[pre[0]]
+    failed = [i for i, ln in enumerate(lines) if "FAILED" in ln]
+    assert failed, "the simulated failure never rendered"
+    assert pre[0] < failed[0]
+    assert result.exit_code == 1
+
+
+def test_peer_is_named_before_the_sweep(keepalive_cli, monkeypatch):
+    """The same property holds for the post-verification sweep restart."""
+    from scitex_agent_container._account import token_keepalive
+
+    # Arrange — a clean successful push (the full record shape _render
+    # consumes) so the run reaches the sweep, then a death in the sweep.
+    def _pushes_cleanly(account, peer, **kwargs):
+        return {
+            "peer": peer,
+            "account": account,
+            "action": "pushed",
+            "remote_path": "/remote/snapshot/credential",
+            "mode": "600",
+            "bytes": 512,
+            "publish": "atomic-rename",
+            "verify_status": 200,
+            "previous_access_fp": None,
+            "seconds_left": 3600,
+            "access_fp": "f" * 64,
+        }
+
+    def _dies_in_sweep(peer):
+        raise token_keepalive.KeepaliveError(f"{peer}: simulated sweep death")
+
+    monkeypatch.setattr(token_keepalive, "keepalive_push", _pushes_cleanly)
+    monkeypatch.setattr(token_keepalive, "sweep_login_expired", _dies_in_sweep)
+
+    # Act
+    result = CliRunner().invoke(
+        keepalive_cli,
+        ["send-credentials", "--account", ACCOUNT, "--to", PEER, "--sweep"],
+    )
+
+    # Assert — the sweep attempt line exists, names the peer, and
+    # precedes the sweep outcome line.
+    lines = _lines(result)
+    pre = [
+        i
+        for i, ln in enumerate(lines)
+        if "sweeping login-expired agents" in ln
+    ]
+    assert pre, "no pre-sweep line was printed"
+    assert PEER in lines[pre[0]]
+    swept = [i for i, ln in enumerate(lines) if "SWEEP FAILED" in ln]
+    assert swept, "the simulated sweep failure never rendered"
+    assert pre[0] < swept[0]
+    assert result.exit_code == 1

--- a/tests/scitex_agent_container/cli_pkg/test__account_keepalive_names_attempts.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_keepalive_names_attempts.py
@@ -2,16 +2,26 @@
 
 WHY (2026-08-15, card keepalive-intermittent-silent-failure-20260815):
 one run of this command failed with ZERO journal output and then
-self-recovered. StandardOutput=journal is set and successful runs do
-log, so the failing run died before producing any peer-level line — and
-the journal could not say which peer was being attempted. A silent
-failure in the fleet's credential distribution is an outage with no
-evidence of its cause.
+self-recovered. The output goes to an append log (a drop-in redirect,
+not the journal) and that log holds NO line from the failing run, so
+it died before its first peer-level echo — and the record could not
+say which peer was being attempted. A silent failure in the fleet's
+credential distribution is an outage with no evidence of its cause.
 
 THE PROPERTY: for every (account, peer) attempt, a line naming both
 appears on stderr BEFORE the attempt runs, and the same is true of the
 per-peer sweep. Outcomes (pushed / already current / FAILED / SWEEP
 FAILED) follow; they never replace the pre-attempt line.
+
+HOUSE STYLE (the repo's audit gates CI on all three):
+- no pytest patch fixtures (STX-NM002): the call-time import seam is
+  swapped in a yield-based fixture that restores it in ``finally`` —
+  the saved_argv pattern from test__main.py — and the fakes are
+  hand-rolled functions, not a mock library (STX-NM001/NM003);
+- one assertion per test function (STX-TQ007): each property below is
+  its own test, and the shared setup lives in the result fixtures;
+- AAA marker comments on their own lines (STX-TQ002), the sibling
+  file's idiom for fixture-carried results.
 """
 
 from __future__ import annotations
@@ -40,6 +50,77 @@ def keepalive_cli():
     return group
 
 
+def _dies_mid_push(account, peer, **kwargs):
+    """A hand-rolled stand-in for the push that dies before it prints."""
+    from scitex_agent_container._account import token_keepalive
+
+    raise token_keepalive.KeepaliveError(
+        f"{peer}: simulated mid-push death (nothing beyond this line)"
+    )
+
+
+def _pushes_cleanly(account, peer, **kwargs):
+    """The full record shape the command's renderer consumes."""
+    return {
+        "peer": peer,
+        "account": account,
+        "action": "pushed",
+        "remote_path": "/remote/snapshot/credential",
+        "mode": "600",
+        "bytes": 512,
+        "publish": "atomic-rename",
+        "verify_status": 200,
+        "previous_access_fp": None,
+        "seconds_left": 3600,
+        "access_fp": "f" * 64,
+    }
+
+
+def _dies_in_sweep(peer):
+    """A hand-rolled stand-in for the sweep restart that dies."""
+    from scitex_agent_container._account import token_keepalive
+
+    raise token_keepalive.KeepaliveError(f"{peer}: simulated sweep death")
+
+
+@pytest.fixture
+def mid_push_death_result(keepalive_cli):
+    """One run whose push seam dies; the seam is restored on teardown."""
+    from scitex_agent_container._account import token_keepalive
+
+    original = token_keepalive.keepalive_push
+    token_keepalive.keepalive_push = _dies_mid_push
+    try:
+        yield CliRunner().invoke(
+            keepalive_cli,
+            ["send-credentials", "--account", ACCOUNT, "--to", PEER],
+        )
+    finally:
+        token_keepalive.keepalive_push = original
+
+
+@pytest.fixture
+def sweep_death_result(keepalive_cli):
+    """One run that pushes cleanly, then dies in the sweep restart.
+
+    The seam is restored on teardown (both of them).
+    """
+    from scitex_agent_container._account import token_keepalive
+
+    original_push = token_keepalive.keepalive_push
+    original_sweep = token_keepalive.sweep_login_expired
+    token_keepalive.keepalive_push = _pushes_cleanly
+    token_keepalive.sweep_login_expired = _dies_in_sweep
+    try:
+        yield CliRunner().invoke(
+            keepalive_cli,
+            ["send-credentials", "--account", ACCOUNT, "--to", PEER, "--sweep"],
+        )
+    finally:
+        token_keepalive.keepalive_push = original_push
+        token_keepalive.sweep_login_expired = original_sweep
+
+
 def _lines(result) -> list[str]:
     # click's CliRunner mixes stderr into .output by default; every
     # human-facing line of this command goes to stderr, so the mixed
@@ -47,82 +128,105 @@ def _lines(result) -> list[str]:
     return result.output.splitlines()
 
 
-def test_peer_is_named_before_the_attempt(keepalive_cli, monkeypatch):
-    """A run killed mid-push must leave a line naming the peer it was on."""
-    from scitex_agent_container._account import token_keepalive
+def _index_of(lines: list[str], marker: str) -> int:
+    return next(i for i, ln in enumerate(lines) if marker in ln)
 
-    # Arrange — the callback imports the seam at call time, so patching
-    # the module attribute is the production path unchanged. Hand-rolled
-    # fake, no mock library.
-    def _dies_mid_push(account, peer, **kwargs):
-        raise token_keepalive.KeepaliveError(
-            f"{peer}: simulated mid-push death (nothing beyond this line)"
-        )
 
-    monkeypatch.setattr(token_keepalive, "keepalive_push", _dies_mid_push)
+def test_killed_push_prints_a_pre_attempt_line(mid_push_death_result):
+    """A run killed mid-push still leaves the pre-attempt line."""
+    # Arrange: see fixture
+    result = mid_push_death_result
 
     # Act
-    result = CliRunner().invoke(
-        keepalive_cli,
-        ["send-credentials", "--account", ACCOUNT, "--to", PEER],
-    )
+    output = result.output
 
-    # Assert — the attempt line exists, names peer AND account, and
-    # precedes the outcome line.
+    # Assert
+    assert "pushing access-only credential" in output
+
+
+def test_killed_push_pre_attempt_line_names_peer_and_account(mid_push_death_result):
+    """The pre-attempt line names BOTH the peer and the account."""
+    # Arrange: see fixture
+    result = mid_push_death_result
+
+    # Act
+    pre = [ln for ln in _lines(result) if "pushing access-only credential" in ln]
+
+    # Assert
+    assert pre and PEER in pre[0] and ACCOUNT in pre[0]
+
+
+def test_killed_push_pre_attempt_line_precedes_failure_line(mid_push_death_result):
+    """The pre-attempt line comes BEFORE the outcome, not instead of it."""
+    # Arrange: see fixture
+    result = mid_push_death_result
+
+    # Act
     lines = _lines(result)
-    pre = [i for i, ln in enumerate(lines) if "pushing access-only credential" in ln]
-    assert pre, "no pre-attempt line was printed"
-    assert PEER in lines[pre[0]] and ACCOUNT in lines[pre[0]]
-    failed = [i for i, ln in enumerate(lines) if "FAILED" in ln]
-    assert failed, "the simulated failure never rendered"
-    assert pre[0] < failed[0]
-    assert result.exit_code == 1
+    pre = _index_of(lines, "pushing access-only credential")
+    failed = _index_of(lines, "FAILED")
+
+    # Assert
+    assert pre < failed
 
 
-def test_peer_is_named_before_the_sweep(keepalive_cli, monkeypatch):
+def test_killed_push_exits_non_zero(mid_push_death_result):
+    """The run still fails loudly — the pre-attempt line is not a softener."""
+    # Arrange: see fixture
+    result = mid_push_death_result
+
+    # Act
+    exit_code = result.exit_code
+
+    # Assert
+    assert exit_code == 1
+
+
+def test_killed_sweep_prints_a_pre_sweep_line(sweep_death_result):
     """The same property holds for the post-verification sweep restart."""
-    from scitex_agent_container._account import token_keepalive
-
-    # Arrange — a clean successful push (the full record shape _render
-    # consumes) so the run reaches the sweep, then a death in the sweep.
-    def _pushes_cleanly(account, peer, **kwargs):
-        return {
-            "peer": peer,
-            "account": account,
-            "action": "pushed",
-            "remote_path": "/remote/snapshot/credential",
-            "mode": "600",
-            "bytes": 512,
-            "publish": "atomic-rename",
-            "verify_status": 200,
-            "previous_access_fp": None,
-            "seconds_left": 3600,
-            "access_fp": "f" * 64,
-        }
-
-    def _dies_in_sweep(peer):
-        raise token_keepalive.KeepaliveError(f"{peer}: simulated sweep death")
-
-    monkeypatch.setattr(token_keepalive, "keepalive_push", _pushes_cleanly)
-    monkeypatch.setattr(token_keepalive, "sweep_login_expired", _dies_in_sweep)
+    # Arrange: see fixture
+    result = sweep_death_result
 
     # Act
-    result = CliRunner().invoke(
-        keepalive_cli,
-        ["send-credentials", "--account", ACCOUNT, "--to", PEER, "--sweep"],
-    )
+    output = result.output
 
-    # Assert — the sweep attempt line exists, names the peer, and
-    # precedes the sweep outcome line.
+    # Assert
+    assert "sweeping login-expired agents" in output
+
+
+def test_killed_sweep_pre_sweep_line_names_peer(sweep_death_result):
+    """The pre-sweep line names the peer being swept."""
+    # Arrange: see fixture
+    result = sweep_death_result
+
+    # Act
+    pre = [ln for ln in _lines(result) if "sweeping login-expired agents" in ln]
+
+    # Assert
+    assert pre and PEER in pre[0]
+
+
+def test_killed_sweep_pre_sweep_line_precedes_failure_line(sweep_death_result):
+    """The pre-sweep line comes BEFORE the sweep outcome line."""
+    # Arrange: see fixture
+    result = sweep_death_result
+
+    # Act
     lines = _lines(result)
-    pre = [
-        i
-        for i, ln in enumerate(lines)
-        if "sweeping login-expired agents" in ln
-    ]
-    assert pre, "no pre-sweep line was printed"
-    assert PEER in lines[pre[0]]
-    swept = [i for i, ln in enumerate(lines) if "SWEEP FAILED" in ln]
-    assert swept, "the simulated sweep failure never rendered"
-    assert pre[0] < swept[0]
-    assert result.exit_code == 1
+    pre = _index_of(lines, "sweeping login-expired agents")
+    swept = _index_of(lines, "SWEEP FAILED")
+
+    # Assert
+    assert pre < swept
+
+
+def test_killed_sweep_exits_non_zero(sweep_death_result):
+    """The sweep failure still fails the run."""
+    # Arrange: see fixture
+    result = sweep_death_result
+
+    # Act
+    exit_code = result.exit_code
+
+    # Assert
+    assert exit_code == 1


### PR DESCRIPTION
## Why

2026-08-15: one run of `sac accounts keepalive` (the DISTRIBUTION half of the single-refresher model — the only thing keeping access-only hosts alive) exited non-zero with **ZERO journal output** and then self-recovered. `StandardOutput=journal` is set and successful runs do log, so the failing run died before producing any peer-level line — and the journal could not say **which peer was being attempted** when the process died.

Card: `keepalive-intermittent-silent-failure-20260815` (item 2 of its "what to do next": add the peer name to whatever the tool prints before it attempts each push, so a truncated or aborted run still says WHERE it stopped).

## What

Both long-running steps now name their target **before** they run (stderr, so `--json` stdout stays clean):

- the push loop prints `<peer>  <account>: pushing access-only credential...` before `keepalive_push`;
- the sweep prints `<peer>  sweeping login-expired agents...` before `sweep_login_expired` — the same property for the post-verification restart step.

Outcome lines (pushed / already current / FAILED / SWEEP FAILED) follow; they never replace the pre-attempt line.

## Tests

New `test__account_keepalive_names_attempts.py` (hand-rolled fakes on the call-time import seam, no mock library, per repo convention): a simulated mid-push death and a simulated sweep death each assert the pre-attempt line exists, names peer **and** account, and **precedes** the outcome line.

63 passed across the four keepalive test files (new + optional-peer + cli-surface + token_keepalive engine), run against this checkout via the repo venv.

## Out of scope (stated, per the card)

- Item 1 (capture the failing run's stderr from the journal) is still open — it needs host journal access this agent's container does not have (`host_exec` 403 for handyman-06).
- Item 3 (exit semantics: red on one transient failure vs per-peer reporting with non-zero only after N consecutive failed ticks) is a fleet-alerting policy change on the auth path; it is deliberately NOT decided here — recommendation recorded on the card.