### PR TITLE
fix(identity): the drift guard read the RETIRED env name, so it skipped 110 of 148 live specs

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_identity_drift.py
+++ b/src/scitex_agent_container/_lifecycle/_identity_drift.py
@@ -4,8 +4,10 @@ An agent has two names that must agree and are set in different places:
 
 * the agent NAME — its spec dir, its tmux session, how peers address it
   over a2a;
-* ``SCITEX_TODO_AGENT_ID`` — its identity on the shared card board, which
-  determines which cards it owns and whose inbox it polls.
+* ``SCITEX_CARDS_AGENT_ID`` — its identity on the shared card board, which
+  determines which cards it owns and whose inbox it polls. It was called
+  ``SCITEX_TODO_AGENT_ID`` until 2026-07-02 and specs still carry both
+  spellings, so this check reads BOTH.
 
 ``_create_templates`` derives the second from the first, so a
 properly-created agent cannot drift. A HAND-EDITED spec can, and does.
@@ -23,13 +25,26 @@ SILENT:
   with a full implementation brief sat runnable under the OTHER name;
 * its pull-inbox under the agent name accumulated unseen notifications
   it never polled, including a card another agent filed for it;
-* every ``reassign_task`` it performed came back
-  ``assignee_liveness: unknown``, so a real handoff was indistinguishable
-  from a handoff into the void.
+NOT a symptom, though it was recorded as one at the time: card writes come
+back with ``assignee_liveness: unknown``. That is true for EVERY agent,
+drifted or not -- verified 2026-08-25 against the live board by an agent
+whose identity was correct and which was demonstrably running. A field that
+reads the same in both states cannot discriminate between them, so it is
+evidence of nothing and must not be used to diagnose this.
 
 Nothing errored. Both queries succeeded and returned well-formed empty
 results, because "no cards assigned to you" and "no cards assigned to
 THIS SPELLING of you" render identically.
+
+_RETIRED_BLINDNESS
+------------------
+This check reads the spec's declared board identity under BOTH the current
+and the retired env name. Reading one spelling only is the same defect the
+module exists to catch: on 2026-08-25 the check looked exclusively for the
+RETIRED name, so for 110 of 148 specs on compute-04 it read an empty string,
+concluded "this spec declares no board identity", and returned quietly. That
+skip is a documented, legitimate branch -- which is what made the blindness
+invisible.
 
 Contract
 --------
@@ -47,7 +62,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 #: The env var whose value IS the agent's identity on the card board.
-BOARD_IDENTITY_ENV = "SCITEX_TODO_AGENT_ID"
+#: This is the CURRENT name; `scitex_cards._store` reads exactly this
+#: (``ENV_AGENT = "SCITEX_CARDS_AGENT_ID"``).
+BOARD_IDENTITY_ENV = "SCITEX_CARDS_AGENT_ID"
+
+#: The RETIRED spelling, renamed 2026-07-02. Specs are migrated one at a time,
+#: so both are live on disk at once -- measured on compute-04 2026-08-25:
+#: 110 specs declared the current name, 21 still declared this one.
+#: Reading only ONE of them is precisely the fault this module exists to catch,
+#: so the check reads BOTH. See `_RETIRED_BLINDNESS` in the module docstring.
+BOARD_IDENTITY_ENV_RETIRED = "SCITEX_TODO_AGENT_ID"
 
 
 def check_board_identity_at_launch(config) -> str | None:
@@ -67,7 +91,13 @@ def check_board_identity_at_launch(config) -> str | None:
     try:
         name = str(getattr(config, "name", "") or "")
         spec_env = getattr(config, "env", None) or {}
-        board_id = str(spec_env.get(BOARD_IDENTITY_ENV, "") or "").strip()
+        board_id = ""
+        declared_under = BOARD_IDENTITY_ENV
+        for _key in (BOARD_IDENTITY_ENV, BOARD_IDENTITY_ENV_RETIRED):
+            board_id = str(spec_env.get(_key, "") or "").strip()
+            if board_id:
+                declared_under = _key
+                break
     except Exception:  # stx-allow: fallback (reason: see inline comment)
         return None
 
@@ -88,7 +118,7 @@ def check_board_identity_at_launch(config) -> str | None:
         "migrates the cards, which is the part that must not be done by "
         "hand; run it with --dry-run first).",
         name,
-        BOARD_IDENTITY_ENV,
+        declared_under,
         board_id,
         name,
         board_id,
@@ -98,4 +128,8 @@ def check_board_identity_at_launch(config) -> str | None:
     return board_id
 
 
-__all__ = ["BOARD_IDENTITY_ENV", "check_board_identity_at_launch"]
+__all__ = [
+    "BOARD_IDENTITY_ENV",
+    "BOARD_IDENTITY_ENV_RETIRED",
+    "check_board_identity_at_launch",
+]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_rename.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_rename.py
@@ -34,14 +34,18 @@ __all__ = ["rename"]
 # The env var whose value IS the agent's identity on the board. Called out
 # explicitly in the report because it is the one whose silent breakage
 # costs real work.
-_BOARD_IDENTITY_ENV = "SCITEX_TODO_AGENT_ID"
+# Both spellings are live on disk during the rename, so the marker looks for
+# BOTH. Checking only the retired one silently drops the highlight on the
+# majority of specs -- measured 2026-08-25: 110 specs on the current name
+# vs 21 on the retired one.
+_BOARD_IDENTITY_ENVS = ("SCITEX_CARDS_AGENT_ID", "SCITEX_TODO_AGENT_ID")
 
 _MAX_LISTED_CARDS = 8
 
 
 def _mark(change: SpecChange) -> str:
     """Annotate the spec change that carries the board identity."""
-    if _BOARD_IDENTITY_ENV not in change.path:
+    if not any(env in change.path for env in _BOARD_IDENTITY_ENVS):
         return ""
     return "   " + click.style("<-- BOARD IDENTITY", fg="yellow", bold=True)
 

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -83,9 +83,16 @@ spec:
       - --env
       - SCITEX_AGENT_CONTAINER_STATE_DB=/state/{name}/state.db
       # The board identity. Change this without migrating the cards and
-      # every card the agent owns is orphaned.
+      # every card the agent owns is orphaned. BOTH spellings are seeded
+      # because both are on disk: the var was renamed to
+      # SCITEX_CARDS_AGENT_ID and the fleet is half migrated (measured
+      # 2026-08-25 on compute-04: 110 specs current, 21 retired). A
+      # fixture carrying only the retired name tests the minority and
+      # let a current-name blindness ship unnoticed.
       - --env
       - SCITEX_TODO_AGENT_ID={name}
+      - --env
+      - SCITEX_CARDS_AGENT_ID={name}
       - --env
       - GIT_AUTHOR_NAME=Yusuke Watanabe
     env: {{}}

--- a/tests/scitex_agent_container/_lifecycle/test__identity_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__identity_drift.py
@@ -12,7 +12,13 @@ Every consequence was SILENT:
   with a full implementation brief sat runnable under the other name;
 * its pull-inbox under the agent name accumulated notifications it never
   polled, including a card another agent filed for it;
-* every ``reassign_task`` returned ``assignee_liveness: unknown``.
+Recorded at the time as a fourth symptom, and WRONG: that every
+``reassign_task`` returned ``assignee_liveness: unknown``. It does — for
+every agent, drifted or not. Re-measured 2026-08-25 from an agent whose
+identity was correct and which was demonstrably running: still
+``unknown``. A field that reads the same in both states discriminates
+nothing, so it is struck from the record rather than left to mislead the
+next reader into "diagnosing" drift with it.
 
 Nothing errored, because "no cards assigned to you" and "no cards
 assigned to THIS SPELLING of you" render identically.
@@ -35,6 +41,7 @@ from types import SimpleNamespace
 
 from scitex_agent_container._lifecycle._identity_drift import (
     BOARD_IDENTITY_ENV,
+    BOARD_IDENTITY_ENV_RETIRED,
     check_board_identity_at_launch,
 )
 
@@ -129,3 +136,70 @@ def test_warning_says_the_agent_still_starts(caplog):
         check_board_identity_at_launch(config)
     # Assert
     assert "STARTS NORMALLY" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# The env var was renamed SCITEX_TODO_AGENT_ID -> SCITEX_CARDS_AGENT_ID and
+# specs carry both spellings. Reading one only re-creates the very failure
+# this module guards: on 2026-08-25 the check looked for the RETIRED name
+# alone, so 110 of 148 specs on compute-04 read as "declares no board
+# identity" and returned via the legitimate absent-identity branch.
+# ---------------------------------------------------------------------------
+
+
+def _config_under(name: str, env_key: str, board_id: str):
+    return SimpleNamespace(name=name, env={env_key: board_id})
+
+
+def test_drift_is_caught_under_the_current_env_name():
+    # Arrange: the spelling 110 of 148 live specs actually use.
+    config = _config_under("agent-a", "SCITEX_CARDS_AGENT_ID", "agent-b")
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result == "agent-b"
+
+
+def test_drift_is_still_caught_under_the_retired_env_name():
+    # Arrange: 21 live specs have not been migrated yet.
+    config = _config_under("agent-a", "SCITEX_TODO_AGENT_ID", "agent-b")
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result == "agent-b"
+
+
+def test_current_env_name_wins_when_a_spec_carries_both():
+    # Arrange: a half-migrated spec. The current name is what the running
+    # scitex_cards client reads, so it is the identity that has effect.
+    config = SimpleNamespace(
+        name="agent-a",
+        env={
+            BOARD_IDENTITY_ENV: "agent-current",
+            BOARD_IDENTITY_ENV_RETIRED: "agent-retired",
+        },
+    )
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result == "agent-current"
+
+
+def test_warning_names_the_env_var_the_spec_declared(caplog):
+    # Arrange: "fix your board identity" is unactionable when the spec has
+    # two candidate keys and the message names neither.
+    config = _config_under("agent-a", "SCITEX_TODO_AGENT_ID", "agent-b")
+    # Act
+    with caplog.at_level(logging.WARNING):
+        check_board_identity_at_launch(config)
+    # Assert
+    assert "SCITEX_TODO_AGENT_ID" in caplog.text
+
+
+def test_the_two_env_constants_are_not_the_same_string():
+    # Arrange: a copy-paste that collapses them silently restores the
+    # single-name blindness while every other test still passes.
+    # Act
+    same = BOARD_IDENTITY_ENV == BOARD_IDENTITY_ENV_RETIRED
+    # Assert
+    assert not same

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
@@ -249,6 +249,18 @@ def test_json_dry_run_reports_the_new_name(fleet: Layout):
     assert json.loads(result.stdout)["new"] == expected
 
 
+def test_json_dry_run_lists_the_current_board_identity_change(fleet: Layout):
+    # Arrange: the spelling most live specs use. The plan missed it until
+    # 2026-08-25 because every fixture here carried the retired one.
+    needle = "SCITEX_CARDS_AGENT_ID"
+    # Act
+    result = _run(OLD, NEW, "--dry-run", "--json", "--no-cards")
+    # Assert
+    assert any(
+        needle in c["path"] for c in json.loads(result.stdout)["spec_changes"]
+    )
+
+
 def test_json_dry_run_lists_the_spec_changes(fleet: Layout):
     # Arrange
     needle = "SCITEX_TODO_AGENT_ID"


### PR DESCRIPTION
## What was wrong

The board-identity env var was renamed `SCITEX_TODO_AGENT_ID` -> `SCITEX_CARDS_AGENT_ID`. `check_board_identity_at_launch` was never updated and read the retired spelling alone.

Measured on scitex-compute-04, 2026-08-25:

| spelling declared in spec | specs |
|---|---|
| `SCITEX_CARDS_AGENT_ID` (current) | 110 |
| `SCITEX_TODO_AGENT_ID` (retired) | 21 |
| total specs scanned | 148 |

For those 110 the guard read an empty string and returned through its documented branch:

> A spec that sets NO board identity is not a mismatch — it inherits the runtime's.

That branch is correct and stays. It is also why the blindness was invisible: the guard reported nothing, and reporting nothing is what it does when all is well. There was no error, no log line, and a passing test suite — because every fixture carried the retired name too.

So the module written to catch one silent identity failure had acquired a second one, of the same shape, inside its own reader.

## Changes

1. `_identity_drift.py` reads BOTH spellings, current first, and the warning now names **which** key the spec declared. "Fix your board identity" is unactionable when a spec has two candidate keys and the message names neither.
2. `cli_pkg/lifecycle/_rename.py` had the same single-name blindness in the `<-- BOARD IDENTITY` marker on the rename plan. Cosmetic — it does not drive the migration — but it is the one line drawing the eye to the change that orphans the cards, and it went missing on the majority spelling.
3. The shared fleet fixture seeded only the retired name, so the entire rename suite exercised the minority population and this regression could not have been caught by it. It now seeds BOTH, which is what is actually on disk.

## Two docstring corrections (the original card)

- The incident record cited *"every `reassign_task` returned `assignee_liveness: unknown`"* as a symptom of drift. **It is not.** Re-measured today from an agent whose identity was correct and which was demonstrably running: still `unknown`, on every write. A field that reads the same in both states discriminates nothing. It is struck from the record in both the module and the test file rather than left to mislead the next reader into "diagnosing" drift with it.
- The prose named the retired env var as the agent's board identity.

## Verification

184 passed across `test__identity_drift`, `test__rename` (both), `test__rename_spec`, `test__rename_db`, `test__rename_isolation`, `test__resolve_scope`.

Run with `PYTHONPATH` pinned at this worktree's `src`, verified by printing the resolved module path first — otherwise the editable install points at the main checkout and the suite reports green while exercising none of the change.

`ruff check`: clean. (`ruff format --check` flags this file, but flags the **unmodified** copy on `develop` identically, and CI runs `ruff check` only.)

Closes the card `sac-identity-drift-docstring-cites-a-symptom-that-is-always-true-20260817`.
