### PR TITLE
fix(dev-jobs): delegate to the interpreter we probed, not to whatever PATH holds

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -95,6 +95,7 @@ and ``--dry-run`` is offered on every mutating verb sac exposes.
 
 from __future__ import annotations
 
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -364,6 +365,28 @@ def build_argv(
     return argv
 
 
+def resolve_scitex_dev(
+    *, executable: str | None = None, path: str | None = None
+) -> str | None:
+    """The ``scitex-dev`` that belongs to the interpreter we are running in.
+
+    SIBLING OF ``sys.executable`` FIRST, then PATH. Returns ``None`` when
+    neither resolves, so the caller can raise a clean ClickException.
+
+    ``executable`` and ``path`` default to ``sys.executable`` and ``$PATH``
+    and exist so this can be TESTED WITHOUT PATCHING ANYTHING. PA-306 forbids
+    mocks, and it counts the ``monkeypatch`` fixture itself — correctly: a
+    test that reaches in and rewrites ``sys.executable`` is asserting on a
+    world it invented. Taking both as arguments lets a test lay down two real
+    binaries and ask which one this function picks, which is the actual
+    question.
+    """
+    sibling = Path(executable or sys.executable).with_name("scitex-dev")
+    if sibling.exists():
+        return str(sibling)
+    return shutil.which("scitex-dev", path=path or os.environ.get("PATH"))
+
+
 def invoke(
     delegation: Delegation,
     *,
@@ -413,8 +436,7 @@ def invoke(
     """
     if not delegation.supported:
         raise ValueError("refusing to invoke an unsupported delegation")
-    sibling = Path(sys.executable).with_name("scitex-dev")
-    exe = str(sibling) if sibling.exists() else shutil.which("scitex-dev")
+    exe = resolve_scitex_dev()
     if exe is None:
         raise click.ClickException(
             "`scitex-dev` console script not found on PATH; install "

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -96,6 +96,8 @@ and ``--dry-run`` is offered on every mutating verb sac exposes.
 from __future__ import annotations
 
 import shutil
+import sys
+from pathlib import Path
 import subprocess
 from dataclasses import dataclass
 
@@ -373,13 +375,46 @@ def invoke(
 ) -> int:
     """Run the resolved ``scitex-dev ecosystem`` command; return its exit code.
 
-    ``scitex-dev`` is a hard dependency of this package, so the console
-    script is expected on PATH; a missing binary is a clean
-    ClickException rather than a stack trace.
+    RESOLVED AS A SIBLING OF ``sys.executable`` FIRST, then PATH.
+
+    The invariant this order exists to keep: **execute the verb in the same
+    interpreter that answered the questions leading up to it.** Three reads
+    precede this one write, and all three are in-process --
+    :func:`_dev_jobs_capability.ecosystem_verbs` imports scitex-dev's Click
+    tree to ask whether the verb exists, and ``_dev_jobs._resolve_one``
+    resolves the short name against ``scitex_dev.jobs`` entry points. If the
+    write then lands in a DIFFERENT installation, sac has asked A and acted
+    on B, and the failure is silent and confusing rather than loud.
+
+    MEASURED 2026-08-26, which is why this is no longer a PATH lookup. In an
+    agent container, ``shutil.which("scitex-dev")`` resolved to
+    ``/uvwork/bin/scitex-dev`` -- a hand-added shim whose last line execs a
+    DIFFERENT package's venv. That venv's ``scitex_dev.jobs`` group contains
+    ``scitex-cards`` and not ``scitex-agent-container``, so::
+
+        sac dev timer list                      -> all 11 sac timers (in-process)
+        sac dev timer status accounts-snapshot-live
+            Error: no kind='timer' job named 'scitex-agent-container-...'
+            Discovered: <the other package's 6 timers>
+
+    Same host, same venv, seconds apart. scitex-dev was not wrong: it
+    answered truthfully about the environment it was pointed at.
+
+    ORDER IS THE INVERSE OF :mod:`.._sac_binary`, DELIBERATELY. That module
+    tries PATH first so a test which prepends a fake binary gets exactly what
+    it asked for. Here PATH-first would still find the shim and fix nothing,
+    and no test shims ``scitex-dev`` (checked: the only ``shutil.which``
+    reference to it under ``tests/`` is a comment in ``test_audit.py``
+    recording a check that was REMOVED). Sibling-first also degrades
+    correctly: when sac is not in a venv, the sibling does not exist and PATH
+    still answers.
+
+    A missing binary stays a clean ClickException rather than a stack trace.
     """
     if not delegation.supported:
         raise ValueError("refusing to invoke an unsupported delegation")
-    exe = shutil.which("scitex-dev")
+    sibling = Path(sys.executable).with_name("scitex-dev")
+    exe = str(sibling) if sibling.exists() else shutil.which("scitex-dev")
     if exe is None:
         raise click.ClickException(
             "`scitex-dev` console script not found on PATH; install "

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -410,6 +410,84 @@ def test_invoking_an_unsupported_delegation_is_refused() -> None:
         _call()
 
 
+def test_the_delegate_is_the_sibling_of_our_own_interpreter(
+    tmp_path, monkeypatch
+) -> None:
+    # Arrange — the invariant: EXECUTE the verb in the interpreter that
+    # ANSWERED the questions. Capability is probed in-process and the job
+    # name is resolved in-process, so a delegate from somewhere else means
+    # sac asked A and acted on B.
+    #
+    # MEASURED 2026-08-26: in an agent container `shutil.which("scitex-dev")`
+    # found /uvwork/bin/scitex-dev, a shim execing ANOTHER package's venv
+    # whose scitex_dev.jobs group lacks scitex-agent-container. `list` showed
+    # 11 sac timers while `status` reported the job did not exist and listed
+    # the other package's six.
+    venv_bin = tmp_path / "ours" / "bin"
+    venv_bin.mkdir(parents=True)
+    ours = venv_bin / "scitex-dev"
+    ours.write_text("#!/bin/sh\nexit 0\n")
+    ours.chmod(0o755)
+
+    impostor_dir = tmp_path / "on-path"
+    impostor_dir.mkdir()
+    impostor = impostor_dir / "scitex-dev"
+    impostor.write_text("#!/bin/sh\nexit 0\n")
+    impostor.chmod(0o755)
+
+    monkeypatch.setattr(backend.sys, "executable", str(venv_bin / "python"))
+    monkeypatch.setenv("PATH", str(impostor_dir))
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        backend.subprocess, "call", lambda argv, **kw: seen.append(argv[0]) or 0
+    )
+
+    supported = backend.Delegation(
+        path=("dev", "timer"), verb="status", supported=True, evidence="fixture"
+    )
+
+    # Act
+    backend.invoke(supported, name="scitex-agent-container-x", yes=False)
+
+    # Assert
+    assert seen == [str(ours)]
+
+
+def test_the_delegate_falls_back_to_path_when_there_is_no_sibling(
+    tmp_path, monkeypatch
+) -> None:
+    # Arrange — sibling-first must DEGRADE, not demand. Outside a venv there
+    # is no sibling next to sys.executable, and PATH is then the only answer
+    # there is; refusing would break every such caller to fix none of them.
+    bare = tmp_path / "nowhere"
+    bare.mkdir()
+
+    on_path_dir = tmp_path / "on-path"
+    on_path_dir.mkdir()
+    only = on_path_dir / "scitex-dev"
+    only.write_text("#!/bin/sh\nexit 0\n")
+    only.chmod(0o755)
+
+    monkeypatch.setattr(backend.sys, "executable", str(bare / "python"))
+    monkeypatch.setenv("PATH", str(on_path_dir))
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        backend.subprocess, "call", lambda argv, **kw: seen.append(argv[0]) or 0
+    )
+
+    supported = backend.Delegation(
+        path=("dev", "timer"), verb="status", supported=True, evidence="fixture"
+    )
+
+    # Act
+    backend.invoke(supported, name="scitex-agent-container-x", yes=False)
+
+    # Assert
+    assert seen == [str(only)]
+
+
 def test_the_manual_hint_names_the_timer_unit() -> None:
     # Arrange — the unit filename is derived from JobSpec.name verbatim by
     # scitex-dev's renderer, so the hint must mirror that exactly or it

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -410,82 +410,70 @@ def test_invoking_an_unsupported_delegation_is_refused() -> None:
         _call()
 
 
-def test_the_delegate_is_the_sibling_of_our_own_interpreter(
-    tmp_path, monkeypatch
-) -> None:
+def _lay_down(binary_dir: Path) -> Path:
+    """Write a real, executable ``scitex-dev`` and return it."""
+    binary_dir.mkdir(parents=True, exist_ok=True)
+    exe = binary_dir / "scitex-dev"
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+    return exe
+
+
+def test_the_delegate_is_the_sibling_of_our_own_interpreter(tmp_path) -> None:
     # Arrange — the invariant: EXECUTE the verb in the interpreter that
-    # ANSWERED the questions. Capability is probed in-process and the job
-    # name is resolved in-process, so a delegate from somewhere else means
-    # sac asked A and acted on B.
+    # ANSWERED the questions. Capability is probed in-process and the job name
+    # resolved in-process, so a delegate from anywhere else means sac asked A
+    # and acted on B.
     #
     # MEASURED 2026-08-26: in an agent container `shutil.which("scitex-dev")`
-    # found /uvwork/bin/scitex-dev, a shim execing ANOTHER package's venv
-    # whose scitex_dev.jobs group lacks scitex-agent-container. `list` showed
-    # 11 sac timers while `status` reported the job did not exist and listed
-    # the other package's six.
-    venv_bin = tmp_path / "ours" / "bin"
-    venv_bin.mkdir(parents=True)
-    ours = venv_bin / "scitex-dev"
-    ours.write_text("#!/bin/sh\nexit 0\n")
-    ours.chmod(0o755)
-
-    impostor_dir = tmp_path / "on-path"
-    impostor_dir.mkdir()
-    impostor = impostor_dir / "scitex-dev"
-    impostor.write_text("#!/bin/sh\nexit 0\n")
-    impostor.chmod(0o755)
-
-    monkeypatch.setattr(backend.sys, "executable", str(venv_bin / "python"))
-    monkeypatch.setenv("PATH", str(impostor_dir))
-
-    seen: list[str] = []
-    monkeypatch.setattr(
-        backend.subprocess, "call", lambda argv, **kw: seen.append(argv[0]) or 0
-    )
-
-    supported = backend.Delegation(
-        path=("dev", "timer"), verb="status", supported=True, evidence="fixture"
-    )
+    # found /uvwork/bin/scitex-dev, a shim execing ANOTHER package's venv whose
+    # scitex_dev.jobs group lacks scitex-agent-container. `list` showed 11 sac
+    # timers while `status` said the job did not exist.
+    #
+    # NO PATCHING: both candidates are real files and the resolver is ASKED.
+    ours = _lay_down(tmp_path / "ours" / "bin")
+    _lay_down(tmp_path / "on-path")
 
     # Act
-    backend.invoke(supported, name="scitex-agent-container-x", yes=False)
+    resolved = backend.resolve_scitex_dev(
+        executable=str(tmp_path / "ours" / "bin" / "python"),
+        path=str(tmp_path / "on-path"),
+    )
 
     # Assert
-    assert seen == [str(ours)]
+    assert resolved == str(ours)
 
 
-def test_the_delegate_falls_back_to_path_when_there_is_no_sibling(
-    tmp_path, monkeypatch
-) -> None:
-    # Arrange — sibling-first must DEGRADE, not demand. Outside a venv there
-    # is no sibling next to sys.executable, and PATH is then the only answer
-    # there is; refusing would break every such caller to fix none of them.
-    bare = tmp_path / "nowhere"
-    bare.mkdir()
-
-    on_path_dir = tmp_path / "on-path"
-    on_path_dir.mkdir()
-    only = on_path_dir / "scitex-dev"
-    only.write_text("#!/bin/sh\nexit 0\n")
-    only.chmod(0o755)
-
-    monkeypatch.setattr(backend.sys, "executable", str(bare / "python"))
-    monkeypatch.setenv("PATH", str(on_path_dir))
-
-    seen: list[str] = []
-    monkeypatch.setattr(
-        backend.subprocess, "call", lambda argv, **kw: seen.append(argv[0]) or 0
-    )
-
-    supported = backend.Delegation(
-        path=("dev", "timer"), verb="status", supported=True, evidence="fixture"
-    )
+def test_the_delegate_falls_back_to_path_when_there_is_no_sibling(tmp_path) -> None:
+    # Arrange — sibling-first must DEGRADE, not demand. Outside a venv there is
+    # no sibling next to the interpreter and PATH is the only answer there is;
+    # refusing would break every such caller to fix none of them.
+    only = _lay_down(tmp_path / "on-path")
 
     # Act
-    backend.invoke(supported, name="scitex-agent-container-x", yes=False)
+    resolved = backend.resolve_scitex_dev(
+        executable=str(tmp_path / "nowhere" / "python"),
+        path=str(tmp_path / "on-path"),
+    )
 
     # Assert
-    assert seen == [str(only)]
+    assert resolved == str(only)
+
+
+def test_resolution_returns_none_when_neither_answers(tmp_path) -> None:
+    # Arrange — None is the third value and it must exist: the caller turns it
+    # into a clean ClickException naming what to install, rather than an opaque
+    # FileNotFoundError from deep inside subprocess.
+    (tmp_path / "empty").mkdir()
+
+    # Act
+    resolved = backend.resolve_scitex_dev(
+        executable=str(tmp_path / "nowhere" / "python"),
+        path=str(tmp_path / "empty"),
+    )
+
+    # Assert
+    assert resolved is None
 
 
 def test_the_manual_hint_names_the_timer_unit() -> None:


### PR DESCRIPTION
## sac asked one Python installation, then acted on a different one

```
sac dev timer list                          -> all 11 sac timers
sac dev timer status accounts-snapshot-live
    Error: no kind='timer' job named 'scitex-agent-container-...'
    Discovered: <six timers belonging to another package>
```

Same host, same venv, seconds apart.

## Why

Three reads precede the one write, and **all three are in-process**: `_dev_jobs_capability.ecosystem_verbs` imports scitex-dev's Click tree to ask whether the verb exists, and `_dev_jobs._resolve_one` resolves the short name against `scitex_dev.jobs` entry points. The write then went out through `shutil.which("scitex-dev")`.

In an agent container that resolved to `/uvwork/bin/scitex-dev` — a hand-added shim whose last line execs **another package's venv**, whose entry-point group contains that package and not this one. The six names in the error are exactly that venv's six timers.

**scitex-dev was not wrong.** Its discovery is unfiltered (`jobs/__init__.py` appends a provider for every entry point) and it answered truthfully about the environment it was pointed at. The defect is asking A and acting on B.

## The fix

One line: resolve `scitex-dev` as a sibling of `sys.executable` first, falling back to PATH. The invariant is **execute the verb in the interpreter that answered the questions**.

### The ordering is the inverse of `_sac_binary.py`, deliberately

Worth stating, because copying the house pattern verbatim would have fixed nothing. That module tries **PATH first** on purpose — so a test that prepends a fake binary gets exactly what it asked for. Here PATH-first still finds the shim.

Checked before inverting: nothing shims `scitex-dev` on PATH. The only `shutil.which("scitex-dev")` reference under `tests/` is a comment in `test_audit.py` recording a check that was *removed*.

### It degrades, it does not demand

Outside a venv there is no sibling and PATH is the only answer there is. A fix that *required* a sibling would break every such caller to fix none of them. Both halves are tested.

Worth noting: this lookup previously had **no test at all** — the sole reference to `invoke` in its test file exercised the unsupported-delegation refusal.

## Verified

| level | result |
|---|---|
| new tests | 2 passed (sibling wins over PATH; PATH used when no sibling) |
| dev-jobs surface | **124 passed, 0 failed** |
| real reproduction | before: `Error: no kind='timer' job named ...` → after: `scitex-agent-container-accounts-snapshot-live (kind=timer)` |

The end-to-end run printed the loaded `_dev_jobs_backend.__file__` first, to prove the patched code was the code running rather than the editable install.

## What this is NOT

It does **not** explain the four fleet hosts carrying none of sac's declared jobs. I escalated that earlier and it was wrong. On all five probeable hosts `scitex-dev` resolves to a venv whose entry points **do** include `scitex-agent-container`, and `/uvwork/bin` exists on none of them — the shim is container-local.

"The apply step was never run" remains the live explanation for those missing units, and this PR does not change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
