### PR TITLE
fix(handoff): report what the peer's exit code proves, not what we hoped to read

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_spec_handoff.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_spec_handoff.py
@@ -242,13 +242,62 @@ def ssh_runner(peer: str, peers: Mapping[str, PeerSpec]) -> PeerShell:
     return run
 
 
+#: What each non-zero exit from :func:`manifest_script` actually PROVES.
+#:
+#: The script's own exits are documented (1 = cd failed, 3 = no md5sum), and
+#: the shell contributes two more that mean the script never ran at all. The
+#: previous message reported every one of them as "Could not read the spec
+#: manifest", which names the wrong subject: on 126/127 the manifest was never
+#: consulted, so the spec dir is not evidence of anything. A reader who
+#: believes that message goes looking for a missing or corrupt spec on the
+#: peer and finds a perfectly good one.
+_MANIFEST_RC_MEANING: dict[int, str] = {
+    1: (
+        "the spec directory exists on the peer but could not be entered "
+        "(`cd` failed) — check its permissions and ownership, not its contents"
+    ),
+    3: (
+        "the peer has no `md5sum`, so delivery cannot be verified — sac "
+        "refuses to proceed unverified rather than claim a transfer it "
+        "cannot check"
+    ),
+    126: (
+        "a command in the manifest script was found but is not executable on "
+        "the peer — the spec manifest was never read, so this says nothing "
+        "about the spec directory"
+    ),
+    127: (
+        "a command in the manifest script (or in the ssh wrapper around it) "
+        "was NOT FOUND on the peer — the spec manifest was never read, so "
+        "this says nothing about the spec directory. Usual causes: a "
+        "non-POSIX login shell, a PATH that a non-interactive ssh session "
+        "does not get, or `find`/`sh` missing from a minimal image"
+    ),
+}
+
+
 def read_remote_manifest(remote_dir: str, shell: PeerShell) -> dict[str, str]:
-    """``{relpath: md5}`` as the PEER reports it. Empty when absent."""
+    """``{relpath: md5}`` as the PEER reports it. Empty when absent.
+
+    A non-zero exit is reported as WHAT IT PROVES, not as the outcome the
+    caller was hoping for. The return code already distinguishes "the peer
+    could not read your spec" from "the peer could not run your script", and
+    reporting both as the former sends the reader to the wrong machine's
+    wrong directory.
+    """
     result = shell(manifest_script(remote_dir))
     if result.returncode != 0:
+        meaning = _MANIFEST_RC_MEANING.get(result.returncode)
+        headline = (
+            f"Spec manifest step failed on the peer (rc={result.returncode})"
+            if meaning
+            else f"Could not read the spec manifest at {remote_dir} "
+            f"(rc={result.returncode})"
+        )
+        detail = f"\n{meaning}." if meaning else ""
         raise RuntimeError(
-            f"Could not read the spec manifest at {remote_dir} "
-            f"(rc={result.returncode}).\n"
+            f"{headline}.{detail}\n"
+            f"spec dir: {remote_dir}\n"
             f"stderr:\n{result.stderr.decode('utf-8', 'replace')}"
         )
     return parse_manifest(result.stdout.decode("utf-8", "replace"))

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__spec_handoff.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__spec_handoff.py
@@ -408,3 +408,113 @@ def test_a_failing_extraction_is_reported_with_the_peers_stderr(spec_src):
 
 
 # EOF
+
+
+class PeerExitingWith:
+    """A peer whose shell exits with a chosen code.
+
+    The RETURN CODE is the subject under test here, so it is supplied
+    directly rather than provoked: reproducing a real rc=127 would mean
+    breaking a PATH on a real machine, which tests what the machine did,
+    not what our message says about it.
+    """
+
+    def __init__(self, returncode: int, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+
+    def __call__(self, script: str, stdin: bytes | None = None):
+        return subprocess.CompletedProcess(
+            args=[], returncode=self.returncode, stdout=b"", stderr=self.stderr
+        )
+
+
+def manifest_failure_message(returncode: int, stderr: bytes = b"") -> str:
+    """The ``RuntimeError`` text raised for ``returncode``.
+
+    Captured through one helper so every claim about that message is its own
+    single-assertion test, the way ``rerouted_delivery_error`` does above.
+    """
+    peer = PeerExitingWith(returncode, stderr)
+    with pytest.raises(RuntimeError) as excinfo:
+        read_remote_manifest(REMOTE_DIR, peer)
+    return str(excinfo.value)
+
+
+def test_command_not_found_does_not_accuse_the_spec_manifest():
+    """rc=127 proves the script never ran, so the manifest was never read.
+
+    Reporting it as "could not read the spec manifest" sends the reader to
+    hunt a missing or corrupt spec on the peer that was fine all along.
+    """
+    # Arrange
+    # Act
+    message = manifest_failure_message(127)
+    # Assert
+    assert "Could not read the spec manifest" not in message
+
+
+def test_command_not_found_names_the_missing_command_as_the_cause():
+    # Arrange
+    # Act
+    message = manifest_failure_message(127)
+    # Assert
+    assert "NOT FOUND on the peer" in message
+
+
+def test_command_not_found_still_reports_the_spec_dir():
+    """Correcting the accusation must not cost the reader the path."""
+    # Arrange
+    # Act
+    message = manifest_failure_message(127)
+    # Assert
+    assert REMOTE_DIR in message
+
+
+def test_a_non_executable_command_is_distinguished_from_a_missing_one():
+    """126 and 127 are different faults and get different remedies."""
+    # Arrange
+    # Act
+    message = manifest_failure_message(126)
+    # Assert
+    assert "not executable" in message
+
+
+def test_a_peer_without_md5sum_is_named_as_such():
+    """Exit 3 is the script's OWN signal — it already knows why it stopped."""
+    # Arrange
+    # Act
+    message = manifest_failure_message(3)
+    # Assert
+    assert "no `md5sum`" in message
+
+
+def test_an_unenterable_spec_dir_points_at_permissions_not_contents():
+    """Exit 1 is the script's ``cd`` failing: the directory IS there."""
+    # Arrange
+    # Act
+    message = manifest_failure_message(1)
+    # Assert
+    assert "could not be entered" in message
+
+
+def test_an_undocumented_exit_keeps_the_original_message():
+    """A claim is made only for codes whose meaning the script fixes.
+
+    Anything else stays exactly as vague as our knowledge of it — inventing a
+    cause for an unknown code is the same defect in the other direction.
+    """
+    # Arrange
+    # Act
+    message = manifest_failure_message(11)
+    # Assert
+    assert "Could not read the spec manifest" in message
+
+
+def test_the_peers_own_stderr_survives_the_rewrite():
+    """Whatever the peer itself said is the most specific evidence there is."""
+    # Arrange
+    # Act
+    message = manifest_failure_message(127, b"sh: 1: find: not found")
+    # Assert
+    assert "sh: 1: find: not found" in message


### PR DESCRIPTION
## The defect

`read_remote_manifest()` reported **every** non-zero exit from the peer as:

```
Could not read the spec manifest at <dir> (rc=127).
```

For `rc=127` that sentence is false, and the code already held the proof: 127
is *command not found*, which means the script never ran, so the manifest was
never consulted. The spec directory is not evidence of anything. A reader who
believes the message goes to the peer hunting a missing or corrupt spec — and
finds a perfectly good one.

`manifest_script()` also documents **its own** exits (`1` = `cd` failed,
`3` = no `md5sum` — with a clear stderr line it already writes), and those were
flattened into the same sentence too.

## The fix

Map each exit to what it **establishes**, and name which machine and which
thing to go look at:

| rc | Reported as |
|----|-------------|
| 1 | dir exists but could not be entered — check permissions, not contents |
| 3 | peer has no `md5sum`; sac refuses to claim a transfer it cannot verify |
| 126 | a command was found but is not executable — manifest never read |
| 127 | a command was NOT FOUND — manifest never read; usual causes: non-POSIX login shell, PATH a non-interactive ssh session doesn't get, minimal image |

An **undocumented** code keeps the original vague wording. Inventing a cause
for an exit we have not characterised is the same defect pointing the other
way — so a claim is made only where the script's contract supports one.

The spec dir stays in every message, so correcting the accusation does not cost
the reader the path, and the peer's own stderr is still passed through
verbatim — it is the most specific evidence available.

## Verification

- 8 new tests, one assertion each, AAA markers, no mocks (the fake peer returns
  a real `subprocess.CompletedProcess`, matching `UnreachablePeer` above it).
  The return code *is* the subject under test, so it is supplied directly
  rather than provoked by breaking a real machine's PATH.
- `tests/scitex_agent_container/cli_pkg/lifecycle/test__spec_handoff.py`:
  **37 passed** in 0.46s (was 29).
- The pre-existing `test_a_peer_that_cannot_be_read_is_an_error` (rc=11)
  still passes unchanged — that is the undocumented-code path.
- `ruff check`: clean. (`ruff format` reports both files unformatted **on
  develop already**, and pre-commit does not run it — not touched, to keep the
  diff to the change.)

Card: `sac-rc127-error-accuses-absent-spec-when-command-was-malformed-20260817`
