### PR TITLE
fix(docstrings): two RST underlines trip check-merge-conflict, blocking the hook

### DIFF
--- a/src/scitex_agent_container/_guard/__init__.py
+++ b/src/scitex_agent_container/_guard/__init__.py
@@ -22,7 +22,7 @@ after it passes a MECHANICAL gate, never on the strength of the worker's
 self-report. A gate reachable by exactly one script is not a gate.
 
 Surface
-=======
+-------
 * :func:`check_deletions` — the whole answer, as one validated
   :class:`DeletionReport`. Never a bool: ``clean``, ``violations`` and
   ``could-not-determine`` are three distinct verdicts, and the third one

--- a/src/scitex_agent_container/runtimes/_mcp_config_file.py
+++ b/src/scitex_agent_container/runtimes/_mcp_config_file.py
@@ -31,7 +31,7 @@ So the exposed set is "every value of every spec-env key, plus every
 per-secret patch can bound.
 
 THE FIX
-=======
+-------
 The SDK's own ``else`` branch passes a ``str``/``Path`` through verbatim::
 
     cmd.extend(["--mcp-config", str(self._options.mcp_servers)])


### PR DESCRIPTION
fix(docstrings): two RST underlines trip check-merge-conflict, blocking the hook

`.githooks/` has never been armed in this repo — `core.hooksPath` is unset, so
`.githooks/pre-push` never runs and the CI rail has no measured pusher for
97.5% of its cards. Arming it is one line
(`scripts/install-git-hooks.sh`), and the open question was what that would
cost, since `.git/config` is SHARED by all 39 worktrees and arming also
switches on `.githooks/pre-commit` for every agent at once.

MEASURED, and the cost is not the problem:

    pre-commit run --all-files, cold (builds every hook env)      7s
    the same run once envs are cached                            1s
    hooks configured                                             5
    hooks that REWRITE files                                     0

So the feared "first-run venv build x 39 worktrees plus network" does not
exist: environments cache per user, and every hook is a read-only check
(check-merge-conflict, check-added-large-files, detect-private-key, and the
two local workflow guards). The worst case of arming is a REFUSED commit,
never a mutated file.

THE ACTUAL BLOCKER IS THIS, and it is why arming would have hurt:

    check for merge conflicts .......... Failed
      src/scitex_agent_container/_guard/__init__.py:25       '=======' found
      src/scitex_agent_container/runtimes/_mcp_config_file.py:34  '=======' found

Both are FALSE POSITIVES. They are RST section underlines in module
docstrings --

    Surface            THE FIX
    =======            =======

-- and the files contain ZERO real conflict markers (`grep -c '^<<<<<<< |^>>>>>>> '`
returns 0 for both). `check-merge-conflict` keys on a line starting with seven
`=`, which is exactly what a correct RST underline for a 7-character heading
looks like. Lengthening the underline does not help; it still starts with seven.

So arming the hook TODAY would have blocked every commit in this repository,
across all 39 worktrees, for two pieces of correct documentation. That is the
blast radius the card asked to measure, and it is a hard blocker rather than a
cost.

This changes the underline character to `-`, which is equally valid RST for a
section, and leaves the headings themselves alone. After it:

    all 5 hooks Passed, 1s
    both files still compile

`--all-files` is a complete enumeration, so these two were the only offenders
in the repo.

NOT ARMING THE HOOK HERE. That is a fleet-wide change to how every agent
commits and it belongs in its own change with its own decision; this only
removes the reason it could not be done. One question from the card also stays
open: pre-commit resolves on compute-04 and on the NAS, but the other hosts'
PATH/HOME were never probed, and the hook's candidate list is HOME-relative.
