### PR TITLE
fix(image): pin scitex-dev>=0.56.6 and gate it BY SYMBOL, so a SIF without the oplog retry cannot ship

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,7 +328,19 @@ dev = [
     # been written to and never read from. A floor that admits 0.49.0 admits a
     # store this package cannot read, so the version that first WORKS is the
     # version this package may depend on.
-    "scitex-dev>=0.49.2",
+    #
+    # RAISED TO 0.56.6 on 2026-08-25, and the difference is again not
+    # cosmetic. Through 0.56.5, Store._append read MAX(seq) ONCE and then
+    # inserted, so concurrent writers on a SINGLE node collided on the oplog
+    # (origin, seq) primary key with no bounded retry — measured 7/8 and 5/8
+    # failures on the two concurrency tests, reproduced three times. The same
+    # release also takes a Postgres advisory lock around CREATE TABLE, which
+    # races pg_type when several Store() constructors start together. sac has
+    # now moved its own state onto this store, so a floor that admits 0.56.5
+    # admits silent write loss on exactly the path the migration depends on.
+    # The container recipes gate this BY SYMBOL (_SEQ_ALLOCATION_ATTEMPTS) —
+    # see apptainer-scitex.def; this specifier is the base layer's half.
+    "scitex-dev>=0.56.6",
     # PS210: tests import scitex_hpc unguarded, so [dev] must include it
     # (otherwise `pip install -e .[dev]` can't run the full suite).
     "scitex-hpc>=0.6.2",

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -735,7 +735,7 @@ from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 # burst of writers on a SINGLE node collided on the oplog (origin, seq)
 # primary key with no bounded retry -- 7/8 and 5/8 failures on the two
 # concurrency tests, reproduced three times. 0.56.6 adds this constant and
-# the retry loop that uses it, plus an advisory lock around CREATE TABLE.
+# the retry loop that uses it, plus an advisory lock around table creation.
 #
 # THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
 # scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -730,6 +730,25 @@ from scitex_cards._throughput import WIP_STATUSES
 # actually need — which is why the number above moved, not just this comment.
 from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 
+# scitex-dev 0.56.6: the bounded (origin, seq) oplog-allocation retry.
+# Through 0.56.5, Store._append read MAX(seq) ONCE and then inserted, so a
+# burst of writers on a SINGLE node collided on the oplog (origin, seq)
+# primary key with no bounded retry -- 7/8 and 5/8 failures on the two
+# concurrency tests, reproduced three times. 0.56.6 adds this constant and
+# the retry loop that uses it, plus an advisory lock around CREATE TABLE.
+#
+# THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
+# scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is
+# what excludes the releases without the retry; this import only catches a
+# version string that lies; and only a concurrent multi-writer append after
+# deploy proves the loop actually settles under contention.
+#
+# The name is PRIVATE -- underscore-prefixed and absent from __all__ -- so
+# upstream may rename or inline it with no deprecation, and that would land
+# here as a dead bake far from scitex-dev's repo. If this line is what broke
+# the build, read scitex_dev/store/_store.py before suspecting the image.
+from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS  # noqa: F401
+
 
 
 # sac #633: auto-provisions a new agent's container overlay root; without

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -215,12 +215,16 @@ From: ./sac-base.sif
         # ecosystem system-deps`` exists and every leaf's
         # ``scitex_dev.system_deps`` entry-point is discoverable for the
         # federated install in section 3.
-        # Floors verified against live PyPI on 2026-07-13 — a floor ABOVE the
+        # Floors verified against live PyPI on 2026-07-13; scitex-dev
+        # re-verified 2026-08-25 (0.56.6 is published and unyanked, and is
+        # the NEWEST release — this floor sits exactly AT the ceiling, so a
+        # yank of 0.56.6 would brick every bake until it is lowered).
+        # A floor ABOVE the
         # newest published version makes the build UNSATISFIABLE (uv/pip
         # resolve exit-255); that is how a >=0.7.38 scitex-todo floor bricked
         # this recipe once already. Never raise a floor without checking that
         # the version exists.
-        #   scitex-dev    >=0.29.0 — keystone aggregator (list/install/check-superset)
+        #   scitex-dev    >=0.56.6 — keystone aggregator (list/install/check-superset)
         #   scitex-writer >=2.29.0 — texlive provider (ships the soul.sty fix)
         #   scitex-audio  >=0.3.0  — ffmpeg/portaudio provider
         #   scitex-cv     >=0.2.0  — opencv-python-headless; provider declares []
@@ -268,7 +272,7 @@ From: ./sac-base.sif
         # ALREADY satisfied by the inherited base venv, so without it the
         # providers freeze at base's build and a routine rebake is a no-op.
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-dev>=0.29.0" \
+            "scitex-dev>=0.56.6" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0" \
@@ -337,7 +341,7 @@ From: ./sac-base.sif
         # already satisfies never re-resolves, so without it these providers
         # freeze at base's build and the routine rebake ships stale.
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-dev>=0.29.0" \
+            "scitex-dev>=0.56.6" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0" \
@@ -471,6 +475,25 @@ from scitex_cards._throughput import WIP_STATUSES
 # a version string that lies; and only a post-deploy write to a card that
 # ALREADY HAS a comment proves the path actually runs.
 from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
+
+# scitex-dev 0.56.6: the bounded (origin, seq) oplog-allocation retry.
+# Through 0.56.5, Store._append read MAX(seq) ONCE and then inserted, so a
+# burst of writers on a SINGLE node collided on the oplog (origin, seq)
+# primary key with no bounded retry -- 7/8 and 5/8 failures on the two
+# concurrency tests, reproduced three times. 0.56.6 adds this constant and
+# the retry loop that uses it, plus an advisory lock around CREATE TABLE.
+#
+# THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
+# scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is
+# what excludes the releases without the retry; this import only catches a
+# version string that lies; and only a concurrent multi-writer append after
+# deploy proves the loop actually settles under contention.
+#
+# The name is PRIVATE -- underscore-prefixed and absent from __all__ -- so
+# upstream may rename or inline it with no deprecation, and that would land
+# here as a dead bake far from scitex-dev's repo. If this line is what broke
+# the build, read scitex_dev/store/_store.py before suspecting the image.
+from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS  # noqa: F401
 
 
 

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -481,7 +481,7 @@ from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 # burst of writers on a SINGLE node collided on the oplog (origin, seq)
 # primary key with no bounded retry -- 7/8 and 5/8 failures on the two
 # concurrency tests, reproduced three times. 0.56.6 adds this constant and
-# the retry loop that uses it, plus an advisory lock around CREATE TABLE.
+# the retry loop that uses it, plus an advisory lock around table creation.
 #
 # THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
 # scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is

--- a/src/scitex_agent_container/containers/sif_symbol_probe.py
+++ b/src/scitex_agent_container/containers/sif_symbol_probe.py
@@ -36,7 +36,7 @@ from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 # burst of writers on a SINGLE node collided on the oplog (origin, seq)
 # primary key with no bounded retry -- 7/8 and 5/8 failures on the two
 # concurrency tests, reproduced three times. 0.56.6 adds this constant and
-# the retry loop that uses it, plus an advisory lock around CREATE TABLE.
+# the retry loop that uses it, plus an advisory lock around table creation.
 #
 # THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
 # scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is

--- a/src/scitex_agent_container/containers/sif_symbol_probe.py
+++ b/src/scitex_agent_container/containers/sif_symbol_probe.py
@@ -31,6 +31,25 @@ from scitex_cards._throughput import WIP_STATUSES
 # ALREADY HAS a comment proves the path actually runs.
 from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 
+# scitex-dev 0.56.6: the bounded (origin, seq) oplog-allocation retry.
+# Through 0.56.5, Store._append read MAX(seq) ONCE and then inserted, so a
+# burst of writers on a SINGLE node collided on the oplog (origin, seq)
+# primary key with no bounded retry -- 7/8 and 5/8 failures on the two
+# concurrency tests, reproduced three times. 0.56.6 adds this constant and
+# the retry loop that uses it, plus an advisory lock around CREATE TABLE.
+#
+# THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
+# scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is
+# what excludes the releases without the retry; this import only catches a
+# version string that lies; and only a concurrent multi-writer append after
+# deploy proves the loop actually settles under contention.
+#
+# The name is PRIVATE -- underscore-prefixed and absent from __all__ -- so
+# upstream may rename or inline it with no deprecation, and that would land
+# here as a dead bake far from scitex-dev's repo. If this line is what broke
+# the build, read scitex_dev/store/_store.py before suspecting the image.
+from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS  # noqa: F401
+
 if "in_progress" not in WIP_STATUSES:
     print(f"FATAL: 'in_progress' missing from WIP_STATUSES: {sorted(WIP_STATUSES)}")
     sys.exit(1)

--- a/src/scitex_agent_container/containers/spartan-sif-bake.sh
+++ b/src/scitex_agent_container/containers/spartan-sif-bake.sh
@@ -321,6 +321,25 @@ from scitex_cards._throughput import WIP_STATUSES
 # ALREADY HAS a comment proves the path actually runs.
 from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 
+# scitex-dev 0.56.6: the bounded (origin, seq) oplog-allocation retry.
+# Through 0.56.5, Store._append read MAX(seq) ONCE and then inserted, so a
+# burst of writers on a SINGLE node collided on the oplog (origin, seq)
+# primary key with no bounded retry -- 7/8 and 5/8 failures on the two
+# concurrency tests, reproduced three times. 0.56.6 adds this constant and
+# the retry loop that uses it, plus an advisory lock around CREATE TABLE.
+#
+# THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
+# scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is
+# what excludes the releases without the retry; this import only catches a
+# version string that lies; and only a concurrent multi-writer append after
+# deploy proves the loop actually settles under contention.
+#
+# The name is PRIVATE -- underscore-prefixed and absent from __all__ -- so
+# upstream may rename or inline it with no deprecation, and that would land
+# here as a dead bake far from scitex-dev's repo. If this line is what broke
+# the build, read scitex_dev/store/_store.py before suspecting the image.
+from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS  # noqa: F401
+
 if "in_progress" not in WIP_STATUSES:
     print(f"FATAL: 'in_progress' missing from WIP_STATUSES: {sorted(WIP_STATUSES)}")
     sys.exit(1)

--- a/src/scitex_agent_container/containers/spartan-sif-bake.sh
+++ b/src/scitex_agent_container/containers/spartan-sif-bake.sh
@@ -326,7 +326,7 @@ from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 # burst of writers on a SINGLE node collided on the oplog (origin, seq)
 # primary key with no bounded retry -- 7/8 and 5/8 failures on the two
 # concurrency tests, reproduced three times. 0.56.6 adds this constant and
-# the retry loop that uses it, plus an advisory lock around CREATE TABLE.
+# the retry loop that uses it, plus an advisory lock around table creation.
 #
 # THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
 # scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is

--- a/tests/develop/test_audit.py
+++ b/tests/develop/test_audit.py
@@ -36,7 +36,7 @@ running against, so the gate reads THE CODE UNDER TEST or fails loudly.
 This mirrors what our sibling gates already do (`test_git_hooks.py`'s
 ``_REPO``, `test_skills_quality.py`'s ``package_root``).
 
-scitex-dev >= 0.31.1 is REQUIRED (see [dev] in pyproject.toml): `path=`
+scitex-dev >= 0.31.1 is REQUIRED by this gate -- `path=`
 first exists there. Older versions also lack the CWD-git-root safety net
 (step 2), so on them the home-disk guess is the ONLY fallback. The
 fixture asserts that support rather than silently dropping `path=` —
@@ -142,7 +142,7 @@ def scitex_dev_audit():
             "installed scitex-dev's audit_all_for_package() has no `path` "
             "parameter, so this gate cannot name the tree under test and "
             "would silently audit a ~/proj guess instead. Upgrade to "
-            "scitex-dev>=0.31.1 (the [dev] floor in pyproject.toml). "
+            "scitex-dev>=0.31.1, the release where `path=` first exists. "
             "Failing loudly rather than auditing the wrong checkout."
         )
     return audit_all_for_package

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -57,6 +57,7 @@ CROSS_PACKAGE_IMPORTS = [
     'scitex_dev.linter._rules._lookup',
     'scitex_dev.linter.checker',
     'scitex_dev.store',
+    'scitex_dev.store._store',
     'scitex_dev.system_deps',
     'scitex_dev.versioning',
     'scitex_logging',

--- a/tests/scitex_agent_container/containers/test_sif_symbol_probe.py
+++ b/tests/scitex_agent_container/containers/test_sif_symbol_probe.py
@@ -131,6 +131,20 @@ def test_probe_checks_the_comment_merge_symbol() -> None:
     assert ("scitex_cards._mirror_rows", "_merge_unseen_comment_rows") in from_imports
 
 
+def test_probe_checks_the_seq_allocation_symbol() -> None:
+    # Arrange - scitex-dev 0.56.6's bounded (origin, seq) oplog-allocation
+    # retry. A bare `import scitex_dev.store` CANNOT catch its absence: 0.56.5
+    # imports perfectly and then loses concurrent same-node writes on the oplog
+    # primary key (7/8 and 5/8 failures, reproduced three times). The module
+    # resolves on both releases and only the ATTRIBUTE differs, so nothing but
+    # the module+symbol pair tells the two apart.
+    source = _probe_source()
+    # Act
+    from_imports = _from_imports(source)
+    # Assert
+    assert ("scitex_dev.store._store", "_SEQ_ALLOCATION_ATTEMPTS") in from_imports
+
+
 def test_probe_fails_loud_on_a_bad_sif() -> None:
     # Arrange — a gate that can only PASS is a hope; the probe must sys.exit()
     # non-zero so a mis-baked SIF is REJECTED, not silently published.
@@ -284,4 +298,28 @@ def test_every_probe_copy_carries_the_comment_merge_symbol(path) -> None:
     assert present, (
         f"{path.name} embeds the symbol probe but not the 0.49.0 "
         "comment-merge check — this copy still passes on a 0.48.0 image"
+    )
+
+
+@pytest.mark.parametrize("path", EMBEDS, ids=lambda p: p.name)
+def test_every_probe_copy_carries_the_seq_allocation_symbol(path) -> None:
+    """The four-copy rule again, for the scitex-dev floor.
+
+    Identical reasoning to the comment-merge check above and a separate test on
+    purpose: the two floors move independently, so one symbol reaching all four
+    copies says nothing about the other. Below scitex-dev 0.56.6, Store._append
+    read MAX(seq) once and inserted, and concurrent writers on a single node
+    collided on the oplog (origin, seq) primary key with no bounded retry. A
+    copy left un-updated keeps baking images that carry that defect while the
+    other copies report a clean gate.
+    Token check, not AST: these are shell heredocs and do not parse as Python.
+    """
+    # Arrange
+    source = path.read_text(encoding="utf-8")
+    # Act
+    present = "_SEQ_ALLOCATION_ATTEMPTS" in source
+    # Assert
+    assert present, (
+        f"{path.name} embeds the symbol probe but not the 0.56.6 "
+        "seq-allocation check - this copy still passes on a 0.56.5 image"
     )


### PR DESCRIPTION
## Why

Every running host is on **scitex-dev 0.56.5**, which fails **7/8 and 5/8** on concurrent store writes: `Store._append` read `MAX(seq)` **once** and inserted, so writers on a single node collided on the oplog `(origin, seq)` primary key with no bounded retry. 0.56.6 adds that retry (`_SEQ_ALLOCATION_ATTEMPTS`) plus an advisory lock around `CREATE TABLE`, which races `pg_type` otherwise.

0.56.6 is on PyPI. **Merged is not live** — nothing reaches a host until the image floor moves. This moves it.

Step 3 of 4 in the SQLite-eradication unblock chain; unblocks #1206's `xfail` flip.

## The floor had to move in TWO places

Picking either alone is a no-op, and the obvious edit is the wrong one on its own:

| site | was | now |
|---|---|---|
| `apptainer-scitex.def:271` (uv branch) | `>=0.29.0` | `>=0.56.6` |
| `apptainer-scitex.def:340` (pip branch) | `>=0.29.0` | `>=0.56.6` |
| `apptainer-scitex.def:223` (prose) | `>=0.29.0` | `>=0.56.6` |
| `pyproject.toml` `[dev]` | `>=0.49.2` | `>=0.56.6` |

- **`apptainer-scitex.def` installs LAST** and re-installs sac with `--no-deps` and no extras (`:207-209` uv, `:328-330` pip), so pyproject's `[dev]` floor never re-resolves in that layer. The file's own ruling at `:302-305` says a floor raised only in `base.def` is silently overridden.
- **Both argv branches move together** because PR #836 raised only the uv branch and left the pip branch eleven lines away while the prose claimed they mirrored.
- **`apptainer-base.def` has no scitex-dev-by-name floor at all** — its only constraint is pyproject's `[dev]`, reached via `[all,dev]` on `:629`. So pyproject moves too.

## The gate

A bare `from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS` in **all four** probe copies (shipped asset, `base.def`, `scitex.def`, spartan bake). No `try/except`, no `hasattr`: an `ImportError` is unhandled, the interpreter exits non-zero, and every call site turns that into a fatal build error.

Verified against the **published 0.56.6 wheel**, not assumed — the name is a module-scope assignment at `_store.py:64`, and it shadow-imports clean with no `PGHOST` and no database, because `_store.py`'s module-level imports are all intra-package relative.

## What this does NOT prove

**Presence is not behaviour.** `_SEQ_ALLOCATION_ATTEMPTS` is a bare `int`. The *floor* excludes the releases without the retry; this import only catches a version string that lies; only a concurrent multi-writer append after deploy proves the loop settles. The same probe passed on a broken scitex-cards 0.49.0 for exactly this reason.

Relatedly: **no test in this repo catches a 0.56.5 environment.** `test_sif_symbol_probe.py` never imports the probe (by design), and the PS-140 gate imports `scitex_dev.store`, which resolves fine on 0.56.5 — only the *attribute* is missing. The gap closes only inside a bake.

## Risks carried deliberately

- **Zero headroom.** 0.56.6 is the newest published scitex-dev, and a floor above the newest release makes the resolve unsatisfiable (exit 255) — that is how a `>=0.7.38` scitex-todo floor bricked this recipe once. Recorded at `:218`.
- **Private symbol, no stability contract** — underscore-prefixed, absent from `__all__`. Named in the probe comment so a dead bake points at the right repo.
- Both scitex.def sites carry `-U`, so a normal bake already lands on the newest scitex-dev regardless of the floor. This is a **guarantee** change more than a behaviour change; the probe import is what converts it into evidence.

## Also

Brings three stale prose floors current — the same prose-outlives-the-argv-floor mode this change cites to justify editing `:223`. `test_audit.py:39` and `:145` called 0.31.1 *"the [dev] floor in pyproject.toml"*; it never was — it is the release where `path=` first exists. Genuinely historical 0.31.1 mentions are left alone.

## Verification

- `87 passed in 73.22s` — `test_sif_symbol_probe.py`, `test__remote_bake_core.py`, `test_cross_package_imports.py`, `test_card_package_boundary.py`, `test_audit.py`.
- The 4 new tests pass by name (`-k seq_allocation`).
- Both CI ruff jobs pass with **CI's exact invocation**. Note the repo's ruff config also selects `I`, which flags a *pre-existing* import-order error in the probe — the original file produces the identical single error (ran as a control), so this change is lint-neutral, and CI never sees it (CI selects only `F401,F811`).
- `test_cross_package_imports.py` was **regenerated, not hand-edited**; final diff is exactly one added line and the provenance stamp is unchanged at 0.56.5.
- Plan was adversarially refuted before implementing: build path, hidden second pins, last-writer, fail-open, and a missed fifth probe copy were each checked and each came back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
