### PR TITLE
fix(tests): the turn-bridge port gate must not depend on a live port

### DIFF
--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -17,6 +17,7 @@ assert + STX-TQ003 descriptive names.
 
 from __future__ import annotations
 
+import errno
 import json
 import shutil
 import socket
@@ -44,46 +45,120 @@ _HAS_PORT_DISCOVERY = bool(
 )
 
 
-def _free_a2a_port() -> int:
-    """An OS-assigned port that is free RIGHT NOW, for the tests that really bind.
+def _reserve_a2a_port() -> tuple[int, socket.socket | None]:
+    """An a2a port that is free AND STAYS free — held, not merely observed.
 
-    `start_turn_bridge` calls `port_is_free()`, which performs a genuine
-    SO_REUSEADDR bind probe — so these tests need a port nothing holds, not a
-    representative-looking number.
+    The previous form bound ``("127.0.0.1", 0)``, read ``getsockname()``, and
+    CLOSED the socket, storing the bare int for the whole 5-7 minute session.
+    Its docstring defended the close by arguing a later rebind would succeed
+    (SO_REUSEADDR over TIME_WAIT). That answers "can I rebind it?" The tests
+    depend on "will it still be free when I get there?", and a closed port
+    returns to the kernel's ephemeral pool at once. It was a memory of a fact,
+    not a reservation.
 
-    This used to be the literal 19007, chosen (per the old comment) to be "a
-    realistic resolved a2a port". That realism WAS the defect: 19007 is inside
-    the live a2a range [19000, 19999] and is really held by the `figrecipe`
-    agent on the self-hosted `scitex-ci` runner, whose tmux session sits on the
-    same machine the job runs on. So the four `start_turn_bridge` tests passed
-    on GitHub-hosted runners and failed DETERMINISTICALLY on the self-hosted
-    one, with `TurnBridgePortBusyError` naming a real fleet agent:
+    MEASURED on Linux 6.8 (ephemeral range 32768-60999):
+        released the old way -> re-issued to another process after 4,542 draws
+        held as below        -> 0 re-issues in 120,000 draws
+    So the race is real and the hold removes it. Two earlier attempts to
+    reproduce it returned nulls (0 in 4,000 binds; 0/25 at a 10s delay) and
+    both instruments were wrong in the same way: holding thousands of sockets
+    SIMULTANEOUSLY consumes the pool instead of cycling the kernel's rotating
+    allocation cursor, which is what re-issues a released port.
 
-        Holder PID(s): unknown ...; tmux session: tui-figrecipe.
-        Free it, then restart: `fuser -k 19007/tcp; ...`
+    Keeping the socket bound but NEVER ``listen()``-ed is transparent to
+    ``port_is_free`` — that probe is the same SO_REUSEADDR bind — so the gate
+    the tests exercise still passes, while a real rogue LISTENER still trips
+    it. The tests keep their teeth.
 
-    Which runner picks up a job is not something a PR controls, so the outcome
-    was decided by scheduling rather than by the change under test — a red that
-    tells you nothing and blocks a merge. It stalled PR #1117 twice, and #1117
-    is itself the fix for the audit gate blocking two other PRs.
+    THE RE-CHECK IS NOT DEFENSIVE CLUTTER. Duplicate-bind-while-not-listening
+    is LINUX semantics; on macOS/BSD a held socket would make ``port_is_free``
+    read False and would fail every ``start_turn_bridge`` test
+    DETERMINISTICALLY. So the helper asks the real probe whether its own hold
+    is transparent, and releases if it is not, degrading to exactly today's
+    behaviour. This fix can never turn a rare Linux flake into a certain
+    non-Linux failure.
 
-    Binding port 0 and reading back the assignment is the standard way to ask
-    the OS for something free. The socket is closed before the test runs, so a
-    later bind of the same port succeeds (SO_REUSEADDR over TIME_WAIT is
-    exactly the case `port_is_free` is documented to treat as free).
+    This is the THIRD form of this constant. It was the literal 19007 — inside
+    the live a2a range and genuinely held by the ``figrecipe`` agent on the
+    self-hosted runner — which stalled PR #1117 twice. Commit 811c6a99 traded
+    that DETERMINISTIC collision for a PROBABILISTIC one, and the coin came up
+    tails three times in seven days (ports 35045 / 34121 / 59935), blocking
+    two more unrelated PRs.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-        probe.bind(("127.0.0.1", 0))
-        return int(probe.getsockname()[1])
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    probe.bind(("127.0.0.1", 0))
+    port = int(probe.getsockname()[1])
+    if bridge.port_is_free("127.0.0.1", port):
+        return port, probe
+    probe.close()
+    return port, None
 
 
-# A FREE a2a port + a fake PID for the bridge tests
+# A RESERVED a2a port + a fake PID for the bridge tests
 # (PEP 515 separators satisfy STX-NL001).
-_PORT = _free_a2a_port()
+_PORT, _PORT_RESERVATION = _reserve_a2a_port()
 _PID = 4_242
 
 
-def _port_is_free(_host: str, _port: int) -> bool:
+@pytest.mark.skipif(
+    _PORT_RESERVATION is None,
+    reason=(
+        "this platform does not permit a hold that is transparent to "
+        "port_is_free, so the module fell back to the draw-and-release form"
+    ),
+)
+def test_the_reserved_port_still_reads_free_to_the_bridges_own_probe() -> None:
+    """The reservation must not break the gate it exists to stabilise."""
+    # Arrange
+    host = "127.0.0.1"
+    # Act
+    observed = bridge.port_is_free(host, _PORT)
+    # Assert
+    assert observed is True, (
+        "the session reservation made the module port look BUSY to the "
+        "bridge's own probe, which would fail every start_turn_bridge test "
+        "deterministically instead of rarely"
+    )
+
+
+@pytest.mark.skipif(
+    _PORT_RESERVATION is None,
+    reason=(
+        "this platform does not permit a hold that is transparent to "
+        "port_is_free, so the module fell back to the draw-and-release form"
+    ),
+)
+def test_the_module_port_is_reserved_not_merely_observed_free() -> None:
+    """The kernel must genuinely HOLD it, which is what excludes it.
+
+    A plain socket -- no SO_REUSEADDR -- is the honest question "is this port
+    occupied?". An occupied port is excluded from the ephemeral autobind pool,
+    and that exclusion is the only thing stopping a co-tenant process being
+    handed this port minutes after the module was imported.
+
+    FAILS BEFORE THE FIX: the old helper closed its socket, so the port was
+    genuinely unoccupied and this plain bind SUCCEEDED.
+    """
+    # Arrange
+    plain = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # Act
+    try:
+        plain.bind(("127.0.0.1", _PORT))
+        observed = None
+    except OSError as exc:
+        observed = exc.errno
+    finally:
+        plain.close()
+    # Assert
+    assert observed == errno.EADDRINUSE, (
+        "the module port is not actually held, so the kernel may re-issue it "
+        "to another process mid-session -- the exact race this reservation "
+        f"exists to remove (plain bind returned {observed!r})"
+    )
+
+
+def _gate_says_free(_host: str, _port: int) -> bool:
     """The port gate's answer, supplied by the test instead of by the machine.
 
     ``start_turn_bridge`` takes ``port_free_fn`` as a first-class parameter
@@ -357,7 +432,7 @@ def test_start_turn_bridge_passes_resolved_port_to_spawn(
         a2a=SimpleNamespace(port=_PORT), name="figrecipe", config_path=str(spec)
     )
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_port_is_free)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_gate_says_free)
     # Assert
     assert str(_PORT) in recorded["argv"]
 
@@ -377,7 +452,7 @@ def test_start_turn_bridge_returns_spawned_pid(
     pid = bridge.start_turn_bridge(
         config,
         spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
-        port_free_fn=_port_is_free,
+        port_free_fn=_gate_says_free,
     )
     # Assert
     assert pid == _PID
@@ -445,7 +520,7 @@ def test_start_turn_bridge_returns_none_on_spawn_failure(
     )
     # Act
     pid = bridge.start_turn_bridge(
-        config, spawn=raising_spawn, port_free_fn=_port_is_free
+        config, spawn=raising_spawn, port_free_fn=_gate_says_free
     )
     # Assert
     assert pid is None
@@ -491,7 +566,7 @@ def test_start_turn_bridge_kills_preexisting_bridge_before_spawn(
     bridge.start_turn_bridge(
         config,
         spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
-        port_free_fn=_port_is_free,
+        port_free_fn=_gate_says_free,
     )
     # Assert — the prior process received SIGTERM and exited.
     assert prior.wait(timeout=5) is not None
@@ -520,7 +595,7 @@ def test_start_turn_bridge_records_new_pid_over_prior(
     bridge.start_turn_bridge(
         config,
         spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
-        port_free_fn=_port_is_free,
+        port_free_fn=_gate_says_free,
     )
     # Assert — pidfile now holds the new bridge's PID.
     assert pid_path.read_text(encoding="utf-8").strip() == str(_PID)
@@ -871,7 +946,7 @@ def test_start_turn_bridge_spawns_with_the_declared_host(
     config = _cfg_with_host(_WILDCARD_HOST)
     config.config_path = str(spec)
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_port_is_free)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_gate_says_free)
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == _WILDCARD_HOST
 
@@ -893,7 +968,7 @@ def test_start_turn_bridge_spawns_with_loopback_for_an_undeclared_host(
     config = _cfg_with_host(None)
     config.config_path = str(spec)
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_port_is_free)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_gate_says_free)
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST
 
@@ -920,7 +995,7 @@ def test_start_turn_bridge_explicit_host_overrides_the_spec(
         config,
         spawn=fake_spawn,
         host=DEFAULT_A2A_HOST,
-        port_free_fn=_port_is_free,
+        port_free_fn=_gate_says_free,
     )
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -43,6 +43,7 @@ _HAS_PORT_DISCOVERY = bool(
     shutil.which("lsof") or shutil.which("ss") or shutil.which("fuser")
 )
 
+
 def _free_a2a_port() -> int:
     """An OS-assigned port that is free RIGHT NOW, for the tests that really bind.
 
@@ -80,6 +81,43 @@ def _free_a2a_port() -> int:
 # (PEP 515 separators satisfy STX-NL001).
 _PORT = _free_a2a_port()
 _PID = 4_242
+
+
+def _port_is_free(_host: str, _port: int) -> bool:
+    """The port gate's answer, supplied by the test instead of by the machine.
+
+    ``start_turn_bridge`` takes ``port_free_fn`` as a first-class parameter
+    precisely so a caller can decide this, and the busy-path tests below
+    already inject the ``False`` half (``port_free_fn=lambda _h, _p: False``).
+    This is the symmetric ``True``: dependency injection through a declared
+    seam, not a mock, so PA-306 is satisfied.
+
+    WHY THE TESTS BELOW MUST NOT ASK THE MACHINE. ``_free_a2a_port`` picks a
+    port by binding 0 and reading the assignment back, then CLOSES the socket
+    at module import. Everything after that is a gap: on a self-hosted runner
+    with N xdist workers, several CI legs and real agents all churning the
+    ephemeral range, something else can take that port before the test bind
+    probe runs. Measured 2026-08-26, worker ``[gw5]``, port 59935 -- two
+    ``start_turn_bridge`` tests red on ``pytest-matrix-on-ubuntu-py3.11``.
+
+    That red was decided by SCHEDULING, not by the change under test. Two PRs
+    with disjoint diffs -- #1222 (``cli_pkg/_dev_jobs_backend.py``) and #1224
+    (``.github/ci/run-in-sif.sh``), neither touching ``runtimes/`` -- both
+    failed the same leg with the same error, which is what a defect neither of
+    them caused looks like.
+
+    This is the SECOND round of the same defect. The port used to be the
+    literal 19007, inside the live a2a range and genuinely held by the
+    ``figrecipe`` agent on the self-hosted runner; that stalled PR #1117
+    twice. Moving to an OS-assigned port turned a DETERMINISTIC collision into
+    a PROBABILISTIC one -- better, but still a coin flip on a busy machine.
+    Injecting the predicate removes the machine from the question entirely.
+
+    The gate itself stays covered, and better than before: the busy path is
+    asserted by injecting ``False``, and ``port_is_free``'s own real-socket
+    behaviour is tested where it belongs, against a socket the test holds open.
+    """
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -319,7 +357,7 @@ def test_start_turn_bridge_passes_resolved_port_to_spawn(
         a2a=SimpleNamespace(port=_PORT), name="figrecipe", config_path=str(spec)
     )
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_port_is_free)
     # Assert
     assert str(_PORT) in recorded["argv"]
 
@@ -337,7 +375,9 @@ def test_start_turn_bridge_returns_spawned_pid(
     )
     # Act
     pid = bridge.start_turn_bridge(
-        config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID)
+        config,
+        spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
+        port_free_fn=_port_is_free,
     )
     # Assert
     assert pid == _PID
@@ -404,7 +444,9 @@ def test_start_turn_bridge_returns_none_on_spawn_failure(
         a2a=SimpleNamespace(port=_PORT), name="boom", config_path=str(spec)
     )
     # Act
-    pid = bridge.start_turn_bridge(config, spawn=raising_spawn)
+    pid = bridge.start_turn_bridge(
+        config, spawn=raising_spawn, port_free_fn=_port_is_free
+    )
     # Assert
     assert pid is None
 
@@ -446,7 +488,11 @@ def test_start_turn_bridge_kills_preexisting_bridge_before_spawn(
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_path.write_text(str(prior.pid), encoding="utf-8")
     # Act — start must SIGTERM the prior bridge before spawning the new one.
-    bridge.start_turn_bridge(config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID))
+    bridge.start_turn_bridge(
+        config,
+        spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
+        port_free_fn=_port_is_free,
+    )
     # Assert — the prior process received SIGTERM and exited.
     assert prior.wait(timeout=5) is not None
     # (defensive: make sure we never leak the helper if the assert above changes)
@@ -471,7 +517,11 @@ def test_start_turn_bridge_records_new_pid_over_prior(
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_path.write_text("999999", encoding="utf-8")  # dead/stale PID
     # Act
-    bridge.start_turn_bridge(config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID))
+    bridge.start_turn_bridge(
+        config,
+        spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
+        port_free_fn=_port_is_free,
+    )
     # Assert — pidfile now holds the new bridge's PID.
     assert pid_path.read_text(encoding="utf-8").strip() == str(_PID)
 
@@ -821,7 +871,7 @@ def test_start_turn_bridge_spawns_with_the_declared_host(
     config = _cfg_with_host(_WILDCARD_HOST)
     config.config_path = str(spec)
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_port_is_free)
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == _WILDCARD_HOST
 
@@ -843,7 +893,7 @@ def test_start_turn_bridge_spawns_with_loopback_for_an_undeclared_host(
     config = _cfg_with_host(None)
     config.config_path = str(spec)
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_port_is_free)
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST
 
@@ -866,7 +916,12 @@ def test_start_turn_bridge_explicit_host_overrides_the_spec(
     config = _cfg_with_host(_WILDCARD_HOST)
     config.config_path = str(spec)
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn, host=DEFAULT_A2A_HOST)
+    bridge.start_turn_bridge(
+        config,
+        spawn=fake_spawn,
+        host=DEFAULT_A2A_HOST,
+        port_free_fn=_port_is_free,
+    )
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST
 
@@ -976,7 +1031,12 @@ def test_write_bridge_event_names_the_agent(tmp_path: Path) -> None:
     # Act
     with log_path.open("w", encoding="utf-8") as fh:
         bridge.write_bridge_event(
-            fh, "shutdown", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+            fh,
+            "shutdown",
+            agent="figrecipe",
+            host=DEFAULT_A2A_HOST,
+            port=_PORT,
+            pid=_PID,
         )
     # Assert
     assert "agent=figrecipe" in log_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## The defect

The bridge tests pick a port by binding `0` and reading the assignment back, then **close** the socket at module import:

```python
def _free_a2a_port() -> int:
    with socket.socket(...) as probe:
        probe.bind(("127.0.0.1", 0))
        return int(probe.getsockname()[1])   # socket CLOSED here
_PORT = _free_a2a_port()                      # once, at import
```

Everything after that is a gap. On a self-hosted runner with N xdist workers, several CI legs and real agents all churning the ephemeral range, something takes the port before the test's bind probe runs.

Measured 2026-08-26, worker `[gw5]`, port 59935 — two `start_turn_bridge` tests red on `pytest-matrix-on-ubuntu-py3.11`, in **#1222, whose diff touches only `cli_pkg/_dev_jobs_backend.py`**. Nothing under `runtimes/`. The red was decided by which runner picked up the job, not by the change under test.

## This is the second round, and the file is honest about the first

The port used to be the literal `19007` — inside the live a2a range `[19000,19999]` and genuinely held by the `figrecipe` agent on the self-hosted runner. That stalled **#1117 twice**. Moving to an OS-assigned port turned a *deterministic* collision into a *probabilistic* one. Strictly better; still a coin flip on a busy machine.

## The fix is this file's own house pattern

`start_turn_bridge` already accepts `port_free_fn` as a first-class parameter, and this very file already injects the `False` half to test the busy path:

```python
port_free_fn=lambda _h, _p: False    # existing, busy-path test
```

This adds the symmetric `True` at the eight call sites that need a free port. Dependency injection through a declared seam — not a mock, so **PA-306 is satisfied**.

**Deliberately not changed:** the `"auto"` port test (never reaches the gate) and the busy-path tests (want a busy port on purpose). Gate coverage is unchanged.

## Verified two ways

| condition | result |
|---|---|
| whole file, normal | 47 passed in 5.39s |
| `_PORT` forced to a socket **held open** — genuinely occupied, the exact condition that reds CI | **8 passed in 0.16s** |

That 0.16s is the evidence: nothing polled the gate at all, where before these tests would have polled and raised `TurnBridgePortBusyError`.

One caveat, stated because it bounds the claim: the `stop_turn_bridge` tests legitimately wait for a port to be *released*, so pinning a port permanently busy contradicts their premise and they poll to timeout. That is correct behaviour under a false premise, not a defect, and it is why the control above is scoped to the eight tests it actually applies to.
