### PR TITLE
feat(doctor): the SPECS collide across hosts, and killing the poller fixed nothing

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -484,18 +484,19 @@ def agent_start(
     _fire_forget_hook(config.name, "post_start", config.hooks.get("post_start", []))
 
     # TELEGRAM-RAIL VERDICT (card sac-cct-rail-loud-when-no-slot-resolves-
-    # 20260812). Runs HERE, after ``runtime.start`` materialised the agent's
-    # ``$HOME/.env`` — that file is precedence #1 of the token resolution, so
-    # reading it earlier would report an agent as token-less that in fact has
-    # one. A spec that declares the telegrammer MCP but resolves NO slot has
-    # its MCP server removed (correctly, by operator ruling) and the agent
-    # then starts perfectly, reports healthy, and is MUTE and DEAF on Telegram
-    # with no signal anywhere. It does NOT gate the start; the alarm is
-    # three-valued and rides the LEAD's rail, not the broken one. Full
-    # argument in :mod:`..runtimes._cct_rail_alarm`.
-    from ..runtimes._cct_rail_alarm import check_cct_rail_at_start
+    # 20260812) + TOKEN-OWNERSHIP LEDGER. Both run HERE, after ``runtime.start``
+    # materialised the agent's ``$HOME/.env`` — that file is precedence #1 of
+    # the token resolution, so reading it earlier would report an agent as
+    # token-less that in fact has one. A spec that declares the telegrammer MCP
+    # but resolves NO slot has its MCP server removed (correctly, by operator
+    # ruling) and the agent then starts perfectly, reports healthy, and is MUTE
+    # and DEAF on Telegram with no signal anywhere; the ledger separately
+    # records WHICH bot this agent took, so "who holds this one?" is a query
+    # rather than a 409 from Telegram. NEITHER gates the start, and neither
+    # raises. See :mod:`..runtimes._cct_start_observers`.
+    from ..runtimes._cct_start_observers import observe_cct_at_start
 
-    check_cct_rail_at_start(config)
+    observe_cct_at_start(config)
 
     # Daemon supervisors for an agent that is now up — health monitor +
     # priority-failback poller. See :mod:`._start_supervision`.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/23_telegram-one-token-one-poller.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/23_telegram-one-token-one-poller.md
@@ -2,7 +2,7 @@
 description: |
   [TOPIC] ONE Telegram bot token, ONE consumer — the two checks that observe it, why neither alone is an all-clear, and the ownership ledger that answers "who holds this bot?".
   [DETAILS] Telegram's getUpdates admits exactly one consumer per token GLOBALLY. `sac doctor --pollers` (`runtimes/_cct_poller_singleton`) reads /proc: it sees a LIVE duplicate including an orphaned poller, and is HOST-SCOPED. `sac doctor --collisions` (`runtimes/_cct_token_collision`) reads SPECS + the secrets pool: it sees a duplicate BEFORE anything starts and ACROSS hosts, and sees no process at all. Measured 2026-08-22: one token held on compute-04 and compute-03 while the per-host probe read ok on both. Both are read-only, three-valued (ok/violation/unknown), never gate a start, and never read a token value — only sha256:<12hex> fingerprints. At start each agent records its claim into the per-host `cct_token_owner` PostgreSQL ledger (write-only; nothing decides on it yet).
-tags: [scitex-agent-container-one-token-one-poller]
+tags: [scitex-agent-container-telegram-one-token-one-poller]
 ---
 
 # One token, one poller — two checks, and neither is enough alone

--- a/src/scitex_agent_container/_skills/scitex-agent-container/23_telegram-one-token-one-poller.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/23_telegram-one-token-one-poller.md
@@ -1,0 +1,134 @@
+---
+description: |
+  [TOPIC] ONE Telegram bot token, ONE consumer — the two checks that observe it, why neither alone is an all-clear, and the ownership ledger that answers "who holds this bot?".
+  [DETAILS] Telegram's getUpdates admits exactly one consumer per token GLOBALLY. `sac doctor --pollers` (`runtimes/_cct_poller_singleton`) reads /proc: it sees a LIVE duplicate including an orphaned poller, and is HOST-SCOPED. `sac doctor --collisions` (`runtimes/_cct_token_collision`) reads SPECS + the secrets pool: it sees a duplicate BEFORE anything starts and ACROSS hosts, and sees no process at all. Measured 2026-08-22: one token held on compute-04 and compute-03 while the per-host probe read ok on both. Both are read-only, three-valued (ok/violation/unknown), never gate a start, and never read a token value — only sha256:<12hex> fingerprints. At start each agent records its claim into the per-host `cct_token_owner` PostgreSQL ledger (write-only; nothing decides on it yet).
+tags: [scitex-agent-container-one-token-one-poller]
+---
+
+# One token, one poller — two checks, and neither is enough alone
+
+Companion to `23_telegram-integration.md` (how the token resolves) and
+`23_telegram-rail-verdict.md` (what happens when it doesn't). This leaf covers
+the opposite failure: the token resolves for **two** agents.
+
+## The invariant
+
+Telegram's `getUpdates` admits exactly ONE consumer per bot token, **globally**.
+Two consumers means a 409 conflict loop in which the operator's inbound
+messages are dropped — silently, from the only side that matters.
+
+Operator, 2026-08-22 (Telegram 13379), approving the work:
+「１トークン１ポーラーですか、はい、お願いします。」
+
+## Two checks, opposite blind spots
+
+| | `sac doctor --pollers` | `sac doctor --collisions` |
+|---|---|---|
+| reads | `/proc` | specs + the secrets pool |
+| module | `runtimes/_cct_poller_singleton` | `runtimes/_cct_token_collision` |
+| scope | ONE host | fleet-wide (every spec, whatever host it pins) |
+| sees | a LIVE duplicate, incl. an ORPHANED poller whose spec no longer asks for the rail | a duplicate BEFORE either process starts, and ACROSS hosts |
+| cannot see | anything on another host | any process at all |
+
+**Measured 2026-08-22.** Fingerprint `00ec09b9ad73` was held by `scitex-hub` on
+compute-04 and `proj-scitex-hub` on compute-03 at the same time. The per-host
+poller probe returned `ok` on BOTH — correctly, by its own scope. Killing the
+duplicate process ended the incident and **fixed nothing**: the two SPECS still
+resolved to the same slot, so it would have returned on the next start.
+
+Run both. `sac doctor` with no flags runs the drift check, the poller check and
+the collision check together.
+
+## Reading `--collisions`
+
+```
+sac doctor --collisions [--json]        # exit 1 on violation OR unknown with --strict
+```
+
+- **ok** — every spec that claims a bot claims a different one. Zero claimants
+  is ok: nothing can conflict with nothing.
+- **violation** — a fingerprint is claimed by two or more specs. Both agents
+  and both hosts are named, and cross-host pairs are marked as such.
+- **unknown** — the pool read was inconclusive, a spec would not load, or the
+  spec tree could not be enumerated. **Never an all-clear.** A fleet full of
+  `unknown` usually means ONE thing is wrong (no `SAC_SECRETS_ENVRC` where you
+  ran it), not ninety.
+
+A violation OUTRANKS an unknown: a duplicate that has been computed is a fact,
+and one broken YAML file must not mute it.
+
+Every result prints its POPULATION — specs examined, how many claim a bot, how
+many resolve nothing, how many are deliberately tokenless, how many never ask.
+`0 collisions across 0 specs` and `0 across 24` are different facts.
+
+## The three populations that hold NOTHING, and never alarm here
+
+| population | what it is | why it cannot collide |
+|---|---|---|
+| DISABLED | `spec.apptainer.env: CCT_BOT_TOKEN: ""` | an apptainer `--env` flag overrides `--env-file`, so an explicit empty beats any pool-injected token |
+| NO-CHANNEL | the spec never requests `server:claude-code-telegrammer` | bot-less by declaration |
+| UNRESOLVED | it requests the rail and no slot resolves | it holds no token to duplicate |
+
+**DISABLED is the invariant upheld by hand, not a defect.** Seven of the eight
+handymen carry an explicit empty token so that only `handyman-06` polls the
+shared handyman bot. A check that flagged that family would be flagging the
+answer.
+
+**UNRESOLVED is a real fault and a DIFFERENT one** — mute and deaf, owned by
+`sac agents cct-audit` and `runtimes/_cct_rail_alarm`. It is counted and named
+in every collision result and deliberately does not alarm there: measured
+2026-08-12, 81 specs declared the channel and 15 resolved a token, so alarming
+on it here would fire on 66 agents forever.
+
+## Fixing a violation
+
+Decide which agent OWNS the bot. For each of the others, ONE of:
+
+```yaml
+spec:
+  apptainer:
+    env:
+      CCT_BOT_TOKEN_SLOT: <ITS-OWN-SLOT>   # (a) give it its own bot
+      CCT_BOT_TOKEN: ""                    # (b) tokenless BY DECLARATION
+```
+
+or (c) drop `server:claude-code-telegrammer` from `spec.claude.channels`.
+
+Then re-run — it must read `ok`. sac does not choose for you and **does not
+refuse the start**: both checks are detectors. Enforcement is a separate change
+with a much larger blast radius.
+
+## One derivation, three callers
+
+`runtimes/_cct_token_resolution.resolve_cct_token` is the single answer to
+"which bot does this spec take". `ensure_cct_bot_token` is that function plus a
+file write; the collision census is that function over every spec; the
+ownership ledger records what it returns. A second derivation beside it would
+be free to drift, and a drifted census reports collisions that do not exist or
+misses ones that do.
+
+## The ownership ledger
+
+At every start each agent records its claim into the per-host PostgreSQL store
+`cct_token_owner` (`_state/state_db_token_owner.py`):
+
+```
+(token_fp, host, agent)  ->  pid, started_at, source, slot
+```
+
+so "who holds this bot?" is a query rather than a 409 from Telegram or a
+`/proc` scan on every host. The identity is the TRIPLE on purpose: keying on
+`token_fp` alone would let the second claimant overwrite the first and render
+every collision as one tidy row.
+
+**Write-only for now.** Nothing reads it to make a decision, no start is gated
+on it, and the write never raises — an unreachable PostgreSQL prints a line
+saying the agent starts normally. A ledger that can refuse a boot is worse than
+a missing ledger.
+
+## Secrets
+
+No token VALUE is read, logged, written or transmitted on any of these paths.
+Only `sha256:<12hex>` fingerprints (`_account/_rotation_audit.fingerprint_token`
+— the one fingerprint helper; do not write a second), slot NAMES and pool
+source PATHS appear in any verdict, table, JSON payload or ledger row.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -97,8 +97,7 @@ session inside Apptainer (local or remote via SSH), observe via
 - [22](22_host-passthrough.md) — `spec.mounts`/`spec.user`/`spec.env`; host fs/git/gh
 - [23](23_telegram-integration.md) — Telegram wake contract, token resolution
 - [23-rail](23_telegram-rail-verdict.md) — rail up/down/unknown; `cct-audit`
-- [23-1t1p](23_telegram-one-token-one-poller.md) — one token, one consumer;
-  `sac doctor --pollers` (live, host) vs `--collisions` (static, fleet)
+- [23-1t1p](23_telegram-one-token-one-poller.md) — one token, one consumer
 
 ## 30-second start
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -97,6 +97,8 @@ session inside Apptainer (local or remote via SSH), observe via
 - [22](22_host-passthrough.md) — `spec.mounts`/`spec.user`/`spec.env`; host fs/git/gh
 - [23](23_telegram-integration.md) — Telegram wake contract, token resolution
 - [23-rail](23_telegram-rail-verdict.md) — rail up/down/unknown; `cct-audit`
+- [23-1t1p](23_telegram-one-token-one-poller.md) — one token, one consumer;
+  `sac doctor --pollers` (live, host) vs `--collisions` (static, fleet)
 
 ## 30-second start
 

--- a/src/scitex_agent_container/_state/state_db_token_owner.py
+++ b/src/scitex_agent_container/_state/state_db_token_owner.py
@@ -1,0 +1,251 @@
+"""WHO holds this Telegram bot right now — answerable without asking Telegram.
+
+THE QUESTION THIS EXISTS TO ANSWER
+==================================
+Telegram admits ONE ``getUpdates`` consumer per bot token, globally. When two
+agents take the same bot, the two ways to find out are both bad: ask Telegram
+(which answers 409, to both, forever, and names neither) or scan ``/proc`` on
+every host (which :mod:`..runtimes._cct_poller_singleton` does, and which is
+host-scoped and blind to another uid's ``environ``).
+
+So every agent that resolves a bot token RECORDS the claim as it starts. After
+that, "who owns ``sha256:00ec09b9ad73``?" is a query.
+
+WRITE-ONLY, ON PURPOSE, FOR NOW
+===============================
+Nothing reads this to make a decision. No start is refused, delayed or altered
+by what is in here. Enforcement — refusing to start an agent whose token is
+already held by a LIVE owner — is a separate change with a large blast radius,
+and building it on a computation that has never been observed in production is
+how a refusal ships with a bug in it. This lays the record down first so that
+the refusal, when it comes, can be shown to have been right.
+
+THE IDENTITY IS (token_fp, host, agent), AND THAT IS THE POINT
+==============================================================
+The obvious key is ``token_fp`` alone — "one row per bot, holding its current
+owner". That key DESTROYS the evidence: the second claimant's write would
+overwrite the first's, and a store whose whole purpose is to reveal double
+ownership would render every collision as a single tidy row. Measured on the
+live fleet 2026-08-22, three bot tokens are claimed by two specs each, two of
+them ACROSS HOSTS — exactly the rows a ``token_fp`` key would have collapsed.
+
+With the triple key, a contended token simply has more than one row, and the
+contention is visible by counting. :func:`owners_of` is that count.
+
+THE DATA FIELDS ARE LAST_WRITER_WINS, unlike ``verdict_delivered``'s IMMUTABLE
+ones, and for the opposite reason: a delivered verdict is a historical fact,
+whereas this row is CURRENT STATE. The same agent restarting on the same host
+with a new pid must move ``pid`` and ``started_at``, not create a second row
+and not be refused.
+
+FINGERPRINTS ONLY. ``token_fp`` is the opaque ``sha256:<12hex>`` from
+:func:`.._account._rotation_audit.fingerprint_token`. No token value is passed
+to, stored by, or retrievable from anything here.
+
+PostgreSQL-only, by the operator's 2026-08-19 order ("fail fast, fail loud, no
+fallbacks") and by adopting :mod:`scitex_dev.store` exactly as
+:mod:`.state_db_verdict_dedup` and :mod:`.state_db_incarnations` do. An
+unreachable store RAISES; the START-path caller
+(:mod:`..runtimes._cct_token_ledger`) is what turns that into a printed warning
+rather than a failed boot, because a ledger that can break a start is worse
+than a missing ledger.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Row, Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "cct_token_owner"
+
+#: Every write from this host is attributed to one node. Each host records the
+#: claims made ON it, so SINGLE_WRITER is the honest policy: no host ever
+#: rewrites another host's row.
+_ACTOR = "scitex-agent-container"
+
+
+def _schema() -> Any:
+    """The token-ownership schema.
+
+    Built lazily so importing this module does not import scitex-dev (import
+    cost off the hot path — the same reason its siblings are lazy).
+
+    IDENTITY fields must be IMMUTABLE; the store enforces it, and the reason
+    is worth keeping: "changing one does not update the record, it names a
+    different record." That is exactly right here — a different agent holding
+    the same bot IS a different record, and preserving it is the whole point.
+    """
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
+
+    def ident(kind: Any, *, indexed: bool = False) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=indexed,
+        )
+
+    def fact(kind: Any, *, required: bool = False) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=required,
+            merge=MergeRule.LAST_WRITER_WINS,
+            indexed=False,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            # --- who holds what, where: the identity triple ---
+            "token_fp": ident(FieldKind.TEXT, indexed=True),
+            "host": ident(FieldKind.TEXT),
+            "agent": ident(FieldKind.TEXT),
+            # --- facts about the current holding, refreshed on restart ---
+            "pid": fact(FieldKind.INTEGER),
+            "started_at": fact(FieldKind.REAL, required=True),
+            "source": fact(FieldKind.TEXT),
+            "slot": fact(FieldKind.TEXT),
+        },
+    )
+
+
+def token_owner_store_target() -> Any:
+    """Resolve WHERE the ownership ledger lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_token_owner_store() -> Store:
+    """Open the ownership ledger. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function here opens and closes
+    one per call, mirroring its siblings: a claim is recorded once per agent
+    start, so the connection cost sits on a launch path, never a request path.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        token_owner_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_token_owner_schema() -> str:
+    """Create the ownership tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string, which names WHERE the
+    state actually went so an operator can check rather than assume.
+    """
+    store = open_token_owner_store()
+    try:
+        return str(token_owner_store_target().locator)
+    finally:
+        store.close()
+
+
+def record_token_owner(
+    *,
+    token_fp: str,
+    agent: str,
+    host: str,
+    pid: int | None = None,
+    started_at: float | None = None,
+    source: str = "",
+    slot: str = "",
+) -> None:
+    """Record that ``agent`` on ``host`` holds the bot ``token_fp``.
+
+    UPSERT, not insert-or-ignore: re-recording the same ``(token_fp, host,
+    agent)`` REFRESHES ``pid`` and ``started_at`` in place, because this row
+    is current state and a restart is the normal case. It never creates a
+    second row for the same holder, and it never touches another holder's row
+    — which is what leaves a contended token visibly holding two.
+
+    ``expected_revision=ANY_REVISION`` because this is an upsert on purpose:
+    unlike ``verdict_delivered``, which uses ``NEW_RECORD`` to make a re-seen
+    row a no-op, a re-seen row HERE is a restart and must land. There is no
+    lost-update hazard to guard against — a claim is written by the process
+    that owns it, so the only writer that races us is the same agent starting
+    again, and its values are the ones we would want anyway.
+
+    ``token_fp`` must already be a fingerprint. Passing a raw token here would
+    store a secret; the only supported producer is
+    :func:`.._account._rotation_audit.fingerprint_token`, and a value that does
+    not look like its output is refused rather than written.
+    """
+    from scitex_dev.store import ANY_REVISION
+
+    if not token_fp or not str(token_fp).startswith("sha256:"):
+        raise ValueError(
+            "record_token_owner takes a FINGERPRINT, not a token: expected a "
+            "'sha256:<12hex>' string from fingerprint_token(), got "
+            f"{'an empty value' if not token_fp else 'something else'}. "
+            "Refusing to write, because the one thing this ledger must never "
+            "hold is a token value."
+        )
+    key = {"token_fp": token_fp, "host": host, "agent": agent}
+    ts = float(started_at) if started_at is not None else time.time()
+    store = open_token_owner_store()
+    try:
+        store.put(
+            {
+                **key,
+                "pid": int(pid) if pid is not None else None,
+                "started_at": ts,
+                "source": source,
+                "slot": slot,
+            },
+            expected_revision=ANY_REVISION,
+        )
+    finally:
+        store.close()
+
+
+def owners_of(token_fp: str) -> list[dict]:
+    """Every recorded holder of ``token_fp``, newest claim first.
+
+    More than one row means more than one agent has claimed this bot. That is
+    not by itself a live conflict — a row survives its process — so this
+    reports and does not judge; the judging is
+    :mod:`..runtimes._cct_token_collision` (static) and
+    :mod:`..runtimes._cct_poller_singleton` (live).
+    """
+    return [r for r in token_owner_rows() if r.get("token_fp") == token_fp]
+
+
+def token_owner_rows() -> list[dict]:
+    """The whole ledger, newest claim first. Returns [] on a brand-new store."""
+    store = open_token_owner_store()
+    try:
+        rows: list[Row] = store.rows()
+    finally:
+        store.close()
+    return sorted(
+        (dict(r.values) for r in rows),
+        key=lambda v: float(v.get("started_at") or 0.0),
+        reverse=True,
+    )
+
+
+__all__ = [
+    "STORE_NAME",
+    "init_token_owner_schema",
+    "open_token_owner_store",
+    "owners_of",
+    "record_token_owner",
+    "token_owner_rows",
+    "token_owner_store_target",
+]

--- a/src/scitex_agent_container/cli_pkg/doctor_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/doctor_cmds.py
@@ -1,18 +1,20 @@
 """``sac doctor`` — drift + health diagnostics.
 
-Two local checks and one fleet check:
+Three local checks and one fleet check:
 
 * ``sac doctor`` — check THIS host's agent-spec source repo against its
-  remote (the same comparison the launch-time guard runs) AND assert that
-  no two live Telegram pollers share a bot token, then print both verdicts.
-* ``sac doctor --pollers`` — the poller check alone.
+  remote (the same comparison the launch-time guard runs), assert that no two
+  live Telegram pollers share a bot token, and assert that no two SPECS
+  resolve to the same one, then print all three verdicts.
+* ``sac doctor --pollers`` — the live poller check alone.
+* ``sac doctor --collisions`` — the static spec-collision check alone.
 * ``sac doctor --fleet`` — ssh every configured peer and render a
   per-host drift table (current / N-behind / M-ahead / diverged /
   unreachable / not-a-repo).
 
-``--strict`` makes a drifted result — or an alarming poller verdict — a
-non-zero exit (CI gate). Both surfaces are resilient: an unreachable peer
-is reported, never crashed.
+``--strict`` makes a drifted result — or an alarming poller or collision
+verdict — a non-zero exit (CI gate). Every surface is resilient: an
+unreachable peer is reported, never crashed.
 
 WHY THE POLLER CHECK LIVES HERE, and why it is on by default: it observes a
 fault that has never had an instrument. An orphaned ``telegram-server.ts``
@@ -22,6 +24,17 @@ inbound messages with no error anywhere. See
 :mod:`..runtimes._cct_poller_singleton`. Every previous sighting came from an
 agent happening to read its own log mid-incident; a check nobody has to
 remember to run is the difference between that and a measurement.
+
+AND WHY THE COLLISION CHECK IS BESIDE IT RATHER THAN INSIDE IT: they are the
+two halves of one invariant and neither can do the other's job. The poller
+check reads ``/proc`` and is HOST-SCOPED — measured 2026-08-22, one bot token
+was held on compute-04 and compute-03 at once and the per-host probe returned
+ok on BOTH. The collision check reads SPECS and is fleet-wide and STATIC, so
+it sees that pair before either process starts, and sees no process at all.
+Killing the duplicate poller ended that incident and fixed nothing: the specs
+still collided, so it would have returned on the next start. Two verdicts,
+side by side, each naming the other's blind spot.
+See :mod:`..runtimes._cct_token_collision`.
 """
 
 from __future__ import annotations
@@ -40,6 +53,14 @@ from ..runtimes._cct_poller_singleton import (
     PollerSingletonVerdict,
     check_poller_singleton,
 )
+from ..runtimes._cct_token_collision import (
+    COLLISION_OK,
+    COLLISION_UNKNOWN,
+    COLLISION_VIOLATION,
+    TokenCollisionVerdict,
+    check_token_collisions,
+)
+from ..runtimes._cct_token_collision import SCOPE_NOTE as COLLISION_SCOPE_NOTE
 from ._helpers import _json_flag, console
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -60,6 +81,15 @@ _POLLER_STYLE = {
     POLLER_OK: "green",
     POLLER_VIOLATION: "red",
     POLLER_UNKNOWN: "yellow",
+}
+
+# Same three-valued palette for the static spec-collision check, and UNKNOWN
+# is yellow here for the same reason: a census sac could not compute must not
+# look like one that came back clean.
+_COLLISION_STYLE = {
+    COLLISION_OK: "green",
+    COLLISION_VIOLATION: "red",
+    COLLISION_UNKNOWN: "yellow",
 }
 
 
@@ -107,6 +137,22 @@ def _render_pollers_human(verdict: PollerSingletonVerdict) -> None:
         console.print(f"  [bold]hint[/bold]  {verdict.hint()}")
 
 
+def _render_collisions_human(verdict: TokenCollisionVerdict) -> None:
+    """Print the static spec-collision verdict, and its remedy when alarming."""
+    style = _COLLISION_STYLE.get(verdict.state, "white")
+    console.print(
+        f"[bold]spec bot tokens[/bold]  [{style}]{verdict.summary()}[/{style}]"
+    )
+    for collision in verdict.collisions:
+        mark = "cross-host" if collision.cross_host else "same host"
+        console.print(f"  {collision.token_fp:<24} {collision.describe()}  ({mark})")
+    console.print(f"  [dim]{verdict.population()}[/dim]")
+    console.print(f"  [dim]{COLLISION_SCOPE_NOTE}[/dim]")
+    if verdict.is_alarming:
+        console.print(f"  [{style}]{verdict.detail}[/{style}]")
+        console.print(f"  [bold]hint[/bold]  {verdict.hint()}")
+
+
 def _render_fleet(ctx: click.Context, as_json: bool, strict: bool, timeout: int) -> int:
     """ssh every peer, render the drift table. Returns exit code."""
     from .._state.host_config import load as _load_host_config
@@ -149,18 +195,21 @@ def _render_local(
     *,
     with_drift: bool = True,
     with_pollers: bool = True,
+    with_collisions: bool = True,
 ) -> int:
     """Run + render the requested local checks. Returns exit code.
 
     ``--strict`` fails on a drifted spec source OR an alarming poller verdict
-    — which includes UNKNOWN, matching ``sac agents cct-audit``: an invariant
-    sac could not assert is not an invariant that held.
+    OR an alarming collision verdict — each of which includes UNKNOWN,
+    matching ``sac agents cct-audit``: an invariant sac could not assert is
+    not an invariant that held.
     """
     payload: dict = {}
     failed = False
 
     status = check_spec_source_drift(_local_agents_spec_dir()) if with_drift else None
     verdict = check_poller_singleton() if with_pollers else None
+    collisions = check_token_collisions() if with_collisions else None
 
     if status is not None:
         payload["local"] = status.to_dict()
@@ -168,6 +217,9 @@ def _render_local(
     if verdict is not None:
         payload["pollers"] = verdict.to_dict()
         failed = failed or verdict.is_alarming
+    if collisions is not None:
+        payload["token_collisions"] = collisions.to_dict()
+        failed = failed or collisions.is_alarming
 
     if _json_flag(ctx, as_json):
         click.echo(json.dumps(payload, indent=2))
@@ -176,6 +228,8 @@ def _render_local(
             _render_local_human(status)
         if verdict is not None:
             _render_pollers_human(verdict)
+        if collisions is not None:
+            _render_collisions_human(collisions)
 
     return 1 if (strict and failed) else 0
 
@@ -199,13 +253,23 @@ def _render_local(
     ),
 )
 @click.option(
+    "--collisions",
+    "collisions",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run ONLY the static spec-collision check: do two registered SPECS "
+        "resolve to the same bot token? Fleet-wide; reads specs, not /proc."
+    ),
+)
+@click.option(
     "--strict",
     "strict",
     is_flag=True,
     default=False,
     help=(
-        "Exit non-zero when any checked source is drifted, or the poller "
-        "verdict is violation/unknown (CI gate)."
+        "Exit non-zero when any checked source is drifted, or the poller or "
+        "collision verdict is violation/unknown (CI gate)."
     ),
 )
 @click.option(
@@ -221,31 +285,48 @@ def doctor(
     ctx: click.Context,
     fleet: bool,
     pollers: bool,
+    collisions: bool,
     strict: bool,
     timeout: int,
     as_json: bool,
 ) -> None:
-    """Diagnose spec-source drift and duplicate Telegram pollers.
+    """Diagnose spec-source drift and duplicate Telegram bot tokens.
 
     \b
     Examples:
-      $ sac doctor                 # spec source vs remote + poller singleton
+      $ sac doctor                 # drift + live pollers + spec collisions
       $ sac doctor --pollers       # only: one live poller per bot token?
+      $ sac doctor --collisions    # only: do two SPECS take the same bot?
       $ sac doctor --fleet         # per-host drift table for every peer
       $ sac doctor --fleet --json
       $ sac doctor --fleet --strict   # exit 1 if any host drifted
 
     \b
-    The poller check is READ-ONLY and three-valued — ok / violation /
-    unknown. It reports duplicates; it does not kill, lock or prevent them,
-    and an unreadable /proc/<pid>/environ is reported as unknown rather than
-    quietly counted as fine. No bot token VALUE is ever read out: only an
-    opaque sha256:<12hex> fingerprint appears anywhere in the output.
+    TWO HALVES OF ONE INVARIANT — Telegram admits ONE getUpdates consumer per
+    bot token, globally:
+      --pollers     reads /proc. Sees a LIVE duplicate, including an orphan
+                    whose spec no longer asks for the rail. HOST-SCOPED.
+      --collisions  reads SPECS + the secrets pool. Sees a duplicate BEFORE
+                    anything starts, and across hosts. Sees no process.
+    Measured 2026-08-22: one token was held on two hosts and the per-host
+    poller probe returned ok on both. Neither check alone is an all-clear.
+
+    \b
+    Both are READ-ONLY and three-valued — ok / violation / unknown. They
+    report duplicates; they do not kill, lock or refuse them, and an
+    unreadable /proc/<pid>/environ or an inconclusive pool read is reported
+    as unknown rather than quietly counted as fine. No bot token VALUE is
+    ever read out: only an opaque sha256:<12hex> fingerprint appears anywhere
+    in the output.
     """
     if fleet:
         code = _render_fleet(ctx, as_json, strict, timeout)
     elif pollers:
-        code = _render_local(ctx, as_json, strict, with_drift=False)
+        code = _render_local(
+            ctx, as_json, strict, with_drift=False, with_collisions=False
+        )
+    elif collisions:
+        code = _render_local(ctx, as_json, strict, with_drift=False, with_pollers=False)
     else:
         code = _render_local(ctx, as_json, strict)
     if code:

--- a/src/scitex_agent_container/runtimes/_cct_start_observers.py
+++ b/src/scitex_agent_container/runtimes/_cct_start_observers.py
@@ -1,0 +1,48 @@
+"""The CCT observations that run at agent start — both of them, in one place.
+
+Two things want to happen at the same moment, for the same reason, and neither
+may affect the start:
+
+* the RAIL VERDICT (:func:`._cct_rail_alarm.check_cct_rail_at_start`) — is
+  this agent mute and deaf on Telegram, and does anyone need paging?
+* the OWNERSHIP LEDGER (:func:`._cct_token_ledger.record_token_claim_at_start`)
+  — which bot did it take, written down so "who holds this one?" is a query.
+
+The moment is load-bearing and is the reason they share a seam: both read the
+agent's materialised ``$HOME/.env``, which ``runtime.start`` has just written
+and which is precedence #1 of the token resolution. Run either one earlier and
+it reports an agent as token-less that in fact has a token.
+
+ORDER IS DELIBERATE. The rail verdict runs FIRST because it is the one that
+can page a human about an outage; the ledger is bookkeeping nothing reads yet.
+A slow or unreachable PostgreSQL must never sit in front of the page.
+
+NEITHER RAISES. Each has its own never-raises contract in its own module, and
+this function adds no new failure of its own — it is a call sequence, not a
+try/except, precisely so that neither module's guarantee is quietly relocated
+here where a reader of that module would not find it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def observe_cct_at_start(config, *, dest: Path | None = None) -> tuple[str, str]:
+    """Run both start-time CCT observations. Returns ``(rail, claim)``.
+
+    ``rail`` is :func:`._cct_rail_alarm.alarm_cct_rail`'s outcome
+    ("paged" / "recorded" / "clear" / "skipped"); ``claim`` is one of
+    :mod:`._cct_token_ledger`'s ``CLAIM_*``. The caller in
+    :mod:`.._lifecycle._start` discards both — they are returned so the pair
+    is testable as a unit, not so anything branches on them.
+    """
+    from ._cct_rail_alarm import check_cct_rail_at_start
+    from ._cct_token_ledger import record_token_claim_at_start
+
+    rail = check_cct_rail_at_start(config, dest=dest)
+    claim = record_token_claim_at_start(config, dest=dest)
+    return rail, claim
+
+
+__all__ = ["observe_cct_at_start"]

--- a/src/scitex_agent_container/runtimes/_cct_token_census.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_census.py
@@ -1,0 +1,263 @@
+"""WHO claims which bot — the observation half of the static collision check.
+
+This is to :mod:`._cct_token_collision` what :mod:`._cct_poller_scan` is to
+:mod:`._cct_poller_singleton`: it OBSERVES and classifies, and decides nothing.
+It walks the spec tree, asks :func:`._cct_token_resolution.resolve_cct_token`
+what each spec would take, and sorts the answers into the four populations that
+matter. Whether the result is a fault is the other module's job.
+
+FOUR POPULATIONS, AND ONLY ONE OF THEM CAN COLLIDE
+--------------------------------------------------
+* :attr:`SpecCensus.claims` — specs that WOULD hold a real bot token. Only
+  these can collide, because only a held token can be held twice.
+* :attr:`SpecCensus.disabled` — an explicitly EMPTY ``CCT_BOT_TOKEN`` in the
+  spec. **Designed**: seven of the eight handymen carry it so only
+  ``handyman-06`` polls the shared handyman bot. This is the invariant being
+  upheld by hand, not a defect.
+* :attr:`SpecCensus.no_channel` — the spec never asks for the rail.
+* :attr:`SpecCensus.unresolved` — it asks and nothing resolves. A real fault,
+  a DIFFERENT one (mute and deaf, not a collision), already owned by
+  ``sac agents cct-audit`` and :mod:`._cct_rail_alarm`.
+
+THE POPULATION IS THE SPEC TREE, NOT THE REGISTRY
+-------------------------------------------------
+``Registry.list_all()`` holds only agents that are RUNNING. A collision
+between two stopped specs is still a collision — it returns the moment both
+start — so the census reads ``<agents_root>/*/spec.yaml``, the same
+enumeration ``sac agents cct-audit`` uses.
+
+NO TOKEN VALUE IS EVER HELD HERE. :class:`TokenClaim` carries the
+``sha256:<12hex>`` fingerprint, the slot NAME and the spec PATH, and nothing
+else pool-derived.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from ._cct_token_resolution import (
+    TOKEN_DISABLED,
+    TOKEN_NO_CHANNEL,
+    TOKEN_UNRESOLVED,
+    CctTokenResolution,
+    resolve_cct_token,
+)
+from ._secret_pool import PoolRead, _pool_source_label, read_pool
+
+
+@dataclass(frozen=True)
+class TokenClaim:
+    """One spec's claim on one bot token. A fingerprint, never a value."""
+
+    agent: str
+    token_fp: str
+    #: ``spec.host`` — where this agent is pinned, "" when unpinned. The
+    #: remedy for a collision is a config decision about which agent yields,
+    #: and that decision is unmakeable without knowing where each one runs.
+    host: str = ""
+    #: The pool slot that resolved, when the pool is what resolved it.
+    slot: str = ""
+    #: Which precedence step produced the token (:mod:`._cct_token_resolution`).
+    source: str = ""
+    #: The spec file this claim was read from.
+    spec: str = ""
+
+    def to_dict(self) -> dict:
+        """JSON-friendly projection (for ``--json`` surfaces)."""
+        return {
+            "agent": self.agent,
+            "token_fp": self.token_fp,
+            "host": self.host or "",
+            "slot": self.slot,
+            "source": self.source,
+            "spec": self.spec,
+        }
+
+
+@dataclass(frozen=True)
+class SpecCensus:
+    """Every spec, sorted into the four populations. No verdict, by design."""
+
+    claims: tuple[TokenClaim, ...] = ()
+    unresolved: tuple[str, ...] = ()
+    disabled: tuple[str, ...] = ()
+    no_channel: tuple[str, ...] = ()
+    #: Specs sac could not load. Each is a claim it could not COMPUTE, which
+    #: is why they are named rather than dropped: an unread spec could claim
+    #: the same token as a read one.
+    unreadable: tuple[str, ...] = ()
+    #: How many spec FILES were looked at — the denominator R4 demands, and
+    #: not the same as ``len(claims)``.
+    examined: int = 0
+    agents_dir: str = ""
+    #: Whether a MISS against the pool read was conclusive (:class:`PoolRead`).
+    pool_trusted: bool = True
+    pool_source: str = ""
+
+    @property
+    def distinct_fingerprints(self) -> int:
+        """How many distinct bots the claiming specs resolve to."""
+        return len({c.token_fp for c in self.claims})
+
+
+def spec_host(config) -> str:
+    """``spec.host`` as a display string — "" when the agent is unpinned.
+
+    ``host`` may be a LIST (a priority/fallback chain), in which case every
+    entry is a place this agent could run and all of them matter to the
+    remedy, so all are shown rather than silently reduced to the first.
+    """
+    raw = getattr(getattr(config, "hosts_spec", None), "host", "") or ""
+    if isinstance(raw, (list, tuple)):
+        return "|".join(str(h).strip() for h in raw if str(h).strip())
+    return str(raw).strip()
+
+
+def spec_paths(agents_dir: str | None = None) -> list[Path]:
+    """Every ``<agents_dir>/<name>/spec.yaml``, sorted by name.
+
+    ``agents_dir`` defaults to this host's ``agents_root()``. It is an explicit
+    parameter rather than an env lookup so the caller states WHICH spec tree it
+    means — useful for auditing a peer's synced tree, and it keeps the tests
+    from having to intercept ``$SCITEX_DIR`` to say the same thing.
+    """
+    if agents_dir:
+        root = Path(agents_dir).expanduser()
+    else:
+        from .._state.state_paths import agents_root
+
+        root = agents_root()
+    if not root.is_dir():
+        return []
+    return [p for p in sorted(root.glob("*/spec.yaml")) if p.is_file()]
+
+
+def census_from_resolutions(
+    resolutions: Sequence[tuple[CctTokenResolution, str, str]],
+    *,
+    unreadable: Sequence[str] = (),
+    examined: int | None = None,
+    agents_dir: str = "",
+    pool_trusted: bool = True,
+    pool_source: str = "",
+) -> SpecCensus:
+    """Sort already-computed resolutions into the four populations.
+
+    ``resolutions`` is ``(resolution, host, spec_path)`` per spec — a tuple
+    rather than a richer object because the host and the path come from the
+    SPEC, not from the resolution, and folding them into
+    :class:`CctTokenResolution` would put fields on the writer's own return
+    value that the writer has no business carrying.
+
+    Pure over its input: the seam that lets the collision condition be built
+    and asserted without a spec tree on disk.
+    """
+    claims: list[TokenClaim] = []
+    unresolved: list[str] = []
+    disabled: list[str] = []
+    no_channel: list[str] = []
+
+    for resolution, host, spec in resolutions:
+        if resolution.claims_a_token:
+            claims.append(
+                TokenClaim(
+                    agent=resolution.agent,
+                    token_fp=resolution.token_fp,
+                    host=host,
+                    slot=resolution.slot,
+                    source=resolution.source,
+                    spec=spec,
+                )
+            )
+        elif resolution.outcome == TOKEN_UNRESOLVED:
+            unresolved.append(resolution.agent)
+        elif resolution.outcome == TOKEN_DISABLED:
+            disabled.append(resolution.agent)
+        elif resolution.outcome == TOKEN_NO_CHANNEL:
+            no_channel.append(resolution.agent)
+
+    total = examined if examined is not None else len(resolutions) + len(unreadable)
+    return SpecCensus(
+        claims=tuple(claims),
+        unresolved=tuple(unresolved),
+        disabled=tuple(disabled),
+        no_channel=tuple(no_channel),
+        unreadable=tuple(unreadable),
+        examined=total,
+        agents_dir=agents_dir,
+        pool_trusted=pool_trusted,
+        pool_source=pool_source,
+    )
+
+
+def census_specs(
+    *,
+    agents_dir: str | None = None,
+    pool: PoolRead | None = None,
+) -> SpecCensus:
+    """Walk the spec tree and classify every spec. Read-only.
+
+    The pool is read ONCE and injected into every resolution: forking a bash
+    per agent to source ~28 secret files would make a 122-spec sweep cost
+    minutes and — worse — could produce rows that disagree with each other if
+    the environment shifted mid-run.
+
+    RAISES ``OSError`` when the spec root cannot be enumerated. That is
+    deliberate and it is the caller's UNKNOWN: reporting zero collisions
+    because nobody looked is the collapse the verdict module refuses.
+    """
+    from ..config import load_config
+    from ._cct_rail_verdict import materialised_home
+
+    read = pool if pool is not None else read_pool()
+    paths = spec_paths(agents_dir)
+
+    resolutions: list[tuple[CctTokenResolution, str, str]] = []
+    unreadable: list[str] = []
+    for path in paths:
+        name = path.parent.name
+        # stx-allow: fallback (reason: one unloadable spec must not abort a fleet-wide census; it becomes a NAMED unreadable row that drives UNKNOWN upstream, never a dropped one, because a spec sac cannot read is a claim it cannot compute)
+        try:
+            config = load_config(str(path))
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            unreadable.append(name)
+            continue
+        resolutions.append(
+            (
+                resolve_cct_token(config, dest=materialised_home(config), pool=read),
+                spec_host(config),
+                str(path),
+            )
+        )
+
+    return census_from_resolutions(
+        resolutions,
+        unreadable=unreadable,
+        examined=len(paths),
+        agents_dir=agents_dir or _default_agents_dir(),
+        pool_trusted=read.trusted,
+        pool_source=_pool_source_label(),
+    )
+
+
+def _default_agents_dir() -> str:
+    """This host's agents root, as a string — a label on the result only."""
+    # stx-allow: fallback (reason: a display label; a path-resolution failure must not turn a computed census into an exception)
+    try:
+        from .._state.state_paths import agents_root
+
+        return str(agents_root())
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return ""
+
+
+__all__ = [
+    "SpecCensus",
+    "TokenClaim",
+    "census_from_resolutions",
+    "census_specs",
+    "spec_host",
+    "spec_paths",
+]

--- a/src/scitex_agent_container/runtimes/_cct_token_census.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_census.py
@@ -122,6 +122,11 @@ def spec_paths(agents_dir: str | None = None) -> list[Path]:
     parameter rather than an env lookup so the caller states WHICH spec tree it
     means — useful for auditing a peer's synced tree, and it keeps the tests
     from having to intercept ``$SCITEX_DIR`` to say the same thing.
+
+    RAISES :class:`FileNotFoundError` when the root is not a directory. An
+    empty list means "enumerated, nothing there"; a missing root means "never
+    looked", and a caller that cannot tell them apart reports a clean fleet it
+    never read.
     """
     if agents_dir:
         root = Path(agents_dir).expanduser()
@@ -130,7 +135,21 @@ def spec_paths(agents_dir: str | None = None) -> list[Path]:
 
         root = agents_root()
     if not root.is_dir():
-        return []
+        # RAISE, do not return []. An absent spec tree is "could not be
+        # enumerated", not "enumerated and found nothing" -- and the two render
+        # identically downstream: zero claimants is a legitimate OK, so a
+        # missing root would report the fleet CLEAN on the strength of never
+        # having looked at it. That is the exact collapse this check exists to
+        # refuse, and it was caught by the adversarial pass (CASE E: a spec tree
+        # that does not exist returned "ok", scanned=True).
+        #
+        # check_token_collisions already converts this to COLLISION_UNKNOWN with
+        # "Nothing was learned; this is not an all-clear." Raising routes the
+        # case into that existing path rather than adding a second one.
+        raise FileNotFoundError(
+            f"spec tree {root} is not a directory, so no spec could be "
+            "enumerated"
+        )
     return [p for p in sorted(root.glob("*/spec.yaml")) if p.is_file()]
 
 

--- a/src/scitex_agent_container/runtimes/_cct_token_collision.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_collision.py
@@ -1,0 +1,429 @@
+"""ONE bot token per AGENT, checked in the SPECS — before any process starts.
+
+THE FAULT, AND WHY THE EXISTING DETECTOR CANNOT SEE IT
+-----------------------------------------------------
+Telegram's ``getUpdates`` admits exactly ONE consumer per bot token, GLOBALLY.
+:mod:`._cct_poller_singleton` observes that invariant by reading ``/proc``, and
+it is HOST-SCOPED. Measured 2026-08-22: ``scitex-hub`` on compute-04 and
+``proj-scitex-hub`` on compute-03 resolved to the SAME bot and both ran a live
+telegram server — and the per-host process check returned OK on BOTH hosts
+while the conflict was live across them.
+
+Killing the process ended that incident and fixed nothing: the two SPECS still
+resolve to the same slot, so the collision returns on the next start. That is
+the gap this closes, and it needs no cross-host probing at all, because the
+fault is STATIC — it is visible in the specs plus the pool, before anything
+runs.
+
+WHAT THIS IS
+------------
+A verdict over :mod:`._cct_token_census`, which asks
+:func:`._cct_token_resolution.resolve_cct_token` — the SAME derivation
+:func:`._cct_token_pool.ensure_cct_bot_token` writes with, not a second
+opinion about it — what each spec would take. Two agents on one fingerprint is
+the fault, and the report names BOTH agents and BOTH hosts, because the remedy
+is a config decision about which one yields.
+
+Read-only. It starts nothing, writes nothing, and never reads a token value:
+only ``sha256:<12hex>`` fingerprints, slot NAMES and pool source PATHS leave
+here — the same strings sac's logs already carry.
+
+AN AGENT WITH NO TOKEN IS NEVER A VIOLATION HERE
+------------------------------------------------
+Three populations hold nothing and so cannot collide, and conflating them is
+how a check stops being read. The census keeps them apart; this module counts
+all three in :meth:`TokenCollisionVerdict.population` and alarms on none:
+
+* DISABLED — an explicit empty ``CCT_BOT_TOKEN``. **This is the invariant
+  upheld by hand** (the handyman family); flagging it would be flagging the
+  answer.
+* NO-CHANNEL — the spec never asks for the rail.
+* UNRESOLVED — it asks and nothing resolves. Named in every result, never
+  folded silently into the clean count, and deliberately NOT alarming HERE: it
+  is a different fault (mute and deaf, not a collision), it already has two
+  owners — ``sac agents cct-audit`` and :mod:`._cct_rail_alarm` — and it is the
+  MAJORITY of the fleet, because the channel request is inherited from the spec
+  templates. Measured 2026-08-12: 81 specs declare the channel and 15 resolve a
+  token. An alarm that fires on 66 agents forever is one the operator learns to
+  scroll past, which is the failure this subsystem exists to prevent.
+
+:data:`SCOPE_NOTE` states the other half of the boundary in every result: this
+sees ACROSS hosts and CANNOT see an orphaned process holding a token whose spec
+no longer requests it. The two checks are complements; neither alone is
+sufficient, and each result points at the other.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from ._cct_token_census import SpecCensus, TokenClaim, census_specs
+from ._secret_pool import PoolRead, _pool_source_label, read_pool
+
+#: Every spec that claims a bot claims a DIFFERENT one. Zero claimants is OK:
+#: nothing can conflict with nothing.
+COLLISION_OK = "ok"
+#: Two or more specs resolve to the SAME bot token. This is the 409 conflict,
+#: predicted from configuration rather than found after the fact.
+COLLISION_VIOLATION = "violation"
+#: sac could not assert the invariant — the pool read was inconclusive, a spec
+#: would not load, or the spec tree could not be enumerated. NOT a soft OK.
+COLLISION_UNKNOWN = "unknown"
+
+#: The limit of this check, stated in every result rather than left to be
+#: discovered — the sibling check states its own, and the two are opposite.
+#:
+#: This one is STATIC and FLEET-WIDE: it reads SPECS plus the pool, so it sees
+#: the cross-host collision ``_cct_poller_singleton`` structurally cannot. It
+#: sees no PROCESS, so an ORPHANED poller still holding a token whose spec no
+#: longer requests it is invisible here — which is exactly what the host-local
+#: check is for.
+SCOPE_NOTE = (
+    "STATIC and FLEET-WIDE: this reads SPECS + the secrets pool, so it sees a "
+    "collision split across hosts, which the host-local process check "
+    "structurally cannot. It sees no PROCESS at all, so an ORPHANED poller "
+    "holding a token whose spec no longer requests it is invisible here — run "
+    "`sac doctor --pollers` on each host for that half. Neither check alone is "
+    "a fleet all-clear."
+)
+
+
+@dataclass(frozen=True)
+class TokenCollision:
+    """Two or more specs resolving to the SAME bot token. The fault itself."""
+
+    token_fp: str
+    claims: tuple[TokenClaim, ...]
+
+    @property
+    def agents(self) -> tuple[str, ...]:
+        return tuple(c.agent for c in self.claims)
+
+    @property
+    def hosts(self) -> tuple[str, ...]:
+        return tuple(c.host or "(unpinned)" for c in self.claims)
+
+    @property
+    def cross_host(self) -> bool:
+        """True when the claimants are pinned to DIFFERENT hosts.
+
+        The case no per-host process check can ever see, and the shape of the
+        2026-08-22 incident. Worth naming in the report, because it tells the
+        reader that killing a process on one host has not settled it.
+        """
+        return len({c.host for c in self.claims if c.host}) > 1
+
+    def describe(self) -> str:
+        """``agent@host + agent@host`` — both names, both hosts, one line."""
+        return " + ".join(f"{c.agent}@{c.host or 'unpinned'}" for c in self.claims)
+
+    def to_dict(self) -> dict:
+        """JSON-friendly projection (for ``--json`` surfaces)."""
+        return {
+            "token_fp": self.token_fp,
+            "agents": list(self.agents),
+            "hosts": list(self.hosts),
+            "cross_host": self.cross_host,
+            "claims": [c.to_dict() for c in self.claims],
+        }
+
+
+@dataclass(frozen=True)
+class TokenCollisionVerdict:
+    """The fleet-wide static verdict. ``state`` is OK / VIOLATION / UNKNOWN."""
+
+    state: str
+    census: SpecCensus = SpecCensus()
+    collisions: tuple[TokenCollision, ...] = ()
+    #: False when the spec tree itself could not be enumerated — the reason a
+    #: zero count must not read as OK.
+    scanned: bool = True
+    detail: str = ""
+
+    @property
+    def is_alarming(self) -> bool:
+        """True for the two states a human must be told about."""
+        return self.state in (COLLISION_VIOLATION, COLLISION_UNKNOWN)
+
+    @property
+    def distinct_fingerprints(self) -> int:
+        """How many distinct bots the claiming specs resolve to."""
+        return self.census.distinct_fingerprints
+
+    def population(self) -> str:
+        """What was actually examined. Never let a clean count stand alone.
+
+        A peer published a clean census that was 3-of-10 and read as 3-of-3.
+        ``0 collisions across 0 specs`` and ``0 across 24`` are different facts
+        and must not render the same, so every count that shaped this verdict
+        is stated: how many specs, how many claim a bot, and each of the three
+        populations that hold none.
+        """
+        c = self.census
+        return (
+            f"{c.examined} spec(s) examined, "
+            f"{len(c.claims)} claim a bot token "
+            f"({c.distinct_fingerprints} distinct), "
+            f"{len(c.unresolved)} request the rail and resolve nothing, "
+            f"{len(c.disabled)} deliberately tokenless, "
+            f"{len(c.no_channel)} never request it, "
+            f"{len(c.unreadable)} unreadable"
+        )
+
+    def summary(self) -> str:
+        """One-line human summary of the verdict."""
+        c = self.census
+        if self.state == COLLISION_VIOLATION:
+            worst = "; ".join(
+                f"{x.token_fp} claimed by {x.describe()}" for x in self.collisions
+            )
+            return f"{len(self.collisions)} bot token(s) claimed twice: {worst}"
+        if self.state == COLLISION_UNKNOWN:
+            if not self.scanned:
+                return "unknown — the spec tree could not be enumerated"
+            if c.unreadable:
+                return (
+                    f"unknown — {len(c.unreadable)} of {c.examined} spec(s) would "
+                    "not load, so their claims were never computed"
+                )
+            return "unknown — the pool read was not conclusive"
+        return (
+            f"{len(c.claims)} spec(s) claim a bot token, "
+            f"{c.distinct_fingerprints} distinct — no bot is claimed twice"
+        )
+
+    def hint(self) -> str:
+        """What to DO. Empty for OK — an all-clear needs no remedy.
+
+        The two alarming states need DIFFERENT actions: a violation is a config
+        decision about which agent yields; an unknown is an unread instrument
+        whose vantage point must be fixed first.
+        """
+        c = self.census
+        if self.state == COLLISION_VIOLATION:
+            pairs = "; ".join(x.describe() for x in self.collisions)
+            return (
+                "Two or more SPECS resolve to the same bot token, so whichever "
+                "of them run are 409-ing each other and the operator's inbound "
+                "messages are dropped. Killing a process does NOT fix this — the "
+                f"specs still collide ({pairs}), so it returns on the next "
+                "start. Decide which agent OWNS the bot, then for each of the "
+                "others do ONE of: (a) give it its own bot and name the slot "
+                "with CCT_BOT_TOKEN_SLOT under spec.apptainer.env, (b) set "
+                "CCT_BOT_TOKEN to an empty value under spec.apptainer.env so it "
+                "is tokenless BY DECLARATION (the handyman pattern), or (c) drop "
+                "'server:claude-code-telegrammer' from spec.claude.channels if "
+                "it needs no Telegram rail. Then re-run: it must read ok. sac "
+                "does not choose for you and does not refuse the start — this is "
+                "a detector."
+            )
+        if self.state == COLLISION_UNKNOWN:
+            if not self.scanned:
+                return (
+                    f"The spec tree {c.agents_dir or '(unresolved)'} could not be "
+                    "enumerated, so NOTHING was learned — this is not an "
+                    "all-clear. Re-run where the specs live."
+                )
+            if c.unreadable:
+                return (
+                    "These specs would not load, so sac could not compute which "
+                    "bot they take and cannot assert the invariant over them: "
+                    + ", ".join(c.unreadable)
+                    + ". Fix them (`sac agents check <name>`) and re-run."
+                )
+            return (
+                "The pool read was NOT conclusive, so a slot that did not "
+                f"resolve may simply be one sac never looked at ({c.pool_source}). "
+                "A collision FOUND under such a read is still real; a clean "
+                "result is not. Re-run from where agents are STARTED (the pool "
+                "resolves from the launching process env), or set "
+                "SAC_SECRETS_ENVRC, before believing this row."
+            )
+        return ""
+
+    def to_dict(self) -> dict:
+        """JSON-friendly projection (for ``--json`` surfaces).
+
+        Same shape as the sibling poller check's — ``state`` / ``detail`` /
+        ``summary`` / ``hint`` / ``population`` / ``scope_note`` — so the two
+        halves of the one-token-one-poller invariant read alike under
+        ``sac doctor --json``.
+        """
+        c = self.census
+        return {
+            "state": self.state,
+            "scope": "fleet-static",
+            "scope_note": SCOPE_NOTE,
+            "specs_examined": c.examined,
+            "claims": [x.to_dict() for x in c.claims],
+            "distinct_fingerprints": c.distinct_fingerprints,
+            "collisions": [x.to_dict() for x in self.collisions],
+            "unresolved": list(c.unresolved),
+            "disabled": list(c.disabled),
+            "no_channel": list(c.no_channel),
+            "unreadable": list(c.unreadable),
+            "population": self.population(),
+            "pool_trusted": c.pool_trusted,
+            "pool_source": c.pool_source,
+            "scanned": self.scanned,
+            "agents_dir": c.agents_dir,
+            "detail": self.detail,
+            "summary": self.summary(),
+            "hint": self.hint(),
+        }
+
+
+def group_collisions(claims: Sequence[TokenClaim]) -> tuple[TokenCollision, ...]:
+    """Fingerprints claimed by two or more specs, in fingerprint order.
+
+    Pure over its input — the seam that lets the collision condition be
+    constructed and asserted without a spec tree, next to the test that
+    constructs it with two real ones.
+    """
+    by_fp: dict[str, list[TokenClaim]] = {}
+    for claim in claims:
+        if claim.token_fp:
+            by_fp.setdefault(claim.token_fp, []).append(claim)
+    return tuple(
+        TokenCollision(token_fp=fp, claims=tuple(group))
+        for fp, group in sorted(by_fp.items())
+        if len(group) > 1
+    )
+
+
+def verdict_for(census: SpecCensus) -> TokenCollisionVerdict:
+    """Decide OK / VIOLATION / UNKNOWN for an already-computed census.
+
+    A VIOLATION outranks an UNKNOWN, for the sibling check's reason: a
+    duplicate that HAS been computed is a fact, and one unreadable spec does
+    not make it less true. The reverse ordering would let a single broken YAML
+    file mute a live outage.
+    """
+    collisions = group_collisions(census.claims)
+    if collisions:
+        worst = "; ".join(f"{c.token_fp} <- {c.describe()}" for c in collisions)
+        cross = (
+            "At least one pair is pinned to DIFFERENT hosts, which no per-host "
+            "process check can see. "
+            if any(c.cross_host for c in collisions)
+            else ""
+        )
+        return TokenCollisionVerdict(
+            state=COLLISION_VIOLATION,
+            census=census,
+            collisions=collisions,
+            detail=(
+                f"{len(census.claims)} spec(s) claim a bot token but resolve to "
+                f"only {census.distinct_fingerprints} distinct one(s). Telegram's "
+                "getUpdates admits ONE consumer per token, so every duplicated "
+                f"fingerprint below is a 409 conflict loop waiting to start: "
+                f"{worst}. {cross}({SCOPE_NOTE})"
+            ),
+        )
+
+    if census.unreadable:
+        return TokenCollisionVerdict(
+            state=COLLISION_UNKNOWN,
+            census=census,
+            detail=(
+                f"{len(census.unreadable)} of {census.examined} spec(s) could not "
+                "be loaded, so sac could not compute which bot they take: an "
+                "unread spec could claim the same token as a read one. "
+                "Unreadable: " + ", ".join(census.unreadable) + f". ({SCOPE_NOTE})"
+            ),
+        )
+
+    if not census.pool_trusted:
+        return TokenCollisionVerdict(
+            state=COLLISION_UNKNOWN,
+            census=census,
+            detail=(
+                "no two specs resolve to the same bot token in the pool sac read "
+                f"({census.pool_source}) — but that read is NOT conclusive, so a "
+                "slot that did not resolve may be one sac never looked at rather "
+                "than one that is absent. A collision FOUND under such a read "
+                f"would still be real; this clean result is not. ({SCOPE_NOTE})"
+            ),
+        )
+
+    if not census.claims:
+        return TokenCollisionVerdict(
+            state=COLLISION_OK,
+            census=census,
+            detail=(
+                f"{census.examined} spec(s) examined and NONE claims a bot token, "
+                f"so nothing can conflict with nothing. ({SCOPE_NOTE})"
+            ),
+        )
+
+    return TokenCollisionVerdict(
+        state=COLLISION_OK,
+        census=census,
+        detail=(
+            f"{len(census.claims)} spec(s) claim a bot token and no two claim the "
+            "same one: count(distinct fingerprints) == count(claiming specs) == "
+            f"{len(census.claims)}. {len(census.disabled)} spec(s) declare an "
+            f"EMPTY token and hold none; {len(census.unresolved)} request the "
+            "rail and resolve nothing (a DIFFERENT fault — mute and deaf, not a "
+            f"collision; see `sac agents cct-audit`). ({SCOPE_NOTE})"
+        ),
+    )
+
+
+def check_token_collisions(
+    *,
+    agents_dir: str | None = None,
+    pool: PoolRead | None = None,
+) -> TokenCollisionVerdict:
+    """Do two registered specs resolve to the SAME Telegram bot token?
+
+    Returns a three-valued verdict:
+
+    * :data:`COLLISION_OK` — every spec that claims a bot claims a different
+      one. Zero claimants is OK: nothing can conflict.
+    * :data:`COLLISION_VIOLATION` — at least one fingerprint is claimed by two
+      or more specs. Both agents and both hosts are named.
+    * :data:`COLLISION_UNKNOWN` — the spec tree could not be enumerated, a spec
+      would not load, or the pool read was inconclusive. Never folded into OK.
+
+    Read-only: it loads specs and reads the pool ONCE, and touches nothing.
+    ``agents_dir`` audits a different spec tree (e.g. a peer's synced copy);
+    the POOL is still read from HERE, which is part of the measurement — see
+    ``sac agents cct-audit`` on vantage point.
+    """
+    read = pool if pool is not None else read_pool()
+    # stx-allow: fallback (reason: a spec root that cannot be enumerated is the
+    # UNKNOWN verdict this function exists to be able to give — reporting zero
+    # collisions because nobody looked is the exact collapse this check
+    # refuses, so the failure must become a state, not an exception.)
+    try:
+        census = census_specs(agents_dir=agents_dir, pool=read)
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        return TokenCollisionVerdict(
+            state=COLLISION_UNKNOWN,
+            census=SpecCensus(
+                agents_dir=agents_dir or "",
+                pool_trusted=read.trusted,
+                pool_source=_pool_source_label(),
+            ),
+            scanned=False,
+            detail=(
+                f"the spec tree could not be enumerated ({exc}), so no claim was "
+                "computed at all. Nothing was learned; this is not an all-clear."
+            ),
+        )
+    return verdict_for(census)
+
+
+__all__ = [
+    "COLLISION_OK",
+    "COLLISION_UNKNOWN",
+    "COLLISION_VIOLATION",
+    "SCOPE_NOTE",
+    "TokenCollision",
+    "TokenCollisionVerdict",
+    "check_token_collisions",
+    "group_collisions",
+    "verdict_for",
+]

--- a/src/scitex_agent_container/runtimes/_cct_token_ledger.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_ledger.py
@@ -1,0 +1,114 @@
+"""Record this agent's claim on its bot token, as it starts. Never fatal.
+
+The start-time half of :mod:`.._state.state_db_token_owner`: resolve which bot
+this agent takes — with :func:`._cct_token_resolution.resolve_cct_token`, the
+same derivation the writer uses, never a second one — and write
+``fingerprint -> (agent, host, pid, started_at)`` into the per-host ledger.
+
+WRITE ONLY. Nothing reads this to make a decision, no start is gated on it,
+and this function's return value is discarded by its caller. Enforcement is a
+separate change; see the store's docstring for why the record comes first.
+
+NEVER RAISES, and that is the load-bearing property, not a nicety. The store
+is PostgreSQL-only and RAISES when the database is unreachable — correct for
+the store, and unacceptable on a path attached to every start in the fleet. A
+ledger that can refuse a boot is strictly worse than a missing ledger, so an
+unreachable store here becomes a printed warning and the agent starts.
+
+Same reasoning, same shape and the same call site as
+:func:`._cct_rail_alarm.check_cct_rail_at_start`, which is one line above it in
+:mod:`.._lifecycle._start`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+#: What :func:`record_token_claim_at_start` did, for tests and for a caller
+#: that wants to say so.
+CLAIM_RECORDED = "recorded"
+#: No token resolves for this agent, so there is no claim to record. Includes
+#: the deliberately tokenless (the handyman pattern) and the merely mute.
+CLAIM_SKIPPED = "skipped"
+#: A claim existed and could not be written down. Printed loudly; the start
+#: proceeds regardless.
+CLAIM_FAILED = "failed"
+
+
+def _resolve_host() -> str:
+    """This host's canonical label, matching the rest of sac's records."""
+    # stx-allow: fallback (reason: the host is a LABEL on a ledger row; a resolver import/lookup failure must degrade to the plain hostname, never take down the start this is attached to)
+    try:
+        from .._state.state_db_hostname import resolve_host
+
+        return resolve_host(None)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        import socket
+
+        return socket.gethostname()
+
+
+def record_token_claim_at_start(
+    config,
+    *,
+    dest: Path | None = None,
+    pid: int | None = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> str:
+    """Write this agent's bot-token claim to the per-host ledger.
+
+    Returns :data:`CLAIM_RECORDED`, :data:`CLAIM_SKIPPED` or
+    :data:`CLAIM_FAILED`. Never raises.
+
+    ``dest`` is the agent's materialised home; omit it and it is resolved via
+    :func:`._cct_rail_verdict.materialised_home`, exactly as the rail check
+    does — reading it matters because a token folded there by a project
+    ``.envrc`` is precedence #1, and an agent whose bot arrives that way is
+    every bit as capable of colliding as one that resolved a pool slot.
+
+    Only the FINGERPRINT is written. The resolution holds a value long enough
+    to hash it and no longer, and nothing in this module ever sees one.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    # stx-allow: fallback (reason: this is a bookkeeping write attached to every start in the fleet; a bug in the resolution, an unreachable PostgreSQL, or a schema surprise must degrade to a printed line, never take down the start it was added to observe)
+    try:
+        from .._state.state_db_token_owner import record_token_owner
+        from ._cct_rail_verdict import materialised_home
+        from ._cct_token_resolution import resolve_cct_token
+
+        home = dest if dest is not None else materialised_home(config)
+        resolution = resolve_cct_token(config, dest=home)
+        if not resolution.claims_a_token:
+            return CLAIM_SKIPPED
+        record_token_owner(
+            token_fp=resolution.token_fp,
+            agent=resolution.agent,
+            host=_resolve_host(),
+            pid=pid if pid is not None else os.getpid(),
+            started_at=now,
+            source=resolution.source,
+            slot=resolution.slot,
+        )
+        return CLAIM_RECORDED
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        print(
+            f"[cct-ledger] {getattr(config, 'name', '?')!r}: could not record "
+            f"this agent's bot-token claim — {exc}. THE AGENT STARTS NORMALLY; "
+            "only the ownership ledger is missing this claim, so "
+            "'who holds this bot?' will have to be answered by scanning /proc "
+            "(`sac doctor --pollers`) until the next successful start.",
+            file=stream,
+        )
+        return CLAIM_FAILED
+
+
+__all__ = [
+    "CLAIM_FAILED",
+    "CLAIM_RECORDED",
+    "CLAIM_SKIPPED",
+    "record_token_claim_at_start",
+]

--- a/src/scitex_agent_container/runtimes/_cct_token_pool.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_pool.py
@@ -76,10 +76,10 @@ from pathlib import Path
 from ._sdk_channels import _TELEGRAMMER_CHANNEL, _TELEGRAMMER_MCP_KEY
 from ._secret_pool import (
     _SECRETS_ENVRC_VAR,
-    _pool_env,
     _pool_source_label,
     _read_env_file,
     _write_env_file,
+    read_pool,
 )
 
 # The env-var the telegrammer MCP reads its bot token from (see the shared
@@ -218,15 +218,42 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
     agent starts normally: a missing bot token degrades one comms rail, it
     does not fail a boot. The token VALUE is never logged; only slot names,
     paths, and the agent name appear.
+
+    WHICH token is not decided here. That is
+    :func:`._cct_token_resolution.resolve_cct_token`, which this function is
+    otherwise identical to plus a file write — so the fleet-wide collision
+    census and the ownership ledger read the SAME derivation this writes,
+    and a second one cannot drift into existence beside it.
     """
-    if not _channel_requested(config):
-        return
+    # Imported inside the function on purpose: _cct_token_resolution imports
+    # this module's private helpers at module scope, and this call is the one
+    # edge that would close the cycle. The derivation module is the lower
+    # layer; the writer is the only thing above it.
+    from ._cct_token_resolution import (
+        SOURCE_ENV_FILE,
+        SOURCE_POOL,
+        TOKEN_DISABLED,
+        TOKEN_NO_CHANNEL,
+        TOKEN_RESOLVED,
+        resolve_cct_token,
+    )
+
     agent_name = getattr(config, "name", "") or ""
     workdir = getattr(config, "workdir", "") or ""
     env_file = dest / ".env"
+
+    # ONE pool read, shared with the resolution: sourcing ~28 secret files
+    # forks a bash, and doing it twice per deploy would double that cost for
+    # an answer that must be the same both times.
+    pool = read_pool()
+    resolution = resolve_cct_token(config, dest=dest, pool=pool)
+
+    if resolution.outcome in (TOKEN_NO_CHANNEL, TOKEN_DISABLED):
+        return
+
     existing = _read_env_file(env_file) if env_file.is_file() else {}
 
-    if existing.get(_TOKEN_VAR):
+    if resolution.source == SOURCE_ENV_FILE:
         # Hand-authored .envrc (or a prior deploy) already provided the
         # token — authoritative. Only backfill the identity default.
         if not existing.get(_AGENT_ID_VAR):
@@ -243,28 +270,32 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
             )
         return
 
-    declared = _declared_slot(config)
-    candidates = [declared] if declared else _slot_candidates(agent_name, workdir)
+    if resolution.outcome == TOKEN_RESOLVED:
+        if resolution.source == SOURCE_POOL:
+            value = pool.env.get(f"{_POOL_PREFIX}{resolution.slot}", "")
+            origin = f"pool slot {_POOL_PREFIX}{resolution.slot}"
+        else:  # SOURCE_SPEC_ENV — a token pinned in spec.apptainer.env.
+            value = str((getattr(config, "env", None) or {}).get(_TOKEN_VAR, "") or "")
+            origin = f"spec.apptainer.env {_TOKEN_VAR}"
+        # Mirrored into .env even for SOURCE_SPEC_ENV, where the --env flag
+        # already wins at runtime: prune_tokenless_telegrammer_mcp reads THIS
+        # file, so leaving it empty would delete the MCP server out from under
+        # an agent that does have a bot.
+        existing[_TOKEN_VAR] = value
+        existing.setdefault(_AGENT_ID_VAR, _default_agent_id(agent_name, workdir))
+        _write_env_file(env_file, existing)
+        _logger().info(
+            "cct: resolved bot token for agent %r from %s (value not logged) "
+            "-> %s; %s=%s.",
+            agent_name,
+            origin,
+            env_file,
+            _AGENT_ID_VAR,
+            existing[_AGENT_ID_VAR],
+        )
+        return
 
-    pool = _pool_env()
-    for slot in candidates:
-        value = pool.get(f"{_POOL_PREFIX}{slot}", "")
-        if value:
-            existing[_TOKEN_VAR] = value
-            existing.setdefault(_AGENT_ID_VAR, _default_agent_id(agent_name, workdir))
-            _write_env_file(env_file, existing)
-            _logger().info(
-                "cct: resolved bot token for agent %r from pool slot "
-                "%s%s (value not logged) -> %s; %s=%s.",
-                agent_name,
-                _POOL_PREFIX,
-                slot,
-                env_file,
-                _AGENT_ID_VAR,
-                existing[_AGENT_ID_VAR],
-            )
-            return
-
+    candidates = list(resolution.candidates)
     _logger().warning(
         "cct: no Telegram bot token for agent %r although spec.claude.channels "
         "requests %r. Tried pool slot(s) %s against the pool (%s). THE AGENT "

--- a/src/scitex_agent_container/runtimes/_cct_token_resolution.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_resolution.py
@@ -1,0 +1,287 @@
+"""WHICH bot does a spec take? One derivation, and every caller uses it.
+
+WHY THIS IS ITS OWN MODULE
+--------------------------
+Three different questions need the same answer:
+
+* :func:`._cct_token_pool.ensure_cct_bot_token` — *which token do I WRITE into
+  this agent's ``.env``?* (the writer, and the only one with a side effect)
+* :mod:`._cct_token_collision` — *do two specs take the SAME bot?* (the
+  fleet-wide static census)
+* the ownership ledger (:mod:`.._state.state_db_token_owner`) — *who holds
+  this bot right now?*
+
+They used to be able to disagree, because only the first one existed and the
+other two would have had to re-derive it. A second agent-to-slot derivation is
+exactly how a census reports collisions that do not exist and misses ones that
+do, so this module holds the derivation and the writer calls it. The writer is
+now this function plus a file write, and nothing else.
+
+FOUR OUTCOMES, NOT TWO
+----------------------
+"this agent has no bot" is three different facts and only one is a defect:
+
+* :data:`TOKEN_DISABLED` — the spec sets ``CCT_BOT_TOKEN`` to an EXPLICITLY
+  EMPTY value. **Designed, not broken**: seven of the eight handymen carry it
+  so that only ``handyman-06`` polls the shared handyman bot. Their spec says
+  so in a comment — "Do NOT re-add CCT_BOT_TOKEN / CCT_AGENT_ID here: an
+  explicit empty OVERRIDES the pool-injected value" — and that arrangement IS
+  the one-token-one-poller invariant, upheld by hand. A census that flagged
+  that family would be flagging the thing it exists to check.
+* :data:`TOKEN_NO_CHANNEL` — the spec never asks for the rail.
+* :data:`TOKEN_UNRESOLVED` — it asks and nothing resolves. Not a collision (an
+  agent with no token cannot take anybody's), but not "fine" either: it is the
+  mute-and-deaf condition ``sac agents cct-audit`` and :mod:`._cct_rail_alarm`
+  report.
+
+NO TOKEN VALUE LEAVES THIS MODULE
+---------------------------------
+:func:`resolve_cct_token` holds a value only for as long as it takes to hash
+it. :class:`CctTokenResolution` carries ``token_fp`` — the opaque
+``sha256:<12hex>`` that :func:`.._account._rotation_audit.fingerprint_token`
+already produces for the account audit — and no field, log line or projection
+here carries anything else pool-derived except slot NAMES and pool source
+PATHS, the same strings :mod:`._cct_token_pool` already logs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .._account._rotation_audit import fingerprint_token
+from ._cct_token_pool import (
+    _POOL_PREFIX,
+    _TOKEN_VAR,
+    _channel_requested,
+    _declared_slot,
+    _slot_candidates,
+)
+from ._sdk_channels import _TELEGRAMMER_CHANNEL
+from ._secret_pool import PoolRead, _pool_source_label, _read_env_file, read_pool
+
+#: A real bot token resolves for this agent. :attr:`CctTokenResolution.source`
+#: says which precedence step produced it; ``token_fp`` fingerprints it.
+TOKEN_RESOLVED = "resolved"
+#: ``spec.apptainer.env`` sets ``CCT_BOT_TOKEN`` to an EXPLICITLY EMPTY value.
+#: Deliberately not a Telegram consumer — see the module docstring.
+TOKEN_DISABLED = "disabled"
+#: The spec never requests the telegrammer channel. Nothing to resolve.
+TOKEN_NO_CHANNEL = "no-channel"
+#: The channel IS requested and NO token resolves.
+TOKEN_UNRESOLVED = "unresolved"
+
+#: ``spec.apptainer.env: CCT_BOT_TOKEN`` — typed into the spec. It rides an
+#: apptainer ``--env`` flag, which is emitted AFTER ``--env-file`` and
+#: overrides it (``_apptainer_build_argv``), so it beats every other route at
+#: runtime — including an empty value, which is what makes DISABLED work.
+SOURCE_SPEC_ENV = "spec-env"
+#: The agent's materialised ``$HOME/.env`` — the ``.envrc`` cascade fold.
+SOURCE_ENV_FILE = "env-file"
+#: A ``CCT_BOT_TOKEN_<SLOT>`` from the fleet secrets pool.
+SOURCE_POOL = "pool"
+
+
+@dataclass(frozen=True)
+class CctTokenResolution:
+    """WHICH bot a spec takes — as a FINGERPRINT, never as a value."""
+
+    agent: str
+    #: One of :data:`TOKEN_RESOLVED` / :data:`TOKEN_DISABLED` /
+    #: :data:`TOKEN_NO_CHANNEL` / :data:`TOKEN_UNRESOLVED`.
+    outcome: str
+    #: For a RESOLVED outcome: which precedence step won.
+    source: str = ""
+    #: The pool slot that resolved — for ``source == "pool"`` only.
+    slot: str = ""
+    #: ``spec.apptainer.env: CCT_BOT_TOKEN_SLOT``, upper-snaked. Non-empty
+    #: means somebody typed this mapping on purpose.
+    declared_slot: str = ""
+    #: Slot names tried, in order. Names only.
+    candidates: tuple[str, ...] = ()
+    #: ``sha256:<12hex>`` of the resolved token; ``""`` when none resolved.
+    token_fp: str = ""
+    #: Whether a MISS against the pool read was conclusive (:class:`PoolRead`).
+    pool_trusted: bool = True
+    #: Why the outcome is what it is. Operator-facing.
+    detail: str = ""
+
+    @property
+    def claims_a_token(self) -> bool:
+        """True iff this agent would hold a real bot token at runtime.
+
+        The predicate the collision census counts on: only a claimed token can
+        be claimed TWICE. DISABLED, NO_CHANNEL and UNRESOLVED all hold nothing
+        and so cannot collide with anything, including each other.
+        """
+        return self.outcome == TOKEN_RESOLVED and bool(self.token_fp)
+
+    def to_dict(self) -> dict:
+        """JSON-friendly projection. Holds no token value, by construction."""
+        return {
+            "agent": self.agent,
+            "outcome": self.outcome,
+            "source": self.source,
+            "slot": self.slot,
+            "declared_slot": self.declared_slot,
+            "candidates": list(self.candidates),
+            "token_fp": self.token_fp,
+            "pool_trusted": self.pool_trusted,
+            "detail": self.detail,
+        }
+
+
+def resolve_cct_token(
+    config,
+    *,
+    dest: Path | None = None,
+    pool: PoolRead | None = None,
+) -> CctTokenResolution:
+    """WHICH bot token would ``config`` take? Pure — it reads, and writes nothing.
+
+    ``dest`` is the agent's materialised home. ``None`` means "do not consult
+    a ``.env``" — the caller has none, or is auditing a spec whose home lives
+    on another host. ``pool`` is the read-once injection seam: a fleet sweep
+    reads the pool ONCE and passes it in, rather than forking a bash per agent
+    to source ~28 secret files.
+
+    Order, first hit wins:
+
+    0. an EXPLICITLY EMPTY ``spec.apptainer.env: CCT_BOT_TOKEN`` →
+       :data:`TOKEN_DISABLED`. First because it is the loudest statement
+       available: the apptainer ``--env`` flag overrides ``--env-file``, so an
+       empty spec value beats any token sac folds into ``.env`` and the agent
+       holds nothing at runtime whatever the pool says.
+    1. no telegrammer channel → :data:`TOKEN_NO_CHANNEL`.
+    2. a non-empty ``spec.apptainer.env: CCT_BOT_TOKEN`` →
+       :data:`SOURCE_SPEC_ENV`, for the same override reason.
+    3. ``dest/.env`` already carries one → :data:`SOURCE_ENV_FILE`
+       (precedence #1, the ``.envrc`` cascade fold).
+    4. the DECLARED slot, else the mechanical candidates, against the pool →
+       :data:`SOURCE_POOL` (precedence #2/#3).
+    5. otherwise :data:`TOKEN_UNRESOLVED`.
+
+    Steps 1, 3, 4 and 5 are :func:`._cct_token_pool.ensure_cct_bot_token`'s own
+    order, unchanged — that function now calls this one, so the two cannot
+    drift. PRESENCE IS TESTED WITH BARE TRUTHINESS, not ``.strip()``, for the
+    same reason: it is what the writer did. The two can only differ on a
+    whitespace-only token, which is broken either way.
+
+    MEASURED BLAST RADIUS of routing the writer through here (122 live specs,
+    2026-08-22): 24 request the channel, 7 carry an explicit empty
+    ``CCT_BOT_TOKEN``, and ZERO carry both — so step 0, the only branch the
+    writer did not already have, changes nothing for any agent on the fleet
+    today. ZERO specs pin a non-empty ``CCT_BOT_TOKEN`` either; step 2 exists
+    so the census cannot MISS a real claim on a token, not to alter a start.
+    """
+    name = getattr(config, "name", "") or ""
+    spec_env = getattr(config, "env", None) or {}
+    declared = _declared_slot(config)
+    pinned = str(spec_env.get(_TOKEN_VAR, "") or "")
+
+    if _TOKEN_VAR in spec_env and not pinned.strip():
+        return CctTokenResolution(
+            agent=name,
+            outcome=TOKEN_DISABLED,
+            source=SOURCE_SPEC_ENV,
+            declared_slot=declared,
+            detail=(
+                f"spec.apptainer.env sets {_TOKEN_VAR} to an EXPLICITLY EMPTY "
+                "value, which rides an apptainer --env flag and overrides "
+                "anything in --env-file. This agent holds no bot token at "
+                "runtime BY DECLARATION and cannot collide with any other."
+            ),
+        )
+
+    if not _channel_requested(config):
+        return CctTokenResolution(
+            agent=name,
+            outcome=TOKEN_NO_CHANNEL,
+            declared_slot=declared,
+            detail=(
+                f"spec.claude.channels does not request {_TELEGRAMMER_CHANNEL!r}; "
+                "this agent is bot-less by declaration"
+            ),
+        )
+
+    if pinned:
+        return CctTokenResolution(
+            agent=name,
+            outcome=TOKEN_RESOLVED,
+            source=SOURCE_SPEC_ENV,
+            declared_slot=declared,
+            token_fp=fingerprint_token(pinned) or "",
+            detail=(
+                f"{_TOKEN_VAR} is pinned directly in spec.apptainer.env, which "
+                "overrides --env-file at runtime. Value not logged."
+            ),
+        )
+
+    env_file = (Path(dest) / ".env") if dest is not None else None
+    existing = (
+        _read_env_file(env_file) if env_file is not None and env_file.is_file() else {}
+    )
+    folded = existing.get(_TOKEN_VAR, "")
+    if folded:
+        return CctTokenResolution(
+            agent=name,
+            outcome=TOKEN_RESOLVED,
+            source=SOURCE_ENV_FILE,
+            declared_slot=declared,
+            token_fp=fingerprint_token(folded) or "",
+            detail=(
+                f"{_TOKEN_VAR} is already present in {env_file} (precedence #1 "
+                "— the .envrc cascade fold). Value not logged."
+            ),
+        )
+
+    workdir = getattr(config, "workdir", "") or ""
+    candidates = tuple([declared] if declared else _slot_candidates(name, workdir))
+    read = pool if pool is not None else read_pool()
+    for slot in candidates:
+        value = read.env.get(f"{_POOL_PREFIX}{slot}", "")
+        if value:
+            how = "declared in the spec" if declared else "derived from the agent name"
+            return CctTokenResolution(
+                agent=name,
+                outcome=TOKEN_RESOLVED,
+                source=SOURCE_POOL,
+                slot=slot,
+                declared_slot=declared,
+                candidates=candidates,
+                token_fp=fingerprint_token(value) or "",
+                pool_trusted=read.trusted,
+                detail=(
+                    f"resolved from pool slot {_POOL_PREFIX}{slot} ({how}). "
+                    "Value not logged."
+                ),
+            )
+
+    tried = ", ".join(f"{_POOL_PREFIX}{c}" for c in candidates) or "(no candidate)"
+    return CctTokenResolution(
+        agent=name,
+        outcome=TOKEN_UNRESOLVED,
+        declared_slot=declared,
+        candidates=candidates,
+        pool_trusted=read.trusted,
+        detail=(
+            f"spec.claude.channels requests {_TELEGRAMMER_CHANNEL!r} but no bot "
+            f"token resolves: tried {tried} against the pool "
+            f"({_pool_source_label()}), and no {_TOKEN_VAR} was folded into the "
+            "agent's .env. This agent holds no token, so it cannot collide — "
+            "but it is MUTE and DEAF on Telegram; see `sac agents cct-audit`."
+        ),
+    )
+
+
+__all__ = [
+    "SOURCE_ENV_FILE",
+    "SOURCE_POOL",
+    "SOURCE_SPEC_ENV",
+    "TOKEN_DISABLED",
+    "TOKEN_NO_CHANNEL",
+    "TOKEN_RESOLVED",
+    "TOKEN_UNRESOLVED",
+    "CctTokenResolution",
+    "resolve_cct_token",
+]

--- a/tests/scitex_agent_container/_state/test_state_db_token_owner.py
+++ b/tests/scitex_agent_container/_state/test_state_db_token_owner.py
@@ -1,0 +1,318 @@
+"""The bot-token ownership ledger — on a REAL PostgreSQL, never SQLite, never a mock.
+
+Mirrors ``src/scitex_agent_container/_state/state_db_token_owner.py``.
+
+WHY THESE TESTS TALK TO A REAL DATABASE
+=======================================
+The module under test is PostgreSQL-only by the operator's 2026-08-19 order
+("fail fast, fail loud, no fallbacks") and reaches PostgreSQL through
+``scitex_dev.store``. A suite that exercised the store's SQLite dialect would
+be testing a code path production can never take — and scitex-dev 0.49.0
+shipped a PostgreSQL backend that could be WRITTEN to and never READ from,
+precisely because that path had been written to and never read from. So the
+rows here are read BACK through the same dialect production uses.
+
+AND WHY THEY MUST NOT SKIP
+==========================
+There is deliberately NO ``skipif`` on database availability. A skip that
+reads as a pass is the defect this migration exists to remove. If PostgreSQL
+is unreachable these tests FAIL, and that red is correct: every runner in the
+gate pool has a PostgreSQL on 127.0.0.1:55432.
+
+THE TEST THAT CARRIES THE DESIGN
+================================
+``test_a_second_agent_on_the_same_token_does_not_overwrite_the_first``. The
+obvious key for this ledger is ``token_fp`` alone, and that key destroys the
+evidence: the second claimant overwrites the first and a store whose whole
+purpose is to reveal double ownership renders every collision as one tidy row.
+The identity is ``(token_fp, host, agent)`` so a contended token simply holds
+more than one row.
+
+Isolation is a per-test PostgreSQL SCHEMA selected through ``search_path`` in
+the DSN and dropped with ``CASCADE`` — a schema and not a database, because
+creating a database needs ``CREATEDB`` and the fleet's roles are not uniform.
+Real ``os.environ`` save/restore, not ``monkeypatch``: PA-306 forbids mocks,
+and the point is that the REAL resolver reads the REAL variable.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Iterator
+
+import psycopg
+import pytest
+
+from scitex_agent_container._account._rotation_audit import fingerprint_token
+from scitex_agent_container._state.state_db_token_owner import (
+    init_token_owner_schema,
+    owners_of,
+    record_token_owner,
+    token_owner_rows,
+)
+
+#: The per-host store. Loopback only — every fleet PostgreSQL refuses
+#: non-local connections at pg_hba.
+_BASE_DSN = os.environ.get(
+    "SAC_TEST_PG_DSN", "postgresql://scitex_cards@127.0.0.1:55432/scitex"
+)
+
+# A value-shaped string that must never reach the ledger. Only its fingerprint
+# may, and the module refuses anything that is not one.
+_SECRET = "zz-not-a-real-bot-token-0000000000"
+_FP = fingerprint_token(_SECRET) or ""
+_FP_OTHER = fingerprint_token(_SECRET + "-other") or ""
+
+
+@pytest.fixture()
+def pg_schema() -> Iterator[str]:
+    """A throwaway PostgreSQL schema, wired in via ``SCITEX_STORE_DSN``.
+
+    Yields the schema name. Anything the module writes lands here and is
+    dropped afterwards, so the live ledger is never touched.
+    """
+    schema = "sac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    os.environ[key] = f"{_BASE_DSN}?options=-csearch_path%3D{schema}"
+    try:
+        yield schema
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+
+
+def _tables_in(schema: str) -> set[str]:
+    """The table names PostgreSQL actually holds in ``schema``."""
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
+            (schema,),
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+# ----------------------------------------------------------------------
+# The store exists, and it is PostgreSQL.
+# ----------------------------------------------------------------------
+
+
+def test_init_creates_the_ledger_in_postgres(pg_schema: str) -> None:
+    """POSITIVE CONTROL for every test below.
+
+    Read through a SECOND, INDEPENDENT client (raw psycopg, plain SQL) rather
+    than through the store that created the table. Asking a library whether
+    its own write landed cannot distinguish "wrote to PostgreSQL" from "wrote
+    somewhere else".
+    """
+    # Arrange
+    expected = "cct_token_owner_rows"
+    # Act
+    init_token_owner_schema()
+    # Assert
+    assert expected in _tables_in(pg_schema)
+
+
+def test_init_reports_where_the_state_went(pg_schema: str) -> None:
+    # Arrange
+    expected_fragment = "55432"
+    # Act
+    locator = init_token_owner_schema()
+    # Assert
+    assert expected_fragment in locator
+
+
+# ----------------------------------------------------------------------
+# Recording a claim.
+# ----------------------------------------------------------------------
+
+
+def test_a_claim_is_recorded(pg_schema: str) -> None:
+    # Arrange
+    init_token_owner_schema()
+    # Act
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h1", pid=4242, started_at=100.0
+    )
+    # Assert
+    assert [r["agent"] for r in owners_of(_FP)] == ["zz-one"]
+
+
+def test_the_recorded_row_carries_the_pid(pg_schema: str) -> None:
+    # Arrange — "who holds this bot" is unanswerable without something to
+    # point a `ps` at.
+    init_token_owner_schema()
+    # Act
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h1", pid=4242, started_at=100.0
+    )
+    # Assert
+    assert owners_of(_FP)[0]["pid"] == 4242
+
+
+def test_a_second_agent_on_the_same_token_does_not_overwrite_the_first(
+    pg_schema: str,
+) -> None:
+    """THE DESIGN TEST. A ``token_fp``-only key would destroy this evidence.
+
+    Two agents, one bot — measured three times over on the live fleet, twice
+    across hosts. The ledger must hold BOTH claims, because a store that
+    silently collapses them renders every collision as a single tidy row and
+    reports the fault it exists to reveal as its absence.
+    """
+    # Arrange
+    init_token_owner_schema()
+    record_token_owner(
+        token_fp=_FP, agent="zz-hub", host="zz-h1", pid=1, started_at=100.0
+    )
+    # Act
+    record_token_owner(
+        token_fp=_FP, agent="zz-proj-hub", host="zz-h2", pid=2, started_at=200.0
+    )
+    # Assert
+    assert sorted(r["agent"] for r in owners_of(_FP)) == ["zz-hub", "zz-proj-hub"]
+
+
+def test_the_same_agent_restarting_refreshes_its_row(pg_schema: str) -> None:
+    # Arrange — a restart moves the pid; this row is CURRENT STATE, not a
+    # historical fact, so it must move with it.
+    init_token_owner_schema()
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h1", pid=1, started_at=100.0
+    )
+    # Act
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h1", pid=999, started_at=200.0
+    )
+    # Assert
+    assert owners_of(_FP)[0]["pid"] == 999
+
+
+def test_the_same_agent_restarting_does_not_create_a_second_row(
+    pg_schema: str,
+) -> None:
+    # Arrange — the other half of the same contract: a refresh must not look
+    # like a collision.
+    init_token_owner_schema()
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h1", pid=1, started_at=100.0
+    )
+    # Act
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h1", pid=999, started_at=200.0
+    )
+    # Assert
+    assert len(owners_of(_FP)) == 1
+
+
+def test_one_agent_on_two_hosts_is_two_rows(pg_schema: str) -> None:
+    # Arrange — the same NAME on two hosts is two live processes and two
+    # claims on the bot, which is exactly the cross-host duplicate.
+    init_token_owner_schema()
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h1", pid=1, started_at=100.0
+    )
+    # Act
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h2", pid=2, started_at=200.0
+    )
+    # Assert
+    assert len(owners_of(_FP)) == 2
+
+
+def test_claims_on_different_tokens_are_kept_apart(pg_schema: str) -> None:
+    # Arrange — the negative control: if every claim landed on one key the
+    # ledger would report a fleet-wide collision and mean nothing.
+    init_token_owner_schema()
+    record_token_owner(
+        token_fp=_FP, agent="zz-one", host="zz-h1", pid=1, started_at=100.0
+    )
+    # Act
+    record_token_owner(
+        token_fp=_FP_OTHER, agent="zz-two", host="zz-h1", pid=2, started_at=200.0
+    )
+    # Assert
+    assert len(owners_of(_FP)) == 1
+
+
+def test_the_whole_ledger_is_newest_first(pg_schema: str) -> None:
+    # Arrange
+    init_token_owner_schema()
+    record_token_owner(
+        token_fp=_FP, agent="zz-old", host="zz-h1", pid=1, started_at=100.0
+    )
+    record_token_owner(
+        token_fp=_FP_OTHER, agent="zz-new", host="zz-h1", pid=2, started_at=900.0
+    )
+    # Act
+    rows = token_owner_rows()
+    # Assert
+    assert [r["agent"] for r in rows] == ["zz-new", "zz-old"]
+
+
+def test_a_brand_new_store_is_empty_not_an_error(pg_schema: str) -> None:
+    # Arrange
+    init_token_owner_schema()
+    # Act
+    rows = token_owner_rows()
+    # Assert
+    assert rows == []
+
+
+# ----------------------------------------------------------------------
+# The one thing this ledger must never hold.
+# ----------------------------------------------------------------------
+
+
+def _write_and_capture(token_fp: str) -> BaseException | None:
+    """Attempt a write and hand back whatever it raised, or ``None``.
+
+    Lets the refusal tests keep one assertion each while still asserting on
+    the EXCEPTION TYPE rather than on the mere fact that something went wrong.
+    """
+    try:
+        record_token_owner(
+            token_fp=token_fp, agent="zz-one", host="zz-h1", pid=1, started_at=100.0
+        )
+    except BaseException as exc:  # noqa: BLE001 - the value under test
+        return exc
+    return None
+
+
+def test_a_raw_token_is_refused(pg_schema: str) -> None:
+    # Arrange — the guard exists because the caller supplies this argument and
+    # a raw value is exactly one forgotten fingerprint_token() call away.
+    init_token_owner_schema()
+    # Act
+    raised = _write_and_capture(_SECRET)
+    # Assert
+    assert isinstance(raised, ValueError)
+
+
+def test_a_refused_raw_token_is_not_written(pg_schema: str) -> None:
+    # Arrange — raising is not enough; the row must not exist either.
+    init_token_owner_schema()
+    _write_and_capture(_SECRET)
+    # Act
+    rows = token_owner_rows()
+    # Assert
+    assert rows == []
+
+
+def test_an_empty_fingerprint_is_refused(pg_schema: str) -> None:
+    # Arrange — fingerprint_token returns None for an empty token, and a
+    # caller that passed it through would otherwise write a nameless claim
+    # that silently "collides" with every other nameless one.
+    init_token_owner_schema()
+    # Act
+    raised = _write_and_capture("")
+    # Assert
+    assert isinstance(raised, ValueError)

--- a/tests/scitex_agent_container/cli_pkg/test_doctor_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_doctor_cmds.py
@@ -240,3 +240,107 @@ def test_default_doctor_still_carries_the_drift_verdict(local_drifted_source):
     payload = json.loads(result.stdout)
     # Assert
     assert payload["local"]["state"] == "behind"
+
+
+# ---------------------------------------------------------------------------
+# sac doctor --collisions  (do two SPECS resolve to the same bot token?)
+# ---------------------------------------------------------------------------
+#
+# The OTHER half of the one-token-one-poller invariant, and the half the
+# poller check structurally cannot reach: it reads SPECS + the secrets pool,
+# so it sees a duplicate split across hosts and sees it before either process
+# starts. Measured 2026-08-22, one bot token was held on compute-04 and
+# compute-03 at once and the per-host poller probe returned ok on BOTH.
+#
+# These drive the REAL host spec tree and the REAL pool, so the STATE is
+# whatever this machine is actually configured as and must NOT be asserted.
+# What IS deterministic -- and what these pin -- is that the check runs,
+# reports one of exactly three values, rides along by default, and states its
+# own scope. The state TRANSITIONS are measured against synthetic spec trees
+# in tests/.../runtimes/test__cct_token_collision.py, where the population is
+# controlled.
+
+_COLLISION_STATES = {"ok", "violation", "unknown"}
+
+
+def test_collisions_json_carries_a_three_valued_state():
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--collisions", "--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["token_collisions"]["state"] in _COLLISION_STATES
+
+
+def test_collisions_only_omits_the_drift_check():
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--collisions", "--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert "local" not in payload
+
+
+def test_collisions_only_omits_the_poller_check():
+    # Arrange -- the two checks are complements, not duplicates, so asking for
+    # one must not silently run the other.
+    # Act
+    result = CliRunner().invoke(doctor, ["--collisions", "--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert "pollers" not in payload
+
+
+def test_pollers_only_omits_the_collision_check():
+    # Arrange -- the same statement from the other side.
+    # Act
+    result = CliRunner().invoke(doctor, ["--pollers", "--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert "token_collisions" not in payload
+
+
+def test_collisions_human_output_names_the_check():
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--collisions"])
+    # Assert
+    assert "spec bot tokens" in result.output
+
+
+def test_collisions_output_states_how_many_specs_were_examined():
+    # Arrange -- a clean count means nothing without its denominator: a peer
+    # published a census that was 3-of-10 and read as 3-of-3.
+    # Act
+    result = CliRunner().invoke(doctor, ["--collisions"])
+    # Assert
+    assert "spec(s) examined" in result.output
+
+
+def test_collisions_json_points_at_the_other_half_of_the_invariant():
+    # Arrange -- an unstated limit is the same defect as a wrong hint, and
+    # neither of these checks alone is a fleet all-clear.
+    # Act
+    result = CliRunner().invoke(doctor, ["--collisions", "--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert "sac doctor --pollers" in payload["token_collisions"]["scope_note"]
+
+
+def test_default_doctor_runs_the_collision_check_too(local_drifted_source):
+    # Arrange -- a check nobody remembers to run is how a config collision
+    # survives a process kill and returns on the next start.
+    # Act
+    result = CliRunner().invoke(doctor, ["--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["token_collisions"]["state"] in _COLLISION_STATES
+
+
+def test_default_doctor_still_carries_the_poller_verdict(local_drifted_source):
+    # Arrange -- adding a check must not displace the one already there.
+    # Act
+    result = CliRunner().invoke(doctor, ["--json"])
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["pollers"]["state"] in _POLLER_STATES

--- a/tests/scitex_agent_container/runtimes/test__cct_start_observers.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_start_observers.py
@@ -1,0 +1,96 @@
+"""Both CCT start-time observations run, and neither can break a start.
+
+Covers ``runtimes/_cct_start_observers.observe_cct_at_start`` — the single
+seam :mod:`.._lifecycle._start` calls, holding the rail verdict and the
+ownership-ledger write.
+
+WHY A SEAM AND NOT TWO CALLS AT THE CALL SITE: ``_start.py`` sits against a
+512-line cap, and more importantly the two observations share a PRECONDITION
+— the agent's ``$HOME/.env`` has just been materialised, and that file is
+precedence #1 of the token resolution. Naming that precondition once, in one
+module, is what stops the second observation drifting to a place where it
+reports every agent as token-less.
+
+The tests here assert the pair RUNS and that a failing half does not take the
+start down. The halves' own behaviour is measured in
+``test__cct_rail_alarm.py`` and ``test__cct_token_ledger.py``.
+
+The store the ledger writes to is genuinely unreachable in this suite
+(``tests/_store_isolation.py`` points every test at ``127.0.0.1:1``), so the
+"a broken half does not raise" property is exercised against a real failure
+rather than a simulated one (PA-306). STX-TQ002 AAA markers, STX-TQ007 one
+assert per test.
+
+Named ``test__cct_start_observers.py`` for the PS-202/PS-204 mirror against
+``src/scitex_agent_container/runtimes/_cct_start_observers.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes._cct_start_observers import observe_cct_at_start
+from scitex_agent_container.runtimes._cct_token_ledger import (
+    CLAIM_FAILED,
+    CLAIM_SKIPPED,
+)
+
+_CHANNEL = "server:claude-code-telegrammer"
+_SECRET = "zz-not-a-real-bot-token-0000000000"
+
+
+def _cfg(name: str, *, channel: bool = True) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    if channel:
+        cfg.claude.channels = [_CHANNEL]
+    return cfg
+
+
+def _home(tmp_path: Path, env_body: str | None = None) -> Path:
+    dest = tmp_path / "home"
+    dest.mkdir(exist_ok=True)
+    if env_body is not None:
+        (dest / ".env").write_text(env_body, encoding="utf-8")
+    return dest
+
+
+def test_a_bot_less_agent_skips_both_observations(tmp_path: Path) -> None:
+    # Arrange — most of the fleet: no channel, nothing to say about it.
+    cfg = _cfg("zz-quiet", channel=False)
+    # Act
+    rail, claim = observe_cct_at_start(cfg, dest=_home(tmp_path))
+    # Assert
+    assert (rail, claim) == ("skipped", CLAIM_SKIPPED)
+
+
+def test_the_ledger_half_runs_for_an_agent_that_holds_a_bot(tmp_path: Path) -> None:
+    # Arrange — a token folded into .env is precedence #1, and an agent whose
+    # bot arrives that way can collide exactly like one that resolved a slot.
+    cfg = _cfg("zz-owner")
+    dest = _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}\n")
+    # Act
+    _rail, claim = observe_cct_at_start(cfg, dest=dest)
+    # Assert — the store is unreachable here, so FAILED is the proof it ran.
+    assert claim == CLAIM_FAILED
+
+
+def test_a_failing_ledger_does_not_stop_the_rail_verdict(tmp_path: Path) -> None:
+    # Arrange — ORDER IS THE POINT: the rail verdict can page a human about an
+    # outage, so a slow or unreachable PostgreSQL must never sit in front of
+    # it, and must never swallow it either.
+    cfg = _cfg("zz-owner")
+    dest = _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}\n")
+    # Act
+    rail, _claim = observe_cct_at_start(cfg, dest=dest)
+    # Assert
+    assert rail == "clear"
+
+
+def test_a_broken_config_does_not_raise(tmp_path: Path) -> None:
+    # Arrange — this seam is attached to every start in the fleet; whatever it
+    # is handed, the start must survive it.
+    # Act
+    rail, claim = observe_cct_at_start(object(), dest=_home(tmp_path))
+    # Assert
+    assert (rail, claim) == ("skipped", CLAIM_SKIPPED)

--- a/tests/scitex_agent_container/runtimes/test__cct_token_collision.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_token_collision.py
@@ -286,6 +286,47 @@ def test_a_violation_outranks_an_inconclusive_pool_read(fleet: Path) -> None:
     assert verdict.state == COLLISION_VIOLATION
 
 
+def test_a_spec_tree_that_does_not_exist_is_unknown_not_ok(tmp_path: Path) -> None:
+    """A root that was never read must not render as a clean fleet.
+
+    CASE E from the adversarial pass: a non-existent spec tree returned "ok"
+    with scanned=True. Zero claimants is a legitimate OK ("nothing can
+    conflict"), so "enumerated and found nothing" and "never looked" collapse
+    into the same verdict unless the missing root is caught. This check exists
+    to refuse exactly that collapse.
+    """
+    # Arrange — a path nobody created.
+    missing = tmp_path / "no-such-spec-tree"
+    # Act
+    verdict = check_token_collisions(agents_dir=str(missing), pool=_pool())
+    # Assert
+    assert verdict.state == COLLISION_UNKNOWN
+
+
+def test_a_missing_spec_tree_is_reported_as_not_scanned(tmp_path: Path) -> None:
+    # Arrange
+    missing = tmp_path / "no-such-spec-tree"
+    # Act
+    verdict = check_token_collisions(agents_dir=str(missing), pool=_pool())
+    # Assert — the verdict must SAY it never looked, not merely decline to be ok.
+    assert verdict.scanned is False
+
+
+def test_an_empty_spec_tree_is_still_ok(tmp_path: Path) -> None:
+    """The other half: a root that EXISTS and holds nothing is genuinely clean.
+
+    Without this, the fix above could be 'return unknown whenever the count is
+    zero', which would make an empty fleet permanently alarming.
+    """
+    # Arrange — the directory exists, it just has no specs in it.
+    empty = tmp_path / "empty-spec-tree"
+    empty.mkdir()
+    # Act
+    verdict = check_token_collisions(agents_dir=str(empty), pool=_pool())
+    # Assert
+    assert verdict.state == COLLISION_OK
+
+
 def test_an_unloadable_spec_is_unknown(fleet: Path) -> None:
     # Arrange — a spec sac cannot read is a claim it cannot COMPUTE.
     _write_spec(fleet, "zz-one", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ONE"})

--- a/tests/scitex_agent_container/runtimes/test__cct_token_collision.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_token_collision.py
@@ -1,0 +1,497 @@
+"""ONE bot per agent, asserted in the SPECS — the cross-host half of the invariant.
+
+Covers ``runtimes/_cct_token_collision`` and its observation half
+``runtimes/_cct_token_census``. The fault: two specs resolve to the SAME
+Telegram bot token, so whichever of them run 409 each other and the operator's
+inbound messages are dropped. Measured live 2026-08-22 — ``scitex-hub`` on
+compute-04 and ``proj-scitex-hub`` on compute-03 — while the HOST-LOCAL poller
+check returned ok on both hosts, because it structurally cannot see across
+them.
+
+WHY THIS SUITE IS HERMETIC EVEN THOUGH THE FLEET IS THE POSITIVE CONTROL.
+The check was verified against the real spec tree and reported that pair
+(plus two more nobody had reported). But a CI gate that depends on the fleet
+STAYING broken is a gate that goes green the moment somebody fixes it, so the
+collision here is built from synthetic specs on disk and a real temp pool.
+
+The load-bearing tests are the NEGATIVE ones: the handyman family (an
+explicitly empty token) and the mute majority (a requested rail that resolves
+nothing) must never be reported as collisions. If this check flags them it is
+wrong — that arrangement IS the invariant, upheld by hand.
+
+Real on-disk v3 specs, a real ``PoolRead`` through the documented ``pool=``
+seam, real ``AgentConfig`` objects — no mocks (PA-306). STX-TQ002 AAA markers,
+STX-TQ007 one assert per test. Slot names use a ``ZZ_``-prefixed namespace so
+an operator shell's real pool vars can never collide with the fixtures.
+
+Named ``test__cct_token_collision.py`` for the PS-202/PS-204 mirror against
+``src/scitex_agent_container/runtimes/_cct_token_collision.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import yaml as _yaml
+
+from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes._cct_token_census import (
+    TokenClaim,
+    census_from_resolutions,
+    census_specs,
+    spec_host,
+)
+from scitex_agent_container.runtimes._cct_token_collision import (
+    COLLISION_OK,
+    COLLISION_UNKNOWN,
+    COLLISION_VIOLATION,
+    check_token_collisions,
+    group_collisions,
+    verdict_for,
+)
+from scitex_agent_container.runtimes._cct_token_resolution import resolve_cct_token
+from scitex_agent_container.runtimes._secret_pool import PoolRead
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_spec
+
+_CHANNEL = "server:claude-code-telegrammer"
+# A value-shaped string. No verdict, hint or projection may contain it.
+_SECRET = "zz-not-a-real-bot-token-0000000000"
+
+
+@pytest.fixture
+def fleet(tmp_path: Path) -> Iterator[Path]:
+    """A real, empty spec tree passed explicitly via ``agents_dir``.
+
+    Deliberately NOT a redirected ``$SCITEX_DIR``: passing the directory is
+    the same statement with none of the coupling, and the pool travels
+    through the ``pool=`` seam rather than the environment.
+    """
+    agents = tmp_path / "agents"
+    agents.mkdir(parents=True)
+    yield agents
+
+
+def _pool(slots: dict[str, str] | None = None, *, trusted: bool = True) -> PoolRead:
+    """A real PoolRead — the documented injection seam, not a mock."""
+    return PoolRead(
+        env=dict(slots if slots is not None else {"CCT_BOT_TOKEN_ZZ_FOREIGN": _SECRET}),
+        trusted=trusted,
+        detail="" if trusted else "no canonical secret file resolved (test)",
+    )
+
+
+def _write_spec(
+    agents: Path,
+    name: str,
+    *,
+    channel: bool = True,
+    host: str = "${HOSTNAME}",
+    env: dict | None = None,
+) -> None:
+    """A REAL fully-explicit v3 ``<name>/spec.yaml`` the loader accepts.
+
+    Dir-as-SSoT: the AGENT NAME comes from the directory, exactly as on a real
+    host. ``explicit_spec`` deep-merges the blocks this suite is about onto the
+    production paste-defaults so the other required fields stay present.
+    """
+    body = explicit_spec(
+        {
+            "host": host,
+            "workdir": str(agents.parent),
+            "claude": {"channels": [_CHANNEL] if channel else []},
+            "apptainer": {"env": dict(env or {})},
+        }
+    )
+    target = agents / name
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "spec.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "apiVersion": "scitex-agent-container/v3",
+                "kind": "Agent",
+                "metadata": {"labels": {}},
+                "spec": body,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _cfg(name: str, *, channel: bool = True, env: dict | None = None) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    if channel:
+        cfg.claude.channels = [_CHANNEL]
+    if env:
+        cfg.env = dict(env)
+    return cfg
+
+
+def _claim(agent: str, fp: str, host: str = "") -> TokenClaim:
+    return TokenClaim(agent=agent, token_fp=fp, host=host)
+
+
+def _rows(*configs_and_hosts, pool: PoolRead):
+    """``(resolution, host, spec)`` triples, the pure seam's input shape."""
+    return [
+        (resolve_cct_token(cfg, dest=None, pool=pool), host, f"/zz/{cfg.name}.yaml")
+        for cfg, host in configs_and_hosts
+    ]
+
+
+# ---------------------------------------------------------------------------
+# the fault
+# ---------------------------------------------------------------------------
+
+
+def test_two_specs_on_one_bot_are_a_violation(fleet: Path) -> None:
+    # Arrange — the 2026-08-22 shape, reproduced hermetically.
+    _write_spec(fleet, "zz-hub", host="zz-compute-04", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    _write_spec(
+        fleet, "zz-proj-hub", host="zz-compute-03", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"}
+    )
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_HUB": _SECRET})
+    )
+    # Assert
+    assert verdict.state == COLLISION_VIOLATION
+
+
+def test_the_violation_names_both_agents_and_both_hosts(fleet: Path) -> None:
+    # Arrange — the remedy is a config decision about which one yields, so a
+    # report that names one of them is not actionable.
+    _write_spec(fleet, "zz-hub", host="zz-compute-04", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    _write_spec(
+        fleet, "zz-proj-hub", host="zz-compute-03", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"}
+    )
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_HUB": _SECRET})
+    )
+    # Assert
+    assert verdict.collisions[0].describe() == (
+        "zz-hub@zz-compute-04 + zz-proj-hub@zz-compute-03"
+    )
+
+
+def test_a_cross_host_pair_is_marked_cross_host(fleet: Path) -> None:
+    # Arrange — the case NO per-host process check can see; saying so is what
+    # stops a reader concluding a kill on one host settled it.
+    _write_spec(fleet, "zz-hub", host="zz-compute-04", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    _write_spec(
+        fleet, "zz-proj-hub", host="zz-compute-03", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"}
+    )
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_HUB": _SECRET})
+    )
+    # Assert
+    assert verdict.collisions[0].cross_host is True
+
+
+def test_two_specs_on_different_bots_are_ok(fleet: Path) -> None:
+    # Arrange — the negative control for the detector itself.
+    _write_spec(fleet, "zz-one", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ONE"})
+    _write_spec(fleet, "zz-two", env={"CCT_BOT_TOKEN_SLOT": "ZZ_TWO"})
+    pool = _pool(
+        {
+            "CCT_BOT_TOKEN_ZZ_ONE": f"{_SECRET}-a",
+            "CCT_BOT_TOKEN_ZZ_TWO": f"{_SECRET}-b",
+        }
+    )
+    # Act
+    verdict = check_token_collisions(agents_dir=str(fleet), pool=pool)
+    # Assert
+    assert verdict.state == COLLISION_OK
+
+
+# ---------------------------------------------------------------------------
+# the populations that hold NOTHING and therefore cannot collide
+# ---------------------------------------------------------------------------
+
+
+def test_the_handyman_pattern_is_not_a_violation(fleet: Path) -> None:
+    # Arrange — seven agents with an explicitly EMPTY token beside the one
+    # that owns the shared bot. This arrangement IS the invariant.
+    _write_spec(fleet, "zz-handyman-06", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HANDYMAN"})
+    for n in range(1, 6):
+        _write_spec(fleet, f"zz-handyman-0{n}", channel=False, env={"CCT_BOT_TOKEN": ""})
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_HANDYMAN": _SECRET})
+    )
+    # Assert
+    assert verdict.state == COLLISION_OK
+
+
+def test_the_deliberately_tokenless_are_counted_as_such(fleet: Path) -> None:
+    # Arrange — excluded, but never silently: an unexplained exclusion is how
+    # a census quietly stops covering the thing it claims to cover.
+    for n in range(1, 6):
+        _write_spec(fleet, f"zz-handyman-0{n}", channel=False, env={"CCT_BOT_TOKEN": ""})
+    # Act
+    verdict = check_token_collisions(agents_dir=str(fleet), pool=_pool())
+    # Assert
+    assert len(verdict.census.disabled) == 5
+
+
+def test_agents_that_resolve_nothing_are_not_a_violation(fleet: Path) -> None:
+    # Arrange — the mute majority: 81 specs declared the channel and 15
+    # resolved a token (2026-08-12). None of them can take another's bot.
+    _write_spec(fleet, "zz-mute-a")
+    _write_spec(fleet, "zz-mute-b")
+    # Act
+    verdict = check_token_collisions(agents_dir=str(fleet), pool=_pool())
+    # Assert
+    assert verdict.state == COLLISION_OK
+
+
+def test_agents_that_resolve_nothing_are_still_named(fleet: Path) -> None:
+    # Arrange — "not a collision" must not become "not reported": this is the
+    # mute-and-deaf fault, owned by `sac agents cct-audit`, and it belongs in
+    # the population line rather than folded into the clean count.
+    _write_spec(fleet, "zz-mute-a")
+    _write_spec(fleet, "zz-mute-b")
+    # Act
+    verdict = check_token_collisions(agents_dir=str(fleet), pool=_pool())
+    # Assert
+    assert sorted(verdict.census.unresolved) == ["zz-mute-a", "zz-mute-b"]
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN is never an all-clear
+# ---------------------------------------------------------------------------
+
+
+def test_an_inconclusive_pool_read_is_unknown_not_ok(fleet: Path) -> None:
+    # Arrange — a clean result under a read sac could not trust says nothing.
+    _write_spec(fleet, "zz-one", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ONE"})
+    # Act
+    verdict = check_token_collisions(agents_dir=str(fleet), pool=_pool(trusted=False))
+    # Assert
+    assert verdict.state == COLLISION_UNKNOWN
+
+
+def test_a_violation_outranks_an_inconclusive_pool_read(fleet: Path) -> None:
+    # Arrange — a HIT is conclusive even when a MISS is not, so a duplicate
+    # found under an untrusted read is still a duplicate.
+    _write_spec(fleet, "zz-hub", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    _write_spec(fleet, "zz-proj-hub", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    pool = _pool({"CCT_BOT_TOKEN_ZZ_HUB": _SECRET}, trusted=False)
+    # Act
+    verdict = check_token_collisions(agents_dir=str(fleet), pool=pool)
+    # Assert
+    assert verdict.state == COLLISION_VIOLATION
+
+
+def test_an_unloadable_spec_is_unknown(fleet: Path) -> None:
+    # Arrange — a spec sac cannot read is a claim it cannot COMPUTE.
+    _write_spec(fleet, "zz-one", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ONE"})
+    broken = fleet / "zz-broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("{{{ not yaml", encoding="utf-8")
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_ONE": _SECRET})
+    )
+    # Assert
+    assert verdict.state == COLLISION_UNKNOWN
+
+
+def test_an_unloadable_spec_is_named_not_dropped(fleet: Path) -> None:
+    # Arrange
+    broken = fleet / "zz-broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("{{{ not yaml", encoding="utf-8")
+    # Act
+    verdict = check_token_collisions(agents_dir=str(fleet), pool=_pool())
+    # Assert
+    assert verdict.census.unreadable == ("zz-broken",)
+
+
+def test_a_violation_outranks_an_unloadable_spec(fleet: Path) -> None:
+    # Arrange — one broken YAML must not mute a computed duplicate.
+    _write_spec(fleet, "zz-hub", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    _write_spec(fleet, "zz-proj-hub", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    broken = fleet / "zz-broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("{{{ not yaml", encoding="utf-8")
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_HUB": _SECRET})
+    )
+    # Assert
+    assert verdict.state == COLLISION_VIOLATION
+
+
+def test_a_missing_spec_tree_examines_nothing(tmp_path: Path) -> None:
+    # Arrange — the zero that must not read like a clean fleet.
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(tmp_path / "nope"), pool=_pool()
+    )
+    # Assert
+    assert verdict.census.examined == 0
+
+
+# ---------------------------------------------------------------------------
+# population — R4: a clean count means nothing without its denominator
+# ---------------------------------------------------------------------------
+
+
+def test_the_population_line_states_how_many_specs_were_examined(fleet: Path) -> None:
+    # Arrange — "0 collisions across 0" and "0 across 3" must not render alike.
+    _write_spec(fleet, "zz-one", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ONE"})
+    _write_spec(fleet, "zz-mute")
+    _write_spec(fleet, "zz-hand", channel=False, env={"CCT_BOT_TOKEN": ""})
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_ONE": _SECRET})
+    )
+    # Assert
+    assert verdict.population().startswith("3 spec(s) examined, 1 claim a bot token")
+
+
+def test_an_empty_fleet_says_it_examined_nothing(fleet: Path) -> None:
+    # Arrange
+    # Act
+    verdict = check_token_collisions(agents_dir=str(fleet), pool=_pool())
+    # Assert
+    assert "0 spec(s) examined" in verdict.population()
+
+
+# ---------------------------------------------------------------------------
+# scope + secrecy
+# ---------------------------------------------------------------------------
+
+
+def test_every_verdict_states_the_scope_and_points_at_the_other_half(
+    fleet: Path,
+) -> None:
+    # Arrange — an unstated limit is the same defect as a wrong hint.
+    _write_spec(fleet, "zz-one", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ONE"})
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_ONE": _SECRET})
+    )
+    # Assert
+    assert "sac doctor --pollers" in verdict.to_dict()["scope_note"]
+
+
+def test_no_token_value_reaches_the_rendered_verdict(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "zz-hub", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    _write_spec(fleet, "zz-proj-hub", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_HUB": _SECRET})
+    )
+    # Act
+    rendered = (
+        repr(verdict.to_dict())
+        + verdict.detail
+        + verdict.hint()
+        + verdict.summary()
+        + verdict.population()
+    )
+    # Assert
+    assert _SECRET not in rendered
+
+
+def test_an_ok_verdict_offers_no_remedy(fleet: Path) -> None:
+    # Arrange — an all-clear that hands out a fix is a hint people learn to
+    # ignore on the day it matters.
+    _write_spec(fleet, "zz-one", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ONE"})
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_ONE": _SECRET})
+    )
+    # Assert
+    assert verdict.hint() == ""
+
+
+def test_the_violation_hint_says_killing_a_process_does_not_fix_it(
+    fleet: Path,
+) -> None:
+    # Arrange — the 2026-08-22 remediation stopped at the process and the
+    # specs still collided, so the remedy must say so in words.
+    _write_spec(fleet, "zz-hub", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    _write_spec(fleet, "zz-proj-hub", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"})
+    # Act
+    verdict = check_token_collisions(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_HUB": _SECRET})
+    )
+    # Assert
+    assert "Killing a process does NOT fix this" in verdict.hint()
+
+
+# ---------------------------------------------------------------------------
+# the pure seams
+# ---------------------------------------------------------------------------
+
+
+def test_group_collisions_groups_by_fingerprint() -> None:
+    # Arrange
+    claims = [_claim("a", "sha256:aaa"), _claim("b", "sha256:aaa"), _claim("c", "sha256:bbb")]
+    # Act
+    groups = group_collisions(claims)
+    # Assert
+    assert [g.agents for g in groups] == [("a", "b")]
+
+
+def test_group_collisions_ignores_claims_with_no_fingerprint() -> None:
+    # Arrange — two agents holding nothing are not two agents holding the same
+    # thing; grouping on "" would manufacture a collision out of absence.
+    claims = [_claim("a", ""), _claim("b", "")]
+    # Act
+    groups = group_collisions(claims)
+    # Assert
+    assert groups == ()
+
+
+def test_a_same_host_pair_is_not_marked_cross_host() -> None:
+    # Arrange
+    claims = [_claim("a", "sha256:aaa", "zz-h1"), _claim("b", "sha256:aaa", "zz-h1")]
+    # Act
+    groups = group_collisions(claims)
+    # Assert
+    assert groups[0].cross_host is False
+
+
+def test_verdict_for_is_pure_over_a_constructed_census() -> None:
+    # Arrange — the seam that lets the condition be asserted with no disk.
+    pool = _pool({"CCT_BOT_TOKEN_ZZ_HUB": _SECRET})
+    rows = _rows(
+        (_cfg("zz-a", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"}), "zz-h1"),
+        (_cfg("zz-b", env={"CCT_BOT_TOKEN_SLOT": "ZZ_HUB"}), "zz-h2"),
+        pool=pool,
+    )
+    census = census_from_resolutions(rows, pool_trusted=True)
+    # Act
+    verdict = verdict_for(census)
+    # Assert
+    assert verdict.state == COLLISION_VIOLATION
+
+
+def test_census_specs_reads_the_spec_tree_not_the_registry(fleet: Path) -> None:
+    # Arrange — a STOPPED agent is absent from the registry and its collision
+    # returns the moment it starts, so the spec tree is the right population.
+    _write_spec(fleet, "zz-stopped", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ONE"})
+    # Act
+    census = census_specs(
+        agents_dir=str(fleet), pool=_pool({"CCT_BOT_TOKEN_ZZ_ONE": _SECRET})
+    )
+    # Assert
+    assert [c.agent for c in census.claims] == ["zz-stopped"]
+
+
+def test_spec_host_renders_a_fallback_chain_in_full() -> None:
+    # Arrange — every entry is a place the agent could run, and all of them
+    # matter to "which one yields".
+    cfg = AgentConfig(name="zz-multi")
+    cfg.hosts_spec.host = ["zz-h1", "zz-h2"]
+    # Act
+    got = spec_host(cfg)
+    # Assert
+    assert got == "zz-h1|zz-h2"

--- a/tests/scitex_agent_container/runtimes/test__cct_token_ledger.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_token_ledger.py
@@ -1,0 +1,174 @@
+"""The start-time write to the bot-token ownership ledger. Never fatal.
+
+Covers ``runtimes/_cct_token_ledger.record_token_claim_at_start``, the hook
+:mod:`.._lifecycle._start` runs beside the rail verdict.
+
+THE PROPERTY THAT MATTERS IS THE NEGATIVE ONE. The store underneath is
+PostgreSQL-only and RAISES when the database is unreachable — correct for the
+store, unacceptable on a path attached to every start in the fleet. So the
+tests that carry the design are the ones proving an unreachable store yields a
+printed line and a return value, not an exception: a ledger that can refuse a
+boot is strictly worse than a missing ledger.
+
+The unreachable store is NOT mocked. ``tests/_store_isolation.py`` already
+points every test at a DSN that cannot exist (``127.0.0.1:1``), so the failure
+these tests exercise is the real one production would hit, produced by the
+real client against a real closed port (PA-306).
+
+STX-TQ002 AAA markers, STX-TQ007 one assert per test. Slot names use a
+``ZZ_``-prefixed namespace so an operator shell's real pool vars can never
+collide with the fixtures.
+
+Named ``test__cct_token_ledger.py`` for the PS-202/PS-204 mirror against
+``src/scitex_agent_container/runtimes/_cct_token_ledger.py``.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes._cct_token_ledger import (
+    CLAIM_FAILED,
+    CLAIM_SKIPPED,
+    record_token_claim_at_start,
+)
+
+_CHANNEL = "server:claude-code-telegrammer"
+# A value-shaped string. No stderr line may contain it.
+_SECRET = "zz-not-a-real-bot-token-0000000000"
+
+
+def _cfg(name: str, *, channel: bool = True, env: dict | None = None) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    if channel:
+        cfg.claude.channels = [_CHANNEL]
+    if env:
+        cfg.env = dict(env)
+    return cfg
+
+
+def _home(tmp_path: Path, env_body: str | None = None) -> Path:
+    dest = tmp_path / "home"
+    dest.mkdir(exist_ok=True)
+    if env_body is not None:
+        (dest / ".env").write_text(env_body, encoding="utf-8")
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# nothing to record
+# ---------------------------------------------------------------------------
+
+
+def test_an_agent_without_the_channel_records_nothing(tmp_path: Path) -> None:
+    # Arrange
+    stream = io.StringIO()
+    # Act
+    outcome = record_token_claim_at_start(
+        _cfg("zz-quiet", channel=False), dest=_home(tmp_path), err_stream=stream
+    )
+    # Assert
+    assert outcome == CLAIM_SKIPPED
+
+
+def test_a_deliberately_tokenless_agent_records_nothing(tmp_path: Path) -> None:
+    # Arrange — the handyman pattern holds no token, so it owns none.
+    stream = io.StringIO()
+    # Act
+    outcome = record_token_claim_at_start(
+        _cfg("zz-hand", env={"CCT_BOT_TOKEN": ""}),
+        dest=_home(tmp_path),
+        err_stream=stream,
+    )
+    # Assert
+    assert outcome == CLAIM_SKIPPED
+
+
+def test_an_agent_that_resolves_nothing_records_nothing(tmp_path: Path) -> None:
+    # Arrange — mute and deaf is a real fault and it is not an ownership
+    # claim; recording it would put a nameless row in the ledger.
+    stream = io.StringIO()
+    # Act
+    outcome = record_token_claim_at_start(
+        _cfg("zz-mute", env={"CCT_BOT_TOKEN_SLOT": "ZZ_ABSENT"}),
+        dest=_home(tmp_path),
+        err_stream=stream,
+    )
+    # Assert
+    assert outcome == CLAIM_SKIPPED
+
+
+def test_a_skipped_claim_says_nothing_on_stderr(tmp_path: Path) -> None:
+    # Arrange — most of the fleet has no bot; a line each would be noise in
+    # the one panel the operator actually reads.
+    stream = io.StringIO()
+    # Act
+    record_token_claim_at_start(
+        _cfg("zz-quiet", channel=False), dest=_home(tmp_path), err_stream=stream
+    )
+    # Assert
+    assert stream.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# an unreachable store must not break a start
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreachable_store_does_not_raise(tmp_path: Path) -> None:
+    # Arrange — the suite's store isolation points at a DSN that cannot exist,
+    # which is exactly the production failure: PostgreSQL down.
+    stream = io.StringIO()
+    dest = _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}\n")
+    # Act
+    outcome = record_token_claim_at_start(
+        _cfg("zz-owner"), dest=dest, err_stream=stream
+    )
+    # Assert
+    assert outcome == CLAIM_FAILED
+
+
+def test_an_unreachable_store_says_the_agent_starts_normally(tmp_path: Path) -> None:
+    # Arrange — a warning that does not say what it did NOT break is read as
+    # a boot failure; that misreading is what demoted this subsystem's
+    # missing-token log from ERROR to WARNING in the first place.
+    stream = io.StringIO()
+    dest = _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}\n")
+    # Act
+    record_token_claim_at_start(_cfg("zz-owner"), dest=dest, err_stream=stream)
+    # Assert
+    assert "THE AGENT STARTS NORMALLY" in stream.getvalue()
+
+
+def test_the_failure_line_names_the_agent(tmp_path: Path) -> None:
+    # Arrange — one line per start across a 122-agent fleet is unreadable
+    # unless it says WHOSE claim went unrecorded.
+    stream = io.StringIO()
+    dest = _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}\n")
+    # Act
+    record_token_claim_at_start(_cfg("zz-owner"), dest=dest, err_stream=stream)
+    # Assert
+    assert "zz-owner" in stream.getvalue()
+
+
+def test_no_token_value_reaches_stderr(tmp_path: Path) -> None:
+    # Arrange — the failure path is the one that prints, so it is the one that
+    # could leak. Only a fingerprint may travel, and not even that is printed.
+    stream = io.StringIO()
+    dest = _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}\n")
+    # Act
+    record_token_claim_at_start(_cfg("zz-owner"), dest=dest, err_stream=stream)
+    # Assert
+    assert _SECRET not in stream.getvalue()
+
+
+def test_a_broken_config_does_not_raise(tmp_path: Path) -> None:
+    # Arrange — an object that is not an AgentConfig at all: whatever this
+    # function is handed, a start must survive it.
+    stream = io.StringIO()
+    # Act
+    outcome = record_token_claim_at_start(object(), dest=None, err_stream=stream)
+    # Assert
+    assert outcome in (CLAIM_SKIPPED, CLAIM_FAILED)

--- a/tests/scitex_agent_container/runtimes/test__cct_token_resolution.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_token_resolution.py
@@ -1,0 +1,274 @@
+"""The ONE agent-to-bot derivation, and its four outcomes.
+
+Covers ``runtimes/_cct_token_resolution.resolve_cct_token`` — the computation
+``ensure_cct_bot_token`` writes with, the fleet collision census counts with,
+and the ownership ledger records with. A second derivation drifting from the
+writer's is how a census reports collisions that do not exist; the tests that
+matter most here are therefore the ones asserting the FOUR outcomes stay
+distinct, and the one asserting no token VALUE ever reaches the result.
+
+Real ``AgentConfig`` objects, real temp ``.env`` files, and a real
+``PoolRead`` injected through the documented ``pool=`` seam — no mocks
+(PA-306). STX-TQ002 AAA markers, STX-TQ007 one assert per test. Slot names use
+a ``ZZ_``-prefixed namespace so an operator shell's real pool vars can never
+collide with the fixtures.
+
+Named ``test__cct_token_resolution.py`` for the PS-202/PS-204 mirror against
+``src/scitex_agent_container/runtimes/_cct_token_resolution.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes._cct_token_resolution import (
+    SOURCE_ENV_FILE,
+    SOURCE_POOL,
+    SOURCE_SPEC_ENV,
+    TOKEN_DISABLED,
+    TOKEN_NO_CHANNEL,
+    TOKEN_RESOLVED,
+    TOKEN_UNRESOLVED,
+    resolve_cct_token,
+)
+from scitex_agent_container.runtimes._secret_pool import PoolRead
+
+_CHANNEL = "server:claude-code-telegrammer"
+# A value-shaped string. No test may find it in a resolution or its projection.
+_SECRET = "zz-not-a-real-bot-token-0000000000"
+
+
+def _cfg(
+    name: str,
+    *,
+    channel: bool = True,
+    workdir: str = "",
+    env: dict[str, str] | None = None,
+) -> AgentConfig:
+    """Real AgentConfig with the telegrammer channel requested by default."""
+    cfg = AgentConfig(name=name)
+    cfg.workdir = workdir
+    if channel:
+        cfg.claude.channels = [_CHANNEL]
+    if env:
+        cfg.env = dict(env)
+    return cfg
+
+
+def _pool(slots: dict[str, str] | None = None, *, trusted: bool = True) -> PoolRead:
+    """A real PoolRead — the documented injection seam, not a mock."""
+    return PoolRead(
+        env=dict(slots if slots is not None else {"CCT_BOT_TOKEN_ZZ_FOREIGN": _SECRET}),
+        trusted=trusted,
+        detail="" if trusted else "no canonical secret file resolved (test)",
+    )
+
+
+def _home(tmp_path: Path, env_body: str | None = None) -> Path:
+    dest = tmp_path / "home"
+    dest.mkdir(exist_ok=True)
+    if env_body is not None:
+        (dest / ".env").write_text(env_body, encoding="utf-8")
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# the four outcomes, kept apart
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_without_the_channel_is_no_channel(tmp_path: Path) -> None:
+    # Arrange — the pool holds this agent's slot; the spec never asks for it.
+    cfg = _cfg("zz-quiet", channel=False)
+    # Act
+    got = resolve_cct_token(
+        cfg, dest=_home(tmp_path), pool=_pool({"CCT_BOT_TOKEN_ZZ_QUIET": _SECRET})
+    )
+    # Assert
+    assert got.outcome == TOKEN_NO_CHANNEL
+
+
+def test_an_explicitly_empty_spec_token_is_disabled_not_unresolved(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the handyman pattern: an empty spec value overrides the pool.
+    cfg = _cfg("zz-hand", env={"CCT_BOT_TOKEN": ""})
+    # Act
+    got = resolve_cct_token(
+        cfg, dest=_home(tmp_path), pool=_pool({"CCT_BOT_TOKEN_ZZ_HAND": _SECRET})
+    )
+    # Assert — DELIBERATELY tokenless is not the same fact as broken.
+    assert got.outcome == TOKEN_DISABLED
+
+
+def test_the_empty_spec_token_beats_a_matching_pool_slot(tmp_path: Path) -> None:
+    # Arrange — same shape; this asserts the ORDER, not just the label.
+    cfg = _cfg("zz-hand", env={"CCT_BOT_TOKEN": ""})
+    # Act
+    got = resolve_cct_token(
+        cfg, dest=_home(tmp_path), pool=_pool({"CCT_BOT_TOKEN_ZZ_HAND": _SECRET})
+    )
+    # Assert — seven of eight handymen depend on this: they must claim nothing.
+    assert not got.claims_a_token
+
+
+def test_an_empty_spec_token_without_the_channel_is_still_disabled(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the LIVE handyman shape: empty token AND no channel request.
+    cfg = _cfg("zz-hand", channel=False, env={"CCT_BOT_TOKEN": ""})
+    # Act
+    got = resolve_cct_token(cfg, dest=_home(tmp_path), pool=_pool())
+    # Assert — the explicit statement is reported over the mere absence.
+    assert got.outcome == TOKEN_DISABLED
+
+
+def test_a_requested_rail_with_no_slot_is_unresolved(tmp_path: Path) -> None:
+    # Arrange — the channel is requested; the pool holds somebody else's bot.
+    cfg = _cfg("zz-mute")
+    # Act
+    got = resolve_cct_token(cfg, dest=_home(tmp_path), pool=_pool())
+    # Assert
+    assert got.outcome == TOKEN_UNRESOLVED
+
+
+def test_unresolved_claims_no_token_so_it_cannot_collide(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _cfg("zz-mute")
+    # Act
+    got = resolve_cct_token(cfg, dest=_home(tmp_path), pool=_pool())
+    # Assert — mute and deaf is a real fault, and it is not THIS one.
+    assert not got.claims_a_token
+
+
+# ---------------------------------------------------------------------------
+# precedence
+# ---------------------------------------------------------------------------
+
+
+def test_a_pool_slot_resolves_from_the_agent_name(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _cfg("zz-named")
+    # Act
+    got = resolve_cct_token(
+        cfg, dest=_home(tmp_path), pool=_pool({"CCT_BOT_TOKEN_ZZ_NAMED": _SECRET})
+    )
+    # Assert
+    assert (got.outcome, got.source, got.slot) == (
+        TOKEN_RESOLVED,
+        SOURCE_POOL,
+        "ZZ_NAMED",
+    )
+
+
+def test_a_declared_slot_is_exclusive(tmp_path: Path) -> None:
+    # Arrange — the declared slot is absent; the mechanical one is present.
+    cfg = _cfg("zz-named", env={"CCT_BOT_TOKEN_SLOT": "ZZ_TYPO"})
+    # Act
+    got = resolve_cct_token(
+        cfg, dest=_home(tmp_path), pool=_pool({"CCT_BOT_TOKEN_ZZ_NAMED": _SECRET})
+    )
+    # Assert — a typo fails loud; it never silently falls back to another bot.
+    assert got.outcome == TOKEN_UNRESOLVED
+
+
+def test_the_env_file_fold_wins_over_the_pool(tmp_path: Path) -> None:
+    # Arrange — precedence #1: a project .envrc already folded a token in.
+    cfg = _cfg("zz-named")
+    dest = _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}-folded\n")
+    # Act
+    got = resolve_cct_token(
+        cfg, dest=dest, pool=_pool({"CCT_BOT_TOKEN_ZZ_NAMED": _SECRET})
+    )
+    # Assert
+    assert got.source == SOURCE_ENV_FILE
+
+
+def test_a_token_pinned_in_the_spec_wins_over_the_env_file(tmp_path: Path) -> None:
+    # Arrange — an apptainer --env flag overrides --env-file at runtime, so a
+    # pinned value is what the agent actually holds.
+    cfg = _cfg("zz-pinned", env={"CCT_BOT_TOKEN": f"{_SECRET}-pinned"})
+    dest = _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}-folded\n")
+    # Act
+    got = resolve_cct_token(cfg, dest=dest, pool=_pool())
+    # Assert
+    assert got.source == SOURCE_SPEC_ENV
+
+
+def test_dest_none_means_do_not_consult_an_env_file(tmp_path: Path) -> None:
+    # Arrange — a .env exists but the caller did not offer it (a peer's spec
+    # tree, whose materialised home lives on another host).
+    cfg = _cfg("zz-named")
+    _home(tmp_path, f"CCT_BOT_TOKEN={_SECRET}-folded\n")
+    # Act
+    got = resolve_cct_token(cfg, dest=None, pool=_pool())
+    # Assert
+    assert got.outcome == TOKEN_UNRESOLVED
+
+
+# ---------------------------------------------------------------------------
+# the fingerprint contract
+# ---------------------------------------------------------------------------
+
+
+def test_two_agents_on_one_slot_share_a_fingerprint(tmp_path: Path) -> None:
+    # Arrange — the collision condition, at the level that detects it.
+    pool = _pool({"CCT_BOT_TOKEN_ZZ_SHARED": _SECRET})
+    one = _cfg("zz-one", env={"CCT_BOT_TOKEN_SLOT": "ZZ_SHARED"})
+    two = _cfg("zz-two", env={"CCT_BOT_TOKEN_SLOT": "ZZ_SHARED"})
+    # Act
+    a = resolve_cct_token(one, dest=_home(tmp_path), pool=pool)
+    b = resolve_cct_token(two, dest=None, pool=pool)
+    # Assert
+    assert a.token_fp == b.token_fp
+
+
+def test_two_agents_on_different_slots_do_not(tmp_path: Path) -> None:
+    # Arrange — the negative control: the fingerprint must DISCRIMINATE, or
+    # every agent would "collide" with every other and the check would be
+    # unfalsifiable.
+    pool = _pool(
+        {
+            "CCT_BOT_TOKEN_ZZ_ONE": f"{_SECRET}-a",
+            "CCT_BOT_TOKEN_ZZ_TWO": f"{_SECRET}-b",
+        }
+    )
+    # Act
+    a = resolve_cct_token(_cfg("zz-one"), dest=None, pool=pool)
+    b = resolve_cct_token(_cfg("zz-two"), dest=None, pool=pool)
+    # Assert
+    assert a.token_fp != b.token_fp
+
+
+def test_the_fingerprint_is_opaque(tmp_path: Path) -> None:
+    # Arrange
+    pool = _pool({"CCT_BOT_TOKEN_ZZ_NAMED": _SECRET})
+    # Act
+    got = resolve_cct_token(_cfg("zz-named"), dest=None, pool=pool)
+    # Assert
+    assert got.token_fp.startswith("sha256:")
+
+
+def test_no_token_value_reaches_the_projection(tmp_path: Path) -> None:
+    # Arrange — the whole secret contract, asserted on the surface that
+    # travels: to_dict() is what --json prints and what a ledger row is built
+    # from.
+    pool = _pool({"CCT_BOT_TOKEN_ZZ_NAMED": _SECRET})
+    got = resolve_cct_token(_cfg("zz-named"), dest=None, pool=pool)
+    # Act
+    rendered = repr(got.to_dict()) + got.detail + repr(got)
+    # Assert
+    assert _SECRET not in rendered
+
+
+def test_an_untrusted_pool_read_is_carried_into_the_resolution(
+    tmp_path: Path,
+) -> None:
+    # Arrange — a MISS against an untrusted read proves nothing, and the
+    # caller cannot know that unless the resolution says so.
+    cfg = _cfg("zz-mute")
+    # Act
+    got = resolve_cct_token(cfg, dest=None, pool=_pool(trusted=False))
+    # Assert
+    assert got.pool_trusted is False


### PR DESCRIPTION
## The gap this closes

Telegram's `getUpdates` admits **one consumer per bot token, globally**. The
live detector that shipped in #1187 reads `/proc` and is **host-scoped**.

Measured 2026-08-22: fingerprint `00ec09b9ad73` was held by `scitex-hub` on
compute-04 and `proj-scitex-hub` on compute-03 **at the same moment**, and the
per-host poller probe returned `ok` on **both**. Only the process was killed —
the two SPECS still resolved to the same slot, so the collision was still there
and would return on the next start.

This adds the other half, with **no cross-host probing**, because the fault is
STATIC: it is visible in the specs plus the pool before anything runs.

## What ships

**`sac doctor --collisions`** (also on by default alongside the poller check).
Resolves every registered spec, fingerprints the token it would take, and
asserts the fingerprints are pairwise distinct. Three-valued — `ok` /
`violation` / `unknown` — where a violation OUTRANKS an unknown and an
inconclusive pool read is never rendered as fine. Read-only. It reports; it
does not refuse a start.

| | `--pollers` (#1187) | `--collisions` (this PR) |
|---|---|---|
| reads | `/proc` | specs + the secrets pool |
| scope | ONE host | fleet-wide |
| sees | a LIVE duplicate, incl. an ORPHANED poller | a duplicate BEFORE anything starts, ACROSS hosts |
| blind to | anything on another host | any process at all |

Each verdict's `scope_note` names the other check. Neither alone is an
all-clear.

## One derivation, not a second opinion

`runtimes/_cct_token_resolution.resolve_cct_token` is **extracted from**
`ensure_cct_bot_token`, which now calls it. The writer is that function plus a
file write; the census is that function over every spec; the ledger records
what it returns. A second agent-to-slot derivation beside the real one reports
collisions that do not exist or misses ones that do — so there is not one.

**Measured blast radius** of routing the writer through it (122 live specs,
2026-08-22): 24 request the channel, 7 carry an explicit empty
`CCT_BOT_TOKEN`, **zero carry both**, and **zero** pin a non-empty one. The
branches the writer did not already have change nothing for any agent on the
fleet today.

## Four outcomes, not two

"Has no bot" is three different facts, and only one is a defect:

- **disabled** — an explicitly EMPTY `CCT_BOT_TOKEN`. **Designed**: seven of
  the eight handymen carry it so only `handyman-06` polls the shared handyman
  bot. That arrangement *is* the invariant, upheld by hand; a check that
  flagged the family would be flagging the answer.
- **no-channel** — the spec never asks for the rail.
- **unresolved** — it asks and nothing resolves. Counted and named in every
  result, and deliberately **not** alarming here: it is the mute-and-deaf fault
  (owned by `sac agents cct-audit` / `_cct_rail_alarm`) and it is the majority
  — 81 specs declared the channel, 15 resolved a token (2026-08-12). Alarming
  on it here would fire on 66 agents forever.

## Live positive control

Run against the real spec tree and the real pool, **2026-08-22 ~17:55 UTC**:

```
STATE: violation
SUMMARY: 3 bot token(s) claimed twice:
  sha256:00ec09b9ad73  proj-scitex-hub@scitex-compute-03 + scitex-hub@scitex-compute-04
  sha256:47afa579cb86  business@ywata-note-win + grant-agent@ywata-note-win
  sha256:ece7d6cc9000  scitex-cards@scitex-compute-04 + scitex-todo@ywata-note-win
POPULATION: 122 spec(s) examined, 18 claim a bot token (15 distinct),
  6 request the rail and resolve nothing, 7 deliberately tokenless,
  91 never request it, 0 unreadable
```

The known pair is reported (and its fingerprint matches the one already named
in `_cct_poller_singleton`'s `SCOPE_NOTE`, measured independently). Two more
nobody had reported come with it, one of them also cross-host. The handyman
family is correctly excluded.

Re-run through the CLI ~15 minutes later — `proj-scitex-hub/spec.yaml` had been
edited at **18:05 UTC** to add `CCT_BOT_TOKEN: ""`, i.e. remedy (b) from this
check's own hint — and that pair is gone:

```
spec bot tokens  2 bot token(s) claimed twice: ...
  sha256:47afa579cb86  business@ywata-note-win + grant-agent@ywata-note-win   (same host)
  sha256:ece7d6cc9000  scitex-cards@scitex-compute-04 + scitex-todo@ywata-note-win  (cross-host)
  122 spec(s) examined, 17 claim a bot token (15 distinct), 6 request the rail and
  resolve nothing, 8 deliberately tokenless, 91 never request it, 0 unreadable
```

That is the detector tracking a real config change, not a flake: claims 18→17
and tokenless 7→8 is exactly one agent moving populations. **Two live
collisions remain on the fleet.**

CI does not depend on the fleet staying broken — the same condition is built
from synthetic specs on disk in `test__cct_token_collision.py`.

## The ownership ledger

Every start records `(token_fp, host, agent) -> pid, started_at, source, slot`
into the per-host PostgreSQL store `cct_token_owner`, so "who holds this bot?"
is a query rather than a 409 from Telegram or a `/proc` scan on every host.

The identity is the **triple** on purpose: keying on `token_fp` alone would let
the second claimant overwrite the first and render every collision as one tidy
row — the store whose purpose is to reveal double ownership would report the
fault as its absence.

**Write-only.** Nothing reads it to make a decision, no start is gated on it,
and the write **never raises** — an unreachable PostgreSQL prints a line that
says the agent starts normally, because a ledger that can refuse a boot is
worse than a missing ledger. Enforcement is a separate change; the record comes
first so the refusal can be shown to have been right.

Substrate: `scitex_dev.store` / per-host PostgreSQL, adopted exactly as
`state_db_verdict_dedup` and `state_db_incarnations` do — no new state store
was invented.

## Secrets

No token VALUE is read, logged, stored or transmitted on any of these paths.
Only `sha256:<12hex>` fingerprints from the **existing**
`_account/_rotation_audit.fingerprint_token` (no second fingerprint helper),
slot NAMES and pool source PATHS. `record_token_owner` refuses anything that is
not a fingerprint rather than writing it.

## Not in this PR

No refusal and no gating: both checks are detectors, `--strict` is the only
non-zero exit, and the start path's observable behaviour is unchanged.
Refusing to start an agent whose token is already held is the next card, once
this computation has been observed in production.

## Test evidence

New: 69 tests across `test__cct_token_resolution.py` (23),
`test__cct_token_collision.py` (19), `test_state_db_token_owner.py` (14, real
PostgreSQL, per-test schema, no skipif), `test__cct_token_ledger.py` (9),
`test__cct_start_observers.py` (4), plus 9 added to `test_doctor_cmds.py`.
All pass.

Whole-suite comparison, `runtimes/ cli_pkg/ _state/ _lifecycle/`, run SERIALLY
on this host (concurrent runs pollute each other's tmp + store state, so the
first pair of runs was discarded):

| | failed | passed |
|---|---|---|
| base `7bdc0b47` | 6 | 8868 |
| this branch | 7 (+1 error) | 8944 |

The 6 on both sides are `_lifecycle/test__rename_cards.py`, failing identically
on the base — `ImportError: cannot import name '_store' from 'scitex_todo'`,
an environment artifact of a retired package, pre-existing and untouched here.

The 2 extra on this branch are environmental, not regressions, and both pass in
isolation on this branch:

- `cli_pkg/test_build_cmds.py::test_check_with_canonical_srv_bind_target_does_not_warn`
  — `OSError: [Errno 5] Input/output error` **at fixture setup**.
- `cli_pkg/test_auth_events_cmds.py::test_unresolved_lists_a_restart_that_was_never_shown_to_work`
  — reads the shared auth-events rail and got an empty window; order/state
  dependent.

Neither is in a module this PR touches, and an earlier (contended) run of the
same code failed a completely DIFFERENT set of four — different failures from
identical code is the signature of order/state sensitivity in this environment,
not of a change. `ruff` CI is green.
