### PR TITLE
fix(tests): the health monitor leaked out of 25 tests and wrote into whichever test ran 90 s later; restore DEFAULT_STATE_ROOT

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -7,6 +7,7 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 from __future__ import annotations
 
 import logging
+import threading
 import time
 import traceback
 from pathlib import Path
@@ -234,6 +235,7 @@ def agent_restart(
     config_resolver: Optional[Callable[[str], str]] = None,
     wait_for_stop_timeout_s: float = _DEFAULT_WAIT_FOR_STOP_TIMEOUT_S,
     successor_auth_check: Optional[Callable[[str], None]] = None,
+    thread_factory: Callable[..., Any] = threading.Thread,
 ) -> bool:
     """Restart an agent by name: resolve spec → stop → settle → start.
 
@@ -450,4 +452,10 @@ def agent_restart(
         runtime_factory=runtime_factory,
         sleep_fn=sleep_fn,
         handover_mod=handover_mod,
+        # Forwarded so a test can keep the health monitor from spawning a
+        # REAL daemon thread that outlives it. Every other seam already
+        # passed through; this one did not, so the 11 restart tests in
+        # test_lifecycle.py each leaked a monitor that fired ~90 s later
+        # into an unrelated test's caplog (develop red, 2026-08-24).
+        thread_factory=thread_factory,
     )

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -43,6 +43,7 @@ from scitex_agent_container._listen._handler_deadline import (
     AGENT_START_DEADLINE_S,
     client_timeout_for,
 )
+from scitex_agent_container._runners import _session_state
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state.registry import Registry
 from scitex_agent_container.config import AgentConfig
@@ -548,12 +549,27 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
     }
     saved = {k: os.environ.get(k) for k in keys}
     saved_default = state_db.DEFAULT_DB_PATH
+    # ``_session_state.DEFAULT_STATE_ROOT`` is bound ONCE, at import time, from
+    # ``runtime_base_dir()`` (_session_state.py:76). Restoring the env var is
+    # therefore NOT enough: whichever test first drags that module into the
+    # interpreter decides the constant for the whole worker, and if that happens
+    # while this fixture's redirect is live the constant keeps pointing into a
+    # tmp_path that pytest then deletes. conftest's autouse
+    # ``_assert_state_floor_intact`` catches it at teardown, and everything
+    # after it in the worker ERRORs -- measured 2026-08-24: this file alone,
+    # then tests/scitex_agent_container/runtimes/test__cct_token_pool.py, gave
+    # 89 passed / 61 errors in one process purely from this leak.
+    # Rebinding it explicitly (same shape as ``state_db.DEFAULT_DB_PATH`` above)
+    # makes the redirect deliberate and, crucially, UNDOES it.
+    saved_state_root = _session_state.DEFAULT_STATE_ROOT
     os.environ.update(keys)
     state_db.DEFAULT_DB_PATH = db
+    _session_state.DEFAULT_STATE_ROOT = runtime_dir
     state_db.init_schema(db)
     try:
         yield db
     finally:
+        _session_state.DEFAULT_STATE_ROOT = saved_state_root
         state_db.DEFAULT_DB_PATH = saved_default
         for k, prev in saved.items():
             if prev is None:

--- a/tests/scitex_agent_container/_lifecycle/test__stale_lease.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stale_lease.py
@@ -27,6 +27,26 @@ from typing import Iterator
 import pytest
 
 
+class FakeThread:
+    """Hand-rolled stand-in for ``threading.Thread`` that NEVER runs.
+
+    This file's spec enables ``health``, so the start path spawns the
+    health monitor. With the real ``threading.Thread`` that daemon thread
+    OUTLIVES the test and, ~90 s later, writes a birth certificate and logs
+    an ERROR into whatever test is running then (develop red, 2026-08-24;
+    measured with a capture-immune probe). Same shape as ``FakeThread`` in
+    ``test_lifecycle.py``. PA-306: a hand-written stand-in, not a mock.
+    """
+
+    def __init__(self, *, target=None, args=(), daemon=False, **_kw) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
 @pytest.fixture
 def db_path(tmp_path: Path) -> Iterator[Path]:
     """Per-test on-disk state.db, exported via env (save/restore).
@@ -427,6 +447,7 @@ def _drive_dead_runtime_start_scenario(
         runtime_factory=lambda _c: runtime,
         handover_mod=_Handover(),
         sleep_fn=lambda _s: None,
+        thread_factory=FakeThread,
     )
     rows = [r for r in list_active_instances() if r["name"] == "zombie"]
     return runtime, rows, dead_pid

--- a/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
@@ -49,6 +49,27 @@ _SIGTERM_DEAF = (
 )
 
 
+
+class FakeThread:
+    """Hand-rolled stand-in for ``threading.Thread`` that NEVER runs.
+
+    This file's spec enables ``health``, so the start path spawns the
+    health monitor. With the real ``threading.Thread`` that daemon thread
+    OUTLIVES the test and, ~90 s later, writes a birth certificate and logs
+    an ERROR into whatever test is running then (develop red, 2026-08-24;
+    measured with a capture-immune probe). Same shape as ``FakeThread`` in
+    ``test_lifecycle.py``. PA-306: a hand-written stand-in, not a mock.
+    """
+
+    def __init__(self, *, target=None, args=(), daemon=False, **_kw) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
 def _no_sleep(_seconds: float) -> None:
     return None
 
@@ -581,6 +602,7 @@ def _restart(tmp_path: Path, runtime: Any, *, name: str = "alpha") -> bool:
         # leg (and off the network).
         successor_auth_check=lambda _path: None,
         wait_for_stop_timeout_s=0.05,
+        thread_factory=FakeThread,
     )
 
 

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -395,6 +395,7 @@ def test_agent_start_happy_path_returns_true(
         runtime_factory=lambda _c: runtime,
         handover_mod=handover,
         sleep_fn=_no_sleep,
+        thread_factory=FakeThread,
     )
     # Assert
     assert ok is True
@@ -413,6 +414,7 @@ def test_agent_start_happy_path_calls_runtime_start_once(
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
+        thread_factory=FakeThread,
     )
     # Assert
     assert len(runtime.start_calls) == 1
@@ -431,6 +433,7 @@ def test_agent_start_happy_path_registers_agent(
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
+        thread_factory=FakeThread,
     )
     # Assert
     assert registry.exists("alpha")
@@ -449,6 +452,7 @@ def test_agent_start_happy_path_invokes_handover(
         runtime_factory=lambda _c: FakeRuntime(start_result=True),
         handover_mod=handover,
         sleep_fn=_no_sleep,
+        thread_factory=FakeThread,
     )
     # Assert
     assert len(handover.ensure_calls) == 1 and len(handover.hydrate_calls) == 1
@@ -472,6 +476,7 @@ def test_agent_start_idempotent_when_already_running(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         liveness_verifier=lambda _cfg, _rt: True,
+        thread_factory=FakeThread,
     )
     # Assert: returns success, says WHY, and never calls start.
     #
@@ -506,6 +511,7 @@ def test_agent_start_force_restarts_when_already_running(
         sleep_fn=_no_sleep,
         force=True,
         liveness_verifier=lambda _cfg, _rt: True,
+        thread_factory=FakeThread,
     )
     # Assert: force triggered stop AND start on the same runtime instance.
     assert len(runtime.stop_calls) == 1 and len(runtime.start_calls) == 1
@@ -536,6 +542,7 @@ def test_agent_start_launches_when_liveness_verifier_returns_false(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         liveness_verifier=lambda _cfg, _rt: False,
+        thread_factory=FakeThread,
     )
     # Assert — fell through to a real launch instead of the silent no-op.
     assert len(runtime.start_calls) == 1
@@ -654,6 +661,7 @@ def _force_restart_running_agent(
         sleep_fn=_no_sleep,
         force=True,
         liveness_verifier=lambda _cfg, _rt: True,
+        thread_factory=FakeThread,
     )
 
 
@@ -720,6 +728,7 @@ def test_agent_start_force_clears_stale_registry_entry(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         force=True,
+        thread_factory=FakeThread,
     )
     # Assert
     assert ok is True and len(runtime.stop_calls) == 1
@@ -745,6 +754,7 @@ def test_agent_start_session_override_mutates_claude_session(
         sleep_fn=_no_sleep,
         session_override="resume",
         resume_id_override="abc-123",
+        thread_factory=FakeThread,
     )
     # Assert
     assert captured["cfg"].claude.session == "resume"
@@ -770,6 +780,7 @@ def test_agent_start_continue_override_beats_spec_fresh(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         session_override="continue",
+        thread_factory=FakeThread,
     )
     # Assert
     assert captured["cfg"].claude.session == "continue"
@@ -795,6 +806,7 @@ def test_agent_start_fresh_override_beats_spec_continue(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         session_override="fresh",
+        thread_factory=FakeThread,
     )
     # Assert
     assert captured["cfg"].claude.session == "fresh"
@@ -820,6 +832,7 @@ def test_agent_start_resume_id_override_mutates_resume_id(
         sleep_fn=_no_sleep,
         session_override="resume",
         resume_id_override="abc-123",
+        thread_factory=FakeThread,
     )
     # Assert
     assert captured["cfg"].claude.resume_id == "abc-123"
@@ -838,6 +851,7 @@ def test_agent_start_runtime_failure_raises_runtime_error(
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
+        thread_factory=FakeThread,
     )
     # Assert
     with pytest.raises(RuntimeError, match="Failed to start"):
@@ -857,6 +871,7 @@ def _start_with_failing_runtime(spec: Path, registry: Registry) -> None:
             runtime_factory=lambda _c: runtime,
             handover_mod=FakeHandover(),
             sleep_fn=_no_sleep,
+            thread_factory=FakeThread,
         )
     except RuntimeError:
         pass
@@ -909,6 +924,7 @@ def test_agent_start_dry_run_does_not_register(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         dry_run=True,
+        thread_factory=FakeThread,
     )
     # Assert
     assert ok is True and not registry.exists("alpha")
@@ -928,6 +944,7 @@ def test_agent_start_dry_run_passes_dry_run_kwarg_to_runtime(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         dry_run=True,
+        thread_factory=FakeThread,
     )
     # Assert
     assert runtime.start_kwargs.get("dry_run") is True
@@ -948,6 +965,7 @@ def test_agent_start_dry_run_typeerror_raises_helpful_runtime_error(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         dry_run=True,
+        thread_factory=FakeThread,
     )
     # Assert
     with pytest.raises(RuntimeError, match="does not support --dry-run"):
@@ -968,6 +986,7 @@ def test_agent_start_hydrate_failure_does_not_block_start(
         runtime_factory=lambda _c: FakeRuntime(start_result=True),
         handover_mod=handover,
         sleep_fn=_no_sleep,
+        thread_factory=FakeThread,
     )
     # Assert
     assert ok is True
@@ -1013,6 +1032,7 @@ def test_agent_start_failback_poller_failure_is_swallowed(
         runtime_factory=lambda _c: FakeRuntime(start_result=True),
         handover_mod=handover,
         sleep_fn=_no_sleep,
+        thread_factory=FakeThread,
     )
     # Assert
     assert ok is True
@@ -1038,6 +1058,7 @@ def test_agent_start_cli_no_preflight_propagates_to_runtime(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         no_preflight=True,
+        thread_factory=FakeThread,
     )
     # Assert
     assert runtime.start_kwargs.get("no_preflight") is True
@@ -1361,6 +1382,7 @@ def test_agent_restart_calls_runtime_stop_then_start(
         runtime_factory=lambda _c: runtime,
         sleep_fn=_no_sleep,
         handover_mod=FakeHandover(),
+        thread_factory=FakeThread,
     )
     # Assert
     assert ok is True and len(runtime.stop_calls) == 1 and len(runtime.start_calls) == 1
@@ -1390,6 +1412,7 @@ def test_agent_restart_clears_dead_session_marker(
             runtime_factory=lambda _c: FakeRuntime(start_result=True),
             sleep_fn=_no_sleep,
             handover_mod=FakeHandover(),
+            thread_factory=FakeThread,
         )
         # Assert — the dead resume marker is gone so the restart is fresh.
         result = sid.read_session_id(state_dir)
@@ -1424,6 +1447,7 @@ def test_agent_restart_clears_dead_session_history(
             runtime_factory=lambda _c: FakeRuntime(start_result=True),
             sleep_fn=_no_sleep,
             handover_mod=FakeHandover(),
+            thread_factory=FakeThread,
         )
         # Assert — the whole history is cleared so no dead uuid can be
         # re-resumed on the next start (the crash-loop is closed).
@@ -1458,6 +1482,7 @@ def test_agent_restart_backs_up_dead_session_history(
             runtime_factory=lambda _c: FakeRuntime(start_result=True),
             sleep_fn=_no_sleep,
             handover_mod=FakeHandover(),
+            thread_factory=FakeThread,
         )
         # Assert
         backups = list(state_dir.glob("session_id_history.dead-*"))
@@ -1483,6 +1508,7 @@ def test_agent_restart_unknown_raises(tmp_path: Path, registry: Registry) -> Non
         sleep_fn=_no_sleep,
         handover_mod=FakeHandover(),
         config_resolver=_no_spec,
+        thread_factory=FakeThread,
     )
     # Assert
     with pytest.raises(RuntimeError, match="not found"):
@@ -1505,6 +1531,7 @@ def test_agent_restart_no_row_falls_back_to_spec_and_starts(
         sleep_fn=_no_sleep,
         handover_mod=FakeHandover(),
         config_resolver=lambda _name: str(spec),
+        thread_factory=FakeThread,
     )
     # Assert — the spec-resolved start ran (fallback path reached the runtime).
     assert ok is True and len(runtime.start_calls) == 1
@@ -1526,6 +1553,7 @@ def test_agent_restart_no_row_force_stops_before_start(
         sleep_fn=_no_sleep,
         handover_mod=FakeHandover(),
         config_resolver=lambda _name: str(spec),
+        thread_factory=FakeThread,
     )
     # Assert — force-stop tolerated the dead session and start still ran.
     assert ok is True and len(runtime.start_calls) == 1
@@ -1560,6 +1588,7 @@ def test_agent_restart_no_row_uses_default_resolver_discovery_chain(
             runtime_factory=lambda _c: runtime,
             sleep_fn=_no_sleep,
             handover_mod=FakeHandover(),
+            thread_factory=FakeThread,
         )
     finally:
         os.chdir(prev_cwd)
@@ -1614,6 +1643,7 @@ def test_agent_restart_passes_assume_yes_to_start_leg(
             sleep_fn=_no_sleep,
             handover_mod=FakeHandover(),
             config_resolver=lambda _name: str(spec),
+            thread_factory=FakeThread,
         )
     finally:
         _start_mod.agent_start = original_start
@@ -1710,6 +1740,7 @@ def _restart_alpha(runtime: _StaggeredRuntime, registry: Registry) -> bool:
         runtime_factory=lambda _c: runtime,
         sleep_fn=_no_sleep,
         handover_mod=FakeHandover(),
+        thread_factory=FakeThread,
     )
 
 
@@ -1827,6 +1858,7 @@ def _restart_alpha_with_short_wait(
         # Short timeout so the test is fast; ``_no_sleep`` makes the poll
         # loop spin as fast as Python allows.
         wait_for_stop_timeout_s=0.05,
+        thread_factory=FakeThread,
     )
 
 


### PR DESCRIPTION
## Two test-isolation defects, one PR — the second is the one that made develop red

### 1. The emitter: a leaked health monitor writing into whichever test ran 90 s later

develop flapped for hours and CI blamed whichever PR was open. The record was always the same shape — a birth-certificate ERROR for an agent belonging to some *other* test, inside an unrelated test's `caplog`:

```
FAILED test__cct_token_pool.py::test_missing_token_never_logs_at_error_level
  ERROR _birth_certificate.py:171 birth certificate NOT recorded for incarnation … (agent alpha)
```

`test_lifecycle.py`'s spec enables `health` (interval 60, restart on-failure). **21 of its 22 `agent_start` calls and all 11 `agent_restart` calls passed no `thread_factory`**, so each spawned the real daemon `health_monitor` via `_start_supervision`. Those threads outlive the test, sleep `interval + backoff` (~90 s), then run

```
health_monitor → restart_and_record → record_local_instance → write_birth_certificate → logger.error
```

against the harness's deliberately unreachable guard store, landing the ERROR in whatever test is running at that instant. `test__stale_lease.py` and `test__stop_escalate.py` did the same on a smaller scale. The file already **contained** a `FakeThread` stand-in and used it in exactly one test — the remedy existed and never reached the other 32 calls.

**Why `agent_restart` could not be seamed at all:** `_stop.py`'s `agent_restart` forwarded `runtime_factory`, `sleep_fn`, `handover_mod` to `agent_start` — but not `thread_factory`. Every restart test spawned a real monitor with no way to inject. Added as a pure passthrough; production default unchanged.

**Measured** with a capture-immune probe (`threading.enumerate()` at session end, written to a file — a `print()`ing probe is muted by pytest capture and reported *zero* for this exact population earlier today, which is how the mechanism was wrongly excluded once):

| | daemon threads alive at session end |
|---|---|
| `test_lifecycle.py` — before | **28** |
| + `agent_start` seams | 11 |
| + `agent_restart` passthrough and seams | **0** |
| `test__stale_lease.py` | 2 → **0** |
| `test__stop_escalate.py` | 2 → **0** |
| `tests/…/_lifecycle/` whole directory | **2257 passed, 3 skipped, 0 failed** |

A workflow agent independently reproduced the CI symptom from `test__stale_lease.py`'s leaked monitor — a second instrument reaching the same emitter.

### 2. `isolated_state` leaking `DEFAULT_STATE_ROOT` to the whole worker

`test__in_sif_broker.py::isolated_state` restored the env var and `state_db.DEFAULT_DB_PATH` but not `_session_state.DEFAULT_STATE_ROOT`, which is bound **once at import time**. Whichever test first imported that module fixed the constant for the worker; when that happened inside the fixture's redirect, it pointed at a `tmp_path` pytest then deleted, and conftest's floor guard errored every later test in the worker: **89 passed / 61 errors → 83 passed / 0 errors** for the same two files. Real, controlled, and — as this PR's own earlier CI run proved — *not* the cause of the red. Kept because it is a genuine defect with its own before/after.

### Deliberately not in this PR

- Other daemon threads these tests leave behind (`sac-off-loop-blocker` ×77, `serve_forever`, pool workers). Same defect class, different emitters — none can reach the birth-certificate logger. Carded: `sac-lifecycle-tests-leak-non-monitor-daemon-threads-20260824`.
- The two victim tests assert more broadly than their docstrings claim (an ERROR filter with no logger name; a `CliRunner` `.output` that merges stderr). Narrowing them is a later change **on purpose**, so that this PR's green means the leak stopped — not that the victims looked away. Carded: `sac-two-flake-victims-assert-wider-than-their-docstrings-20260824`.

### What green here does and does not prove

The PR matrix is py3.11 + py3.13; the leg that was red on develop is **py3.12, which runs only post-merge**. Green here proves 3.11/3.13 did not break. The proof of the fix is the measurement table above (taken on 3.12.3) and develop's own py3.12 leg after merge.

Card: `sac-isolated-state-fixture-leaks-session-state-root-for-the-whole-worker-20260824`
