### PR TITLE
test(loopback): let run_loopback take the reserved socket, so the bind race closes instead of narrowing

### DIFF
--- a/tests/develop/test_dead_port_helper.py
+++ b/tests/develop/test_dead_port_helper.py
@@ -59,9 +59,11 @@ import errno
 import shutil
 import socket
 import subprocess
+import urllib.request
 
 import pytest
 
+from tests.scitex_agent_container._helpers.loopback_server import run_loopback
 from tests.scitex_agent_container._helpers.ports import (
     DeadPortAllocator,
     bind_without_listen,
@@ -410,4 +412,92 @@ def test_reserved_port_close_inside_block_is_safe():
     # Act
     err = _bind_error(port)
     # Assert — no double-close explosion on the way out of the block.
+    assert err is None
+
+
+# ---------------------------------------------------------------------------
+# run_loopback(sock=...) — closing the window rather than narrowing it.
+#
+# reserved_port is honest that it cannot get to zero on its own: "between that
+# close() and the server's bind() the port IS free ... If a server DOES accept
+# an fd, pass it this socket instead and the race disappears entirely."
+# uvicorn.Config accepts fd=, so these assert the entirely.
+#
+# This is not theoretical. The gap fired on develop 2026-08-23 (py3.12,
+# [Errno 98] on a port the loopback helper had just been handed) and, per
+# _helpers/ports.py, on 2026-08-12 against py3.11. Which leg goes red is
+# whichever worker loses the race, which is why the same bug looks like a
+# different bug each time.
+# ---------------------------------------------------------------------------
+
+
+async def _no_content_app(scope, receive, send) -> None:
+    """Smallest ASGI app that proves a real server bound and answered."""
+    await send({"type": "http.response.start", "status": 204, "headers": []})
+    await send({"type": "http.response.body", "body": b""})
+
+
+def test_run_loopback_serves_on_the_very_port_that_was_reserved():
+    # Arrange — the whole point: the port the server ends up on must be the
+    # port that was HELD, with no interval in which anyone could take it.
+    with reserved_port() as sock:
+        reserved = int(sock.getsockname()[1])
+        # Act
+        with run_loopback(_no_content_app, sock=sock) as served:
+            pass
+    # Assert
+    assert served == reserved
+
+
+def test_run_loopback_with_a_socket_actually_answers():
+    # Arrange — equality of port numbers would also hold if the server never
+    # started, so bind a real request to it. This is the falsifying half.
+    with reserved_port() as sock:
+        port = int(sock.getsockname()[1])
+        # Act
+        with run_loopback(_no_content_app, sock=sock):
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/", timeout=10
+            ) as resp:
+                status = resp.status
+    # Assert
+    assert status == 204
+
+
+def test_run_loopback_refuses_a_port_and_a_socket_together():
+    # Arrange — two sources for one value is how a test ends up asserting
+    # against a port the server is not on.
+    sock = bind_without_listen()
+    port = int(sock.getsockname()[1])
+    # Act
+    def _both() -> None:
+        with run_loopback(_no_content_app, port, sock=sock):
+            pass
+    # Assert
+    with pytest.raises(TypeError):
+        _both()
+    sock.close()
+
+
+def test_run_loopback_requires_either_a_port_or_a_socket():
+    # Arrange — omitting both used to be a TypeError from the signature; it
+    # must stay an error now that port is optional.
+    app = _no_content_app
+    # Act
+    def _neither() -> None:
+        with run_loopback(app):
+            pass
+    # Assert
+    with pytest.raises(TypeError):
+        _neither()
+
+
+def test_old_idiom_hands_over_a_port_anyone_can_take():
+    # Arrange — the negative control for the four above. If this ever stops
+    # passing, the old idiom has been fixed elsewhere and these tests have
+    # stopped discriminating between the two shapes.
+    port = _old_broken_closed_port()
+    # Act
+    err = _bind_error(port)
+    # Assert — free for the taking, which is the bug the fd path removes.
     assert err is None

--- a/tests/scitex_agent_container/_helpers/loopback_server.py
+++ b/tests/scitex_agent_container/_helpers/loopback_server.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import socket
 import threading
 import time
 from typing import Any, Iterator
@@ -170,21 +171,72 @@ async def await_until_serving(
 
 @contextlib.contextmanager
 def run_loopback(
-    app: Any, port: int, *, timeout_s: float | None = None, **config_kwargs: Any
+    app: Any,
+    port: int | None = None,
+    *,
+    sock: socket.socket | None = None,
+    timeout_s: float | None = None,
+    **config_kwargs: Any,
 ) -> Iterator[int]:
     """Serve ``app`` on ``127.0.0.1:port`` for the duration of the block.
 
     Teardown flips ``should_exit`` and joins, so the ``finally`` fires even on
     test failure and a hung client never strands the server.
+
+    PASS ``sock`` (from ``_helpers.ports.reserved_port``) INSTEAD OF ``port``
+    AND THE BIND RACE DISAPPEARS. With a bare int the caller has necessarily
+    already released the port -- the ``bind(0) -> getsockname() -> close() ->
+    return int`` idiom -- so between that close and uvicorn's bind the port is
+    free for anyone, including another xdist worker running this same helper.
+    That is not hypothetical: it reddened develop on 2026-08-23 (py3.12,
+    ``[Errno 98] address already in use`` on a port this helper had just been
+    handed) and, per ``_helpers/ports.py``, on 2026-08-12 against py3.11. The
+    leg differs each time because the loser of the race does.
+
+    ``reserved_port`` narrows that window but cannot close it, and says so
+    itself: "no helper can shrink that to zero without passing the file
+    descriptor to the server ... If a server DOES accept an fd, pass it this
+    socket instead and the race disappears entirely." ``uvicorn.Config`` does
+    accept ``fd``, so here it can be closed rather than narrowed:
+
+        with reserved_port() as sock:
+            with run_loopback(app, sock=sock) as port:
+                ...
+
+    OWNERSHIP, since an fd handed across an API is where double-close bugs
+    live: uvicorn reaches the fd through ``socket.fromfd``, which DUPS it. The
+    server closes its own duplicate on shutdown and ``reserved_port`` closes
+    the original; neither touches the other's. So the socket must stay OPEN for
+    the whole block -- do not ``detach()`` it, and do not close it before this
+    contextmanager exits.
+
+    The int form is kept working for the ~14 call sites that still use it. It
+    is not deprecated-by-stealth: a caller with no socket to hand over (a port
+    read from a config file, say) is asking for something else entirely.
     """
-    config = uvicorn.Config(
-        app,
-        host="127.0.0.1",
-        port=port,
-        log_level="warning",
-        ws="none",
-        **config_kwargs,
-    )
+    if sock is not None:
+        if port is not None:
+            raise TypeError(
+                "run_loopback: pass EITHER port= OR sock=, not both — with a "
+                "socket the port is read from it, and a second value could "
+                "disagree with the fd actually being served"
+            )
+        port = int(sock.getsockname()[1])
+        config_kwargs["fd"] = sock.fileno()
+        config = uvicorn.Config(
+            app, log_level="warning", ws="none", **config_kwargs
+        )
+    elif port is None:
+        raise TypeError("run_loopback: one of port= or sock= is required")
+    else:
+        config = uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            ws="none",
+            **config_kwargs,
+        )
     server = uvicorn.Server(config)
     thread, crash = serve_in_thread(server, port)
     wait_until_serving(


### PR DESCRIPTION
develop went red on 2026-08-23 (py3.12) with a bind collision on a port the loopback helper had just been handed. **It is not a regression**, and the cure was already in the tree with nobody using it.

## Not a regression — two runs, two different tests

```
run 1   _runners/test_session_daemon_liveness_artifact   assert 'stopping' == 'ready'
run 2   _listen/test_server.py::test_cross_host_send_    OSError errno 98,
                                                         address in use :44867
```

A deterministic break fails the *same* test twice. Per `_helpers/ports.py` the identical race fired on **2026-08-12 against py3.11**. Which leg goes red is whichever worker loses the race — which is why one bug keeps arriving disguised as several.

The commit that surfaced it (`53ab1b0d`) touched exactly two files, neither in `_listen` nor `_runners`. Adding a test file reshuffles xdist distribution, which changes what runs concurrently. **Trigger, not cause.**

## The cause

```python
def _free_port() -> int:
    with contextlib.closing(socket.socket()) as s:
        s.bind(("127.0.0.1", 0))
        return s.getsockname()[1]    # socket CLOSED, port returned,
                                     # uvicorn binds it LATER
```

Between that close and the server's bind the port belongs to nobody, and the suite runs under xdist — a sibling worker running the same helper is the realistic thief.

## The cure existed and had zero adopters

`_helpers/ports.py` exports `reserved_port`, whose docstring names this exact case — *"the caller is about to start a REAL server — uvicorn, http.server, a subprocess — on this port"* — and `tests/develop/test_dead_port_helper.py` keeps the broken idiom **verbatim** as a negative control called `_old_broken_closed_port`.

```
rg 'reserved_port' tests/   (excluding ports.py and its own test)  ->  0 hits
```

Someone diagnosed the race, wrote the cure, and wrote falsifiable tests proving the cure differs from the disease. Nothing then used it. That is "a check nobody reads" in different clothes: **a fix nobody adopts.**

## What this changes

```python
with reserved_port() as sock:
    with run_loopback(app, sock=sock) as port:
        ...
```

`reserved_port` is honest that holding the socket only *narrows* the window, and says what would close it: *"no helper can shrink that to zero without passing the file descriptor to the server … If a server DOES accept an fd, pass it this socket instead and the race disappears entirely."* `uvicorn.Config` accepts `fd=`. So this **closes** it — the socket stays bound from reservation through serving and there is no instant when the port is free.

**Ownership**, since an fd across an API boundary is where double-close bugs live: uvicorn reaches it via `socket.fromfd`, which **dups**. The server closes its duplicate at shutdown, `reserved_port` closes the original, neither touches the other's. Documented in the docstring, including *do not `detach()`*.

The int form is untouched and not deprecated-by-stealth — a caller with no socket to hand over is asking for something different.

## Tests — five, one assertion each, control kept

| test | asserts |
|---|---|
| `serves_on_the_very_port_that_was_reserved` | the port served IS the port held |
| `with_a_socket_actually_answers` | a real 204 over the fd — equal port numbers would also hold if the server never started |
| `refuses_a_port_and_a_socket_together` | two sources for one value is how a test asserts against a port the server is not on |
| `requires_either_a_port_or_a_socket` | omitting both stays an error now that `port` is optional |
| `old_idiom_hands_over_a_port_anyone_can_take` | **the control** — if this stops passing, the four above have stopped discriminating |

**Verified on py3.12 specifically**, the leg that was red:

```
tests/develop/test_dead_port_helper.py                 30 passed
+ tests/scitex_agent_container/_listen/test_server.py  98 passed in 12.09s
```

The 68 `_listen` tests are **unchanged** by this PR and still pass — that is the backwards-compatibility check for the ~14 files still calling the int form.

## What this deliberately does NOT do

**No call-site migration.** 37–41 files still use the old idiom and `_listen/test_server.py` still has its own `_free_port`. Converting them is a real refactor of several large tests and belongs in its own change with its own dry run; bundling it here would make the capability and the sweep pass or fail together. This makes the safe path exist and proves it — adoption follows.

**No revert of `53ab1b0d`.** It is a good change, it is not the cause, and reverting would hide a defect that returns the next time anyone adds a test file.
