### PR TITLE
feat(jobs): declare the credential snapshot as a timer, because a daemon has no cron form

### DIFF
--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -128,6 +128,19 @@ BORN_CANONICAL: frozenset[str] = frozenset(
         # No host has ever carried a `sac.accounts-entitlement` unit, so
         # there is no orphan for a migration to displace.
         "scitex-agent-container-accounts-entitlement",
+        # Added 2026-08-26. NOT a rename, deliberately, even though
+        # laptop-01 does carry a hand-written `sac-creds-watch.service`:
+        # that unit runs the `watch-live` DAEMON, while this job is a
+        # 2-minute timer over the one-shot `sync-live`. A Rename row would
+        # tell the migrator to stop the fleet's ONLY working credential
+        # watcher and install a timer in its place, in one unsupervised
+        # step — the same stop-then-install order that took the sole OAuth
+        # refresher down for ~2 minutes on 2026-08-18. Declaring it born
+        # canonical lets both run (sync-live is a no-op when the store
+        # already matches), so laptop-01 keeps its watcher until this timer
+        # is VERIFIED firing on all seven hosts; retiring the hand-written
+        # unit is a separate, deliberate step on the migration card.
+        "scitex-agent-container-accounts-snapshot-live",
     }
 )
 

--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -321,4 +321,43 @@ def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
             on_boot_sec="3min",
             on_unit_active_sec="30min",
         ),
+        JobSpec(
+            name="scitex-agent-container-accounts-snapshot-live",
+            schedule="*/2 * * * *",  # every 2min (cron form; timer below)
+            command=f"/usr/bin/timeout 60 {sac} accounts sync-live",
+            description=(
+                "Snapshots a `claude /login` performed in ANY host's TUI into "
+                "that host's account store, so logging in from an arbitrary "
+                "agent is safe. WHY IT EXISTS (measured 2026-08-25): the "
+                "credential watcher was running on laptop-01 ONLY, 1 host of "
+                "7, because it had been created there by hand as "
+                "sac-creds-watch.service and never entered this federation. "
+                "On the other six a TUI login writes the live credential and "
+                "NOTHING saves it, so the next distribution overwrites it and "
+                "the operator's login silently disappears -- the exact "
+                "conflict he described being afraid of. The same absence "
+                "shows in the data: laptop-01 was the only host whose "
+                "`.credentials.json` was current outside the distribution "
+                "burst, while nas-03's was TEN DAYS STALE (2026-08-16), the "
+                "most likely reason six subagents died that day with 'Login "
+                "expired'. WHY A TIMER AND NOT THE WATCHER, as a cost rather "
+                "than a preference: the instantaneous form is `accounts "
+                "watch-live`, a long-running daemon, and sac lowers EVERY "
+                "declared job to cron with allow_lossy=False, so a daemon has "
+                "no representation this federation can carry -- kind='service' "
+                "validates on JobSpec and then fails the lowering guard. A "
+                "2-minute poll of the one-shot `sync-live` leaves a window: a "
+                "login is lost only if a distribution burst lands inside those "
+                "2 minutes, against the 100% loss six hosts carry today, using "
+                "the path the fleet already supports. Idempotent by contract "
+                "-- creds_sync is a no-op when the store already matches or is "
+                "newer, fails loud rather than saving a stale token, and "
+                "refuses any write that would change a store's recorded "
+                "identity, the guard added in 2026-07 after sync_live "
+                "snapshotted one account's token into another account's store."
+            ),
+            kind="timer",
+            on_boot_sec="1min",
+            on_unit_active_sec="2min",
+        ),
     ]


### PR DESCRIPTION
## What

Declares `scitex-agent-container-accounts-snapshot-live` — a 2-minute timer over the one-shot `sac accounts sync-live` — so a `claude /login` performed in ANY host's TUI is snapshotted into that host's account store.

## Why

Six of seven hosts have nothing that saves a TUI login. The live credential is written and never snapshotted, so the next distribution overwrites it and the operator's login silently disappears.

Measured 2026-08-25: the watcher ran on **laptop-01 only**, because it was created there **by hand** as `sac-creds-watch.service` and never entered this federation. The data agrees — laptop-01 was the only host whose `.credentials.json` was current outside the distribution burst, while nas-03's was **ten days stale**, the most likely reason six subagents died that day with "Login expired".

## Why a timer and not the watcher

This is a cost, not a preference. The instantaneous form is `accounts watch-live`, a long-running daemon. sac lowers **every** declared job to cron via `collect_cron_jobs(jobs, allow_lossy=False)`, and a daemon has no cron representation — so `kind="service"` validates on `JobSpec` and then fails the lowering guard.

Declaring it that way reddened **eight** shared guards at once. Eight guards disagreeing is the design speaking, not a parser gap: the tree carries 30 `kind="timer"`, 1 `kind="systemd"`, and no service at all. Weakening eight safety rails to get a job onto six hosts is the wrong trade, so the daemon is not what landed. Tracked separately as `sac-job-grammar-needs-a-non-cron-form-for-daemons`, which also blocks `sac-listen`.

`accounts sync-live` is the one-shot half of the same substrate: idempotent, a no-op when the store already matches or is newer, and it fails loud rather than saving a stale token.

**Residual cost, stated rather than buried:** a login is lost only if a distribution burst lands inside the 2-minute window — against the 100% loss six of seven hosts carry today.

## BORN_CANONICAL, not a Rename row

laptop-01 does carry a hand-written `sac-creds-watch.service`, but that unit runs the *daemon* while this job is a timer over the *one-shot*. A `Rename` would tell the migrator to stop the fleet's only working credential watcher and install a timer in one unsupervised step — the same stop-then-install order that took the sole OAuth refresher down ~2 minutes on 2026-08-18.

Both can run (`sync-live` is a no-op when the store matches), so laptop-01 keeps its watcher until this timer is verified firing on all seven hosts. Retiring the hand-written unit stays a separate deliberate step, preserving **declare → verify → delete**.

## Verification

- Control run on `develop`, same test selection: **261 passed / 0 failed** — there were no pre-existing failures to hide behind.
- This branch, same selection: **261 passed / 0 failed**.
- Positive control that the job is actually live in the federation: **11 declared** (was 10), `kind=timer`, `*/2 * * * *`, absolute self-bounding command.
- The local full suite was still running (network-bound) when this was opened; CI is the authoritative full-suite verdict.

Nothing is installed on any host by this PR and no hand-written unit is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
