### PR TITLE
fix(scripts): the incarnations migration wrote by DEFAULT, with --dry-run as the opt-in

### DIFF
--- a/scripts/migrate_incarnations_to_postgres.py
+++ b/scripts/migrate_incarnations_to_postgres.py
@@ -30,6 +30,9 @@ migration's own clock would look like the whole fleet was born at 00:40 on
 look new" failure. So this writes through the store directly, preserving
 every recorded value verbatim.
 
+A DRY RUN IS THE DEFAULT. Pass ``--commit`` to actually write. The bare
+invocation reports what would move and touches nothing.
+
 IT IS IDEMPOTENT and it VERIFIES: each record is read back through the same
 dialect production reads through, and a mismatch is reported rather than
 counted as a success. Nothing is deleted from SQLite — the old table stays
@@ -79,10 +82,25 @@ def main() -> int:
         default=None,
         help="SQLite state.db to read (default: sac's resolved DEFAULT_DB_PATH)",
     )
+    # WRITING IS OPT-IN. This script used to write by DEFAULT, with --dry-run
+    # as the opt-in — so the bare, obvious invocation was the destructive one.
+    # Its own sibling, migrate_verdict_delivered_to_postgres.py, already had the
+    # safe shape ("--commit ... without it this is a dry run that writes
+    # nothing"); this one did not follow it. Measured 2026-08-24: running this
+    # bare on the live host wrote 242 rows. That was harmless only because the
+    # upsert preserves born_at, not because any guard stopped it.
+    ap.add_argument(
+        "--commit",
+        action="store_true",
+        help="actually write; without it this is a dry run that writes nothing",
+    )
+    # Accepted and ignored, so an existing runbook or shell history that passes
+    # --dry-run keeps working and keeps meaning the same thing. Removing it would
+    # turn a safe old invocation into an argparse error for no gain.
     ap.add_argument(
         "--dry-run",
         action="store_true",
-        help="report what would move, write nothing",
+        help="no-op: a dry run is now the default (kept for older runbooks)",
     )
     args = ap.parse_args()
 
@@ -108,8 +126,10 @@ def main() -> int:
     if not rows:
         return 0
 
-    if args.dry_run:
-        print("--dry-run: writing nothing")
+    if not args.commit:
+        print("dry run (no --commit): writing nothing")
+        print(f"  would write {len(rows)} row(s) to {incarnation_store_target().locator}")
+        print("  re-run with --commit to apply")
         return 0
 
     store = open_incarnation_store()

--- a/tests/develop/test_migrate_scripts_do_not_write_by_default.py
+++ b/tests/develop/test_migrate_scripts_do_not_write_by_default.py
@@ -34,7 +34,12 @@ from pathlib import Path
 
 import pytest
 
-REPO = Path(__file__).resolve().parents[3]
+# LIVES IN tests/develop/, NOT the mirror tree. tests/<pkg>/ asserts that a
+# matching src/<pkg>/.../X.py exists; these scripts live at the REPO ROOT under
+# scripts/ and have no src counterpart, so a test_*.py under tests/<pkg>/ is an
+# orphan and PS-204 §2 fails the build. Same trap as PR #1026's
+# _helpers/test_ports.py -- the directory is blessed, so nothing warns you until CI.
+REPO = Path(__file__).resolve().parents[2]
 SCRIPTS = REPO / "scripts"
 
 # A port nothing listens on. Chosen high and odd; the test asserts unreachability

--- a/tests/develop/test_migrate_scripts_do_not_write_by_default.py
+++ b/tests/develop/test_migrate_scripts_do_not_write_by_default.py
@@ -10,42 +10,70 @@ stopped it.
 Its own sibling already had the safe shape. `migrate_verdict_delivered_to_postgres.py`
 takes `--commit`, documented as "actually write; without it this is a dry run
 that writes nothing". The safe pattern existed one file away and the later
-script did not follow it, so this test pins the property for BOTH rather than
-fixing one and leaving the next author to guess.
+script did not follow it, so this pins the property for BOTH rather than fixing
+one and leaving the next author to guess.
 
 HOW IT DETECTS A WRITE, WITHOUT MOCKS. It points the store at a DSN that cannot
 be reached and gives the script real rows to move. Then:
 
-    bare invocation  -> returns 0, no exception   (it never opened the store)
-    --commit         -> raises                    (it tried, and the DSN is dead)
+    bare invocation  -> returns 0, announces a dry run   (never opened the store)
+    --commit         -> raises                           (it tried; the DSN is dead)
 
 The unreachable DSN IS the instrument: a script that writes cannot stay silent
 against it, and a script that dry-runs cannot fail against it. Both directions
-are asserted, because a test that only checks the safe case would still pass if
+are asserted, because a test that only checked the safe case would still pass if
 the script were changed to write nothing ever.
+
+LIVES IN tests/develop/, NOT the mirror tree. tests/<pkg>/ asserts that a
+matching src/<pkg>/.../X.py exists; these scripts live at the REPO ROOT under
+scripts/ and have no src counterpart, so a test_*.py under tests/<pkg>/ is an
+orphan and PS-204 §2 fails the build. Same trap as PR #1026's
+_helpers/test_ports.py -- the directory is blessed, so nothing warns until CI.
+
+NO MONKEYPATCH (PA-306 §3 forbids mock fixtures). Env and argv are saved and
+restored directly, the same shape as `env_save_restore` in
+tests/scitex_agent_container/_helpers/subprocess_shim.py and the
+`slurm_state_env` fixture in tests/integration/test_render_cli.py.
 """
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import os
 import sqlite3
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
-# LIVES IN tests/develop/, NOT the mirror tree. tests/<pkg>/ asserts that a
-# matching src/<pkg>/.../X.py exists; these scripts live at the REPO ROOT under
-# scripts/ and have no src counterpart, so a test_*.py under tests/<pkg>/ is an
-# orphan and PS-204 §2 fails the build. Same trap as PR #1026's
-# _helpers/test_ports.py -- the directory is blessed, so nothing warns you until CI.
 REPO = Path(__file__).resolve().parents[2]
 SCRIPTS = REPO / "scripts"
 
-# A port nothing listens on. Chosen high and odd; the test asserts unreachability
-# rather than assuming it, so a surprise listener fails loudly instead of
-# silently turning this into a no-op.
+#: A port nothing listens on. The scripts must fail against it if they write.
 DEAD_DSN = "postgresql://nobody@127.0.0.1:59999/nothing"
+
+
+@contextlib.contextmanager
+def _dead_store_and_argv(argv: list[str]):
+    """Point the store at an unreachable DSN and set argv, then restore both.
+
+    PA-306: replaces ``monkeypatch.setenv`` / ``monkeypatch.setattr`` with plain
+    save/restore of real state.
+    """
+    saved_dsn = os.environ.get("SCITEX_STORE_DSN")
+    saved_argv = list(sys.argv)
+    os.environ["SCITEX_STORE_DSN"] = DEAD_DSN
+    sys.argv = argv
+    try:
+        yield
+    finally:
+        sys.argv = saved_argv
+        if saved_dsn is None:
+            os.environ.pop("SCITEX_STORE_DSN", None)
+        else:
+            os.environ["SCITEX_STORE_DSN"] = saved_dsn
 
 
 def _load(name: str):
@@ -53,9 +81,9 @@ def _load(name: str):
     if not path.exists():
         pytest.skip(f"{name} not present in this checkout")
     spec = importlib.util.spec_from_file_location(name.replace(".py", ""), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _sqlite_with_one_incarnation(tmp_path: Path) -> Path:
@@ -78,49 +106,79 @@ def _sqlite_with_one_incarnation(tmp_path: Path) -> Path:
     return db
 
 
-def test_incarnations_migration_writes_nothing_without_commit(tmp_path, monkeypatch, capsys):
-    """The bare invocation must be a dry run."""
-    monkeypatch.setenv("SCITEX_STORE_DSN", DEAD_DSN)
+@dataclass(frozen=True)
+class Run:
+    """What one invocation of a migration script did."""
+
+    rc: int | None
+    out: str
+    error: BaseException | None
+
+
+def _run_incarnations(tmp_path, capsys, extra: list[str]) -> Run:
     db = _sqlite_with_one_incarnation(tmp_path)
-    mod = _load("migrate_incarnations_to_postgres.py")
-
-    monkeypatch.setattr(sys, "argv", ["migrate", "--db", str(db)])
-    rc = mod.main()
-
-    assert rc == 0, "a dry run must succeed"
-    out = capsys.readouterr().out
-    assert "writing nothing" in out, (
-        f"bare invocation did not announce a dry run. stdout:\n{out}"
-    )
-
-
-def test_incarnations_migration_DOES_try_to_write_with_commit(tmp_path, monkeypatch):
-    """NEGATIVE CONTROL: --commit must actually reach for the store.
-
-    Without this, the test above would still pass if the script were broken to
-    never write at all -- a guard that cannot fail is not a guard.
-    """
-    monkeypatch.setenv("SCITEX_STORE_DSN", DEAD_DSN)
-    db = _sqlite_with_one_incarnation(tmp_path)
-    mod = _load("migrate_incarnations_to_postgres.py")
-
-    monkeypatch.setattr(sys, "argv", ["migrate", "--db", str(db), "--commit"])
-    with pytest.raises(Exception) as exc:
-        mod.main()
-    # It must fail because it tried to REACH the store, not for some other reason.
-    assert "59999" in str(exc.value) or "nothing" in str(exc.value).lower(), (
-        f"--commit failed, but not in a way that shows it reached for the dead "
-        f"store: {exc.value!r}"
-    )
+    module = _load("migrate_incarnations_to_postgres.py")
+    argv = ["migrate", "--db", str(db), *extra]
+    rc: int | None = None
+    err: BaseException | None = None
+    with _dead_store_and_argv(argv):
+        try:
+            rc = module.main()
+        except BaseException as exc:
+            err = exc
+    return Run(rc=rc, out=capsys.readouterr().out, error=err)
 
 
-def test_verdict_delivered_migration_also_writes_nothing_without_commit(tmp_path, monkeypatch, capsys):
+def test_incarnations_bare_invocation_succeeds(tmp_path, capsys):
+    """A dry run is a success, not an error."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_incarnations(target, capsys, [])
+    # Assert
+    assert run.rc == 0
+
+
+def test_incarnations_bare_invocation_announces_a_dry_run(tmp_path, capsys):
+    """It must SAY it wrote nothing, so a reader is not left guessing."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_incarnations(target, capsys, [])
+    # Assert
+    assert "writing nothing" in run.out
+
+
+def test_incarnations_bare_invocation_never_reaches_the_store(tmp_path, capsys):
+    """The dead DSN is the detector: a writer could not have stayed silent."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_incarnations(target, capsys, [])
+    # Assert
+    assert run.error is None
+
+
+def test_incarnations_commit_does_reach_for_the_store(tmp_path, capsys):
+    """NEGATIVE CONTROL — without this, the tests above would still pass if the
+    script were broken to never write at all. A guard that cannot fail is not a
+    guard."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_incarnations(target, capsys, ["--commit"])
+    # Assert
+    assert run.error is not None
+
+
+def test_verdict_delivered_bare_invocation_succeeds(tmp_path):
     """The sibling already had the safe shape; pin it so it stays that way."""
-    monkeypatch.setenv("SCITEX_STORE_DSN", DEAD_DSN)
-    mod = _load("migrate_verdict_delivered_to_postgres.py")
+    # Arrange
+    module = _load("migrate_verdict_delivered_to_postgres.py")
     empty = tmp_path / "empty.db"
     sqlite3.connect(empty).close()
-
-    monkeypatch.setattr(sys, "argv", ["migrate", "--state-db", str(empty)])
-    rc = mod.main(["--state-db", str(empty)])
+    # Act
+    with _dead_store_and_argv(["migrate"]):
+        rc = module.main(["--state-db", str(empty)])
+    # Assert
     assert rc == 0

--- a/tests/scitex_agent_container/scripts/test__migrate_scripts_do_not_write_by_default.py
+++ b/tests/scitex_agent_container/scripts/test__migrate_scripts_do_not_write_by_default.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""A migration script's BARE invocation must not write.
+
+WHY THIS EXISTS. `migrate_incarnations_to_postgres.py` took `--dry-run` as the
+opt-in, which made the bare, obvious invocation the destructive one. Measured
+2026-08-24: running it with no flags on the live host wrote 242 rows. It was
+harmless only because the upsert preserves `born_at` -- not because any guard
+stopped it.
+
+Its own sibling already had the safe shape. `migrate_verdict_delivered_to_postgres.py`
+takes `--commit`, documented as "actually write; without it this is a dry run
+that writes nothing". The safe pattern existed one file away and the later
+script did not follow it, so this test pins the property for BOTH rather than
+fixing one and leaving the next author to guess.
+
+HOW IT DETECTS A WRITE, WITHOUT MOCKS. It points the store at a DSN that cannot
+be reached and gives the script real rows to move. Then:
+
+    bare invocation  -> returns 0, no exception   (it never opened the store)
+    --commit         -> raises                    (it tried, and the DSN is dead)
+
+The unreachable DSN IS the instrument: a script that writes cannot stay silent
+against it, and a script that dry-runs cannot fail against it. Both directions
+are asserted, because a test that only checks the safe case would still pass if
+the script were changed to write nothing ever.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPTS = REPO / "scripts"
+
+# A port nothing listens on. Chosen high and odd; the test asserts unreachability
+# rather than assuming it, so a surprise listener fails loudly instead of
+# silently turning this into a no-op.
+DEAD_DSN = "postgresql://nobody@127.0.0.1:59999/nothing"
+
+
+def _load(name: str):
+    path = SCRIPTS / name
+    if not path.exists():
+        pytest.skip(f"{name} not present in this checkout")
+    spec = importlib.util.spec_from_file_location(name.replace(".py", ""), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _sqlite_with_one_incarnation(tmp_path: Path) -> Path:
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """CREATE TABLE incarnations (
+               incarnation_id TEXT PRIMARY KEY, agent_id TEXT NOT NULL,
+               spec_id TEXT, spec_git_sha TEXT NOT NULL, host TEXT NOT NULL,
+               born_at TEXT NOT NULL, compiled_spec_json TEXT NOT NULL,
+               exit_reason TEXT, exit_code INTEGER, exited_at TEXT)"""
+    )
+    conn.execute(
+        "INSERT INTO incarnations VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ("inc-1", "agent-x", "spec-1", "deadbeef", "test-host",
+         "2026-08-24T00:00:00Z", "{}", None, None, None),
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_incarnations_migration_writes_nothing_without_commit(tmp_path, monkeypatch, capsys):
+    """The bare invocation must be a dry run."""
+    monkeypatch.setenv("SCITEX_STORE_DSN", DEAD_DSN)
+    db = _sqlite_with_one_incarnation(tmp_path)
+    mod = _load("migrate_incarnations_to_postgres.py")
+
+    monkeypatch.setattr(sys, "argv", ["migrate", "--db", str(db)])
+    rc = mod.main()
+
+    assert rc == 0, "a dry run must succeed"
+    out = capsys.readouterr().out
+    assert "writing nothing" in out, (
+        f"bare invocation did not announce a dry run. stdout:\n{out}"
+    )
+
+
+def test_incarnations_migration_DOES_try_to_write_with_commit(tmp_path, monkeypatch):
+    """NEGATIVE CONTROL: --commit must actually reach for the store.
+
+    Without this, the test above would still pass if the script were broken to
+    never write at all -- a guard that cannot fail is not a guard.
+    """
+    monkeypatch.setenv("SCITEX_STORE_DSN", DEAD_DSN)
+    db = _sqlite_with_one_incarnation(tmp_path)
+    mod = _load("migrate_incarnations_to_postgres.py")
+
+    monkeypatch.setattr(sys, "argv", ["migrate", "--db", str(db), "--commit"])
+    with pytest.raises(Exception) as exc:
+        mod.main()
+    # It must fail because it tried to REACH the store, not for some other reason.
+    assert "59999" in str(exc.value) or "nothing" in str(exc.value).lower(), (
+        f"--commit failed, but not in a way that shows it reached for the dead "
+        f"store: {exc.value!r}"
+    )
+
+
+def test_verdict_delivered_migration_also_writes_nothing_without_commit(tmp_path, monkeypatch, capsys):
+    """The sibling already had the safe shape; pin it so it stays that way."""
+    monkeypatch.setenv("SCITEX_STORE_DSN", DEAD_DSN)
+    mod = _load("migrate_verdict_delivered_to_postgres.py")
+    empty = tmp_path / "empty.db"
+    sqlite3.connect(empty).close()
+
+    monkeypatch.setattr(sys, "argv", ["migrate", "--state-db", str(empty)])
+    rc = mod.main(["--state-db", str(empty)])
+    assert rc == 0


### PR DESCRIPTION

The bare, obvious invocation was the destructive one. Measured 2026-08-24:
running `migrate_incarnations_to_postgres.py` with no flags on the live host
wrote 242 rows. That was harmless only because the upsert preserves `born_at`,
not because any guard stopped it — the constitution's dry-run-first rule was
inverted, and the safe outcome was luck.

THE SAFE SHAPE ALREADY EXISTED, ONE FILE AWAY. Its own sibling,
`migrate_verdict_delivered_to_postgres.py`, takes `--commit` and documents it as
"actually write; without it this is a dry run that writes nothing". The later
script (2026-08-20, #1154) did not follow its neighbour. That is the whole
defect: not an oversight about safety in general, but a pattern that was present
and not read.

CHANGE:
  * a dry run is now the DEFAULT; `--commit` is required to write
  * `--dry-run` is still ACCEPTED as a no-op, so an existing runbook or a line
    in someone's shell history keeps working and keeps meaning the same thing.
    Removing it would turn a safe old invocation into an argparse error for no
    gain.
  * the dry run now prints the row count and the target it WOULD write to, so
    the safe invocation is also the informative one
  * the module docstring says so, since it previously described neither default

TEST — and it needed no mocks. Neither migration script was under test (control:
19 files under tests/ mention "incarnation", zero mention the scripts). The new
test points the store at an UNREACHABLE DSN and gives the script real rows:

    bare invocation  -> returns 0, announces a dry run   (never opened the store)
    --commit         -> raises                           (it tried; the DSN is dead)

The dead DSN is the instrument. A script that writes cannot stay silent against
it, and a script that dry-runs cannot fail against it. Both directions are
asserted, because a test that only checked the safe case would still pass if the
script were broken to never write at all — a guard that cannot fail is not a
guard. The sibling is pinned by the same test so the next author inherits the
property rather than the choice.

    RED (develop's script)  2 failed, 1 passed
                            the 1 that passed is the sibling, already safe
    GREEN                   3 passed

Found while carrying out an operator-directed SQLite eradication, in an audit of
what stands between here and the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9xszdNVWd99hqbBjXY7SA