### PR TITLE
feat(ci): CI provisions its own database instead of borrowing the fleet's

### DIFF
--- a/.github/ci/exec-in-sif.sh
+++ b/.github/ci/exec-in-sif.sh
@@ -208,6 +208,135 @@ fi
 ci_tmpdir_prune
 # --- end scitex-agent-container-specific -------------------------------------
 
+# --- a throwaway PostgreSQL for the suite ------------------------------------
+# WHY THIS EXISTS. 308 tests across 28 files need a writable PostgreSQL. They
+# used to get one from the runner's own loopback :55432, and on 2026-08-26 that
+# stopped being true everywhere at once: the fleet is one primary (nas-03) plus
+# READ-ONLY REPLICAS, and every runner's local cluster is a replica. Two of the
+# three runners lacked a .pgpass row so the fixture skipped silently and the job
+# went GREEN having run none of it; the third had the row, connected, and died
+# on CREATE SCHEMA. Same commit, opposite verdicts, decided by which host drew
+# the job. The gate was a coin flip, and two thirds of the time it was blind.
+#
+# Pointing the tests at the primary instead was considered and rejected: that is
+# ~616 DDL statements per leg on the production cluster, replicated to every
+# standby, on a database that lost a primary-key index to a libc mismatch the
+# day before. Tests get their OWN database or none.
+#
+# WHY HERE and not inside the SIF: ci-cpu.sif ships no server binaries
+# (`command -v initdb pg_ctl postgres` prints nothing in it) and apptainer does
+# not nest, so the server cannot be started from the test process. This script
+# is the one place that runs on the RUNNER, and it is shared verbatim by the PR
+# gate and the release gate -- which is the point. Putting this in the workflow
+# YAML would fork those two apart again, and this file's own header is a
+# monument to what that cost last time.
+#
+# FAIL SOFT, DELIBERATELY. Every failure path below leaves SAC_TEST_PG_DSN
+# UNSET and continues. The fixture then skips with a ::warning:: naming the
+# reason (see tests/_store_isolation.py). That is a real trade and it is the
+# right way round: this script is shared by both gates, so `exit 1` here takes
+# down every build in the repo including ones that touch no database. A missing
+# test database must degrade to a LOUD skip, never to an outage.
+#
+# TEARDOWN IS BY REAPER, NOT BY TRAP, and that is forced: this script ends in
+# `exec`, which replaces the shell, so an EXIT trap would never fire. The same
+# reasoning the tmpdir prune above already uses applies -- age is what separates
+# a leftover from a live concurrent sibling, and a reaper survives SIGKILL and
+# reboots, which a trap does not.
+CI_PG_ROOT="${TMPDIR:-/tmp}/sac-ci-pg"
+mkdir -p "$CI_PG_ROOT" 2>/dev/null || true
+
+# Reap leftovers from runs that were killed before they could clean up. The 6 h
+# floor is deliberately far longer than any leg: a concurrent matrix sibling on
+# this same runner must never be shot.
+find "$CI_PG_ROOT" -mindepth 1 -maxdepth 1 -type d -mmin +360 2>/dev/null |
+    while read -r stale; do
+        if [ -f "$stale/postmaster.pid" ]; then
+            stale_pid="$(head -1 "$stale/postmaster.pid" 2>/dev/null)"
+            case "$stale_pid" in [0-9]*) kill "$stale_pid" 2>/dev/null || true ;; esac
+        fi
+        rm -rf "$stale" 2>/dev/null || true
+        echo "exec-in-sif: reaped stale CI postgres $stale"
+    done
+
+# Resolve the server image by GLOB. The filename differs per host -- measured
+# 2026-08-26: compute-03 carries postgres18.sif, compute-01 and compute-04 carry
+# postgres18-18.4.sif and compute-01 has both -- so a literal name would work on
+# one runner and not the next, which is the failure shape this whole change
+# exists to end.
+CI_PG_SIF=""
+for _cand in "$HOME"/.scitex/pg/postgres*.sif; do
+    [ -f "$_cand" ] && CI_PG_SIF="$_cand"
+done
+
+if [ -z "$CI_PG_SIF" ]; then
+    echo "::warning::no postgres SIF under $HOME/.scitex/pg — PostgreSQL tests will SKIP (loudly). Looked for postgres*.sif."
+else
+    # A free port, chosen by ASKING THE KERNEL rather than assuming. Do not
+    # hardcode: 55432 is the fleet cluster and compute-03 already runs an
+    # unrelated postgres on 5433. Binding port 0 and reading the assignment
+    # back races with other bidders in principle; in practice the window is
+    # microseconds and the alternative -- a fixed guess -- is wrong on a host
+    # nobody has probed yet.
+    CI_PG_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()' 2>/dev/null || echo "")"
+    CI_PG_DATA="$CI_PG_ROOT/$$-$(date +%s)"
+
+    if [ -z "$CI_PG_PORT" ]; then
+        echo "::warning::could not obtain a free port for the CI postgres — PostgreSQL tests will SKIP (loudly)."
+    else
+        # NOTE ON THE DATADIR: it is under TMPDIR, never under ~/.scitex/pg.
+        # That directory holds the SIFs AND the LIVE data -- ~/.scitex/pg/18/main
+        # carries standby.signal and ~/.scitex/pg/cards18 is the card store. A
+        # mistyped -D there destroys a replica of a cluster that is already one
+        # libc incident deep.
+        mkdir -p "$CI_PG_DATA"
+        if "$APPTAINER" exec --bind "$CI_PG_ROOT" "$CI_PG_SIF" \
+               initdb -D "$CI_PG_DATA" -U ci_tests --auth=trust >/dev/null 2>&1; then
+            "$APPTAINER" exec --bind "$CI_PG_ROOT" "$CI_PG_SIF" \
+                postgres -D "$CI_PG_DATA" -p "$CI_PG_PORT" \
+                -c listen_addresses=127.0.0.1 \
+                -c unix_socket_directories="$CI_PG_DATA" \
+                -c fsync=off \
+                -c full_page_writes=off -c synchronous_commit=off \
+                >"$CI_PG_DATA/server.log" 2>&1 &
+            # unix_socket_directories is NOT optional here, and the failure it
+            # prevents is not guessable from its message. MEASURED on
+            # scitex-compute-04 2026-08-26: without it the server starts, binds
+            # the TCP port, and then dies with
+            #   FATAL: could not create lock file
+            #     "/var/run/postgresql/.s.PGSQL.<port>.lock": Read-only file system
+            # A SIF is a read-only image, and PostgreSQL insists on a writable
+            # directory for its Unix socket even when every client will speak
+            # TCP. The datadir is already writable and already ours.
+            #
+            # fsync/full_page_writes off: this database is discarded at the end
+            # of the job, so durability buys nothing and costs wall clock.
+
+            CI_PG_READY=""
+            for _i in $(seq 1 40); do
+                if "$APPTAINER" exec --bind "$CI_PG_ROOT" "$CI_PG_SIF" \
+                       pg_isready -h 127.0.0.1 -p "$CI_PG_PORT" -q >/dev/null 2>&1; then
+                    CI_PG_READY=yes
+                    break
+                fi
+                sleep 0.5
+            done
+
+            if [ -n "$CI_PG_READY" ]; then
+                export APPTAINERENV_SAC_TEST_PG_DSN="postgresql://127.0.0.1:$CI_PG_PORT/postgres"
+                export APPTAINERENV_PGUSER="ci_tests"
+                echo "exec-in-sif: CI postgres ready on 127.0.0.1:$CI_PG_PORT (data=$CI_PG_DATA, image=$(basename "$CI_PG_SIF"))"
+            else
+                echo "::warning::CI postgres did not accept connections within 20s — PostgreSQL tests will SKIP (loudly). Log tail:"
+                tail -5 "$CI_PG_DATA/server.log" 2>/dev/null || true
+            fi
+        else
+            echo "::warning::initdb failed for the CI postgres — PostgreSQL tests will SKIP (loudly)."
+        fi
+    fi
+fi
+# --- end throwaway PostgreSQL ------------------------------------------------
+
 # Build the argv as an ARRAY so the GPFS bind can be dropped cleanly rather than
 # passed as an empty string. --pwd "$PWD" keeps the checkout as cwd.
 APPTAINER_ARGV=(exec --pwd "$PWD")

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -427,6 +427,14 @@ fi
 # after EVERY test, so loadscope's "same worker per module" buys nothing here —
 # it only serialized. `load` spreads the parametrized cases across ALL workers.
 #
+# -rs: PRINT SKIP REASONS. Without it `-q` prints a bare count, and on
+# 2026-08-26 that made a blind gate look like a healthy one: 308 PostgreSQL
+# tests were skipping on two of three runners for want of a writable database
+# and every one of those runs reported green. Establishing that took
+# reconstructing 392 - 84 = 308 by arithmetic from a 9.9 MB log, because
+# nothing in the output said which tests were skipped or why. A skip that
+# nobody can see is a pass.
+#
 # nice -n 19 ionice -c 3: run at the lowest CPU + idle I/O priority so that if
 # this node is ever shared with interactive/dev work, CI grabs otherwise-idle
 # cores but YIELDS the CPU and disk to any higher-priority process — "all
@@ -434,6 +442,6 @@ fi
 # which execs ionice, which execs python (still PID-traceable, signals/exit
 # code propagate to the runner step).
 exec nice -n 19 ionice -c 3 \
-    python -m pytest tests/ -n "$WORKERS" --dist load -q \
+    python -m pytest tests/ -n "$WORKERS" --dist load -q -rs \
     --cov=src/scitex_agent_container --cov-report=xml --cov-report=term \
     -p no:cacheprovider

--- a/tests/_store_isolation.py
+++ b/tests/_store_isolation.py
@@ -82,6 +82,31 @@ PG_REQUIRED = os.environ.get("SAC_TEST_PG_REQUIRED") == "1"
 FLEET_SYSTEM_ID = os.environ.get("SAC_TEST_PG_FORBIDDEN_SYSTEM_ID", "7672112238472680366")
 
 
+def pg_endpoint_port() -> str:
+    """The PORT of the database under test, as a locator would print it.
+
+    Four tests assert that ``init_*_schema()`` returns a locator NAMING the
+    endpoint it wrote to — the property being that state cannot land somewhere
+    without saying where. They each hardcoded ``"55432"``, which was not the
+    property but an assumption about the environment: the fleet's loopback
+    port. It held only because every runner happened to have the fleet cluster
+    there.
+
+    MEASURED 2026-08-26: the moment CI provisioned its own throwaway database
+    on an ephemeral port, all four failed with
+    ``assert '55432' in 'postgres[host=127.0.0.1 db=postgres port=46313]'``.
+    The locator was correct; the expectation was pinned to a machine.
+
+    Deriving it from ``PG_BASE_DSN`` keeps the assertion testing the thing it
+    was written to test — the locator names the endpoint — while surviving any
+    database the suite is pointed at.
+    """
+    from urllib.parse import urlsplit
+
+    port = urlsplit(PG_BASE_DSN).port
+    return str(port) if port else "5432"
+
+
 def _default_test_pg_user() -> str:
     """The login role tests authenticate as when nothing declares one.
 

--- a/tests/_store_isolation.py
+++ b/tests/_store_isolation.py
@@ -255,11 +255,18 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
         ``hard`` fails the run; otherwise it skips. Either way the reason
         names the DSN and the role, so a skip on a host that is SUPPOSED to
         have a writable database reads as the misconfiguration it is instead
-        of disappearing into a skip count. The GitHub ``::warning::`` is
-        emitted on the skip path too: an annotation blocks nothing, but it
-        puts the words on the summary page, and the diagnosis of the
-        2026-08-26 incident required reconstructing the skip count by
-        arithmetic from a 9.9 MB log because nothing said it out loud.
+        of disappearing into a skip count.
+
+        VISIBILITY COMES FROM ``-rs``, NOT FROM AN ANNOTATION, and that is a
+        correction rather than a preference. The first version of this
+        printed a GitHub ``::warning::`` here. MEASURED on run
+        32919218635: the reason text appears **308 times** in the CI log
+        while the annotation appears **zero** times — pytest captures fixture
+        stdout, so the annotation never reached the step output at all. It
+        was decoration that looked like a safeguard. The mechanism that
+        actually works is ``-rs`` on the pytest invocation, which prints
+        every skip reason in the summary; that is what put those 308 lines
+        there.
         """
         _restore_identity()
         message = (
@@ -267,7 +274,6 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
         )
         if hard:
             pytest.fail(message, pytrace=False)
-        print(f"::warning title=PostgreSQL coverage skipped::{message}", flush=True)
         pytest.skip(message)
 
     try:

--- a/tests/_store_isolation.py
+++ b/tests/_store_isolation.py
@@ -47,6 +47,40 @@ import pytest
 #: where libpq finds it without any credential entering this file.
 PG_BASE_DSN = os.environ.get("SAC_TEST_PG_DSN", "postgresql://127.0.0.1:55432/scitex")
 
+#: Was the target DECLARED, or did we fall back to the default?
+#:
+#: The distinction decides skip-vs-fail, and it is the whole point. "This
+#: laptop has no cluster" is a fact about a machine and may be skipped. "The
+#: target somebody explicitly configured does not work" is a
+#: MISCONFIGURATION, and a misconfiguration that skips is indistinguishable
+#: from a pass — which is exactly how this suite came to report green while
+#: executing zero PostgreSQL coverage.
+PG_DSN_WAS_DECLARED = "SAC_TEST_PG_DSN" in os.environ
+
+#: Set to "1" to make an unusable target a hard FAILURE rather than a skip.
+#:
+#: Intended for the RELEASE gate. A pull request may proceed with PostgreSQL
+#: coverage skipped, because the alternative is a blocked queue; a TAG must
+#: not publish having silently run none of it.
+PG_REQUIRED = os.environ.get("SAC_TEST_PG_REQUIRED") == "1"
+
+#: The fleet's replication cluster, which tests must NEVER write to.
+#:
+#: Every node of it — primary and replicas alike — reports this identifier,
+#: so one comparison recognises the production cluster no matter which host
+#: the DSN happens to resolve to, and no matter which node is primary today.
+#: That last part matters: the operator has stated failover is expected
+#: (2026-08-26), so a guard naming a HOST would protect the wrong machine the
+#: moment the primary moves. Identity travels with the cluster; addresses do
+#: not.
+#:
+#: This exists because the honest fix for CI is to give tests their own
+#: throwaway database, and the failure mode of that work is pointing at the
+#: real cluster by accident. The cluster lost a primary-key index to a libc
+#: mismatch on 2026-08-25; it does not need CI creating and dropping schemas
+#: in it as well.
+FLEET_SYSTEM_ID = os.environ.get("SAC_TEST_PG_FORBIDDEN_SYSTEM_ID", "7672112238472680366")
+
 
 def _default_test_pg_user() -> str:
     """The login role tests authenticate as when nothing declares one.
@@ -201,9 +235,87 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
     os.environ[pguser_key] = PG_TEST_USER
 
     schema = "sac_test_" + uuid.uuid4().hex[:12]
+
+    def _restore_identity() -> None:
+        """Put PGPASSFILE/PGUSER back exactly as they were.
+
+        Hoisted out of the handlers because it now has FOUR call sites and
+        one of them is a teardown that previously skipped it — see the
+        ``finally`` below.
+        """
+        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
+            if saved_ is None:
+                os.environ.pop(key_, None)
+            else:
+                os.environ[key_] = saved_
+
+    def _unusable(reason: str, *, hard: bool) -> None:
+        """Report an unusable target — loudly, and never silently.
+
+        ``hard`` fails the run; otherwise it skips. Either way the reason
+        names the DSN and the role, so a skip on a host that is SUPPOSED to
+        have a writable database reads as the misconfiguration it is instead
+        of disappearing into a skip count. The GitHub ``::warning::`` is
+        emitted on the skip path too: an annotation blocks nothing, but it
+        puts the words on the summary page, and the diagnosis of the
+        2026-08-26 incident required reconstructing the skip count by
+        arithmetic from a 9.9 MB log because nothing said it out loud.
+        """
+        _restore_identity()
+        message = (
+            f"PostgreSQL fixture cannot use {PG_BASE_DSN} as {PG_TEST_USER}: {reason}"
+        )
+        if hard:
+            pytest.fail(message, pytrace=False)
+        print(f"::warning title=PostgreSQL coverage skipped::{message}", flush=True)
+        pytest.skip(message)
+
     try:
         with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            # Refuse the production cluster BEFORE issuing any DDL. On a
+            # replica the CREATE would fail anyway; on the PRIMARY it would
+            # succeed, which is the outcome worth preventing.
+            row = conn.execute(
+                "SELECT system_identifier::text, pg_is_in_recovery() "
+                "FROM pg_control_system()"
+            ).fetchone()
+            if row and row[0] == FLEET_SYSTEM_ID:
+                # Same cluster, two very different situations, and collapsing
+                # them turns this guard into an outage. Measured 2026-08-26:
+                # treating both as fatal made every runner RED, because
+                # loopback on a runner IS a fleet replica and always will be.
+                if not row[1]:
+                    # NOT in recovery -> this is the PRIMARY, where a CREATE
+                    # SCHEMA would SUCCEED. That is the only case worth
+                    # failing over: the write lands in production.
+                    _unusable(
+                        f"that is the fleet PRIMARY (system_identifier={row[0]}). "
+                        f"Tests must never create schemas in production; point "
+                        f"SAC_TEST_PG_DSN at a throwaway database.",
+                        hard=True,
+                    )
+                # In recovery -> a read-only replica. Nothing can be written
+                # here, so this is simply "no writable database on this host",
+                # which per the operator's 2026-08-26 ruling (one primary, all
+                # else read-only replicas) is the PERMANENT shape of every
+                # runner until CI provisions its own database.
+                _unusable(
+                    f"loopback is a read-only replica of the fleet cluster "
+                    f"(system_identifier={row[0]}); there is no writable "
+                    f"database on this host",
+                    hard=PG_REQUIRED or PG_DSN_WAS_DECLARED,
+                )
             conn.execute(f'CREATE SCHEMA "{schema}"')
+    except psycopg.errors.ReadOnlySqlTransaction as exc:
+        # CONNECTED, but the server will not accept writes — a read-only
+        # replica. This is NOT the "no cluster here" case below and must not
+        # be folded into it: psycopg models it as InternalError, not
+        # OperationalError, so the handler that follows never saw it and the
+        # tests errored instead. Per the operator's 2026-08-26 ruling the
+        # fleet is one primary plus read-only replicas, so loopback on a
+        # runner is a replica BY DESIGN and this is now the expected shape
+        # until CI provisions its own database.
+        _unusable(f"the server is a read-only replica ({exc})", hard=PG_REQUIRED or PG_DSN_WAS_DECLARED)
     except psycopg.OperationalError as exc:
         # SKIP, not fail: not every machine that runs this suite still has a
         # local cluster. The fleet's stores were consolidated onto the primary
@@ -219,15 +331,12 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
         # The reason string names the DSN so a skip on a host that is SUPPOSED
         # to have a cluster reads as the misconfiguration it is, instead of
         # disappearing into a skip count.
-        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
-            if saved_ is None:
-                os.environ.pop(key_, None)
-            else:
-                os.environ[key_] = saved_
-        pytest.skip(
-            f"no reachable PostgreSQL for the test fixture at {PG_BASE_DSN} "
-            f"as {PG_TEST_USER}: {exc}"
-        )
+        #
+        # STILL A SKIP BY DEFAULT, but no longer a silent one, and no longer
+        # unconditional: if somebody DECLARED SAC_TEST_PG_DSN, an unreachable
+        # target is their configuration being wrong, not this machine lacking
+        # a cluster, and it fails.
+        _unusable(f"no reachable PostgreSQL ({exc})", hard=PG_REQUIRED or PG_DSN_WAS_DECLARED)
 
     key = "SCITEX_STORE_DSN"
     saved = os.environ.get(key)
@@ -239,10 +348,17 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
             os.environ.pop(key, None)
         else:
             os.environ[key] = saved
-        with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
-            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
-        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
-            if saved_ is None:
-                os.environ.pop(key_, None)
-            else:
-                os.environ[key_] = saved_
+        # The DROP is wrapped because the identity restore below MUST happen
+        # even when it raises. Previously it did not: the connect/DROP sat
+        # outside any try with the restore after it, so a server that went
+        # read-only or unreachable mid-run left this fixture's PGPASSFILE and
+        # PGUSER installed in os.environ for every later test on the same
+        # xdist worker. A leaked identity does not fail here; it fails
+        # somewhere else, later, as something that looks unrelated.
+        try:
+            with psycopg.connect(
+                PG_BASE_DSN, connect_timeout=10, autocommit=True
+            ) as conn:
+                conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            _restore_identity()

--- a/tests/scitex_agent_container/_state/test_relocation_pg.py
+++ b/tests/scitex_agent_container/_state/test_relocation_pg.py
@@ -26,6 +26,8 @@ never touched. Real store, real database, no mocks (PA-306), one assert each
 
 from __future__ import annotations
 
+from tests._store_isolation import pg_endpoint_port
+
 from functools import partial
 
 import pytest
@@ -66,7 +68,7 @@ def _relocation(to_host: str, at: float) -> Relocation:
 
 def test_init_reports_where_the_state_went(pg_schema: str) -> None:
     # Arrange
-    expected_fragment = "55432"
+    expected_fragment = pg_endpoint_port()
     # Act
     locator = init_relocation_schema()
     # Assert

--- a/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
+++ b/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
@@ -18,6 +18,8 @@ Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
 
 from __future__ import annotations
 
+from tests._store_isolation import pg_endpoint_port
+
 import pytest
 
 from scitex_agent_container._state.state_db_pending_approval import (
@@ -241,7 +243,7 @@ def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> 
         init_pending_prompts_schema,
     )
 
-    expected = "55432"
+    expected = pg_endpoint_port()
     # Act
     locator = init_pending_prompts_schema()
     # Assert

--- a/tests/scitex_agent_container/_state/test_state_db_token_owner.py
+++ b/tests/scitex_agent_container/_state/test_state_db_token_owner.py
@@ -37,6 +37,8 @@ and the point is that the REAL resolver reads the REAL variable.
 
 from __future__ import annotations
 
+from tests._store_isolation import pg_endpoint_port
+
 import psycopg
 
 from scitex_agent_container._account._rotation_audit import fingerprint_token
@@ -95,7 +97,7 @@ def test_init_creates_the_ledger_in_postgres(pg_schema: str) -> None:
 
 def test_init_reports_where_the_state_went(pg_schema: str) -> None:
     # Arrange
-    expected_fragment = "55432"
+    expected_fragment = pg_endpoint_port()
     # Act
     locator = init_token_owner_schema()
     # Assert

--- a/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
+++ b/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
@@ -48,6 +48,8 @@ and the point is that the REAL resolver reads the REAL variable.
 
 from __future__ import annotations
 
+from tests._store_isolation import pg_endpoint_port
+
 import psycopg
 
 from scitex_agent_container._state.state_db_verdict_dedup import (
@@ -105,7 +107,7 @@ def test_init_reports_where_the_state_went(pg_schema: str) -> None:
     cannot say where it is is a store nobody can verify.
     """
     # Arrange
-    expected_fragment = "55432"
+    expected_fragment = pg_endpoint_port()
     # Act
     locator = init_verdict_dedup_schema()
     # Assert


### PR DESCRIPTION
> **Stacked on #1220** — that PR is the first commit here. Merge #1220 first; GitHub will retarget this one. Reviewing only the second commit (`44fbfb67`) gives the diff this PR is about.

## Stage 1 made the gate honest. This makes it covered.

#1220 taught the suite to say out loud when it is *not* exercising PostgreSQL. It did not restore the coverage: 308 tests across 28 files still skip. This runs them.

## Why they stopped running

The fleet is one primary (nas-03) plus **read-only replicas**, and every runner's local `:55432` is a replica. The tests need a writable database and there is no longer one anywhere on the host.

**Pointing them at the primary was considered and rejected**: ~616 DDL statements per matrix leg against the production cluster, replicated to every standby, on a database that lost a primary-key index to a libc mismatch the day before. Tests get their own database or none.

## Why the provisioning lives in `exec-in-sif.sh`

`ci-cpu.sif` ships no server binaries and apptainer does not nest, so the server cannot be started from inside the test process. This script is the one place that runs **on the runner** — and it is shared *verbatim* by the PR gate and the release gate. Putting this in the workflow YAML would fork those two apart again, and this file's own header is a monument to what that cost the last time they diverged.

## Measured end-to-end on scitex-compute-04, before the final form was written

```
initdb: OK (port 39359)
ready : yes
guard : in_recovery=false  sysid=7678148447502556495
write : CREATE+DROP SCHEMA OK
```

The `sysid` differs from the fleet's `7672112238472680366`, so **#1220's cluster guard admits this database as a genuine throwaway while still refusing the production primary**. The two changes compose exactly as intended.

## The failure that cost a round

The first attempt started the server, bound the TCP port, and then died:

```
FATAL: could not create lock file "/var/run/postgresql/.s.PGSQL.<port>.lock": Read-only file system
```

A SIF is a read-only image, and PostgreSQL demands a **writable** directory for its Unix socket even when every client will speak TCP. Hence `unix_socket_directories` pointed at the datadir. No amount of reading the design would have found this; only running it did.

## Fail soft, on every path

Missing image, no free port, `initdb` failure, server never ready — each leaves `SAC_TEST_PG_DSN` unset, prints a `::warning::` naming the reason, and continues. #1220 then turns that into a loud, explained skip.

This is deliberate and it is the right way round: the script is shared by both gates, so `exit 1` here breaks every build in the repo including ones that touch no database. **A missing test database must degrade to a visible skip, never to an outage.**

## Teardown is a reaper, not a trap

Forced rather than chosen: this script ends in `exec`, which replaces the shell, so an EXIT trap can never fire. Leftovers are cleaned at the **start** of the next run, with a 6 h age floor so a concurrent matrix sibling on the same runner is never shot — the same age-based rule the tmpdir prune above it already uses, and unlike a trap it survives SIGKILL and reboot.

## Two details that would otherwise be flakes

- The image is resolved by **glob**. Measured: compute-03 carries `postgres18.sif`; compute-01 and compute-04 carry `postgres18-18.4.sif`. A literal name works on one runner and not the next.
- The port is obtained by **asking the kernel**, not assumed. `55432` is the fleet cluster, and compute-03 already runs an unrelated postgres on `5433`.

## What a reviewer should check

The datadir is under `TMPDIR` and **never** under `~/.scitex/pg` — that tree holds the SIFs *and* the live data (`18/main` carries `standby.signal`, `cards18` is the card store). A mistyped `-D` there destroys a replica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
