### PR TITLE
fix(agents-list): the local leg read the CONTAINER's HOME, so a container saw 1 agent of 122

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
+from . import _agent_list_roots
+
 
 def _is_self_peer_marker(spec_path: Path) -> bool:
     """Return True iff ``spec_path`` is a self-peer registration marker.
@@ -83,7 +85,7 @@ def _discover_defined_agents() -> list[tuple[str, Path]]:
             roots.append(project / "agents")
     except Exception:  # stx-allow: fallback (reason: see inline comment)
         pass
-    roots.append(Path.home() / ".scitex" / "agent-container" / "agents")
+    roots.extend(_agent_list_roots.user_scope_roots())
 
     for root in roots:
         if not root.is_dir():
@@ -258,254 +260,19 @@ def _load_or_synthesize_config(spec_path: Path | None, name: str) -> Any:
         return None
 
 
-def _default_remote_status_probe(
-    specs: dict[str, Path],
-    run_ssh: Callable[[list[str]], int] | None,
-) -> Callable[[str, str], str]:
-    """The production status probe: ssh the peer's tmux, map the verdict.
-
-    Returns a ``(name, host) -> status`` callable. It routes through the
-    ALREADY-deployed :func:`_lifecycle._verdict_resolve.remote_process_signal`
-    (ssh ``tmux has-session`` on the peer) and maps its TERNARY verdict:
-
-        ALIVE -> "running", DEAD -> "stopped", UNKNOWN -> "unknown".
-
-    UNKNOWN maps to "unknown" — hidden from the default view but COUNTED in the
-    footer and shown in ``-v`` (the render layer's non-live handling). A wedged
-    ssh / bare-PATH / auth / ProxyJump hiccup did not OBSERVE the peer, so it
-    must not masquerade as "running" — the ~17 stale ``spartan-bmNNN`` rows that
-    rendered as a comforting green were exactly this lie. "Never hide" always
-    meant "do not DELETE a live agent", not "report an un-probed one as up":
-    only a POSITIVE remote absence (the peer's own ``tmux has-session`` rc=1)
-    reads "stopped". ``run_ssh`` is threaded straight into
-    ``remote_process_signal`` so tests inject a real rc-returning callable and
-    never shell out.
-    """
-
-    def _probe(name: str, host: str) -> str:
-        from ..._lifecycle._verdict import ALIVE, DEAD
-        from ..._lifecycle._verdict_resolve import remote_process_signal
-
-        config = _load_or_synthesize_config(specs.get(name), name)
-        if config is None:
-            return "unknown"
-        # stx-allow: fallback (a probe that blew up observed NOTHING — "unknown"
-        # (hidden + footer-counted), never a false "running" that would slander
-        # an un-probed peer as up)
-        try:
-            signal = remote_process_signal(config, host, run_ssh=run_ssh)
-        except Exception:  # stx-allow: fallback (reason: see inline comment)
-            return "unknown"
-        return {ALIVE: "running", DEAD: "stopped"}.get(signal.verdict, "unknown")
-
-    return _probe
-
-
-def _probe_remote_statuses(
-    candidates: list[dict],
-    probe: Callable[[str, str], str],
-    max_parallel_probes: int,
-    probe_timeout_s: float,
-) -> dict[str, str]:
-    """``{name: status}`` from ``probe`` over a bounded pool with a hard timeout.
-
-    Mirrors the local liveness pass in :func:`_agent_list.get_agent_list_data`:
-    a dedicated ``ThreadPoolExecutor`` with a per-future timeout and
-    ``shutdown(wait=False)`` so one wedged peer cannot serialize (or hang) the
-    whole ``sac agents list``. A timed-out / raised probe maps to "unknown" —
-    hidden from the default view but COUNTED in the footer: a probe that could
-    not run is not evidence a remote agent died, but neither is it evidence it
-    is running, so it must not render as a comforting green.
-    """
-    import time as _time
-    from concurrent.futures import ThreadPoolExecutor
-    from concurrent.futures import TimeoutError as _FuturesTimeout
-
-    statuses: dict[str, str] = {}
-    if not candidates:
-        return statuses
-    workers = max(1, min(max_parallel_probes, len(candidates)))
-    pool = ThreadPoolExecutor(max_workers=workers)
-    try:
-        future_to_name = {
-            pool.submit(probe, c["name"], c["host"]): c["name"] for c in candidates
-        }
-        # ONE shared wall-clock budget for the batch. future.result(timeout=T)
-        # in submission order restarts the deadline PER FUTURE, so n stalled
-        # probes cost about ceil(n/workers)*T even though the pool is parallel
-        # -- precisely the serialization the docstring above promises cannot
-        # happen. The local pass in _agent_list.get_agent_list_data was fixed
-        # for todo#254 and its comment already claims "same defect, same fix, as
-        # _probe_remote_statuses"; the fix never landed here. A comment is not a
-        # fix, and only the test caught the difference.
-        _deadline = _time.monotonic() + probe_timeout_s
-        for future in list(future_to_name):
-            name = future_to_name[future]
-            _remaining = max(0.0, _deadline - _time.monotonic())
-            # stx-allow: fallback (a per-probe timeout/exception is "unknown" —
-            # hidden from the default view + counted in the footer; a probe that
-            # could not run must not masquerade as a running remote row)
-            try:
-                statuses[name] = future.result(timeout=_remaining)
-            except _FuturesTimeout:  # stx-allow: fallback (reason: see inline comment)
-                statuses[name] = "unknown"
-                future.cancel()
-            except Exception:  # stx-allow: fallback (reason: see inline comment)
-                statuses[name] = "unknown"
-    finally:
-        pool.shutdown(wait=False)
-    return statuses
-
-
-def remote_instance_rows(
-    *,
-    registered: set[str],
-    display_host: str,
-    port_claims: dict[str, int],
-    running_only: bool = False,
-    capability: str | None = None,
-    machine: str | None = None,
-    group: str | None = None,
-    instances_oracle: Callable[[], list[dict]] | None = None,
-    status_probe: Callable[[str, str], str] | None = None,
-    run_ssh: Callable[[list[str]], int] | None = None,
-    max_parallel_probes: int = 8,
-    probe_timeout_s: float = 12.0,
-) -> list[dict]:
-    """Rows for agents recorded as running on a REMOTE peer (master-authoritative).
-
-    THE READ-SIDE the fleet view was missing. On dispatch, the master already
-    records an ``instances`` row (``host=<peer>``, ``remote=1``, ``pid=NULL``;
-    see ``_dispatch.try_dispatch_remote``) and tombstones it on stop — but
-    :func:`get_agent_list_data` only ever read the JSON ``Registry`` (local,
-    hostless) and the on-disk spec walk, so a spartan-dispatched agent fell
-    through to a misleading ``defined`` / ``local`` row. This reads the active
-    ``remote=1`` rows and emits a proper ``host=<peer>`` row per remote agent.
-
-    Precedence: a LOCAL ``Registry`` row wins (its name is in ``registered``,
-    so it is skipped here) and this in turn suppresses the defined-on-disk row
-    (the caller feeds the union of covered names into
-    :func:`defined_agent_rows`). Keyed on the authoritative ``remote`` flag, NOT
-    a hostname compare, so a same-host-named local start is never mistaken for a
-    cross-host one.
-
-    STATUS IS LIVE, never a trusted stale row: each remote row's status comes
-    from an ssh probe of the peer's own tmux (see
-    :func:`_default_remote_status_probe`), so an agent that died on a
-    login-node reboot reads ``stopped`` rather than a comforting ``running`` —
-    and a peer the probe could NOT reach (wedged ssh, a broken ProxyJump to a
-    compute node, auth) reads ``unknown`` (hidden from the default view but
-    counted in the footer), NOT a false ``running``. Probes run through a
-    bounded pool (:func:`_probe_remote_statuses`) to keep list latency bounded.
-    Both the ``status_probe`` and the underlying ``run_ssh`` are injection seams
-    so tests never shell out.
-
-    The Account column is derived from the agent's on-disk spec (which lives on
-    the master's disk — that is how it was dispatched) via
-    :func:`_safe_account_for`, exactly like :func:`defined_agent_rows`, so a
-    remote row no longer shows a bare ``—``.
-
-    These agents are never locally LIVE, so — exactly like
-    :func:`defined_agent_rows` — they carry the never-checked auth shape
-    (``verdict_for(None)``) and the empty movement trio, keeping the ``--json``
-    row shape uniform. Helpers resolve through the ``_agent_list`` module
-    namespace so the suite's real-attribute seams keep working.
-    """
-    from ..._state.auth_state import verdict_for
-    from ..._state.state_db import list_active_instances
-    from ...config import load_config
-    from . import _agent_list as _al
-
-    del running_only  # accepted for signature-parity; remote status is always
-    # probed (a remote row's whole value is its live status), and the render
-    # layer — not this builder — hides non-running rows in the default view.
-
-    oracle = instances_oracle or (lambda: list_active_instances(host=None))
-    discover = getattr(_al, "_discover_defined_agents", _discover_defined_agents)
-    specs: dict[str, Path] = {name: path for name, path in discover()}
-
-    # First pass: keep only the active REMOTE rows, apply the label filters
-    # (loading the agent's on-disk spec for its labels), collect candidates.
-    candidates: list[dict] = []
-    for entry in oracle():
-        name = entry.get("name")
-        if not name or name in registered:  # a local Registry row wins
-            continue
-        if not entry.get("remote"):  # key on the authoritative flag
-            continue
-        spec_path = specs.get(name)
-        labels: dict[str, str] = {}
-        # stx-allow: fallback (label filtering is best-effort; an unreadable
-        # spec yields empty labels, never a crash of the list)
-        try:
-            if spec_path is not None:
-                labels = load_config(str(spec_path)).labels
-        except Exception:  # stx-allow: fallback (reason: see inline comment)
-            labels = {}
-        if machine and labels.get("machine") != machine:
-            continue
-        if capability and not _al._label_capability_matches(labels, capability):
-            continue
-        if group and not _al._label_group_matches(labels, group):
-            continue
-        candidates.append(
-            {
-                "name": name,
-                "host": entry.get("host") or "",
-                "started_at": entry.get("started_at") or "-",
-                "a2a_port": entry.get("a2a_port")
-                or entry.get("bound_port")
-                or port_claims.get(name),
-                "spec_path": spec_path,
-                "labels": labels,
-            }
-        )
-
-    # Second pass: LIVE status via the injected (or default ssh) probe.
-    probe = status_probe or _default_remote_status_probe(specs, run_ssh)
-    statuses = _probe_remote_statuses(
-        candidates, probe, max_parallel_probes, probe_timeout_s
-    )
-
-    # Third pass: build the rows (mirrors ``defined_agent_rows``' shape).
-    rows: list[dict] = []
-    for cand in candidates:
-        name = cand["name"]
-        host = cand["host"]
-        spec_path = cand["spec_path"]
-        # Account from the on-disk spec — the SAME spec-derived label
-        # ``defined_agent_rows`` uses. The remote agent's spec DOES live on the
-        # master's disk (that is how it was ssh-dispatched), so this kills the
-        # bare "—" the Account column showed for every remote row. (This is the
-        # spec-derived label, NOT the exact runtime pool pick — that accurate
-        # value needs a DB column and is a separate follow-up.) Best-effort: an
-        # unreadable spec yields "" so the list never crashes on it.
-        account = ""
-        if spec_path is not None:
-            # stx-allow: fallback (a broken/unreadable spec must not crash the
-            # list; "" is the honest empty, exactly as before this change)
-            try:
-                account = _al._safe_account_for(load_config(str(spec_path)))
-            except Exception:  # stx-allow: fallback (reason: see inline comment)
-                account = ""
-        row: dict = {
-            "name": name,
-            # A probe that could not OBSERVE the peer is "unknown" (hidden from
-            # the default view, counted in the footer), never a false "running".
-            "status": statuses.get(name, "unknown"),
-            "screen": "-",
-            "multiplexer": None,
-            "started_at": cand["started_at"],
-            "host": host,
-            "host_display": _al._host_display_for(host, display_host),
-            "path": str(spec_path or ""),
-            "a2a_port": cand["a2a_port"],
-            "account": account,
-            "remote": True,
-        }
-        row.update(dict(_al._MOVEMENT_DEFAULTS))
-        row.update(verdict_for(None))
-        if cand["labels"]:
-            row["labels"] = cand["labels"]
-        rows.append(row)
-    return rows
+# Remote-instance probing moved to ``_agent_list_remote_rows`` (2026-08-23,
+# 512-line cap). Re-exported here so ``_agent_list`` and the
+# ``_al.remote_instance_rows`` test seam keep resolving unchanged — the same
+# re-export convention this module's header already documents.
+#
+# The two underscore-prefixed probes are re-exported too, deliberately: the
+# suite imports them from HERE (test__agent_list_remote.py:45-48), so they are
+# part of this module's de-facto contract regardless of the leading underscore.
+# Exporting only the public name broke collection outright — which is the
+# useful kind of failure, since it named the contract instead of leaving it to
+# be discovered later.
+from ._agent_list_remote_rows import (  # noqa: E402,F401
+    _default_remote_status_probe,
+    _probe_remote_statuses,
+    remote_instance_rows,
+)

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_remote_rows.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_remote_rows.py
@@ -1,0 +1,285 @@
+"""Remote-instance rows for ``sac agents list`` — network probing, not disk.
+
+Extracted from ``_agent_list_discover`` (2026-08-23) when that module hit the
+512-line cap. The split follows the concern boundary its own docstring already
+named: ``_agent_list_discover`` walks the LOCAL filesystem and builds rows for
+what it finds there, while everything here reaches ACROSS THE NETWORK — ssh to a
+peer's tmux, map the verdict, synthesize rows for instances this host does not
+own.
+
+Keeping ssh probing inside a module called ``_discover`` was the drift; a reader
+looking for "why is my peer reported down" had no reason to open a file about
+disk discovery.
+
+``_agent_list_discover`` re-exports :func:`remote_instance_rows`, so existing
+importers and the ``_al.remote_instance_rows`` test seam keep resolving
+unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+__all__ = ["remote_instance_rows"]
+
+
+def _default_remote_status_probe(
+    specs: dict[str, Path],
+    run_ssh: Callable[[list[str]], int] | None,
+) -> Callable[[str, str], str]:
+    """The production status probe: ssh the peer's tmux, map the verdict.
+
+    Returns a ``(name, host) -> status`` callable. It routes through the
+    ALREADY-deployed :func:`_lifecycle._verdict_resolve.remote_process_signal`
+    (ssh ``tmux has-session`` on the peer) and maps its TERNARY verdict:
+
+        ALIVE -> "running", DEAD -> "stopped", UNKNOWN -> "unknown".
+
+    UNKNOWN maps to "unknown" — hidden from the default view but COUNTED in the
+    footer and shown in ``-v`` (the render layer's non-live handling). A wedged
+    ssh / bare-PATH / auth / ProxyJump hiccup did not OBSERVE the peer, so it
+    must not masquerade as "running" — the ~17 stale ``spartan-bmNNN`` rows that
+    rendered as a comforting green were exactly this lie. "Never hide" always
+    meant "do not DELETE a live agent", not "report an un-probed one as up":
+    only a POSITIVE remote absence (the peer's own ``tmux has-session`` rc=1)
+    reads "stopped". ``run_ssh`` is threaded straight into
+    ``remote_process_signal`` so tests inject a real rc-returning callable and
+    never shell out.
+    """
+
+    def _probe(name: str, host: str) -> str:
+        from ..._lifecycle._verdict import ALIVE, DEAD
+        from ..._lifecycle._verdict_resolve import remote_process_signal
+
+        # Imported inside the call, not at module scope: ``_agent_list_discover``
+        # imports THIS module for the ``remote_instance_rows`` re-export, so a
+        # top-level import here would close the cycle.
+        from ._agent_list_discover import _load_or_synthesize_config
+
+        config = _load_or_synthesize_config(specs.get(name), name)
+        if config is None:
+            return "unknown"
+        # stx-allow: fallback (a probe that blew up observed NOTHING — "unknown"
+        # (hidden + footer-counted), never a false "running" that would slander
+        # an un-probed peer as up)
+        try:
+            signal = remote_process_signal(config, host, run_ssh=run_ssh)
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            return "unknown"
+        return {ALIVE: "running", DEAD: "stopped"}.get(signal.verdict, "unknown")
+
+    return _probe
+
+
+def _probe_remote_statuses(
+    candidates: list[dict],
+    probe: Callable[[str, str], str],
+    max_parallel_probes: int,
+    probe_timeout_s: float,
+) -> dict[str, str]:
+    """``{name: status}`` from ``probe`` over a bounded pool with a hard timeout.
+
+    Mirrors the local liveness pass in :func:`_agent_list.get_agent_list_data`:
+    a dedicated ``ThreadPoolExecutor`` with a per-future timeout and
+    ``shutdown(wait=False)`` so one wedged peer cannot serialize (or hang) the
+    whole ``sac agents list``. A timed-out / raised probe maps to "unknown" —
+    hidden from the default view but COUNTED in the footer: a probe that could
+    not run is not evidence a remote agent died, but neither is it evidence it
+    is running, so it must not render as a comforting green.
+    """
+    import time as _time
+    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import TimeoutError as _FuturesTimeout
+
+    statuses: dict[str, str] = {}
+    if not candidates:
+        return statuses
+    workers = max(1, min(max_parallel_probes, len(candidates)))
+    pool = ThreadPoolExecutor(max_workers=workers)
+    try:
+        future_to_name = {
+            pool.submit(probe, c["name"], c["host"]): c["name"] for c in candidates
+        }
+        # ONE shared wall-clock budget for the batch. future.result(timeout=T)
+        # in submission order restarts the deadline PER FUTURE, so n stalled
+        # probes cost about ceil(n/workers)*T even though the pool is parallel
+        # -- precisely the serialization the docstring above promises cannot
+        # happen. The local pass in _agent_list.get_agent_list_data was fixed
+        # for todo#254 and its comment already claims "same defect, same fix, as
+        # _probe_remote_statuses"; the fix never landed here. A comment is not a
+        # fix, and only the test caught the difference.
+        _deadline = _time.monotonic() + probe_timeout_s
+        for future in list(future_to_name):
+            name = future_to_name[future]
+            _remaining = max(0.0, _deadline - _time.monotonic())
+            # stx-allow: fallback (a per-probe timeout/exception is "unknown" —
+            # hidden from the default view + counted in the footer; a probe that
+            # could not run must not masquerade as a running remote row)
+            try:
+                statuses[name] = future.result(timeout=_remaining)
+            except _FuturesTimeout:  # stx-allow: fallback (reason: see inline comment)
+                statuses[name] = "unknown"
+                future.cancel()
+            except Exception:  # stx-allow: fallback (reason: see inline comment)
+                statuses[name] = "unknown"
+    finally:
+        pool.shutdown(wait=False)
+    return statuses
+
+
+def remote_instance_rows(
+    *,
+    registered: set[str],
+    display_host: str,
+    port_claims: dict[str, int],
+    running_only: bool = False,
+    capability: str | None = None,
+    machine: str | None = None,
+    group: str | None = None,
+    instances_oracle: Callable[[], list[dict]] | None = None,
+    status_probe: Callable[[str, str], str] | None = None,
+    run_ssh: Callable[[list[str]], int] | None = None,
+    max_parallel_probes: int = 8,
+    probe_timeout_s: float = 12.0,
+) -> list[dict]:
+    """Rows for agents recorded as running on a REMOTE peer (master-authoritative).
+
+    THE READ-SIDE the fleet view was missing. On dispatch, the master already
+    records an ``instances`` row (``host=<peer>``, ``remote=1``, ``pid=NULL``;
+    see ``_dispatch.try_dispatch_remote``) and tombstones it on stop — but
+    :func:`get_agent_list_data` only ever read the JSON ``Registry`` (local,
+    hostless) and the on-disk spec walk, so a spartan-dispatched agent fell
+    through to a misleading ``defined`` / ``local`` row. This reads the active
+    ``remote=1`` rows and emits a proper ``host=<peer>`` row per remote agent.
+
+    Precedence: a LOCAL ``Registry`` row wins (its name is in ``registered``,
+    so it is skipped here) and this in turn suppresses the defined-on-disk row
+    (the caller feeds the union of covered names into
+    :func:`defined_agent_rows`). Keyed on the authoritative ``remote`` flag, NOT
+    a hostname compare, so a same-host-named local start is never mistaken for a
+    cross-host one.
+
+    STATUS IS LIVE, never a trusted stale row: each remote row's status comes
+    from an ssh probe of the peer's own tmux (see
+    :func:`_default_remote_status_probe`), so an agent that died on a
+    login-node reboot reads ``stopped`` rather than a comforting ``running`` —
+    and a peer the probe could NOT reach (wedged ssh, a broken ProxyJump to a
+    compute node, auth) reads ``unknown`` (hidden from the default view but
+    counted in the footer), NOT a false ``running``. Probes run through a
+    bounded pool (:func:`_probe_remote_statuses`) to keep list latency bounded.
+    Both the ``status_probe`` and the underlying ``run_ssh`` are injection seams
+    so tests never shell out.
+
+    The Account column is derived from the agent's on-disk spec (which lives on
+    the master's disk — that is how it was dispatched) via
+    :func:`_safe_account_for`, exactly like :func:`defined_agent_rows`, so a
+    remote row no longer shows a bare ``—``.
+
+    These agents are never locally LIVE, so — exactly like
+    :func:`defined_agent_rows` — they carry the never-checked auth shape
+    (``verdict_for(None)``) and the empty movement trio, keeping the ``--json``
+    row shape uniform. Helpers resolve through the ``_agent_list`` module
+    namespace so the suite's real-attribute seams keep working.
+    """
+    from ..._state.auth_state import verdict_for
+    from ..._state.state_db import list_active_instances
+    from ...config import load_config
+    from . import _agent_list as _al
+
+    del running_only  # accepted for signature-parity; remote status is always
+    # probed (a remote row's whole value is its live status), and the render
+    # layer — not this builder — hides non-running rows in the default view.
+
+    # Function-scope for the same cycle reason as in _default_remote_status_probe.
+    from ._agent_list_discover import _discover_defined_agents
+
+    oracle = instances_oracle or (lambda: list_active_instances(host=None))
+    discover = getattr(_al, "_discover_defined_agents", _discover_defined_agents)
+    specs: dict[str, Path] = {name: path for name, path in discover()}
+
+    # First pass: keep only the active REMOTE rows, apply the label filters
+    # (loading the agent's on-disk spec for its labels), collect candidates.
+    candidates: list[dict] = []
+    for entry in oracle():
+        name = entry.get("name")
+        if not name or name in registered:  # a local Registry row wins
+            continue
+        if not entry.get("remote"):  # key on the authoritative flag
+            continue
+        spec_path = specs.get(name)
+        labels: dict[str, str] = {}
+        # stx-allow: fallback (label filtering is best-effort; an unreadable
+        # spec yields empty labels, never a crash of the list)
+        try:
+            if spec_path is not None:
+                labels = load_config(str(spec_path)).labels
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            labels = {}
+        if machine and labels.get("machine") != machine:
+            continue
+        if capability and not _al._label_capability_matches(labels, capability):
+            continue
+        if group and not _al._label_group_matches(labels, group):
+            continue
+        candidates.append(
+            {
+                "name": name,
+                "host": entry.get("host") or "",
+                "started_at": entry.get("started_at") or "-",
+                "a2a_port": entry.get("a2a_port")
+                or entry.get("bound_port")
+                or port_claims.get(name),
+                "spec_path": spec_path,
+                "labels": labels,
+            }
+        )
+
+    # Second pass: LIVE status via the injected (or default ssh) probe.
+    probe = status_probe or _default_remote_status_probe(specs, run_ssh)
+    statuses = _probe_remote_statuses(
+        candidates, probe, max_parallel_probes, probe_timeout_s
+    )
+
+    # Third pass: build the rows (mirrors ``defined_agent_rows``' shape).
+    rows: list[dict] = []
+    for cand in candidates:
+        name = cand["name"]
+        host = cand["host"]
+        spec_path = cand["spec_path"]
+        # Account from the on-disk spec — the SAME spec-derived label
+        # ``defined_agent_rows`` uses. The remote agent's spec DOES live on the
+        # master's disk (that is how it was ssh-dispatched), so this kills the
+        # bare "—" the Account column showed for every remote row. (This is the
+        # spec-derived label, NOT the exact runtime pool pick — that accurate
+        # value needs a DB column and is a separate follow-up.) Best-effort: an
+        # unreadable spec yields "" so the list never crashes on it.
+        account = ""
+        if spec_path is not None:
+            # stx-allow: fallback (a broken/unreadable spec must not crash the
+            # list; "" is the honest empty, exactly as before this change)
+            try:
+                account = _al._safe_account_for(load_config(str(spec_path)))
+            except Exception:  # stx-allow: fallback (reason: see inline comment)
+                account = ""
+        row: dict = {
+            "name": name,
+            # A probe that could not OBSERVE the peer is "unknown" (hidden from
+            # the default view, counted in the footer), never a false "running".
+            "status": statuses.get(name, "unknown"),
+            "screen": "-",
+            "multiplexer": None,
+            "started_at": cand["started_at"],
+            "host": host,
+            "host_display": _al._host_display_for(host, display_host),
+            "path": str(spec_path or ""),
+            "a2a_port": cand["a2a_port"],
+            "account": account,
+            "remote": True,
+        }
+        row.update(dict(_al._MOVEMENT_DEFAULTS))
+        row.update(verdict_for(None))
+        if cand["labels"]:
+            row["labels"] = cand["labels"]
+        rows.append(row)
+    return rows

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_roots.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_roots.py
@@ -1,0 +1,83 @@
+"""User-scope ``agents/`` roots for the ``sac agents list`` disk walk.
+
+One responsibility: answer "which directories hold agent specs for this
+process?" — and answer it through the SAME resolver the rest of sac uses,
+so ``sac agents list`` cannot disagree with ``sac agents find`` about which
+agents exist.
+
+WHY THIS MODULE EXISTS (measured 2026-08-23, scitex-compute-04)
+
+``_agent_list_discover`` hardcoded ``Path.home() / ".scitex" /
+"agent-container" / "agents"``. That is correct on a bare host and WRONG
+inside a container: there ``Path.home()`` is the agent's own home
+(``/home/agent``), while the operator's specs live in a bind-mounted
+``/home/ywatanabe``. The container home has no ``agents/`` tree at all, so
+the walk skipped its only real root and produced ZERO defined rows.
+
+The runtime already exports ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` pointing
+at the operator's tree for exactly this reason, and
+:func:`scitex_agent_container.config._resolve._search_dirs` already honours
+it — which is why ``sac agents find`` and ``sac agents start`` see those
+agents. Only this walk did not, so two commands in one CLI disagreed about
+what exists.
+
+The visible symptom: from inside a container the fleet listing reported ONE
+local row (a project-local test fixture, ``sdk-test``) while
+``/home/ywatanabe/.scitex/agent-container/agents`` held 121 ``spec.yaml``
+and the peer legs — which reach other hosts over ssh, landing as the
+operator with the right ``$HOME`` — reported 121 and 131. Every locally
+running agent therefore read as merely "defined", INCLUDING THE AGENT
+MAKING THE QUERY, which is the property that makes the listing unsafe to
+reason about: an instrument that cannot see the hand holding it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+__all__ = ["user_scope_roots"]
+
+
+def _legacy_home_root() -> Path:
+    """The pre-2026-08-23 hardcoded root.
+
+    Kept as the fallback so that a resolver failure degrades to the OLD
+    behaviour (find the host's agents when running on a bare host) rather
+    than to NO behaviour. Discovering the historical root beats discovering
+    nothing.
+    """
+    return Path.home() / ".scitex" / "agent-container" / "agents"
+
+
+def user_scope_roots(
+    search_dirs: Callable[[], tuple[Path, list[Path], list[Path]]] | None = None,
+) -> list[Path]:
+    """Return the user-scope ``agents/`` roots, highest priority first.
+
+    Delegates to :func:`config._resolve._search_dirs`, which returns
+    ``(primary, env_dirs, fleet_dirs)`` and folds in
+    ``$SCITEX_AGENT_CONTAINER_YAML_DIRS``. Order is preserved from the
+    resolver; callers de-duplicate by agent name, so a root appearing twice
+    is harmless.
+
+    Non-existent roots are NOT filtered here — the caller already skips a
+    root that is not a directory, and dropping them silently would hide the
+    very condition this module was written to expose.
+
+    ``search_dirs`` is the injection seam for the resolver. Production passes
+    nothing and gets the real one; a caller that needs to exercise the
+    fallback branch supplies its own. It is a PARAMETER rather than something
+    a test rewrites at runtime, so the failure path is reached the same way
+    in a test as it would be in production.
+    """
+    # stx-allow: fallback (reason: see _legacy_home_root — a resolver
+    # import/resolution failure must degrade to the historical root, not to
+    # an empty search that would silently report zero agents.)
+    try:
+        if search_dirs is None:
+            from ...config._resolve import _search_dirs as search_dirs
+        primary, env_dirs, fleet_dirs = search_dirs()
+        return [primary, *env_dirs, *fleet_dirs]
+    except Exception:  # stx-allow: fallback (reason: see comment above)
+        return [_legacy_home_root()]

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_roots.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_roots.py
@@ -1,0 +1,96 @@
+"""``sac agents list`` must look where ``sac agents find`` looks.
+
+WHY THIS FILE EXISTS. Measured 2026-08-23 on scitex-compute-04: from inside a
+container the fleet listing reported ONE local agent while
+``/home/ywatanabe/.scitex/agent-container/agents`` held 121 ``spec.yaml``. The
+walk hardcoded ``Path.home() / ".scitex" / "agent-container" / "agents"``, and
+inside a container ``Path.home()`` is the AGENT's home (``/home/agent``), which
+has no ``agents/`` tree at all. So the only root it looked at did not exist, and
+the loop that skips a non-directory root skipped the entire search.
+
+The runtime already exports ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` pointing at
+the operator's bind-mounted tree for exactly this reason, and
+``config._resolve._search_dirs`` already honours it — which is why
+``sac agents find`` and ``sac agents start`` could see agents that
+``sac agents list`` swore did not exist. Two commands in one CLI, one truth,
+one of them wrong.
+
+WHY IT IS PINNED RATHER THAN COMMENTED. The failure produces a CONFIDENT EMPTY
+ANSWER, which reads exactly like a finding: three agents on 2026-08-09 concluded
+the fleet registry had been wiped and two escalated it as P1 data loss against a
+healthy database; on 2026-08-23 a fourth read the same zero and reported "107 of
+123 agents are down" to the operator; a fifth was one control away from telling
+him three peers had abandoned their work. Nobody investigates a zero.
+
+The sharpest symptom, and the one the fix is measured against: the listing
+reported the agent MAKING THE QUERY as not-running. An instrument that cannot
+see the hand holding it has no business being trusted about anything else.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg._helpers import _agent_list_roots
+
+_ENV_VAR = "SCITEX_AGENT_CONTAINER_YAML_DIRS"
+
+
+@pytest.fixture()
+def container_shaped_env(tmp_path):
+    """A real container shape: specs live where the env var points, NOT in HOME.
+
+    Sets the real ``os.environ`` and restores it on teardown rather than
+    rewriting production internals, so the code under test resolves its roots
+    exactly as it does in production.
+    """
+    operator_tree = tmp_path / "operator" / "agents"
+    (operator_tree / "peer-agent").mkdir(parents=True)
+    (operator_tree / "peer-agent" / "spec.yaml").write_text("apiVersion: v1\n")
+    container_home = tmp_path / "container-home"
+    container_home.mkdir()
+
+    saved = {k: os.environ.get(k) for k in (_ENV_VAR, "HOME", "SAC_AGENT_SCOPE")}
+    os.environ[_ENV_VAR] = str(operator_tree)
+    os.environ["HOME"] = str(container_home)
+    os.environ.pop("SAC_AGENT_SCOPE", None)
+    try:
+        yield operator_tree
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def test_the_operator_declared_agents_dir_is_searched(
+    container_shaped_env,
+) -> None:
+    # Arrange: the container shape — $HOME has no agents tree, the specs are
+    # only reachable through $SCITEX_AGENT_CONTAINER_YAML_DIRS.
+
+    # Act
+    roots = _agent_list_roots.user_scope_roots()
+
+    # Assert: before the fix the sole root was $HOME/.scitex/.../agents, which
+    # does not exist here, and the walk found nothing.
+    assert container_shaped_env in roots
+
+
+def test_resolver_failure_falls_back_to_the_historical_root(tmp_path) -> None:
+    # Arrange: a resolver that fails, injected as the collaborator. Degrading
+    # to the OLD root must beat degrading to no search at all — a resolver
+    # hiccup must never silently report zero agents, which is the exact
+    # failure mode this module exists to prevent.
+    def exploding_resolver() -> tuple[Path, list[Path], list[Path]]:
+        raise RuntimeError("resolver unavailable")
+
+    # Act
+    roots = _agent_list_roots.user_scope_roots(search_dirs=exploding_resolver)
+
+    # Assert
+    assert roots == [Path.home() / ".scitex" / "agent-container" / "agents"]


### PR DESCRIPTION
## The defect

`_agent_list_discover` hardcoded `Path.home() / ".scitex" / "agent-container" / "agents"`.

Right on a bare host. Wrong inside a container, where `Path.home()` is the agent's own home (`/home/agent`) and holds no agents tree at all — so the walk skipped its only real root, and the loop that skips a non-directory root skipped the entire search.

## Measured, both directions

Same container on scitex-compute-04:

```
BEFORE (hardcoded Path.home()):    1 agent discovered
AFTER  (resolver-based):         122 agents discovered
is the querying agent in its own listing?   False -> True
```

The negative control — restoring the hardcoded root — reproduces the old result exactly, so the green is not vacuous.

## Why it is a design bug, not a typo

The runtime **already** exports `$SCITEX_AGENT_CONTAINER_YAML_DIRS` pointing at the operator's bind-mounted tree for precisely this reason, and `config._resolve._search_dirs` **already** honours it. That is why `sac agents find` and `sac agents start` could see agents that `sac agents list` swore did not exist — two commands in one CLI, one truth, one of them wrong.

`_agent_list_roots.user_scope_roots()` routes the walk through that same resolver.

## Why it mattered

The failure produces a **confident empty answer**, which reads exactly like a finding, and nobody investigates a zero. It has now caught five agents:

- three on 2026-08-09 concluded the fleet registry had been wiped; two escalated it as P1 data loss against a healthy database
- one reported "107 of 123 agents are down" to the operator (since withdrawn)
- one was a single self-check away from telling him three peers had abandoned their work

And the listing reported **the agent making the query** as not running — an instrument that cannot see the hand holding it.

## Also in this change

Forced by the 512-line cap, and worth having on its own merits: ~250 lines of **remote network probing** lived in a module named `_discover` (a local filesystem walk). Extracted to `_agent_list_remote_rows.py`.

`_agent_list_discover` re-exports `remote_instance_rows` **and** `_default_remote_status_probe` / `_probe_remote_statuses`, because the suite imports those from the old path — an underscore that everyone imports is public whatever it is spelled.

## Testing

```
279 passed in tests/scitex_agent_container/cli_pkg/_helpers/
ruff: All checks passed!
```

Two new tests pin the container shape and the resolver-failure fallback. The resolver is an **injected parameter** rather than something a test rewrites at runtime, so the fallback branch is reached the same way in a test as in production (PA-306: no `monkeypatch`).

## What this does NOT fix

Same card, still open:

- `liveness_unknown` / `probe_error` are still always null, including for the 4 of 10 hosts that never answer
- nothing per-rail — an agent can be responsive on one rail and mute on another at the same instant
- `agent_list(machine=...)` still matches a **label**, not a hostname, and returns a clean empty list for a real hostname

Card: `sac-agent-liveness-undetectable-and-no-autoheal-20260823`
