### PR TITLE
chore(release): 0.27.0 - a job with nothing to do is not a job that failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-08-26
+
+**A job that has nothing to do is not a job that failed.** The theme of this
+release is gates and scheduled work telling the truth about their own outcome:
+a paused account, an empty snapshot run, a skipped database test and a CI
+summary that listed only skips were each reporting success or failure on
+grounds that had nothing to do with the thing they measured.
+
+### Added
+- `sac accounts pause` / `resume`: an account the operator has deliberately
+  STOPPED is no longer treated as a broken one, so the keepalive job stops
+  failing on his behalf (#1226).
+- The credential pool asks whether an account may still RUN, not merely whether
+  its token is fresh (#1217).
+- The credential snapshot is declared as a **timer**, because a daemon has no
+  cron form (#1219).
+- CI provisions its own PostgreSQL instead of borrowing the fleet's, so a test
+  run can no longer depend on — or disturb — live fleet state (#1221).
+
+### Fixed
+- **A CI summary listing only skips hid the failures it was added beside.**
+  `pytest -r` REPLACES the reported set rather than appending to it, so `-rs`
+  deleted every `FAILED` line from the summary. Now `-rfEs`, with a guard that
+  fails in both directions (#1224).
+- **A PostgreSQL gate that skips silently is a gate that passes** (#1220).
+- The turn-bridge port gate no longer depends on a live port, closing a TOCTOU
+  where the probe's answer expired before the caller used it (#1225).
+- A scheduled snapshotter no longer calls "nothing to do" a failure (#1223).
+- dev-jobs delegate to the interpreter we probed, not to whatever `PATH` holds
+  (#1222).
+- **The identity drift guard read the RETIRED env name**, so it skipped 110 of
+  148 live specs — the guard was running and measuring almost nothing (#1215).
+- The image pins `scitex-dev>=0.56.6` and gates it BY SYMBOL, so a SIF built
+  without the oplog retry cannot ship (#1214).
+
+### Documentation
+- How a BYO machine joins the overlay, and the four traps that cost a day
+  (#1216).
+
 ## [0.26.3] - 2026-08-24
 
 **Off SQLite.** Every remaining piece of runtime state that a container wrote

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.26.3"
+version = "0.27.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump + CHANGELOG for **0.27.0**. Twelve commits since `v0.26.3`.

Minor bump rather than patch because four of the twelve are features.

### Added
- `sac accounts pause` / `resume` (#1226) — a deliberately stopped account no longer fails the keepalive job on the operator's behalf.
- The credential pool asks whether an account may still RUN, not merely whether its token is fresh (#1217).
- The credential snapshot is declared as a timer, because a daemon has no cron form (#1219).
- CI provisions its own PostgreSQL instead of borrowing the fleet's (#1221).

### Fixed
The fixes share one theme, which is what makes this release coherent: **gates reporting an outcome unrelated to what they measured.**

- `pytest -r` REPLACES the reported set rather than appending, so `-rs` had deleted every `FAILED` line from CI summaries (#1224). Now `-rfEs`, with a guard that fails in both directions.
- A PostgreSQL gate that skipped silently read as a pass (#1220).
- The identity drift guard read the RETIRED env name and so skipped 110 of 148 live specs (#1215).
- The turn-bridge port gate no longer depends on a live port (#1225) — closes a TOCTOU where the probe's answer expired before the caller used it.
- A scheduled snapshotter no longer calls "nothing to do" a failure (#1223).
- dev-jobs delegate to the interpreter we probed, not to whatever `PATH` holds (#1222).
- The image pins `scitex-dev>=0.56.6` and gates it BY SYMBOL (#1214).

### Verification
- `v0.26.3` is tagged and **already on PyPI** (checked the index, not the local tag list). `git describe` from develop reports `v0.26.2` because v0.26.3 was cut from `main` and is not reachable from develop — the real delta is 12 commits, not the 100 that `describe` implies.
- develop HEAD `9dcbaf0a`: 5/5 CI runs green, queried by commit sha rather than a `--limit` window.
- No stray `0.26.3` references outside the CHANGELOG's historical entry; `__version__` derives from package metadata, so the `pyproject` bump is sufficient.

After this lands: `develop → main` PR, then tag `v0.27.0` from `main`, which is what triggers the PyPI publish.
