### PR TITLE
fix(ci): point the verdict rail at a login role — the retired superuser broke every run

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -353,7 +353,21 @@ jobs:
       # even though it is on the operator's interactive PATH.
       - name: Write the CI verdict to the card and notify the pushing agent
         env:
-          SCITEX_CARDS_DB: ${{ vars.SCITEX_CARDS_DB || 'postgresql://scitex_cards@127.0.0.1:55432/scitex_cards' }}
+          # THE FALLBACK NAMES A LOGIN ROLE, and that is the whole fix here.
+          # It used to be `postgresql://scitex_cards@...`. `scitex_cards` was
+          # the cluster's shared superuser and was demoted to NOLOGIN on
+          # 2026-08-24 with its password removed from every ~/.pgpass, so this
+          # step began failing on EVERY push with
+          #   fe_sendauth: no password supplied
+          # while the test legs themselves passed — a green suite reported as
+          # a red run, on develop and on every open PR at once.
+          #
+          # `ywatanabe__cli` is the interactive/tooling login leaf. libpq
+          # matches it in the runner user's ~/.pgpass, so no credential
+          # appears here. Verified from the runner's own host both with and
+          # without PGPASSFILE exported, because this step runs in a
+          # non-interactive shell that sources no profile.
+          SCITEX_CARDS_DB: ${{ vars.SCITEX_CARDS_DB || 'postgresql://ywatanabe__cli@127.0.0.1:55432/scitex_cards' }}
           TEST_RESULT: ${{ needs.test.result }}
           # Reads the FAILED JOBS' logs so a red verdict names the failing
           # test. Deliberately the per-JOB log endpoint: this job is itself


### PR DESCRIPTION
**Self-inflicted, found by checking my own work.** Retiring the shared `scitex_cards` superuser (NOLOGIN + password removed from every `~/.pgpass`) broke `ci-verdict-to-pushing-agent` on **every push**:

```
cannot open the PostgreSQL store postgresql://scitex_cards@127.0.0.1:55432/scitex_cards
... fe_sendauth: no password supplied
```

## Why it is the nasty kind of failure
The test legs **passed**. Only the step that *writes the verdict* failed — so a green suite was reported as a red run, on `develop` and every open PR at once. I verified #1205 went green and merged it **without re-checking develop after the merge**, which is precisely where this was visible.

## Two fixes, deliberately both
- **`vars.SCITEX_CARDS_DB`** set to the same value — already applied, so it takes effect on every branch *without waiting for this to merge*. That override exists for exactly this.
- **This workflow default**, so the fallback is not a landmine for whoever later clears the variable.

`ywatanabe__cli` is the interactive/tooling login leaf; libpq matches it in the runner user’s `~/.pgpass`, so no credential appears in the workflow.

## Verified, not assumed
From the runner’s own host, both with and without `PGPASSFILE` exported (this step runs in a non-interactive shell that sources no profile):

```
connected as ywatanabe__cli, tasks=5982
```

Swept `.github/` for other references to the retired role — none remain but the explanatory comment added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)