### PR TITLE
[HOLD — blocked upstream] feat(state): port the a2a port ledger to PostgreSQL

### DIFF
--- a/src/scitex_agent_container/_state/port_allocator_pg.py
+++ b/src/scitex_agent_container/_state/port_allocator_pg.py
@@ -1,0 +1,342 @@
+"""``a2a_ports`` — the A2A port claim ledger, on PostgreSQL only.
+
+Step 4 of the operator's sqlite→PostgreSQL migration (approved 2026-08-24).
+The move is by ADOPTING :mod:`scitex_dev.store`, the fleet's own store
+primitive, exactly as :mod:`.state_db_incarnations` did — not by sac growing
+a private psycopg layer. That primitive implements the operator's 2026-08-19
+rule ("fail fast, fail loud, no fallbacks"): it resolves ``SCITEX_STORE_DSN``
+or the per-host PostgreSQL and has deliberately NO SQLite fallback, so a host
+whose database is unreachable raises rather than quietly allocating ports
+into a file nobody reads.
+
+``db_path`` IS GONE from every function. It named a SQLite file; there is no
+file. Callers that threaded it through simply stop.
+
+THE IDENTITY IS THE PORT, AND THAT IS THE WHOLE DESIGN
+======================================================
+The obvious port of this module keys the store on ``name``, because
+:func:`get_port` and :func:`release_port` both look up by agent. That would
+be wrong in a way tests would not catch.
+
+The invariant this module exists to hold is ``UNIQUE(port)`` — a DIFFERENT
+column from the lookup key. Keyed on ``name``, two agents claiming port 8080
+are two DIFFERENT records, and the store would accept both: mutual exclusion
+on the port silently gone, while every unit test still passes. That is the
+exact collision this module's SQLite version was rewritten to stop, and the
+comments there record what it cost — the v0.21.19 release died on
+``sqlite3.IntegrityError: UNIQUE constraint failed: a2a_ports.port``,
+reproduced deterministically at 16 threads as 6 raw driver escapes.
+
+So ``port`` is the sole IDENTITY field. The store's own identity uniqueness
+CARRIES the invariant structurally: one row per port, by construction, on
+every backend, without a secondary constraint to remember. ``name`` becomes
+data ABOUT the claim.
+
+The price is honest and worth stating: "which port does this agent hold?"
+becomes a scan over claims rather than a keyed lookup. ``name`` is indexed
+to keep that cheap, and the ledger is bounded by the port range — tens of
+rows, not millions.
+
+ATOMIC CLAIM-OR-LOSE, PRESERVED EXACTLY
+=======================================
+The SQLite version's hard-won idiom is ``INSERT ... ON CONFLICT DO NOTHING``
+followed by a read-back: one statement decides the race, and the read-back
+says who won. Its predecessor — ``SELECT`` for a clash, then a bare
+``INSERT`` — was a TOCTOU, and WHICH error a caller got was decided by thread
+timing, which is why the failure moved between releases and read as a flake.
+
+``put(..., expected_revision=NEW_RECORD)`` is the same contract. The store's
+guard states it directly: NEW_RECORD means "the record must NOT exist", and a
+lost race raises :class:`RevisionMismatchError` ("the id is taken"). Either
+our row lands or it does not; there is no window between the check and the
+write. The read-back after a loss is what tells us whose it is.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: The store name. Kept as the old table name so the ledger stays greppable
+#: across the migration and in operator muscle memory.
+STORE_NAME = "a2a_ports"
+
+#: Recorded on every write as the acting component.
+_ACTOR = "scitex-agent-container"
+
+__all__ = [
+    "STORE_NAME",
+    "claim_port",
+    "get_port",
+    "init_port_schema",
+    "list_claims",
+    "open_port_store",
+    "port_store_target",
+    "release_port",
+]
+
+
+def _schema() -> Any:
+    """The claim-ledger schema.
+
+    Built lazily so importing this module does not import scitex-dev — the
+    SQLite version was equally lazy about ``state_db``, for the same reason.
+
+    ``port`` is the sole IDENTITY and is IMMUTABLE, which the store enforces
+    on identities: changing one does not update the record, it names a
+    different record. That is precisely right here — a claim on a different
+    port IS a different claim.
+
+    ``name`` is indexed because every lookup in this module goes through it
+    (see the module docstring on why the access pattern inverts).
+    """
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
+
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def fact(kind: Any, *, required: bool = False, indexed: bool = False) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=required,
+            merge=MergeRule.LAST_WRITER_WINS,
+            indexed=indexed,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "port": ident(FieldKind.INTEGER),
+            "name": fact(FieldKind.TEXT, required=True, indexed=True),
+            "claimed_at": fact(FieldKind.TEXT, required=True),
+        },
+    )
+
+
+def port_store_target() -> Any:
+    """Resolve WHERE the claims live. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_port_store() -> "Store":
+    """Open the claim store. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public function opens and closes one
+    per call, mirroring the old ``with open_db(...)`` shape: claims happen on
+    launch and release paths, never on a request path.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        port_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def init_port_schema() -> str:
+    """Create the claim tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR — the PostgreSQL equivalent of the
+    ``Path`` the SQLite version returned, and useful the same way: it names
+    WHERE the state actually went.
+    """
+    store = open_port_store()
+    try:
+        return str(port_store_target().locator)
+    finally:
+        store.close()
+
+
+def _claims(store: "Store") -> list[Any]:
+    """Every visible claim. One place, so the hidden-row view is uniform."""
+    return store.rows()
+
+
+def get_port(agent_name: str) -> int | None:
+    """The port ``agent_name`` currently holds, or ``None``.
+
+    A scan by design — see the module docstring: the identity is the port,
+    so the agent is data. The ledger is bounded by the configured range.
+    """
+    store = open_port_store()
+    try:
+        for row in _claims(store):
+            if row.values.get("name") == agent_name:
+                return int(row.values["port"])
+        return None
+    finally:
+        store.close()
+
+
+def _try_claim(store: "Store", *, port: int, agent_name: str, now: str) -> bool:
+    """Attempt an atomic create-only claim on ``port``. True iff we won it.
+
+    ``NEW_RECORD`` is the store's "the record must NOT exist" assertion, so
+    this cannot interleave the way a SELECT-then-INSERT could. A lost race
+    raises ``RevisionMismatchError`` and is reported as False — losing is a
+    normal outcome here, not an error, exactly as ``ON CONFLICT DO NOTHING``
+    treated it.
+
+    A RELEASED PORT IS HIDDEN, NOT ABSENT, and that distinction is the bug
+    this branch exists to fix. ``release_port`` hides the row; the record
+    still EXISTS for the revision check, so a later ``NEW_RECORD`` claim on
+    a genuinely free port failed with "already claimed by another agent".
+    ``is_hidden`` is three-valued precisely so a caller can tell "released"
+    from "held" — a hidden claim is unhidden and overwritten, which is what
+    releasing then re-claiming a port means.
+    """
+    from scitex_dev.store import ANY_REVISION, NEW_RECORD, RevisionMismatchError
+
+    hidden = store.is_hidden({"port": port})
+    if hidden is True:
+        store.unhide({"port": port}, expected_revision=ANY_REVISION)
+        store.put(
+            {"port": port, "name": agent_name, "claimed_at": now},
+            expected_revision=ANY_REVISION,
+        )
+        return True
+
+    try:
+        store.put(
+            {"port": port, "name": agent_name, "claimed_at": now},
+            expected_revision=NEW_RECORD,
+        )
+    except RevisionMismatchError:
+        return False
+    return True
+
+
+def _holder_of(store: "Store", port: int) -> str | None:
+    """Which agent holds ``port``, or ``None`` if it is free."""
+    row = store.get({"port": port})
+    return None if row is None else str(row.values["name"])
+
+
+def claim_port(
+    agent_name: str,
+    *,
+    range_: tuple[int, int] | None = None,
+    explicit: int | None = None,
+    explicit_is_pin: bool = True,
+) -> int:
+    """Atomically claim a free port for ``agent_name``.
+
+    Behaviour is preserved from the SQLite version verbatim, including the
+    distinction that a routine restart once died on:
+
+    * ``explicit_is_pin=True`` — an OPERATOR PIN from ``spec.a2a.port``. A
+      foreign holder is a real misconfiguration, so raise and make it
+      visible; handing back a different port would break the contract the
+      pin exists to state.
+    * ``explicit_is_pin=False`` — a port WE auto-allocated earlier and are
+      merely RE-claiming across a restart. That is a preference, not a pin:
+      if it was taken while we were down, a NEW free port is the correct
+      answer and failing the launch is not, so fall through to the scan.
+
+    Idempotent: a second call for the same agent returns the existing port
+    without mutating state.
+
+    Raises:
+        RuntimeError: when no free port remains in ``range_``, or when an
+            operator-PINNED ``explicit`` port is held by another agent.
+    """
+    from .port_allocator import _now_iso, _resolve_range
+
+    lo, hi = _resolve_range(range_)
+    now = _now_iso()
+
+    store = open_port_store()
+    try:
+        # Idempotent fast path: same agent -> return the existing claim.
+        for row in _claims(store):
+            if row.values.get("name") != agent_name:
+                continue
+            existing = int(row.values["port"])
+            if explicit is None or explicit == existing:
+                return existing
+            # The operator changed the pin between starts. Release the old
+            # claim so the new one can be attempted below.
+            store.hide({"port": existing}, expected_revision=_ANY())
+            break
+
+        if explicit is not None:
+            if _try_claim(store, port=explicit, agent_name=agent_name, now=now):
+                return int(explicit)
+
+            holder = _holder_of(store, explicit)
+            if holder == agent_name:
+                # We raced OURSELVES (two starts of one agent). Honour the
+                # documented idempotency rather than failing a legitimate
+                # re-entry.
+                return int(explicit)
+
+            if explicit_is_pin:
+                owner = holder if holder is not None else "another agent"
+                raise RuntimeError(
+                    f"a2a port {explicit} already claimed by "
+                    f"{owner!r}; cannot pin for {agent_name!r}"
+                )
+            # Not a pin — fall through to the auto scan.
+
+        for candidate in range(lo, hi + 1):
+            if _try_claim(store, port=candidate, agent_name=agent_name, now=now):
+                return candidate
+        raise RuntimeError(
+            f"no free a2a port in range [{lo}, {hi}] (all claimed); "
+            "extend a2a.port_range in ~/.scitex/agent-container/config.yaml"
+        )
+    finally:
+        store.close()
+
+
+def _ANY() -> Any:
+    """``ANY_REVISION``, imported lazily like every other store symbol here."""
+    from scitex_dev.store import ANY_REVISION
+
+    return ANY_REVISION
+
+
+def release_port(agent_name: str) -> bool:
+    """Drop the claim. Idempotent — True iff a claim was actually released."""
+    store = open_port_store()
+    try:
+        for row in _claims(store):
+            if row.values.get("name") == agent_name:
+                store.hide({"port": int(row.values["port"])}, expected_revision=_ANY())
+                return True
+        return False
+    finally:
+        store.close()
+
+
+def list_claims() -> list[dict]:
+    """Every live claim, ascending by port — the shape the CLI renders."""
+    store = open_port_store()
+    try:
+        claims = [
+            {
+                "name": row.values["name"],
+                "port": int(row.values["port"]),
+                "claimed_at": row.values["claimed_at"],
+            }
+            for row in _claims(store)
+        ]
+    finally:
+        store.close()
+    return sorted(claims, key=lambda c: c["port"])

--- a/tests/scitex_agent_container/_state/test_port_allocator_pg.py
+++ b/tests/scitex_agent_container/_state/test_port_allocator_pg.py
@@ -1,0 +1,259 @@
+"""The A2A port ledger on a REAL PostgreSQL — never SQLite, never a mock.
+
+Mirrors ``src/scitex_agent_container/_state/port_allocator_pg.py``.
+
+THE TEST THAT CARRIES THE DESIGN
+================================
+``test_two_agents_cannot_hold_the_same_port``. The obvious port of this
+module keys the store on ``name``, and that version passes every other test
+in this file while silently losing ``UNIQUE(port)`` — two agents would simply
+be two different records. This module exists to stop exactly that collision:
+its SQLite predecessor's comments record the v0.21.19 release dying on
+``UNIQUE constraint failed: a2a_ports.port``, reproduced at 16 threads as 6
+raw driver escapes. So the port is the IDENTITY, and this test is what says
+so in a way a future refactor cannot quietly undo.
+
+``test_concurrent_claims_are_all_distinct`` is the same invariant under the
+condition that produced the original bug — real threads racing on one range —
+because a mutual-exclusion claim that is only tested serially is untested.
+
+Isolation is the shared ``pg_schema`` fixture: a throwaway PostgreSQL schema
+selected through ``search_path`` and dropped afterwards, so the live per-host
+ledger is never touched. Real ``os.environ``, real store, real database —
+PA-306 forbids mocks, and a mocked store here would test nothing at all.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+
+import pytest
+
+from scitex_agent_container._state.port_allocator_pg import (
+    claim_port,
+    get_port,
+    init_port_schema,
+    list_claims,
+    release_port,
+)
+
+
+def _claim_in_race_range(agent_name: str) -> int:
+    """One racing claimant. A module-level def so the pool can map it."""
+    return claim_port(agent_name, range_=(9500, 9599))
+
+
+# ----------------------------------------------------------------------
+# The store exists, and it is PostgreSQL.
+# ----------------------------------------------------------------------
+
+
+def test_init_reports_where_the_state_went(pg_schema: str) -> None:
+    # Arrange
+    expected_fragment = "55432"
+    # Act
+    locator = init_port_schema()
+    # Assert
+    assert expected_fragment in locator
+
+
+# ----------------------------------------------------------------------
+# Claiming.
+# ----------------------------------------------------------------------
+
+
+def test_an_explicit_port_is_claimed(pg_schema: str) -> None:
+    # Arrange
+    init_port_schema()
+    # Act
+    port = claim_port("zz-a", explicit=9001)
+    # Assert
+    assert port == 9001
+
+
+def test_a_claim_is_readable_by_agent_name(pg_schema: str) -> None:
+    # Arrange
+    init_port_schema()
+    claim_port("zz-a", explicit=9001)
+    # Act
+    found = get_port("zz-a")
+    # Assert
+    assert found == 9001
+
+
+def test_reclaiming_the_same_port_is_idempotent(pg_schema: str) -> None:
+    # Arrange — a second start of one agent must not fail a legitimate
+    # re-entry, and must not mutate state.
+    init_port_schema()
+    claim_port("zz-a", explicit=9001)
+    # Act
+    again = claim_port("zz-a", explicit=9001)
+    # Assert
+    assert again == 9001
+
+
+def test_an_agent_holds_exactly_one_claim_after_reclaim(pg_schema: str) -> None:
+    # Arrange
+    init_port_schema()
+    claim_port("zz-a", explicit=9001)
+    # Act
+    claim_port("zz-a", explicit=9001)
+    # Assert
+    assert len([c for c in list_claims() if c["name"] == "zz-a"]) == 1
+
+
+def test_auto_scan_returns_a_port_in_range(pg_schema: str) -> None:
+    # Arrange
+    init_port_schema()
+    # Act
+    port = claim_port("zz-a", range_=(9200, 9210))
+    # Assert
+    assert 9200 <= port <= 9210
+
+
+def test_auto_scan_skips_a_taken_port(pg_schema: str) -> None:
+    # Arrange
+    init_port_schema()
+    claim_port("zz-holder", explicit=9200)
+    # Act
+    port = claim_port("zz-a", range_=(9200, 9210))
+    # Assert
+    assert port != 9200
+
+
+def test_an_exhausted_range_raises(pg_schema: str) -> None:
+    # Arrange — a one-port range, already held.
+    init_port_schema()
+    claim_port("zz-holder", explicit=9300)
+    # Act
+    attempt = partial(claim_port, "zz-a", range_=(9300, 9300))
+    # Assert
+    with pytest.raises(RuntimeError, match="no free a2a port"):
+        attempt()
+
+
+# ----------------------------------------------------------------------
+# THE INVARIANT.
+# ----------------------------------------------------------------------
+
+
+def test_two_agents_cannot_hold_the_same_port(pg_schema: str) -> None:
+    """THE DESIGN TEST — see the module docstring.
+
+    A store keyed on ``name`` passes every other test here and fails this
+    one, because there the two claims are simply two records.
+    """
+    # Arrange
+    init_port_schema()
+    claim_port("zz-first", explicit=9400)
+    try:
+        claim_port("zz-second", explicit=9400, explicit_is_pin=True)
+    except RuntimeError:
+        pass
+    # Act
+    holders = [c["name"] for c in list_claims() if c["port"] == 9400]
+    # Assert
+    assert holders == ["zz-first"]
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BLOCKED UPSTREAM on scitex_dev.store 0.56.5 — card "
+        "scitex-dev-store-concurrent-writes-collide-20260824. Concurrent "
+        "same-node writes race the oplog (origin, seq) allocation and escape "
+        "as a raw psycopg UniqueViolation, with DISTINCT identities, under "
+        "both WriterPolicy modes. Kept RUNNING rather than deleted or skipped: "
+        "xfail turns green the moment the store is fixed, so this file tells "
+        "us instead of us having to remember. Do NOT merge this module while "
+        "this xfails — the SQLite version it replaces handles this case, and "
+        "shipping it would reintroduce the bug that killed v0.21.19."
+    ),
+    strict=False,
+    raises=Exception,
+)
+def test_concurrent_claims_are_all_distinct(pg_schema: str) -> None:
+    """Mutual exclusion under the condition that produced the original bug.
+
+    The SQLite predecessor's TOCTOU reproduced deterministically at 16
+    threads; a serial-only test would have passed against it.
+    """
+    # Arrange
+    init_port_schema()
+    names = [f"zz-race-{i}" for i in range(12)]
+    # Act
+    with ThreadPoolExecutor(max_workers=12) as pool:
+        claim = partial(_claim_in_race_range)
+        ports = list(pool.map(claim, names))
+    # Assert
+    assert len(set(ports)) == len(ports)
+
+
+# ----------------------------------------------------------------------
+# Pins vs preferences — the distinction a routine restart once died on.
+# ----------------------------------------------------------------------
+
+
+def test_a_pinned_port_held_by_another_agent_raises(pg_schema: str) -> None:
+    # Arrange — an operator pin is a contract; a foreign holder is a real
+    # misconfiguration and must be visible.
+    init_port_schema()
+    claim_port("zz-holder", explicit=9600)
+    # Act
+    attempt = partial(claim_port, "zz-a", explicit=9600, explicit_is_pin=True)
+    # Assert
+    with pytest.raises(RuntimeError, match="cannot pin"):
+        attempt()
+
+
+def test_a_non_pinned_port_held_by_another_agent_falls_through(
+    pg_schema: str,
+) -> None:
+    # Arrange — a port we merely held before a restart is a preference. If it
+    # was taken while we were down, a NEW port is the right answer; failing
+    # the launch is not.
+    init_port_schema()
+    claim_port("zz-holder", explicit=9700)
+    # Act
+    port = claim_port(
+        "zz-a", explicit=9700, explicit_is_pin=False, range_=(9700, 9710)
+    )
+    # Assert
+    assert port != 9700
+
+
+# ----------------------------------------------------------------------
+# Releasing.
+# ----------------------------------------------------------------------
+
+
+def test_release_reports_that_it_released(pg_schema: str) -> None:
+    # Arrange
+    init_port_schema()
+    claim_port("zz-a", explicit=9800)
+    # Act
+    released = release_port("zz-a")
+    # Assert
+    assert released is True
+
+
+def test_release_is_idempotent(pg_schema: str) -> None:
+    # Arrange
+    init_port_schema()
+    claim_port("zz-a", explicit=9800)
+    release_port("zz-a")
+    # Act
+    again = release_port("zz-a")
+    # Assert
+    assert again is False
+
+
+def test_a_released_port_can_be_claimed_by_another_agent(pg_schema: str) -> None:
+    # Arrange — the whole point of releasing.
+    init_port_schema()
+    claim_port("zz-a", explicit=9800)
+    release_port("zz-a")
+    # Act
+    port = claim_port("zz-b", explicit=9800)
+    # Assert
+    assert port == 9800


### PR DESCRIPTION
**DO NOT MERGE.** Blocked on a scitex_dev.store defect, not on this branch. Opened for review and so the work is visible, not to land.

## Why it is held
`test_concurrent_claims_are_all_distinct` **xfails**: concurrent same-node writes race the store oplog `(origin, seq)` allocation and escape as a raw `psycopg.UniqueViolation` — with *distinct* identities, under both `WriterPolicy` modes (`store/_policy.py:125` says sequence numbers are keyed by origin regardless of mode).

That is not academic here. This module was rewritten in SQLite *because* concurrent claims escaped as `sqlite3.IntegrityError` and killed release v0.21.19, and the operator relaunches ~14 agents at once. Merging now would reintroduce a fixed production bug with a new traceback.

Filed upstream with a standalone reproduction (no sac code, ~20 lines, self-cleaning schema): card `scitex-dev-store-concurrent-writes-collide-20260824`. It also surfaced a *second* defect — `Store.__init__` races its own `CREATE TABLE` on `pg_type`.

The test is left **running as xfail** rather than skipped or deleted: it turns green by itself when the store is fixed, so the file tells us instead of someone having to remember.

## The design decision worth reviewing
The obvious port keys the store on `name` (both lookups are by agent). That silently destroys the invariant: `UNIQUE(port)` is a *different* column from the lookup key, so two agents claiming one port would just be two records — mutual exclusion gone, every other test still green.

So **`port` is the sole IDENTITY** and the store’s own uniqueness carries the invariant structurally. Price: "which port does this agent hold" becomes an indexed scan over a range-bounded ledger.

- `put(..., expected_revision=NEW_RECORD)` reproduces `INSERT ... ON CONFLICT DO NOTHING` + read-back exactly — no TOCTOU window.
- A released port is **hidden, not absent**, so `_try_claim` consults the three-valued `is_hidden` and unhides; without that a freed port reads as held (caught by a test).
- Pin vs preference preserved: `explicit_is_pin=True` raises on a foreign holder; `False` falls through to the scan.

## Verification
15 tests against a **real PostgreSQL**, no mocks, one assert each: **14 pass, 1 xfail (upstream)**. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)