### PR TITLE
fix(tests): a PostgreSQL gate that skips silently is a gate that passes

### DIFF
--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -427,6 +427,14 @@ fi
 # after EVERY test, so loadscope's "same worker per module" buys nothing here —
 # it only serialized. `load` spreads the parametrized cases across ALL workers.
 #
+# -rs: PRINT SKIP REASONS. Without it `-q` prints a bare count, and on
+# 2026-08-26 that made a blind gate look like a healthy one: 308 PostgreSQL
+# tests were skipping on two of three runners for want of a writable database
+# and every one of those runs reported green. Establishing that took
+# reconstructing 392 - 84 = 308 by arithmetic from a 9.9 MB log, because
+# nothing in the output said which tests were skipped or why. A skip that
+# nobody can see is a pass.
+#
 # nice -n 19 ionice -c 3: run at the lowest CPU + idle I/O priority so that if
 # this node is ever shared with interactive/dev work, CI grabs otherwise-idle
 # cores but YIELDS the CPU and disk to any higher-priority process — "all
@@ -434,6 +442,6 @@ fi
 # which execs ionice, which execs python (still PID-traceable, signals/exit
 # code propagate to the runner step).
 exec nice -n 19 ionice -c 3 \
-    python -m pytest tests/ -n "$WORKERS" --dist load -q \
+    python -m pytest tests/ -n "$WORKERS" --dist load -q -rs \
     --cov=src/scitex_agent_container --cov-report=xml --cov-report=term \
     -p no:cacheprovider

--- a/tests/_store_isolation.py
+++ b/tests/_store_isolation.py
@@ -47,6 +47,40 @@ import pytest
 #: where libpq finds it without any credential entering this file.
 PG_BASE_DSN = os.environ.get("SAC_TEST_PG_DSN", "postgresql://127.0.0.1:55432/scitex")
 
+#: Was the target DECLARED, or did we fall back to the default?
+#:
+#: The distinction decides skip-vs-fail, and it is the whole point. "This
+#: laptop has no cluster" is a fact about a machine and may be skipped. "The
+#: target somebody explicitly configured does not work" is a
+#: MISCONFIGURATION, and a misconfiguration that skips is indistinguishable
+#: from a pass — which is exactly how this suite came to report green while
+#: executing zero PostgreSQL coverage.
+PG_DSN_WAS_DECLARED = "SAC_TEST_PG_DSN" in os.environ
+
+#: Set to "1" to make an unusable target a hard FAILURE rather than a skip.
+#:
+#: Intended for the RELEASE gate. A pull request may proceed with PostgreSQL
+#: coverage skipped, because the alternative is a blocked queue; a TAG must
+#: not publish having silently run none of it.
+PG_REQUIRED = os.environ.get("SAC_TEST_PG_REQUIRED") == "1"
+
+#: The fleet's replication cluster, which tests must NEVER write to.
+#:
+#: Every node of it — primary and replicas alike — reports this identifier,
+#: so one comparison recognises the production cluster no matter which host
+#: the DSN happens to resolve to, and no matter which node is primary today.
+#: That last part matters: the operator has stated failover is expected
+#: (2026-08-26), so a guard naming a HOST would protect the wrong machine the
+#: moment the primary moves. Identity travels with the cluster; addresses do
+#: not.
+#:
+#: This exists because the honest fix for CI is to give tests their own
+#: throwaway database, and the failure mode of that work is pointing at the
+#: real cluster by accident. The cluster lost a primary-key index to a libc
+#: mismatch on 2026-08-25; it does not need CI creating and dropping schemas
+#: in it as well.
+FLEET_SYSTEM_ID = os.environ.get("SAC_TEST_PG_FORBIDDEN_SYSTEM_ID", "7672112238472680366")
+
 
 def _default_test_pg_user() -> str:
     """The login role tests authenticate as when nothing declares one.
@@ -201,9 +235,87 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
     os.environ[pguser_key] = PG_TEST_USER
 
     schema = "sac_test_" + uuid.uuid4().hex[:12]
+
+    def _restore_identity() -> None:
+        """Put PGPASSFILE/PGUSER back exactly as they were.
+
+        Hoisted out of the handlers because it now has FOUR call sites and
+        one of them is a teardown that previously skipped it — see the
+        ``finally`` below.
+        """
+        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
+            if saved_ is None:
+                os.environ.pop(key_, None)
+            else:
+                os.environ[key_] = saved_
+
+    def _unusable(reason: str, *, hard: bool) -> None:
+        """Report an unusable target — loudly, and never silently.
+
+        ``hard`` fails the run; otherwise it skips. Either way the reason
+        names the DSN and the role, so a skip on a host that is SUPPOSED to
+        have a writable database reads as the misconfiguration it is instead
+        of disappearing into a skip count. The GitHub ``::warning::`` is
+        emitted on the skip path too: an annotation blocks nothing, but it
+        puts the words on the summary page, and the diagnosis of the
+        2026-08-26 incident required reconstructing the skip count by
+        arithmetic from a 9.9 MB log because nothing said it out loud.
+        """
+        _restore_identity()
+        message = (
+            f"PostgreSQL fixture cannot use {PG_BASE_DSN} as {PG_TEST_USER}: {reason}"
+        )
+        if hard:
+            pytest.fail(message, pytrace=False)
+        print(f"::warning title=PostgreSQL coverage skipped::{message}", flush=True)
+        pytest.skip(message)
+
     try:
         with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            # Refuse the production cluster BEFORE issuing any DDL. On a
+            # replica the CREATE would fail anyway; on the PRIMARY it would
+            # succeed, which is the outcome worth preventing.
+            row = conn.execute(
+                "SELECT system_identifier::text, pg_is_in_recovery() "
+                "FROM pg_control_system()"
+            ).fetchone()
+            if row and row[0] == FLEET_SYSTEM_ID:
+                # Same cluster, two very different situations, and collapsing
+                # them turns this guard into an outage. Measured 2026-08-26:
+                # treating both as fatal made every runner RED, because
+                # loopback on a runner IS a fleet replica and always will be.
+                if not row[1]:
+                    # NOT in recovery -> this is the PRIMARY, where a CREATE
+                    # SCHEMA would SUCCEED. That is the only case worth
+                    # failing over: the write lands in production.
+                    _unusable(
+                        f"that is the fleet PRIMARY (system_identifier={row[0]}). "
+                        f"Tests must never create schemas in production; point "
+                        f"SAC_TEST_PG_DSN at a throwaway database.",
+                        hard=True,
+                    )
+                # In recovery -> a read-only replica. Nothing can be written
+                # here, so this is simply "no writable database on this host",
+                # which per the operator's 2026-08-26 ruling (one primary, all
+                # else read-only replicas) is the PERMANENT shape of every
+                # runner until CI provisions its own database.
+                _unusable(
+                    f"loopback is a read-only replica of the fleet cluster "
+                    f"(system_identifier={row[0]}); there is no writable "
+                    f"database on this host",
+                    hard=PG_REQUIRED or PG_DSN_WAS_DECLARED,
+                )
             conn.execute(f'CREATE SCHEMA "{schema}"')
+    except psycopg.errors.ReadOnlySqlTransaction as exc:
+        # CONNECTED, but the server will not accept writes — a read-only
+        # replica. This is NOT the "no cluster here" case below and must not
+        # be folded into it: psycopg models it as InternalError, not
+        # OperationalError, so the handler that follows never saw it and the
+        # tests errored instead. Per the operator's 2026-08-26 ruling the
+        # fleet is one primary plus read-only replicas, so loopback on a
+        # runner is a replica BY DESIGN and this is now the expected shape
+        # until CI provisions its own database.
+        _unusable(f"the server is a read-only replica ({exc})", hard=PG_REQUIRED or PG_DSN_WAS_DECLARED)
     except psycopg.OperationalError as exc:
         # SKIP, not fail: not every machine that runs this suite still has a
         # local cluster. The fleet's stores were consolidated onto the primary
@@ -219,15 +331,12 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
         # The reason string names the DSN so a skip on a host that is SUPPOSED
         # to have a cluster reads as the misconfiguration it is, instead of
         # disappearing into a skip count.
-        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
-            if saved_ is None:
-                os.environ.pop(key_, None)
-            else:
-                os.environ[key_] = saved_
-        pytest.skip(
-            f"no reachable PostgreSQL for the test fixture at {PG_BASE_DSN} "
-            f"as {PG_TEST_USER}: {exc}"
-        )
+        #
+        # STILL A SKIP BY DEFAULT, but no longer a silent one, and no longer
+        # unconditional: if somebody DECLARED SAC_TEST_PG_DSN, an unreachable
+        # target is their configuration being wrong, not this machine lacking
+        # a cluster, and it fails.
+        _unusable(f"no reachable PostgreSQL ({exc})", hard=PG_REQUIRED or PG_DSN_WAS_DECLARED)
 
     key = "SCITEX_STORE_DSN"
     saved = os.environ.get(key)
@@ -239,10 +348,17 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
             os.environ.pop(key, None)
         else:
             os.environ[key] = saved
-        with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
-            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
-        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
-            if saved_ is None:
-                os.environ.pop(key_, None)
-            else:
-                os.environ[key_] = saved_
+        # The DROP is wrapped because the identity restore below MUST happen
+        # even when it raises. Previously it did not: the connect/DROP sat
+        # outside any try with the restore after it, so a server that went
+        # read-only or unreachable mid-run left this fixture's PGPASSFILE and
+        # PGUSER installed in os.environ for every later test on the same
+        # xdist worker. A leaked identity does not fail here; it fails
+        # somewhere else, later, as something that looks unrelated.
+        try:
+            with psycopg.connect(
+                PG_BASE_DSN, connect_timeout=10, autocommit=True
+            ) as conn:
+                conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            _restore_identity()


### PR DESCRIPTION
## The bug is not that CI went red. It is that CI went green.

For at least a day this suite reported **green while running zero PostgreSQL coverage**, and nothing in the output said so.

The fleet is one primary (nas-03) with read-only replicas, and every self-hosted runner's loopback `:55432` is one of those replicas. Two of the three online runners have no `.pgpass` row for the test role, so the fixture failed at **connect**, hit `except psycopg.OperationalError`, and silently skipped 308 tests → green. The third runner *has* the row, so it connected and died on `CREATE SCHEMA` → 308 errors → red.

Same commit, same code, opposite verdicts, decided by which host drew the job.

Neither outcome was informative. The red looked like a code defect and wasn't. The green looked like a pass and was zero coverage. Establishing what had happened required reconstructing `392 − 84 = 308` by arithmetic from a 9.9 MB log, because `-q` prints a bare skip count and no reasons.

## The proximate defect is one line of taxonomy

`psycopg` models "connected, but the server is read-only" as `ReadOnlySqlTransaction → InternalError` — **not** `OperationalError` (measured; sqlstate 25006). So the handler caught *cannot connect* and let *cannot write* through as an error.

## What changes: silence becomes hard to get

- **Skip-vs-fail now turns on whether the target was declared.** "This machine has no cluster" is a fact about a machine and may skip. "The target somebody configured does not work" is a **misconfiguration** and fails — because a misconfiguration that skips is indistinguishable from a pass, which is the entire incident.
- `ReadOnlySqlTransaction` is caught explicitly and reported as what it is.
- Every skip names the DSN, the role and the reason, and emits a GitHub `::warning::`.
- `-rs` on the pytest invocation, so skip reasons exist at all.
- `SAC_TEST_PG_REQUIRED=1` turns any unusable target into a hard failure — intended for the **release** gate. A PR may proceed with PostgreSQL coverage skipped; a tag must not publish having silently run none of it.

## A fleet guard keyed to the cluster, not a host

Before issuing DDL the fixture reads `pg_control_system()`. If `system_identifier` matches the production cluster **and** the server is not in recovery — i.e. it is the **primary**, where `CREATE SCHEMA` would *succeed* — it fails hard. Tests must never create schemas in production; that cluster lost a primary-key index to a libc mismatch on 2026-08-25 and does not need CI churn as well.

The identifier is identical on primary and replicas, so one comparison recognises production regardless of which node is primary today. That matters because **failover is expected**, and a guard naming a *host* would protect the wrong machine the moment the primary moves.

The severity split is not cosmetic. Treating "same cluster" as uniformly fatal was my first version, and it produced 34 errors on a plain local run — every runner red, worse than the defect being fixed, because loopback on a runner *is* a replica and permanently will be. Only the primary case is dangerous; the replica case is simply "no writable database here".

## Also fixed (pre-existing)

The teardown ran `DROP SCHEMA` outside any `try`, with the `PGPASSFILE`/`PGUSER` restore *after* it. A `DROP` that raised — exactly what a server going read-only mid-run causes — stranded this fixture's identity in `os.environ` for every later test on the same xdist worker. A leaked identity does not fail where it leaks; it fails later, looking unrelated.

## Measured, across all 28 `pg_schema`-dependent files

| scenario | result |
|---|---|
| default target (fleet replica) | **190 passed, 279 skipped, 0 errors** — every skip explained |
| explicit unreachable DSN | fails, does not skip |
| `SAC_TEST_PG_REQUIRED=1` | fails, does not skip |

## Scope: this makes the gate honest, not covered

The PostgreSQL tests still do not run on CI. Restoring real coverage is the follow-up — a host-side ephemeral database, which pre-flight confirms is viable: every runner host carries a postgres SIF in `~/.scitex/pg` plus apptainer. It must pick a free port at runtime and keep its datadir **outside** `~/.scitex/pg`, where the live standby data sits.

Not done here, and worth a reviewer's eye: `psycopg.errors.ReadOnlySqlTransaction` is verified in the host venv but **not** inside `ci-cpu.sif`, where the tests actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
