### PR TITLE
fix(state): route the two raw `instances` readers through the accessor that already existed

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_rename_plan.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_plan.py
@@ -131,21 +131,25 @@ def _open_instance_pid(db_path: Path, name: str) -> int | None:
     """Return the pid of an open ``instances`` row for ``name``, if any."""
     if not db_path.is_file():
         return None
-    import sqlite3
+    # Through the OWNING module, not through its table. The raw SELECT this
+    # replaces would keep reading a SQLite ``instances`` table after that
+    # table moves backend, and would report "not running" for every agent
+    # rather than failing — the same silent-stranding shape found in
+    # ``_authheal/_specimen`` during the sqlite->PostgreSQL migration.
+    #
+    # ``list_active_instances`` already applies ``ended_at IS NULL`` and
+    # orders by ``started_at DESC``, so only this function's two extra
+    # conditions remain here: the name, and a pid that is actually recorded.
+    from .._state.state_db_instances import list_active_instances
 
-    conn = sqlite3.connect(str(db_path))
     try:
-        row = conn.execute(
-            "SELECT pid FROM instances "
-            "WHERE name = ? AND ended_at IS NULL AND pid IS NOT NULL "
-            "ORDER BY started_at DESC LIMIT 1",
-            (name,),
-        ).fetchone()
-    except sqlite3.Error:  # stx-allow: fallback (reason: a fresh DB has no instances table — absence of the table is absence of evidence, not evidence of running)
+        rows = list_active_instances(db_path=db_path)
+    except Exception:  # stx-allow: fallback (reason: a fresh DB has no instances table — absence of the table is absence of evidence, not evidence of running. Kept deliberately broad: the raw version caught sqlite3.Error, and the accessor may raise a different type per backend, so narrowing it here would turn a fresh database into a crash mid-rename.)
         return None
-    finally:
-        conn.close()
-    return int(row[0]) if row else None
+    for row in rows:
+        if row.get("name") == name and row.get("pid") is not None:
+            return int(row["pid"])
+    return None
 
 
 def probe_running(name: str, layout: Layout) -> tuple[str, str]:

--- a/src/scitex_agent_container/cli_pkg/send_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/send_cmds.py
@@ -276,13 +276,18 @@ def _is_known_agent(name: str) -> bool:
             return True
     except Exception:  # stx-allow: fallback (reason: see comment above)
         return True
-    from .._state.state_db import open_db
+    # Through the OWNING module, not through its table. This used to open a
+    # raw connection and SELECT from ``instances`` directly, which reads the
+    # same rows today and strands the moment that table moves backend — the
+    # sqlite->PostgreSQL migration is doing exactly that, and the identical
+    # pattern in ``_authheal/_specimen`` would have silently returned "no such
+    # row" forever. ``last_known_instance`` already answers this question
+    # (latest row for the name, active OR ended, ``None`` when never seen),
+    # so nothing new had to be written — the accessor was there and this call
+    # site was simply going around it.
+    from .._state.state_db_instances import last_known_instance
 
-    with open_db() as conn:
-        row = conn.execute(
-            "SELECT 1 FROM instances WHERE name = ? LIMIT 1", (name,)
-        ).fetchone()
-    return row is not None
+    return last_known_instance(name) is not None
 
 
 def _refuse_unknown_agent(name: str) -> NoReturn:

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -107,7 +107,20 @@ FROZEN_SQLITE = frozenset(
     {
         "_authheal/_specimen.py",
         "_lifecycle/_rename_db.py",
-        "_lifecycle/_rename_plan.py",
+        # _lifecycle/_rename_plan.py LEFT THIS SET 2026-08-24, and like
+        # _authheal/_specimen.py it left WITHOUT being ported — it was reading
+        # a table it does not own. It opened its own sqlite3 connection to
+        # SELECT a pid FROM `instances`, which belongs to state_db_instances.
+        # That read would have survived the `instances` move to PostgreSQL
+        # without raising and simply answered "not running" for every agent,
+        # because this caller treats any error as absence of evidence. It now
+        # calls list_active_instances(), so the accessor's backend is the only
+        # thing that has to change when that table moves.
+        #
+        # `_rename_db.py` deliberately STAYS: it enumerates sqlite_master to
+        # rewrite an agent's rows across every table, which is SQLite-engine
+        # code rather than merely SQLite-backed, and is a rewrite rather than
+        # a port. It leaves this set when that rewrite happens, not before.
         "_state/auth_state.py",
         "_state/dispatch_ledger.py",
         # _state/inbound_ledger.py LEFT THIS SET 2026-08-20 — the FOURTH table


### PR DESCRIPTION
**Preparatory work for moving `instances` off SQLite**, defusing two landmines found by sweeping for the defect class #1203 nearly shipped: a module reading another module’s *table* instead of calling its API, so the reader strands the moment that table changes backend.

## Neither is broken today. Both would have been — silently.

| file | raw SQL | what it decides |
|---|---|---|
| `cli_pkg/send_cmds.py` | `SELECT 1 FROM instances WHERE name = ? LIMIT 1` | was this name ever an agent |
| `_lifecycle/_rename_plan.py` | `SELECT pid FROM instances WHERE … LIMIT 1` | is this agent running, mid-rename |

The first caller swallows exceptions to preserve a pre-existing message; the second treats *any* error as "no evidence of running". So after a backend move neither raises — one answers "never an agent" and the other "not running", indefinitely. Same shape as the `_specimen` bug, which returned `<state.db unreadable>` forever.

## No new code was needed — and that corrects something I wrote
I had recorded on the migration card that `state_db.py` is a connection provider *"with no API layer"*, and concluded these callers had nothing to call. Wrong. `state_db_instances.py` already exposes:

- `last_known_instance(name)` — latest row, active or ended, `None` when never seen → exactly the existence question
- `list_active_instances()` — `ended_at IS NULL`, ordered `started_at DESC` → exactly the pid question, minus two conditions

The accessors were there; these two call sites were going around them.

## One deliberate choice
`_rename_plan`’s original caught `sqlite3.Error` so a fresh database reads as "no evidence of running" rather than crashing a rename. Through the accessor the exception type becomes backend-dependent, so the catch stays **broad, with the reason written down** — narrowing it would turn a fresh database into a crash mid-rename. `sqlite3` is now gone from that module entirely.

## Verification
**118 tests pass** (`test_state_db_instances`, `test__rename`, `test__instances`, `test__instances_pid`); ruff clean.

*Note for reviewers: my first run named non-existent test files and reported `collected 0 items … no tests ran` with exit code 0. A green exit with zero collected is not a pass — the count above is from the real covering files.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)