### PR TITLE
fix(accounts): a scheduled snapshotter must not call "nothing to do" a failure

### DIFF
--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -324,7 +324,17 @@ def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-accounts-snapshot-live",
             schedule="*/2 * * * *",  # every 2min (cron form; timer below)
-            command=f"/usr/bin/timeout 60 {sac} accounts sync-live",
+            # --poll IS LOAD-BEARING, not cosmetic. Without it this timer
+            # failed EVERY TWO MINUTES on every host whose live credential was
+            # absent or expired -- on 2026-08-26 that was three of the five it
+            # was armed on (compute-01 absent, compute-03 expired ~7.9d,
+            # laptop-01 expired ~4.6d). An expired live credential is the
+            # NORMAL state of a host nobody logged into today, so the
+            # fail-loud contract that is right for a hand-run invocation makes
+            # a SCHEDULED one permanently red: 720 failures a day that protect
+            # nothing and drown out any real problem. --poll turns "nothing to
+            # snapshot" into exit 0 and leaves every safety refusal intact.
+            command=f"/usr/bin/timeout 60 {sac} accounts sync-live --poll",
             description=(
                 "Snapshots a `claude /login` performed in ANY host's TUI into "
                 "that host's account store, so logging in from an arbitrary "

--- a/src/scitex_agent_container/cli_pkg/_account_sync_live.py
+++ b/src/scitex_agent_container/cli_pkg/_account_sync_live.py
@@ -20,7 +20,17 @@ import click
     default=False,
     help="Emit a JSON object describing what happened.",
 )
-def account_sync_live(as_json: bool) -> None:
+@click.option(
+    "--poll",
+    is_flag=True,
+    default=False,
+    help=(
+        "Treat 'no snapshottable credential' as a no-op (exit 0) instead of a "
+        "failure. For scheduled callers; a hand-run invocation wants the loud "
+        "default."
+    ),
+)
+def account_sync_live(as_json: bool, poll: bool) -> None:
     """Snapshot the live credential into its matching account store.
 
     Reads the live ``~/.claude/.credentials.json`` + the active email
@@ -30,6 +40,31 @@ def account_sync_live(as_json: bool) -> None:
 
     Fails loud (non-zero exit) when the live credential is absent,
     malformed, or expired — never saves a stale token.
+
+    ``--poll`` MAKES THAT LAST CASE A NO-OP INSTEAD, and the distinction is
+    the point: "there is nothing to snapshot" is not the same event as
+    "something went wrong". A human running this by hand has just logged in
+    and wants to be told if the save failed, so the loud default is right for
+    them. A TIMER has no such context, and on a host nobody logged into today
+    the live credential is absent or expired as a matter of course.
+
+    MEASURED 2026-08-26, which is why this flag exists. The 2-minute
+    snapshot timer was armed on five hosts and only two had a usable live
+    credential:
+        compute-04  valid                 -> exit 0
+        nas-03      valid                 -> exit 0
+        compute-01  absent                -> exit 1
+        compute-03  expired ~7.9 days     -> exit 1
+        laptop-01   expired ~4.6 days     -> exit 1
+    Three hosts would have failed every two minutes forever — 720 failures a
+    day each — which does not protect anything and makes the unit's exit
+    status meaningless. A job that is always red cannot report a NEW problem.
+    The refusal itself was correct every time; wrapping a fail-loud one-shot
+    in a poll was the error.
+
+    Nothing about the SAFETY contract changes: a stale token is still never
+    written, an identity change is still refused. Only the exit code for
+    "nothing to do" moves, and only when the caller asks for it.
 
     \b
     Examples:
@@ -51,8 +86,12 @@ def account_sync_live(as_json: bool) -> None:
                 )
             )
         else:
-            click.echo(f"Error: {exc}", err=True)
-        raise SystemExit(1)
+            # "nothing to snapshot" reads as a NOTE under --poll and as an
+            # ERROR otherwise, so the log line matches the exit code rather
+            # than contradicting it.
+            label = "Nothing to snapshot" if poll else "Error"
+            click.echo(f"{label}: {exc}", err=not poll)
+        raise SystemExit(0 if poll else 1)
 
     if as_json:
         click.echo(

--- a/tests/scitex_agent_container/cli_pkg/test_account_group_sync_live.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group_sync_live.py
@@ -125,6 +125,51 @@ def test_sync_live_exits_nonzero_when_live_absent(sandbox_home):
     assert result.exit_code == 1
 
 
+def test_poll_exits_zero_when_live_absent(sandbox_home):
+    # Arrange — the two tests above pin the LOUD default and must keep
+    # passing; this pins the other half. A scheduled caller has no human to
+    # tell, and on a host nobody logged into today an absent live credential
+    # is the NORMAL resting state, not an incident.
+    #
+    # MEASURED 2026-08-26: without this flag the 2-minute snapshot timer was
+    # armed on five hosts and failed on three of them (absent, expired 7.9d,
+    # expired 4.6d) — 720 failures a day each. A job that is always red can
+    # never report a NEW problem.
+    (sandbox_home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": "x@y.com"}})
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live", "--poll"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_poll_exits_zero_when_live_expired(sandbox_home):
+    # Arrange — an expired live cred under --poll is "nothing to snapshot",
+    # not a failure. The SAFETY behaviour is unchanged: it is still not saved.
+    _write_live(sandbox_home, "alpha@example.com", int((time.time() - 10_000) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live", "--poll"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_poll_wording_does_not_call_a_no_op_an_error(sandbox_home):
+    # Arrange — the exit code and the words must agree. A line reading
+    # "Error:" beside exit 0 teaches whoever greps the journal that errors
+    # here are ignorable, which is how a real one later gets skipped.
+    (sandbox_home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": "x@y.com"}})
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live", "--poll"])
+    # Assert
+    assert "Error" not in result.output, result.output
+
+
 def test_sync_live_error_message_points_at_login(sandbox_home):
     # Arrange
     _write_live(sandbox_home, "alpha@example.com", int((time.time() - 10_000) * 1_000))


### PR DESCRIPTION
## I armed a timer that failed every two minutes on three of five hosts

```
compute-04  live credential valid       -> exit 0
nas-03      valid                       -> exit 0
compute-01  ABSENT                      -> exit 1
compute-03  expired ~7.9 days           -> exit 1
laptop-01   expired ~4.6 days           -> exit 1
```

720 failures a day, per host, forever.

## The refusals were all correct

`sync-live` is documented to fail loud when the live credential is absent, malformed, or expired, and it never saves a stale token. It behaved exactly as designed every time.

**The error was mine: I wrapped a fail-loud one-shot in a poll.**

Those are different callers with different needs. A human runs this after logging in and wants to be told if the save did not happen. A **timer** has no such context — and on any host nobody logged into today, an absent or expired live credential is the *normal resting state*, not an incident.

Reporting it as failure 720 times a day protects nothing and destroys the unit's exit status as a signal: **a job that is always red can never report a new problem.** Same shape as the `accounts-keepalive` job that has been failing every minute on every host for one dead account.

## What `--poll` changes

Exactly one thing: *"there is nothing to snapshot"* exits 0 instead of 1.

Every safety refusal is untouched — a stale token is still never written, an identity change is still refused, and the default invocation is still loud.

### The wording moves with the exit code

Under `--poll` the line reads `Nothing to snapshot: ...` on stdout, not `Error: ...` on stderr. A journal line saying "Error" beside exit 0 teaches whoever greps it that errors here are ignorable — which is how a real one gets skipped later.

## Verified where the failure actually occurs

My **first** attempt at this test ran on a host that *had* a credential, so both arms exited 0 for reasons unrelated to the flag and the "pass" meant nothing. Redone against an isolated `HOME`, printing a control proving the credential really was absent:

```
--poll     -> "Nothing to snapshot: ..."   exit 0
(default)  -> "Error: ..."                 exit 1
```

| suite | result |
|---|---|
| `test_account_group_sync_live.py` | **15 passed** — including the two pre-existing tests pinning the loud default, so the flag is additive |
| jobs surface (`_jobs/` + `test__dev_jobs_apply.py`) | **261 passed** — the JobSpec `command` string is what eight shared guards assert on, so this is not incidental |

Three new tests pin the poll half, including one asserting the output does **not** say "Error" when the exit code is 0.

## Follow-up

Once merged, the three hosts currently disabled or unarmed (compute-01, compute-03, laptop-01) get re-armed through the declared path. compute-04 and nas-03 are already firing and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
