### PR TITLE
fix(image): publish a stable browser path so config can name it

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -242,6 +242,49 @@ From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c5
     # the caveat about SDK/claude-session agents.
     npx puppeteer browsers install chrome-headless-shell || true
 
+    # ---- 3b. A STABLE PATH FOR THE BROWSER -----------------------------
+    # Puppeteer installs under a VERSION-NUMBERED directory:
+    #
+    #   /root/.cache/puppeteer/chrome/linux-148.0.7778.97/chrome-linux64/chrome
+    #   /root/.cache/puppeteer/chrome-headless-shell/linux-<ver>/.../chrome-headless-shell
+    #
+    # and the install above is UNPINNED, so that <ver> moves on every
+    # rebuild. Nothing outside this image can therefore name the browser
+    # and still be correct tomorrow.
+    #
+    # WHY THIS EXISTS, measured 2026-08-23. The shared agent baseline
+    # pinned a browser as
+    #   --executablePath /home/agent/.cache/ms-playwright/chromium-1228/...
+    # That path exists in NO container: not the base browser (a different
+    # root entirely), and not the four per-agent overlays that DO carry
+    # ms-playwright, which are on chromium-1234. So chrome-devtools and
+    # playwright were declared for every agent and could start for none of
+    # them -- silently, because an MCP server that fails to launch produces
+    # no error anyone reads.
+    #
+    # Repointing that config at today's versioned path would fix it until
+    # the next rebuild and then break it the same way again. A version
+    # inside a path IS the defect, so the image publishes a stable name and
+    # the config names THAT.
+    mkdir -p /opt/browser
+    for _b in chrome chrome-headless-shell; do
+        # Highest version last, so a cache holding several resolves to the
+        # newest rather than to whatever sorts first lexically.
+        _found=$(ls -1d /root/.cache/puppeteer/"$_b"/linux-*/*/"$_b" 2>/dev/null | sort -V | tail -n 1)
+        if [ -n "$_found" ] && [ -x "$_found" ]; then
+            ln -sfn "$_found" /opt/browser/"$_b"
+            echo "BROWSER: /opt/browser/$_b -> $_found"
+        else
+            # LOUD, because the `|| true` above makes a failed download
+            # indistinguishable from a successful one. An image that
+            # silently ships without a browser is exactly how the fleet came
+            # to run two dead MCP servers without anyone noticing.
+            echo "BROWSER: WARNING - no $_b under /root/.cache/puppeteer;" \
+                 "browser MCP servers will not start in this image" >&2
+        fi
+    done
+    unset _b _found
+
     rm -rf /var/lib/apt/lists/*
 
     # ---- 4. Rust toolchain + cargo-binstall ----------------------------


### PR DESCRIPTION
fix(image): publish a stable browser path so config can name it

The image installs a browser under a VERSION-NUMBERED directory and the
install is unpinned:

    npx puppeteer browsers install chrome-headless-shell || true
    -> /root/.cache/puppeteer/chrome/linux-148.0.7778.97/chrome-linux64/chrome
    -> /root/.cache/puppeteer/chrome-headless-shell/linux-<ver>/.../chrome-headless-shell

so the version moves on every rebuild and nothing outside the image can
name the browser and still be right tomorrow.

WHAT THIS COST, measured 2026-08-23. The shared agent baseline pinned

    --executablePath /home/agent/.cache/ms-playwright/chromium-1228/chrome-linux64/chrome

which exists in NO container: not the base browser (a different root
entirely), and not the four per-agent overlays that do carry
ms-playwright, which are on chromium-1234 (`dotfiles` measured that, with
1234 as the control so the 1228 zero is a real absence). So chrome-devtools
and playwright were declared for every agent and could start for none of
them, silently -- an MCP server that fails to launch produces no error
anyone reads.

Repointing the config at today's versioned path would fix it until the next
rebuild and then break it the same way again. A version inside a path IS
the defect, so the image now publishes a stable name:

    /opt/browser/chrome
    /opt/browser/chrome-headless-shell

Resolution verified against the real cache in this container before
committing:

    chrome                -> linux-148.0.7778.97/chrome-linux64/chrome        executable
    chrome-headless-shell -> linux-148.0.7778.97/.../chrome-headless-shell    executable
    negative control: the same glob for `firefox` correctly resolves nothing
    sort -V: linux-148.0.10 sorts after linux-148.0.9, so a multi-version
             cache picks the newest rather than the lexically-last

AND THE FAILURE IS NOW LOUD. The `|| true` on the install above makes a
failed download indistinguishable from a successful one, which is how an
image could ship with no browser and nobody notice. When no binary
resolves, the build now prints a warning naming the missing browser and
saying the MCP servers will not start. It does not fail the build --
browsers are not required for every consumer of this image -- but it stops
being silent.

SEQUENCING, because getting this backwards repeats the bug: the config must
NOT be repointed at /opt/browser until an image carrying this change is
built and deployed. Until then that path does not exist either.
