### PR TITLE
feat(env): derive PGUSER=<host_user>__<agent> at launch (pg role rework b2)

### DIFF
--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -305,6 +305,7 @@ def effective_env(
     being stored three layers downstream in someone else's database.
     """
     from ._board_identity_env import apply_board_identity_alias
+    from ._pg_identity_env import apply_pg_identity
 
     merged = merge_fleet_env(getattr(config, "env", None), defaults=defaults)
     apptainer = getattr(config, "apptainer", None)
@@ -313,8 +314,14 @@ def effective_env(
     # spelling still launches with one. See the branch in
     # ``apply_board_identity_alias`` for why the name is the right answer and
     # why it cannot override a deliberate alias.
-    return apply_board_identity_alias(
+    aliased = apply_board_identity_alias(
         merged, raw_args=raw_args, agent_name=getattr(config, "name", None)
+    )
+    # Same shape for the PostgreSQL login: ``PGUSER=<host_user>__<name>``
+    # unless a spec declares its own (b2 of the pg55432 role rework — see
+    # ``_pg_identity_env`` for why specs stopped carrying DSN userinfo).
+    return apply_pg_identity(
+        aliased, raw_args=raw_args, agent_name=getattr(config, "name", None)
     )
 
 

--- a/src/scitex_agent_container/runtimes/_pg_identity_env.py
+++ b/src/scitex_agent_container/runtimes/_pg_identity_env.py
@@ -1,0 +1,86 @@
+"""Per-agent PostgreSQL identity — inject ``PGUSER`` when no layer declares it.
+
+b2 of the pg55432 role rework (operator-approved 2026-08-24): the shared
+superuser stopped travelling inside DSN userinfo. Specs now carry a
+userinfo-less ``SCITEX_CARDS_DB`` (dotfiles PR #391), the per-agent roles
+``<host_user>__<agent>`` exist in the cluster, and libpq resolves the password
+from ``PGPASSFILE`` on its own. What remains is the USER: with no userinfo and
+no ``PGUSER``, libpq falls back to the OS user — inside a container that is
+the invoking host user, whose role is deliberately ``NOLOGIN`` (it is the
+permission umbrella, not a login identity). Every agent would fail to connect
+at its next start, loudly but pointlessly.
+
+This module supplies the missing name the same way
+:mod:`._board_identity_env` supplies the board identity: derived from the
+agent's own name at launch, injected only when NOTHING else declares it.
+116 specs therefore need no per-spec ``PGUSER`` line (D15: generate, don't
+hardcode), and a spec that DOES declare one — in ``spec.env`` or in
+``apptainer.raw_args`` — always wins, silently, because a default exists in
+order to be overridden (:mod:`._fleet_env`'s own rule).
+
+The derived name is ``<host_user>__<agent_name>``. ``host_user`` is the OS
+user launching the container (``getpass.getuser()``), not a constant: the
+role tree is per-owner (``ywatanabe`` today, anyone else the day the fleet
+gains a second human), and sac's neutrality rule — logic never names a
+consumer — holds.
+"""
+
+from __future__ import annotations
+
+import getpass
+import logging
+from typing import Any, Iterable, Mapping
+
+from ._board_identity_env import raw_args_env
+
+logger = logging.getLogger(__name__)
+
+# The libpq user variable. Everything speaking to PostgreSQL through libpq or
+# psycopg honours it; nothing else in the fleet uses the name.
+PG_USER_ENV = "PGUSER"
+
+
+def derive_pg_role(agent_name: str, *, host_user: str | None = None) -> str:
+    """The cluster role an agent authenticates as: ``<host_user>__<agent>``."""
+    user = host_user or getpass.getuser()
+    return f"{user}__{agent_name}"
+
+
+def apply_pg_identity(
+    env: Mapping[str, Any],
+    *,
+    raw_args: Iterable[Any] | None = None,
+    agent_name: str | None = None,
+    host_user: str | None = None,
+) -> dict[str, str]:
+    """Fill in ``PGUSER`` when absent everywhere. Returns a NEW dict.
+
+    Declared-anywhere wins: a ``PGUSER`` in ``env`` (spec.env or a fleet
+    default) or in ``raw_args`` ``--env`` form suppresses injection — the
+    latter because apptainer appends ``raw_args`` after the rendered ``--env``
+    flags and its ``--env`` is last-wins, so injecting here would LOOK
+    overridden in the argv while this function believed it decided. Same
+    reasoning as :func:`._board_identity_env.apply_board_identity_alias`.
+
+    No ``agent_name`` -> no injection: a derived role must be derived from a
+    real identity, and inventing one would put a WRONG login on every
+    connection — worse than libpq's own loud fallback failure.
+    """
+    out: dict[str, str] = {str(k): str(v) for k, v in env.items()}
+    if PG_USER_ENV in out:
+        return out
+    if PG_USER_ENV in raw_args_env(raw_args):
+        return out
+    if not agent_name:
+        return out
+    role = derive_pg_role(str(agent_name), host_user=host_user)
+    logger.debug("pg_identity: injecting %s=%s", PG_USER_ENV, role)
+    out[PG_USER_ENV] = role
+    return out
+
+
+__all__ = [
+    "PG_USER_ENV",
+    "apply_pg_identity",
+    "derive_pg_role",
+]

--- a/tests/scitex_agent_container/runtimes/test__pg_identity_env.py
+++ b/tests/scitex_agent_container/runtimes/test__pg_identity_env.py
@@ -1,0 +1,126 @@
+"""Per-agent ``PGUSER`` injection — derived when absent, never clobbering.
+
+Mirrors ``src/scitex_agent_container/runtimes/_pg_identity_env.py``.
+
+The load-bearing property is the same precedence rule the module states: a
+spec that declares ``PGUSER`` anywhere (``spec.env`` or ``raw_args``) wins,
+and an agent that declares nothing still launches with the derived
+``<host_user>__<name>`` — because after dotfiles PR #391 the DSNs carry no
+userinfo, so an agent with neither would authenticate as the NOLOGIN umbrella
+role and fail at start.
+
+Real dicts, real ``getpass.getuser()``, ``SimpleNamespace`` configs like the
+neighbouring ``test__fleet_env.py`` — no mocks (PA-306). One assert per test
+(PA-307).
+"""
+
+from __future__ import annotations
+
+import getpass
+from types import SimpleNamespace
+
+from scitex_agent_container.runtimes._fleet_env import effective_env
+from scitex_agent_container.runtimes._pg_identity_env import (
+    PG_USER_ENV,
+    apply_pg_identity,
+    derive_pg_role,
+)
+
+
+# ----------------------------------------------------------------------
+# Derivation.
+# ----------------------------------------------------------------------
+
+
+def test_derive_pg_role_joins_host_user_and_agent_name() -> None:
+    # Arrange
+    agent_name = "scitex-io"
+    # Act
+    role = derive_pg_role(agent_name, host_user="ywatanabe")
+    # Assert
+    assert role == "ywatanabe__scitex-io"
+
+
+def test_derive_pg_role_defaults_to_the_invoking_os_user() -> None:
+    # Arrange
+    agent_name = "scitex-io"
+    # Act
+    role = derive_pg_role(agent_name)
+    # Assert
+    assert role == f"{getpass.getuser()}__scitex-io"
+
+
+# ----------------------------------------------------------------------
+# Injection and precedence.
+# ----------------------------------------------------------------------
+
+
+def test_injects_derived_pguser_when_nothing_declares_one() -> None:
+    # Arrange
+    env: dict[str, str] = {"OTHER": "x"}
+    # Act
+    out = apply_pg_identity(env, agent_name="scitex-io", host_user="ywatanabe")
+    # Assert
+    assert out[PG_USER_ENV] == "ywatanabe__scitex-io"
+
+
+def test_spec_env_pguser_wins_over_derivation() -> None:
+    # Arrange
+    env = {PG_USER_ENV: "svc_notifyd"}
+    # Act
+    out = apply_pg_identity(env, agent_name="scitex-io", host_user="ywatanabe")
+    # Assert
+    assert out[PG_USER_ENV] == "svc_notifyd"
+
+
+def test_raw_args_pguser_suppresses_injection() -> None:
+    # Arrange — apptainer --env is last-wins, so an injected value would be
+    # overridden in the argv while this function believed it decided.
+    raw_args = ["--env", f"{PG_USER_ENV}=svc_gui"]
+    # Act
+    out = apply_pg_identity({}, raw_args=raw_args, agent_name="scitex-io")
+    # Assert
+    assert PG_USER_ENV not in out
+
+
+def test_no_agent_name_means_no_injection() -> None:
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    out = apply_pg_identity(env, agent_name=None)
+    # Assert
+    assert PG_USER_ENV not in out
+
+
+def test_input_mapping_is_not_mutated() -> None:
+    # Arrange
+    env: dict[str, str] = {}
+    # Act
+    apply_pg_identity(env, agent_name="scitex-io")
+    # Assert
+    assert env == {}
+
+
+# ----------------------------------------------------------------------
+# End-to-end through effective_env (the entry point argv rendering uses).
+# ----------------------------------------------------------------------
+
+
+def test_effective_env_carries_derived_pguser() -> None:
+    # Arrange
+    config = SimpleNamespace(env={}, apptainer=None, name="scitex-io")
+    # Act
+    out = effective_env(config, defaults={})
+    # Assert
+    assert out[PG_USER_ENV] == f"{getpass.getuser()}__scitex-io"
+
+
+def test_effective_env_respects_spec_declared_pguser() -> None:
+    # Arrange
+    config = SimpleNamespace(
+        env={PG_USER_ENV: "svc_cards_sync"}, apptainer=None, name="scitex-io"
+    )
+    # Act
+    out = effective_env(config, defaults={})
+    # Assert
+    assert out[PG_USER_ENV] == "svc_cards_sync"


### PR DESCRIPTION
Part of the operator-approved pg55432 role rework. Specs stopped carrying the shared superuser inside DSN userinfo (dotfiles PR #391); this injects the per-agent login PGUSER=<host_user>__<agent> at container launch unless a spec declares its own, mirroring the board-identity injection. 9 new tests; 80 neighbouring tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9xszdNVWd99hqbBjXY7SA