### PR TITLE
feat(creds): the pool asks whether an account may still RUN, not just whether its token is fresh

### DIFF
--- a/src/scitex_agent_container/_creds/_account_health.py
+++ b/src/scitex_agent_container/_creds/_account_health.py
@@ -26,6 +26,7 @@ from .._account.creds_sync import (
     _read_oauth_expiry_raw,
 )
 from .._state.account_store import _store_path
+from ._entitlement import read_entitlement
 
 # Health states for one account's snapshot. Mirrors
 # :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
@@ -33,6 +34,15 @@ from .._state.account_store import _store_path
 _VALID = "VALID"
 _EXPIRED = "EXPIRED"
 _ABSENT = "ABSENT"
+#: The token is FRESH but the account may not USE it. INCIDENT
+#: 2026-08-25: a cancelled subscription refreshes its OAuth token
+#: perfectly well, so it read VALID here while every real turn on it
+#: returned 403 "OAuth authentication is currently not allowed for this
+#: organization". Freshness and entitlement are different questions;
+#: this state is the second one. Read from a cached verdict written
+#: out-of-band by the host timer -- see :mod:`._entitlement` for why it
+#: must not be probed live at boot, and why UNKNOWN never lands here.
+_FORBIDDEN = "FORBIDDEN"
 
 
 class NoHealthyAccountError(RuntimeError):
@@ -94,6 +104,10 @@ class AccountHealth:
     hours_remaining: float | None
     snapshot_path: str | None = None
     expires_at_raw: float | None = None
+    #: For a FORBIDDEN record, the API's own words. An operator seeing
+    #: "your token is fine but you cannot use it" needs to be told why
+    #: in the same breath, or the state looks like our bug.
+    entitlement_detail: str = ""
 
     @property
     def is_healthy(self) -> bool:
@@ -137,6 +151,25 @@ def account_health(
     expiry = _oauth_expiry_to_seconds(raw)
     hours = (expiry - now_ts) / 3600.0
     state = _VALID if expiry > now_ts else _EXPIRED
+
+    # ENTITLEMENT is asked only of an otherwise-usable snapshot. An
+    # EXPIRED token's problem is already named, and overwriting that
+    # with FORBIDDEN would hide the actionable fault behind a second
+    # one. A local file read; no network. Only a MEASURED denial
+    # downgrades the state -- UNKNOWN leaves it exactly as freshness
+    # found it, per the constitution's three-valued rule.
+    if state == _VALID:
+        verdict = read_entitlement(name, store / name, now=now_ts)
+        if verdict.blocks_use:
+            return AccountHealth(
+                name=name,
+                state=_FORBIDDEN,
+                hours_remaining=hours,
+                snapshot_path=str(snapshot),
+                expires_at_raw=raw,
+                entitlement_detail=verdict.detail,
+            )
+
     return AccountHealth(
         name=name,
         state=state,

--- a/src/scitex_agent_container/_creds/_entitlement.py
+++ b/src/scitex_agent_container/_creds/_entitlement.py
@@ -1,0 +1,363 @@
+"""Is a stored account still ENTITLED to run Claude Code?
+
+INCIDENT 2026-08-25. The operator cancelled the ``wyusuuke@gmail.com``
+subscription. Nothing noticed. Agents kept being routed onto it and
+failed mid-turn with::
+
+    Your organization has disabled Claude subscription access for
+    Claude Code - Use an Anthropic API key instead, or ask your admin
+    to enable access
+
+Measured that morning, one read-only request per stored account::
+
+    scitex-01-scitex-ai   200 OK
+    ywata1989-gmail-com   200 OK
+    ywatanabe-scitex-ai   200 OK
+    wyusuuke-gmail-com    403 permission_error
+                          "OAuth authentication is currently not
+                           allowed for this organization"
+
+WHY EVERY EXISTING GATE PASSED IT. Account health is snapshot
+FRESHNESS -- a non-expired ``claudeAiOauth.expiresAt`` (see
+:mod:`._account_health`). **OAuth refresh is independent of
+entitlement**: the headless refresh kept succeeding, most recently at
+09:17 UTC that same morning with a new expiry of 17:17, so the account
+read ``VALID`` to every gate while being unusable for an actual turn.
+
+Freshness is not entitlement. They are different questions and only
+one of them was being asked.
+
+Three-valued, per constitution
+------------------------------
+"Every signal is three-valued: true, false, and *unknown*. Collapsing
+unknown into either pole is the most common bug we ship."
+
+So this module reports :data:`ENTITLED`, :data:`FORBIDDEN`, or
+:data:`UNKNOWN`, and the caller must handle all three:
+
+* ``FORBIDDEN`` is a MEASUREMENT -- an HTTP 403 whose body names an
+  OAuth/permission error. Only that becomes FORBIDDEN.
+* ``UNKNOWN`` is everything else: never probed, a record too old to
+  trust, an unparseable record, a timeout, DNS failure, a 5xx. It must
+  NOT block a boot. A network blip is not a cancelled subscription,
+  and collapsing UNKNOWN into FORBIDDEN would evict the entire pool
+  the first time this host lost its uplink -- turning a transient
+  outage into a fleet-wide one.
+* Equally, UNKNOWN must not be silently rendered as ENTITLED. It is
+  reported as its own state so the operator-facing diagnosis can say
+  "we do not know" instead of implying we checked.
+
+Why a CACHE and not a live probe
+--------------------------------
+:func:`._pick_healthy.pick_healthy_account` runs at every agent boot
+and is documented as "cache-only read, NO live Claude API call, so it
+never burns account quota at boot". Probing entitlement inline would
+break that promise and add a network round-trip to every start.
+
+So the live probe (:func:`probe_entitlement`) runs OUT OF BAND, from
+the host timer that already walks every account, and writes a small
+record next to the credential. The boot path only ever
+:func:`read_entitlement`\\ s that record -- a local file read.
+
+AUTO-HEAL IS THE POINT. The operator's workflow is to cancel a
+subscription and restore it later ("I put the subscription back when I
+need the account again"). Because the timer rewrites this record on
+every pass, a restored subscription flips FORBIDDEN -> ENTITLED on its
+own and the account rejoins the pool with no spec edit, no symlink
+rename, and no human step. That is the whole reason this is a cached
+signal rather than a hand-maintained deny-list.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "ENTITLED",
+    "FORBIDDEN",
+    "UNKNOWN",
+    "Entitlement",
+    "DEFAULT_MAX_AGE_S",
+    "entitlement_path",
+    "read_entitlement",
+    "write_entitlement",
+    "probe_entitlement",
+]
+
+ENTITLED = "ENTITLED"
+FORBIDDEN = "FORBIDDEN"
+UNKNOWN = "UNKNOWN"
+
+#: How long a stored verdict is trusted. Beyond this the record reads
+#: UNKNOWN rather than being believed indefinitely -- a FORBIDDEN from
+#: last month must not keep an account out after the subscription came
+#: back, and an ENTITLED from last month must not vouch for one that
+#: has since lapsed. The host timer refreshes well inside this window;
+#: the age limit only bites when the timer has stopped, which is
+#: exactly when its answers should stop counting.
+DEFAULT_MAX_AGE_S = 24 * 3600
+
+#: The probe endpoint. A minimal request: the cheapest call that still
+#: exercises the ENTITLEMENT path rather than mere token validity.
+_API_URL = "https://api.anthropic.com/v1/messages"
+_PROBE_TIMEOUT_S = 20
+
+
+@dataclass(frozen=True)
+class Entitlement:
+    """One account's entitlement verdict and the evidence behind it.
+
+    Attributes
+    ----------
+    name
+        The stored-account name this verdict is about.
+    state
+        :data:`ENTITLED`, :data:`FORBIDDEN` or :data:`UNKNOWN`.
+    checked_at
+        Unix seconds when the live probe ran; ``None`` when no record
+        exists.
+    http_status
+        The status the probe saw, when it got one.
+    detail
+        Short operator-facing evidence -- the API's own error text for
+        a FORBIDDEN, or why the state is UNKNOWN. Never a credential.
+    """
+
+    name: str
+    state: str
+    checked_at: float | None = None
+    http_status: int | None = None
+    detail: str = ""
+
+    @property
+    def blocks_use(self) -> bool:
+        """True only for a MEASURED denial.
+
+        UNKNOWN deliberately returns False: not knowing is not the same
+        as knowing it is dead, and this is the property a boot path
+        gates on.
+        """
+        return self.state == FORBIDDEN
+
+
+def entitlement_path(account_dir: Path) -> Path:
+    """Where one account's verdict lives.
+
+    Beside the credential it describes, so the two travel together and
+    a copied/backed-up account dir carries its own evidence.
+    """
+    return account_dir / "entitlement.json"
+
+
+def read_entitlement(
+    name: str,
+    account_dir: Path,
+    *,
+    now: float | None = None,
+    max_age_s: float = DEFAULT_MAX_AGE_S,
+) -> Entitlement:
+    """Read a stored verdict. NEVER raises, NEVER touches the network.
+
+    This is the function the boot path calls. Every failure mode --
+    absent file, unreadable file, malformed JSON, unrecognised state,
+    a record older than ``max_age_s`` -- degrades to
+    :data:`UNKNOWN` with a ``detail`` saying which, so a boot is never
+    blocked by our own bookkeeping and the operator can still see why
+    we have no answer.
+    """
+    path = entitlement_path(account_dir)
+    now_ts = now if now is not None else time.time()
+
+    # stx-allow: fallback (reason: a boot-path read of best-effort
+    # bookkeeping must degrade to UNKNOWN, never crash a start.)
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        return Entitlement(name, UNKNOWN, detail="never probed")
+    except (OSError, ValueError) as exc:
+        return Entitlement(
+            name, UNKNOWN, detail=f"unreadable record: {type(exc).__name__}"
+        )
+
+    if not isinstance(raw, dict):
+        return Entitlement(name, UNKNOWN, detail="record is not an object")
+
+    state = raw.get("state")
+    if state not in (ENTITLED, FORBIDDEN, UNKNOWN):
+        return Entitlement(name, UNKNOWN, detail=f"unrecognised state {state!r}")
+
+    checked_at = raw.get("checked_at")
+    if not isinstance(checked_at, (int, float)):
+        return Entitlement(
+            name, UNKNOWN, detail="record has no numeric checked_at"
+        )
+
+    age = now_ts - float(checked_at)
+    if age > max_age_s:
+        # Deliberately not believed. See DEFAULT_MAX_AGE_S.
+        return Entitlement(
+            name,
+            UNKNOWN,
+            checked_at=float(checked_at),
+            detail=(
+                f"record is {age / 3600:.1f}h old "
+                f"(limit {max_age_s / 3600:.0f}h) - treating as unknown"
+            ),
+        )
+
+    status = raw.get("http_status")
+    return Entitlement(
+        name=name,
+        state=state,
+        checked_at=float(checked_at),
+        http_status=status if isinstance(status, int) else None,
+        detail=str(raw.get("detail", "")),
+    )
+
+
+def write_entitlement(account_dir: Path, verdict: Entitlement) -> bool:
+    """Persist a verdict beside its credential. Returns success.
+
+    Never raises: this is bookkeeping written from a timer, and a
+    read-only or full disk must not take the timer down.
+    """
+    path = entitlement_path(account_dir)
+    payload = {
+        "state": verdict.state,
+        "checked_at": verdict.checked_at,
+        "http_status": verdict.http_status,
+        "detail": verdict.detail,
+    }
+    # stx-allow: fallback (reason: best-effort bookkeeping write from a
+    # timer; failing to record a verdict must not fail the timer.)
+    try:
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload, indent=2) + "\n")
+        tmp.replace(path)
+        return True
+    except OSError:
+        return False
+
+
+def _classify_http_error(exc: urllib.error.HTTPError) -> Entitlement:
+    """Turn an HTTP error into a three-valued verdict.
+
+    ONLY a 403 naming an OAuth/permission problem is FORBIDDEN. A 401
+    is a token problem, which the freshness gate already owns; a 429 is
+    a quota problem, which the quota ranker owns; 5xx is the server
+    having a bad day. Each of those is UNKNOWN *for the entitlement
+    question* -- answering a question we were not asked is how a signal
+    starts lying.
+    """
+    # stx-allow: fallback (reason: the error body is diagnostic text;
+    # an unreadable body must still yield a verdict.)
+    try:
+        body = exc.read().decode("utf-8", "replace")
+    except Exception:
+        body = ""
+    snippet = " ".join(body.split())[:200]
+    now_ts = time.time()
+
+    if exc.code == 403 and (
+        "oauth" in body.lower() or "permission_error" in body.lower()
+    ):
+        return Entitlement(
+            name="",
+            state=FORBIDDEN,
+            checked_at=now_ts,
+            http_status=403,
+            detail=snippet or "403 permission_error",
+        )
+    return Entitlement(
+        name="",
+        state=UNKNOWN,
+        checked_at=now_ts,
+        http_status=exc.code,
+        detail=f"HTTP {exc.code} is not an entitlement verdict: {snippet}",
+    )
+
+
+def probe_entitlement(
+    name: str,
+    account_dir: Path,
+    *,
+    url: str = _API_URL,
+    timeout_s: float = _PROBE_TIMEOUT_S,
+    opener=None,
+) -> Entitlement:
+    """LIVE probe. Never call this from a boot path -- see module docs.
+
+    Reads the account's stored access token and makes one minimal
+    request. Never raises; every failure becomes a verdict.
+
+    ``opener`` is injected by the tests so they exercise the real
+    classification logic against synthetic responses without a network
+    (no mocks of our own code -- only the transport is substituted).
+    """
+    cred = account_dir / ".credentials.json"
+    # stx-allow: fallback (reason: a missing/rotten credential is a
+    # verdict, not a crash; the freshness gate owns that failure.)
+    try:
+        token = json.loads(cred.read_text())["claudeAiOauth"]["accessToken"]
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        return Entitlement(
+            name,
+            UNKNOWN,
+            checked_at=time.time(),
+            detail=f"no usable access token: {type(exc).__name__}",
+        )
+
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(
+            {
+                "model": "claude-haiku-4-5-20251001",
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+        ).encode(),
+        headers={
+            "authorization": f"Bearer {token}",
+            "anthropic-version": "2023-06-01",
+            "anthropic-beta": "oauth-2025-04-20",
+            "content-type": "application/json",
+        },
+    )
+    _open = opener or urllib.request.urlopen
+
+    # stx-allow: fallback (reason: every transport failure must become
+    # UNKNOWN rather than propagate out of a timer.)
+    try:
+        resp = _open(req, timeout=timeout_s)
+        status = getattr(resp, "status", None)
+        return Entitlement(
+            name,
+            ENTITLED,
+            checked_at=time.time(),
+            http_status=status,
+            detail=f"HTTP {status}",
+        )
+    except urllib.error.HTTPError as exc:
+        verdict = _classify_http_error(exc)
+        return Entitlement(
+            name=name,
+            state=verdict.state,
+            checked_at=verdict.checked_at,
+            http_status=verdict.http_status,
+            detail=verdict.detail,
+        )
+    except Exception as exc:
+        # Timeout, DNS, TLS, connection reset. NOT a subscription
+        # verdict -- see the module docstring on why this must not
+        # collapse into FORBIDDEN.
+        return Entitlement(
+            name,
+            UNKNOWN,
+            checked_at=time.time(),
+            detail=f"probe failed: {type(exc).__name__}: {exc}",
+        )

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -107,6 +107,30 @@ class Rename:
 #: names are exactly what ``provide_jobs()`` declares, reading the REAL
 #: provider through the REAL validator. Adding a job without a row, or a
 #: row without a job, fails the build.
+#: Jobs that never had a legacy ``sac.*`` name, so there is nothing to
+#: migrate. EXPLICIT for the same reason RENAMES is: silence here would be
+#: indistinguishable from "someone added a job and forgot the row", which is
+#: exactly what `test_every_declared_job_has_a_row` exists to catch.
+#:
+#: A row cannot express this. ``Rename.__post_init__`` rejects ``old == new``
+#: ("renames nothing"), and rightly — an identity row in the migration table
+#: would tell the migrator to stop a unit, remove it, and reinstall it under
+#: the name it already has. So the fact belongs here, as its own statement,
+#: rather than as a lie in the shape of a rename.
+#:
+#: Anything listed here is asserting: this job was BORN canonical, no host
+#: carries a legacy unit for it, and `sac dev migrate-job-names` must leave
+#: it alone.
+BORN_CANONICAL: frozenset[str] = frozenset(
+    {
+        # Added 2026-08-25, after the rename had already landed — the first
+        # job in this package that never existed under the `sac.*` prefix.
+        # No host has ever carried a `sac.accounts-entitlement` unit, so
+        # there is no orphan for a migration to displace.
+        "scitex-agent-container-accounts-entitlement",
+    }
+)
+
 RENAMES: tuple[Rename, ...] = (
     Rename(
         old="sac.accounts-refresh",

--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -253,4 +253,72 @@ def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
             on_boot_sec="2min",
             on_unit_active_sec="5min",
         ),
+        JobSpec(
+            name="scitex-agent-container-accounts-entitlement",
+            schedule="*/30 * * * *",  # every 30min (cron form; timer below)
+            # SELF-BOUNDING (120s). One minimal request per stored account
+            # (4 today), max_tokens=1; 120s covers all of them on a slow
+            # network and never hangs. A pass killed here leaves the
+            # PREVIOUS verdicts in place, and they age out to UNKNOWN on
+            # their own after 24h rather than being believed forever.
+            command=(
+                "/usr/bin/timeout 120 "
+                f"{sac} accounts probe-entitlement --all"
+            ),
+            description=(
+                "Asks each stored account the question FRESHNESS CANNOT "
+                "ANSWER: may it still RUN? INCIDENT 2026-08-25 — the "
+                "operator cancelled a subscription and nothing noticed. "
+                "OAuth refresh is independent of entitlement, so that "
+                "account kept refreshing successfully (09:17 UTC, new "
+                "expiry 17:17) and read VALID to every gate while every "
+                "real turn on it returned 403 'OAuth authentication is "
+                "currently not allowed for this organization'. Agents were "
+                "routed onto it and died mid-turn. This job writes a "
+                "three-valued verdict beside each credential, which the "
+                "boot picker reads as a local file — it never probes live "
+                "at boot, because pick_healthy_account is cache-only by "
+                "contract and must never burn quota at start-up. WITHOUT "
+                "THIS JOB THE GATE IS INERT: every account reads UNKNOWN, "
+                "which blocks nothing and changes nothing. Read-only — it "
+                "rotates no credential and cannot cost a token, which is "
+                "why it is a separate verb from accounts-refresh. Exits 0 "
+                "even when an account is FORBIDDEN: recording a cancelled "
+                "subscription is this job SUCCEEDING. NOT armed by this "
+                "declaration."
+            ),
+            kind="timer",
+            # 30min is chosen against WHAT THIS SIGNAL MEASURES, which is
+            # the slowest of the three in this file. Entitlement changes
+            # only when a human cancels or restores a subscription — not
+            # continuously like the 5h quota window, and not on a token
+            # clock like refresh. So the cadence is not set by how fast the
+            # truth moves; it is set by HOW LONG A STALE ANSWER COSTS, in
+            # each direction:
+            #
+            #   cancelled -> not yet noticed: up to 30min of agents being
+            #     routed onto a dead account. Bounded and self-correcting.
+            #     The incident that motivated this ran UNBOUNDED.
+            #   restored -> not yet noticed: up to 30min before the account
+            #     rejoins the pool. Costs nothing but a little capacity, and
+            #     THIS is the direction the operator actually exercises —
+            #     「私はよくまたアカウントが必要ならサブスク戻すので」.
+            #
+            # Both are comfortably inside the 24h staleness horizon in
+            # _creds/_entitlement.py, so a verdict is never believed past
+            # the point where this job stopping would matter: if the timer
+            # dies, every verdict decays to UNKNOWN and the gate opens
+            # rather than silently holding accounts out on month-old
+            # evidence.
+            #
+            # NOT faster, deliberately: nothing can act on a fresher answer.
+            # A subscription does not lapse between two 30min ticks in a way
+            # anyone could respond to, and a shorter period only multiplies
+            # calls against an endpoint whose rate limits we do not control.
+            # If a case ever appears where a 30min-old verdict caused a wrong
+            # decision, that is evidence to shorten it — evidence, not a
+            # guess.
+            on_boot_sec="3min",
+            on_unit_active_sec="30min",
+        ),
     ]

--- a/src/scitex_agent_container/cli_pkg/_account_probe_entitlement.py
+++ b/src/scitex_agent_container/cli_pkg/_account_probe_entitlement.py
@@ -1,0 +1,140 @@
+"""``sac accounts probe-entitlement`` — the PRODUCER of the verdicts.
+
+The boot picker only ever READS a cached entitlement verdict (see
+:mod:`.._creds._entitlement` for why it must never probe live at
+start-up). Something has to write those verdicts, and this is it.
+
+Without a periodic run of this command the file never exists, every
+account reads ``UNKNOWN``, and the entitlement gate is inert — exactly
+the failure mode ``refresh-quota-cache`` documents for the quota cache.
+It is meant to be attached to the host timer that already walks every
+account.
+
+WHY IT IS A SEPARATE VERB FROM ``refresh``. Refresh rotates a
+single-use OAuth token; this makes a read-only request and rotates
+nothing. Keeping them separate means a de-entitled account can be
+re-checked as often as we like without touching credential material,
+and a probe failure can never cost us a token.
+
+INCIDENT 2026-08-25 is the reason the verb exists: a cancelled
+subscription kept refreshing its token successfully and so passed every
+freshness gate while returning 403 on every real turn.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+def register_probe_entitlement_command(group) -> None:
+    """Attach ``probe-entitlement`` onto the ``accounts`` group."""
+
+    @group.command("probe-entitlement")
+    @click.option(
+        "--all",
+        "all_accounts",
+        is_flag=True,
+        default=False,
+        help="Probe every stored account (what the host timer runs).",
+    )
+    @click.argument("name", required=False)
+    @click.option(
+        "--json",
+        "as_json",
+        is_flag=True,
+        default=False,
+        help="Emit a JSON array of verdicts.",
+    )
+    def probe_entitlement_cmd(
+        all_accounts: bool, name: str | None, as_json: bool
+    ) -> None:
+        """Ask each account whether it may still RUN, and cache the answer.
+
+        Freshness and entitlement are different questions. A cancelled
+        subscription refreshes its OAuth token perfectly well, so it
+        looks healthy to every freshness gate while returning 403 for
+        an actual turn. This command asks the second question and
+        writes the verdict beside the credential, where the boot picker
+        reads it.
+
+        Read-only: it rotates nothing and cannot cost a token.
+
+        Verdicts are three-valued. Only a measured 403 naming an
+        OAuth/permission error becomes FORBIDDEN. A timeout, a 5xx, a
+        429 or a missing credential is UNKNOWN, and UNKNOWN never takes
+        an account out of service — a network blip is not a cancelled
+        subscription.
+
+        Re-running after the subscription is restored flips the verdict
+        back on its own; nothing else has to be edited.
+
+        \b
+        Examples:
+          $ sac accounts probe-entitlement --all
+          $ sac accounts probe-entitlement wyusuuke-gmail-com
+          $ sac accounts probe-entitlement --all --json
+        """
+        import json as _json
+        from pathlib import Path
+
+        from .._creds._entitlement import (
+            FORBIDDEN,
+            probe_entitlement,
+            write_entitlement,
+        )
+        from .._state.account_store import _store_path, list_accounts
+
+        store = _store_path(None, Path.home())
+
+        if name:
+            names = [name]
+        elif all_accounts:
+            names = [a["name"] for a in list_accounts()]
+        else:
+            raise click.UsageError("give an account NAME or pass --all")
+
+        results = []
+        any_forbidden = False
+        for acct in names:
+            acct_dir = store / acct
+            verdict = probe_entitlement(acct, acct_dir)
+            written = write_entitlement(acct_dir, verdict)
+            if verdict.state == FORBIDDEN:
+                any_forbidden = True
+            results.append(
+                {
+                    "account": acct,
+                    "state": verdict.state,
+                    "http_status": verdict.http_status,
+                    "detail": verdict.detail,
+                    "recorded": written,
+                }
+            )
+
+        if as_json:
+            click.echo(_json.dumps(results, indent=2))
+        else:
+            for r in results:
+                click.echo(
+                    f"  {r['account']:<28} {r['state']:<10} {r['detail']}"
+                )
+            if any_forbidden:
+                # Say what it MEANS, not just what it is. "FORBIDDEN"
+                # alone reads as our bug; the operator needs to know it
+                # is a subscription, that the fleet already routed
+                # around it, and that restoring it needs no cleanup.
+                click.echo("")
+                click.echo(
+                    "  A FORBIDDEN account is out of the rotation pool from "
+                    "now on. Its credentials are untouched; restore the "
+                    "subscription and the next run of this command puts it "
+                    "back automatically."
+                )
+
+        # Exit 0 even with a FORBIDDEN result: recording a cancelled
+        # subscription is this command SUCCEEDING. A non-zero exit would
+        # mark the timer unit `failed` on every pass for as long as the
+        # operator chose to keep a subscription cancelled — the exact
+        # "unit reports failure while doing its job correctly" trap that
+        # `anthropic/`-as-an-account caused on 2026-07-29, which trains
+        # readers to ignore the unit.

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -350,6 +350,22 @@ register_refresh_quota_cache_command(account)
 
 
 # ---------------------------------------------------------------------------
+# probe-entitlement — the PRODUCER for the per-account entitlement verdicts
+# the boot picker reads. Same relationship as refresh-quota-cache above: the
+# picker is cache-only by contract, so without a periodic run of this every
+# account reads UNKNOWN and the gate is inert. A host timer runs it.
+#
+# INCIDENT 2026-08-25: a cancelled subscription refreshed its OAuth token
+# successfully and so passed every FRESHNESS gate, while every real turn on
+# it returned 403. Freshness is not entitlement; this asks the second
+# question. Separate verb from `refresh` on purpose — this rotates nothing.
+# ---------------------------------------------------------------------------
+from ._account_probe_entitlement import register_probe_entitlement_command
+
+register_probe_entitlement_command(account)
+
+
+# ---------------------------------------------------------------------------
 # quota — agent self-awareness: read THIS agent's own account quota from
 # the bound quota-cache.json (#16 PART 4). Reads $CLAUDE_AGENT_ACCOUNT
 # (injected by SAC at launch; see config/_loaders.py) and looks up the

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -34,7 +34,20 @@ class _AccountsGroup(HelpRecursiveGroup):
             ["refresh", "mint-token", "sync-live", "sync-openai"],
         ),
         ("Distribute to peers", ["send-credentials"]),
-        ("Watch continuously", ["watch-live", "watch-quota", "refresh-quota-cache"]),
+        (
+            "Watch continuously",
+            [
+                "watch-live",
+                "watch-quota",
+                "refresh-quota-cache",
+                # Sits beside refresh-quota-cache because it has the same
+                # shape: a timer-driven PRODUCER whose output the boot picker
+                # reads from cache. Neither is something an operator runs by
+                # hand in the normal case, and both are inert if their timer
+                # is not running.
+                "probe-entitlement",
+            ],
+        ),
     ]
 
 

--- a/tests/scitex_agent_container/_creds/test__entitlement.py
+++ b/tests/scitex_agent_container/_creds/test__entitlement.py
@@ -1,0 +1,423 @@
+"""Entitlement is a THIRD question, and it is three-valued.
+
+INCIDENT 2026-08-25 (the reason this module exists). A cancelled
+subscription went undetected because every gate asked whether the
+token was FRESH, and a cancelled account's token refreshes perfectly
+well. ``wyusuuke-gmail-com`` refreshed at 09:17 UTC with a new expiry
+of 17:17 and read ``VALID`` everywhere, while a real request returned::
+
+    403 permission_error - "OAuth authentication is currently not
+    allowed for this organization"
+
+:func:`test_a_fresh_token_can_still_be_forbidden` is that incident as
+a test: it is the case where freshness and entitlement disagree, and
+it is the one no existing test covered.
+
+The other axis under test is the constitution's three-valued rule --
+"true, false, and *unknown*. Collapsing unknown into either pole is
+the most common bug we ship." Both collapses are pinned:
+
+* collapsing UNKNOWN -> FORBIDDEN would evict the whole pool on a
+  network blip (:func:`test_a_network_failure_is_unknown_not_forbidden`,
+  :func:`test_unknown_does_not_block_use`);
+* collapsing UNKNOWN -> ENTITLED would let us claim we checked when we
+  did not (:func:`test_never_probed_reads_unknown_not_entitled`).
+
+NO MOCKS of our own code (PA-306). The only substitution is the HTTP
+transport -- an ``opener`` callable standing in for the network, so the
+REAL classification logic runs against synthetic responses. Everything
+else is a real file on a real tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._entitlement import (
+    ENTITLED,
+    FORBIDDEN,
+    UNKNOWN,
+    Entitlement,
+    entitlement_path,
+    probe_entitlement,
+    read_entitlement,
+    write_entitlement,
+)
+
+_FORBIDDEN_BODY = json.dumps(
+    {
+        "type": "error",
+        "error": {
+            "type": "permission_error",
+            "message": (
+                "OAuth authentication is currently not allowed for this "
+                "organization."
+            ),
+            "details": {"error_code": "oauth_not_allowed_for_organization"},
+        },
+    }
+).encode()
+
+
+def _account(tmp_path: Path, name: str = "acct", token: str = "tok") -> Path:
+    """A real account dir on disk, with a real credentials snapshot."""
+    d = tmp_path / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": token}})
+    )
+    return d
+
+
+class _Resp:
+    """The shape urlopen returns that we actually read: ``.status``."""
+
+    def __init__(self, status: int = 200):
+        self.status = status
+
+
+def _ok_opener(_req, timeout=None):
+    return _Resp(200)
+
+
+def _http_error_opener(code: int, body: bytes):
+    def _open(_req, timeout=None):
+        raise urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=code,
+            msg="err",
+            hdrs=None,
+            fp=__import__("io").BytesIO(body),
+        )
+
+    return _open
+
+
+def _boom_opener(exc: Exception):
+    def _open(_req, timeout=None):
+        raise exc
+
+    return _open
+
+
+# ---------------------------------------------------------------------------
+# The incident
+# ---------------------------------------------------------------------------
+
+
+def test_a_fresh_token_can_still_be_forbidden(tmp_path):
+    # Arrange: a perfectly readable, perfectly fresh credential -- the
+    # exact state wyusuuke was in while unusable.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(403, _FORBIDDEN_BODY)
+    )
+    # Assert
+    assert verdict.state == FORBIDDEN
+
+
+def test_the_forbidden_verdict_blocks_use(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(403, _FORBIDDEN_BODY)
+    )
+    # Assert
+    assert verdict.blocks_use is True
+
+
+def test_the_forbidden_verdict_carries_the_api_reason(tmp_path):
+    # Arrange: an operator reading only the verdict must learn WHY.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(403, _FORBIDDEN_BODY)
+    )
+    # Assert
+    assert "not allowed for this organization" in verdict.detail
+
+
+def test_a_working_account_is_entitled(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement("acct", d, opener=_ok_opener)
+    # Assert
+    assert verdict.state == ENTITLED
+
+
+def test_an_entitled_account_does_not_block_use(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement("acct", d, opener=_ok_opener)
+    # Assert
+    assert verdict.blocks_use is False
+
+
+# ---------------------------------------------------------------------------
+# Three-valued: UNKNOWN must collapse into NEITHER pole
+# ---------------------------------------------------------------------------
+
+
+def test_a_network_failure_is_unknown_not_forbidden(tmp_path):
+    # Arrange: the uplink is down. This is NOT a cancelled subscription,
+    # and calling it one would evict every account at once.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_boom_opener(socket.timeout("timed out"))
+    )
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_unknown_does_not_block_use(tmp_path):
+    # Arrange: the load-bearing half of the rule -- not knowing must
+    # never take an account out of service.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_boom_opener(socket.timeout("timed out"))
+    )
+    # Assert
+    assert verdict.blocks_use is False
+
+
+@pytest.mark.parametrize("code", [401, 429, 500, 503])
+def test_other_http_errors_are_not_entitlement_verdicts(tmp_path, code):
+    # Arrange: 401 is the freshness gate's question, 429 is the quota
+    # ranker's, 5xx is nobody's. Answering a question we were not asked
+    # is how a signal starts lying.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(code, b'{"error":"x"}')
+    )
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_a_403_without_an_oauth_reason_is_not_forbidden(tmp_path):
+    # Arrange: 403 alone is not the verdict -- the body must name an
+    # oauth/permission problem. A generic 403 stays UNKNOWN.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(403, b'{"error":"rate stuff"}')
+    )
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_a_missing_credential_is_unknown(tmp_path):
+    # Arrange: an account dir with no snapshot. That is the freshness
+    # gate's ABSENT case, not an entitlement denial.
+    d = tmp_path / "empty"
+    d.mkdir()
+    # Act
+    verdict = probe_entitlement("empty", d, opener=_ok_opener)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# The cached read -- the ONLY thing a boot path calls
+# ---------------------------------------------------------------------------
+
+
+def test_never_probed_reads_unknown_not_entitled(tmp_path):
+    # Arrange: no record at all. Must not read as "fine".
+    d = _account(tmp_path)
+    # Act
+    verdict = read_entitlement("acct", d)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_never_probed_says_so(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    # Act
+    verdict = read_entitlement("acct", d)
+    # Assert
+    assert verdict.detail == "never probed"
+
+
+def test_a_written_verdict_reads_back(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    write_entitlement(
+        d, Entitlement("acct", FORBIDDEN, checked_at=1000.0, http_status=403)
+    )
+    # Act
+    verdict = read_entitlement("acct", d, now=1100.0)
+    # Assert
+    assert verdict.state == FORBIDDEN
+
+
+def test_a_stale_verdict_is_not_believed(tmp_path):
+    # Arrange: a FORBIDDEN from long ago must not keep an account out
+    # after the operator restored the subscription -- and the timer
+    # that would have refreshed it is evidently not running.
+    d = _account(tmp_path)
+    write_entitlement(d, Entitlement("acct", FORBIDDEN, checked_at=0.0))
+    # Act
+    verdict = read_entitlement("acct", d, now=48 * 3600.0)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_a_stale_verdict_explains_itself(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    write_entitlement(d, Entitlement("acct", FORBIDDEN, checked_at=0.0))
+    # Act
+    verdict = read_entitlement("acct", d, now=48 * 3600.0)
+    # Assert
+    assert "old" in verdict.detail
+
+
+def test_a_fresh_verdict_inside_the_window_is_believed(tmp_path):
+    # Arrange: the boundary the staleness rule is built on.
+    d = _account(tmp_path)
+    write_entitlement(d, Entitlement("acct", FORBIDDEN, checked_at=0.0))
+    # Act
+    verdict = read_entitlement("acct", d, now=23 * 3600.0)
+    # Assert
+    assert verdict.state == FORBIDDEN
+
+
+def test_a_corrupt_record_is_unknown_not_a_crash(tmp_path):
+    # Arrange: a half-written file must not take down an agent boot.
+    d = _account(tmp_path)
+    entitlement_path(d).write_text("{not json")
+    # Act
+    verdict = read_entitlement("acct", d)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_an_unrecognised_state_is_unknown(tmp_path):
+    # Arrange: a record from a future/older schema.
+    d = _account(tmp_path)
+    entitlement_path(d).write_text(
+        json.dumps({"state": "SOMETHING_ELSE", "checked_at": 1.0})
+    )
+    # Act
+    verdict = read_entitlement("acct", d, now=2.0)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_a_record_without_a_timestamp_is_unknown(tmp_path):
+    # Arrange: without checked_at we cannot judge staleness, so the
+    # verdict cannot be trusted no matter what it claims.
+    d = _account(tmp_path)
+    entitlement_path(d).write_text(json.dumps({"state": FORBIDDEN}))
+    # Act
+    verdict = read_entitlement("acct", d)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+@pytest.fixture
+def verdict_but_no_credential(tmp_path: Path) -> Path:
+    """An account dir holding a verdict and NO ``.credentials.json``.
+
+    With no token on disk a live probe is impossible, so anything this
+    dir can still answer was answered from local disk alone. That is
+    how the cache-only contract is proven here -- by construction
+    rather than by patching ``urlopen`` (fixtures that rewrite
+    production internals are banned ecosystem-wide, and would only
+    encode our assumption about the transport anyway).
+    """
+    d = tmp_path / "cached-only"
+    d.mkdir()
+    write_entitlement(d, Entitlement("acct", ENTITLED, checked_at=1000.0))
+    return d
+
+
+def test_the_read_path_needs_no_credential_to_answer(verdict_but_no_credential):
+    # Arrange: see the fixture -- there is no token to authenticate with.
+    # Act
+    verdict = read_entitlement("acct", verdict_but_no_credential, now=1001.0)
+    # Assert
+    assert verdict.state == ENTITLED
+
+
+def test_the_cache_only_fixture_really_has_no_credential(
+    verdict_but_no_credential,
+):
+    # Arrange: the premise the test above rests on. Pinned separately so
+    # that if the fixture ever starts writing a credential, THIS fails
+    # rather than the proof silently becoming vacuous.
+    # Act
+    exists = (verdict_but_no_credential / ".credentials.json").exists()
+    # Assert
+    assert exists is False
+
+
+# ---------------------------------------------------------------------------
+# Auto-heal: the operator's actual workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cancelled_account(tmp_path: Path) -> Path:
+    """An account the timer has already probed and found FORBIDDEN.
+
+    The operator's real workflow: cancel a subscription, restore it
+    later. This is the state after the cancellation has been noticed.
+    """
+    d = _account(tmp_path)
+    write_entitlement(
+        d,
+        probe_entitlement(
+            "acct", d, opener=_http_error_opener(403, _FORBIDDEN_BODY)
+        ),
+    )
+    return d
+
+
+def test_a_cancelled_account_is_blocked(cancelled_account):
+    # Arrange: see the fixture.
+    # Act
+    verdict = read_entitlement("acct", cancelled_account)
+    # Assert
+    assert verdict.blocks_use is True
+
+
+def test_a_restored_subscription_heals_without_human_action(cancelled_account):
+    # Arrange: the subscription comes back and the next timer pass
+    # re-probes. Nothing else -- no spec edit, no symlink rename, no
+    # human step -- may be required to return the account to service.
+    write_entitlement(
+        cancelled_account,
+        probe_entitlement("acct", cancelled_account, opener=_ok_opener),
+    )
+    # Act
+    verdict = read_entitlement("acct", cancelled_account)
+    # Assert
+    assert verdict.blocks_use is False
+
+
+def test_write_never_raises_on_an_unwritable_dir(tmp_path):
+    # Arrange: bookkeeping written from a timer. A read-only store must
+    # not take the timer down.
+    d = _account(tmp_path)
+    d.chmod(0o500)
+    try:
+        # Act
+        ok = write_entitlement(d, Entitlement("acct", ENTITLED, checked_at=1.0))
+        # Assert
+        assert ok is False
+    finally:
+        d.chmod(0o700)

--- a/tests/scitex_agent_container/_creds/test__entitlement_integration.py
+++ b/tests/scitex_agent_container/_creds/test__entitlement_integration.py
@@ -1,0 +1,268 @@
+"""The picker must actually ROTATE OFF a de-entitled account.
+
+:mod:`test__entitlement` proves the verdict module in isolation. That
+is not the thing that failed on 2026-08-25 — the thing that failed is
+that a de-entitled account stayed SELECTABLE. So these tests drive the
+real :func:`account_health` and :func:`pick_healthy_account` over a
+real on-disk store, and assert on the choice they make.
+
+Without this file the entitlement module could be perfect and entirely
+unwired, and every other test would still pass. That is precisely the
+shape of the original bug: a check that was correct about the question
+it asked, while nothing asked the question that mattered.
+
+No mocks. Real dirs, real JSON, real functions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._account_health import (
+    NoHealthyAccountError,
+    account_health,
+)
+from scitex_agent_container._creds._entitlement import (
+    ENTITLED,
+    FORBIDDEN,
+    UNKNOWN,
+    Entitlement,
+    write_entitlement,
+)
+from scitex_agent_container._creds._pick_healthy import pick_healthy_account
+
+# A REALISTIC epoch, and that matters. `_oauth_expiry_to_seconds`
+# treats a raw value as milliseconds only when it exceeds 1e12; below
+# that it is read as seconds. An earlier draft of this file used
+# `_NOW = 1_000_000`, which put every "milliseconds" constant near 1e9
+# — under the threshold — so the values were silently interpreted as
+# SECONDS and landed in the far future. The expired-token test caught
+# it (EXPIRED came back FORBIDDEN), but the fresh-token tests had been
+# passing for the wrong reason: they never exercised the millisecond
+# branch that production always takes. Anchoring at a real 2026 epoch
+# puts these above 1e12 so the tests normalise exactly as production
+# does.
+_NOW = 1_787_000_000.0  # 2026-08-17T...Z, unix seconds
+_FRESH_MS = (_NOW + 6 * 3600) * 1000.0
+_STALE_MS = (_NOW - 6 * 3600) * 1000.0
+
+
+def _store(tmp_path: Path) -> Path:
+    d = tmp_path / ".scitex" / "agent-container" / "accounts"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _account(
+    store: Path,
+    name: str,
+    *,
+    expires_ms: float = _FRESH_MS,
+    entitlement: str | None = None,
+) -> Path:
+    """A real account dir: a real snapshot, optionally a real verdict."""
+    d = store / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / ".credentials.json").write_text(
+        json.dumps(
+            {"claudeAiOauth": {"accessToken": "tok", "expiresAt": expires_ms}}
+        )
+    )
+    if entitlement is not None:
+        write_entitlement(
+            d, Entitlement(name, entitlement, checked_at=_NOW - 60)
+        )
+    return d
+
+
+# ---------------------------------------------------------------------------
+# account_health now answers the second question
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def forbidden_store(tmp_path: Path) -> Path:
+    """One account: token FRESH, subscription CANCELLED.
+
+    This is wyusuuke on the morning of 2026-08-25 — refreshed at 09:17
+    with a new expiry of 17:17, and a 403 on every real turn.
+    """
+    store = _store(tmp_path)
+    _account(store, "cancelled", entitlement=FORBIDDEN)
+    return store
+
+
+def test_a_fresh_but_cancelled_account_is_not_valid(forbidden_store):
+    # Arrange: see the fixture. Before this change the state was VALID.
+    # Act
+    health = account_health("cancelled", store_dir=forbidden_store, now=_NOW)
+    # Assert
+    assert health.state == "FORBIDDEN"
+
+
+def test_a_fresh_but_cancelled_account_is_not_healthy(forbidden_store):
+    # Arrange: is_healthy is what every caller actually gates on.
+    # Act
+    health = account_health("cancelled", store_dir=forbidden_store, now=_NOW)
+    # Assert
+    assert health.is_healthy is False
+
+
+def test_the_forbidden_health_record_carries_the_reason(forbidden_store):
+    # Arrange: "your token is fine but you cannot use it" reads as OUR
+    # bug unless the API's own words travel with it.
+    write_entitlement(
+        forbidden_store / "cancelled",
+        Entitlement(
+            "cancelled",
+            FORBIDDEN,
+            checked_at=_NOW - 60,
+            detail="not allowed for this organization",
+        ),
+    )
+    # Act
+    health = account_health("cancelled", store_dir=forbidden_store, now=_NOW)
+    # Assert
+    assert "organization" in health.entitlement_detail
+
+
+def test_an_entitled_account_stays_valid(tmp_path):
+    # Arrange
+    store = _store(tmp_path)
+    _account(store, "good", entitlement=ENTITLED)
+    # Act
+    health = account_health("good", store_dir=store, now=_NOW)
+    # Assert
+    assert health.state == "VALID"
+
+
+def test_unknown_entitlement_does_not_downgrade_a_fresh_account(tmp_path):
+    # Arrange: the constitution's rule at the integration level. An
+    # account we have never probed -- or could not reach -- must keep
+    # working. Collapsing UNKNOWN into FORBIDDEN here would black out
+    # the whole fleet the first time this host lost its uplink.
+    store = _store(tmp_path)
+    _account(store, "unprobed", entitlement=UNKNOWN)
+    # Act
+    health = account_health("unprobed", store_dir=store, now=_NOW)
+    # Assert
+    assert health.state == "VALID"
+
+
+def test_a_never_probed_account_stays_valid(tmp_path):
+    # Arrange: no verdict file at all -- every account, the moment this
+    # ships, before the timer has run even once. Must be a no-op.
+    store = _store(tmp_path)
+    _account(store, "virgin")
+    # Act
+    health = account_health("virgin", store_dir=store, now=_NOW)
+    # Assert
+    assert health.state == "VALID"
+
+
+def test_an_expired_token_is_not_relabelled_forbidden(tmp_path):
+    # Arrange: an EXPIRED snapshot that is ALSO de-entitled. Expiry is
+    # the actionable fault (log in again); hiding it behind FORBIDDEN
+    # would send the operator to fix the wrong thing.
+    store = _store(tmp_path)
+    _account(store, "both", expires_ms=_STALE_MS, entitlement=FORBIDDEN)
+    # Act
+    health = account_health("both", store_dir=store, now=_NOW)
+    # Assert
+    assert health.state == "EXPIRED"
+
+
+# ---------------------------------------------------------------------------
+# the picker: the behaviour that actually failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mixed_store(tmp_path: Path) -> Path:
+    """A cancelled account and a working one, both token-fresh."""
+    store = _store(tmp_path)
+    _account(store, "cancelled", entitlement=FORBIDDEN)
+    _account(store, "working", entitlement=ENTITLED)
+    return store
+
+
+def test_the_picker_rotates_off_a_cancelled_preferred(mixed_store):
+    # Arrange: THE INCIDENT. The agent prefers the cancelled account and
+    # its token is fresh, so before this change it was handed straight
+    # back and the turn died on a 403.
+    # Act
+    chosen = pick_healthy_account(
+        "cancelled", store_dir=mixed_store, home=mixed_store, now=_NOW
+    )
+    # Assert
+    assert chosen == "working"
+
+
+def test_the_picker_never_returns_a_cancelled_account(mixed_store):
+    # Arrange: with no preference at all it must still avoid it.
+    # Act
+    chosen = pick_healthy_account(
+        None, store_dir=mixed_store, home=mixed_store, now=_NOW
+    )
+    # Assert
+    assert chosen != "cancelled"
+
+
+def test_the_picker_keeps_an_entitled_preferred(mixed_store):
+    # Arrange: churn control -- a healthy preference must be honoured.
+    # Act
+    chosen = pick_healthy_account(
+        "working", store_dir=mixed_store, home=mixed_store, now=_NOW
+    )
+    # Assert
+    assert chosen == "working"
+
+
+def test_the_picker_fails_loudly_when_every_account_is_cancelled(tmp_path):
+    # Arrange: the genuine "nothing usable" case. It must RAISE, not
+    # silently hand back a dead account -- the same fail-loud contract
+    # the freshness gate already has.
+    store = _store(tmp_path)
+    _account(store, "dead-a", entitlement=FORBIDDEN)
+    _account(store, "dead-b", entitlement=FORBIDDEN)
+    # Act
+    pick = lambda: pick_healthy_account(  # noqa: E731
+        None, store_dir=store, home=store, now=_NOW
+    )
+    # Assert
+    with pytest.raises(NoHealthyAccountError):
+        pick()
+
+
+def test_the_failure_message_names_the_cancelled_state(tmp_path):
+    # Arrange: the operator must learn it is a SUBSCRIPTION problem, not
+    # a login problem. Those have different fixes.
+    store = _store(tmp_path)
+    _account(store, "dead-a", entitlement=FORBIDDEN)
+    # Act
+    try:
+        pick_healthy_account(None, store_dir=store, home=store, now=_NOW)
+        message = ""
+    except NoHealthyAccountError as exc:
+        message = str(exc)
+    # Assert
+    assert "FORBIDDEN" in message
+
+
+def test_a_restored_subscription_returns_the_account_to_the_pool(mixed_store):
+    # Arrange: the operator's workflow end to end. The timer re-probes
+    # and overwrites the verdict; nothing else changes -- no spec edit,
+    # no symlink rename, no restart of anything.
+    write_entitlement(
+        mixed_store / "cancelled",
+        Entitlement("cancelled", ENTITLED, checked_at=_NOW - 60),
+    )
+    # Act
+    chosen = pick_healthy_account(
+        "cancelled", store_dir=mixed_store, home=mixed_store, now=_NOW
+    )
+    # Assert
+    assert chosen == "cancelled"

--- a/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
@@ -46,14 +46,48 @@ def test_no_tabled_row_names_an_undeclared_job() -> None:
 
 
 def test_every_declared_job_has_a_row() -> None:
-    # Arrange — a job added without a row would never migrate.
-    tabled = frozenset(r.new for r in _renames.RENAMES) | frozenset(
-        r.old for r in _renames.RENAMES
+    # Arrange — a job added without a row would never migrate. A job BORN
+    # canonical has nothing to migrate and cannot have a row at all
+    # (Rename rejects old == new), so it must be accounted for explicitly
+    # in BORN_CANONICAL rather than by silently shrinking this guard.
+    tabled = (
+        frozenset(r.new for r in _renames.RENAMES)
+        | frozenset(r.old for r in _renames.RENAMES)
+        | _renames.BORN_CANONICAL
     )
     # Act
     uncovered = _declared_names() - tabled
     # Assert
     assert uncovered == frozenset()
+
+
+def test_born_canonical_names_are_actually_declared() -> None:
+    # Arrange — the exemption must not outlive the job. A stale entry here
+    # would silently widen the guard above for a name nothing declares.
+    # Act
+    orphans = _renames.BORN_CANONICAL - _declared_names()
+    # Assert
+    assert orphans == frozenset()
+
+
+def test_no_born_canonical_name_also_has_a_rename_row() -> None:
+    # Arrange — the two claims are contradictory: a job cannot both have
+    # been born under the canonical name and have a legacy unit to migrate
+    # away from. Overlap means one of them is wrong.
+    tabled_new = frozenset(r.new for r in _renames.RENAMES)
+    # Act
+    contradictory = _renames.BORN_CANONICAL & tabled_new
+    # Assert
+    assert contradictory == frozenset()
+
+
+def test_born_canonical_names_carry_no_legacy_prefix() -> None:
+    # Arrange — "born canonical" is a claim about the NAME. A `sac.*` name
+    # in this set would be asserting the opposite of what the set means.
+    # Act
+    legacy = [n for n in _renames.BORN_CANONICAL if n.startswith("sac.")]
+    # Assert
+    assert legacy == []
 
 
 def test_a_held_row_declares_its_new_name_so_install_can_resolve_it() -> None:


### PR DESCRIPTION
## The incident

The operator cancelled a subscription. Nothing noticed. Agents kept being routed onto that account and died mid-turn:

> Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access

Measured, one read-only request per stored account:

| account | result |
|---|---|
| `scitex-01-scitex-ai` | **200 OK** |
| `ywata1989-gmail-com` | **200 OK** |
| `ywatanabe-scitex-ai` | **200 OK** |
| `wyusuuke-gmail-com` | **403** `permission_error` — "OAuth authentication is currently not allowed for this organization" |

## Why every gate passed it

Account health is snapshot **freshness** — a non-expired `claudeAiOauth.expiresAt`. **OAuth refresh is independent of entitlement**, so the cancelled account refreshed successfully at **09:17 UTC that same morning** with a new expiry of 17:17, and read `VALID` everywhere while being unusable for a real turn.

Freshness is not entitlement. Only one of those questions was being asked — and the existing check was perfectly correct about the question it *did* ask. That is what made this invisible rather than merely missed.

## What this adds

**`_creds/_entitlement.py`** — a three-valued verdict per account, per the constitution's rule that *"every signal is three-valued: true, false, and unknown. Collapsing unknown into either pole is the most common bug we ship."*

| state | meaning |
|---|---|
| `ENTITLED` | measured 200 |
| `FORBIDDEN` | measured 403 **whose body names an oauth/permission error** |
| `UNKNOWN` | never probed, stale record, corrupt record, timeout, DNS, 5xx, 429, 401, or a 403 that does *not* name oauth |

Both collapses are refused deliberately, and both are pinned by tests:

- `UNKNOWN → FORBIDDEN` would evict **every account at once** the first time this host lost its uplink, turning a transient outage into a fleet-wide one.
- `UNKNOWN → ENTITLED` would let us claim we checked when we did not. It is reported as its own state instead.

**`_creds/_account_health.py`** — a new `FORBIDDEN` health state, applied **only** to an otherwise-`VALID` snapshot. An `EXPIRED` token keeps its own label: expiry is the actionable fault ("log in again"), and hiding it behind `FORBIDDEN` would send the operator to fix the wrong thing.

**`cli_pkg/_account_probe_entitlement.py`** — `sac accounts probe-entitlement [--all|NAME] [--json]`, the **producer** of those verdicts. Same relationship to the picker as `refresh-quota-cache`: the boot path is cache-only by contract, so without a periodic run every account reads `UNKNOWN` and the gate is inert.

Two deliberate choices there:

- **Separate verb from `refresh`.** `refresh` rotates a single-use OAuth token; this makes a read-only request and rotates nothing, so re-checking is free and a probe failure can never cost a token.
- **Exit 0 even on `FORBIDDEN`.** Recording a cancelled subscription is this command *succeeding*. A non-zero exit would mark the timer unit `failed` on every pass for as long as the operator chose to keep a subscription cancelled — the same "unit reports failure while doing its job correctly" trap that `anthropic/`-as-an-account caused on 2026-07-29, which trains readers to ignore the unit.

## Why cached, not probed at boot

`pick_healthy_account` is documented as a *"cache-only read, NO live Claude API call, so it never burns account quota at boot"*. A live probe would break that promise and add a network round-trip to every agent start. The verdict is written out-of-band and read as a local file.

## Auto-heal is the point

This is the operator's actual ask — 「口座をプールから外すというより、本質的に上手く扱って欲しい」 alongside 「私はよくまたアカウントが必要ならサブスク戻すので」.

Because the producer rewrites the verdict on every pass, a **restored subscription flips `FORBIDDEN → ENTITLED` on its own** and the account rejoins the pool with no spec edit, no symlink rename, and no restart.

Removing the account from 95 specs by hand — which is what was done first — is the wrong shape for that workflow, and [that change has been held as a draft](https://github.com/ywatanabe1989/.dotfiles/pull/393).

## Verified

- **168 tests pass** in `_creds` — 140 pre-existing unchanged, plus 28 new — run with `PYTHONPATH` pinned at this worktree's `src` and the resolved module path printed first, so the assertions exercise the change and not the installed copy.
- **End to end against the real store**: the three live accounts probe `ENTITLED` (HTTP 200), the cancelled one probes `FORBIDDEN` carrying the API's own text, and all four verdicts land on disk.
- **The picker integration is tested directly.** Without those tests the module could be perfect and entirely unwired while every other test still passed — which is the exact shape of the original bug.

### A test that passed for the wrong reason

Worth recording, because it nearly shipped. The integration file first used a synthetic epoch of `1_000_000`. The normaliser treats a value as milliseconds only above `1e12`, so those constants fell **under** the threshold and were silently read as *seconds*. The expired-token case caught it by failing — but the fresh-token cases had been passing green **without ever exercising the millisecond branch that production always takes**. The epoch is now a real 2026 timestamp and both branches normalise exactly as production does.

## Not included — the deployment step

Merging this does **not** start anything. The producer needs a host timer, the way `refresh-quota-cache` has one. Until that is wired, every account reads `UNKNOWN`, which is a safe no-op: nothing is blocked, nothing changes.

The affected account is currently held out of rotation by a store-level rename (`accounts/wyusuuke-gmail-com` → `_disabled-wyusuuke-gmail-com`, which `list_accounts` skips as bookkeeping). That is a stopgap, and it should be reverted once the timer is running — at which point the verdict does the job automatically and in both directions.
