### PR TITLE
fix(to_home): the CURRENT board identity was the one var this guard missed

### DIFF
--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -160,6 +160,22 @@ _CARDS_STORE_IDENTITY_VARS = frozenset(
 _RUNTIME_ONLY_VARS = (
     frozenset(
         {
+            # The CURRENT board identity. Its retired predecessor
+            # ``SCITEX_TODO_AGENT_ID`` was listed here from the start and this
+            # one never was, so the canonical name was the ONE identity var
+            # this guard did not cover (measured 2026-08-22:
+            # ``_is_runtime_only_var("SCITEX_CARDS_AGENT_ID")`` was False while
+            # the legacy name, SAC_NAME and SCITEX_CARDS_DB were all True).
+            #
+            # It is a LATENT trap, not a live bug: no template references
+            # ``${SCITEX_CARDS_AGENT_ID}`` today, so nothing has been baked. The
+            # moment one does — and retiring the legacy key from the baseline
+            # ``.mcp.json`` requires exactly that — deploy-time interpolation
+            # would substitute the DEPLOYING process's identity into every
+            # agent's materialized file. That is the 2026-07-02 wrong-identity
+            # incident this whole mechanism exists to prevent, re-entered
+            # through the migration meant to close it.
+            "SCITEX_CARDS_AGENT_ID",
             # scitex-todo >= 0.7.30 names
             "SCITEX_TODO_AGENT_ID",
             "SCITEX_TODO_TASKS_YAML_SHARED",

--- a/tests/scitex_agent_container/runtimes/test__to_home_text.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_text.py
@@ -47,6 +47,22 @@ def test_interpolate_env_keeps_scitex_todo_agent_id_literal_even_when_set(
     assert out == "agent=${SCITEX_TODO_AGENT_ID}"
 
 
+def test_interpolate_env_keeps_scitex_cards_agent_id_literal_even_when_set(
+    env_save_restore,
+):
+    # The CURRENT board identity. Its RETIRED predecessor
+    # (SCITEX_TODO_AGENT_ID, above) was guarded from the start and this one
+    # was not, so the canonical name was the only identity var deploy-time
+    # interpolation would still have baked — and retiring the legacy key from
+    # the baseline .mcp.json requires a template to reference this one.
+    # Arrange
+    env_save_restore.set("SCITEX_CARDS_AGENT_ID", "agent:scitex-agent-container")
+    # Act
+    out = interpolate_env("agent=${SCITEX_CARDS_AGENT_ID}")
+    # Assert
+    assert out == "agent=${SCITEX_CARDS_AGENT_ID}"
+
+
 def test_interpolate_env_keeps_legacy_scitex_todo_agent_literal_even_when_set(
     env_save_restore,
 ):


### PR DESCRIPTION
`interpolate_env` keeps per-agent identity vars as a literal `${VAR}` so each agent expands them from its **own** env at runtime. That is the fix for the 2026-07-02 wrong-identity incident, where deploy-time substitution baked the **deploying** process's identity into every agent's materialized file.

`_RUNTIME_ONLY_VARS` listed the **retired** name and not the current one:

| var | guarded before this PR |
|---|---|
| `SCITEX_TODO_AGENT_ID` (retired) | ✅ True |
| `SCITEX_CARDS_AGENT_ID` (**current**) | ❌ **False** |
| `SCITEX_CARDS_DB` | ✅ True |
| `SAC_NAME` | ✅ True |

Measured by calling the predicate, not by reading the set.

## Latent, not live — and why it lands first

No template references `${SCITEX_CARDS_AGENT_ID}` today, so nothing has been baked. It becomes live the moment one does — and **retiring the legacy key from the baseline `.mcp.json` requires exactly that**. The migration intended to close the 2026-07-02 incident would have re-entered it.

So any change that teaches a template the canonical name is unsafe until this guard covers it. This is the prerequisite, not the cleanup.

## Positive control

A green run proves nothing on its own, so the environment was made to go red. With the source change reverted and the test kept:

```
- agent=${SCITEX_CARDS_AGENT_ID}
+ agent=agent:scitex-agent-container      <- the deploying process's identity
1 failed, 15 passed
```

With the fix: **16 passed**.

## Test

Follows the file's existing convention — the project's `env_save_restore` fixture (not `monkeypatch`, per PA-306), AAA markers, one assertion.

Context: card `sac-unexpanded-legacy-board-id-live-on-10-of-11-cards-servers-20260822`.