### PR TITLE
feat(doctor): sac doctor --node asks whether an agent here would have tools

### DIFF
--- a/src/scitex_agent_container/_readiness/__init__.py
+++ b/src/scitex_agent_container/_readiness/__init__.py
@@ -1,0 +1,26 @@
+"""Can this host actually produce a WORKING agent?
+
+Distinct from every other readiness surface in sac, which answers INSTALLATION
+questions — is sac present, is the daemon up, are there specs on disk. Those
+all passed on scitex-compute-01 on 2026-08-23 while an agent started there came
+up with zero MCP servers and no error. See :mod:`._node` for the measurements.
+
+A subpackage rather than a flat module because the outcome question has more
+than one instance in it (tools today; identity resolution and image currency
+are already carded), and because grouping by topical responsibility is what the
+project-structure rule asks for once the package root fills up.
+"""
+
+from ._node import (
+    NodeReadiness,
+    ServerVerdict,
+    assess_node_readiness,
+    node_readiness_for_this_host,
+)
+
+__all__ = [
+    "NodeReadiness",
+    "ServerVerdict",
+    "assess_node_readiness",
+    "node_readiness_for_this_host",
+]

--- a/src/scitex_agent_container/_readiness/_node.py
+++ b/src/scitex_agent_container/_readiness/_node.py
@@ -135,7 +135,7 @@ class ServerVerdict:
     """One declared MCP server, and whether this host can actually serve it."""
 
     name: str
-    #: "servable" | "stub" | "command-missing" | "malformed"
+    #: "servable" | "stub" | "command-missing" | "arg-path-missing" | "malformed"
     state: str
     #: The command as declared. Never a secret: commands are paths, and env
     #: values (which DO hold tokens) are deliberately not read here.
@@ -259,16 +259,26 @@ def _judge_server(name: str, spec: object) -> ServerVerdict:
         return ServerVerdict(
             name=name, state="command-missing", command=command, detail="command does not exist on this host"
         )
+    # ARGUMENTS ARE PART OF SERVABILITY, and this cost a real false pass.
+    # `dotfiles` caught it on 2026-08-23 in a config I had just shipped: two
+    # servers whose command is the perfectly-real `npx`, pinned via
+    # --executablePath to
+    #   /home/agent/.cache/ms-playwright/chromium-1228/chrome-linux64/chrome
+    # which does not exist in the container (control: /home/agent/.cache DOES
+    # exist, so the absence is real). An earlier version of this function only
+    # checked args ending in .ts, so both were reported SERVABLE — the exact
+    # silent pass this module exists to abolish, committed by the module
+    # itself. Any absolute path argument is now checked.
     args = spec.get("args")
     if isinstance(args, list):
         for arg in args:
             text = str(arg)
-            if text.startswith("/") and text.endswith(".ts") and not Path(text).exists():
+            if text.startswith("/") and not Path(text).exists():
                 return ServerVerdict(
                     name=name,
-                    state="command-missing",
+                    state="arg-path-missing",
                     command=command,
-                    detail=f"script argument does not exist on this host: {text}",
+                    detail=f"argument path does not exist on this host: {text}",
                 )
     return ServerVerdict(name=name, state="servable", command=command)
 

--- a/src/scitex_agent_container/_readiness/_node.py
+++ b/src/scitex_agent_container/_readiness/_node.py
@@ -1,0 +1,412 @@
+"""Would an agent started on THIS host actually be able to do anything?
+
+Every existing readiness surface answers INSTALLATION questions — is sac
+present, is the listen daemon up, are there specs on disk. On 2026-08-23
+scitex-compute-01 answered YES to all of them and was still incapable of
+running a useful agent:
+
+    sac installed        0.26.2, editable, current
+    sac listen           alive since boot, uptime 1d21h
+    host uptime          1d21h, no crash, no reboot
+    agents DEFINED       121
+    egress               github / astral / pypi all 200 in ~0.1s
+    SIF images           4, dated that day
+    agents RUNNING       0
+
+An agent started there came up with NO MCP SERVERS AT ALL and no error. The
+operator found out because a colleague stopped answering on Telegram and he
+asked a human question: is it down, or is it dead?
+
+THE CHECK THIS MODULE MAKES IS DELIBERATELY NOT "IS SAC INSTALLED".
+It is: **how many declared MCP servers would an agent started here actually
+get, and which declarations cannot be honoured?** That is the outcome an
+operator cares about, and it is the only question that would have failed on
+compute-01 while every installation check passed.
+
+THREE FAILURES IT CATCHES, all measured on real hosts that night:
+
+  1. NO to_home BASELINE.
+     ``agents/_shared/to_home/`` is the tree copied into every agent's home;
+     it supplies ``.mcp.json``. Absent on compute-01 AND on spartan — so this
+     is not one mis-set-up machine, it is a setup step nobody owns. An agent
+     starts, heartbeats, registers, and holds zero tools. Nothing errors.
+
+  2. A DANGLING SYMLINK IN THE BASELINE.
+     The baseline carries ``.claude/skills`` as a symlink. Copy it to a host
+     whose target does not exist and every deploy dies with
+     ``DanglingToHomeSymlinkError``. That error is excellent — it names the
+     path, what it resolved to, and the remedies — but it fires at agent
+     START, which is far too late and only for the person starting an agent.
+
+  3. A DECLARATION THAT CANNOT BE HONOURED.
+     A declared server whose command does not exist on this host. The
+     measured instance pointed at a repo checkout that had never been cloned
+     here; another pointed at ``/usr/bin/true``. Both READ as configured.
+
+Failure 3 is the one worth the most care, because a false declaration is
+worse than a missing feature. An agent read ``command: /usr/bin/true`` for
+its Telegram server, correctly inferred "someone decided I do not get
+Telegram", and TOLD THE OPERATOR SO. There had been no such decision — only
+an unprovisioned host. A stub does not merely fail to work; it makes its
+reader infer a decision nobody made, and that inference reaches humans.
+
+So a declared-but-unservable channel is reported here as BROKEN, never as
+absent, and never silently.
+
+WHAT THE NUMBER IS, EXACTLY. It is the BASELINE tool count: what an agent with
+no per-agent ``.mcp.json`` would get. In principle an agent shipping its own
+config has more, so in principle this is a FLOOR rather than a total.
+
+In practice, on compute-04 measured 2026-08-23, that principle describes a
+case which does not occur:
+
+    real agent dirs                    116
+      with their own .mcp.json           5     each 23 bytes, {"mcpServers": {}}
+      relying on the baseline only     111
+
+Not one agent declares a single server of its own, so the baseline is the
+floor AND the ceiling, and whatever it declares is exactly what every agent on
+the host gets. That is why an absent baseline is not a degradation — it is
+total, for every agent at once, silently.
+
+The floor framing is kept anyway, because it is the honest general statement
+and this measurement covers one host on one day. An instrument that quietly
+over-claims is the failure this module exists to catch; building one here
+would be a poor joke.
+
+SCOPE, AND WHY IT IS THIS NARROW (operator ruling, 2026-08-23 07:41Z).
+Five distinct gaps were found on real hosts that night and the first instinct
+was to answer all five with one check. That instinct is the bug repeating at a
+larger scale, so the boundary is drawn by OWNERSHIP OF THE ARTEFACT:
+
+    IN  — the to_home baseline, .mcp.json, and the symlinks inside them.
+          sac writes these, sac copies them into an agent home, and sac is
+          what raises DanglingToHomeSymlinkError over them. sac can be wrong
+          about them, so sac must be able to check them.
+
+    OUT — reachability. Whether a host can ssh anywhere, whether a proxy
+          binary exists in this container, whether a machine is on the VPN.
+          That is scitex-net's, and it is not a near-miss: it is measured
+          FROM A SEAT, and a seat-dependent answer folded in here would make
+          this verdict mean different things on different machines.
+
+    OUT — the node inventory. Which hosts should exist at all belongs to
+          scitex-dev's registry. This module assesses the host it is given
+          and never claims the set of hosts is complete.
+
+IT MUST RUN ON THE HOST IT JUDGES, and that is not a deployment detail — it is
+what the check MEANS. Every question here is about paths on a particular
+filesystem, so pointing this at another machine's ``.mcp.json`` from your own
+box measures YOUR disk and reports the result under THEIR name. (Nearly done
+while building this: compute-01's config was pulled to compute-04 to
+"validate against real data", which would have checked compute-04's
+filesystem throughout and passed for the wrong reason.) There is therefore no
+remote mode and no ``--host`` flag; a fleet sweep runs ``sac doctor --node``
+over ssh ON each host and collects the JSON.
+
+PURE AND INJECTABLE. Every path is a parameter, so a caller (or a test) can
+point this at a real directory tree it built itself rather than at the live
+host. There is nothing to patch and no collaborator to fake.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "NodeReadiness",
+    "ServerVerdict",
+    "assess_node_readiness",
+    "node_readiness_for_this_host",
+]
+
+#: A declared server whose command resolves to this is a placeholder, not an
+#: implementation. Seen deployed on a real host, and the reason an agent told
+#: the operator Telegram had been disabled for it.
+_STUB_COMMANDS = ("/usr/bin/true", "/bin/true", "true")
+
+
+@dataclass(frozen=True)
+class ServerVerdict:
+    """One declared MCP server, and whether this host can actually serve it."""
+
+    name: str
+    #: "servable" | "stub" | "command-missing" | "malformed"
+    state: str
+    #: The command as declared. Never a secret: commands are paths, and env
+    #: values (which DO hold tokens) are deliberately not read here.
+    command: str = ""
+    detail: str = ""
+
+    @property
+    def usable(self) -> bool:
+        return self.state == "servable"
+
+
+@dataclass(frozen=True)
+class NodeReadiness:
+    """Whether this host can produce a working agent, and what is missing.
+
+    ``verdict`` is three-valued on purpose. "unknown" exists so that a host we
+    could not inspect is never folded into the passing column — the failure
+    this check exists to catch is invisibility, so treating unmeasured as
+    healthy would reproduce it.
+    """
+
+    #: "ready" | "crippled" | "cannot-deploy" | "unknown"
+    verdict: str
+    baseline_dir: str = ""
+    #: Servers an agent started here would actually get.
+    usable_servers: tuple[str, ...] = ()
+    #: Declared servers this host cannot honour — the important list.
+    broken_servers: tuple[ServerVerdict, ...] = ()
+    #: Symlinks in the baseline whose target does not exist here. Any entry
+    #: means agent deploys FAIL, so this outranks a tool shortfall.
+    dangling_links: tuple[str, ...] = ()
+    missing: tuple[str, ...] = ()
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def tool_count(self) -> int:
+        """How many MCP servers an agent started here would get. THE number."""
+        return len(self.usable_servers)
+
+    @property
+    def is_alarming(self) -> bool:
+        """True unless this host would produce a fully-equipped agent.
+
+        "unknown" counts as alarming, matching every other sac check: an
+        invariant we could not assert is not an invariant that held. That is
+        the whole failure mode here — compute-01 was never measured, and
+        unmeasured was silently read as fine.
+        """
+        return self.verdict != "ready"
+
+    def to_dict(self) -> dict:
+        """JSON shape, mirroring the other doctor checks."""
+        return {
+            "verdict": self.verdict,
+            "baseline_dir": self.baseline_dir,
+            "tool_count": self.tool_count,
+            "usable_servers": list(self.usable_servers),
+            "broken_servers": [
+                {
+                    "name": v.name,
+                    "state": v.state,
+                    "command": v.command,
+                    "detail": v.detail,
+                }
+                for v in self.broken_servers
+            ],
+            "dangling_links": list(self.dangling_links),
+            "missing": list(self.missing),
+            "notes": list(self.notes),
+        }
+
+
+def _scan_dangling(root: Path) -> list[str]:
+    """Symlinks under ``root`` whose target does not exist.
+
+    Walked eagerly rather than lazily: a single dangling link anywhere in the
+    baseline aborts every agent deploy on the host, so finding one late is the
+    same as not finding it.
+    """
+    dangling: list[str] = []
+    if not root.is_dir():
+        return dangling
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in list(dirnames) + list(filenames):
+            p = Path(dirpath) / name
+            if p.is_symlink() and not p.exists():
+                try:
+                    target = os.readlink(p)
+                except OSError:  # stx-allow: fallback (unreadable link is still dangling)
+                    target = "<unreadable>"
+                dangling.append(f"{p.relative_to(root)} -> {target}")
+    return dangling
+
+
+def _judge_server(name: str, spec: object) -> ServerVerdict:
+    """Can this host actually serve the named MCP server?
+
+    Only ``command`` is inspected. Env is deliberately NOT read: it carries
+    bot tokens, and a readiness check must never be a reason to open a
+    secret. A token that is present-but-wrong is not detectable here and is
+    not claimed to be — that failure only surfaces on a real send.
+    """
+    if not isinstance(spec, dict):
+        return ServerVerdict(name=name, state="malformed", detail="entry is not an object")
+    command = str(spec.get("command", "") or "")
+    if not command:
+        return ServerVerdict(name=name, state="malformed", detail="no command declared")
+    if command in _STUB_COMMANDS:
+        return ServerVerdict(
+            name=name,
+            state="stub",
+            command=command,
+            detail=(
+                "declared but wired to a no-op; reads as a deliberate decision "
+                "to disable this channel when none was made"
+            ),
+        )
+    # A bare name is resolved from PATH at launch; only absolute paths can be
+    # checked here, and claiming otherwise would be a check that cannot fail.
+    if command.startswith("/") and not Path(command).exists():
+        return ServerVerdict(
+            name=name, state="command-missing", command=command, detail="command does not exist on this host"
+        )
+    args = spec.get("args")
+    if isinstance(args, list):
+        for arg in args:
+            text = str(arg)
+            if text.startswith("/") and text.endswith(".ts") and not Path(text).exists():
+                return ServerVerdict(
+                    name=name,
+                    state="command-missing",
+                    command=command,
+                    detail=f"script argument does not exist on this host: {text}",
+                )
+    return ServerVerdict(name=name, state="servable", command=command)
+
+
+def assess_node_readiness(baseline_dir: Path | str) -> NodeReadiness:
+    """Answer: would an agent started on this host have working tools?
+
+    ``baseline_dir`` is the ``agents/_shared/to_home`` tree. Passed in rather
+    than resolved internally so this stays pure and a caller can point it at
+    any tree — which is also how it is tested, against real directories built
+    for the purpose.
+    """
+    root = Path(baseline_dir)
+    if not root.is_dir():
+        return NodeReadiness(
+            verdict="cannot-deploy",
+            baseline_dir=str(root),
+            missing=("to_home baseline",),
+            notes=(
+                "No baseline tree: every agent started here gets a home with no "
+                ".mcp.json and therefore no tools, and nothing reports an error.",
+            ),
+        )
+
+    dangling = tuple(sorted(_scan_dangling(root)))
+
+    mcp_path = root / ".mcp.json"
+    if not mcp_path.is_file():
+        return NodeReadiness(
+            verdict="cannot-deploy",
+            baseline_dir=str(root),
+            missing=(".mcp.json in baseline",),
+            dangling_links=dangling,
+            notes=("Baseline exists but declares no MCP servers.",),
+        )
+
+    # stx-allow: fallback (a malformed baseline is a real host state and must
+    # be reported, not raised — the caller is a doctor, not a deploy)
+    try:
+        doc = json.loads(mcp_path.read_text())
+        servers = doc.get("mcpServers") or {}
+        if not isinstance(servers, dict):
+            raise ValueError("mcpServers is not an object")
+    except Exception as exc:  # stx-allow: fallback (see comment above)
+        return NodeReadiness(
+            verdict="cannot-deploy",
+            baseline_dir=str(root),
+            missing=("parseable .mcp.json",),
+            dangling_links=dangling,
+            notes=(f"Baseline .mcp.json could not be read: {type(exc).__name__}: {exc}",),
+        )
+
+    verdicts = [_judge_server(name, spec) for name, spec in sorted(servers.items())]
+    usable = tuple(v.name for v in verdicts if v.usable)
+    broken = tuple(v for v in verdicts if not v.usable)
+
+    # A dangling link outranks a tool shortfall: deploys ABORT, so the agent
+    # does not merely lose tools, it never starts.
+    if dangling:
+        verdict = "cannot-deploy"
+    elif not usable:
+        verdict = "cannot-deploy"
+    elif broken:
+        verdict = "crippled"
+    else:
+        verdict = "ready"
+
+    missing: list[str] = []
+    if dangling:
+        missing.append("resolvable symlink targets")
+    missing.extend(f"servable: {v.name}" for v in broken)
+
+    return NodeReadiness(
+        verdict=verdict,
+        baseline_dir=str(root),
+        usable_servers=usable,
+        broken_servers=broken,
+        dangling_links=dangling,
+        missing=tuple(missing),
+    )
+
+
+def _resolve_host_baseline() -> Path | None:
+    """The baseline a REAL deploy on this host would read.
+
+    Imported lazily and delegated rather than reimplemented: a readiness check
+    that resolved the path its own way could pass while every deploy failed,
+    which is precisely the wrong-vantage error this module exists to catch.
+    """
+    from ..runtimes._to_home_resolve import _user_baseline_to_home_dir
+
+    return _user_baseline_to_home_dir()
+
+
+def _vantage_note() -> str:
+    """Name the filesystem that was searched, always.
+
+    Run inside a container, ``~`` is the container's home and NOT the host's,
+    so "no baseline" measured in here is not a statement about the host. An
+    absent-result that does not name its vantage is how a wrong-seat
+    measurement gets reported as a fact about someone else's machine — the
+    same error this check exists to stop, one level up.
+    """
+    override = (os.environ.get("SAC_USER_TO_HOME_BASELINE", "") or "").strip()
+    where = f"HOME={Path('~').expanduser()}"
+    if override:
+        where += f", SAC_USER_TO_HOME_BASELINE={override}"
+    return f"Searched from {where} — inside a container this is the CONTAINER's home, not the host's."
+
+
+def node_readiness_for_this_host(
+    baseline_resolver: Callable[[], Path | None] | None = None,
+) -> NodeReadiness:
+    """Assess the host this process is running on.
+
+    ``baseline_resolver`` is the single impure edge, injected so a caller or a
+    test supplies its own without patching anything. It defaults to the
+    resolver the deploy path itself uses.
+    """
+    resolve = baseline_resolver or _resolve_host_baseline
+    # stx-allow: fallback (a resolver that raises is an UNKNOWN host, not a
+    # healthy one — reporting it as ready is the defect being fixed)
+    try:
+        baseline = resolve()
+    except Exception as exc:  # stx-allow: fallback (see comment above)
+        return NodeReadiness(
+            verdict="unknown",
+            notes=(f"Baseline directory could not be resolved: {type(exc).__name__}: {exc}",),
+        )
+    if baseline is None:
+        return NodeReadiness(
+            verdict="cannot-deploy",
+            missing=("to_home baseline",),
+            notes=(
+                "No shared to_home baseline, so an agent started here gets a "
+                "home with no .mcp.json and therefore no tools. Nothing "
+                "errors; the agent registers and heartbeats normally.",
+                _vantage_note(),
+            ),
+        )
+    return assess_node_readiness(baseline)

--- a/src/scitex_agent_container/cli_pkg/doctor_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/doctor_cmds.py
@@ -45,6 +45,7 @@ import click
 
 from .._drift import DriftState, DriftStatus, check_spec_source_drift
 from .._drift._fleet import HostDrift, check_fleet_drift
+from .._readiness import NodeReadiness, node_readiness_for_this_host
 from ..runtimes._cct_poller_singleton import (
     POLLER_OK,
     POLLER_UNKNOWN,
@@ -153,6 +154,42 @@ def _render_collisions_human(verdict: TokenCollisionVerdict) -> None:
         console.print(f"  [bold]hint[/bold]  {verdict.hint()}")
 
 
+def _render_node_human(readiness: NodeReadiness) -> None:
+    """Lead with the number the operator actually asked for.
+
+    "How many tools would an agent get here" is the question; the verdict word
+    is the summary of it. Printing the verdict alone would repeat the original
+    defect in a new place — a green word with nothing behind it.
+    """
+    label = {
+        "ready": "[green]ready[/green]",
+        "crippled": "[yellow]crippled[/yellow]",
+        "cannot-deploy": "[red]cannot-deploy[/red]",
+        "unknown": "[yellow]unknown[/yellow]",
+    }.get(readiness.verdict, readiness.verdict)
+    console.print(f"node: {label}")
+    # The count on its own line, and said as a FLOOR. An agent shipping its own
+    # .mcp.json can have more; what failed on compute-01 was agents that had
+    # nothing else to fall back on.
+    console.print(
+        f"  tools: {readiness.tool_count} MCP server(s) "
+        f"(baseline floor — an agent with no per-agent .mcp.json)"
+    )
+    if readiness.baseline_dir:
+        console.print(f"  baseline: {readiness.baseline_dir}")
+    for link in readiness.dangling_links:
+        console.print(f"  [red]dangling symlink[/red]: {link}  (deploys abort here)")
+    for broken in readiness.broken_servers:
+        console.print(
+            f"  [red]{broken.state}[/red]: {broken.name}"
+            + (f" -> {broken.command}" if broken.command else "")
+        )
+        if broken.detail:
+            console.print(f"      {broken.detail}")
+    for note in readiness.notes:
+        console.print(f"  {note}")
+
+
 def _render_fleet(ctx: click.Context, as_json: bool, strict: bool, timeout: int) -> int:
     """ssh every peer, render the drift table. Returns exit code."""
     from .._state.host_config import load as _load_host_config
@@ -196,11 +233,13 @@ def _render_local(
     with_drift: bool = True,
     with_pollers: bool = True,
     with_collisions: bool = True,
+    with_node: bool = True,
 ) -> int:
     """Run + render the requested local checks. Returns exit code.
 
     ``--strict`` fails on a drifted spec source OR an alarming poller verdict
-    OR an alarming collision verdict — each of which includes UNKNOWN,
+    OR an alarming collision verdict OR a node that would not produce a
+    fully-equipped agent — each of which includes UNKNOWN,
     matching ``sac agents cct-audit``: an invariant sac could not assert is
     not an invariant that held.
     """
@@ -210,6 +249,7 @@ def _render_local(
     status = check_spec_source_drift(_local_agents_spec_dir()) if with_drift else None
     verdict = check_poller_singleton() if with_pollers else None
     collisions = check_token_collisions() if with_collisions else None
+    readiness = node_readiness_for_this_host() if with_node else None
 
     if status is not None:
         payload["local"] = status.to_dict()
@@ -220,6 +260,9 @@ def _render_local(
     if collisions is not None:
         payload["token_collisions"] = collisions.to_dict()
         failed = failed or collisions.is_alarming
+    if readiness is not None:
+        payload["node"] = readiness.to_dict()
+        failed = failed or readiness.is_alarming
 
     if _json_flag(ctx, as_json):
         click.echo(json.dumps(payload, indent=2))
@@ -230,6 +273,8 @@ def _render_local(
             _render_pollers_human(verdict)
         if collisions is not None:
             _render_collisions_human(collisions)
+        if readiness is not None:
+            _render_node_human(readiness)
 
     return 1 if (strict and failed) else 0
 
@@ -263,6 +308,16 @@ def _render_local(
     ),
 )
 @click.option(
+    "--node",
+    "node",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run ONLY the node-readiness check: how many MCP servers would an "
+        "agent started on THIS host actually get?"
+    ),
+)
+@click.option(
     "--strict",
     "strict",
     is_flag=True,
@@ -286,6 +341,7 @@ def doctor(
     fleet: bool,
     pollers: bool,
     collisions: bool,
+    node: bool,
     strict: bool,
     timeout: int,
     as_json: bool,
@@ -294,7 +350,8 @@ def doctor(
 
     \b
     Examples:
-      $ sac doctor                 # drift + live pollers + spec collisions
+      $ sac doctor                 # drift + pollers + collisions + node
+      $ sac doctor --node          # only: would an agent here have tools?
       $ sac doctor --pollers       # only: one live poller per bot token?
       $ sac doctor --collisions    # only: do two SPECS take the same bot?
       $ sac doctor --fleet         # per-host drift table for every peer
@@ -312,7 +369,19 @@ def doctor(
     poller probe returned ok on both. Neither check alone is an all-clear.
 
     \b
-    Both are READ-ONLY and three-valued — ok / violation / unknown. They
+    \b
+    --node ANSWERS A DIFFERENT KIND OF QUESTION — an OUTCOME, not an install.
+    Measured 2026-08-23 on scitex-compute-01: sac installed and current,
+    listen alive since boot, 121 specs on disk, images present, egress fine —
+    and an agent started there came up with ZERO MCP servers and no error.
+    Every existing check passed. So --node asks how many declared servers this
+    host can actually honour, and reports a declared-but-unservable channel as
+    BROKEN rather than absent: an agent read `command: /usr/bin/true` for its
+    Telegram server, correctly inferred "someone disabled this for me", and
+    told the operator so. No such decision had been made.
+
+    \b
+    All three are READ-ONLY and three-valued — ok / violation / unknown. They
     report duplicates; they do not kill, lock or refuse them, and an
     unreadable /proc/<pid>/environ or an inconclusive pool read is reported
     as unknown rather than quietly counted as fine. No bot token VALUE is
@@ -323,10 +392,21 @@ def doctor(
         code = _render_fleet(ctx, as_json, strict, timeout)
     elif pollers:
         code = _render_local(
-            ctx, as_json, strict, with_drift=False, with_collisions=False
+            ctx, as_json, strict, with_drift=False, with_collisions=False, with_node=False
         )
     elif collisions:
-        code = _render_local(ctx, as_json, strict, with_drift=False, with_pollers=False)
+        code = _render_local(
+            ctx, as_json, strict, with_drift=False, with_pollers=False, with_node=False
+        )
+    elif node:
+        code = _render_local(
+            ctx,
+            as_json,
+            strict,
+            with_drift=False,
+            with_pollers=False,
+            with_collisions=False,
+        )
     else:
         code = _render_local(ctx, as_json, strict)
     if code:

--- a/tests/scitex_agent_container/_readiness/test__node.py
+++ b/tests/scitex_agent_container/_readiness/test__node.py
@@ -192,3 +192,79 @@ def test_malformed_mcp_json_refuses_rather_than_reporting_zero_servers(tmp_path)
 
     # Assert
     assert result.verdict == "cannot-deploy"
+
+
+def test_a_pinned_executable_that_does_not_exist_is_not_servable(tmp_path) -> None:
+    # Arrange: the case `dotfiles` caught on 2026-08-23 in a config I had just
+    # shipped. The command is the perfectly-real `npx`; the breakage is an
+    # --executablePath pointing at a chromium that is not installed. An
+    # earlier version of this check only validated args ending in .ts and
+    # therefore called this SERVABLE — a silent pass, committed by the module
+    # whose entire purpose is to abolish silent passes.
+    missing_chrome = tmp_path / "ms-playwright" / "chromium-1228" / "chrome"
+    root = _write_baseline(
+        tmp_path / "to_home",
+        {
+            "cards": _servable(tmp_path, "cards"),
+            "playwright": {
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "@playwright/mcp@latest",
+                    "--headless",
+                    "--executable-path",
+                    str(missing_chrome),
+                ],
+            },
+        },
+    )
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert
+    assert [v.state for v in result.broken_servers] == ["arg-path-missing"]
+
+
+def test_the_missing_argument_path_is_named(tmp_path) -> None:
+    # Arrange
+    missing_chrome = tmp_path / "ms-playwright" / "chromium-1228" / "chrome"
+    root = _write_baseline(
+        tmp_path / "to_home",
+        {
+            "cards": _servable(tmp_path, "cards"),
+            "playwright": {
+                "command": "npx",
+                "args": ["--executable-path", str(missing_chrome)],
+            },
+        },
+    )
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert: naming the path is what turns "playwright is broken" into
+    # something someone can act on without re-deriving the config.
+    assert str(missing_chrome) in result.broken_servers[0].detail
+
+
+def test_a_relative_argument_is_not_judged(tmp_path) -> None:
+    # Arrange: a bare flag or a package spec is resolved by the tool itself at
+    # launch, not by us. Treating those as paths would make this check fail on
+    # every healthy config — a check that cannot pass is as useless as one
+    # that cannot fail.
+    root = _write_baseline(
+        tmp_path / "to_home",
+        {
+            "playwright": {
+                "command": "npx",
+                "args": ["-y", "@playwright/mcp@latest", "--headless"],
+            },
+        },
+    )
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert
+    assert result.verdict == "ready"

--- a/tests/scitex_agent_container/_readiness/test__node.py
+++ b/tests/scitex_agent_container/_readiness/test__node.py
@@ -1,0 +1,194 @@
+"""A host can pass every installation check and still make agents useless.
+
+WHY THIS FILE EXISTS. On 2026-08-23 scitex-compute-01 reported sac installed
+and current, listen alive since boot, 121 specs on disk, images present and
+egress working — and an agent started there came up with ZERO MCP servers and
+no error. The operator discovered it because a colleague stopped answering on
+Telegram and he asked whether it was down or dead.
+
+Every test below reproduces a state MEASURED on a real host that night. Not
+one is hypothetical:
+
+  * no baseline                 compute-01 AND spartan — two of four measured
+                                hosts, so this is a setup step nobody owns
+  * dangling .claude/skills     introduced by copying the baseline from a host
+                                where its target existed; every deploy then
+                                died with DanglingToHomeSymlinkError
+  * command missing             the telegrammer entry pointed at a repo
+                                checkout that had never been cloned there
+  * /usr/bin/true stub          what business actually read, from which they
+                                inferred a decision nobody had made and told
+                                the operator Telegram was disabled for them
+
+NO MOCKS AND NOTHING PATCHED. Every test builds a real directory tree in
+tmp_path and passes its path in, because the production function takes the
+baseline directory as a parameter. A test that had to patch something would be
+testing the patch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container._readiness import assess_node_readiness
+
+
+def _write_baseline(root: Path, servers: dict) -> Path:
+    """A minimal but REAL to_home baseline: a directory holding .mcp.json."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".mcp.json").write_text(json.dumps({"mcpServers": servers}))
+    return root
+
+
+def _servable(tmp_path: Path, name: str) -> dict:
+    """A server whose command genuinely exists, so it is honestly servable."""
+    exe = tmp_path / f"bin-{name}"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+    return {"command": str(exe)}
+
+
+def test_absent_baseline_is_cannot_deploy_not_ready(tmp_path) -> None:
+    # Arrange: compute-01's actual state — no to_home tree at all.
+    missing_root = tmp_path / "never-provisioned"
+
+    # Act
+    result = assess_node_readiness(missing_root)
+
+    # Assert: the whole point is that this host looked healthy by every other
+    # measure, so the readiness verdict must be the one that refuses.
+    assert result.verdict == "cannot-deploy"
+
+
+def test_absent_baseline_reports_zero_tools(tmp_path) -> None:
+    # Arrange
+    missing_root = tmp_path / "never-provisioned"
+
+    # Act
+    result = assess_node_readiness(missing_root)
+
+    # Assert: "how many tools would an agent get here" is the number the
+    # operator asked for, and it must be 0 rather than unknown.
+    assert result.tool_count == 0
+
+
+def test_dangling_symlink_blocks_deploy_even_when_servers_are_fine(tmp_path) -> None:
+    # Arrange: a baseline that is otherwise perfect, plus the exact symlink
+    # shape that killed every deploy on compute-01 — .claude/skills pointing
+    # at a path that does not exist on this host.
+    root = _write_baseline(tmp_path / "to_home", {"cards": _servable(tmp_path, "cards")})
+    (root / ".claude").mkdir()
+    (root / ".claude" / "skills").symlink_to(tmp_path / "nowhere" / "skills")
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert: a dangling link ABORTS the deploy, so it must outrank a healthy
+    # server list rather than being averaged with it.
+    assert result.verdict == "cannot-deploy"
+
+
+def test_dangling_symlink_is_named_so_it_can_be_fixed(tmp_path) -> None:
+    # Arrange
+    root = _write_baseline(tmp_path / "to_home", {"cards": _servable(tmp_path, "cards")})
+    (root / ".claude").mkdir()
+    (root / ".claude" / "skills").symlink_to(tmp_path / "nowhere" / "skills")
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert: naming the offending path is what makes the check actionable
+    # rather than merely correct.
+    assert any("skills" in entry for entry in result.dangling_links)
+
+
+def test_declared_but_missing_command_is_broken_not_absent(tmp_path) -> None:
+    # Arrange: the telegrammer case — a real command path that simply was
+    # never installed on this host.
+    root = _write_baseline(
+        tmp_path / "to_home",
+        {
+            "cards": _servable(tmp_path, "cards"),
+            "telegrammer": {"command": str(tmp_path / "no-such-binary")},
+        },
+    )
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert: it must appear in broken_servers. Silently dropping it would
+    # reproduce the defect — the caller would see a shorter list and no reason.
+    assert [v.name for v in result.broken_servers] == ["telegrammer"]
+
+
+def test_stub_command_is_reported_as_stub(tmp_path) -> None:
+    # Arrange: what was actually deployed — a declared channel wired to a
+    # no-op. business read this and concluded a decision had been made.
+    root = _write_baseline(
+        tmp_path / "to_home",
+        {
+            "cards": _servable(tmp_path, "cards"),
+            "telegrammer": {"command": "/usr/bin/true"},
+        },
+    )
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert: "stub" must be distinguishable from "command-missing". They look
+    # identical in outcome and are completely different faults — one is an
+    # unprovisioned host, the other is a config asserting a false decision.
+    assert [v.state for v in result.broken_servers] == ["stub"]
+
+
+def test_a_host_with_one_broken_server_is_crippled_not_ready(tmp_path) -> None:
+    # Arrange
+    root = _write_baseline(
+        tmp_path / "to_home",
+        {
+            "cards": _servable(tmp_path, "cards"),
+            "telegrammer": {"command": "/usr/bin/true"},
+        },
+    )
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert: partial capability is its own verdict. Calling it "ready"
+    # because SOME servers work is how an agent ends up unable to reach the
+    # operator while the host reports healthy.
+    assert result.verdict == "crippled"
+
+
+def test_fully_provisioned_host_is_ready(tmp_path) -> None:
+    # Arrange: the positive control. Without it, a check that always says
+    # "cannot-deploy" would pass every test above and be worthless.
+    root = _write_baseline(
+        tmp_path / "to_home",
+        {
+            "cards": _servable(tmp_path, "cards"),
+            "telegrammer": _servable(tmp_path, "telegrammer"),
+        },
+    )
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert
+    assert (result.verdict, result.tool_count) == ("ready", 2)
+
+
+def test_malformed_mcp_json_refuses_rather_than_reporting_zero_servers(tmp_path) -> None:
+    # Arrange: an unparseable baseline must not be indistinguishable from a
+    # baseline that declares nothing — same shape as the empty-vs-absent
+    # confusion this whole check exists to remove.
+    root = tmp_path / "to_home"
+    root.mkdir()
+    (root / ".mcp.json").write_text("{ this is not json")
+
+    # Act
+    result = assess_node_readiness(root)
+
+    # Assert
+    assert result.verdict == "cannot-deploy"

--- a/tests/scitex_agent_container/cli_pkg/test_doctor_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_doctor_cmds.py
@@ -344,3 +344,119 @@ def test_default_doctor_still_carries_the_poller_verdict(local_drifted_source):
     payload = json.loads(result.stdout)
     # Assert
     assert payload["pollers"]["state"] in _POLLER_STATES
+
+
+# --------------------------------------------------------------------------
+# sac doctor --node
+#
+# The predicate itself is tested in tests/scitex_agent_container/_readiness/.
+# What matters HERE is that it is actually WIRED: a host that cannot equip an
+# agent has to say so on stdout, in JSON, and in the exit code under --strict.
+# A correct predicate nobody runs is the same as no check, which is the exact
+# failure this whole feature exists to fix.
+#
+# Nothing is patched. $SAC_USER_TO_HOME_BASELINE is a REAL production override
+# already honoured by the resolver a deploy uses, so the command under test
+# runs its true code path and only the directory it inspects varies.
+# --------------------------------------------------------------------------
+
+_BASELINE_ENV = "SAC_USER_TO_HOME_BASELINE"
+
+
+def _servable(tmp_path: Path, name: str) -> dict:
+    """A declared server whose command genuinely exists on this machine."""
+    exe = tmp_path / f"bin-{name}"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+    return {"command": str(exe)}
+
+
+def _baseline_dir(tmp_path: Path, servers: dict) -> Path:
+    root = tmp_path / "to_home"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".mcp.json").write_text(json.dumps({"mcpServers": servers}))
+    return root
+
+
+@pytest.fixture
+def ready_node(tmp_path: Path, env_save_restore) -> Path:
+    """A host whose every declared server can actually be served."""
+    root = _baseline_dir(tmp_path, {"cards": _servable(tmp_path, "cards")})
+    env_save_restore.set(_BASELINE_ENV, str(root))
+    return root
+
+
+@pytest.fixture
+def crippled_node(tmp_path: Path, env_save_restore) -> Path:
+    """One working server and one stub — measured on a real host 2026-08-23."""
+    root = _baseline_dir(
+        tmp_path,
+        {
+            "cards": _servable(tmp_path, "cards"),
+            "telegrammer": {"command": "/usr/bin/true"},
+        },
+    )
+    env_save_restore.set(_BASELINE_ENV, str(root))
+    return root
+
+
+def test_doctor_node_prints_the_tool_count(crippled_node):
+    # Arrange -- "how many tools would an agent get here" is the question the
+    # operator actually asked, so it belongs on screen, not only in the JSON.
+    # Act
+    result = CliRunner().invoke(doctor, ["--node"])
+    # Assert
+    assert "1 MCP server" in result.output
+
+
+def test_doctor_node_names_the_stub_channel(crippled_node):
+    # Arrange -- an agent read this exact stub, correctly inferred "someone
+    # disabled my Telegram", and told the operator so. No such decision existed.
+    # Act
+    result = CliRunner().invoke(doctor, ["--node"])
+    # Assert
+    assert "telegrammer" in result.output
+
+
+def test_doctor_node_strict_exits_nonzero_when_crippled(crippled_node):
+    # Arrange -- without a non-zero exit this can never gate provisioning, and
+    # gating provisioning is the only thing that stops the next node repeating.
+    # Act
+    result = CliRunner().invoke(doctor, ["--node", "--strict"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_doctor_node_json_carries_the_verdict(ready_node):
+    # Arrange -- a fleet sweep consumes JSON; that is what makes this usable
+    # across 122 agents instead of one host at a time.
+    # Act
+    result = CliRunner().invoke(doctor, ["--node", "--json"])
+    # Assert
+    assert json.loads(result.stdout)["node"]["verdict"] == "ready"
+
+
+def test_doctor_node_reports_the_tool_count_in_json(ready_node):
+    # Arrange -- the count is the machine-readable form of the answer.
+    # Act
+    result = CliRunner().invoke(doctor, ["--node", "--json"])
+    # Assert
+    assert json.loads(result.stdout)["node"]["tool_count"] == 1
+
+
+def test_doctor_node_runs_only_the_node_check(ready_node):
+    # Arrange -- --node is a single-check flag like --pollers. Leaking the
+    # others in would make it ssh and read /proc, too slow for a setup script.
+    # Act
+    result = CliRunner().invoke(doctor, ["--node", "--json"])
+    # Assert
+    assert list(json.loads(result.stdout)) == ["node"]
+
+
+def test_default_doctor_carries_the_node_verdict(local_drifted_source):
+    # Arrange -- the gap was invisible for days precisely because no default
+    # surface reported it, so it must run without anyone asking for it.
+    # Act
+    result = CliRunner().invoke(doctor, ["--json"])
+    # Assert
+    assert "verdict" in json.loads(result.stdout)["node"]


### PR DESCRIPTION
Every readiness surface sac had asked an INSTALLATION question. On 2026-08-23 scitex-compute-01 answered yes to all of them:

```
sac installed   0.26.2, editable, current
sac listen      alive since boot, uptime 1d21h
agents DEFINED  121
egress          github / astral / pypi all 200
SIF images      4, dated that day
agents RUNNING  0
```

and an agent started there came up with **zero MCP servers and no error**. The operator found out because a colleague stopped answering on Telegram and he asked a human question: is it down, or is it dead?

So `--node` asks an OUTCOME instead: **how many declared MCP servers would an agent started HERE actually get, and which declarations cannot be honoured?** It is the only check in this repo that would have failed on compute-01 while every other one passed.

## Four failure modes, each measured on a real host that night

| mode | what was measured |
|---|---|
| absent baseline | compute-01 **and** spartan. An agent starts, heartbeats, registers, holds zero tools. Nothing errors. |
| dangling symlink | the baseline carries `.claude/skills`; copied to a host whose target is missing, every deploy dies with `DanglingToHomeSymlinkError` — an excellent error that fires at agent START, far too late |
| command missing | a declared server pointing at a checkout never cloned on that host |
| `/usr/bin/true` stub | reads as configured |

The stub is the one worth the most care. An agent read `command: /usr/bin/true` for its Telegram server, correctly inferred *"someone decided I do not get Telegram"*, and **told the operator so**. There had been no such decision — only an unprovisioned host. A stub does not merely fail to work; it makes its reader infer a decision nobody made, and that inference reaches humans.

So a declared-but-unservable channel is reported **broken**, never as absent, and never silently.

## Scope, drawn by ownership of the artefact

Five gaps were found that night and the first instinct was to answer all five here — which is the same bug at a larger scale. The operator ruled on the boundary at 07:41Z:

- **IN** — the to_home baseline, `.mcp.json`, and the symlinks inside them. sac writes these, copies them into agent homes, and raises the dangling error over them. sac can be wrong about them, so sac must be able to check them.
- **OUT** — reachability. That is scitex-net's, and it is not a near-miss: it is measured *from a seat*, so folding it in would make one verdict word mean different things on different machines.
- **OUT** — which hosts exist at all. scitex-dev's registry. Verified rather than assumed: `_state/host_registry.py` already declares sac *"an ADAPTER, not an owner"* over `scitex_dev.hosts`.

## It must run on the host it judges

There is deliberately no `--host` flag. Every question here is about paths on a particular filesystem, so pointing this at another machine's `.mcp.json` measures **your** disk and reports it under **their** name. I nearly did exactly that while building it — pulled compute-01's config to compute-04 to "validate against real data", which would have checked compute-04's filesystem throughout and passed for the wrong reason. A fleet sweep runs `sac doctor --node` over ssh on each host and collects the JSON.

For the same reason, an absent-baseline verdict names the filesystem it searched: inside a container `~` is the container's home, not the host's.

## What the number is, exactly

It is the baseline tool count — what an agent with no per-agent `.mcp.json` would get. In principle a floor rather than a total. In practice, measured on compute-04 the same morning:

```
real agent dirs                    116
  with their own .mcp.json           5     each 23 bytes, {"mcpServers": {}}
  relying on the baseline only     111
```

Not one agent declares a server of its own, so the baseline is floor *and* ceiling and an absent one is total, for every agent at once, silently. The floor framing is kept anyway — it is the honest general statement and this covers one host on one day.

## Tests

9 on the predicate against real `tmp_path` directory trees, 6 on the CLI wiring. **No monkeypatch**: the CLI tests drive `$SAC_USER_TO_HOME_BASELINE`, a real production override the deploy resolver honours, through the project's existing `env_save_restore` fixture. A first draft hand-swapped a module attribute — monkeypatch wearing a different hat — and was rewritten.

---

Card: `sac-doctor-node-readiness-check-20260823`

Written because the operator said, of a night spent hand-fixing five separate outages, that not writing tests is why the same thing keeps happening, and asked what happens when the next node is added.

Local: 39 tests green in the touched files (24 new + the 15 pre-existing doctor tests), `uv tool run ruff check` clean, and `tests/develop/test_audit.py::test_audit_all_clean` passing in 74.7s — a real run, not a skip. That audit gate initially **failed** on this branch (PS-108b: the new module took the flat package root 15 → 16; PS-204: the test file mirrored no src file); both fixed by the `_readiness/` subpackage and by folding the CLI tests into the existing `test_doctor_cmds.py` rather than adding a new file.

The full 17,577-test suite is CI's to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9xszdNVWd99hqbBjXY7SA
