### PR TITLE
fix(keepalive): the supervisor rail never declared the laptop optional, so 23.1% of its runs red

### DIFF
--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -120,12 +120,39 @@ def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
             # without ever hanging forever. A pass killed here leaves the
             # peer's previous credential intact — nothing is published
             # unverified.
+            # ywata-note-win IS DECLARED OPTIONAL, and that declaration is the
+            # difference between two rails running the same verb.
+            #
+            # MEASURED 2026-08-23, both sides, because a divergence claim needs
+            # both. The INSTALLED timer unit on compute-04 carries a drop-in
+            # (…keepalive.service.d/optional-peer.conf) whose ExecStart ends
+            # `--optional-peer ywata-note-win`. This JobSpec did not. Same verb,
+            # two policies — and only one of them was in git.
+            #
+            # The cost, from the supervisor's own execution log
+            # (~/.scitex/dev/runtime/periodic-executions.jsonl, surfaced by
+            # handyman-06): the supervisor rail failed 96 of 416 runs = 23.1%,
+            # still failing the day this was written, while the timer rail with
+            # the declaration runs ~2 failures/day over the same window.
+            #
+            # The laptop is DOCUMENTED intermittently reachable — the 2026-08-16
+            # "No route to host" incident is the reason --optional-peer exists at
+            # all. A peer known to come and go must be declared, or every one of
+            # its absences reds a unit whose real job (keeping the always-on
+            # hosts' credentials alive) succeeded.
+            #
+            # NOT CLAIMED: that this explains all 96. Every failed record carries
+            # error=None, so the failing peer is still unidentified; output
+            # capture in the execution log is the instrument that would prove it.
+            # This change is justified on its own — one verb, one policy — rather
+            # than on being the whole cause.
             command=(
                 "/usr/bin/timeout 300 "
                 f"{sac} accounts keepalive --all "
                 "--to ywata-note-win "
                 "--to scitex-compute-03 "
-                "--to scitex-compute-04"
+                "--to scitex-compute-04 "
+                "--optional-peer ywata-note-win"
             ),
             description=(
                 "The DISTRIBUTION half of the single-refresher model, and "

--- a/tests/scitex_agent_container/_jobs/_jobspec_helpers.py
+++ b/tests/scitex_agent_container/_jobs/_jobspec_helpers.py
@@ -40,3 +40,21 @@ def _split_command(command: str) -> tuple[str, str, str]:
 def _job(name: str):
     (match,) = [j for j in provide_jobs() if j.name == name]
     return match
+
+
+def _peer_sets(command: str) -> tuple[set[str], set[str]]:
+    """``(targeted, declared_optional)`` — the two peer sets in a command.
+
+    Read from the command rather than restated in each test on purpose. An
+    assertion that hard-codes both the peer list and the expected peer list is
+    parameterised by the value it is checking and cannot fail — the same trap
+    :func:`_split_command` avoids by checking the payload's SHAPE. Pulling both
+    sets out of the one string under test keeps the relation between them
+    (targeted vs forgiven) the thing being asserted.
+    """
+    tokens = command.split()
+    targeted = {tokens[i + 1] for i, t in enumerate(tokens) if t == "--to"}
+    optional = {
+        tokens[i + 1] for i, t in enumerate(tokens) if t == "--optional-peer"
+    }
+    return targeted, optional

--- a/tests/scitex_agent_container/_jobs/test__specs_accounts.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_accounts.py
@@ -23,7 +23,7 @@ jobs_mod = pytest.importorskip(
 
 from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
 
-from ._jobspec_helpers import _job, _split_command  # noqa: E402
+from ._jobspec_helpers import _job, _peer_sets, _split_command  # noqa: E402
 
 
 def test_accounts_keepalive_job_name_is_package_prefixed() -> None:
@@ -54,7 +54,76 @@ def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
     job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     bound, _payload, rest = _split_command(job.command)
-    assert (bound, rest) == ("/usr/bin/timeout 300", "accounts keepalive --all --to ywata-note-win --to scitex-compute-03 --to scitex-compute-04")
+    assert (bound, rest) == (
+        "/usr/bin/timeout 300",
+        "accounts keepalive --all "
+        "--to ywata-note-win --to scitex-compute-03 --to scitex-compute-04 "
+        "--optional-peer ywata-note-win",
+    )
+
+#: Hosts DOCUMENTED as intermittently reachable, so a failure to reach one is
+#: not evidence the job failed. ywata-note-win earns this by measurement, not
+#: opinion: the 2026-08-16 "No route to host" incident is the reason
+#: `--optional-peer` exists at all. The next entry here should arrive the same
+#: way — with an incident behind it — never on a hunch that a host looks flaky.
+_INTERMITTENT_PEERS = frozenset({"ywata-note-win"})
+
+def test_accounts_keepalive_still_targets_the_intermittent_peer() -> None:
+    # Arrange — the PREMISE of the test below, asserted separately so it
+    # cannot fail silently. "Declared optional" is only meaningful for a host
+    # the job actually pushes to; if ywata-note-win ever drops out of the peer
+    # list, the optional-peer assertion would pass vacuously and stop guarding
+    # anything. This turns that into its own red line: drop the host, and you
+    # are told to drop it from _INTERMITTENT_PEERS too.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    targeted, _optional = _peer_sets(job.command)
+    # Assert
+    assert _INTERMITTENT_PEERS <= targeted, (
+        f"no longer targeted at all: {sorted(_INTERMITTENT_PEERS - targeted)}"
+        " — if that is deliberate, remove it from _INTERMITTENT_PEERS so the"
+        " optional-peer assertion does not start passing vacuously"
+    )
+
+def test_accounts_keepalive_declares_every_intermittent_peer_optional() -> None:
+    # Arrange — THE PROPERTY, not the string. The whole-command assertion
+    # above goes red on ANY edit and gets updated by whoever made the edit,
+    # which makes it a changelog rather than a guard. This states the rule that
+    # must survive the next peer-list edit: a host documented as intermittently
+    # reachable must be declared optional wherever it is targeted.
+    #
+    # The cost of leaving it undeclared was measured on 2026-08-23 from the
+    # supervisor's own execution log: 96 of 416 runs failed (23.1%) on the rail
+    # WITHOUT the declaration, against ~2/day on the rail with it. Undeclared,
+    # one absence of a laptop reds a unit whose real job — keeping the
+    # ALWAYS-ON hosts' credentials alive — succeeded. A red that does not mean
+    # "act" is worse than no red: it trains everyone to skip the alarm that
+    # eventually matters.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    _targeted, optional = _peer_sets(job.command)
+    # Assert
+    assert _INTERMITTENT_PEERS <= optional, (
+        "targeted but not declared optional: "
+        f"{sorted(_INTERMITTENT_PEERS - optional)}"
+    )
+
+def test_accounts_keepalive_declares_optional_only_hosts_it_targets() -> None:
+    # Arrange — the other direction, and it is not symmetry for its own sake.
+    # `--optional-peer` names a host whose failure is FORGIVEN. A name there
+    # that appears in no `--to` is either a typo or a stale entry, and either
+    # way it forgives nothing while reading as though a decision was made.
+    # Worse, that same typo inside a real pair (`--to a --optional-peer
+    # a-typo`) leaves the intermittent host targeted and NOT forgiven — the
+    # exact failure the test above exists to prevent, wearing the appearance
+    # of a fix.
+    # Act
+    job = _job("scitex-agent-container-accounts-keepalive")
+    targeted, optional = _peer_sets(job.command)
+    # Assert
+    assert optional <= targeted, (
+        f"declared optional but never targeted: {sorted(optional - targeted)}"
+    )
 
 def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() -> None:
     # Arrange — belt-and-braces, the counterpart of accounts-refresh's


### PR DESCRIPTION
Two rails run the SAME verb with TWO policies, and only one of them was in git.

## Measured, both sides

A divergence claim needs both sides measured, so here they are (2026-08-23):

| | peers | `--optional-peer` |
|---|---|---|
| **supervisor rail** — `_jobs/_specs_accounts.py:125` | 3 (`ywata-note-win`, `compute-03`, `compute-04`) | **none** |
| **timer rail** — installed drop-in `…keepalive.service.d/optional-peer.conf` on compute-04 | 6 (+ `compute-01`, `compute-02`, `spartan`) | `ywata-note-win` |

The working configuration lives in a **host-local drop-in that exists in no repository**.

## The cost

From the supervisor's own execution log (`~/.scitex/dev/runtime/periodic-executions.jsonl`), surfaced by handyman-06 on `keepalive-intermittent-silent-failure-20260815`:

```
supervisor rail, no declaration    96 of 416 runs failed   23.1%
timer rail, declaration present    ~2 failures/day
still failing the day this was written (last 2026-08-23 09:15:32Z)
```

`ywata-note-win` is a laptop and is **documented** intermittently reachable — the 2026-08-16 "No route to host" incident is the reason `--optional-peer` exists at all. Undeclared, one absence of that laptop reds a unit whose real job — keeping the ALWAYS-ON hosts' credentials alive — succeeded.

A red that does not mean "act" is worse than no red: it trains everyone to skip the alarm that eventually matters.

## What this does NOT claim

**Not that it explains all 96.** Every failed record carries `error=None`, so the failing peer is still unidentified; output capture in the execution log is the instrument that would settle it, and that is a separate change. This one is justified on its own — one verb, one policy — rather than on being the whole cause.

## Scope held deliberately minimal

Only the declaration is added. The timer rail's **wider peer list is not copied over**: compute-02 per the fleet audit cannot run agents at all, and widening a credential push on inference is not something to slip into a fix. The peer-set divergence and the unversioned drop-in are recorded as findings on the P1 card rather than silently "fixed" here.

Consequence flagged by handyman-06 and agreed: this does **not** satisfy their keepalive timer's exit criterion (supervisor argv covering 01/02/spartan), so their timer stays until the peer-set / canonical-rail decision lands.

## Tests

The existing whole-command assertion went red — that is it working. But it pins the exact string, so it reds on *any* edit and gets updated by whoever made the edit: a changelog, not a guard. Three tests state the property instead, over sets read **from** the command (a test that pins its expectation to the value it is checking cannot fail — the same trap `_split_command` already avoids by checking the payload's SHAPE):

| test | asserts |
|---|---|
| `still_targets_the_intermittent_peer` | the premise, so the next one cannot pass vacuously if the host is dropped from `--to` |
| `declares_every_intermittent_peer_optional` | targeted ⟹ declared |
| `declares_optional_only_hosts_it_targets` | declared ⟹ targeted — catches the typo (`--to a --optional-peer a-typo`) that leaves the real host unforgiven while looking like a fix |

**Negative control**, because a test that passes both ways is not a guard. With the declaration removed from the source, the property test fails and *names the host*:

```
E   AssertionError: targeted but not declared optional: ['ywata-note-win']
E   assert frozenset({'ywata-note-win'}) <= set()
```

Restored afterwards, and the restore verified by diff.

```
227 passed   tests/scitex_agent_container/_jobs/
```

Run against the worktree's own source, verified rather than assumed:

```
SOURCE: .../.worktrees/keepalive-optional/src/scitex_agent_container/__init__.py
```
