### PR TITLE
release: 0.27.0

### DIFF
--- a/.github/ci/exec-in-sif.sh
+++ b/.github/ci/exec-in-sif.sh
@@ -208,6 +208,135 @@ fi
 ci_tmpdir_prune
 # --- end scitex-agent-container-specific -------------------------------------
 
+# --- a throwaway PostgreSQL for the suite ------------------------------------
+# WHY THIS EXISTS. 308 tests across 28 files need a writable PostgreSQL. They
+# used to get one from the runner's own loopback :55432, and on 2026-08-26 that
+# stopped being true everywhere at once: the fleet is one primary (nas-03) plus
+# READ-ONLY REPLICAS, and every runner's local cluster is a replica. Two of the
+# three runners lacked a .pgpass row so the fixture skipped silently and the job
+# went GREEN having run none of it; the third had the row, connected, and died
+# on CREATE SCHEMA. Same commit, opposite verdicts, decided by which host drew
+# the job. The gate was a coin flip, and two thirds of the time it was blind.
+#
+# Pointing the tests at the primary instead was considered and rejected: that is
+# ~616 DDL statements per leg on the production cluster, replicated to every
+# standby, on a database that lost a primary-key index to a libc mismatch the
+# day before. Tests get their OWN database or none.
+#
+# WHY HERE and not inside the SIF: ci-cpu.sif ships no server binaries
+# (`command -v initdb pg_ctl postgres` prints nothing in it) and apptainer does
+# not nest, so the server cannot be started from the test process. This script
+# is the one place that runs on the RUNNER, and it is shared verbatim by the PR
+# gate and the release gate -- which is the point. Putting this in the workflow
+# YAML would fork those two apart again, and this file's own header is a
+# monument to what that cost last time.
+#
+# FAIL SOFT, DELIBERATELY. Every failure path below leaves SAC_TEST_PG_DSN
+# UNSET and continues. The fixture then skips with a ::warning:: naming the
+# reason (see tests/_store_isolation.py). That is a real trade and it is the
+# right way round: this script is shared by both gates, so `exit 1` here takes
+# down every build in the repo including ones that touch no database. A missing
+# test database must degrade to a LOUD skip, never to an outage.
+#
+# TEARDOWN IS BY REAPER, NOT BY TRAP, and that is forced: this script ends in
+# `exec`, which replaces the shell, so an EXIT trap would never fire. The same
+# reasoning the tmpdir prune above already uses applies -- age is what separates
+# a leftover from a live concurrent sibling, and a reaper survives SIGKILL and
+# reboots, which a trap does not.
+CI_PG_ROOT="${TMPDIR:-/tmp}/sac-ci-pg"
+mkdir -p "$CI_PG_ROOT" 2>/dev/null || true
+
+# Reap leftovers from runs that were killed before they could clean up. The 6 h
+# floor is deliberately far longer than any leg: a concurrent matrix sibling on
+# this same runner must never be shot.
+find "$CI_PG_ROOT" -mindepth 1 -maxdepth 1 -type d -mmin +360 2>/dev/null |
+    while read -r stale; do
+        if [ -f "$stale/postmaster.pid" ]; then
+            stale_pid="$(head -1 "$stale/postmaster.pid" 2>/dev/null)"
+            case "$stale_pid" in [0-9]*) kill "$stale_pid" 2>/dev/null || true ;; esac
+        fi
+        rm -rf "$stale" 2>/dev/null || true
+        echo "exec-in-sif: reaped stale CI postgres $stale"
+    done
+
+# Resolve the server image by GLOB. The filename differs per host -- measured
+# 2026-08-26: compute-03 carries postgres18.sif, compute-01 and compute-04 carry
+# postgres18-18.4.sif and compute-01 has both -- so a literal name would work on
+# one runner and not the next, which is the failure shape this whole change
+# exists to end.
+CI_PG_SIF=""
+for _cand in "$HOME"/.scitex/pg/postgres*.sif; do
+    [ -f "$_cand" ] && CI_PG_SIF="$_cand"
+done
+
+if [ -z "$CI_PG_SIF" ]; then
+    echo "::warning::no postgres SIF under $HOME/.scitex/pg — PostgreSQL tests will SKIP (loudly). Looked for postgres*.sif."
+else
+    # A free port, chosen by ASKING THE KERNEL rather than assuming. Do not
+    # hardcode: 55432 is the fleet cluster and compute-03 already runs an
+    # unrelated postgres on 5433. Binding port 0 and reading the assignment
+    # back races with other bidders in principle; in practice the window is
+    # microseconds and the alternative -- a fixed guess -- is wrong on a host
+    # nobody has probed yet.
+    CI_PG_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()' 2>/dev/null || echo "")"
+    CI_PG_DATA="$CI_PG_ROOT/$$-$(date +%s)"
+
+    if [ -z "$CI_PG_PORT" ]; then
+        echo "::warning::could not obtain a free port for the CI postgres — PostgreSQL tests will SKIP (loudly)."
+    else
+        # NOTE ON THE DATADIR: it is under TMPDIR, never under ~/.scitex/pg.
+        # That directory holds the SIFs AND the LIVE data -- ~/.scitex/pg/18/main
+        # carries standby.signal and ~/.scitex/pg/cards18 is the card store. A
+        # mistyped -D there destroys a replica of a cluster that is already one
+        # libc incident deep.
+        mkdir -p "$CI_PG_DATA"
+        if "$APPTAINER" exec --bind "$CI_PG_ROOT" "$CI_PG_SIF" \
+               initdb -D "$CI_PG_DATA" -U ci_tests --auth=trust >/dev/null 2>&1; then
+            "$APPTAINER" exec --bind "$CI_PG_ROOT" "$CI_PG_SIF" \
+                postgres -D "$CI_PG_DATA" -p "$CI_PG_PORT" \
+                -c listen_addresses=127.0.0.1 \
+                -c unix_socket_directories="$CI_PG_DATA" \
+                -c fsync=off \
+                -c full_page_writes=off -c synchronous_commit=off \
+                >"$CI_PG_DATA/server.log" 2>&1 &
+            # unix_socket_directories is NOT optional here, and the failure it
+            # prevents is not guessable from its message. MEASURED on
+            # scitex-compute-04 2026-08-26: without it the server starts, binds
+            # the TCP port, and then dies with
+            #   FATAL: could not create lock file
+            #     "/var/run/postgresql/.s.PGSQL.<port>.lock": Read-only file system
+            # A SIF is a read-only image, and PostgreSQL insists on a writable
+            # directory for its Unix socket even when every client will speak
+            # TCP. The datadir is already writable and already ours.
+            #
+            # fsync/full_page_writes off: this database is discarded at the end
+            # of the job, so durability buys nothing and costs wall clock.
+
+            CI_PG_READY=""
+            for _i in $(seq 1 40); do
+                if "$APPTAINER" exec --bind "$CI_PG_ROOT" "$CI_PG_SIF" \
+                       pg_isready -h 127.0.0.1 -p "$CI_PG_PORT" -q >/dev/null 2>&1; then
+                    CI_PG_READY=yes
+                    break
+                fi
+                sleep 0.5
+            done
+
+            if [ -n "$CI_PG_READY" ]; then
+                export APPTAINERENV_SAC_TEST_PG_DSN="postgresql://127.0.0.1:$CI_PG_PORT/postgres"
+                export APPTAINERENV_PGUSER="ci_tests"
+                echo "exec-in-sif: CI postgres ready on 127.0.0.1:$CI_PG_PORT (data=$CI_PG_DATA, image=$(basename "$CI_PG_SIF"))"
+            else
+                echo "::warning::CI postgres did not accept connections within 20s — PostgreSQL tests will SKIP (loudly). Log tail:"
+                tail -5 "$CI_PG_DATA/server.log" 2>/dev/null || true
+            fi
+        else
+            echo "::warning::initdb failed for the CI postgres — PostgreSQL tests will SKIP (loudly)."
+        fi
+    fi
+fi
+# --- end throwaway PostgreSQL ------------------------------------------------
+
 # Build the argv as an ARRAY so the GPFS bind can be dropped cleanly rather than
 # passed as an empty string. --pwd "$PWD" keeps the checkout as cwd.
 APPTAINER_ARGV=(exec --pwd "$PWD")

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -427,6 +427,14 @@ fi
 # after EVERY test, so loadscope's "same worker per module" buys nothing here —
 # it only serialized. `load` spreads the parametrized cases across ALL workers.
 #
+# -rs: PRINT SKIP REASONS. Without it `-q` prints a bare count, and on
+# 2026-08-26 that made a blind gate look like a healthy one: 308 PostgreSQL
+# tests were skipping on two of three runners for want of a writable database
+# and every one of those runs reported green. Establishing that took
+# reconstructing 392 - 84 = 308 by arithmetic from a 9.9 MB log, because
+# nothing in the output said which tests were skipped or why. A skip that
+# nobody can see is a pass.
+#
 # nice -n 19 ionice -c 3: run at the lowest CPU + idle I/O priority so that if
 # this node is ever shared with interactive/dev work, CI grabs otherwise-idle
 # cores but YIELDS the CPU and disk to any higher-priority process — "all
@@ -434,6 +442,6 @@ fi
 # which execs ionice, which execs python (still PID-traceable, signals/exit
 # code propagate to the runner step).
 exec nice -n 19 ionice -c 3 \
-    python -m pytest tests/ -n "$WORKERS" --dist load -q \
+    python -m pytest tests/ -n "$WORKERS" --dist load -q -rs \
     --cov=src/scitex_agent_container --cov-report=xml --cov-report=term \
     -p no:cacheprovider

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -427,13 +427,24 @@ fi
 # after EVERY test, so loadscope's "same worker per module" buys nothing here —
 # it only serialized. `load` spreads the parametrized cases across ALL workers.
 #
-# -rs: PRINT SKIP REASONS. Without it `-q` prints a bare count, and on
-# 2026-08-26 that made a blind gate look like a healthy one: 308 PostgreSQL
-# tests were skipping on two of three runners for want of a writable database
-# and every one of those runs reported green. Establishing that took
-# reconstructing 392 - 84 = 308 by arithmetic from a 9.9 MB log, because
-# nothing in the output said which tests were skipped or why. A skip that
-# nobody can see is a pass.
+# -rfEs: PRINT FAILURES, ERRORS AND SKIP REASONS. Without the `s` a bare `-q`
+# prints only a count, and on 2026-08-26 that made a blind gate look like a
+# healthy one: 308 PostgreSQL tests were skipping on two of three runners for
+# want of a writable database and every one of those runs reported green.
+# Establishing that took reconstructing 392 - 84 = 308 by arithmetic from a
+# 9.9 MB log, because nothing in the output said which tests were skipped or
+# why. A skip that nobody can see is a pass.
+#
+# THE `f` AND `E` ARE NOT DECORATION — DO NOT TRIM THEM BACK TO `-rs`.
+# pytest's -r REPLACES the default set, it does not add to it. The default is
+# `fE`, so `-rs` means "skips ONLY" and DELETES the FAILED lines from the short
+# summary. This bit us the same day it was introduced: run 32943760311 reported
+# `2 failed, 17626 passed` while `grep FAILED` over the whole 445 KB log
+# returned NOTHING, so the two failing test ids had to be recovered from the
+# traceback headers instead. Measured on pytest 8.4.2:
+#     -rs    -> summary lists SKIPPED only
+#     -rfEs  -> summary lists FAILED and SKIPPED
+# A failure nobody can see is the same defect as a skip nobody can see.
 #
 # nice -n 19 ionice -c 3: run at the lowest CPU + idle I/O priority so that if
 # this node is ever shared with interactive/dev work, CI grabs otherwise-idle
@@ -442,6 +453,6 @@ fi
 # which execs ionice, which execs python (still PID-traceable, signals/exit
 # code propagate to the runner step).
 exec nice -n 19 ionice -c 3 \
-    python -m pytest tests/ -n "$WORKERS" --dist load -q -rs \
+    python -m pytest tests/ -n "$WORKERS" --dist load -q -rfEs \
     --cov=src/scitex_agent_container --cov-report=xml --cov-report=term \
     -p no:cacheprovider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-08-26
+
+**A job that has nothing to do is not a job that failed.** The theme of this
+release is gates and scheduled work telling the truth about their own outcome:
+a paused account, an empty snapshot run, a skipped database test and a CI
+summary that listed only skips were each reporting success or failure on
+grounds that had nothing to do with the thing they measured.
+
+### Added
+- `sac accounts pause` / `resume`: an account the operator has deliberately
+  STOPPED is no longer treated as a broken one, so the keepalive job stops
+  failing on his behalf (#1226).
+- The credential pool asks whether an account may still RUN, not merely whether
+  its token is fresh (#1217).
+- The credential snapshot is declared as a **timer**, because a daemon has no
+  cron form (#1219).
+- CI provisions its own PostgreSQL instead of borrowing the fleet's, so a test
+  run can no longer depend on — or disturb — live fleet state (#1221).
+
+### Fixed
+- **A CI summary listing only skips hid the failures it was added beside.**
+  `pytest -r` REPLACES the reported set rather than appending to it, so `-rs`
+  deleted every `FAILED` line from the summary. Now `-rfEs`, with a guard that
+  fails in both directions (#1224).
+- **A PostgreSQL gate that skips silently is a gate that passes** (#1220).
+- The turn-bridge port gate no longer depends on a live port, closing a TOCTOU
+  where the probe's answer expired before the caller used it (#1225).
+- A scheduled snapshotter no longer calls "nothing to do" a failure (#1223).
+- dev-jobs delegate to the interpreter we probed, not to whatever `PATH` holds
+  (#1222).
+- **The identity drift guard read the RETIRED env name**, so it skipped 110 of
+  148 live specs — the guard was running and measuring almost nothing (#1215).
+- The image pins `scitex-dev>=0.56.6` and gates it BY SYMBOL, so a SIF built
+  without the oplog retry cannot ship (#1214).
+
+### Documentation
+- How a BYO machine joins the overlay, and the four traps that cost a day
+  (#1216).
+
 ## [0.26.3] - 2026-08-24
 
 **Off SQLite.** Every remaining piece of runtime state that a container wrote

--- a/docs/byo-node-onboarding.md
+++ b/docs/byo-node-onboarding.md
@@ -1,0 +1,257 @@
+# Bringing a machine onto the fleet overlay (BYO nodes)
+
+How a machine that the fleet does not own joins the private overlay, what it
+is allowed to reach once it has, and the platform-specific traps that cost
+real time the first time.
+
+Written from the onboarding of `scitex-laptop-02` (a MacBook Air) on
+2026-08-25, which was deliberately run as a **bring-your-own** machine — the
+same path an external user or a self-hosting user would take — rather than as
+a fleet-owned host.
+
+Every number and policy body below was read off the live control server on
+2026-08-25; where something is **not** working, this document says so rather
+than describing the intent.
+
+---
+
+## 1. The shape
+
+- Control server: **headscale v0.23.0**, on `scitex-compute-04`.
+  - config: `~ywatanabe/.scitex/headscale/config.yaml`
+  - `server_url: http://192.168.11.174:8080`, `listen_addr: 0.0.0.0:8080`
+  - supervised by `/etc/systemd/system/headscale.service` (`Restart=always`,
+    enabled)
+- Overlay range: `100.64.0.0/10` (plus `fd7a:115c:a1e0::/48`).
+- `derp.urls: []` — **no public DERP relays**, by a standing 2026-08-14
+  ruling recorded in the config file itself. Do not add Tailscale's public
+  DERP map back "to make it work"; that decision has already been made and
+  reversed once.
+
+### Nodes, as of 2026-08-25
+
+| id | node | user | overlay IP | forced tag(s) |
+|----|------|------|-----------|---------------|
+| 1 | scitex-compute-04 | fleet | 100.64.0.1 | `tag:scitex-compute`, `tag:scitex-writer` |
+| 2 | scitex-compute-01 | fleet | 100.64.0.2 | `tag:scitex-compute` |
+| 4 | scitex-compute-03 | fleet | 100.64.0.4 | `tag:scitex-compute` |
+| 5 | dxp480tplus-994 | fleet | 100.64.0.5 | `tag:scitex-nas` |
+| 6 | ywata-note-win | fleet | 100.64.0.6 | `tag:scitex-laptop` |
+| 7 | scitex-compute-02 | fleet | 100.64.0.7 | `tag:scitex-compute` |
+| 8 | watanas2 | fleet | 100.64.0.8 | `tag:scitex-nas` |
+| 9 | yusuke-s-macbook-air | **byo** | 100.64.0.9 | `tag:scitex-byo` |
+
+Node id 3 is absent: it was `scitex-compute-02`'s stale registration, deleted
+after the machine re-registered as id 7.
+
+`scitex-primary` and `cards-primary` resolve to `100.64.0.1` via `/etc/hosts`
+on every overlay host. Nothing should hard-code `100.64.0.1`; the alias is
+what makes a future failover a one-line change instead of a fleet-wide edit.
+
+---
+
+## 2. The trust model
+
+A BYO machine is **not** a fleet machine. It is registered under a separate
+headscale user (`byo`, not `fleet`) and carries `tag:scitex-byo`, and the ACL
+gives that tag exactly one destination.
+
+The live policy, read back with `headscale policy get`:
+
+```json
+{
+  "tagOwners": {
+    "tag:scitex-compute": ["fleet"],
+    "tag:scitex-nas":     ["fleet"],
+    "tag:scitex-laptop":  ["fleet"],
+    "tag:scitex-writer":  ["fleet"],
+    "tag:scitex-byo":     ["byo"]
+  },
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["tag:scitex-compute", "tag:scitex-nas", "tag:scitex-laptop"],
+      "dst": ["tag:scitex-compute:*", "tag:scitex-nas:*", "tag:scitex-laptop:*"]
+    },
+    {
+      "action": "accept",
+      "proto": "tcp",
+      "src": ["tag:scitex-byo"],
+      "dst": ["tag:scitex-writer:55432"]
+    }
+  ]
+}
+```
+
+Read plainly:
+
+- fleet-tagged nodes reach each other on any port;
+- a `tag:scitex-byo` node reaches **one TCP port on one tag** — the single
+  writer's PostgreSQL at 55432 — and nothing else on the overlay;
+- `tag:scitex-byo` is not in any `dst`, so nothing on the overlay can
+  initiate a connection **to** the BYO machine either.
+
+Three properties of this that matter more than the rule text:
+
+1. **`tag:scitex-writer` is a role, not a host.** compute-04 holds it today.
+   When the writer moves, the tag moves; the ACL does not change and neither
+   does any client's DSN, because both go through the name.
+2. **The tags are real.** Every row in the table above carries a `forced_tag`
+   on the server. This is worth checking rather than assuming: an ACL whose
+   `src`/`dst` tags match no node denies everything and *looks* exactly like
+   correct isolation. Confirm with
+   `headscale nodes list -o json` and read `forced_tags`, not the default
+   table view — which shows the *user* column and no tags at all.
+3. **Verify isolation after every re-registration, not once.** A node that
+   logs out and logs back in can come back under a different user or with no
+   tag. The MacBook's isolation was proven twice for this reason, the second
+   time after a full logout / re-register cycle.
+
+---
+
+## 3. Joining a machine
+
+### 3.1 Issue a preauth key for the right user
+
+```bash
+headscale -c ~/.scitex/headscale/config.yaml users create byo        # once
+headscale -c ~/.scitex/headscale/config.yaml preauthkeys create \
+    --user byo --expiration 1h
+```
+
+Use `--user byo` for a bring-your-own machine and `--user fleet` for a
+machine the fleet owns. This is the decision that determines the trust zone;
+everything after it is mechanics.
+
+### 3.2 Register from the client
+
+```bash
+tailscale login --login-server http://192.168.11.174:8080 --authkey <key>
+```
+
+### 3.3 Apply the tag on the server
+
+```bash
+headscale -c ~/.scitex/headscale/config.yaml nodes tag -i <id> -t tag:scitex-byo
+```
+
+### 3.4 Prove the isolation, from the client
+
+```bash
+nc -z -G 5 100.64.0.1 55432   && echo "writer reachable (expected)"
+nc -z -G 5 100.64.0.2 22      && echo "REACHED A FLEET HOST — ACL IS WRONG"
+```
+
+The second command must fail. If it succeeds, stop and fix the policy before
+handing the machine to anyone.
+
+---
+
+## 4. `server_url` is handed to the client, and it overrides `--login-server`
+
+**This is the single most expensive thing to learn the hard way, so it gets
+its own section.**
+
+headscale gives every registering client its own configured `server_url`, and
+the client then uses *that* — not the URL you passed on the command line.
+`--login-server` gets you to the registration endpoint; it does not decide
+where the client talks afterwards.
+
+The consequence: `server_url` must be reachable **from every client**, and
+changing it changes it for all of them at once.
+
+On 2026-08-25 `server_url` was changed from the LAN address to a public
+hostname in order to let a laptop join from outside the LAN. Every node that
+subsequently tried to re-register was handed the new URL. Registration broke
+fleet-wide; the MacBook and compute-02 both dropped off. Rolling `server_url`
+back restored it, and compute-02 recovered on its own.
+
+If off-LAN joining is attempted again, the order must be:
+
+1. prove **one** node registers through the public URL, end to end, from
+   outside the LAN;
+2. only then consider changing `server_url` for everyone.
+
+Related gotcha from the same afternoon: `GET /key` on the control server
+returns HTTP 500 unless you pass the protocol version, `GET /key?v=106`. A
+bare `/key` failing is a malformed request, not a broken server — and it was
+briefly and wrongly reported as evidence that a tunnel had broken
+registration. The origin and the tunnel return byte-identical responses.
+
+**Current state: off-LAN joining does not work.** `vpn.scitex.ai` exists and
+answers `/health` and `/derp` with 200, but no node has been proven to
+*register* through it, and `server_url` remains the LAN address. Treat the
+hostname as groundwork, not as a working path.
+
+---
+
+## 5. macOS specifics
+
+### 5.1 Use the standalone build, not the App Store build
+
+A custom control server needs the standalone (`macsys`) Tailscale build. Its
+daemon runs as a **system extension**, `io.tailscale.ipn.macsys`, not as a
+plain `tailscaled` process.
+
+### 5.2 `pgrep` does not see it
+
+```bash
+pgrep -x tailscaled          # prints nothing — even while the daemon is running
+systemextensionsctl list     # this is the honest check
+```
+
+`pgrep -x tailscaled` reported "not running" on macOS while the daemon was
+alive at pid 75430, and again on QNAP while it was alive at pid 27850. A
+process-name mismatch and an absent process are indistinguishable in
+`pgrep`'s output. Ask the service's own CLI, which knows its pid.
+
+### 5.3 `timeout` does not exist
+
+`timeout` is GNU coreutils and is absent on macOS and on QNAP. A probe of the
+form
+
+```bash
+timeout 6 bash -c "cat < /dev/null > /dev/tcp/HOST/PORT" && echo ok || echo unreachable
+```
+
+prints `unreachable` **without ever opening a socket**, because the missing
+binary fails and the `||` fires. This produced a false "these hosts have no
+outbound network path" report that had to be retracted. On macOS use
+`nc -z -G <sec> HOST PORT`; where `nc` is also absent, use a bare
+`bash -c 'exec 3<>/dev/tcp/H/P'` with no `timeout` prefix and bound the whole
+thing with ssh's own timeout instead.
+
+The general rule, which is the part worth carrying to the next platform: **a
+probe that cannot run returns the same string as a probe that ran and found
+nothing.** Before trusting a negative from an unfamiliar host, prove the
+instrument exists there — `command -v timeout` costs one token.
+
+### 5.4 Two GUI approvals, neither scriptable
+
+Both must be clicked by whoever is sitting at the machine:
+
+1. **System extension approval** — System Settings → Privacy & Security,
+   after the first launch.
+2. **Local network permission** — a prompt on first connection attempt.
+
+Neither can be driven over SSH, and having the machine's admin password does
+not avoid them. Plan for a human at the keyboard; for a genuinely remote BYO
+user this is the step to put in their instructions with a screenshot.
+
+---
+
+## 6. What a self-hosting user needs
+
+The parts above are what a third party would repeat, in order:
+
+1. reach the control server (today: on the LAN; off-LAN is not yet proven);
+2. get a preauth key issued **under the `byo` user**, not `fleet`;
+3. register, get tagged `tag:scitex-byo`;
+4. reach exactly one port — the writer's 55432 — and hold a per-principal
+   credential for it;
+5. have that isolation re-verified after any re-registration.
+
+Step 4 is where this connects to the database side: a BYO node gets a
+per-principal role, never the shared legacy one. Network reachability and
+database authority are two separate gates, and passing the first must not
+imply the second.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.26.3"
+version = "0.27.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,7 +328,19 @@ dev = [
     # been written to and never read from. A floor that admits 0.49.0 admits a
     # store this package cannot read, so the version that first WORKS is the
     # version this package may depend on.
-    "scitex-dev>=0.49.2",
+    #
+    # RAISED TO 0.56.6 on 2026-08-25, and the difference is again not
+    # cosmetic. Through 0.56.5, Store._append read MAX(seq) ONCE and then
+    # inserted, so concurrent writers on a SINGLE node collided on the oplog
+    # (origin, seq) primary key with no bounded retry — measured 7/8 and 5/8
+    # failures on the two concurrency tests, reproduced three times. The same
+    # release also takes a Postgres advisory lock around CREATE TABLE, which
+    # races pg_type when several Store() constructors start together. sac has
+    # now moved its own state onto this store, so a floor that admits 0.56.5
+    # admits silent write loss on exactly the path the migration depends on.
+    # The container recipes gate this BY SYMBOL (_SEQ_ALLOCATION_ATTEMPTS) —
+    # see apptainer-scitex.def; this specifier is the base layer's half.
+    "scitex-dev>=0.56.6",
     # PS210: tests import scitex_hpc unguarded, so [dev] must include it
     # (otherwise `pip install -e .[dev]` can't run the full suite).
     "scitex-hpc>=0.6.2",

--- a/src/scitex_agent_container/_account/mint_token.py
+++ b/src/scitex_agent_container/_account/mint_token.py
@@ -131,13 +131,39 @@ def mint_access_only_artifact(
     # --- EXCLUSIVE-STRICT health gate --------------------------------------
     health = account_health(account, store_dir=store_dir, home=_home, now=now_s)
     if not health.is_healthy:
+        # ONE BRANCH PER STATE, and the remedy belongs to the state.
+        # This was a two-way branch written before FORBIDDEN existed, so
+        # every non-EXPIRED refusal claimed "no credential snapshot on
+        # disk" — which is what the operator's red keepalive told him
+        # about `wyusuuke-gmail-com` on 2026-08-26 while that account's
+        # .credentials.json sat there, 1146 bytes, refreshed hours
+        # earlier. It named the wrong fault and offered a remedy that
+        # cannot work. PAUSED would have fallen into the same else, so
+        # the branch is made explicit here rather than compounded.
+        if health.state == "PAUSED":
+            reason = health.pause_reason or "no reason recorded"
+            raise MintError(
+                f"cannot mint: account '{account}' is PAUSED ({reason}) — "
+                "this is a decision, not a fault; nothing is broken and "
+                f"nothing was deleted. Run `sac accounts resume {account}` "
+                "to put it back in service."
+            )
+        if health.state == "FORBIDDEN":
+            detail = health.entitlement_detail or "no detail recorded"
+            raise MintError(
+                f"cannot mint: account '{account}' is FORBIDDEN — its OAuth "
+                "token is fine but the API refuses it: "
+                f"{detail}. The credential is not the problem, the "
+                "subscription is. Restore it (the entitlement probe clears "
+                f"this on its own within 30 minutes), or run `sac accounts "
+                f"pause {account} --reason ...` so this stops failing."
+            )
         if health.state == "EXPIRED":
-            hrs = (
+            detail = (
                 f" (expired {abs(health.hours_remaining or 0):.1f}h ago)"
                 if health.hours_remaining is not None
                 else " (expired)"
             )
-            detail = hrs
         else:  # ABSENT — dir exists but snapshot is missing/unparseable
             detail = " (no credential snapshot on disk)"
         raise MintError(

--- a/src/scitex_agent_container/_account/quota_watch.py
+++ b/src/scitex_agent_container/_account/quota_watch.py
@@ -31,6 +31,38 @@ _DEFAULT_LOG_PATH = (
 )
 
 
+def _paused_candidates(
+    accounts: list[dict],
+    current_email: str | None,
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> list[str]:
+    """Which non-current accounts were dropped because they are PAUSED.
+
+    The ONLY consumer is the "nothing to rotate to" alert, and it exists
+    so that alert can name the real reason. Same candidate set and same
+    health call as :func:`_select_next_account`, asked one question
+    later: not "who can I use" but "who did I refuse, and was it his
+    decision or a fault".
+    """
+    from .._creds._pick_healthy import account_health
+
+    out: list[str] = []
+    for acct in accounts:
+        if acct.get("email_address") == current_email:
+            continue
+        name = acct.get("name", "")
+        if not name:
+            continue
+        if account_health(name, store_dir=store_dir, home=home, now=now).state == (
+            "PAUSED"
+        ):
+            out.append(name)
+    return out
+
+
 def _select_next_account(
     accounts: list[dict],
     current_email: str | None,
@@ -41,8 +73,18 @@ def _select_next_account(
 ) -> dict | None:
     """Pick the HEALTHY account with lowest 5h usage that isn't the current one.
 
-    Health is credential-snapshot freshness — a non-expired
-    ``claudeAiOauth.expiresAt`` — reusing
+    Health is credential-snapshot freshness AND the operator's own
+    pause decision (2026-08-26): :func:`.._creds._account_health` now
+    also returns ``PAUSED``, which ``is_healthy`` excludes, so an
+    account the operator has rested is never rotated onto. That is
+    correct on its own terms — rotating onto a rested account is
+    exactly the spend he paused it to avoid — but it means "no
+    candidate" no longer implies a fault, which is why
+    :func:`check_and_rotate` asks :func:`_paused_candidates` before it
+    writes an alert about one.
+
+    Freshness itself is a non-expired ``claudeAiOauth.expiresAt``,
+    reusing
     :func:`.._creds._pick_healthy.account_health` (the same predicate the
     boot-time picker uses). An account whose stored credential is EXPIRED
     or ABSENT is NEVER selected, even when its usage reads 0.0%.
@@ -158,6 +200,32 @@ def check_and_rotate(
             # EXPIRED/ABSENT". Staying put is the safe choice — rotating to
             # an unhealthy account would hand the fleet a dead token
             # (the 2026-07-06 expired-account bug). Never rotate here.
+            #
+            # THERE IS NOW A THIRD WAY TO GET HERE, and it must not be
+            # reported with the diagnosis written for the other two. A
+            # PAUSED account is dropped from the candidate set on
+            # purpose (a rested account should not be rotated onto), but
+            # saying "absent or credential-expired" names a fault that
+            # does not exist and prescribes a command that does nothing.
+            # The operator's stated workflow is to pause several
+            # accounts to rest quota; the survivor then crosses this
+            # threshold and this is the sentence he gets.
+            rested = _paused_candidates(
+                accounts, current_email, store_dir=store_dir, home=home
+            )
+            if rested:
+                return {
+                    "action": "no_accounts",
+                    "quota_5h_pct": q5,
+                    "quota_7d_pct": q7,
+                    "switched_to": None,
+                    "message": (
+                        f"ALERT: quota {q5}% (5h) — no account to rotate to: "
+                        f"{len(rested)} PAUSED ({', '.join(rested)}); staying "
+                        f"put. Lift one with `sac accounts resume "
+                        f"{rested[0]}` if you want the headroom back."
+                    ),
+                }
             return {
                 "action": "no_accounts",
                 "quota_5h_pct": q5,

--- a/src/scitex_agent_container/_creds/_account_health.py
+++ b/src/scitex_agent_container/_creds/_account_health.py
@@ -26,6 +26,7 @@ from .._account.creds_sync import (
     _read_oauth_expiry_raw,
 )
 from .._state.account_store import _store_path
+from ._entitlement import read_entitlement
 
 # Health states for one account's snapshot. Mirrors
 # :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
@@ -33,6 +34,15 @@ from .._state.account_store import _store_path
 _VALID = "VALID"
 _EXPIRED = "EXPIRED"
 _ABSENT = "ABSENT"
+#: The token is FRESH but the account may not USE it. INCIDENT
+#: 2026-08-25: a cancelled subscription refreshes its OAuth token
+#: perfectly well, so it read VALID here while every real turn on it
+#: returned 403 "OAuth authentication is currently not allowed for this
+#: organization". Freshness and entitlement are different questions;
+#: this state is the second one. Read from a cached verdict written
+#: out-of-band by the host timer -- see :mod:`._entitlement` for why it
+#: must not be probed live at boot, and why UNKNOWN never lands here.
+_FORBIDDEN = "FORBIDDEN"
 
 
 class NoHealthyAccountError(RuntimeError):
@@ -94,6 +104,10 @@ class AccountHealth:
     hours_remaining: float | None
     snapshot_path: str | None = None
     expires_at_raw: float | None = None
+    #: For a FORBIDDEN record, the API's own words. An operator seeing
+    #: "your token is fine but you cannot use it" needs to be told why
+    #: in the same breath, or the state looks like our bug.
+    entitlement_detail: str = ""
 
     @property
     def is_healthy(self) -> bool:
@@ -137,6 +151,25 @@ def account_health(
     expiry = _oauth_expiry_to_seconds(raw)
     hours = (expiry - now_ts) / 3600.0
     state = _VALID if expiry > now_ts else _EXPIRED
+
+    # ENTITLEMENT is asked only of an otherwise-usable snapshot. An
+    # EXPIRED token's problem is already named, and overwriting that
+    # with FORBIDDEN would hide the actionable fault behind a second
+    # one. A local file read; no network. Only a MEASURED denial
+    # downgrades the state -- UNKNOWN leaves it exactly as freshness
+    # found it, per the constitution's three-valued rule.
+    if state == _VALID:
+        verdict = read_entitlement(name, store / name, now=now_ts)
+        if verdict.blocks_use:
+            return AccountHealth(
+                name=name,
+                state=_FORBIDDEN,
+                hours_remaining=hours,
+                snapshot_path=str(snapshot),
+                expires_at_raw=raw,
+                entitlement_detail=verdict.detail,
+            )
+
     return AccountHealth(
         name=name,
         state=state,

--- a/src/scitex_agent_container/_creds/_account_health.py
+++ b/src/scitex_agent_container/_creds/_account_health.py
@@ -27,6 +27,7 @@ from .._account.creds_sync import (
 )
 from .._state.account_store import _store_path
 from ._entitlement import read_entitlement
+from ._pause import read_pause
 
 # Health states for one account's snapshot. Mirrors
 # :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
@@ -43,6 +44,13 @@ _ABSENT = "ABSENT"
 #: out-of-band by the host timer -- see :mod:`._entitlement` for why it
 #: must not be probed live at boot, and why UNKNOWN never lands here.
 _FORBIDDEN = "FORBIDDEN"
+#: The operator has DECIDED to stop using this account for a while.
+#: OPERATOR REQUEST 2026-08-26: he stops and restarts subscriptions
+#: while watching quota, and asked that nothing fail during the rest.
+#: Read from an operator-authored sidecar -- see :mod:`._pause` for why
+#: a decision must not share a file with an observation, and why this
+#: state outranks every measured one below.
+_PAUSED = "PAUSED"
 
 
 class NoHealthyAccountError(RuntimeError):
@@ -83,8 +91,13 @@ class AccountHealth:
         :func:`_account.creds_sync.slugify_email`).
     state
         ``"VALID"`` (non-expired snapshot present), ``"EXPIRED"`` (a
-        snapshot exists but its ``expiresAt`` is in the past), or
-        ``"ABSENT"`` (no snapshot file on disk, or unparseable).
+        snapshot exists but its ``expiresAt`` is in the past),
+        ``"ABSENT"`` (no snapshot file on disk, or unparseable),
+        ``"FORBIDDEN"`` (fresh, but a measured 403 says this account may
+        not use Claude Code), or ``"PAUSED"`` (the operator decided to
+        rest it). The last two are different KINDS of answer -- one
+        measured, one authored -- which is why they are separate states
+        and never collapse into each other.
     hours_remaining
         Signed hours to expiry (positive = remaining, negative =
         past) for VALID/EXPIRED; ``None`` for ABSENT.
@@ -108,6 +121,13 @@ class AccountHealth:
     #: "your token is fine but you cannot use it" needs to be told why
     #: in the same breath, or the state looks like our bug.
     entitlement_detail: str = ""
+    #: For a PAUSED record, the operator's OWN words for why he stopped
+    #: it. A SEPARATE field from ``entitlement_detail`` on purpose: one
+    #: carries what Anthropic said about us, the other carries what we
+    #: decided about Anthropic, and a single field would make a probe's
+    #: sentence and a human's sentence indistinguishable at the point of
+    #: reading. See :mod:`._pause`.
+    pause_reason: str = ""
 
     @property
     def is_healthy(self) -> bool:
@@ -140,6 +160,35 @@ def account_health(
     # expiry, so the record can never quote a different file state than
     # the one it judged (a mid-probe rewrite yields a coherent record).
     raw = _read_oauth_expiry_raw(snapshot) if snapshot.is_file() else None
+
+    # A PAUSE OUTRANKS EVERY MEASUREMENT, and is asked FIRST -- before
+    # the ABSENT return below and before the entitlement read further
+    # down. The rule this extends is already written for the layer
+    # underneath ("overwriting that with FORBIDDEN would hide the
+    # actionable fault behind a second one"): report the fact the
+    # operator can ACT on. When he has decided to rest an account,
+    # "FORBIDDEN" or "ABSENT" is a true sentence about a question nobody
+    # is asking, and rendering it would make a deliberate rest look like
+    # a fault -- the exact confusion :mod:`._pause` exists to prevent.
+    # A local file read; no network.
+    pause = read_pause(name, store / name)
+    if pause.active:
+        return AccountHealth(
+            name=name,
+            state=_PAUSED,
+            # The evidence fields are still filled in from whatever the
+            # snapshot read found, so a paused account's record can
+            # still be adjudicated without un-pausing it first.
+            hours_remaining=(
+                None
+                if raw is None
+                else (_oauth_expiry_to_seconds(raw) - now_ts) / 3600.0
+            ),
+            snapshot_path=str(snapshot),
+            expires_at_raw=raw,
+            pause_reason=pause.reason,
+        )
+
     if raw is None:
         return AccountHealth(
             name=name,
@@ -229,17 +278,24 @@ def _format_states(healths: list[AccountHealth]) -> str:
     parts: list[str] = []
     for h in healths:
         if h.hours_remaining is None or h.expires_at_raw is None:
-            parts.append(
+            base = (
                 f"{h.name}={h.state} (no numeric claudeAiOauth.expiresAt; "
                 f"file={h.snapshot_path})"
             )
         else:
             expiry_s = _oauth_expiry_to_seconds(h.expires_at_raw)
-            parts.append(
+            base = (
                 f"{h.name}={h.state} ({h.hours_remaining:+.1f}h; "
                 f"expiresAt={h.expires_at_raw:.0f} = {_iso_utc(expiry_s)}; "
                 f"file={h.snapshot_path})"
             )
+        # A boot blocked BY A PAUSE must name WHICH pause, in the first
+        # error its operator reads. Without this the message says the
+        # account is unusable and offers `claude /login` — advice that
+        # cannot work, for a condition one `sac accounts resume` lifts.
+        if h.pause_reason:
+            base += f"; paused: {h.pause_reason}"
+        parts.append(base)
     return ", ".join(parts) if parts else "(no candidates)"
 
 

--- a/src/scitex_agent_container/_creds/_entitlement.py
+++ b/src/scitex_agent_container/_creds/_entitlement.py
@@ -1,0 +1,363 @@
+"""Is a stored account still ENTITLED to run Claude Code?
+
+INCIDENT 2026-08-25. The operator cancelled the ``wyusuuke@gmail.com``
+subscription. Nothing noticed. Agents kept being routed onto it and
+failed mid-turn with::
+
+    Your organization has disabled Claude subscription access for
+    Claude Code - Use an Anthropic API key instead, or ask your admin
+    to enable access
+
+Measured that morning, one read-only request per stored account::
+
+    scitex-01-scitex-ai   200 OK
+    ywata1989-gmail-com   200 OK
+    ywatanabe-scitex-ai   200 OK
+    wyusuuke-gmail-com    403 permission_error
+                          "OAuth authentication is currently not
+                           allowed for this organization"
+
+WHY EVERY EXISTING GATE PASSED IT. Account health is snapshot
+FRESHNESS -- a non-expired ``claudeAiOauth.expiresAt`` (see
+:mod:`._account_health`). **OAuth refresh is independent of
+entitlement**: the headless refresh kept succeeding, most recently at
+09:17 UTC that same morning with a new expiry of 17:17, so the account
+read ``VALID`` to every gate while being unusable for an actual turn.
+
+Freshness is not entitlement. They are different questions and only
+one of them was being asked.
+
+Three-valued, per constitution
+------------------------------
+"Every signal is three-valued: true, false, and *unknown*. Collapsing
+unknown into either pole is the most common bug we ship."
+
+So this module reports :data:`ENTITLED`, :data:`FORBIDDEN`, or
+:data:`UNKNOWN`, and the caller must handle all three:
+
+* ``FORBIDDEN`` is a MEASUREMENT -- an HTTP 403 whose body names an
+  OAuth/permission error. Only that becomes FORBIDDEN.
+* ``UNKNOWN`` is everything else: never probed, a record too old to
+  trust, an unparseable record, a timeout, DNS failure, a 5xx. It must
+  NOT block a boot. A network blip is not a cancelled subscription,
+  and collapsing UNKNOWN into FORBIDDEN would evict the entire pool
+  the first time this host lost its uplink -- turning a transient
+  outage into a fleet-wide one.
+* Equally, UNKNOWN must not be silently rendered as ENTITLED. It is
+  reported as its own state so the operator-facing diagnosis can say
+  "we do not know" instead of implying we checked.
+
+Why a CACHE and not a live probe
+--------------------------------
+:func:`._pick_healthy.pick_healthy_account` runs at every agent boot
+and is documented as "cache-only read, NO live Claude API call, so it
+never burns account quota at boot". Probing entitlement inline would
+break that promise and add a network round-trip to every start.
+
+So the live probe (:func:`probe_entitlement`) runs OUT OF BAND, from
+the host timer that already walks every account, and writes a small
+record next to the credential. The boot path only ever
+:func:`read_entitlement`\\ s that record -- a local file read.
+
+AUTO-HEAL IS THE POINT. The operator's workflow is to cancel a
+subscription and restore it later ("I put the subscription back when I
+need the account again"). Because the timer rewrites this record on
+every pass, a restored subscription flips FORBIDDEN -> ENTITLED on its
+own and the account rejoins the pool with no spec edit, no symlink
+rename, and no human step. That is the whole reason this is a cached
+signal rather than a hand-maintained deny-list.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "ENTITLED",
+    "FORBIDDEN",
+    "UNKNOWN",
+    "Entitlement",
+    "DEFAULT_MAX_AGE_S",
+    "entitlement_path",
+    "read_entitlement",
+    "write_entitlement",
+    "probe_entitlement",
+]
+
+ENTITLED = "ENTITLED"
+FORBIDDEN = "FORBIDDEN"
+UNKNOWN = "UNKNOWN"
+
+#: How long a stored verdict is trusted. Beyond this the record reads
+#: UNKNOWN rather than being believed indefinitely -- a FORBIDDEN from
+#: last month must not keep an account out after the subscription came
+#: back, and an ENTITLED from last month must not vouch for one that
+#: has since lapsed. The host timer refreshes well inside this window;
+#: the age limit only bites when the timer has stopped, which is
+#: exactly when its answers should stop counting.
+DEFAULT_MAX_AGE_S = 24 * 3600
+
+#: The probe endpoint. A minimal request: the cheapest call that still
+#: exercises the ENTITLEMENT path rather than mere token validity.
+_API_URL = "https://api.anthropic.com/v1/messages"
+_PROBE_TIMEOUT_S = 20
+
+
+@dataclass(frozen=True)
+class Entitlement:
+    """One account's entitlement verdict and the evidence behind it.
+
+    Attributes
+    ----------
+    name
+        The stored-account name this verdict is about.
+    state
+        :data:`ENTITLED`, :data:`FORBIDDEN` or :data:`UNKNOWN`.
+    checked_at
+        Unix seconds when the live probe ran; ``None`` when no record
+        exists.
+    http_status
+        The status the probe saw, when it got one.
+    detail
+        Short operator-facing evidence -- the API's own error text for
+        a FORBIDDEN, or why the state is UNKNOWN. Never a credential.
+    """
+
+    name: str
+    state: str
+    checked_at: float | None = None
+    http_status: int | None = None
+    detail: str = ""
+
+    @property
+    def blocks_use(self) -> bool:
+        """True only for a MEASURED denial.
+
+        UNKNOWN deliberately returns False: not knowing is not the same
+        as knowing it is dead, and this is the property a boot path
+        gates on.
+        """
+        return self.state == FORBIDDEN
+
+
+def entitlement_path(account_dir: Path) -> Path:
+    """Where one account's verdict lives.
+
+    Beside the credential it describes, so the two travel together and
+    a copied/backed-up account dir carries its own evidence.
+    """
+    return account_dir / "entitlement.json"
+
+
+def read_entitlement(
+    name: str,
+    account_dir: Path,
+    *,
+    now: float | None = None,
+    max_age_s: float = DEFAULT_MAX_AGE_S,
+) -> Entitlement:
+    """Read a stored verdict. NEVER raises, NEVER touches the network.
+
+    This is the function the boot path calls. Every failure mode --
+    absent file, unreadable file, malformed JSON, unrecognised state,
+    a record older than ``max_age_s`` -- degrades to
+    :data:`UNKNOWN` with a ``detail`` saying which, so a boot is never
+    blocked by our own bookkeeping and the operator can still see why
+    we have no answer.
+    """
+    path = entitlement_path(account_dir)
+    now_ts = now if now is not None else time.time()
+
+    # stx-allow: fallback (reason: a boot-path read of best-effort
+    # bookkeeping must degrade to UNKNOWN, never crash a start.)
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        return Entitlement(name, UNKNOWN, detail="never probed")
+    except (OSError, ValueError) as exc:
+        return Entitlement(
+            name, UNKNOWN, detail=f"unreadable record: {type(exc).__name__}"
+        )
+
+    if not isinstance(raw, dict):
+        return Entitlement(name, UNKNOWN, detail="record is not an object")
+
+    state = raw.get("state")
+    if state not in (ENTITLED, FORBIDDEN, UNKNOWN):
+        return Entitlement(name, UNKNOWN, detail=f"unrecognised state {state!r}")
+
+    checked_at = raw.get("checked_at")
+    if not isinstance(checked_at, (int, float)):
+        return Entitlement(
+            name, UNKNOWN, detail="record has no numeric checked_at"
+        )
+
+    age = now_ts - float(checked_at)
+    if age > max_age_s:
+        # Deliberately not believed. See DEFAULT_MAX_AGE_S.
+        return Entitlement(
+            name,
+            UNKNOWN,
+            checked_at=float(checked_at),
+            detail=(
+                f"record is {age / 3600:.1f}h old "
+                f"(limit {max_age_s / 3600:.0f}h) - treating as unknown"
+            ),
+        )
+
+    status = raw.get("http_status")
+    return Entitlement(
+        name=name,
+        state=state,
+        checked_at=float(checked_at),
+        http_status=status if isinstance(status, int) else None,
+        detail=str(raw.get("detail", "")),
+    )
+
+
+def write_entitlement(account_dir: Path, verdict: Entitlement) -> bool:
+    """Persist a verdict beside its credential. Returns success.
+
+    Never raises: this is bookkeeping written from a timer, and a
+    read-only or full disk must not take the timer down.
+    """
+    path = entitlement_path(account_dir)
+    payload = {
+        "state": verdict.state,
+        "checked_at": verdict.checked_at,
+        "http_status": verdict.http_status,
+        "detail": verdict.detail,
+    }
+    # stx-allow: fallback (reason: best-effort bookkeeping write from a
+    # timer; failing to record a verdict must not fail the timer.)
+    try:
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload, indent=2) + "\n")
+        tmp.replace(path)
+        return True
+    except OSError:
+        return False
+
+
+def _classify_http_error(exc: urllib.error.HTTPError) -> Entitlement:
+    """Turn an HTTP error into a three-valued verdict.
+
+    ONLY a 403 naming an OAuth/permission problem is FORBIDDEN. A 401
+    is a token problem, which the freshness gate already owns; a 429 is
+    a quota problem, which the quota ranker owns; 5xx is the server
+    having a bad day. Each of those is UNKNOWN *for the entitlement
+    question* -- answering a question we were not asked is how a signal
+    starts lying.
+    """
+    # stx-allow: fallback (reason: the error body is diagnostic text;
+    # an unreadable body must still yield a verdict.)
+    try:
+        body = exc.read().decode("utf-8", "replace")
+    except Exception:
+        body = ""
+    snippet = " ".join(body.split())[:200]
+    now_ts = time.time()
+
+    if exc.code == 403 and (
+        "oauth" in body.lower() or "permission_error" in body.lower()
+    ):
+        return Entitlement(
+            name="",
+            state=FORBIDDEN,
+            checked_at=now_ts,
+            http_status=403,
+            detail=snippet or "403 permission_error",
+        )
+    return Entitlement(
+        name="",
+        state=UNKNOWN,
+        checked_at=now_ts,
+        http_status=exc.code,
+        detail=f"HTTP {exc.code} is not an entitlement verdict: {snippet}",
+    )
+
+
+def probe_entitlement(
+    name: str,
+    account_dir: Path,
+    *,
+    url: str = _API_URL,
+    timeout_s: float = _PROBE_TIMEOUT_S,
+    opener=None,
+) -> Entitlement:
+    """LIVE probe. Never call this from a boot path -- see module docs.
+
+    Reads the account's stored access token and makes one minimal
+    request. Never raises; every failure becomes a verdict.
+
+    ``opener`` is injected by the tests so they exercise the real
+    classification logic against synthetic responses without a network
+    (no mocks of our own code -- only the transport is substituted).
+    """
+    cred = account_dir / ".credentials.json"
+    # stx-allow: fallback (reason: a missing/rotten credential is a
+    # verdict, not a crash; the freshness gate owns that failure.)
+    try:
+        token = json.loads(cred.read_text())["claudeAiOauth"]["accessToken"]
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        return Entitlement(
+            name,
+            UNKNOWN,
+            checked_at=time.time(),
+            detail=f"no usable access token: {type(exc).__name__}",
+        )
+
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(
+            {
+                "model": "claude-haiku-4-5-20251001",
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+        ).encode(),
+        headers={
+            "authorization": f"Bearer {token}",
+            "anthropic-version": "2023-06-01",
+            "anthropic-beta": "oauth-2025-04-20",
+            "content-type": "application/json",
+        },
+    )
+    _open = opener or urllib.request.urlopen
+
+    # stx-allow: fallback (reason: every transport failure must become
+    # UNKNOWN rather than propagate out of a timer.)
+    try:
+        resp = _open(req, timeout=timeout_s)
+        status = getattr(resp, "status", None)
+        return Entitlement(
+            name,
+            ENTITLED,
+            checked_at=time.time(),
+            http_status=status,
+            detail=f"HTTP {status}",
+        )
+    except urllib.error.HTTPError as exc:
+        verdict = _classify_http_error(exc)
+        return Entitlement(
+            name=name,
+            state=verdict.state,
+            checked_at=verdict.checked_at,
+            http_status=verdict.http_status,
+            detail=verdict.detail,
+        )
+    except Exception as exc:
+        # Timeout, DNS, TLS, connection reset. NOT a subscription
+        # verdict -- see the module docstring on why this must not
+        # collapse into FORBIDDEN.
+        return Entitlement(
+            name,
+            UNKNOWN,
+            checked_at=time.time(),
+            detail=f"probe failed: {type(exc).__name__}: {exc}",
+        )

--- a/src/scitex_agent_container/_creds/_pause.py
+++ b/src/scitex_agent_container/_creds/_pause.py
@@ -1,0 +1,303 @@
+"""Has the operator DECIDED to stop using this account for a while?
+
+OPERATOR REQUEST 2026-08-26, verbatim::
+
+    WYSU、u、Ke のほうは除外というか休止ってできますか？すなわちまた
+    アカウント復活させるので場合によってそれはクオーターを見ながら
+    無駄遣いをしないように止めたり再開したりしてるんですけど、なので
+    その休止の間も失敗しないようにしてほしいんですよ。
+
+He offered 「除外」 (exclusion) and rejected it for 「休止」 -- a PAUSE. He
+stops and restarts subscriptions deliberately, watching quota, and the
+requirement is the last clause: **while an account is paused, nothing
+must fail because of it.**
+
+WHAT FAILS TODAY. One unusable account reds the credential-distribution
+timer on every single pass. Measured chain, 2026-08-26:
+``entitlement.json`` for ``wyusuuke-gmail-com`` holds ``{"state":
+"FORBIDDEN", "http_status": 403}``; :func:`._account_health.account_health`
+turns a VALID snapshot with a blocking verdict into ``FORBIDDEN``;
+:func:`_account.mint_token.mint_access_only_artifact` refuses to mint from
+anything whose ``is_healthy`` is False; that ``MintError`` becomes a
+``KeepaliveError`` per peer; and
+``cli_pkg/_account_keepalive.py`` sets ``failed = True`` and exits 1. One
+resting account x N peers = a permanently red unit, and a signal that is
+always red is one nobody reads -- which is the same reasoning that
+produced ``--optional-peer``. That flag forgives an intermittent PEER;
+nothing here forgave an account whose absence is INTENDED.
+
+PAUSE IS A DECISION; ENTITLEMENT IS AN OBSERVATION
+--------------------------------------------------
+These are the two halves the design must never collapse:
+
+* :mod:`._entitlement` records something MEASURED. A probe authored it,
+  a later probe overwrites it, and nobody types it. It therefore decays
+  (``DEFAULT_MAX_AGE_S``) -- an answer whose prober has stopped running
+  must stop counting.
+* A pause is AUTHORED. No probe can discover it and no probe may lift
+  it. It therefore does **not** decay: a decision does not go stale
+  because nobody re-asserted it, and an expiring pause would un-pause
+  the account behind the operator's back -- the same conflation from
+  the other side.
+
+The separation is enforced by file, not by discipline: this record lives
+in its own sidecar with exactly two writers, both of them operator verbs
+(``sac accounts pause`` / ``sac accounts resume``). ``probe-entitlement``
+has no code path to this file, so it does not need to be TOLD to leave
+it alone -- and it deliberately keeps probing a paused account, so the
+entitlement verdict underneath is already current the moment the
+operator resumes.
+
+WHY A NEW FILE AND NOT A FIELD ON AN EXISTING ONE
+-------------------------------------------------
+Both obvious candidates destroy the flag:
+
+* ``account.json`` -- :func:`_state.account_store.save_account` writes a
+  full object (``payload = dict(metadata); payload["name"] = name``) and
+  ``_account/creds_sync.py`` calls it on every ``sync-live`` with the
+  one-key dict ``{"email_address": ...}``. Any ``paused`` key there is
+  gone at the next credential sync.
+* ``entitlement.json`` -- :func:`._entitlement.write_entitlement` writes
+  its whole four-key object, from a ``*/30`` timer. A pause there is
+  erased within half an hour.
+
+A pause that silently lifts itself is precisely what the operator asked
+us to prevent. So: a sidecar named for its question, beside the
+credential it describes, exactly like ``entitlement.json`` /
+``identity.json`` / ``usage.json``.
+
+PRESENCE IS THE PAUSE
+---------------------
+There is no ``"paused": false`` record. The file exists (with a
+non-empty reason) or the account is not paused; ``resume`` deletes it.
+One spelling per state -- a ``paused: false`` record would be a second
+way to say what the filesystem already says, and the two would drift.
+
+THE REASON IS REQUIRED, AND THAT IS NOT DECORATION
+--------------------------------------------------
+A pause with no stated reason is indistinguishable on disk from an
+account somebody abandoned. The reason is the only thing that makes a
+pause liftable months later, which matters because this record has no
+expiry. The fleet already ruled the same way on ``scitex-cards``'
+``parked`` field: it is a REASON, not a flag, because "a park with no
+stated reason is exactly the abandonment the sweep should still catch".
+A whitespace-only reason is therefore NOT a pause.
+
+DEGRADE TOWARDS VISIBLE, NOT TOWARDS SILENT
+-------------------------------------------
+:func:`read_pause` never raises and never networks, like
+:func:`._entitlement.read_entitlement`. Every failure mode -- absent,
+unreadable, malformed, empty reason -- degrades to ``active=False``
+carrying a non-empty ``problem``. That direction is chosen: an
+unreadable pause record puts the account back in the pool and reds the
+timer again, which is loud and re-pausable. The other direction takes
+an account out of service silently and forever.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "Pause",
+    "pause_path",
+    "read_pause",
+    "write_pause",
+    "clear_pause",
+    "format_age",
+]
+
+
+def format_age(seconds: float | None) -> str:
+    """Render a pause's age the way an operator reads it: ``3d`` / ``4h``.
+
+    Coarse on purpose. This number exists so a pause that has stood for
+    forty days READS as ``40d`` on the keepalive line every run, against
+    the operator's own seven-day horizon for forgotten work. Minute
+    precision on a multi-week decision would be noise.
+    """
+    if seconds is None:
+        return "an unknown time"
+    seconds = max(0.0, float(seconds))
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m"
+    if seconds < 86400:
+        return f"{seconds / 3600:.0f}h"
+    return f"{seconds / 86400:.0f}d"
+
+
+@dataclass(frozen=True)
+class Pause:
+    """One account's pause decision, and the evidence behind it.
+
+    Attributes
+    ----------
+    name
+        The stored-account name this decision is about.
+    active
+        Whether the account is paused RIGHT NOW. False for every
+        failure mode (see :func:`read_pause`), never ``None`` -- the
+        callers of this flag are a boot picker and a timer, and both
+        must be able to act on it without a third branch.
+    reason
+        The operator's own words for WHY. Empty when not paused.
+    since
+        Unix seconds when the pause was written; ``None`` when the
+        record carried no usable timestamp (which does not invalidate
+        the pause -- the reason is the load-bearing field).
+    by
+        Who wrote it (``user@host``), for the audit trail. Best-effort.
+    problem
+        Non-empty only when a record EXISTS but could not be believed.
+        Rendered by the operator-facing verbs so an unreadable pause is
+        visible rather than merely inert.
+    """
+
+    name: str
+    active: bool = False
+    reason: str = ""
+    since: float | None = None
+    by: str = ""
+    problem: str = ""
+
+    def age_seconds(self, now: float | None = None) -> float | None:
+        """How long this pause has stood, or ``None`` without a ``since``."""
+        if self.since is None:
+            return None
+        return (now if now is not None else time.time()) - self.since
+
+    def age_human(self, now: float | None = None) -> str:
+        """:meth:`age_seconds` rendered for a log line — ``3d`` / ``4h``."""
+        return format_age(self.age_seconds(now))
+
+
+def pause_path(account_dir: Path) -> Path:
+    """Where one account's pause decision lives.
+
+    Beside the credential it applies to, so a copied or backed-up
+    account dir carries its own decision -- the same rule
+    :func:`._entitlement.entitlement_path` states for the verdict.
+    """
+    return account_dir / "pause.json"
+
+
+def read_pause(name: str, account_dir: Path) -> Pause:
+    """Read a stored pause. NEVER raises, NEVER touches the network.
+
+    Called from the boot picker and from the credential-distribution
+    timer, so it is a plain local file read for the same reason
+    :func:`._entitlement.read_entitlement` is: the picker runs at every
+    agent boot and must not grow a round-trip.
+
+    Deliberately has NO ``max_age_s`` -- and, unlike its sibling, no
+    ``now`` seam either, because there is nothing here for a clock to
+    decide. See the module docstring: a measurement decays, a decision
+    does not. Age is a rendering question, answered by
+    :meth:`Pause.age_seconds`, which takes its own ``now``.
+
+    Every failure mode degrades to ``active=False`` with ``problem``
+    saying which: absent (the normal case, and the only one with an
+    empty ``problem``), unreadable, not an object, or a reason that is
+    missing / empty / whitespace-only.
+    """
+    path = pause_path(account_dir)
+
+    # stx-allow: fallback (reason: a boot-path read of an operator
+    # decision must degrade to "not paused", never crash a start.)
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        return Pause(name)
+    except (OSError, ValueError) as exc:
+        return Pause(
+            name,
+            problem=f"unreadable pause record: {type(exc).__name__}",
+        )
+
+    if not isinstance(raw, dict):
+        return Pause(name, problem="pause record is not an object")
+
+    reason = str(raw.get("reason", "")).strip()
+    if not reason:
+        # A record with no stated reason is not a pause. See the module
+        # docstring: this is the shape an abandoned account also has,
+        # and refusing it here is what keeps the two distinguishable.
+        return Pause(
+            name,
+            problem=(
+                "pause record carries no reason - refusing to treat it as a "
+                "pause. Re-run `sac accounts pause` with --reason."
+            ),
+        )
+
+    since_raw = raw.get("since")
+    since = float(since_raw) if isinstance(since_raw, (int, float)) else None
+    # A pause with an unusable timestamp is STILL a pause. The reason is
+    # what makes it one; `since` only decides how the age renders, and
+    # discarding an operator's decision over a bad clock stamp would be
+    # the silent direction this module refuses.
+    return Pause(
+        name=name,
+        active=True,
+        reason=reason,
+        since=since,
+        by=str(raw.get("by", "")),
+    )
+
+
+def write_pause(account_dir: Path, pause: Pause) -> bool:
+    """Persist a pause decision beside its credential. Returns success.
+
+    Unlike :func:`._entitlement.write_entitlement` -- which is
+    best-effort bookkeeping from a timer and swallows its own failures
+    -- this returns the outcome to a HUMAN who just typed a command.
+    The caller must refuse to report a pause it could not write; an
+    operator who is told an account is paused, and whose keepalive then
+    keeps failing on it, has been lied to about the one thing he asked
+    for.
+    """
+    path = pause_path(account_dir)
+    payload = {
+        "reason": pause.reason,
+        "since": pause.since,
+        "by": pause.by,
+    }
+    # stx-allow: fallback (reason: the boolean IS the error channel here
+    # - the CLI renders a refusal from it - so a read-only or full disk
+    # must return False rather than raise past the verb.)
+    try:
+        account_dir.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+        tmp.replace(path)
+        return True
+    except OSError:
+        return False
+
+
+def clear_pause(account_dir: Path) -> bool:
+    """Delete the pause record. Returns True iff a record was removed.
+
+    Absence IS "not paused", so deletion is the whole of ``resume``.
+    A False return means there was nothing to lift, which the verb
+    reports rather than treating as an error -- resuming an account
+    that is already running is a no-op the operator is allowed to make.
+
+    Only ``FileNotFoundError`` is absorbed. Any OTHER ``OSError`` (a
+    read-only store, a permission problem) propagates, because it means
+    the pause is STILL THERE: reporting that as "nothing to lift" would
+    tell the operator he had resumed an account that stays paused --
+    exactly the lie :func:`write_pause` refuses in the other direction.
+    """
+    path = pause_path(account_dir)
+    # stx-allow: fallback (reason: an already-absent record is the
+    # success case for `resume`, not an exception. Every other OSError
+    # is deliberately NOT caught - see the docstring.)
+    try:
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -295,13 +295,45 @@ def pick_healthy_account(
     #    read and cost the investigation hours).
     if not fresh:
         probe_ts = now if now is not None else time.time()
+        # THE REMEDY MUST MATCH THE STATE THAT BLOCKED THE BOOT.
+        # `claude /login` + `sync-live` refreshes a token; it does not
+        # lift a pause, and a paused account is out of service by the
+        # operator's own decision, not by any fault. Reviewed
+        # 2026-08-26: with everything paused this raised the sentence
+        # above, whose BRIEF — the red line `_start_single` prints, and
+        # the one actually read — never said PAUSED at all and offered
+        # a command that cannot work. That is the same two-way branch
+        # written before a new state existed which was repaired one
+        # layer down in `mint_token`; repairing it here too is the
+        # other half.
+        paused = [h for h in healths if h.state == "PAUSED"]
+        if paused and len(paused) == len(healths):
+            names = ", ".join(h.name for h in paused)
+            raise NoHealthyAccountError(
+                f"every stored account is PAUSED (probed at "
+                f"{_iso_utc(probe_ts)}): {_format_states(healths)}. Fix: "
+                f"`sac accounts resume {paused[0].name}` — this is a "
+                "decision you made, not a fault; nothing is broken and "
+                "nothing was deleted.",
+                brief=(
+                    f"every stored account is PAUSED ({names}) — run "
+                    f"`sac accounts resume {paused[0].name}`"
+                ),
+            )
         raise NoHealthyAccountError(
             f"no healthy stored account (probed at {_iso_utc(probe_ts)}): "
             f"{_format_states(healths)}. Fix: `claude /login` to one of "
-            "them, then `sac accounts sync-live`, then restart the agent.",
+            "them, then `sac accounts sync-live`, then restart the agent"
+            + (
+                f" — but note {len(paused)} of them are PAUSED and need "
+                "`sac accounts resume` instead."
+                if paused
+                else "."
+            ),
             brief=(
                 f"no fresh account among {', '.join(h.name for h in healths)}"
                 " — run `claude /login` then `sac accounts sync-live`"
+                + (f" ({len(paused)} are PAUSED — resume those)" if paused else "")
             ),
         )
 

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -128,6 +128,19 @@ BORN_CANONICAL: frozenset[str] = frozenset(
         # No host has ever carried a `sac.accounts-entitlement` unit, so
         # there is no orphan for a migration to displace.
         "scitex-agent-container-accounts-entitlement",
+        # Added 2026-08-26. NOT a rename, deliberately, even though
+        # laptop-01 does carry a hand-written `sac-creds-watch.service`:
+        # that unit runs the `watch-live` DAEMON, while this job is a
+        # 2-minute timer over the one-shot `sync-live`. A Rename row would
+        # tell the migrator to stop the fleet's ONLY working credential
+        # watcher and install a timer in its place, in one unsupervised
+        # step — the same stop-then-install order that took the sole OAuth
+        # refresher down for ~2 minutes on 2026-08-18. Declaring it born
+        # canonical lets both run (sync-live is a no-op when the store
+        # already matches), so laptop-01 keeps its watcher until this timer
+        # is VERIFIED firing on all seven hosts; retiring the hand-written
+        # unit is a separate, deliberate step on the migration card.
+        "scitex-agent-container-accounts-snapshot-live",
     }
 )
 

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -107,6 +107,30 @@ class Rename:
 #: names are exactly what ``provide_jobs()`` declares, reading the REAL
 #: provider through the REAL validator. Adding a job without a row, or a
 #: row without a job, fails the build.
+#: Jobs that never had a legacy ``sac.*`` name, so there is nothing to
+#: migrate. EXPLICIT for the same reason RENAMES is: silence here would be
+#: indistinguishable from "someone added a job and forgot the row", which is
+#: exactly what `test_every_declared_job_has_a_row` exists to catch.
+#:
+#: A row cannot express this. ``Rename.__post_init__`` rejects ``old == new``
+#: ("renames nothing"), and rightly — an identity row in the migration table
+#: would tell the migrator to stop a unit, remove it, and reinstall it under
+#: the name it already has. So the fact belongs here, as its own statement,
+#: rather than as a lie in the shape of a rename.
+#:
+#: Anything listed here is asserting: this job was BORN canonical, no host
+#: carries a legacy unit for it, and `sac dev migrate-job-names` must leave
+#: it alone.
+BORN_CANONICAL: frozenset[str] = frozenset(
+    {
+        # Added 2026-08-25, after the rename had already landed — the first
+        # job in this package that never existed under the `sac.*` prefix.
+        # No host has ever carried a `sac.accounts-entitlement` unit, so
+        # there is no orphan for a migration to displace.
+        "scitex-agent-container-accounts-entitlement",
+    }
+)
+
 RENAMES: tuple[Rename, ...] = (
     Rename(
         old="sac.accounts-refresh",

--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -324,7 +324,17 @@ def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
         JobSpec(
             name="scitex-agent-container-accounts-snapshot-live",
             schedule="*/2 * * * *",  # every 2min (cron form; timer below)
-            command=f"/usr/bin/timeout 60 {sac} accounts sync-live",
+            # --poll IS LOAD-BEARING, not cosmetic. Without it this timer
+            # failed EVERY TWO MINUTES on every host whose live credential was
+            # absent or expired -- on 2026-08-26 that was three of the five it
+            # was armed on (compute-01 absent, compute-03 expired ~7.9d,
+            # laptop-01 expired ~4.6d). An expired live credential is the
+            # NORMAL state of a host nobody logged into today, so the
+            # fail-loud contract that is right for a hand-run invocation makes
+            # a SCHEDULED one permanently red: 720 failures a day that protect
+            # nothing and drown out any real problem. --poll turns "nothing to
+            # snapshot" into exit 0 and leaves every safety refusal intact.
+            command=f"/usr/bin/timeout 60 {sac} accounts sync-live --poll",
             description=(
                 "Snapshots a `claude /login` performed in ANY host's TUI into "
                 "that host's account store, so logging in from an arbitrary "

--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -253,4 +253,72 @@ def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
             on_boot_sec="2min",
             on_unit_active_sec="5min",
         ),
+        JobSpec(
+            name="scitex-agent-container-accounts-entitlement",
+            schedule="*/30 * * * *",  # every 30min (cron form; timer below)
+            # SELF-BOUNDING (120s). One minimal request per stored account
+            # (4 today), max_tokens=1; 120s covers all of them on a slow
+            # network and never hangs. A pass killed here leaves the
+            # PREVIOUS verdicts in place, and they age out to UNKNOWN on
+            # their own after 24h rather than being believed forever.
+            command=(
+                "/usr/bin/timeout 120 "
+                f"{sac} accounts probe-entitlement --all"
+            ),
+            description=(
+                "Asks each stored account the question FRESHNESS CANNOT "
+                "ANSWER: may it still RUN? INCIDENT 2026-08-25 — the "
+                "operator cancelled a subscription and nothing noticed. "
+                "OAuth refresh is independent of entitlement, so that "
+                "account kept refreshing successfully (09:17 UTC, new "
+                "expiry 17:17) and read VALID to every gate while every "
+                "real turn on it returned 403 'OAuth authentication is "
+                "currently not allowed for this organization'. Agents were "
+                "routed onto it and died mid-turn. This job writes a "
+                "three-valued verdict beside each credential, which the "
+                "boot picker reads as a local file — it never probes live "
+                "at boot, because pick_healthy_account is cache-only by "
+                "contract and must never burn quota at start-up. WITHOUT "
+                "THIS JOB THE GATE IS INERT: every account reads UNKNOWN, "
+                "which blocks nothing and changes nothing. Read-only — it "
+                "rotates no credential and cannot cost a token, which is "
+                "why it is a separate verb from accounts-refresh. Exits 0 "
+                "even when an account is FORBIDDEN: recording a cancelled "
+                "subscription is this job SUCCEEDING. NOT armed by this "
+                "declaration."
+            ),
+            kind="timer",
+            # 30min is chosen against WHAT THIS SIGNAL MEASURES, which is
+            # the slowest of the three in this file. Entitlement changes
+            # only when a human cancels or restores a subscription — not
+            # continuously like the 5h quota window, and not on a token
+            # clock like refresh. So the cadence is not set by how fast the
+            # truth moves; it is set by HOW LONG A STALE ANSWER COSTS, in
+            # each direction:
+            #
+            #   cancelled -> not yet noticed: up to 30min of agents being
+            #     routed onto a dead account. Bounded and self-correcting.
+            #     The incident that motivated this ran UNBOUNDED.
+            #   restored -> not yet noticed: up to 30min before the account
+            #     rejoins the pool. Costs nothing but a little capacity, and
+            #     THIS is the direction the operator actually exercises —
+            #     「私はよくまたアカウントが必要ならサブスク戻すので」.
+            #
+            # Both are comfortably inside the 24h staleness horizon in
+            # _creds/_entitlement.py, so a verdict is never believed past
+            # the point where this job stopping would matter: if the timer
+            # dies, every verdict decays to UNKNOWN and the gate opens
+            # rather than silently holding accounts out on month-old
+            # evidence.
+            #
+            # NOT faster, deliberately: nothing can act on a fresher answer.
+            # A subscription does not lapse between two 30min ticks in a way
+            # anyone could respond to, and a shorter period only multiplies
+            # calls against an endpoint whose rate limits we do not control.
+            # If a case ever appears where a 30min-old verdict caused a wrong
+            # decision, that is evidence to shorten it — evidence, not a
+            # guess.
+            on_boot_sec="3min",
+            on_unit_active_sec="30min",
+        ),
     ]

--- a/src/scitex_agent_container/_jobs/_specs_accounts.py
+++ b/src/scitex_agent_container/_jobs/_specs_accounts.py
@@ -321,4 +321,43 @@ def accounts_jobs(*, executable: str | None = None) -> "list[JobSpec]":
             on_boot_sec="3min",
             on_unit_active_sec="30min",
         ),
+        JobSpec(
+            name="scitex-agent-container-accounts-snapshot-live",
+            schedule="*/2 * * * *",  # every 2min (cron form; timer below)
+            command=f"/usr/bin/timeout 60 {sac} accounts sync-live",
+            description=(
+                "Snapshots a `claude /login` performed in ANY host's TUI into "
+                "that host's account store, so logging in from an arbitrary "
+                "agent is safe. WHY IT EXISTS (measured 2026-08-25): the "
+                "credential watcher was running on laptop-01 ONLY, 1 host of "
+                "7, because it had been created there by hand as "
+                "sac-creds-watch.service and never entered this federation. "
+                "On the other six a TUI login writes the live credential and "
+                "NOTHING saves it, so the next distribution overwrites it and "
+                "the operator's login silently disappears -- the exact "
+                "conflict he described being afraid of. The same absence "
+                "shows in the data: laptop-01 was the only host whose "
+                "`.credentials.json` was current outside the distribution "
+                "burst, while nas-03's was TEN DAYS STALE (2026-08-16), the "
+                "most likely reason six subagents died that day with 'Login "
+                "expired'. WHY A TIMER AND NOT THE WATCHER, as a cost rather "
+                "than a preference: the instantaneous form is `accounts "
+                "watch-live`, a long-running daemon, and sac lowers EVERY "
+                "declared job to cron with allow_lossy=False, so a daemon has "
+                "no representation this federation can carry -- kind='service' "
+                "validates on JobSpec and then fails the lowering guard. A "
+                "2-minute poll of the one-shot `sync-live` leaves a window: a "
+                "login is lost only if a distribution burst lands inside those "
+                "2 minutes, against the 100% loss six hosts carry today, using "
+                "the path the fleet already supports. Idempotent by contract "
+                "-- creds_sync is a no-op when the store already matches or is "
+                "newer, fails loud rather than saving a stale token, and "
+                "refuses any write that would change a store's recorded "
+                "identity, the guard added in 2026-07 after sync_live "
+                "snapshotted one account's token into another account's store."
+            ),
+            kind="timer",
+            on_boot_sec="1min",
+            on_unit_active_sec="2min",
+        ),
     ]

--- a/src/scitex_agent_container/_lifecycle/_identity_drift.py
+++ b/src/scitex_agent_container/_lifecycle/_identity_drift.py
@@ -4,8 +4,10 @@ An agent has two names that must agree and are set in different places:
 
 * the agent NAME — its spec dir, its tmux session, how peers address it
   over a2a;
-* ``SCITEX_TODO_AGENT_ID`` — its identity on the shared card board, which
-  determines which cards it owns and whose inbox it polls.
+* ``SCITEX_CARDS_AGENT_ID`` — its identity on the shared card board, which
+  determines which cards it owns and whose inbox it polls. It was called
+  ``SCITEX_TODO_AGENT_ID`` until 2026-07-02 and specs still carry both
+  spellings, so this check reads BOTH.
 
 ``_create_templates`` derives the second from the first, so a
 properly-created agent cannot drift. A HAND-EDITED spec can, and does.
@@ -23,13 +25,26 @@ SILENT:
   with a full implementation brief sat runnable under the OTHER name;
 * its pull-inbox under the agent name accumulated unseen notifications
   it never polled, including a card another agent filed for it;
-* every ``reassign_task`` it performed came back
-  ``assignee_liveness: unknown``, so a real handoff was indistinguishable
-  from a handoff into the void.
+NOT a symptom, though it was recorded as one at the time: card writes come
+back with ``assignee_liveness: unknown``. That is true for EVERY agent,
+drifted or not -- verified 2026-08-25 against the live board by an agent
+whose identity was correct and which was demonstrably running. A field that
+reads the same in both states cannot discriminate between them, so it is
+evidence of nothing and must not be used to diagnose this.
 
 Nothing errored. Both queries succeeded and returned well-formed empty
 results, because "no cards assigned to you" and "no cards assigned to
 THIS SPELLING of you" render identically.
+
+_RETIRED_BLINDNESS
+------------------
+This check reads the spec's declared board identity under BOTH the current
+and the retired env name. Reading one spelling only is the same defect the
+module exists to catch: on 2026-08-25 the check looked exclusively for the
+RETIRED name, so for 110 of 148 specs on compute-04 it read an empty string,
+concluded "this spec declares no board identity", and returned quietly. That
+skip is a documented, legitimate branch -- which is what made the blindness
+invisible.
 
 Contract
 --------
@@ -47,7 +62,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 #: The env var whose value IS the agent's identity on the card board.
-BOARD_IDENTITY_ENV = "SCITEX_TODO_AGENT_ID"
+#: This is the CURRENT name; `scitex_cards._store` reads exactly this
+#: (``ENV_AGENT = "SCITEX_CARDS_AGENT_ID"``).
+BOARD_IDENTITY_ENV = "SCITEX_CARDS_AGENT_ID"
+
+#: The RETIRED spelling, renamed 2026-07-02. Specs are migrated one at a time,
+#: so both are live on disk at once -- measured on compute-04 2026-08-25:
+#: 110 specs declared the current name, 21 still declared this one.
+#: Reading only ONE of them is precisely the fault this module exists to catch,
+#: so the check reads BOTH. See `_RETIRED_BLINDNESS` in the module docstring.
+BOARD_IDENTITY_ENV_RETIRED = "SCITEX_TODO_AGENT_ID"
 
 
 def check_board_identity_at_launch(config) -> str | None:
@@ -67,7 +91,13 @@ def check_board_identity_at_launch(config) -> str | None:
     try:
         name = str(getattr(config, "name", "") or "")
         spec_env = getattr(config, "env", None) or {}
-        board_id = str(spec_env.get(BOARD_IDENTITY_ENV, "") or "").strip()
+        board_id = ""
+        declared_under = BOARD_IDENTITY_ENV
+        for _key in (BOARD_IDENTITY_ENV, BOARD_IDENTITY_ENV_RETIRED):
+            board_id = str(spec_env.get(_key, "") or "").strip()
+            if board_id:
+                declared_under = _key
+                break
     except Exception:  # stx-allow: fallback (reason: see inline comment)
         return None
 
@@ -88,7 +118,7 @@ def check_board_identity_at_launch(config) -> str | None:
         "migrates the cards, which is the part that must not be done by "
         "hand; run it with --dry-run first).",
         name,
-        BOARD_IDENTITY_ENV,
+        declared_under,
         board_id,
         name,
         board_id,
@@ -98,4 +128,8 @@ def check_board_identity_at_launch(config) -> str | None:
     return board_id
 
 
-__all__ = ["BOARD_IDENTITY_ENV", "check_board_identity_at_launch"]
+__all__ = [
+    "BOARD_IDENTITY_ENV",
+    "BOARD_IDENTITY_ENV_RETIRED",
+    "check_board_identity_at_launch",
+]

--- a/src/scitex_agent_container/_state/account_store.py
+++ b/src/scitex_agent_container/_state/account_store.py
@@ -25,6 +25,22 @@ from typing import Any
 
 _DEFAULT_STORE_SUBDIR = Path(".scitex") / "agent-container" / "accounts"
 _METADATA_FILENAME = "account.json"
+#: Sidecars that describe the STORED account and must never be copied
+#: into ``~/.claude`` by :func:`switch_account`. Each answers a question
+#: about the account in the store — who it is, whether the API still
+#: accepts it, how much of its quota is gone, whether the operator has
+#: rested it — and none of them says anything about the LIVE login the
+#: switch is establishing. They are listed by name rather than filtered
+#: by suffix so a new credential file added beside them still travels.
+_STORE_ONLY_SIDECARS = frozenset(
+    {
+        _METADATA_FILENAME,
+        "pause.json",
+        "entitlement.json",
+        "identity.json",
+        "usage.json",
+    }
+)
 _CREDENTIALS_FILENAME = ".credentials.json"
 
 # ``sac`` is a first-class short alias for ``agent-container``.
@@ -411,8 +427,17 @@ def switch_account(
     try:
         claude_dir.mkdir(parents=True, exist_ok=True)
         for src in account_dir.iterdir():
-            if src.name == _METADATA_FILENAME:
-                continue  # metadata stays in the account dir; never copy into ~/.claude/
+            if src.name in _STORE_ONLY_SIDECARS:
+                # These describe the STORED ACCOUNT, not the live login,
+                # and none of them has a reader under ~/.claude (checked
+                # 2026-08-26: zero references fleet-wide). Copying them
+                # there produces decision- and verdict-shaped litter in a
+                # directory that is backed up, bind-mounted and copied,
+                # where a future reader could reasonably mistake one for
+                # authority over the live session. `pause.json` is the
+                # one that made this worth naming: a switch used to
+                # deposit the operator's PAUSE DECISION into ~/.claude.
+                continue
             dst = claude_dir / src.name
             tmp = dst.with_suffix(dst.suffix + ".tmp")
             shutil.copy2(src, tmp)

--- a/src/scitex_agent_container/cli_pkg/_account_keepalive.py
+++ b/src/scitex_agent_container/cli_pkg/_account_keepalive.py
@@ -282,6 +282,7 @@ def register_keepalive_command(group: click.Group) -> None:
             refresh_holder_accounts,
             sweep_login_expired,
         )
+        from . import _account_keepalive_pause as _kp
 
         if bool(account_labels) == all_accounts:
             raise click.UsageError(
@@ -323,6 +324,34 @@ def register_keepalive_command(group: click.Group) -> None:
         verified_peers: list[str] = []
         failed = False
         tolerated: list[str] = []
+
+        # A PAUSED account is a DECISION, not a failure. The partition
+        # happens HERE — before the loop, before any mint, before any ssh —
+        # so a paused account can never reach `failed` below. That is the
+        # whole mechanism: no new boolean, no second tolerance list, and the
+        # exit at the end of this callback is untouched. See
+        # :mod:`._account_keepalive_pause` for why this is a skip rather
+        # than a tolerated failure, and why there is no --paused-account
+        # flag.
+        accounts, skipped = _kp.partition_paused(accounts)
+        for account_label, pause in skipped:
+            click.echo(_kp.skip_line(account_label, pause), err=True)
+            records.append(_kp.skip_record(account_label, pause))
+
+        # Empty-because-PAUSED exits 0. Empty-because-this-host-is-not-the-
+        # origin still exits 1, at the guard above. The ordering is the
+        # point: collapsing the two would re-create the always-red bug in
+        # the one case where the operator has paused everything.
+        if not accounts and skipped:
+            click.echo(
+                _kp.all_paused_line(len(skipped), all_accounts=all_accounts),
+                err=True,
+            )
+            if as_json:
+                click.echo(  # stx-allow: STX-IO006
+                    _json.dumps(records, ensure_ascii=False, indent=2)
+                )
+            return
 
         for account_label in accounts:
             for peer in peers:

--- a/src/scitex_agent_container/cli_pkg/_account_keepalive_pause.py
+++ b/src/scitex_agent_container/cli_pkg/_account_keepalive_pause.py
@@ -1,0 +1,226 @@
+"""The credential-distribution run's PAUSE partition, and how it says so.
+
+OPERATOR REQUEST 2026-08-26. He stops and restarts Anthropic
+subscriptions deliberately, watching quota, and asked for one thing
+about the gap between: 「その休止の間も失敗しないようにしてほしい」 --
+while an account is paused, nothing must fail because of it.
+
+WHAT FAILED. ``sac accounts send-credentials --all`` enumerates every
+account this host holds refresh material for and pushes an access-only
+copy to each peer. A rested account still holds refresh material, so it
+was still enumerated; minting from it raised ``MintError`` (its
+entitlement verdict reads FORBIDDEN, or its token is simply not being
+kept alive), which became a ``KeepaliveError`` per peer, which set the
+run's single ``failed`` boolean, which exited 1. One resting account x
+N peers x a short timer = hundreds of failures a day, none of which
+means anything. That is the same defect ``--optional-peer`` was written
+for -- "a signal that is always red is one nobody reads" -- one axis
+over: that flag forgives an intermittent PEER, and nothing forgave an
+ACCOUNT whose absence is intended.
+
+THE MECHANISM IS A PARTITION, NOT A SECOND TOLERANCE. The paused
+accounts are removed from the list BEFORE the push loop, so they cannot
+reach ``failed`` at all. The exit-code logic is untouched; there is no
+new boolean and no new forgiveness path. Two consequences follow, both
+deliberate:
+
+* A SKIP IS NOT A TOLERATED FAILURE, and the run never merges the two
+  counts. A tolerated failure is work that failed and we forgave; a
+  skip is work we correctly did not do. Collapsing them would let a
+  real peer failure hide inside a count of skips.
+* Skipping BEATS tolerating here. Reusing the optional-peer path would
+  be a smaller diff but would still open one ssh connection and print
+  one FAILED line per peer, per account, per pass. Tolerance is the
+  right verb for a peer that MIGHT be up; skip is the right verb for an
+  account the operator has decided is down.
+
+WHY NO ``--paused-account`` FLAG. ``--optional-peer``'s doctrine is "a
+declaration, not a detector … the unit file states exactly which hosts
+may be absent", and this does not violate it. A peer's intermittency is
+per-INVOCATION policy, which belongs where ``systemctl cat`` shows it.
+A pause is a property of the ACCOUNT: already written down, already
+timestamped, already carrying its reason and its author. On the command
+line it would mean editing the JobSpec and redeploying the unit on
+every pause -- a redeploy per pause, the opposite of the one-command
+stop/restart that was asked for. The explicitness lives in
+``pause.json``, and :func:`skip_line` prints the reason AND the age on
+every run, so ``journalctl`` states it as plainly as the unit file
+would.
+
+THE AGE IS IN THE LINE ON PURPOSE. A pause does not expire (see
+:mod:`.._creds._pause`), so the only thing standing between a
+deliberate rest and a forgotten account is that the rest keeps
+announcing how long it has stood. A forty-day pause reads ``40d``,
+against the operator's own seven-day horizon for forgotten work.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .._creds._pause import Pause, read_pause
+
+__all__ = [
+    "partition_paused",
+    "refresh_targets_and_notes",
+    "skip_line",
+    "skip_record",
+    "all_paused_line",
+]
+
+
+def partition_paused(
+    accounts: list[str],
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+) -> tuple[list[str], list[tuple[str, Pause]]]:
+    """Split ``accounts`` into (to-push, paused-with-their-decision).
+
+    Order is preserved in both halves so the run's output stays
+    deterministic and diffable across passes.
+
+    ``store_dir`` / ``home`` are the SAME test seams every function on
+    this path already takes (``account_health``,
+    ``mint_access_only_artifact``, ``keepalive_push``), so a test drives
+    this against a real store on a real ``tmp_path`` with nothing
+    substituted.
+    """
+    from .._state.account_store import _store_path
+
+    store = _store_path(store_dir, home if home is not None else Path.home())
+    judged = [(name, read_pause(name, store / name)) for name in accounts]
+    return (
+        [name for name, pause in judged if not pause.active],
+        [(name, pause) for name, pause in judged if pause.active],
+    )
+
+
+def refresh_targets_and_notes(
+    targets: list[str],
+    *,
+    all_accounts: bool,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> tuple[list[str], list[str]]:
+    """The same partition, for ``sac accounts refresh``. Returns (targets, lines).
+
+    THERE ARE TWO ACCOUNT TIMERS AND A PAUSE MUST REACH BOTH.
+    ``send-credentials`` DISTRIBUTES a credential; ``refresh`` RENEWS
+    one, on its own timer
+    (``sac accounts refresh --all --include-active --sync-active-login``).
+    Reviewed 2026-08-26: the first cut of the pause change taught the
+    distributor to skip a rested account and left the renewer
+    enumerating straight from ``list_accounts``, so every account the
+    operator had stopped was still refreshed over the network on every
+    pass. Two consequences, and both are his own words:
+
+    * A paused account is by construction one whose token is no longer
+      being kept alive, so within hours it stops being "skipped, still
+      fresh" and starts being ATTEMPTED every pass. Each failure feeds
+      ``alert_failed_refreshes``, and when he has paused EVERYTHING
+      every attempt fails and this command exits 1 on every pass --
+      「休止の間も失敗しないようにしてほしい」, one timer over from the
+      one that was fixed.
+    * Each attempt is a network round-trip against a subscription he
+      asked us to stop touching, which is 「無駄遣いをしないように」
+      whatever the exit code says.
+
+    A half-honoured pause is worse than none, because it teaches him
+    the pause works.
+
+    AN EXPLICITLY NAMED ACCOUNT IS STILL REFRESHED. A pause silences
+    the surfaces that enumerate on their own; it is not a lock against
+    the operator typing the name himself, and refusing there would make
+    an account he is about to resume harder to prepare. It gets a note
+    instead, so the two surfaces never disagree in silence.
+    """
+    if not all_accounts:
+        notes = []
+        for name in targets:
+            pause = read_pause(name, _account_dir(name, store_dir, home))
+            if pause.active:
+                notes.append(
+                    f"note: '{name}' is PAUSED ({pause.reason}) — refreshing "
+                    "it anyway because you named it. `--all` skips paused "
+                    "accounts; naming one does not."
+                )
+        return targets, notes
+    remaining, rested = partition_paused(targets, store_dir=store_dir, home=home)
+    return remaining, [skip_line(name, pause, now=now) for name, pause in rested]
+
+
+def _account_dir(name: str, store_dir: Path | None, home: Path | None) -> Path:
+    from .._state.account_store import _store_path
+
+    return _store_path(store_dir, home if home is not None else Path.home()) / name
+
+
+def skip_line(account: str, pause: Pause, *, now: float | None = None) -> str:
+    """The one stderr line a skipped account gets, per run.
+
+    States four things, and each earns its place: that nothing was
+    pushed, that nothing FAILED (the operator's actual requirement --
+    the line must not read like a soft error), how long the pause has
+    stood, and the exact command that lifts it. His words are quoted
+    back to him verbatim: 「また復活させる」 -- he intends to bring these
+    accounts back, so the line has to be readable as a standing
+    reminder, not as noise to filter out.
+    """
+    return (
+        f"  {'(paused)':20s}  {account}: SKIPPED — paused "
+        f"{pause.age_human(now)} ago: {pause.reason}. Nothing pushed, "
+        f"nothing failed. `sac accounts resume {account}` puts it back."
+    )
+
+
+def skip_record(account: str, pause: Pause) -> dict[str, Any]:
+    """The ``--json`` record for a skipped account.
+
+    ``ok`` is True because the run did the right thing, and ``skipped``
+    names WHY so a consumer can tell "pushed successfully" from "did not
+    need pushing" without parsing prose. ``peer`` is None because no
+    peer was involved -- this decision is made once per account, before
+    any peer is contacted.
+    """
+    return {
+        "account": account,
+        "peer": None,
+        "ok": True,
+        "skipped": "paused",
+        "reason": pause.reason,
+        "since": pause.since,
+    }
+
+
+def all_paused_line(count: int, *, all_accounts: bool = True) -> str:
+    """The summary when EVERY account this run was going to push is paused.
+
+    This case must exit 0, and it must not be confused with the
+    ``--all`` guard that refuses when this host holds refresh material
+    for nothing. That guard exits 1 because a host which cannot keep
+    anybody alive has to say so; this one exits 0 because the empty list
+    is exactly what the operator asked for. Same empty list, opposite
+    verdicts, so the two sentences must not sound alike either.
+
+    ``all_accounts`` IS NOT COSMETIC. Reviewed 2026-08-26: the single
+    wording said the accounts were ones "this host holds refresh
+    material for", which is the ``--all`` guard's premise and is
+    established by ``refresh_holder_accounts()``. That function is never
+    called on the explicit ``--account NAME`` path, so on that path the
+    sentence stated a fact the run had not measured. The caller knows
+    which form it is; it passes that in rather than letting this module
+    borrow a premise.
+    """
+    if all_accounts:
+        return (
+            f"  all {count} account(s) this host holds refresh material for "
+            "are PAUSED — nothing to push, and that is the intended state, "
+            "not a failure."
+        )
+    return (
+        f"  every account you named ({count}) is PAUSED — nothing to push, "
+        "and that is the intended state, not a failure."
+    )

--- a/src/scitex_agent_container/cli_pkg/_account_list_build.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_build.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .._creds._pause import Pause
     from ._account_list_render import AccountRow
 
 # ``AccountRow`` is imported INSIDE the functions that construct it, not at
@@ -173,6 +174,29 @@ def verify_stored_identities(accounts: list[dict], *, opener=None) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def read_account_pause(name: str) -> "Pause":
+    """This host's pause decision for ``name`` — a plain local file read.
+
+    The listing reads the PAUSE DIRECTLY rather than switching from
+    :func:`account_freshness` to :func:`account_health`. Both would
+    surface PAUSED, and the swap is arguably the better long-run shape,
+    but it would also start rendering FORBIDDEN on a screen the operator
+    refreshes every few seconds — a visible behaviour change to a
+    different signal, riding along in a change about pausing. That is a
+    separate defect ("the list never surfaces the entitlement verdict")
+    and deserves its own change and its own test.
+
+    Reading the pause on its own is also strictly more capable here: a
+    paused account whose token has EXPIRED still renders as PAUSED,
+    because the decision is true regardless of what the snapshot says.
+    """
+    from .._creds._pause import read_pause
+    from .._state.account_store import _store_path
+
+    store = _store_path(None, Path.home())
+    return read_pause(name, store / name)
+
+
 def build_stored_rows(
     accounts: list[dict],
     *,
@@ -210,6 +234,7 @@ def build_stored_rows(
         usage = usage_for_account(acct, refresh=refresh, passive=passive) or {}
         ident = identities.get(name)
         reading = classify_usage(usage, ident)
+        pause = read_account_pause(name)
         rows.append(
             AccountRow(
                 host=host,
@@ -228,6 +253,8 @@ def build_stored_rows(
                 identity_state=ident.state if ident else "unverified",
                 verified_email=ident.verified_email if ident else None,
                 duplicate_of=ident.duplicate_of if ident else None,
+                pause_reason=pause.reason,
+                pause_since=pause.since,
             )
         )
     return rows
@@ -276,6 +303,17 @@ def build_stored_json(
         fresh = account_freshness(name)
         entry["freshness"] = fresh.state
         entry["freshness_hours"] = fresh.hours
+        # A SIBLING key, never folded into `freshness`. Freshness is a
+        # measurement of a token; a pause is a decision about an account.
+        # A consumer that wants either must not have to disentangle them
+        # from one string — and `None` (not `{"paused": false}`) is the
+        # only spelling of "not paused", matching the disk.
+        pause = read_account_pause(name)
+        entry["paused"] = (
+            {"reason": pause.reason, "since": pause.since, "by": pause.by}
+            if pause.active
+            else None
+        )
         usage = usage_for_account(acct, refresh=refresh, passive=passive)
         entry["usage"] = usage
         ident = identities.get(name)

--- a/src/scitex_agent_container/cli_pkg/_account_list_collapse.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_collapse.py
@@ -93,19 +93,66 @@ def _fmt_hosts_cell(group: AccountGroup, all_hosts: list[str]) -> str:
     return f"{len(present)}/{len(all_hosts)} (not on {', '.join(missing)})"
 
 
+def _row_state(row: AccountRow) -> str:
+    """The state this row AGREES ON — a pause outranks the token reading.
+
+    A pause is a per-host FILE, exactly like the credential beside it,
+    so one machine can be resting an account while another is still
+    pushing it. That is a divergence, and this column exists to surface
+    divergence rather than average it away. Folding the pause into the
+    agreement key is what lets the cell say ``VALID x2; PAUSED on
+    compute-01`` instead of quietly rendering every host as VALID
+    because the pause lives in a field the key never looked at.
+
+    PAUSED wins over the freshness reading for the same reason
+    :func:`.._creds._account_health.account_health` checks it first:
+    when the operator has decided to rest an account, its token's TTL is
+    a true answer to a question nobody is asking.
+    """
+    return "PAUSED" if row.pause_reason else row.freshness_state
+
+
 def _fmt_status_cell(group: AccountGroup) -> str:
     """The agreed credential status, or the disagreement spelled out.
 
     Never reduces divergence to a representative value: an EXPIRED
     credential hidden behind three VALID ones is the one thing this column
     exists to surface.
+
+    Reviewed 2026-08-26: this used to call :func:`_fmt_status`
+    POSITIONALLY, dropping the pause keywords entirely, so the DEFAULT
+    ``sac accounts list`` — the collapsed table, the one the operator
+    actually types — rendered a paused account as ``VALID +7h59m``. The
+    pause was visible only under ``--refresh``, which he does not run.
     """
-    states = {r.freshness_state for r in group.rows}
+    states = {_row_state(r) for r in group.rows}
     if len(states) == 1:
-        return _fmt_status(group.rows[0].freshness_state, group.rows[0].freshness_hours)
-    majority = max(states, key=lambda s: sum(r.freshness_state == s for r in group.rows))
-    odd = [r for r in group.rows if r.freshness_state != majority]
-    detail = ", ".join(f"{r.freshness_state} on {r.host or '?'}" for r in odd)
+        head = group.rows[0]
+        return _fmt_status(
+            head.freshness_state,
+            head.freshness_hours,
+            pause_reason=head.pause_reason,
+            pause_since=head.pause_since,
+        )
+    # A TIE MUST BREAK THE SAME WAY EVERY RUN. ``max`` over a SET of
+    # equally-common states picks whichever the set happens to yield
+    # first, and Python randomises string hashing per process — so two
+    # hosts disagreeing one-to-one rendered as ``VALID x1; PAUSED on
+    # h2`` in one run and ``PAUSED x1; VALID on h1`` in the next, for
+    # identical input. Both sentences are true, which is why nobody
+    # caught it: on a screen the operator refreshes every few seconds
+    # it reads as the fleet flapping. First-seen row order is the
+    # tie-break, so the answer follows the host order the table is
+    # already printed in. A real majority is unaffected.
+    first_seen: dict[str, int] = {}
+    for row in group.rows:
+        first_seen.setdefault(_row_state(row), len(first_seen))
+    majority = max(
+        states,
+        key=lambda s: (sum(_row_state(r) == s for r in group.rows), -first_seen[s]),
+    )
+    odd = [r for r in group.rows if _row_state(r) != majority]
+    detail = ", ".join(f"{_row_state(r)} on {r.host or '?'}" for r in odd)
     return f"{majority} x{len(group.rows) - len(odd)}; {detail}"
 
 

--- a/src/scitex_agent_container/cli_pkg/_account_list_fleet.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_fleet.py
@@ -129,6 +129,19 @@ def rows_from_stored(stored: list[dict], host: str) -> list:
     account is not this account's usage, however freshly it was fetched, and it
     must not be rendered under the wrong name just because it survived an ssh
     hop.
+
+    ``paused`` IS READ HERE FOR THE SAME REASON THE TABLE EXISTS. This
+    function feeds the DEFAULT ``sac accounts list`` — including this
+    machine's own accounts, which reach it through
+    :func:`._account_list_build.build_stored_json` rather than through
+    ssh. Reviewed 2026-08-26: the first cut of the pause change wired
+    the key into ``build_stored_json`` and never read it back out here,
+    so a paused account still rendered ``VALID +7h59m`` on the one
+    screen the operator actually types, and only ``--refresh`` showed
+    the pause. A pause never expires and nothing nags him about one, so
+    the listing IS the standing reminder; dropping it at this boundary
+    made the reminder not exist. A peer running an older ``sac`` simply
+    omits the key, which the ``.get`` below reads as "not paused".
     """
     from ._account_list_render import AccountRow
 
@@ -143,6 +156,7 @@ def rows_from_stored(stored: list[dict], host: str) -> list:
         state = entry.get("usage_state") or "unknown"
         known = state == "known"
         identity = entry.get("identity") if isinstance(entry.get("identity"), dict) else {}
+        paused = entry.get("paused") if isinstance(entry.get("paused"), dict) else {}
         rows.append(
             AccountRow(
                 host=host,
@@ -161,6 +175,8 @@ def rows_from_stored(stored: list[dict], host: str) -> list:
                 identity_state=str(identity.get("state") or "unverified"),
                 verified_email=_as_str(identity.get("verified_email")),
                 duplicate_of=_as_str(identity.get("duplicate_of")),
+                pause_reason=_as_str(paused.get("reason")) or "",
+                pause_since=_as_float(paused.get("since")),
             )
         )
     return rows

--- a/src/scitex_agent_container/cli_pkg/_account_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_render.py
@@ -41,6 +41,7 @@ contract downstream consumers parse.
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -135,6 +136,18 @@ class AccountRow:
     identity_state: str = "unverified"
     verified_email: str | None = None
     duplicate_of: str | None = None
+    # The operator's OWN reason for resting this account, and when he
+    # decided it. Empty / None means not paused — presence is the pause,
+    # exactly as it is on disk (see :mod:`.._creds._pause`). Both default,
+    # so every hand-rolled AccountRow in the existing tests still
+    # constructs, which is this dataclass's stated design.
+    #
+    # It is here at all because 「また復活させる」 — he intends to bring
+    # these accounts back. A pause that is invisible on the screen he
+    # actually reads is a trap: it never expires and nothing nags, so the
+    # listing IS the reminder.
+    pause_reason: str = ""
+    pause_since: float | None = None
     # WHICH MACHINE this credential lives on. Empty on the single-host path,
     # which is why the Host column only appears once something fills it in.
     # A credential is a per-host FILE and is not on the sync rail, so the same
@@ -150,7 +163,44 @@ class AccountRow:
 # ---------------------------------------------------------------------------
 
 
-def _fmt_status(state: str, hours: float | None) -> str:
+#: How much of an operator's reason survives into the Status cell. Long
+#: enough to be recognised, short enough not to shove the columns beside
+#: it off the terminal.
+_PAUSE_REASON_CHARS = 40
+
+
+def _fmt_status(
+    state: str,
+    hours: float | None,
+    *,
+    pause_reason: str = "",
+    pause_since: float | None = None,
+    now_ts: float | None = None,
+) -> str:
+    """The Status cell: what this credential is, in one phrase.
+
+    A PAUSE OUTRANKS THE TTL AND REPLACES IT. The cell normally reads
+    ``VALID +2h26m``, and that TTL belongs to the TOKEN. Printing it
+    beside PAUSED — ``PAUSED +6.2h`` — would be read as "the pause
+    expires in 6.2 hours", which is a lie about the one property that
+    makes a pause trustworthy: it never expires. So the paused row
+    carries the age of the DECISION and the operator's own words
+    instead, and no token TTL at all. There is precedent for a
+    non-freshness value in this field (``CONFIGURED``, for the Codex
+    login, which has no TTL to show either).
+    """
+    if pause_reason:
+        from .._creds._pause import format_age
+
+        age = (
+            format_age((now_ts if now_ts is not None else time.time()) - pause_since)
+            if pause_since is not None
+            else "?"
+        )
+        reason = pause_reason.strip()
+        if len(reason) > _PAUSE_REASON_CHARS:
+            reason = reason[: _PAUSE_REASON_CHARS - 1].rstrip() + "…"
+        return f"PAUSED {age} — {reason}"
     if state == "ABSENT":
         return "ABSENT"
     if hours is None:
@@ -250,7 +300,12 @@ def render_stored_table(
         cells = [
             r.provider,
             r.name,
-            _fmt_status(r.freshness_state, r.freshness_hours),
+            _fmt_status(
+                r.freshness_state,
+                r.freshness_hours,
+                pause_reason=r.pause_reason,
+                pause_since=r.pause_since,
+            ),
             _fmt_identity_cell(r),
             _fmt_last_update_cell(r.snapshot_as_of, now=now),
         ]

--- a/src/scitex_agent_container/cli_pkg/_account_pause.py
+++ b/src/scitex_agent_container/cli_pkg/_account_pause.py
@@ -1,0 +1,350 @@
+"""``sac accounts pause`` / ``sac accounts resume`` — stop an account, keep it.
+
+OPERATOR REQUEST 2026-08-26, verbatim::
+
+    WYSU、u、Ke のほうは除外というか休止ってできますか？…また
+    アカウント復活させるので…クオーターを見ながら無駄遣いをしないように
+    止めたり再開したりしてるんですけど、なのでその休止の間も失敗しない
+    ようにしてほしいんですよ。
+
+He offered 「除外」 (exclusion) and rejected it, in the same sentence,
+for 「休止」 — a PAUSE. The two verbs here are that word, and the word
+is load-bearing: ``disable`` was the obvious English alternative and is
+refused, because "disabled" reads as a capability judgement. That is
+already what FORBIDDEN means (a measured 403 from the API), and reusing
+its vocabulary here would collapse the two ideas this whole change
+exists to keep apart. ``pause`` is also existing house vocabulary for a
+deliberate, reversible stop — see the fleet-wide periodic pause in
+:mod:`.._lifecycle._periodic_drive`.
+
+WHY ``--reason`` IS REQUIRED
+----------------------------
+It is not decoration and it is not a nicety. This record has no expiry
+(:mod:`.._creds._pause` explains why: a decision does not go stale
+because nobody re-asserted it), so nothing will ever come along and
+clean up a pause the operator has forgotten. The reason is the only
+thing that distinguishes, months later, a deliberate rest from an
+account somebody abandoned — they are otherwise the same file on disk.
+The fleet already ruled the same way on ``scitex-cards``' ``parked``
+field, for the same reason and in nearly the same words: "a park with
+no stated reason is exactly the abandonment the sweep should still
+catch." Whitespace-only is refused for that reason, not on principle.
+
+WHY ``pause`` CAN REFUSE
+------------------------
+Pausing every usable account leaves the picker with nothing and every
+``sac agents start`` preflight fails. So ``pause`` refuses when it
+would leave zero accounts that read VALID right now, names them, and
+``--yes`` overrides. What it deliberately does NOT do is make the
+picker ignore a pause when everything is paused: that would be a gate
+that cannot fail — the account would be paused right up until the
+moment the pause mattered.
+
+WHAT NEITHER VERB DOES
+----------------------
+Neither touches a credential, a token, an entitlement verdict or a
+directory. ``pause`` writes one small JSON file; ``resume`` deletes it.
+That is the whole of it, and it is why 「また復活させる」 costs one
+command. In particular the entitlement probe keeps running THROUGH a
+pause on purpose, so the subscription verdict underneath is already
+current the moment the operator resumes.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import click
+
+__all__ = ["register_pause_commands"]
+
+
+def _who() -> str:
+    """``user@host`` for the audit trail. Best-effort, never a secret.
+
+    FALLS THROUGH THE OS, NOT STRAIGHT TO A LITERAL. Reviewed
+    2026-08-26: the first cut read only ``$USER`` / ``$LOGNAME`` and
+    recorded ``unknown@<host>`` when neither was set — which is the
+    NORMAL case for anything run from systemd, cron or a bare container
+    shell, and was in fact what the reviewer's own run wrote. A pause
+    has no expiry, so months later this field and the reason are the
+    only two things separating a deliberate rest from an abandoned
+    account; answering half of that with the string "unknown", and
+    doing so most reliably in non-interactive contexts, is the wrong
+    way to be approximate. :func:`getpass.getuser` consults ``pwd``
+    when the environment is silent.
+    """
+    import getpass
+    import socket
+
+    # stx-allow: fallback (reason: an unresolvable uid or hostname must
+    # not stop an operator from pausing an account; both fields are
+    # audit hints, and the reason is the load-bearing one.)
+    try:
+        user = getpass.getuser()
+    except (KeyError, OSError):
+        user = "unknown"
+    try:
+        host = socket.gethostname()
+    except OSError:
+        host = "unknown-host"
+    return f"{user}@{host}"
+
+
+def _known_accounts() -> list[str]:
+    from .._state.account_store import list_accounts
+
+    return sorted(str(a.get("name", "")) for a in list_accounts() if a.get("name"))
+
+
+def _resolve_account_dir(name: str) -> Path:
+    """The account's directory, or raise a click error naming the real ones.
+
+    MEMBERSHIP IN THE ENUMERATOR, NOT MERE EXISTENCE ON DISK. Anything
+    :func:`._state.account_store.list_accounts` does not name is
+    refused, because that enumerator is what every reader of a pause
+    goes through: ``sac accounts send-credentials --all`` reaches it via
+    ``refresh_holder_accounts``, and ``sac accounts list`` calls it
+    directly.
+
+    Reviewed 2026-08-26, measured on a store with the real shape. The
+    first cut checked ``account_dir.is_dir()``, which is true of things
+    that are not accounts: ``pause anthropic`` (the PROVIDER dir),
+    ``pause _backup`` and ``pause .swap-backup-20260815`` (store
+    bookkeeping and editor litter) all exited 0 saying "paused", wrote
+    a ``pause.json`` where nothing would ever read it, and the very
+    next keepalive run still enumerated and still failed. A verb that
+    reports a decision recorded somewhere inert is the wrong direction
+    to degrade in for a change whose whole premise is that an authored
+    decision must never be silently lost.
+
+    This is reachable in the real store rather than hypothetical: the
+    accounts are symlinked short names (``wyusuuke-gmail-com ->
+    anthropic/wyusuuke-gmail-com``), so an ``ls`` shows ``anthropic``
+    sitting among the account names, and ``anthropic`` used to pause
+    successfully. Membership implies existence, so nothing legal is
+    lost — ``_``/``.``-prefixed names are documented as never being
+    account names, and a BARE account dir (no metadata, no credential)
+    is still enumerated, so it stays pausable.
+    """
+    from .._state.account_store import _store_path
+
+    known = _known_accounts()
+    if name not in known:
+        raise click.ClickException(
+            f"unknown account '{name}' — this host stores: "
+            f"{', '.join(known) if known else '(none)'}"
+        )
+    return _store_path(None, Path.home()) / name
+
+
+def _still_servable(exclude: str) -> list[str]:
+    """Accounts that read VALID right now, ignoring ``exclude``."""
+    from .._creds._account_health import account_health
+
+    out: list[str] = []
+    for name in _known_accounts():
+        if name == exclude:
+            continue
+        if account_health(name).state == "VALID":
+            out.append(name)
+    return out
+
+
+def _would_strand_the_picker(name: str) -> bool:
+    """Would pausing ``name`` take the LAST pickable account out of service?
+
+    Both halves are load-bearing, and the second was missing.
+
+    Reviewed 2026-08-26: the guard asked only "is anything ELSE
+    VALID?", so it fired on a target that was not VALID either — and
+    then stated, as its reason, that the target "currently reads
+    VALID". Measured on a store holding one EXPIRED and one FORBIDDEN
+    account: ``pause <the FORBIDDEN one>`` was refused, both clauses of
+    the refusal false, and the operator had to reach for ``--yes`` to
+    do something that could not have broken anything.
+
+    That is precisely the account class this feature exists for. His
+    FORBIDDEN account is the one he wants to rest, and the fleet's
+    others read EXPIRED between keepalive passes, so the real workflow
+    walked straight into a refusal built for a different situation.
+
+    An account that is not VALID cannot be picked, so pausing it
+    removes nothing from the picker's set and there is nothing to
+    refuse. The guard now asks the TARGET's own state first.
+    """
+    from .._creds._account_health import account_health
+
+    if account_health(name).state != "VALID":
+        return False
+    return not _still_servable(name)
+
+
+def register_pause_commands(group: click.Group) -> None:
+    """Attach ``pause`` and ``resume`` onto the accounts group."""
+
+    @group.command("pause")
+    @click.argument("name")
+    @click.option(
+        "--reason",
+        required=True,
+        help=(
+            "WHY this account is being rested, in your own words. Required, "
+            "and whitespace-only is refused. A pause never expires, so this "
+            "sentence is the only thing that will tell you months from now "
+            "whether the account is resting or forgotten — and it is what "
+            "every keepalive run prints back at you until you resume it."
+        ),
+    )
+    @click.option(
+        "--yes",
+        "-y",
+        is_flag=True,
+        default=False,
+        help=(
+            "Pause even when it would leave NO account reading VALID. "
+            "Without it that case is refused, because an all-paused store "
+            "fails every agent boot."
+        ),
+    )
+    def account_pause(name: str, reason: str, yes: bool) -> None:
+        """Stop using an account WITHOUT deleting it — a decision, not a fault.
+
+        For the workflow of stopping a subscription and putting it back
+        later. Nothing is deleted and no credential is touched;
+        `sac accounts resume NAME` puts it back in one command.
+
+        EXACTLY WHAT A PAUSE STOPS, stated narrowly on purpose. No NEW
+        agent boot picks the account, quota rotation never lands on it,
+        its credential is no longer refreshed or pushed to peers, and
+        both credential timers report it SKIPPED instead of failing.
+
+        WHAT IT DOES NOT STOP: an agent already running on that
+        credential keeps its token until it restarts, a peer keeps
+        serving the copy it already has until that copy expires (hours),
+        and `sac accounts switch` will still put the account on this
+        host's live login if you ask it to by name.
+
+        A pause is never discovered and never lifted by any probe.
+        `sac accounts probe-entitlement` keeps recording whether the
+        subscription is live underneath, so that verdict is already
+        current when you resume — but only these verbs, run by you, can
+        pause or resume.
+
+        A pause does NOT expire. Nothing will un-pause it for you; that
+        is what makes it trustworthy, and it is why --reason is
+        required.
+
+        It is written HERE, on this host, beside this host's copy of the
+        credential — the path is printed. Peers stop receiving the
+        credential immediately and drop the account when their copy
+        expires.
+        """
+        from .._creds._pause import Pause, pause_path, read_pause, write_pause
+
+        if not reason.strip():
+            raise click.ClickException(
+                "--reason is empty. A pause with no stated reason is "
+                "indistinguishable from an abandoned account, and nothing "
+                "will ever expire it for you. Say why."
+            )
+
+        account_dir = _resolve_account_dir(name)
+        existing = read_pause(name, account_dir)
+        if existing.problem:
+            click.echo(
+                f"note: the existing pause record was not usable "
+                f"({existing.problem}). Overwriting it.",
+                err=True,
+            )
+
+        if not yes and not existing.active and _would_strand_the_picker(name):
+            raise click.ClickException(
+                f"refusing to pause '{name}': it is the last stored "
+                "account that currently reads VALID, so pausing it "
+                "would leave the picker with nothing and fail every "
+                "agent boot. Pass --yes if that is what you want."
+            )
+
+        record = Pause(
+            name=name,
+            active=True,
+            reason=reason.strip(),
+            since=time.time(),
+            by=_who(),
+        )
+        if not write_pause(account_dir, record):
+            raise click.ClickException(
+                f"could not write {pause_path(account_dir)} — the account is "
+                "NOT paused. Check the store's permissions and free space; "
+                "reporting a pause we failed to record would be the one lie "
+                "this command must not tell."
+            )
+        click.echo(
+            f"paused {name}: {record.reason}\n"
+            f"  record: {pause_path(account_dir)}\n"
+            f"  nothing was deleted; `sac accounts resume {name}` lifts it."
+        )
+
+    @group.command("resume")
+    @click.argument("name")
+    def account_resume(name: str) -> None:
+        """Put a paused account back in service. The inverse of `pause`.
+
+        Prints the reason that was lifted, how long the pause stood, and
+        what the account's health reads NOW — a resumed account whose
+        subscription is still cancelled reads FORBIDDEN, not VALID. That
+        is a different problem with a different fix (restore the
+        subscription; the entitlement probe picks it up within 30
+        minutes on its own).
+        """
+        from .._creds._account_health import account_health
+        from .._creds._pause import clear_pause, pause_path, read_pause
+
+        account_dir = _resolve_account_dir(name)
+        existing = read_pause(name, account_dir)
+        # :func:`clear_pause` deliberately propagates every OSError that
+        # is not FileNotFoundError, because a permission-denied unlink
+        # means the pause is STILL THERE and calling that "nothing to
+        # lift" would be the lie in the other direction. That decision
+        # is right and the RENDERING of it was missing: without this,
+        # the one verb whose whole promise is that 「また復活させる」
+        # costs one command ended in a Python stack trace on a
+        # read-only store.
+        try:
+            removed = clear_pause(account_dir)
+        except OSError as exc:
+            raise click.ClickException(
+                f"could not remove {pause_path(account_dir)} ({exc}) — "
+                f"'{name}' is STILL PAUSED. Fix the store's permissions "
+                "and re-run; nothing else was changed."
+            ) from exc
+
+        if not removed:
+            click.echo(f"{name} was not paused — nothing to lift.")
+        elif existing.active:
+            click.echo(
+                f"resumed {name} after {existing.age_human()} — lifted: "
+                f"{existing.reason}"
+            )
+        else:
+            click.echo(
+                f"resumed {name}: removed an unusable pause record "
+                f"({existing.problem or 'no reason recorded'}), which was "
+                "not holding the account back anyway."
+            )
+
+        # State the RESULT, never imply it. A pause was one reason this
+        # account was out of service; it may not have been the only one,
+        # and an operator told "resumed" who then watches it keep failing
+        # has been answered about the wrong question.
+        health = account_health(name)
+        click.echo(f"  health now: {health.state}")
+        if health.state == "FORBIDDEN":
+            click.echo(
+                "  the pause is lifted, but the API still refuses this "
+                f"account: {health.entitlement_detail}. Restore the "
+                "subscription — probe-entitlement clears this on its own "
+                "within 30 minutes."
+            )

--- a/src/scitex_agent_container/cli_pkg/_account_probe_entitlement.py
+++ b/src/scitex_agent_container/cli_pkg/_account_probe_entitlement.py
@@ -1,0 +1,140 @@
+"""``sac accounts probe-entitlement`` — the PRODUCER of the verdicts.
+
+The boot picker only ever READS a cached entitlement verdict (see
+:mod:`.._creds._entitlement` for why it must never probe live at
+start-up). Something has to write those verdicts, and this is it.
+
+Without a periodic run of this command the file never exists, every
+account reads ``UNKNOWN``, and the entitlement gate is inert — exactly
+the failure mode ``refresh-quota-cache`` documents for the quota cache.
+It is meant to be attached to the host timer that already walks every
+account.
+
+WHY IT IS A SEPARATE VERB FROM ``refresh``. Refresh rotates a
+single-use OAuth token; this makes a read-only request and rotates
+nothing. Keeping them separate means a de-entitled account can be
+re-checked as often as we like without touching credential material,
+and a probe failure can never cost us a token.
+
+INCIDENT 2026-08-25 is the reason the verb exists: a cancelled
+subscription kept refreshing its token successfully and so passed every
+freshness gate while returning 403 on every real turn.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+def register_probe_entitlement_command(group) -> None:
+    """Attach ``probe-entitlement`` onto the ``accounts`` group."""
+
+    @group.command("probe-entitlement")
+    @click.option(
+        "--all",
+        "all_accounts",
+        is_flag=True,
+        default=False,
+        help="Probe every stored account (what the host timer runs).",
+    )
+    @click.argument("name", required=False)
+    @click.option(
+        "--json",
+        "as_json",
+        is_flag=True,
+        default=False,
+        help="Emit a JSON array of verdicts.",
+    )
+    def probe_entitlement_cmd(
+        all_accounts: bool, name: str | None, as_json: bool
+    ) -> None:
+        """Ask each account whether it may still RUN, and cache the answer.
+
+        Freshness and entitlement are different questions. A cancelled
+        subscription refreshes its OAuth token perfectly well, so it
+        looks healthy to every freshness gate while returning 403 for
+        an actual turn. This command asks the second question and
+        writes the verdict beside the credential, where the boot picker
+        reads it.
+
+        Read-only: it rotates nothing and cannot cost a token.
+
+        Verdicts are three-valued. Only a measured 403 naming an
+        OAuth/permission error becomes FORBIDDEN. A timeout, a 5xx, a
+        429 or a missing credential is UNKNOWN, and UNKNOWN never takes
+        an account out of service — a network blip is not a cancelled
+        subscription.
+
+        Re-running after the subscription is restored flips the verdict
+        back on its own; nothing else has to be edited.
+
+        \b
+        Examples:
+          $ sac accounts probe-entitlement --all
+          $ sac accounts probe-entitlement wyusuuke-gmail-com
+          $ sac accounts probe-entitlement --all --json
+        """
+        import json as _json
+        from pathlib import Path
+
+        from .._creds._entitlement import (
+            FORBIDDEN,
+            probe_entitlement,
+            write_entitlement,
+        )
+        from .._state.account_store import _store_path, list_accounts
+
+        store = _store_path(None, Path.home())
+
+        if name:
+            names = [name]
+        elif all_accounts:
+            names = [a["name"] for a in list_accounts()]
+        else:
+            raise click.UsageError("give an account NAME or pass --all")
+
+        results = []
+        any_forbidden = False
+        for acct in names:
+            acct_dir = store / acct
+            verdict = probe_entitlement(acct, acct_dir)
+            written = write_entitlement(acct_dir, verdict)
+            if verdict.state == FORBIDDEN:
+                any_forbidden = True
+            results.append(
+                {
+                    "account": acct,
+                    "state": verdict.state,
+                    "http_status": verdict.http_status,
+                    "detail": verdict.detail,
+                    "recorded": written,
+                }
+            )
+
+        if as_json:
+            click.echo(_json.dumps(results, indent=2))
+        else:
+            for r in results:
+                click.echo(
+                    f"  {r['account']:<28} {r['state']:<10} {r['detail']}"
+                )
+            if any_forbidden:
+                # Say what it MEANS, not just what it is. "FORBIDDEN"
+                # alone reads as our bug; the operator needs to know it
+                # is a subscription, that the fleet already routed
+                # around it, and that restoring it needs no cleanup.
+                click.echo("")
+                click.echo(
+                    "  A FORBIDDEN account is out of the rotation pool from "
+                    "now on. Its credentials are untouched; restore the "
+                    "subscription and the next run of this command puts it "
+                    "back automatically."
+                )
+
+        # Exit 0 even with a FORBIDDEN result: recording a cancelled
+        # subscription is this command SUCCEEDING. A non-zero exit would
+        # mark the timer unit `failed` on every pass for as long as the
+        # operator chose to keep a subscription cancelled — the exact
+        # "unit reports failure while doing its job correctly" trap that
+        # `anthropic/`-as-an-account caused on 2026-07-29, which trains
+        # readers to ignore the unit.

--- a/src/scitex_agent_container/cli_pkg/_account_refresh.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh.py
@@ -307,6 +307,19 @@ def account_refresh(
     else:
         targets = [name]  # type: ignore[list-item]
 
+    # THE OTHER ACCOUNT TIMER HONOURS THE PAUSE TOO. `send-credentials`
+    # distributes a credential and `refresh` renews one; a pause the operator
+    # set must reach both, or the half that ignores it keeps failing about a
+    # rested account and keeps spending its quota to do so. See
+    # :func:`._account_keepalive_pause.refresh_targets_and_notes`.
+    from . import _account_keepalive_pause as _kp
+
+    targets, pause_notes = _kp.refresh_targets_and_notes(
+        list(targets), all_accounts=bool(do_all), home=home
+    )
+    for pause_note in pause_notes:
+        click.echo(pause_note, err=True)
+
     # Active-login family detection (for --sync-active-login). Read the live
     # ~/.claude login's refresh_token ONCE (realpath, symlinks followed) and
     # find the target account whose snapshot refresh_token EQUALS it —

--- a/src/scitex_agent_container/cli_pkg/_account_sync_live.py
+++ b/src/scitex_agent_container/cli_pkg/_account_sync_live.py
@@ -20,7 +20,17 @@ import click
     default=False,
     help="Emit a JSON object describing what happened.",
 )
-def account_sync_live(as_json: bool) -> None:
+@click.option(
+    "--poll",
+    is_flag=True,
+    default=False,
+    help=(
+        "Treat 'no snapshottable credential' as a no-op (exit 0) instead of a "
+        "failure. For scheduled callers; a hand-run invocation wants the loud "
+        "default."
+    ),
+)
+def account_sync_live(as_json: bool, poll: bool) -> None:
     """Snapshot the live credential into its matching account store.
 
     Reads the live ``~/.claude/.credentials.json`` + the active email
@@ -30,6 +40,31 @@ def account_sync_live(as_json: bool) -> None:
 
     Fails loud (non-zero exit) when the live credential is absent,
     malformed, or expired — never saves a stale token.
+
+    ``--poll`` MAKES THAT LAST CASE A NO-OP INSTEAD, and the distinction is
+    the point: "there is nothing to snapshot" is not the same event as
+    "something went wrong". A human running this by hand has just logged in
+    and wants to be told if the save failed, so the loud default is right for
+    them. A TIMER has no such context, and on a host nobody logged into today
+    the live credential is absent or expired as a matter of course.
+
+    MEASURED 2026-08-26, which is why this flag exists. The 2-minute
+    snapshot timer was armed on five hosts and only two had a usable live
+    credential:
+        compute-04  valid                 -> exit 0
+        nas-03      valid                 -> exit 0
+        compute-01  absent                -> exit 1
+        compute-03  expired ~7.9 days     -> exit 1
+        laptop-01   expired ~4.6 days     -> exit 1
+    Three hosts would have failed every two minutes forever — 720 failures a
+    day each — which does not protect anything and makes the unit's exit
+    status meaningless. A job that is always red cannot report a NEW problem.
+    The refusal itself was correct every time; wrapping a fail-loud one-shot
+    in a poll was the error.
+
+    Nothing about the SAFETY contract changes: a stale token is still never
+    written, an identity change is still refused. Only the exit code for
+    "nothing to do" moves, and only when the caller asks for it.
 
     \b
     Examples:
@@ -51,8 +86,12 @@ def account_sync_live(as_json: bool) -> None:
                 )
             )
         else:
-            click.echo(f"Error: {exc}", err=True)
-        raise SystemExit(1)
+            # "nothing to snapshot" reads as a NOTE under --poll and as an
+            # ERROR otherwise, so the log line matches the exit code rather
+            # than contradicting it.
+            label = "Nothing to snapshot" if poll else "Error"
+            click.echo(f"{label}: {exc}", err=not poll)
+        raise SystemExit(0 if poll else 1)
 
     if as_json:
         click.echo(

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -95,7 +95,10 @@ and ``--dry-run`` is offered on every mutating verb sac exposes.
 
 from __future__ import annotations
 
+import os
 import shutil
+import sys
+from pathlib import Path
 import subprocess
 from dataclasses import dataclass
 
@@ -362,6 +365,28 @@ def build_argv(
     return argv
 
 
+def resolve_scitex_dev(
+    *, executable: str | None = None, path: str | None = None
+) -> str | None:
+    """The ``scitex-dev`` that belongs to the interpreter we are running in.
+
+    SIBLING OF ``sys.executable`` FIRST, then PATH. Returns ``None`` when
+    neither resolves, so the caller can raise a clean ClickException.
+
+    ``executable`` and ``path`` default to ``sys.executable`` and ``$PATH``
+    and exist so this can be TESTED WITHOUT PATCHING ANYTHING. PA-306 forbids
+    mocks, and it counts the ``monkeypatch`` fixture itself — correctly: a
+    test that reaches in and rewrites ``sys.executable`` is asserting on a
+    world it invented. Taking both as arguments lets a test lay down two real
+    binaries and ask which one this function picks, which is the actual
+    question.
+    """
+    sibling = Path(executable or sys.executable).with_name("scitex-dev")
+    if sibling.exists():
+        return str(sibling)
+    return shutil.which("scitex-dev", path=path or os.environ.get("PATH"))
+
+
 def invoke(
     delegation: Delegation,
     *,
@@ -373,13 +398,45 @@ def invoke(
 ) -> int:
     """Run the resolved ``scitex-dev ecosystem`` command; return its exit code.
 
-    ``scitex-dev`` is a hard dependency of this package, so the console
-    script is expected on PATH; a missing binary is a clean
-    ClickException rather than a stack trace.
+    RESOLVED AS A SIBLING OF ``sys.executable`` FIRST, then PATH.
+
+    The invariant this order exists to keep: **execute the verb in the same
+    interpreter that answered the questions leading up to it.** Three reads
+    precede this one write, and all three are in-process --
+    :func:`_dev_jobs_capability.ecosystem_verbs` imports scitex-dev's Click
+    tree to ask whether the verb exists, and ``_dev_jobs._resolve_one``
+    resolves the short name against ``scitex_dev.jobs`` entry points. If the
+    write then lands in a DIFFERENT installation, sac has asked A and acted
+    on B, and the failure is silent and confusing rather than loud.
+
+    MEASURED 2026-08-26, which is why this is no longer a PATH lookup. In an
+    agent container, ``shutil.which("scitex-dev")`` resolved to
+    ``/uvwork/bin/scitex-dev`` -- a hand-added shim whose last line execs a
+    DIFFERENT package's venv. That venv's ``scitex_dev.jobs`` group contains
+    ``scitex-cards`` and not ``scitex-agent-container``, so::
+
+        sac dev timer list                      -> all 11 sac timers (in-process)
+        sac dev timer status accounts-snapshot-live
+            Error: no kind='timer' job named 'scitex-agent-container-...'
+            Discovered: <the other package's 6 timers>
+
+    Same host, same venv, seconds apart. scitex-dev was not wrong: it
+    answered truthfully about the environment it was pointed at.
+
+    ORDER IS THE INVERSE OF :mod:`.._sac_binary`, DELIBERATELY. That module
+    tries PATH first so a test which prepends a fake binary gets exactly what
+    it asked for. Here PATH-first would still find the shim and fix nothing,
+    and no test shims ``scitex-dev`` (checked: the only ``shutil.which``
+    reference to it under ``tests/`` is a comment in ``test_audit.py``
+    recording a check that was REMOVED). Sibling-first also degrades
+    correctly: when sac is not in a venv, the sibling does not exist and PATH
+    still answers.
+
+    A missing binary stays a clean ClickException rather than a stack trace.
     """
     if not delegation.supported:
         raise ValueError("refusing to invoke an unsupported delegation")
-    exe = shutil.which("scitex-dev")
+    exe = resolve_scitex_dev()
     if exe is None:
         raise click.ClickException(
             "`scitex-dev` console script not found on PATH; install "

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -34,7 +34,20 @@ class _AccountsGroup(HelpRecursiveGroup):
             ["refresh", "mint-token", "sync-live", "sync-openai"],
         ),
         ("Distribute to peers", ["send-credentials"]),
-        ("Watch continuously", ["watch-live", "watch-quota", "refresh-quota-cache"]),
+        (
+            "Watch continuously",
+            [
+                "watch-live",
+                "watch-quota",
+                "refresh-quota-cache",
+                # Sits beside refresh-quota-cache because it has the same
+                # shape: a timer-driven PRODUCER whose output the boot picker
+                # reads from cache. Neither is something an operator runs by
+                # hand in the normal case, and both are inert if their timer
+                # is not running.
+                "probe-entitlement",
+            ],
+        ),
     ]
 
 
@@ -347,6 +360,22 @@ register_refresh_command(account)
 from ._account_refresh_quota_cache import register_refresh_quota_cache_command
 
 register_refresh_quota_cache_command(account)
+
+
+# ---------------------------------------------------------------------------
+# probe-entitlement — the PRODUCER for the per-account entitlement verdicts
+# the boot picker reads. Same relationship as refresh-quota-cache above: the
+# picker is cache-only by contract, so without a periodic run of this every
+# account reads UNKNOWN and the gate is inert. A host timer runs it.
+#
+# INCIDENT 2026-08-25: a cancelled subscription refreshed its OAuth token
+# successfully and so passed every FRESHNESS gate, while every real turn on
+# it returned 403. Freshness is not entitlement; this asks the second
+# question. Separate verb from `refresh` on purpose — this rotates nothing.
+# ---------------------------------------------------------------------------
+from ._account_probe_entitlement import register_probe_entitlement_command
+
+register_probe_entitlement_command(account)
 
 
 # ---------------------------------------------------------------------------

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -28,7 +28,21 @@ class _AccountsGroup(HelpRecursiveGroup):
 
     COMMAND_CATEGORIES = [
         ("Inspect (read-only)", ["list", "status", "quota"]),
-        ("Stored accounts", ["save", "delete", "switch", "login"]),
+        (
+            "Stored accounts",
+            [
+                "save",
+                "delete",
+                "switch",
+                "login",
+                # Beside `delete` on purpose: both take an account out of
+                # service, and a reader deciding between them should see them
+                # together. The pair exists so that choice is available at
+                # all — before it, stopping an account meant deleting it.
+                "pause",
+                "resume",
+            ],
+        ),
         (
             "Credential material",
             ["refresh", "mint-token", "sync-live", "sync-openai"],
@@ -376,6 +390,23 @@ register_refresh_quota_cache_command(account)
 from ._account_probe_entitlement import register_probe_entitlement_command
 
 register_probe_entitlement_command(account)
+
+
+# ---------------------------------------------------------------------------
+# pause / resume — the OPERATOR's own switch, and the counterpart to
+# probe-entitlement above. That verb records what Anthropic MEASURED about an
+# account; these two record what the operator DECIDED about it. Separate
+# files, disjoint writers: no probe can lift a pause, and no pause can be
+# discovered.
+#
+# OPERATOR REQUEST 2026-08-26: he stops and restarts subscriptions while
+# watching quota, and asked that nothing fail during the rest. Before this,
+# one rested account exited `sac accounts send-credentials` non-zero on every
+# pass, pinning the credential alarm red permanently.
+# ---------------------------------------------------------------------------
+from ._account_pause import register_pause_commands
+
+register_pause_commands(account)
 
 
 # ---------------------------------------------------------------------------

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_rename.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_rename.py
@@ -34,14 +34,18 @@ __all__ = ["rename"]
 # The env var whose value IS the agent's identity on the board. Called out
 # explicitly in the report because it is the one whose silent breakage
 # costs real work.
-_BOARD_IDENTITY_ENV = "SCITEX_TODO_AGENT_ID"
+# Both spellings are live on disk during the rename, so the marker looks for
+# BOTH. Checking only the retired one silently drops the highlight on the
+# majority of specs -- measured 2026-08-25: 110 specs on the current name
+# vs 21 on the retired one.
+_BOARD_IDENTITY_ENVS = ("SCITEX_CARDS_AGENT_ID", "SCITEX_TODO_AGENT_ID")
 
 _MAX_LISTED_CARDS = 8
 
 
 def _mark(change: SpecChange) -> str:
     """Annotate the spec change that carries the board identity."""
-    if _BOARD_IDENTITY_ENV not in change.path:
+    if not any(env in change.path for env in _BOARD_IDENTITY_ENVS):
         return ""
     return "   " + click.style("<-- BOARD IDENTITY", fg="yellow", bold=True)
 

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -730,6 +730,25 @@ from scitex_cards._throughput import WIP_STATUSES
 # actually need — which is why the number above moved, not just this comment.
 from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 
+# scitex-dev 0.56.6: the bounded (origin, seq) oplog-allocation retry.
+# Through 0.56.5, Store._append read MAX(seq) ONCE and then inserted, so a
+# burst of writers on a SINGLE node collided on the oplog (origin, seq)
+# primary key with no bounded retry -- 7/8 and 5/8 failures on the two
+# concurrency tests, reproduced three times. 0.56.6 adds this constant and
+# the retry loop that uses it, plus an advisory lock around table creation.
+#
+# THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
+# scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is
+# what excludes the releases without the retry; this import only catches a
+# version string that lies; and only a concurrent multi-writer append after
+# deploy proves the loop actually settles under contention.
+#
+# The name is PRIVATE -- underscore-prefixed and absent from __all__ -- so
+# upstream may rename or inline it with no deprecation, and that would land
+# here as a dead bake far from scitex-dev's repo. If this line is what broke
+# the build, read scitex_dev/store/_store.py before suspecting the image.
+from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS  # noqa: F401
+
 
 
 # sac #633: auto-provisions a new agent's container overlay root; without

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -215,12 +215,16 @@ From: ./sac-base.sif
         # ecosystem system-deps`` exists and every leaf's
         # ``scitex_dev.system_deps`` entry-point is discoverable for the
         # federated install in section 3.
-        # Floors verified against live PyPI on 2026-07-13 — a floor ABOVE the
+        # Floors verified against live PyPI on 2026-07-13; scitex-dev
+        # re-verified 2026-08-25 (0.56.6 is published and unyanked, and is
+        # the NEWEST release — this floor sits exactly AT the ceiling, so a
+        # yank of 0.56.6 would brick every bake until it is lowered).
+        # A floor ABOVE the
         # newest published version makes the build UNSATISFIABLE (uv/pip
         # resolve exit-255); that is how a >=0.7.38 scitex-todo floor bricked
         # this recipe once already. Never raise a floor without checking that
         # the version exists.
-        #   scitex-dev    >=0.29.0 — keystone aggregator (list/install/check-superset)
+        #   scitex-dev    >=0.56.6 — keystone aggregator (list/install/check-superset)
         #   scitex-writer >=2.29.0 — texlive provider (ships the soul.sty fix)
         #   scitex-audio  >=0.3.0  — ffmpeg/portaudio provider
         #   scitex-cv     >=0.2.0  — opencv-python-headless; provider declares []
@@ -268,7 +272,7 @@ From: ./sac-base.sif
         # ALREADY satisfied by the inherited base venv, so without it the
         # providers freeze at base's build and a routine rebake is a no-op.
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-dev>=0.29.0" \
+            "scitex-dev>=0.56.6" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0" \
@@ -337,7 +341,7 @@ From: ./sac-base.sif
         # already satisfies never re-resolves, so without it these providers
         # freeze at base's build and the routine rebake ships stale.
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-dev>=0.29.0" \
+            "scitex-dev>=0.56.6" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0" \
@@ -471,6 +475,25 @@ from scitex_cards._throughput import WIP_STATUSES
 # a version string that lies; and only a post-deploy write to a card that
 # ALREADY HAS a comment proves the path actually runs.
 from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
+
+# scitex-dev 0.56.6: the bounded (origin, seq) oplog-allocation retry.
+# Through 0.56.5, Store._append read MAX(seq) ONCE and then inserted, so a
+# burst of writers on a SINGLE node collided on the oplog (origin, seq)
+# primary key with no bounded retry -- 7/8 and 5/8 failures on the two
+# concurrency tests, reproduced three times. 0.56.6 adds this constant and
+# the retry loop that uses it, plus an advisory lock around table creation.
+#
+# THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
+# scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is
+# what excludes the releases without the retry; this import only catches a
+# version string that lies; and only a concurrent multi-writer append after
+# deploy proves the loop actually settles under contention.
+#
+# The name is PRIVATE -- underscore-prefixed and absent from __all__ -- so
+# upstream may rename or inline it with no deprecation, and that would land
+# here as a dead bake far from scitex-dev's repo. If this line is what broke
+# the build, read scitex_dev/store/_store.py before suspecting the image.
+from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS  # noqa: F401
 
 
 

--- a/src/scitex_agent_container/containers/sif_symbol_probe.py
+++ b/src/scitex_agent_container/containers/sif_symbol_probe.py
@@ -31,6 +31,25 @@ from scitex_cards._throughput import WIP_STATUSES
 # ALREADY HAS a comment proves the path actually runs.
 from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 
+# scitex-dev 0.56.6: the bounded (origin, seq) oplog-allocation retry.
+# Through 0.56.5, Store._append read MAX(seq) ONCE and then inserted, so a
+# burst of writers on a SINGLE node collided on the oplog (origin, seq)
+# primary key with no bounded retry -- 7/8 and 5/8 failures on the two
+# concurrency tests, reproduced three times. 0.56.6 adds this constant and
+# the retry loop that uses it, plus an advisory lock around table creation.
+#
+# THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
+# scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is
+# what excludes the releases without the retry; this import only catches a
+# version string that lies; and only a concurrent multi-writer append after
+# deploy proves the loop actually settles under contention.
+#
+# The name is PRIVATE -- underscore-prefixed and absent from __all__ -- so
+# upstream may rename or inline it with no deprecation, and that would land
+# here as a dead bake far from scitex-dev's repo. If this line is what broke
+# the build, read scitex_dev/store/_store.py before suspecting the image.
+from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS  # noqa: F401
+
 if "in_progress" not in WIP_STATUSES:
     print(f"FATAL: 'in_progress' missing from WIP_STATUSES: {sorted(WIP_STATUSES)}")
     sys.exit(1)

--- a/src/scitex_agent_container/containers/spartan-sif-bake.sh
+++ b/src/scitex_agent_container/containers/spartan-sif-bake.sh
@@ -321,6 +321,25 @@ from scitex_cards._throughput import WIP_STATUSES
 # ALREADY HAS a comment proves the path actually runs.
 from scitex_cards._mirror_rows import _merge_unseen_comment_rows  # noqa: F401
 
+# scitex-dev 0.56.6: the bounded (origin, seq) oplog-allocation retry.
+# Through 0.56.5, Store._append read MAX(seq) ONCE and then inserted, so a
+# burst of writers on a SINGLE node collided on the oplog (origin, seq)
+# primary key with no bounded retry -- 7/8 and 5/8 failures on the two
+# concurrency tests, reproduced three times. 0.56.6 adds this constant and
+# the retry loop that uses it, plus an advisory lock around table creation.
+#
+# THIS IMPORT PROVES PRESENCE, NOT BEHAVIOUR -- the same narrow job as the
+# scitex-cards import above, and the same 2026-08-23 lesson. The FLOOR is
+# what excludes the releases without the retry; this import only catches a
+# version string that lies; and only a concurrent multi-writer append after
+# deploy proves the loop actually settles under contention.
+#
+# The name is PRIVATE -- underscore-prefixed and absent from __all__ -- so
+# upstream may rename or inline it with no deprecation, and that would land
+# here as a dead bake far from scitex-dev's repo. If this line is what broke
+# the build, read scitex_dev/store/_store.py before suspecting the image.
+from scitex_dev.store._store import _SEQ_ALLOCATION_ATTEMPTS  # noqa: F401
+
 if "in_progress" not in WIP_STATUSES:
     print(f"FATAL: 'in_progress' missing from WIP_STATUSES: {sorted(WIP_STATUSES)}")
     sys.exit(1)

--- a/tests/_store_isolation.py
+++ b/tests/_store_isolation.py
@@ -82,6 +82,31 @@ PG_REQUIRED = os.environ.get("SAC_TEST_PG_REQUIRED") == "1"
 FLEET_SYSTEM_ID = os.environ.get("SAC_TEST_PG_FORBIDDEN_SYSTEM_ID", "7672112238472680366")
 
 
+def pg_endpoint_port() -> str:
+    """The PORT of the database under test, as a locator would print it.
+
+    Four tests assert that ``init_*_schema()`` returns a locator NAMING the
+    endpoint it wrote to — the property being that state cannot land somewhere
+    without saying where. They each hardcoded ``"55432"``, which was not the
+    property but an assumption about the environment: the fleet's loopback
+    port. It held only because every runner happened to have the fleet cluster
+    there.
+
+    MEASURED 2026-08-26: the moment CI provisioned its own throwaway database
+    on an ephemeral port, all four failed with
+    ``assert '55432' in 'postgres[host=127.0.0.1 db=postgres port=46313]'``.
+    The locator was correct; the expectation was pinned to a machine.
+
+    Deriving it from ``PG_BASE_DSN`` keeps the assertion testing the thing it
+    was written to test — the locator names the endpoint — while surviving any
+    database the suite is pointed at.
+    """
+    from urllib.parse import urlsplit
+
+    port = urlsplit(PG_BASE_DSN).port
+    return str(port) if port else "5432"
+
+
 def _default_test_pg_user() -> str:
     """The login role tests authenticate as when nothing declares one.
 
@@ -255,11 +280,18 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
         ``hard`` fails the run; otherwise it skips. Either way the reason
         names the DSN and the role, so a skip on a host that is SUPPOSED to
         have a writable database reads as the misconfiguration it is instead
-        of disappearing into a skip count. The GitHub ``::warning::`` is
-        emitted on the skip path too: an annotation blocks nothing, but it
-        puts the words on the summary page, and the diagnosis of the
-        2026-08-26 incident required reconstructing the skip count by
-        arithmetic from a 9.9 MB log because nothing said it out loud.
+        of disappearing into a skip count.
+
+        VISIBILITY COMES FROM ``-rs``, NOT FROM AN ANNOTATION, and that is a
+        correction rather than a preference. The first version of this
+        printed a GitHub ``::warning::`` here. MEASURED on run
+        32919218635: the reason text appears **308 times** in the CI log
+        while the annotation appears **zero** times — pytest captures fixture
+        stdout, so the annotation never reached the step output at all. It
+        was decoration that looked like a safeguard. The mechanism that
+        actually works is ``-rs`` on the pytest invocation, which prints
+        every skip reason in the summary; that is what put those 308 lines
+        there.
         """
         _restore_identity()
         message = (
@@ -267,7 +299,6 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
         )
         if hard:
             pytest.fail(message, pytrace=False)
-        print(f"::warning title=PostgreSQL coverage skipped::{message}", flush=True)
         pytest.skip(message)
 
     try:

--- a/tests/_store_isolation.py
+++ b/tests/_store_isolation.py
@@ -47,6 +47,40 @@ import pytest
 #: where libpq finds it without any credential entering this file.
 PG_BASE_DSN = os.environ.get("SAC_TEST_PG_DSN", "postgresql://127.0.0.1:55432/scitex")
 
+#: Was the target DECLARED, or did we fall back to the default?
+#:
+#: The distinction decides skip-vs-fail, and it is the whole point. "This
+#: laptop has no cluster" is a fact about a machine and may be skipped. "The
+#: target somebody explicitly configured does not work" is a
+#: MISCONFIGURATION, and a misconfiguration that skips is indistinguishable
+#: from a pass — which is exactly how this suite came to report green while
+#: executing zero PostgreSQL coverage.
+PG_DSN_WAS_DECLARED = "SAC_TEST_PG_DSN" in os.environ
+
+#: Set to "1" to make an unusable target a hard FAILURE rather than a skip.
+#:
+#: Intended for the RELEASE gate. A pull request may proceed with PostgreSQL
+#: coverage skipped, because the alternative is a blocked queue; a TAG must
+#: not publish having silently run none of it.
+PG_REQUIRED = os.environ.get("SAC_TEST_PG_REQUIRED") == "1"
+
+#: The fleet's replication cluster, which tests must NEVER write to.
+#:
+#: Every node of it — primary and replicas alike — reports this identifier,
+#: so one comparison recognises the production cluster no matter which host
+#: the DSN happens to resolve to, and no matter which node is primary today.
+#: That last part matters: the operator has stated failover is expected
+#: (2026-08-26), so a guard naming a HOST would protect the wrong machine the
+#: moment the primary moves. Identity travels with the cluster; addresses do
+#: not.
+#:
+#: This exists because the honest fix for CI is to give tests their own
+#: throwaway database, and the failure mode of that work is pointing at the
+#: real cluster by accident. The cluster lost a primary-key index to a libc
+#: mismatch on 2026-08-25; it does not need CI creating and dropping schemas
+#: in it as well.
+FLEET_SYSTEM_ID = os.environ.get("SAC_TEST_PG_FORBIDDEN_SYSTEM_ID", "7672112238472680366")
+
 
 def _default_test_pg_user() -> str:
     """The login role tests authenticate as when nothing declares one.
@@ -201,9 +235,87 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
     os.environ[pguser_key] = PG_TEST_USER
 
     schema = "sac_test_" + uuid.uuid4().hex[:12]
+
+    def _restore_identity() -> None:
+        """Put PGPASSFILE/PGUSER back exactly as they were.
+
+        Hoisted out of the handlers because it now has FOUR call sites and
+        one of them is a teardown that previously skipped it — see the
+        ``finally`` below.
+        """
+        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
+            if saved_ is None:
+                os.environ.pop(key_, None)
+            else:
+                os.environ[key_] = saved_
+
+    def _unusable(reason: str, *, hard: bool) -> None:
+        """Report an unusable target — loudly, and never silently.
+
+        ``hard`` fails the run; otherwise it skips. Either way the reason
+        names the DSN and the role, so a skip on a host that is SUPPOSED to
+        have a writable database reads as the misconfiguration it is instead
+        of disappearing into a skip count. The GitHub ``::warning::`` is
+        emitted on the skip path too: an annotation blocks nothing, but it
+        puts the words on the summary page, and the diagnosis of the
+        2026-08-26 incident required reconstructing the skip count by
+        arithmetic from a 9.9 MB log because nothing said it out loud.
+        """
+        _restore_identity()
+        message = (
+            f"PostgreSQL fixture cannot use {PG_BASE_DSN} as {PG_TEST_USER}: {reason}"
+        )
+        if hard:
+            pytest.fail(message, pytrace=False)
+        print(f"::warning title=PostgreSQL coverage skipped::{message}", flush=True)
+        pytest.skip(message)
+
     try:
         with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+            # Refuse the production cluster BEFORE issuing any DDL. On a
+            # replica the CREATE would fail anyway; on the PRIMARY it would
+            # succeed, which is the outcome worth preventing.
+            row = conn.execute(
+                "SELECT system_identifier::text, pg_is_in_recovery() "
+                "FROM pg_control_system()"
+            ).fetchone()
+            if row and row[0] == FLEET_SYSTEM_ID:
+                # Same cluster, two very different situations, and collapsing
+                # them turns this guard into an outage. Measured 2026-08-26:
+                # treating both as fatal made every runner RED, because
+                # loopback on a runner IS a fleet replica and always will be.
+                if not row[1]:
+                    # NOT in recovery -> this is the PRIMARY, where a CREATE
+                    # SCHEMA would SUCCEED. That is the only case worth
+                    # failing over: the write lands in production.
+                    _unusable(
+                        f"that is the fleet PRIMARY (system_identifier={row[0]}). "
+                        f"Tests must never create schemas in production; point "
+                        f"SAC_TEST_PG_DSN at a throwaway database.",
+                        hard=True,
+                    )
+                # In recovery -> a read-only replica. Nothing can be written
+                # here, so this is simply "no writable database on this host",
+                # which per the operator's 2026-08-26 ruling (one primary, all
+                # else read-only replicas) is the PERMANENT shape of every
+                # runner until CI provisions its own database.
+                _unusable(
+                    f"loopback is a read-only replica of the fleet cluster "
+                    f"(system_identifier={row[0]}); there is no writable "
+                    f"database on this host",
+                    hard=PG_REQUIRED or PG_DSN_WAS_DECLARED,
+                )
             conn.execute(f'CREATE SCHEMA "{schema}"')
+    except psycopg.errors.ReadOnlySqlTransaction as exc:
+        # CONNECTED, but the server will not accept writes — a read-only
+        # replica. This is NOT the "no cluster here" case below and must not
+        # be folded into it: psycopg models it as InternalError, not
+        # OperationalError, so the handler that follows never saw it and the
+        # tests errored instead. Per the operator's 2026-08-26 ruling the
+        # fleet is one primary plus read-only replicas, so loopback on a
+        # runner is a replica BY DESIGN and this is now the expected shape
+        # until CI provisions its own database.
+        _unusable(f"the server is a read-only replica ({exc})", hard=PG_REQUIRED or PG_DSN_WAS_DECLARED)
     except psycopg.OperationalError as exc:
         # SKIP, not fail: not every machine that runs this suite still has a
         # local cluster. The fleet's stores were consolidated onto the primary
@@ -219,15 +331,12 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
         # The reason string names the DSN so a skip on a host that is SUPPOSED
         # to have a cluster reads as the misconfiguration it is, instead of
         # disappearing into a skip count.
-        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
-            if saved_ is None:
-                os.environ.pop(key_, None)
-            else:
-                os.environ[key_] = saved_
-        pytest.skip(
-            f"no reachable PostgreSQL for the test fixture at {PG_BASE_DSN} "
-            f"as {PG_TEST_USER}: {exc}"
-        )
+        #
+        # STILL A SKIP BY DEFAULT, but no longer a silent one, and no longer
+        # unconditional: if somebody DECLARED SAC_TEST_PG_DSN, an unreachable
+        # target is their configuration being wrong, not this machine lacking
+        # a cluster, and it fails.
+        _unusable(f"no reachable PostgreSQL ({exc})", hard=PG_REQUIRED or PG_DSN_WAS_DECLARED)
 
     key = "SCITEX_STORE_DSN"
     saved = os.environ.get(key)
@@ -239,10 +348,17 @@ def pg_schema(_no_accidental_fleet_store_writes: None) -> Iterator[str]:
             os.environ.pop(key, None)
         else:
             os.environ[key] = saved
-        with psycopg.connect(PG_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
-            conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
-        for key_, saved_ in ((pgpass_key, saved_pgpass), (pguser_key, saved_pguser)):
-            if saved_ is None:
-                os.environ.pop(key_, None)
-            else:
-                os.environ[key_] = saved_
+        # The DROP is wrapped because the identity restore below MUST happen
+        # even when it raises. Previously it did not: the connect/DROP sat
+        # outside any try with the restore after it, so a server that went
+        # read-only or unreachable mid-run left this fixture's PGPASSFILE and
+        # PGUSER installed in os.environ for every later test on the same
+        # xdist worker. A leaked identity does not fail here; it fails
+        # somewhere else, later, as something that looks unrelated.
+        try:
+            with psycopg.connect(
+                PG_BASE_DSN, connect_timeout=10, autocommit=True
+            ) as conn:
+                conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            _restore_identity()

--- a/tests/develop/test_audit.py
+++ b/tests/develop/test_audit.py
@@ -36,7 +36,7 @@ running against, so the gate reads THE CODE UNDER TEST or fails loudly.
 This mirrors what our sibling gates already do (`test_git_hooks.py`'s
 ``_REPO``, `test_skills_quality.py`'s ``package_root``).
 
-scitex-dev >= 0.31.1 is REQUIRED (see [dev] in pyproject.toml): `path=`
+scitex-dev >= 0.31.1 is REQUIRED by this gate -- `path=`
 first exists there. Older versions also lack the CWD-git-root safety net
 (step 2), so on them the home-disk guess is the ONLY fallback. The
 fixture asserts that support rather than silently dropping `path=` —
@@ -142,7 +142,7 @@ def scitex_dev_audit():
             "installed scitex-dev's audit_all_for_package() has no `path` "
             "parameter, so this gate cannot name the tree under test and "
             "would silently audit a ~/proj guess instead. Upgrade to "
-            "scitex-dev>=0.31.1 (the [dev] floor in pyproject.toml). "
+            "scitex-dev>=0.31.1, the release where `path=` first exists. "
             "Failing loudly rather than auditing the wrong checkout."
         )
     return audit_all_for_package

--- a/tests/develop/test_ci_pytest_summary_flags.py
+++ b/tests/develop/test_ci_pytest_summary_flags.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CI's short test summary must list FAILURES, not only skips.
+
+2026-08-26. ``-rs`` was added to CI's pytest invocation so that skip reasons
+would print: 308 PostgreSQL tests had been skipping on two of three runners for
+want of a writable database, every one of those runs reported green, and
+establishing it took reconstructing ``392 - 84 = 308`` by arithmetic from a
+9.9 MB log because nothing in the output said which tests skipped or why.
+
+That flag fixed one blind spot and opened its neighbour the same day. pytest's
+``-r`` REPLACES the reported-character set rather than adding to it. The
+default is ``fE``, so ``-rs`` means "skips ONLY" and DELETES the FAILED lines
+from the short summary. Run 32943760311 reported ``2 failed, 17626 passed``
+while ``grep FAILED`` over the entire 445 KB job log returned NOTHING, and the
+two failing test ids had to be recovered from ``____ test ____`` traceback
+headers instead.
+
+A failure nobody can see is the same defect as a skip nobody can see, so the
+reasoning that added ``s`` is the reasoning that requires keeping ``f`` and
+``E``.
+
+These tests hold that in place. One reads the flag out of the REAL CI script.
+The others drive REAL pytest against a REAL failing test and prove the flag in
+that script actually produces a FAILED line -- with a control proving the same
+harness reports its ABSENCE under the old ``-rs``, because a gate that cannot
+fail is not a gate.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CI_SCRIPT = _REPO_ROOT / ".github" / "ci" / "run-in-sif.sh"
+
+# The characters whose meaning this test defends:
+#   f -> FAILED lines in the short summary   (deleted by a bare -rs)
+#   E -> ERROR lines for collection/fixture failures
+#   s -> SKIPPED lines with their reasons    (the 2026-08-26 addition)
+_REQUIRED_REPORT_CHARS = ("f", "E", "s")
+
+# What a summary that reports failures looks like, and what it looks like when
+# the characters have been trimmed back.
+_FAILED_MARKER = "FAILED"
+_SKIPPED_MARKER = "SKIPPED"
+
+
+def _ci_pytest_report_flag() -> str:
+    """Return the ``-r<chars>`` argument CI passes to pytest, e.g. ``rfEs``.
+
+    Read out of the real script rather than duplicated here, so trimming the
+    flag in ``run-in-sif.sh`` turns these tests red instead of leaving a
+    description that agrees with itself.
+    """
+    text = _CI_SCRIPT.read_text()
+    invocation = [
+        line
+        for line in text.splitlines()
+        if "python -m pytest tests/" in line and not line.lstrip().startswith("#")
+    ]
+    assert len(invocation) == 1, (
+        f"expected exactly one uncommented pytest invocation in {_CI_SCRIPT}, "
+        f"found {len(invocation)}: {invocation!r}"
+    )
+    found = re.findall(r"(?<!\S)-(r[a-zA-Z]+)(?!\S)", invocation[0])
+    assert len(found) == 1, (
+        f"expected exactly one -r flag in CI's pytest invocation, found {found!r} "
+        f"in: {invocation[0].strip()!r}"
+    )
+    return found[0]
+
+
+def _run_pytest_with(report_flag: str, workdir: Path) -> str:
+    """Drive REAL pytest over a REAL failing test and return its output.
+
+    ``-c`` points at an ini inside ``workdir`` so the repo's own configuration
+    (and its ``required_plugins``) cannot influence the result, and so rootdir
+    discovery cannot wander back into the repository.
+    """
+    ini = workdir / "pytest.ini"
+    ini.write_text("[pytest]\n")
+    (workdir / "test_subject.py").write_text(
+        "import pytest\n"
+        "\n"
+        "def test_that_fails():\n"
+        "    assert False\n"
+        "\n"
+        '@pytest.mark.skip(reason="deliberately skipped")\n'
+        "def test_that_skips():\n"
+        "    pass\n"
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            f"-{report_flag}",
+            "-c",
+            str(ini),
+            "-p",
+            "no:cacheprovider",
+            str(workdir / "test_subject.py"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+    )
+    output = proc.stdout + proc.stderr
+    # A run that never executed the subject proves nothing about the flag.
+    assert "1 failed" in output, (
+        f"the subject test did not run as expected under -{report_flag}; "
+        f"output was:\n{output}"
+    )
+    return output
+
+
+def test_ci_pytest_invocation_reports_failures_errors_and_skips() -> None:
+    """The flag in the real CI script carries f, E and s."""
+    # Arrange
+    flag = _ci_pytest_report_flag()
+    # Act
+    missing = [char for char in _REQUIRED_REPORT_CHARS if char not in flag[1:]]
+    # Assert
+    assert not missing, (
+        f"CI's pytest invocation uses -{flag}, which drops {missing!r}. "
+        "pytest's -r REPLACES the default 'fE' rather than adding to it, so "
+        "asking only for skips deletes the FAILED lines from the summary "
+        "(run 32943760311: '2 failed' with zero greppable FAILED lines)."
+    )
+
+
+def test_the_flag_ci_actually_uses_produces_a_failed_line(tmp_path: Path) -> None:
+    """Exercise the real flag against a real failure, not just its spelling."""
+    # Arrange
+    flag = _ci_pytest_report_flag()
+    # Act
+    output = _run_pytest_with(flag, tmp_path)
+    # Assert
+    assert _FAILED_MARKER in output, (
+        "CI's own report flag did not produce a FAILED line in the short "
+        f"summary; output was:\n{output}"
+    )
+
+
+def test_the_flag_ci_actually_uses_still_produces_a_skipped_line(
+    tmp_path: Path,
+) -> None:
+    """The 2026-08-26 skip-visibility fix must survive this change."""
+    # Arrange
+    flag = _ci_pytest_report_flag()
+    # Act
+    output = _run_pytest_with(flag, tmp_path)
+    # Assert
+    assert _SKIPPED_MARKER in output, (
+        "CI's own report flag did not produce a SKIPPED line, so the "
+        f"skip-visibility fix has been lost; output was:\n{output}"
+    )
+
+
+def test_the_old_flag_still_reported_skips(tmp_path: Path) -> None:
+    """Half of the control: ``-rs`` was never wrong about skips."""
+    # Arrange
+    old_flag = "rs"
+    # Act
+    output = _run_pytest_with(old_flag, tmp_path)
+    # Assert
+    assert _SKIPPED_MARKER in output, (
+        f"-rs should still report skips; output was:\n{output}"
+    )
+
+
+def test_the_old_flag_hides_failures_so_this_gate_can_fail(tmp_path: Path) -> None:
+    """The control proper: under ``-rs`` the FAILED line really is absent.
+
+    Without this, the tests above could pass on a pytest that always prints
+    FAILED regardless of the flag -- in which case they would be describing a
+    property nothing enforces. This proves the harness can tell them apart.
+    """
+    # Arrange
+    old_flag = "rs"
+    # Act
+    output = _run_pytest_with(old_flag, tmp_path)
+    # Assert
+    assert _FAILED_MARKER not in output, (
+        "-rs unexpectedly produced a FAILED line, so this control no longer "
+        "distinguishes the two flags and the gate above proves nothing. "
+        f"pytest {pytest.__version__} output was:\n{output}"
+    )

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -57,6 +57,7 @@ CROSS_PACKAGE_IMPORTS = [
     'scitex_dev.linter._rules._lookup',
     'scitex_dev.linter.checker',
     'scitex_dev.store',
+    'scitex_dev.store._store',
     'scitex_dev.system_deps',
     'scitex_dev.versioning',
     'scitex_logging',

--- a/tests/scitex_agent_container/_account/test_mint_token_refusal_messages.py
+++ b/tests/scitex_agent_container/_account/test_mint_token_refusal_messages.py
@@ -1,0 +1,254 @@
+"""WHICH fault the mint refusal names, and which remedy it offers.
+
+THIS FILE EXISTS BECAUSE THE MESSAGE WAS THE INCIDENT. On 2026-08-26
+the operator's credential timer told him, on every pass, that
+``wyusuuke-gmail-com`` had "no credential snapshot on disk" — while
+that account's ``.credentials.json`` sat there, 1146 bytes, refreshed
+hours earlier. The file was never the problem: the API had started
+answering 403 ``oauth_not_allowed_for_organization`` because the
+subscription was cancelled. The refusal in
+:func:`_account.mint_token.mint_access_only_artifact` was a two-way
+branch — EXPIRED, else "no snapshot" — written before FORBIDDEN
+existed, so a state it had never heard of fell into the ``else`` and
+inherited a sentence about a missing file. He was handed the wrong
+fault and a remedy (`claude /login`) that could not work.
+
+Reviewed 2026-08-26: the branch was repaired and the repair was
+UNTESTED. Deleting both new branches left 896 tests green across
+``_account`` and ``_creds``, and ``rg -c "cannot mint" tests/``
+returned nothing — no test in the repo asserted on ANY mint refusal
+message. A fix nothing can hold in place is a fix that comes back.
+
+So the assertions below are deliberately shaped around the failure
+rather than around the feature. The one that matters most is negative:
+a FORBIDDEN account's refusal must NOT contain "no credential snapshot
+on disk", because that is the exact wrong sentence, and asserting only
+that the new words are present would stay green if the old ones came
+back beside them.
+
+NO MOCKS (PA-306). Real account directories on a real ``tmp_path``,
+real ``entitlement.json`` written by the same
+:func:`._creds._entitlement.write_entitlement` the ``*/30`` probe
+calls, and a real ``pause.json`` written by the same
+:func:`._creds._pause.write_pause` the ``pause`` verb calls. The
+function under test already takes ``store_dir`` / ``home`` / ``now``
+as real parameters, so nothing needs substituting.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._account.mint_token import (
+    MintError,
+    mint_access_only_artifact,
+)
+from scitex_agent_container._creds._entitlement import (
+    FORBIDDEN,
+    Entitlement,
+    write_entitlement,
+)
+from scitex_agent_container._creds._pause import Pause, write_pause
+
+_LABEL = "alpha-example-com"
+_DENIAL = "Your organization has disabled Claude Code"
+_REASON = "quota rest — the subscription is stopped for now"
+#: The sentence that made this file necessary. It is TRUE only of
+#: ABSENT, and every other state that prints it is lying to the reader.
+_WRONG_SENTENCE = "no credential snapshot on disk"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    path = tmp_path / "accounts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_fresh_account(store: Path, label: str = _LABEL) -> Path:
+    """A stored account whose token is unambiguously fresh for eight hours."""
+    account_dir = store / label
+    account_dir.mkdir(parents=True, exist_ok=True)
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "oat-test-access",
+                    "refreshToken": "oat-test-refresh",
+                    "expiresAt": int((time.time() + 8 * 3600) * 1000),
+                    "scopes": ["user:inference"],
+                }
+            }
+        )
+    )
+    return account_dir
+
+
+@pytest.fixture
+def paused(store: Path) -> Path:
+    """A fresh account the operator has rested. Nothing is broken here."""
+    account_dir = _write_fresh_account(store)
+    write_pause(
+        account_dir,
+        Pause(
+            name=_LABEL,
+            active=True,
+            reason=_REASON,
+            since=time.time() - 3600,
+            by="operator@test-host",
+        ),
+    )
+    return store
+
+
+@pytest.fixture
+def forbidden(store: Path) -> Path:
+    """A fresh account the API refuses — the operator's 2026-08-26 case."""
+    account_dir = _write_fresh_account(store)
+    write_entitlement(
+        account_dir,
+        Entitlement(
+            name=_LABEL,
+            state=FORBIDDEN,
+            checked_at=time.time(),
+            http_status=403,
+            detail=_DENIAL,
+        ),
+    )
+    return store
+
+
+@pytest.fixture
+def absent(store: Path) -> Path:
+    """The ONE state for which "no credential snapshot on disk" is true."""
+    (store / _LABEL).mkdir(parents=True, exist_ok=True)
+    return store
+
+
+def _refusal(store: Path, tmp_path: Path) -> str:
+    with pytest.raises(MintError) as excinfo:
+        mint_access_only_artifact(
+            _LABEL, store_dir=store, home=tmp_path, hostname="test-host"
+        )
+    return str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# PAUSED — a decision, and the remedy is one command
+# ---------------------------------------------------------------------------
+
+
+def test_a_paused_account_is_refused_as_paused(paused, tmp_path):
+    """Without its own branch this falls into the ``else`` and says ABSENT."""
+    # Arrange
+    store = paused
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert "is PAUSED" in message
+
+
+def test_a_paused_refusal_names_the_command_that_lifts_it(paused, tmp_path):
+    """A pause is lifted by exactly one verb; the refusal has to say which."""
+    # Arrange
+    store = paused
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert f"sac accounts resume {_LABEL}" in message
+
+
+def test_a_paused_refusal_quotes_the_operators_own_reason(paused, tmp_path):
+    """He wrote the reason precisely so it would come back to him here."""
+    # Arrange
+    store = paused
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert _REASON in message
+
+
+def test_a_paused_refusal_does_not_claim_the_snapshot_is_missing(paused, tmp_path):
+    """PAUSED would have inherited the same wrong sentence FORBIDDEN did."""
+    # Arrange
+    store = paused
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert _WRONG_SENTENCE not in message
+
+
+# ---------------------------------------------------------------------------
+# FORBIDDEN — the incident itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_forbidden_account_is_refused_as_forbidden(forbidden, tmp_path):
+    # Arrange
+    store = forbidden
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert "is FORBIDDEN" in message
+
+
+def test_a_forbidden_refusal_does_not_claim_the_snapshot_is_missing(
+    forbidden, tmp_path
+):
+    """THE ASSERTION THAT PINS THE 2026-08-26 BUG. Negative on purpose.
+
+    Asserting only that the new words appear would stay green if the
+    old sentence came back beside them, and the old sentence is what
+    sent the operator looking for a file that was never missing.
+    """
+    # Arrange
+    store = forbidden
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert _WRONG_SENTENCE not in message
+
+
+def test_a_forbidden_refusal_quotes_the_apis_own_words(forbidden, tmp_path):
+    """"Your token is fine but you cannot use it" needs the API's reason."""
+    # Arrange
+    store = forbidden
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert _DENIAL in message
+
+
+def test_a_forbidden_refusal_offers_the_pause_as_a_way_to_stop_the_noise(
+    forbidden, tmp_path
+):
+    """This is the account the operator asked to be able to rest."""
+    # Arrange
+    store = forbidden
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert f"sac accounts pause {_LABEL}" in message
+
+
+# ---------------------------------------------------------------------------
+# ABSENT — the control. The old sentence is CORRECT here and must survive.
+# ---------------------------------------------------------------------------
+
+
+def test_an_absent_snapshot_still_says_the_snapshot_is_missing(absent, tmp_path):
+    """The reversing control for both negative assertions above.
+
+    Without it, deleting the sentence everywhere would satisfy them —
+    and then the one state it truthfully describes would lose it.
+    """
+    # Arrange
+    store = absent
+    # Act
+    message = _refusal(store, tmp_path)
+    # Assert
+    assert _WRONG_SENTENCE in message

--- a/tests/scitex_agent_container/_creds/test__entitlement.py
+++ b/tests/scitex_agent_container/_creds/test__entitlement.py
@@ -1,0 +1,423 @@
+"""Entitlement is a THIRD question, and it is three-valued.
+
+INCIDENT 2026-08-25 (the reason this module exists). A cancelled
+subscription went undetected because every gate asked whether the
+token was FRESH, and a cancelled account's token refreshes perfectly
+well. ``wyusuuke-gmail-com`` refreshed at 09:17 UTC with a new expiry
+of 17:17 and read ``VALID`` everywhere, while a real request returned::
+
+    403 permission_error - "OAuth authentication is currently not
+    allowed for this organization"
+
+:func:`test_a_fresh_token_can_still_be_forbidden` is that incident as
+a test: it is the case where freshness and entitlement disagree, and
+it is the one no existing test covered.
+
+The other axis under test is the constitution's three-valued rule --
+"true, false, and *unknown*. Collapsing unknown into either pole is
+the most common bug we ship." Both collapses are pinned:
+
+* collapsing UNKNOWN -> FORBIDDEN would evict the whole pool on a
+  network blip (:func:`test_a_network_failure_is_unknown_not_forbidden`,
+  :func:`test_unknown_does_not_block_use`);
+* collapsing UNKNOWN -> ENTITLED would let us claim we checked when we
+  did not (:func:`test_never_probed_reads_unknown_not_entitled`).
+
+NO MOCKS of our own code (PA-306). The only substitution is the HTTP
+transport -- an ``opener`` callable standing in for the network, so the
+REAL classification logic runs against synthetic responses. Everything
+else is a real file on a real tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._entitlement import (
+    ENTITLED,
+    FORBIDDEN,
+    UNKNOWN,
+    Entitlement,
+    entitlement_path,
+    probe_entitlement,
+    read_entitlement,
+    write_entitlement,
+)
+
+_FORBIDDEN_BODY = json.dumps(
+    {
+        "type": "error",
+        "error": {
+            "type": "permission_error",
+            "message": (
+                "OAuth authentication is currently not allowed for this "
+                "organization."
+            ),
+            "details": {"error_code": "oauth_not_allowed_for_organization"},
+        },
+    }
+).encode()
+
+
+def _account(tmp_path: Path, name: str = "acct", token: str = "tok") -> Path:
+    """A real account dir on disk, with a real credentials snapshot."""
+    d = tmp_path / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": token}})
+    )
+    return d
+
+
+class _Resp:
+    """The shape urlopen returns that we actually read: ``.status``."""
+
+    def __init__(self, status: int = 200):
+        self.status = status
+
+
+def _ok_opener(_req, timeout=None):
+    return _Resp(200)
+
+
+def _http_error_opener(code: int, body: bytes):
+    def _open(_req, timeout=None):
+        raise urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=code,
+            msg="err",
+            hdrs=None,
+            fp=__import__("io").BytesIO(body),
+        )
+
+    return _open
+
+
+def _boom_opener(exc: Exception):
+    def _open(_req, timeout=None):
+        raise exc
+
+    return _open
+
+
+# ---------------------------------------------------------------------------
+# The incident
+# ---------------------------------------------------------------------------
+
+
+def test_a_fresh_token_can_still_be_forbidden(tmp_path):
+    # Arrange: a perfectly readable, perfectly fresh credential -- the
+    # exact state wyusuuke was in while unusable.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(403, _FORBIDDEN_BODY)
+    )
+    # Assert
+    assert verdict.state == FORBIDDEN
+
+
+def test_the_forbidden_verdict_blocks_use(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(403, _FORBIDDEN_BODY)
+    )
+    # Assert
+    assert verdict.blocks_use is True
+
+
+def test_the_forbidden_verdict_carries_the_api_reason(tmp_path):
+    # Arrange: an operator reading only the verdict must learn WHY.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(403, _FORBIDDEN_BODY)
+    )
+    # Assert
+    assert "not allowed for this organization" in verdict.detail
+
+
+def test_a_working_account_is_entitled(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement("acct", d, opener=_ok_opener)
+    # Assert
+    assert verdict.state == ENTITLED
+
+
+def test_an_entitled_account_does_not_block_use(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement("acct", d, opener=_ok_opener)
+    # Assert
+    assert verdict.blocks_use is False
+
+
+# ---------------------------------------------------------------------------
+# Three-valued: UNKNOWN must collapse into NEITHER pole
+# ---------------------------------------------------------------------------
+
+
+def test_a_network_failure_is_unknown_not_forbidden(tmp_path):
+    # Arrange: the uplink is down. This is NOT a cancelled subscription,
+    # and calling it one would evict every account at once.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_boom_opener(socket.timeout("timed out"))
+    )
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_unknown_does_not_block_use(tmp_path):
+    # Arrange: the load-bearing half of the rule -- not knowing must
+    # never take an account out of service.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_boom_opener(socket.timeout("timed out"))
+    )
+    # Assert
+    assert verdict.blocks_use is False
+
+
+@pytest.mark.parametrize("code", [401, 429, 500, 503])
+def test_other_http_errors_are_not_entitlement_verdicts(tmp_path, code):
+    # Arrange: 401 is the freshness gate's question, 429 is the quota
+    # ranker's, 5xx is nobody's. Answering a question we were not asked
+    # is how a signal starts lying.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(code, b'{"error":"x"}')
+    )
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_a_403_without_an_oauth_reason_is_not_forbidden(tmp_path):
+    # Arrange: 403 alone is not the verdict -- the body must name an
+    # oauth/permission problem. A generic 403 stays UNKNOWN.
+    d = _account(tmp_path)
+    # Act
+    verdict = probe_entitlement(
+        "acct", d, opener=_http_error_opener(403, b'{"error":"rate stuff"}')
+    )
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_a_missing_credential_is_unknown(tmp_path):
+    # Arrange: an account dir with no snapshot. That is the freshness
+    # gate's ABSENT case, not an entitlement denial.
+    d = tmp_path / "empty"
+    d.mkdir()
+    # Act
+    verdict = probe_entitlement("empty", d, opener=_ok_opener)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# The cached read -- the ONLY thing a boot path calls
+# ---------------------------------------------------------------------------
+
+
+def test_never_probed_reads_unknown_not_entitled(tmp_path):
+    # Arrange: no record at all. Must not read as "fine".
+    d = _account(tmp_path)
+    # Act
+    verdict = read_entitlement("acct", d)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_never_probed_says_so(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    # Act
+    verdict = read_entitlement("acct", d)
+    # Assert
+    assert verdict.detail == "never probed"
+
+
+def test_a_written_verdict_reads_back(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    write_entitlement(
+        d, Entitlement("acct", FORBIDDEN, checked_at=1000.0, http_status=403)
+    )
+    # Act
+    verdict = read_entitlement("acct", d, now=1100.0)
+    # Assert
+    assert verdict.state == FORBIDDEN
+
+
+def test_a_stale_verdict_is_not_believed(tmp_path):
+    # Arrange: a FORBIDDEN from long ago must not keep an account out
+    # after the operator restored the subscription -- and the timer
+    # that would have refreshed it is evidently not running.
+    d = _account(tmp_path)
+    write_entitlement(d, Entitlement("acct", FORBIDDEN, checked_at=0.0))
+    # Act
+    verdict = read_entitlement("acct", d, now=48 * 3600.0)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_a_stale_verdict_explains_itself(tmp_path):
+    # Arrange
+    d = _account(tmp_path)
+    write_entitlement(d, Entitlement("acct", FORBIDDEN, checked_at=0.0))
+    # Act
+    verdict = read_entitlement("acct", d, now=48 * 3600.0)
+    # Assert
+    assert "old" in verdict.detail
+
+
+def test_a_fresh_verdict_inside_the_window_is_believed(tmp_path):
+    # Arrange: the boundary the staleness rule is built on.
+    d = _account(tmp_path)
+    write_entitlement(d, Entitlement("acct", FORBIDDEN, checked_at=0.0))
+    # Act
+    verdict = read_entitlement("acct", d, now=23 * 3600.0)
+    # Assert
+    assert verdict.state == FORBIDDEN
+
+
+def test_a_corrupt_record_is_unknown_not_a_crash(tmp_path):
+    # Arrange: a half-written file must not take down an agent boot.
+    d = _account(tmp_path)
+    entitlement_path(d).write_text("{not json")
+    # Act
+    verdict = read_entitlement("acct", d)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_an_unrecognised_state_is_unknown(tmp_path):
+    # Arrange: a record from a future/older schema.
+    d = _account(tmp_path)
+    entitlement_path(d).write_text(
+        json.dumps({"state": "SOMETHING_ELSE", "checked_at": 1.0})
+    )
+    # Act
+    verdict = read_entitlement("acct", d, now=2.0)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_a_record_without_a_timestamp_is_unknown(tmp_path):
+    # Arrange: without checked_at we cannot judge staleness, so the
+    # verdict cannot be trusted no matter what it claims.
+    d = _account(tmp_path)
+    entitlement_path(d).write_text(json.dumps({"state": FORBIDDEN}))
+    # Act
+    verdict = read_entitlement("acct", d)
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+@pytest.fixture
+def verdict_but_no_credential(tmp_path: Path) -> Path:
+    """An account dir holding a verdict and NO ``.credentials.json``.
+
+    With no token on disk a live probe is impossible, so anything this
+    dir can still answer was answered from local disk alone. That is
+    how the cache-only contract is proven here -- by construction
+    rather than by patching ``urlopen`` (fixtures that rewrite
+    production internals are banned ecosystem-wide, and would only
+    encode our assumption about the transport anyway).
+    """
+    d = tmp_path / "cached-only"
+    d.mkdir()
+    write_entitlement(d, Entitlement("acct", ENTITLED, checked_at=1000.0))
+    return d
+
+
+def test_the_read_path_needs_no_credential_to_answer(verdict_but_no_credential):
+    # Arrange: see the fixture -- there is no token to authenticate with.
+    # Act
+    verdict = read_entitlement("acct", verdict_but_no_credential, now=1001.0)
+    # Assert
+    assert verdict.state == ENTITLED
+
+
+def test_the_cache_only_fixture_really_has_no_credential(
+    verdict_but_no_credential,
+):
+    # Arrange: the premise the test above rests on. Pinned separately so
+    # that if the fixture ever starts writing a credential, THIS fails
+    # rather than the proof silently becoming vacuous.
+    # Act
+    exists = (verdict_but_no_credential / ".credentials.json").exists()
+    # Assert
+    assert exists is False
+
+
+# ---------------------------------------------------------------------------
+# Auto-heal: the operator's actual workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cancelled_account(tmp_path: Path) -> Path:
+    """An account the timer has already probed and found FORBIDDEN.
+
+    The operator's real workflow: cancel a subscription, restore it
+    later. This is the state after the cancellation has been noticed.
+    """
+    d = _account(tmp_path)
+    write_entitlement(
+        d,
+        probe_entitlement(
+            "acct", d, opener=_http_error_opener(403, _FORBIDDEN_BODY)
+        ),
+    )
+    return d
+
+
+def test_a_cancelled_account_is_blocked(cancelled_account):
+    # Arrange: see the fixture.
+    # Act
+    verdict = read_entitlement("acct", cancelled_account)
+    # Assert
+    assert verdict.blocks_use is True
+
+
+def test_a_restored_subscription_heals_without_human_action(cancelled_account):
+    # Arrange: the subscription comes back and the next timer pass
+    # re-probes. Nothing else -- no spec edit, no symlink rename, no
+    # human step -- may be required to return the account to service.
+    write_entitlement(
+        cancelled_account,
+        probe_entitlement("acct", cancelled_account, opener=_ok_opener),
+    )
+    # Act
+    verdict = read_entitlement("acct", cancelled_account)
+    # Assert
+    assert verdict.blocks_use is False
+
+
+def test_write_never_raises_on_an_unwritable_dir(tmp_path):
+    # Arrange: bookkeeping written from a timer. A read-only store must
+    # not take the timer down.
+    d = _account(tmp_path)
+    d.chmod(0o500)
+    try:
+        # Act
+        ok = write_entitlement(d, Entitlement("acct", ENTITLED, checked_at=1.0))
+        # Assert
+        assert ok is False
+    finally:
+        d.chmod(0o700)

--- a/tests/scitex_agent_container/_creds/test__entitlement_integration.py
+++ b/tests/scitex_agent_container/_creds/test__entitlement_integration.py
@@ -1,0 +1,268 @@
+"""The picker must actually ROTATE OFF a de-entitled account.
+
+:mod:`test__entitlement` proves the verdict module in isolation. That
+is not the thing that failed on 2026-08-25 — the thing that failed is
+that a de-entitled account stayed SELECTABLE. So these tests drive the
+real :func:`account_health` and :func:`pick_healthy_account` over a
+real on-disk store, and assert on the choice they make.
+
+Without this file the entitlement module could be perfect and entirely
+unwired, and every other test would still pass. That is precisely the
+shape of the original bug: a check that was correct about the question
+it asked, while nothing asked the question that mattered.
+
+No mocks. Real dirs, real JSON, real functions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._account_health import (
+    NoHealthyAccountError,
+    account_health,
+)
+from scitex_agent_container._creds._entitlement import (
+    ENTITLED,
+    FORBIDDEN,
+    UNKNOWN,
+    Entitlement,
+    write_entitlement,
+)
+from scitex_agent_container._creds._pick_healthy import pick_healthy_account
+
+# A REALISTIC epoch, and that matters. `_oauth_expiry_to_seconds`
+# treats a raw value as milliseconds only when it exceeds 1e12; below
+# that it is read as seconds. An earlier draft of this file used
+# `_NOW = 1_000_000`, which put every "milliseconds" constant near 1e9
+# — under the threshold — so the values were silently interpreted as
+# SECONDS and landed in the far future. The expired-token test caught
+# it (EXPIRED came back FORBIDDEN), but the fresh-token tests had been
+# passing for the wrong reason: they never exercised the millisecond
+# branch that production always takes. Anchoring at a real 2026 epoch
+# puts these above 1e12 so the tests normalise exactly as production
+# does.
+_NOW = 1_787_000_000.0  # 2026-08-17T...Z, unix seconds
+_FRESH_MS = (_NOW + 6 * 3600) * 1000.0
+_STALE_MS = (_NOW - 6 * 3600) * 1000.0
+
+
+def _store(tmp_path: Path) -> Path:
+    d = tmp_path / ".scitex" / "agent-container" / "accounts"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _account(
+    store: Path,
+    name: str,
+    *,
+    expires_ms: float = _FRESH_MS,
+    entitlement: str | None = None,
+) -> Path:
+    """A real account dir: a real snapshot, optionally a real verdict."""
+    d = store / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / ".credentials.json").write_text(
+        json.dumps(
+            {"claudeAiOauth": {"accessToken": "tok", "expiresAt": expires_ms}}
+        )
+    )
+    if entitlement is not None:
+        write_entitlement(
+            d, Entitlement(name, entitlement, checked_at=_NOW - 60)
+        )
+    return d
+
+
+# ---------------------------------------------------------------------------
+# account_health now answers the second question
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def forbidden_store(tmp_path: Path) -> Path:
+    """One account: token FRESH, subscription CANCELLED.
+
+    This is wyusuuke on the morning of 2026-08-25 — refreshed at 09:17
+    with a new expiry of 17:17, and a 403 on every real turn.
+    """
+    store = _store(tmp_path)
+    _account(store, "cancelled", entitlement=FORBIDDEN)
+    return store
+
+
+def test_a_fresh_but_cancelled_account_is_not_valid(forbidden_store):
+    # Arrange: see the fixture. Before this change the state was VALID.
+    # Act
+    health = account_health("cancelled", store_dir=forbidden_store, now=_NOW)
+    # Assert
+    assert health.state == "FORBIDDEN"
+
+
+def test_a_fresh_but_cancelled_account_is_not_healthy(forbidden_store):
+    # Arrange: is_healthy is what every caller actually gates on.
+    # Act
+    health = account_health("cancelled", store_dir=forbidden_store, now=_NOW)
+    # Assert
+    assert health.is_healthy is False
+
+
+def test_the_forbidden_health_record_carries_the_reason(forbidden_store):
+    # Arrange: "your token is fine but you cannot use it" reads as OUR
+    # bug unless the API's own words travel with it.
+    write_entitlement(
+        forbidden_store / "cancelled",
+        Entitlement(
+            "cancelled",
+            FORBIDDEN,
+            checked_at=_NOW - 60,
+            detail="not allowed for this organization",
+        ),
+    )
+    # Act
+    health = account_health("cancelled", store_dir=forbidden_store, now=_NOW)
+    # Assert
+    assert "organization" in health.entitlement_detail
+
+
+def test_an_entitled_account_stays_valid(tmp_path):
+    # Arrange
+    store = _store(tmp_path)
+    _account(store, "good", entitlement=ENTITLED)
+    # Act
+    health = account_health("good", store_dir=store, now=_NOW)
+    # Assert
+    assert health.state == "VALID"
+
+
+def test_unknown_entitlement_does_not_downgrade_a_fresh_account(tmp_path):
+    # Arrange: the constitution's rule at the integration level. An
+    # account we have never probed -- or could not reach -- must keep
+    # working. Collapsing UNKNOWN into FORBIDDEN here would black out
+    # the whole fleet the first time this host lost its uplink.
+    store = _store(tmp_path)
+    _account(store, "unprobed", entitlement=UNKNOWN)
+    # Act
+    health = account_health("unprobed", store_dir=store, now=_NOW)
+    # Assert
+    assert health.state == "VALID"
+
+
+def test_a_never_probed_account_stays_valid(tmp_path):
+    # Arrange: no verdict file at all -- every account, the moment this
+    # ships, before the timer has run even once. Must be a no-op.
+    store = _store(tmp_path)
+    _account(store, "virgin")
+    # Act
+    health = account_health("virgin", store_dir=store, now=_NOW)
+    # Assert
+    assert health.state == "VALID"
+
+
+def test_an_expired_token_is_not_relabelled_forbidden(tmp_path):
+    # Arrange: an EXPIRED snapshot that is ALSO de-entitled. Expiry is
+    # the actionable fault (log in again); hiding it behind FORBIDDEN
+    # would send the operator to fix the wrong thing.
+    store = _store(tmp_path)
+    _account(store, "both", expires_ms=_STALE_MS, entitlement=FORBIDDEN)
+    # Act
+    health = account_health("both", store_dir=store, now=_NOW)
+    # Assert
+    assert health.state == "EXPIRED"
+
+
+# ---------------------------------------------------------------------------
+# the picker: the behaviour that actually failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mixed_store(tmp_path: Path) -> Path:
+    """A cancelled account and a working one, both token-fresh."""
+    store = _store(tmp_path)
+    _account(store, "cancelled", entitlement=FORBIDDEN)
+    _account(store, "working", entitlement=ENTITLED)
+    return store
+
+
+def test_the_picker_rotates_off_a_cancelled_preferred(mixed_store):
+    # Arrange: THE INCIDENT. The agent prefers the cancelled account and
+    # its token is fresh, so before this change it was handed straight
+    # back and the turn died on a 403.
+    # Act
+    chosen = pick_healthy_account(
+        "cancelled", store_dir=mixed_store, home=mixed_store, now=_NOW
+    )
+    # Assert
+    assert chosen == "working"
+
+
+def test_the_picker_never_returns_a_cancelled_account(mixed_store):
+    # Arrange: with no preference at all it must still avoid it.
+    # Act
+    chosen = pick_healthy_account(
+        None, store_dir=mixed_store, home=mixed_store, now=_NOW
+    )
+    # Assert
+    assert chosen != "cancelled"
+
+
+def test_the_picker_keeps_an_entitled_preferred(mixed_store):
+    # Arrange: churn control -- a healthy preference must be honoured.
+    # Act
+    chosen = pick_healthy_account(
+        "working", store_dir=mixed_store, home=mixed_store, now=_NOW
+    )
+    # Assert
+    assert chosen == "working"
+
+
+def test_the_picker_fails_loudly_when_every_account_is_cancelled(tmp_path):
+    # Arrange: the genuine "nothing usable" case. It must RAISE, not
+    # silently hand back a dead account -- the same fail-loud contract
+    # the freshness gate already has.
+    store = _store(tmp_path)
+    _account(store, "dead-a", entitlement=FORBIDDEN)
+    _account(store, "dead-b", entitlement=FORBIDDEN)
+    # Act
+    pick = lambda: pick_healthy_account(  # noqa: E731
+        None, store_dir=store, home=store, now=_NOW
+    )
+    # Assert
+    with pytest.raises(NoHealthyAccountError):
+        pick()
+
+
+def test_the_failure_message_names_the_cancelled_state(tmp_path):
+    # Arrange: the operator must learn it is a SUBSCRIPTION problem, not
+    # a login problem. Those have different fixes.
+    store = _store(tmp_path)
+    _account(store, "dead-a", entitlement=FORBIDDEN)
+    # Act
+    try:
+        pick_healthy_account(None, store_dir=store, home=store, now=_NOW)
+        message = ""
+    except NoHealthyAccountError as exc:
+        message = str(exc)
+    # Assert
+    assert "FORBIDDEN" in message
+
+
+def test_a_restored_subscription_returns_the_account_to_the_pool(mixed_store):
+    # Arrange: the operator's workflow end to end. The timer re-probes
+    # and overwrites the verdict; nothing else changes -- no spec edit,
+    # no symlink rename, no restart of anything.
+    write_entitlement(
+        mixed_store / "cancelled",
+        Entitlement("cancelled", ENTITLED, checked_at=_NOW - 60),
+    )
+    # Act
+    chosen = pick_healthy_account(
+        "cancelled", store_dir=mixed_store, home=mixed_store, now=_NOW
+    )
+    # Assert
+    assert chosen == "cancelled"

--- a/tests/scitex_agent_container/_creds/test__pause.py
+++ b/tests/scitex_agent_container/_creds/test__pause.py
@@ -1,0 +1,603 @@
+"""A pause is a DECISION, and no probe may write it, lift it, or expire it.
+
+OPERATOR REQUEST 2026-08-26. He stops and restarts Anthropic
+subscriptions while watching quota, and asked for exactly one property
+of the gap between: 「その休止の間も失敗しないようにしてほしい」 --
+while an account is paused, nothing must fail because of it.
+
+The design that delivers that has one load-bearing claim, and
+:func:`test_a_pause_survives_the_entitlement_probe` is that claim as a
+test. Both obvious places to store the flag are REWRITTEN WHOLESALE by
+something that runs on a timer: ``account.json`` by ``save_account`` on
+every ``sync-live``, and ``entitlement.json`` by the ``*/30``
+entitlement probe. A pause put in either would silently lift itself
+within half an hour, which is precisely the failure the operator asked
+us to prevent. That test calls the REAL ``write_entitlement`` -- the
+exact function the probe calls -- against a real account dir and
+asserts the pause is untouched afterwards.
+
+The other axis is the CONFLATION these two records must not undergo:
+
+* PAUSE outranks FORBIDDEN and never renders as it, because one is
+  authored and one is measured, and only the authored one is
+  actionable by the person reading it;
+* they occupy SEPARATE fields on the health record, so a probe's
+  sentence and a human's sentence can never be mistaken for each other
+  at the point of reading;
+* a pause does not decay the way an entitlement verdict does -- a
+  measurement whose prober stopped running must stop counting, but a
+  decision does not go stale because nobody re-asserted it.
+
+NO MOCKS (PA-306), and no ``monkeypatch`` either: every account here is
+a real directory with a real credentials snapshot on a real
+``tmp_path``, and every function under test already takes the
+``store_dir`` / ``home`` seam that the boot picker, the minter and the
+keepalive push all take.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._account_health import (
+    NoHealthyAccountError,
+    account_health,
+)
+from scitex_agent_container._creds._entitlement import (
+    ENTITLED,
+    FORBIDDEN,
+    Entitlement,
+    write_entitlement,
+)
+from scitex_agent_container._creds._pause import (
+    Pause,
+    clear_pause,
+    format_age,
+    pause_path,
+    read_pause,
+    write_pause,
+)
+from scitex_agent_container._creds._pick_healthy import pick_healthy_account
+
+_HOUR = 3600.0
+_DAY = 86400.0
+ALPHA = "alpha-example-com"
+BETA = "beta-example-com"
+
+
+def _write_account(store: Path, name: str, *, hours_left: float = 8.0) -> Path:
+    """A real account dir: a credentials snapshot with a real expiry, on disk."""
+    account_dir = store / name
+    account_dir.mkdir(parents=True, exist_ok=True)
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "access-not-a-real-token",
+                    "refreshToken": "refresh-not-a-real-token",
+                    "expiresAt": int((time.time() + hours_left * _HOUR) * 1000),
+                }
+            }
+        )
+    )
+    return account_dir
+
+
+def _write_pause(account_dir: Path, name: str, reason: str, *, ago: float = 0.0):
+    written = write_pause(
+        account_dir,
+        Pause(
+            name=name,
+            active=True,
+            reason=reason,
+            since=time.time() - ago,
+            by="tester@test-host",
+        ),
+    )
+    assert written, "fixture failed to write the pause record"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    """An empty account store on a real tmp_path."""
+    path = tmp_path / ".scitex" / "agent-container" / "accounts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def fresh_account(store: Path) -> Path:
+    """One account with a token that is hours from expiry."""
+    return _write_account(store, ALPHA)
+
+
+@pytest.fixture
+def paused_account(fresh_account: Path) -> Path:
+    """...which the operator has since paused."""
+    _write_pause(fresh_account, ALPHA, "quota rest")
+    return fresh_account
+
+
+# ---------------------------------------------------------------------------
+# THE ONE THE DESIGN STANDS ON: a probe cannot erase a decision
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pause_after_a_probe_wrote_its_verdict(fresh_account: Path) -> Pause:
+    """Pause the account, then run the probe's OWN write path over it."""
+    _write_pause(fresh_account, ALPHA, "quota rest - restarting it later")
+    write_entitlement(
+        fresh_account, Entitlement(ALPHA, ENTITLED, checked_at=time.time())
+    )
+    return read_pause(ALPHA, fresh_account)
+
+
+def test_a_pause_survives_the_entitlement_probe(
+    pause_after_a_probe_wrote_its_verdict: Pause,
+):
+    """Had the flag lived in entitlement.json, this would fail in 30 minutes."""
+    # Arrange
+    pause = pause_after_a_probe_wrote_its_verdict
+    # Act
+    active = pause.active
+    # Assert
+    assert active is True
+
+
+def test_the_probe_does_not_alter_the_operators_reason(
+    pause_after_a_probe_wrote_its_verdict: Pause,
+):
+    """Not merely still-paused: still paused for the SAME stated reason."""
+    # Arrange
+    pause = pause_after_a_probe_wrote_its_verdict
+    # Act
+    reason = pause.reason
+    # Assert
+    assert reason == "quota rest - restarting it later"
+
+
+def test_an_entitled_verdict_does_not_lift_a_pause(
+    store: Path, tmp_path: Path, paused_account: Path
+):
+    """A GOOD verdict must not un-pause an account either.
+
+    RENAMED 2026-08-26, because the old name —
+    ``test_a_paused_account_is_still_probed_underneath`` — claimed more
+    than the body checks. Nothing here measures whether the probe runs;
+    the assertion holds whether or not one ever runs again. A reader
+    auditing "does the entitlement probe keep going during a pause?"
+    would have found that name, believed the claim was gated, and
+    stopped looking. The claim IS carried, honestly, by
+    :func:`test_a_pause_survives_the_entitlement_probe` and
+    :func:`test_resuming_reveals_the_verdict_recorded_during_the_pause`.
+
+    What this one is actually worth: the precedence tests below all use
+    a FORBIDDEN verdict, so they would still pass if a good verdict
+    cleared the pause. This is the other direction — an ENTITLED
+    reading is a measurement too, and no measurement lifts a decision.
+    """
+    # Arrange
+    write_entitlement(paused_account, Entitlement(ALPHA, ENTITLED, checked_at=time.time()))
+    # Act
+    state = account_health(ALPHA, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "PAUSED"
+
+
+def test_resuming_reveals_the_verdict_recorded_during_the_pause(
+    store: Path, tmp_path: Path, paused_account: Path
+):
+    # Arrange
+    write_entitlement(paused_account, Entitlement(ALPHA, ENTITLED, checked_at=time.time()))
+    clear_pause(paused_account)
+    # Act
+    state = account_health(ALPHA, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "VALID"
+
+
+# ---------------------------------------------------------------------------
+# Health state
+# ---------------------------------------------------------------------------
+
+
+def test_an_unpaused_fresh_account_reads_valid(
+    store: Path, tmp_path: Path, fresh_account: Path
+):
+    """The control. Without it, PAUSED could be coming from the fixture."""
+    # Arrange
+    name = ALPHA
+    # Act
+    state = account_health(name, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "VALID"
+
+
+def test_a_paused_account_reads_paused(
+    store: Path, tmp_path: Path, paused_account: Path
+):
+    # Arrange
+    name = ALPHA
+    # Act
+    state = account_health(name, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "PAUSED"
+
+
+def test_a_paused_account_is_not_healthy(
+    store: Path, tmp_path: Path, paused_account: Path
+):
+    """``is_healthy`` is the ONE predicate the picker and the minter gate on."""
+    # Arrange
+    name = ALPHA
+    # Act
+    healthy = account_health(name, store_dir=store, home=tmp_path).is_healthy
+    # Assert
+    assert healthy is False
+
+
+def test_a_paused_health_record_carries_the_reason(
+    store: Path, tmp_path: Path, paused_account: Path
+):
+    # Arrange
+    name = ALPHA
+    # Act
+    reason = account_health(name, store_dir=store, home=tmp_path).pause_reason
+    # Assert
+    assert reason == "quota rest"
+
+
+# ---------------------------------------------------------------------------
+# Precedence: a decision outranks a measurement, and never borrows its field
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def forbidden_account(fresh_account: Path) -> Path:
+    """A fresh token whose subscription the API has measured as refused."""
+    write_entitlement(
+        fresh_account,
+        Entitlement(
+            ALPHA,
+            FORBIDDEN,
+            checked_at=time.time(),
+            http_status=403,
+            detail="oauth_not_allowed_for_organization",
+        ),
+    )
+    return fresh_account
+
+
+def test_without_a_pause_a_cancelled_account_reads_forbidden(
+    store: Path, tmp_path: Path, forbidden_account: Path
+):
+    """The control for the precedence tests below."""
+    # Arrange
+    name = ALPHA
+    # Act
+    state = account_health(name, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "FORBIDDEN"
+
+
+def test_a_pause_outranks_a_forbidden_verdict(
+    store: Path, tmp_path: Path, forbidden_account: Path
+):
+    """The case the operator will actually hit.
+
+    The accounts he wants to rest are the ones whose subscriptions he
+    cancelled, so their verdict already reads FORBIDDEN. If the measured
+    denial won, pausing would change nothing visible and he could not
+    tell "I stopped this" from "this broke".
+    """
+    # Arrange
+    _write_pause(forbidden_account, ALPHA, "resting it while the sub is off")
+    # Act
+    state = account_health(ALPHA, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "PAUSED"
+
+
+def test_a_paused_record_does_not_carry_the_apis_words(
+    store: Path, tmp_path: Path, forbidden_account: Path
+):
+    """Two fields, never one. A probe's sentence is not a human's sentence."""
+    # Arrange
+    _write_pause(forbidden_account, ALPHA, "resting it while the sub is off")
+    # Act
+    detail = account_health(ALPHA, store_dir=store, home=tmp_path).entitlement_detail
+    # Assert
+    assert detail == ""
+
+
+def test_a_paused_record_carries_the_operators_words(
+    store: Path, tmp_path: Path, forbidden_account: Path
+):
+    # Arrange
+    _write_pause(forbidden_account, ALPHA, "resting it while the sub is off")
+    # Act
+    reason = account_health(ALPHA, store_dir=store, home=tmp_path).pause_reason
+    # Assert
+    assert reason == "resting it while the sub is off"
+
+
+# ---------------------------------------------------------------------------
+# The decision is true whatever the credential is doing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def account_with_no_snapshot(store: Path) -> Path:
+    """A real account directory whose credential file is simply not there."""
+    account_dir = store / ALPHA
+    account_dir.mkdir(parents=True, exist_ok=True)
+    return account_dir
+
+
+def test_without_a_pause_a_missing_snapshot_reads_absent(
+    store: Path, tmp_path: Path, account_with_no_snapshot: Path
+):
+    """The control: ABSENT is what this account says when nobody paused it."""
+    # Arrange
+    name = ALPHA
+    # Act
+    state = account_health(name, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "ABSENT"
+
+
+def test_a_paused_account_with_no_snapshot_still_reads_paused(
+    store: Path, tmp_path: Path, account_with_no_snapshot: Path
+):
+    """Report the fact the operator can act on, not a fault he did not cause."""
+    # Arrange
+    _write_pause(account_with_no_snapshot, ALPHA, "resting")
+    # Act
+    state = account_health(ALPHA, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "PAUSED"
+
+
+# ---------------------------------------------------------------------------
+# No age decay
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ancient_pause(fresh_account: Path) -> Pause:
+    """A pause written 400 days ago and never re-asserted."""
+    _write_pause(fresh_account, ALPHA, "long rest", ago=400 * _DAY)
+    return read_pause(ALPHA, fresh_account)
+
+
+def test_a_400_day_old_pause_is_still_a_pause(ancient_pause: Pause):
+    """An entitlement verdict would have decayed to UNKNOWN after 24 hours.
+
+    Copying that here would un-pause an account behind the operator's
+    back -- the same conflation, from the other side.
+    """
+    # Arrange
+    pause = ancient_pause
+    # Act
+    active = pause.active
+    # Assert
+    assert active is True
+
+
+def test_a_long_pause_renders_its_age_in_days(ancient_pause: Pause):
+    """The age is what stands in for the expiry this record refuses to have."""
+    # Arrange
+    pause = ancient_pause
+    # Act
+    rendered = pause.age_human()
+    # Assert
+    assert rendered == "400d"
+
+
+# ---------------------------------------------------------------------------
+# Degrade towards VISIBLE, never towards silent
+# ---------------------------------------------------------------------------
+
+_UNUSABLE_RECORDS = [
+    pytest.param("not json at all", id="not-json"),
+    pytest.param(json.dumps({"reason": "   "}), id="whitespace-reason"),
+    pytest.param(json.dumps({"since": 1.0, "by": "x"}), id="no-reason-key"),
+    pytest.param(json.dumps(["a", "list"]), id="not-an-object"),
+]
+
+
+@pytest.mark.parametrize("body", _UNUSABLE_RECORDS)
+def test_an_unusable_pause_record_does_not_pause(fresh_account: Path, body: str):
+    """Chosen direction: back in the pool, loudly, rather than out of service
+    silently and forever."""
+    # Arrange
+    pause_path(fresh_account).write_text(body)
+    # Act
+    active = read_pause(ALPHA, fresh_account).active
+    # Assert
+    assert active is False
+
+
+@pytest.mark.parametrize("body", _UNUSABLE_RECORDS)
+def test_an_unusable_pause_record_states_its_problem(fresh_account: Path, body: str):
+    """``problem`` is what makes an unusable record visible rather than inert."""
+    # Arrange
+    pause_path(fresh_account).write_text(body)
+    # Act
+    problem = read_pause(ALPHA, fresh_account).problem
+    # Assert
+    assert problem != ""
+
+
+def test_an_unusable_pause_record_leaves_the_account_usable(
+    store: Path, tmp_path: Path, fresh_account: Path
+):
+    # Arrange
+    pause_path(fresh_account).write_text("not json at all")
+    # Act
+    state = account_health(ALPHA, store_dir=store, home=tmp_path).state
+    # Assert
+    assert state == "VALID"
+
+
+def test_an_absent_record_is_not_a_pause(fresh_account: Path):
+    # Arrange
+    name = ALPHA
+    # Act
+    active = read_pause(name, fresh_account).active
+    # Assert
+    assert active is False
+
+
+def test_an_absent_record_reports_no_problem(fresh_account: Path):
+    """Absence is the NORMAL not-paused, and must not look like damage."""
+    # Arrange
+    name = ALPHA
+    # Act
+    problem = read_pause(name, fresh_account).problem
+    # Assert
+    assert problem == ""
+
+
+# ---------------------------------------------------------------------------
+# Lifting one
+# ---------------------------------------------------------------------------
+
+
+def test_clear_pause_reports_that_it_removed_a_record(paused_account: Path):
+    # Arrange
+    account_dir = paused_account
+    # Act
+    removed = clear_pause(account_dir)
+    # Assert
+    assert removed is True
+
+
+def test_clear_pause_reports_nothing_to_lift_the_second_time(paused_account: Path):
+    """Resuming an already-running account is a no-op, not an error."""
+    # Arrange
+    clear_pause(paused_account)
+    # Act
+    removed = clear_pause(paused_account)
+    # Assert
+    assert removed is False
+
+
+def test_lifting_a_pause_makes_the_account_usable_again(
+    store: Path, tmp_path: Path, paused_account: Path
+):
+    """One command, no spec edit, no rename — 「また復活させる」."""
+    # Arrange
+    clear_pause(paused_account)
+    # Act
+    healthy = account_health(ALPHA, store_dir=store, home=tmp_path).is_healthy
+    # Assert
+    assert healthy is True
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [(90, "1m"), (4 * _HOUR, "4h"), (40 * _DAY, "40d"), (None, "an unknown time")],
+)
+def test_format_age_is_coarse_on_purpose(seconds, expected):
+    """A multi-week decision reported to the minute would be noise."""
+    # Arrange
+    value = seconds
+    # Act
+    rendered = format_age(value)
+    # Assert
+    assert rendered == expected
+
+
+# ---------------------------------------------------------------------------
+# The picker
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def one_paused_one_running(store: Path) -> Path:
+    """Two real accounts; the operator has rested exactly one of them."""
+    paused_dir = _write_account(store, ALPHA)
+    _write_account(store, BETA)
+    _write_pause(paused_dir, ALPHA, "quota rest")
+    return store
+
+
+def test_the_picker_skips_a_paused_account(
+    tmp_path: Path, one_paused_one_running: Path
+):
+    # Arrange
+    store_dir = one_paused_one_running
+    # Act
+    picked = pick_healthy_account(None, store_dir=store_dir, home=tmp_path)
+    # Assert
+    assert picked == BETA
+
+
+def test_the_picker_rotates_off_a_pinned_paused_account(
+    tmp_path: Path, one_paused_one_running: Path
+):
+    """The case that actually matters.
+
+    A spec that PINS the paused account is exactly how an agent would
+    otherwise keep booting onto the account the operator is resting --
+    the waste 「無駄遣いをしないように」 names.
+    """
+    # Arrange
+    store_dir = one_paused_one_running
+    # Act
+    picked = pick_healthy_account(ALPHA, store_dir=store_dir, home=tmp_path)
+    # Assert
+    assert picked == BETA
+
+
+@pytest.fixture
+def boot_error_with_everything_paused(store: Path, tmp_path: Path) -> str:
+    """The message an agent boot renders when every account is rested."""
+    alpha_dir = _write_account(store, ALPHA)
+    beta_dir = _write_account(store, BETA)
+    _write_pause(alpha_dir, ALPHA, "resting alpha for quota")
+    _write_pause(beta_dir, BETA, "beta subscription is off")
+    with pytest.raises(NoHealthyAccountError) as exc:
+        pick_healthy_account(None, store_dir=store, home=tmp_path)
+    return str(exc.value)
+
+
+def test_the_boot_error_names_the_paused_state(
+    boot_error_with_everything_paused: str,
+):
+    # Arrange
+    message = boot_error_with_everything_paused
+    # Act
+    mentions_state = "PAUSED" in message
+    # Assert
+    assert mentions_state is True
+
+
+def test_the_boot_error_quotes_the_first_pauses_reason(
+    boot_error_with_everything_paused: str,
+):
+    """Without the reason the message offers ``claude /login`` — advice that
+    cannot work, for a condition one ``sac accounts resume`` lifts."""
+    # Arrange
+    message = boot_error_with_everything_paused
+    # Act
+    quoted = "paused: resting alpha for quota" in message
+    # Assert
+    assert quoted is True
+
+
+def test_the_boot_error_quotes_the_second_pauses_reason(
+    boot_error_with_everything_paused: str,
+):
+    # Arrange
+    message = boot_error_with_everything_paused
+    # Act
+    quoted = "paused: beta subscription is off" in message
+    # Assert
+    assert quoted is True

--- a/tests/scitex_agent_container/_creds/test__pause_remedies.py
+++ b/tests/scitex_agent_container/_creds/test__pause_remedies.py
@@ -1,0 +1,277 @@
+"""When a pause blocks something, the message must offer the lever that lifts it.
+
+A NEW STATE FLOWING INTO A MESSAGE WRITTEN FOR TWO is the defect this
+file guards, and it has now happened three times in this codebase. The
+original was :func:`._account.mint_token.mint_access_only_artifact`: a
+two-way branch (EXPIRED, else "no snapshot on disk") written before
+FORBIDDEN existed, so on 2026-08-26 the operator's timer told him a
+file was missing while it sat there, refreshed hours earlier.
+
+Reviewed 2026-08-26: that repair was applied at the mint and NOT at its
+two siblings, both of which drop a PAUSED account and then explain the
+absence with the vocabulary of a fault.
+
+* THE BOOT PICKER. ``_start_single`` prints ``exc.brief`` in red and
+  ``str(exc)`` dim, so the brief is the line that is actually read.
+  With every account paused it said "no fresh account among … — run
+  ``claude /login`` then ``sac accounts sync-live``". Neither command
+  lifts a pause; ``sac accounts resume`` does. The dim line named the
+  pauses and then closed with the same wrong instruction.
+* QUOTA ROTATION. ``check_and_rotate`` reported "no HEALTHY account to
+  rotate to (other accounts absent or credential-expired)". In the
+  operator's stated workflow — rest three accounts, keep one — that
+  names a fault that does not exist while the surviving account keeps
+  burning, which is the opposite of what he paused the others for.
+
+Both are asserted here with the UNPAUSED case as the reversing
+control, because a fix that made every message say "resume" would be
+just as wrong in the other direction: an expired token really is fixed
+by ``claude /login``, and losing that would trade one wrong remedy for
+another.
+
+NO MOCKS (PA-306): real account dirs on a real ``tmp_path``, real
+``pause.json`` files written by :func:`._pause.write_pause`, and the
+``store_dir`` / ``home`` / ``now`` parameters both functions already
+take.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._pause import Pause, write_pause
+
+ALPHA = "alpha-example-com"
+BETA = "beta-example-com"
+ALPHA_REASON = "resting alpha while the quota recovers"
+BETA_REASON = "beta's subscription is stopped for now"
+
+
+def _write_account(store: Path, name: str, *, hours_left: float = 8.0) -> Path:
+    account_dir = store / name
+    account_dir.mkdir(parents=True, exist_ok=True)
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "access-not-a-real-token",
+                    "refreshToken": "refresh-not-a-real-token",
+                    "expiresAt": int((time.time() + hours_left * 3600) * 1000),
+                }
+            }
+        )
+    )
+    (account_dir / "account.json").write_text(
+        json.dumps({"name": name, "email_address": f"{name}@example.com"})
+    )
+    return account_dir
+
+
+def _pause(account_dir: Path, name: str, reason: str) -> None:
+    write_pause(
+        account_dir,
+        Pause(
+            name=name,
+            active=True,
+            reason=reason,
+            since=time.time() - 7200,
+            by="operator@test-host",
+        ),
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    path = tmp_path / ".scitex" / "agent-container" / "accounts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def all_paused(store: Path) -> Path:
+    """Both accounts fresh, both rested. Nothing is broken in this store."""
+    _pause(_write_account(store, ALPHA), ALPHA, ALPHA_REASON)
+    _pause(_write_account(store, BETA), BETA, BETA_REASON)
+    return store
+
+
+@pytest.fixture
+def all_expired(store: Path) -> Path:
+    """The reversing control: nothing paused, every token stale."""
+    _write_account(store, ALPHA, hours_left=-5.0)
+    _write_account(store, BETA, hours_left=-5.0)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# The boot picker
+# ---------------------------------------------------------------------------
+
+
+def _boot_error(store: Path, tmp_path: Path):
+    from scitex_agent_container._creds._pick_healthy import (
+        NoHealthyAccountError,
+        pick_healthy_account,
+    )
+
+    with pytest.raises(NoHealthyAccountError) as excinfo:
+        pick_healthy_account(None, store_dir=store, home=tmp_path)
+    return excinfo.value
+
+
+def test_an_all_paused_boot_error_says_paused_in_the_line_that_is_read(
+    all_paused, tmp_path
+):
+    """``brief`` is the RED line; the dim one is not where a reader starts."""
+    # Arrange
+    store = all_paused
+    # Act
+    brief = _boot_error(store, tmp_path).brief
+    # Assert
+    assert "PAUSED" in brief
+
+
+def test_an_all_paused_boot_error_offers_resume_in_the_line_that_is_read(
+    all_paused, tmp_path
+):
+    """``claude /login`` cannot lift a pause. One command can."""
+    # Arrange
+    store = all_paused
+    # Act
+    brief = _boot_error(store, tmp_path).brief
+    # Assert
+    assert "sac accounts resume" in brief
+
+
+def test_an_all_paused_boot_error_does_not_offer_login_in_the_line_that_is_read(
+    all_paused, tmp_path
+):
+    """The negative half: a remedy that cannot work must not be the one shown."""
+    # Arrange
+    store = all_paused
+    # Act
+    brief = _boot_error(store, tmp_path).brief
+    # Assert
+    assert "claude /login" not in brief
+
+
+def test_an_all_paused_boot_error_names_every_reason_in_the_detail(
+    all_paused, tmp_path
+):
+    """The dim line still carries the evidence: WHICH pause, and why."""
+    # Arrange
+    store = all_paused
+    # Act
+    detail = str(_boot_error(store, tmp_path))
+    # Assert
+    assert ALPHA_REASON in detail and BETA_REASON in detail
+
+
+def test_an_all_expired_boot_error_still_offers_login(all_expired, tmp_path):
+    """THE REVERSING CONTROL. An expired token really is fixed by a login.
+
+    Without this, replacing the remedy everywhere would satisfy the
+    assertions above and would break the case they were written for.
+    """
+    # Arrange
+    store = all_expired
+    # Act
+    brief = _boot_error(store, tmp_path).brief
+    # Assert
+    assert "claude /login" in brief
+
+
+def test_an_all_expired_boot_error_does_not_say_paused(all_expired, tmp_path):
+    """The control for the PAUSED assertion: it must come from the pauses."""
+    # Arrange
+    store = all_expired
+    # Act
+    brief = _boot_error(store, tmp_path).brief
+    # Assert
+    assert "PAUSED" not in brief
+
+
+# ---------------------------------------------------------------------------
+# Quota rotation
+# ---------------------------------------------------------------------------
+
+
+_ACCOUNTS = [
+    {"name": ALPHA, "email_address": f"{ALPHA}@example.com"},
+    {"name": BETA, "email_address": f"{BETA}@example.com"},
+]
+_CURRENT = f"{ALPHA}@example.com"
+
+
+def _rested(store: Path, tmp_path: Path) -> list[str]:
+    """The list the "nothing to rotate to" alert builds its diagnosis from.
+
+    HONEST SCOPE, stated rather than implied: this drives the INPUT to
+    that message, not ``check_and_rotate`` end to end. Reaching the
+    message itself needs a live quota reading from Anthropic, which
+    this suite has no offline way to produce. What is measured here is
+    the discriminator — "was the candidate refused by the operator's
+    decision, or by a fault?" — which is the half that was missing and
+    the half a future edit can silently break. The wording that hangs
+    off it is one branch away in ``check_and_rotate``.
+    """
+    from scitex_agent_container._account.quota_watch import _paused_candidates
+
+    return _paused_candidates(
+        _ACCOUNTS, _CURRENT, store_dir=store, home=tmp_path
+    )
+
+
+def test_rotation_reports_a_paused_alternative_as_paused(all_paused, tmp_path):
+    """An empty list here makes the alert blame a fault that does not exist."""
+    # Arrange
+    store = all_paused
+    # Act
+    rested = _rested(store, tmp_path)
+    # Assert
+    assert BETA in rested
+
+
+def test_rotation_reports_no_paused_alternative_when_none_is_paused(
+    all_expired, tmp_path
+):
+    """The control: an EXPIRED alternative is a fault and must not read as a rest."""
+    # Arrange
+    store = all_expired
+    # Act
+    rested = _rested(store, tmp_path)
+    # Assert
+    assert rested == []
+
+
+def test_a_paused_account_is_never_rotated_onto(all_paused, tmp_path):
+    """Rotating onto a rested account is exactly the spend he paused it to avoid."""
+    # Arrange
+    from scitex_agent_container._account.quota_watch import _select_next_account
+
+    store = all_paused
+    # Act
+    picked = _select_next_account(
+        _ACCOUNTS, _CURRENT, store_dir=store, home=tmp_path
+    )
+    # Assert
+    assert picked is None
+
+
+def test_an_unpaused_healthy_alternative_is_still_rotated_onto(store, tmp_path):
+    """The control for the assertion above: rotation must still work."""
+    # Arrange
+    _write_account(store, ALPHA)
+    _write_account(store, BETA)
+    from scitex_agent_container._account.quota_watch import _select_next_account
+
+    # Act
+    picked = _select_next_account(
+        _ACCOUNTS, _CURRENT, store_dir=store, home=tmp_path
+    )
+    # Assert
+    assert picked is not None and picked["name"] == BETA

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -83,9 +83,16 @@ spec:
       - --env
       - SCITEX_AGENT_CONTAINER_STATE_DB=/state/{name}/state.db
       # The board identity. Change this without migrating the cards and
-      # every card the agent owns is orphaned.
+      # every card the agent owns is orphaned. BOTH spellings are seeded
+      # because both are on disk: the var was renamed to
+      # SCITEX_CARDS_AGENT_ID and the fleet is half migrated (measured
+      # 2026-08-25 on compute-04: 110 specs current, 21 retired). A
+      # fixture carrying only the retired name tests the minority and
+      # let a current-name blindness ship unnoticed.
       - --env
       - SCITEX_TODO_AGENT_ID={name}
+      - --env
+      - SCITEX_CARDS_AGENT_ID={name}
       - --env
       - GIT_AUTHOR_NAME=Yusuke Watanabe
     env: {{}}

--- a/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
@@ -46,14 +46,48 @@ def test_no_tabled_row_names_an_undeclared_job() -> None:
 
 
 def test_every_declared_job_has_a_row() -> None:
-    # Arrange — a job added without a row would never migrate.
-    tabled = frozenset(r.new for r in _renames.RENAMES) | frozenset(
-        r.old for r in _renames.RENAMES
+    # Arrange — a job added without a row would never migrate. A job BORN
+    # canonical has nothing to migrate and cannot have a row at all
+    # (Rename rejects old == new), so it must be accounted for explicitly
+    # in BORN_CANONICAL rather than by silently shrinking this guard.
+    tabled = (
+        frozenset(r.new for r in _renames.RENAMES)
+        | frozenset(r.old for r in _renames.RENAMES)
+        | _renames.BORN_CANONICAL
     )
     # Act
     uncovered = _declared_names() - tabled
     # Assert
     assert uncovered == frozenset()
+
+
+def test_born_canonical_names_are_actually_declared() -> None:
+    # Arrange — the exemption must not outlive the job. A stale entry here
+    # would silently widen the guard above for a name nothing declares.
+    # Act
+    orphans = _renames.BORN_CANONICAL - _declared_names()
+    # Assert
+    assert orphans == frozenset()
+
+
+def test_no_born_canonical_name_also_has_a_rename_row() -> None:
+    # Arrange — the two claims are contradictory: a job cannot both have
+    # been born under the canonical name and have a legacy unit to migrate
+    # away from. Overlap means one of them is wrong.
+    tabled_new = frozenset(r.new for r in _renames.RENAMES)
+    # Act
+    contradictory = _renames.BORN_CANONICAL & tabled_new
+    # Assert
+    assert contradictory == frozenset()
+
+
+def test_born_canonical_names_carry_no_legacy_prefix() -> None:
+    # Arrange — "born canonical" is a claim about the NAME. A `sac.*` name
+    # in this set would be asserting the opposite of what the set means.
+    # Act
+    legacy = [n for n in _renames.BORN_CANONICAL if n.startswith("sac.")]
+    # Assert
+    assert legacy == []
 
 
 def test_a_held_row_declares_its_new_name_so_install_can_resolve_it() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__identity_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__identity_drift.py
@@ -12,7 +12,13 @@ Every consequence was SILENT:
   with a full implementation brief sat runnable under the other name;
 * its pull-inbox under the agent name accumulated notifications it never
   polled, including a card another agent filed for it;
-* every ``reassign_task`` returned ``assignee_liveness: unknown``.
+Recorded at the time as a fourth symptom, and WRONG: that every
+``reassign_task`` returned ``assignee_liveness: unknown``. It does — for
+every agent, drifted or not. Re-measured 2026-08-25 from an agent whose
+identity was correct and which was demonstrably running: still
+``unknown``. A field that reads the same in both states discriminates
+nothing, so it is struck from the record rather than left to mislead the
+next reader into "diagnosing" drift with it.
 
 Nothing errored, because "no cards assigned to you" and "no cards
 assigned to THIS SPELLING of you" render identically.
@@ -35,6 +41,7 @@ from types import SimpleNamespace
 
 from scitex_agent_container._lifecycle._identity_drift import (
     BOARD_IDENTITY_ENV,
+    BOARD_IDENTITY_ENV_RETIRED,
     check_board_identity_at_launch,
 )
 
@@ -129,3 +136,70 @@ def test_warning_says_the_agent_still_starts(caplog):
         check_board_identity_at_launch(config)
     # Assert
     assert "STARTS NORMALLY" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# The env var was renamed SCITEX_TODO_AGENT_ID -> SCITEX_CARDS_AGENT_ID and
+# specs carry both spellings. Reading one only re-creates the very failure
+# this module guards: on 2026-08-25 the check looked for the RETIRED name
+# alone, so 110 of 148 specs on compute-04 read as "declares no board
+# identity" and returned via the legitimate absent-identity branch.
+# ---------------------------------------------------------------------------
+
+
+def _config_under(name: str, env_key: str, board_id: str):
+    return SimpleNamespace(name=name, env={env_key: board_id})
+
+
+def test_drift_is_caught_under_the_current_env_name():
+    # Arrange: the spelling 110 of 148 live specs actually use.
+    config = _config_under("agent-a", "SCITEX_CARDS_AGENT_ID", "agent-b")
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result == "agent-b"
+
+
+def test_drift_is_still_caught_under_the_retired_env_name():
+    # Arrange: 21 live specs have not been migrated yet.
+    config = _config_under("agent-a", "SCITEX_TODO_AGENT_ID", "agent-b")
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result == "agent-b"
+
+
+def test_current_env_name_wins_when_a_spec_carries_both():
+    # Arrange: a half-migrated spec. The current name is what the running
+    # scitex_cards client reads, so it is the identity that has effect.
+    config = SimpleNamespace(
+        name="agent-a",
+        env={
+            BOARD_IDENTITY_ENV: "agent-current",
+            BOARD_IDENTITY_ENV_RETIRED: "agent-retired",
+        },
+    )
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result == "agent-current"
+
+
+def test_warning_names_the_env_var_the_spec_declared(caplog):
+    # Arrange: "fix your board identity" is unactionable when the spec has
+    # two candidate keys and the message names neither.
+    config = _config_under("agent-a", "SCITEX_TODO_AGENT_ID", "agent-b")
+    # Act
+    with caplog.at_level(logging.WARNING):
+        check_board_identity_at_launch(config)
+    # Assert
+    assert "SCITEX_TODO_AGENT_ID" in caplog.text
+
+
+def test_the_two_env_constants_are_not_the_same_string():
+    # Arrange: a copy-paste that collapses them silently restores the
+    # single-name blindness while every other test still passes.
+    # Act
+    same = BOARD_IDENTITY_ENV == BOARD_IDENTITY_ENV_RETIRED
+    # Assert
+    assert not same

--- a/tests/scitex_agent_container/_state/test_account_store_switch_sidecars.py
+++ b/tests/scitex_agent_container/_state/test_account_store_switch_sidecars.py
@@ -1,0 +1,135 @@
+"""A switch establishes a LIVE LOGIN; the store's sidecars stay in the store.
+
+``switch_account`` copies an account directory's files into
+``~/.claude`` so the next ``claude`` invocation uses that credential. It
+did so by copying EVERYTHING except ``account.json``, which was fine
+while the only other file was the credential and became less fine with
+each sidecar the store learned to keep beside it.
+
+Reviewed 2026-08-26, when the pause change added a fifth. Measured:
+after seeding an account with a credential, an entitlement verdict and
+an ACTIVE PAUSE and calling ``switch_account``, ``~/.claude`` held
+``['.credentials.json', 'entitlement.json', 'pause.json']``. The store's
+pause survived intact — nothing was corrupted and nothing was
+resurrected — so this is litter rather than a defect in the pause
+itself. It is worth removing anyway, and the pause is what made it
+worth naming: ``~/.claude`` is a directory that gets copied, backed up
+and bind-mounted, and a decision-shaped file sitting in it invites a
+future reader to treat it as authority over the live session. It is not
+one; nothing reads it there (checked fleet-wide: zero references).
+
+Each of these files answers a question about the STORED ACCOUNT — who
+it is, whether the API still accepts it, how much quota is gone,
+whether the operator has rested it — and none of them says anything
+about the login being established. The credential does, and the
+credential still travels; the control below is what pins that.
+
+NO MOCKS (PA-306): a real store and a real ``$HOME`` on ``tmp_path``,
+driven through the ``store_dir`` / ``home`` parameters the function
+already takes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._entitlement import (
+    FORBIDDEN,
+    Entitlement,
+    write_entitlement,
+)
+from scitex_agent_container._creds._pause import Pause, read_pause, write_pause
+from scitex_agent_container._state.account_store import switch_account
+
+NAME = "alpha-example-com"
+REASON = "quota rest — restarting the subscription later"
+
+
+@pytest.fixture
+def switched(tmp_path: Path) -> Path:
+    """Seed one account with every sidecar, switch onto it, return ``~/.claude``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    store = tmp_path / "accounts"
+    account_dir = store / NAME
+    account_dir.mkdir(parents=True)
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "access-not-a-real-token",
+                    "refreshToken": "refresh-not-a-real-token",
+                    "expiresAt": int((time.time() + 8 * 3600) * 1000),
+                }
+            }
+        )
+    )
+    (account_dir / "account.json").write_text(json.dumps({"name": NAME}))
+    (account_dir / "usage.json").write_text(json.dumps({"used_pct_5h": 12.0}))
+    (account_dir / "identity.json").write_text(json.dumps({"state": "verified"}))
+    write_entitlement(
+        account_dir,
+        Entitlement(
+            name=NAME,
+            state=FORBIDDEN,
+            checked_at=time.time(),
+            http_status=403,
+            detail="Your organization has disabled Claude Code",
+        ),
+    )
+    write_pause(
+        account_dir,
+        Pause(
+            name=NAME,
+            active=True,
+            reason=REASON,
+            since=time.time() - 3600,
+            by="operator@test-host",
+        ),
+    )
+    result = switch_account(NAME, store_dir=store, home=home)
+    assert result["success"] is True, result
+    return home / ".claude"
+
+
+@pytest.mark.parametrize(
+    "sidecar",
+    ["pause.json", "entitlement.json", "identity.json", "usage.json", "account.json"],
+)
+def test_a_store_sidecar_does_not_follow_the_switch(switched: Path, sidecar: str):
+    """``pause.json`` is the one that made this worth fixing; the rest ride along."""
+    # Arrange
+    landed = switched / sidecar
+    # Act
+    exists = landed.exists()
+    # Assert
+    assert exists is False
+
+
+def test_the_credential_itself_still_follows_the_switch(switched: Path):
+    """THE REVERSING CONTROL. Copying nothing would satisfy every test above.
+
+    The credential is the entire purpose of the copy loop, so this is
+    the assertion that stops the fix from becoming a bigger bug than
+    the litter it removes.
+    """
+    # Arrange
+    landed = switched / ".credentials.json"
+    # Act
+    payload = json.loads(landed.read_text())
+    # Assert
+    assert payload["claudeAiOauth"]["accessToken"] == "access-not-a-real-token"
+
+
+def test_the_stores_own_pause_is_untouched_by_a_switch(switched: Path, tmp_path: Path):
+    """A switch reads the account dir; it must not disturb the decision in it."""
+    # Arrange
+    account_dir = tmp_path / "accounts" / NAME
+    # Act
+    stored = read_pause(NAME, account_dir)
+    # Assert
+    assert stored.active is True and stored.reason == REASON

--- a/tests/scitex_agent_container/_state/test_relocation_pg.py
+++ b/tests/scitex_agent_container/_state/test_relocation_pg.py
@@ -26,6 +26,8 @@ never touched. Real store, real database, no mocks (PA-306), one assert each
 
 from __future__ import annotations
 
+from tests._store_isolation import pg_endpoint_port
+
 from functools import partial
 
 import pytest
@@ -66,7 +68,7 @@ def _relocation(to_host: str, at: float) -> Relocation:
 
 def test_init_reports_where_the_state_went(pg_schema: str) -> None:
     # Arrange
-    expected_fragment = "55432"
+    expected_fragment = pg_endpoint_port()
     # Act
     locator = init_relocation_schema()
     # Assert

--- a/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
+++ b/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
@@ -18,6 +18,8 @@ Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
 
 from __future__ import annotations
 
+from tests._store_isolation import pg_endpoint_port
+
 import pytest
 
 from scitex_agent_container._state.state_db_pending_approval import (
@@ -241,7 +243,7 @@ def test_init_returns_a_locator_naming_the_postgres_endpoint(pg_schema: str) -> 
         init_pending_prompts_schema,
     )
 
-    expected = "55432"
+    expected = pg_endpoint_port()
     # Act
     locator = init_pending_prompts_schema()
     # Assert

--- a/tests/scitex_agent_container/_state/test_state_db_token_owner.py
+++ b/tests/scitex_agent_container/_state/test_state_db_token_owner.py
@@ -37,6 +37,8 @@ and the point is that the REAL resolver reads the REAL variable.
 
 from __future__ import annotations
 
+from tests._store_isolation import pg_endpoint_port
+
 import psycopg
 
 from scitex_agent_container._account._rotation_audit import fingerprint_token
@@ -95,7 +97,7 @@ def test_init_creates_the_ledger_in_postgres(pg_schema: str) -> None:
 
 def test_init_reports_where_the_state_went(pg_schema: str) -> None:
     # Arrange
-    expected_fragment = "55432"
+    expected_fragment = pg_endpoint_port()
     # Act
     locator = init_token_owner_schema()
     # Assert

--- a/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
+++ b/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
@@ -48,6 +48,8 @@ and the point is that the REAL resolver reads the REAL variable.
 
 from __future__ import annotations
 
+from tests._store_isolation import pg_endpoint_port
+
 import psycopg
 
 from scitex_agent_container._state.state_db_verdict_dedup import (
@@ -105,7 +107,7 @@ def test_init_reports_where_the_state_went(pg_schema: str) -> None:
     cannot say where it is is a store nobody can verify.
     """
     # Arrange
-    expected_fragment = "55432"
+    expected_fragment = pg_endpoint_port()
     # Act
     locator = init_verdict_dedup_schema()
     # Assert

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
@@ -249,6 +249,18 @@ def test_json_dry_run_reports_the_new_name(fleet: Layout):
     assert json.loads(result.stdout)["new"] == expected
 
 
+def test_json_dry_run_lists_the_current_board_identity_change(fleet: Layout):
+    # Arrange: the spelling most live specs use. The plan missed it until
+    # 2026-08-25 because every fixture here carried the retired one.
+    needle = "SCITEX_CARDS_AGENT_ID"
+    # Act
+    result = _run(OLD, NEW, "--dry-run", "--json", "--no-cards")
+    # Assert
+    assert any(
+        needle in c["path"] for c in json.loads(result.stdout)["spec_changes"]
+    )
+
+
 def test_json_dry_run_lists_the_spec_changes(fleet: Layout):
     # Arrange
     needle = "SCITEX_TODO_AGENT_ID"

--- a/tests/scitex_agent_container/cli_pkg/test__account_keepalive_paused_account.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_keepalive_paused_account.py
@@ -1,0 +1,510 @@
+"""A PAUSED account must not make the credential alarm red. Ever.
+
+THIS IS THE OPERATOR'S ACTUAL REQUIREMENT, 2026-08-26::
+
+    …また アカウント復活させるので…クオーターを見ながら無駄遣いを
+    しないように止めたり再開したりしてるんですけど、なのでその休止の
+    間も失敗しないようにしてほしいんですよ。
+
+"…so I'd like it not to FAIL during the pause either." Everything else
+in this change is machinery; this file is the requirement.
+
+WHAT IT REPLACES. ``sac accounts send-credentials --all`` enumerates
+every account this host holds refresh material for. A rested account
+still holds refresh material, so it was still enumerated, and minting
+from it raised ``MintError`` -> ``KeepaliveError`` on every peer, which
+set the run's single ``failed`` boolean, which exited 1. Measured
+2026-08-26: ``wyusuuke-gmail-com`` reads FORBIDDEN (403,
+``oauth_not_allowed_for_organization``) and the unit had been failing
+on it on every pass. One account the operator had deliberately stopped
+was pinning the fleet's credential alarm red permanently — and a
+signal that is always red is one nobody reads. That is the same
+sentence ``--optional-peer`` was written for, one axis over: that flag
+forgives an intermittent PEER; nothing forgave an ACCOUNT whose absence
+is intended.
+
+HOW THE GATE IS MADE ABLE TO FAIL, and what it honestly cannot show
+-------------------------------------------------------------------
+Every push in this file fails, because no peer here is reachable: the
+target is a name absent from ``config.yaml``, which
+``resolve_peer_transport`` refuses with ``UnknownPeerError`` before any
+ssh is attempted. That keeps the tests offline and deterministic, and
+it constrains what the EXIT CODE can prove:
+
+* WHEN EVERY ACCOUNT IS PAUSED there is nothing left to push, so the
+  exit code is the whole answer:
+  :func:`test_pausing_every_account_exits_zero` versus its control
+  :func:`test_without_the_pauses_the_same_store_exits_one`. Same store,
+  same argv, the pause files the only difference — 0 against 1.
+
+* WHEN ONE ACCOUNT SURVIVES the run still exits 1, because the
+  SURVIVOR's push has nowhere to go. An exit-0-with-a-survivor test
+  cannot be written offline: it would need a peer that accepts a real
+  credential. So the mechanism is measured where it actually lives
+  instead — the paused account must contribute NOTHING to the failure
+  tally, which is asserted as: it is never attempted, it produces no
+  FAILED line, and the run's FAILED lines number one rather than two.
+  Each has a control that reverses when the pause file is removed.
+  This is stated rather than papered over: no assertion here claims
+  the exit code proves the survivor case.
+
+An earlier draft declared the unreachable peer with
+``--optional-peer`` so that everything was forgiven and the run exited
+0 with a survivor. Its control — the same store with no pause — ALSO
+exited 0, which is how the false gate was caught: the 0 was the
+optional-peer tolerance, not the pause. The flag is gone for that
+reason.
+
+NO MOCKS (PA-306) and no ``monkeypatch``: real account directories with
+real credential snapshots on a real ``tmp_path``, and click's own
+``CliRunner(env=...)`` isolation to point the store at them.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._creds._pause import Pause, write_pause
+
+ALPHA = "alpha-example-com"
+BETA = "beta-example-com"
+_ABSENT_PEER = "peer-not-in-config"
+
+
+def _write_account(store: Path, name: str) -> Path:
+    """A real account dir holding REFRESH material, so ``--all`` enumerates it."""
+    account_dir = store / name
+    account_dir.mkdir(parents=True, exist_ok=True)
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "access-not-a-real-token",
+                    "refreshToken": "refresh-not-a-real-token",
+                    "expiresAt": int((time.time() + 8 * 3600) * 1000),
+                }
+            }
+        )
+    )
+    return account_dir
+
+
+def _write_pause(account_dir: Path, name: str, reason: str, *, ago: float = 0.0):
+    written = write_pause(
+        account_dir,
+        Pause(
+            name=name,
+            active=True,
+            reason=reason,
+            since=time.time() - ago,
+            by="tester@test-host",
+        ),
+    )
+    assert written, "fixture failed to write the pause record"
+
+
+@pytest.fixture
+def keepalive_cli() -> click.Group:
+    """A bare group with the real command registered onto it."""
+    from scitex_agent_container.cli_pkg._account_keepalive import (
+        register_keepalive_command,
+    )
+
+    @click.group()
+    def group():
+        pass
+
+    register_keepalive_command(group)
+    return group
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    path = tmp_path / ".scitex" / "agent-container" / "accounts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    """Point the store cascade at the tmp_path — click's own env isolation."""
+    return {"HOME": str(tmp_path), "SCITEX_DIR": str(tmp_path / ".scitex")}
+
+
+def _run(cli: click.Group, env: dict[str, str], *extra: str):
+    return CliRunner().invoke(
+        cli,
+        ["send-credentials", "--all", "--to", _ABSENT_PEER, *extra],
+        env=env,
+    )
+
+
+@pytest.fixture
+def two_accounts(store: Path) -> Path:
+    _write_account(store, ALPHA)
+    _write_account(store, BETA)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# EVERY account rested — where the exit code is the whole answer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def result_with_everything_paused(keepalive_cli, env, two_accounts: Path):
+    _write_pause(two_accounts / ALPHA, ALPHA, "resting alpha")
+    _write_pause(two_accounts / BETA, BETA, "resting beta")
+    return _run(keepalive_cli, env)
+
+
+@pytest.fixture
+def result_with_nothing_paused(keepalive_cli, env, two_accounts: Path):
+    return _run(keepalive_cli, env)
+
+
+# ---------------------------------------------------------------------------
+# The summary must not borrow the --all guard's premise
+# ---------------------------------------------------------------------------
+#
+# Reviewed 2026-08-26. The all-paused sentence said the accounts were the
+# ones "this host holds refresh material for". That fact is established by
+# ``refresh_holder_accounts()``, which the explicit ``--account NAME`` path
+# never calls — so on that path the run stated something it had not
+# measured. Small, and worth fixing precisely because the sentence's own
+# reasoning is about not sounding like the --all origin guard: it borrowed
+# that guard's premise while trying to avoid its meaning.
+
+
+@pytest.fixture
+def named_account_result(keepalive_cli, env, two_accounts: Path):
+    """``--account BETA`` where BETA is paused — the explicit path."""
+    _write_pause(two_accounts / BETA, BETA, "quota rest")
+    return CliRunner().invoke(
+        keepalive_cli,
+        ["send-credentials", "--account", BETA, "--to", _ABSENT_PEER],
+        env=env,
+    )
+
+
+def test_the_explicit_path_still_exits_zero_when_the_named_account_is_paused(
+    named_account_result,
+):
+    """The requirement does not depend on which form he typed."""
+    # Arrange
+    result = named_account_result
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code == 0, result.output
+
+
+def test_the_explicit_path_says_every_account_you_named(named_account_result):
+    """Wording taken from the call site, which knows which form this was."""
+    # Arrange
+    output = named_account_result.output
+    # Act
+    said = "every account you named" in output
+    # Assert
+    assert said is True, output
+
+
+def test_the_explicit_path_does_not_claim_a_refresh_holder_sweep(
+    named_account_result,
+):
+    """The negative half: it must not state the --all guard's premise."""
+    # Arrange
+    output = named_account_result.output
+    # Act
+    claimed = "holds refresh material for" in output
+    # Assert
+    assert claimed is False, output
+
+
+def test_the_all_path_still_says_holds_refresh_material_for(
+    result_with_everything_paused,
+):
+    """The reversing control: the --all sentence must survive unchanged."""
+    # Arrange
+    output = result_with_everything_paused.output
+    # Act
+    said = "holds refresh material for" in output
+    # Assert
+    assert said is True, output
+
+
+def test_pausing_every_account_exits_zero(result_with_everything_paused):
+    """THE REQUIREMENT. 「その休止の間も失敗しないようにしてほしい」.
+
+    WHERE THE 0 COMES FROM, said plainly so the pairing does not imply
+    more than it measures. It is the PARTITION: the paused accounts
+    never enter the push loop, so ``failed`` is never set. Reviewed
+    2026-08-26 by deleting the all-paused early-return block that sits
+    beside this test — this stayed GREEN, and only
+    :func:`test_pausing_every_account_says_that_is_the_intended_state`
+    went red. That block supplies the SENTENCE, not the exit code, and
+    reading this test as its gate would be wrong.
+
+    The two assertions below are what the block's absence would have to
+    survive as well.
+    """
+    # Arrange
+    result = result_with_everything_paused
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code == 0
+
+
+def test_pausing_every_account_reports_no_failure_of_any_kind(
+    result_with_everything_paused,
+):
+    """Exit 0 with a FAILED line in the journal is still a red-looking run.
+
+    The operator reads ``journalctl``, not ``$?``. A future change that
+    added a post-loop "we pushed to nobody" failure would break his
+    requirement while the exit-code test above stayed green.
+    """
+    # Arrange
+    output = result_with_everything_paused.output
+    # Act
+    failures = "FAILED" in output
+    # Assert
+    assert failures is False
+
+
+def test_without_the_pauses_the_same_store_exits_one(result_with_nothing_paused):
+    """The gate can fail. Same store, same argv, no pause files — red.
+
+    Without this, a change that exited 0 unconditionally would pass the
+    test above and look exactly like the feature working.
+    """
+    # Arrange
+    result = result_with_nothing_paused
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code == 1
+
+
+def test_pausing_every_account_says_that_is_the_intended_state(
+    result_with_everything_paused,
+):
+    """An empty list because the operator emptied it is not a failure, and the
+    run has to say which of the two empties this is."""
+    # Arrange
+    output = result_with_everything_paused.output
+    # Act
+    said = "are PAUSED — nothing to push" in output
+    # Assert
+    assert said is True
+
+
+@pytest.fixture
+def result_on_a_host_that_is_not_the_origin(keepalive_cli, env, store: Path):
+    """An account store with no refresh material anywhere in it."""
+    return _run(keepalive_cli, env)
+
+
+def test_a_host_that_is_not_the_origin_still_exits_one(
+    result_on_a_host_that_is_not_the_origin,
+):
+    """The pair that stops "empty means success" from swallowing the guard.
+
+    Two empty lists, opposite verdicts: a host that holds refresh
+    material for nobody cannot keep any peer alive and must say so,
+    while a host whose accounts are all paused is doing exactly what it
+    was told. Collapsing them would re-create the always-red bug in the
+    one case where the operator has paused everything.
+    """
+    # Arrange
+    result = result_on_a_host_that_is_not_the_origin
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code == 1
+
+
+def test_a_host_that_is_not_the_origin_says_why(
+    result_on_a_host_that_is_not_the_origin,
+):
+    # Arrange
+    output = result_on_a_host_that_is_not_the_origin.output
+    # Act
+    said = "not the origin" in output
+    # Assert
+    assert said is True
+
+
+# ---------------------------------------------------------------------------
+# ONE account rested, one still running — the partition itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def result_with_beta_paused(keepalive_cli, env, two_accounts: Path):
+    _write_pause(two_accounts / BETA, BETA, "quota rest", ago=3 * 86400)
+    return _run(keepalive_cli, env)
+
+
+def test_a_paused_account_is_never_attempted(result_with_beta_paused):
+    """Skip, not tolerate. No mint, no ssh, no FAILED line — nothing at all.
+
+    Tolerating would still open one connection and print one FAILED line
+    per peer per pass, which is the 115 MB journal the operator is
+    looking at. Tolerance is the right verb for a peer that MIGHT be up;
+    skip is the right verb for an account he has decided is down.
+    """
+    # Arrange
+    output = result_with_beta_paused.output
+    # Act
+    attempted = f"{BETA}: pushing" in output
+    # Assert
+    assert attempted is False
+
+
+def test_without_the_pause_that_account_is_attempted(result_with_nothing_paused):
+    """The control for the assertion above."""
+    # Arrange
+    output = result_with_nothing_paused.output
+    # Act
+    attempted = f"{BETA}: pushing" in output
+    # Assert
+    assert attempted is True
+
+
+def test_a_paused_account_contributes_no_failure(result_with_beta_paused):
+    """The failure tally is what `failed` is computed from, so this is the
+    closest an offline test gets to the exit code itself."""
+    # Arrange
+    output = result_with_beta_paused.output
+    # Act
+    failures = [line for line in output.splitlines() if ": FAILED" in line]
+    # Assert
+    assert len(failures) == 1
+
+
+def test_without_the_pause_both_accounts_contribute_failures(
+    result_with_nothing_paused,
+):
+    """The control: two accounts, two failures, which is today's red unit."""
+    # Arrange
+    output = result_with_nothing_paused.output
+    # Act
+    failures = [line for line in output.splitlines() if ": FAILED" in line]
+    # Assert
+    assert len(failures) == 2
+
+
+def test_the_surviving_account_is_still_attempted(result_with_beta_paused):
+    """Without this, a bug that skipped EVERY account would pass the rest."""
+    # Arrange
+    output = result_with_beta_paused.output
+    # Act
+    attempted = f"{ALPHA}: pushing" in output
+    # Assert
+    assert attempted is True
+
+
+# ---------------------------------------------------------------------------
+# The skip must be LOUD — he intends to bring these accounts back
+# ---------------------------------------------------------------------------
+
+
+def test_the_run_names_the_skipped_account(result_with_beta_paused):
+    # Arrange
+    output = result_with_beta_paused.output
+    # Act
+    named = f"{BETA}: SKIPPED — paused" in output
+    # Assert
+    assert named is True
+
+
+def test_the_run_quotes_the_operators_reason(result_with_beta_paused):
+    # Arrange
+    output = result_with_beta_paused.output
+    # Act
+    quoted = "quota rest" in output
+    # Assert
+    assert quoted is True
+
+
+def test_the_run_prints_how_long_the_pause_has_stood(result_with_beta_paused):
+    """The age stands in for the expiry this record deliberately lacks.
+
+    Nothing will ever lift a pause on its own, so the only thing between
+    a deliberate rest and a forgotten account is that every run says how
+    old it is.
+    """
+    # Arrange
+    output = result_with_beta_paused.output
+    # Act
+    aged = "paused 3d ago" in output
+    # Assert
+    assert aged is True
+
+
+def test_the_run_prints_the_command_that_lifts_it(result_with_beta_paused):
+    # Arrange
+    output = result_with_beta_paused.output
+    # Act
+    told = f"sac accounts resume {BETA}" in output
+    # Assert
+    assert told is True
+
+
+def test_the_run_says_the_skip_was_not_a_failure(result_with_beta_paused):
+    """A line the operator scans must not READ like a soft error."""
+    # Arrange
+    output = result_with_beta_paused.output
+    # Act
+    said = "Nothing pushed, nothing failed." in output
+    # Assert
+    assert said is True
+
+
+# ---------------------------------------------------------------------------
+# The machine-readable record
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def json_records(keepalive_cli, env, two_accounts: Path):
+    _write_pause(two_accounts / BETA, BETA, "quota rest")
+    result = _run(keepalive_cli, env, "--json")
+    return json.loads(result.stdout)
+
+
+def test_the_json_record_marks_the_skip_as_a_pause(json_records):
+    """``skipped`` names WHY, so a consumer need not parse prose."""
+    # Arrange
+    records = json_records
+    # Act
+    skipped = [r["account"] for r in records if r.get("skipped") == "paused"]
+    # Assert
+    assert skipped == [BETA]
+
+
+def test_the_json_record_does_not_call_a_skip_a_failure(json_records):
+    """The run did the right thing; ``ok`` must say so."""
+    # Arrange
+    records = json_records
+    # Act
+    skip = next(r for r in records if r.get("skipped") == "paused")
+    # Assert
+    assert skip["ok"] is True
+
+
+def test_the_json_record_carries_the_reason(json_records):
+    # Arrange
+    records = json_records
+    # Act
+    skip = next(r for r in records if r.get("skipped") == "paused")
+    # Assert
+    assert skip["reason"] == "quota rest"

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_build_paused_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_build_paused_wiring.py
@@ -1,0 +1,394 @@
+"""A pause on DISK must reach the screen the operator actually types.
+
+WHY THIS FILE EXISTS AT ALL. ``test__account_list_paused_row.py`` proves
+the RENDERER can print PAUSED, by hand-rolling an ``AccountRow`` and
+pushing it through the table. That is a good test and it is not this
+one: it never asks whether anything READS a ``pause.json`` and fills
+that row in. Reviewed 2026-08-26, three separate ways of severing the
+wiring left all of the new tests green:
+
+* ``build_stored_rows`` dropping ``pause_reason`` — the local builder
+  stops carrying the pause, and a paused account renders ``VALID
+  +6h12m``.
+* ``build_stored_json`` dropping the ``paused`` key — the documented
+  ``--json`` sibling disappears for every downstream consumer.
+* ``rows_from_stored`` never reading that key — the SHIPPED defect. The
+  data crossed the wire correctly and was thrown away at the renderer,
+  so the DEFAULT ``sac accounts list`` (which goes through the fleet
+  path, for this machine's own accounts too) showed ``VALID +7h59m``
+  while ``sac accounts list --refresh`` showed ``PAUSED``. Only the
+  second is a command he runs.
+
+That matters more here than it would elsewhere: a pause never expires
+and nothing nags him about one, so 「また復活させる」 depends on the
+listing BEING the standing reminder. A reminder that renders only under
+a flag he does not type is not one.
+
+Every test below therefore starts from a real ``pause.json`` on a real
+``tmp_path`` store and ends at a rendered cell, and every one has a
+control with the pause file absent — without the control, a bug that
+printed PAUSED on every row would pass. NO MOCKS (PA-306): no
+``monkeypatch``, no substituted reader; ``$HOME`` is redirected with the
+suite's own ``env_save_restore`` fixture, which is the same real seam
+the neighbouring list tests use.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._creds._pause import Pause, write_pause
+from scitex_agent_container._state.account_store import save_account
+from scitex_agent_container.cli_pkg._account_list_build import (
+    build_stored_json,
+    build_stored_rows,
+)
+from scitex_agent_container.cli_pkg._account_list_collapse import (
+    AccountGroup,
+    _fmt_status_cell,
+)
+from scitex_agent_container.cli_pkg._account_list_fleet import rows_from_stored
+from scitex_agent_container.cli_pkg._account_list_render import (
+    AccountRow,
+    render_stored_table_to_str,
+)
+from scitex_agent_container.cli_pkg.account_group import account
+
+NAME = "work"
+REASON = "quota rest — restarting the subscription later"
+#: Token TTL on the hand-rolled fleet rows. Named so the stability test can
+#: build the expected cell rather than hard-coding a rendered TTL.
+_HOURS = 7.9
+
+
+@pytest.fixture(autouse=True)
+def sandbox_home(tmp_path, env_save_restore) -> Path:
+    """Redirect ``$HOME`` so the account-store cascade lands in ``tmp_path``.
+
+    Same shape as ``test__account_list_render.py::sandbox_home``. Click's
+    ``CliRunner`` does not isolate ``Path.home()``, and the store
+    resolves through it, so this is what keeps the real fleet store
+    untouched.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.delete("TZ")
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_TZ")
+    return home
+
+
+def _seed_account(home: Path) -> Path:
+    """A real stored account with a token that is fresh for eight hours."""
+    save_account(NAME, {"email_address": "w@example.com"}, home=home)
+    account_dir = home / ".scitex" / "agent-container" / "accounts" / NAME
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "access-not-a-real-token",
+                    "refreshToken": "refresh-not-a-real-token",
+                    "expiresAt": int((time.time() + 8 * 3600) * 1000),
+                }
+            }
+        )
+    )
+    return account_dir
+
+
+@pytest.fixture
+def paused_account(sandbox_home) -> Path:
+    """The stored account, rested one day ago, with the record on disk."""
+    account_dir = _seed_account(sandbox_home)
+    write_pause(
+        account_dir,
+        Pause(
+            name=NAME,
+            active=True,
+            reason=REASON,
+            since=time.time() - 86400,
+            by="operator@test-host",
+        ),
+    )
+    return account_dir
+
+
+@pytest.fixture
+def running_account(sandbox_home) -> Path:
+    """The identical account with NO pause file — the control for every case."""
+    return _seed_account(sandbox_home)
+
+
+_ACCOUNTS = [{"name": NAME, "email_address": "w@example.com"}]
+
+
+# ---------------------------------------------------------------------------
+# The local builder: does a file on disk reach the row?
+# ---------------------------------------------------------------------------
+
+
+def test_build_stored_rows_carries_the_reason_from_disk(paused_account):
+    """Severing this makes a paused account render as ``VALID +6h12m``."""
+    # Arrange
+    accounts = list(_ACCOUNTS)
+    # Act
+    rows = build_stored_rows(accounts, passive=True)
+    # Assert
+    assert rows[0].pause_reason == REASON
+
+
+def test_build_stored_rows_carries_no_reason_without_a_pause(running_account):
+    """The control: the reason must come from the file, not from the builder."""
+    # Arrange
+    accounts = list(_ACCOUNTS)
+    # Act
+    rows = build_stored_rows(accounts, passive=True)
+    # Assert
+    assert rows[0].pause_reason == ""
+
+
+def test_build_stored_rows_carries_the_decision_timestamp(paused_account):
+    """Without ``since`` the cell can print PAUSED but not how long for."""
+    # Arrange
+    accounts = list(_ACCOUNTS)
+    # Act
+    rows = build_stored_rows(accounts, passive=True)
+    # Assert
+    assert rows[0].pause_since is not None
+
+
+def test_build_stored_json_emits_the_documented_paused_key(paused_account):
+    """``--json`` consumers read this key; renaming it must go red."""
+    # Arrange
+    accounts = list(_ACCOUNTS)
+    # Act
+    entries = build_stored_json(accounts, passive=True)
+    # Assert
+    assert entries[0]["paused"]["reason"] == REASON
+
+
+def test_build_stored_json_says_null_when_not_paused(running_account):
+    """The control, and the on-the-wire spelling: ``None``, never ``false``."""
+    # Arrange
+    accounts = list(_ACCOUNTS)
+    # Act
+    entries = build_stored_json(accounts, passive=True)
+    # Assert
+    assert entries[0]["paused"] is None
+
+
+# ---------------------------------------------------------------------------
+# The fleet boundary: does the key survive being turned back into a row?
+# ---------------------------------------------------------------------------
+
+
+def test_rows_from_stored_reads_the_paused_key(paused_account):
+    """THE SHIPPED DEFECT: the key crossed the wire and was dropped here."""
+    # Arrange
+    entries = build_stored_json(_ACCOUNTS, passive=True)
+    # Act
+    rows = rows_from_stored(entries, "some-host")
+    # Assert
+    assert rows[0].pause_reason == REASON
+
+
+def test_rows_from_stored_carries_no_reason_without_a_pause(running_account):
+    """The control for the assertion above."""
+    # Arrange
+    entries = build_stored_json(_ACCOUNTS, passive=True)
+    # Act
+    rows = rows_from_stored(entries, "some-host")
+    # Assert
+    assert rows[0].pause_reason == ""
+
+
+def test_a_peer_running_an_older_sac_omits_the_key_and_is_not_paused():
+    """An older peer sends no ``paused`` at all; that is "not paused"."""
+    # Arrange — exactly the entry shape a pre-pause sac emits.
+    entries = [{"name": NAME, "freshness": "VALID", "freshness_hours": 7.9}]
+    # Act
+    rows = rows_from_stored(entries, "old-peer")
+    # Assert
+    assert rows[0].pause_reason == ""
+
+
+# ---------------------------------------------------------------------------
+# The collapsed cell: the DEFAULT table's own formatter
+# ---------------------------------------------------------------------------
+
+
+def _group(*rows: AccountRow) -> AccountGroup:
+    return AccountGroup(provider="claude-code", name=NAME, rows=list(rows))
+
+
+def _row(host: str, **overrides) -> AccountRow:
+    base = dict(
+        host=host,
+        name=NAME,
+        freshness_state="VALID",
+        freshness_hours=_HOURS,
+        used_pct_5h=None,
+        used_pct_7d=None,
+        snapshot_as_of=None,
+    )
+    base.update(overrides)
+    return AccountRow(**base)
+
+
+def test_the_collapsed_status_cell_says_paused():
+    """It called ``_fmt_status`` POSITIONALLY and dropped the pause kwargs."""
+    # Arrange
+    group = _group(_row("h1", pause_reason=REASON, pause_since=time.time() - 86400))
+    # Act
+    cell = _fmt_status_cell(group)
+    # Assert
+    assert cell.startswith("PAUSED")
+
+
+def test_the_collapsed_status_cell_says_valid_without_a_pause():
+    """The control for the assertion above."""
+    # Arrange
+    group = _group(_row("h1"))
+    # Act
+    cell = _fmt_status_cell(group)
+    # Assert
+    assert cell.startswith("VALID")
+
+
+def test_one_host_pausing_and_another_not_is_shown_as_a_disagreement():
+    """A pause is a per-host FILE, so hosts CAN disagree — and must not be averaged.
+
+    This column's whole job is that an odd host is named rather than
+    absorbed. Folding the pause into the agreement key is what makes
+    that true of a pause as well as of an expiry.
+    """
+    # Arrange
+    group = _group(
+        _row("h1"),
+        _row("h2", pause_reason=REASON, pause_since=time.time() - 86400),
+    )
+    # Act
+    cell = _fmt_status_cell(group)
+    # Assert
+    assert "PAUSED on h2" in cell
+
+
+def test_a_one_to_one_disagreement_renders_the_same_way_every_run():
+    """Found by this suite failing intermittently, and it is a real defect.
+
+    ``max`` over a SET of equally-common states returns whichever the
+    set yields first, and Python randomises string hashing per process.
+    So the SAME two hosts rendered ``VALID x1; PAUSED on h2`` in one run
+    and ``PAUSED x1; VALID on h1`` in the next. Both sentences are true,
+    which is why it went unnoticed; on a screen refreshed every few
+    seconds it reads as the fleet flapping between two states.
+
+    First-seen row order is now the tie-break, so this asserts the
+    stable answer rather than merely that SOMETHING was said.
+
+    HONEST LIMIT: the twenty iterations run in ONE process and
+    therefore share one hash seed, so they do not sample the variation
+    they describe — the loop only pins that nothing else is
+    non-deterministic. What catches a regression is the exact expected
+    string: without the tie-break it is wrong on roughly half of
+    Python's hash seeds, which is how this surfaced (green on its first
+    runs, red later on identical code). A gate that fails half the time
+    is a gate; one that reads "something was printed" is not.
+    """
+    # Arrange
+    group = _group(
+        _row("h1"),
+        _row("h2", pause_reason=REASON, pause_since=time.time() - 86400),
+    )
+    # Act
+    cells = {_fmt_status_cell(group) for _ in range(20)}
+    # Assert
+    assert cells == {"VALID x1; PAUSED on h2"}
+
+
+# ---------------------------------------------------------------------------
+# End to end: the command he actually types
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_list_shows_paused(paused_account):
+    """``sac accounts list`` — no --refresh, which is the whole point."""
+    # Arrange
+    args = ["list", "--no-fanout"]
+    # Act
+    result = CliRunner().invoke(account, args)
+    # Assert
+    assert "PAUSED" in result.output, result.output
+
+
+def test_the_default_list_does_not_show_paused_without_a_pause(running_account):
+    """The control: PAUSED must come from the file, not from the table."""
+    # Arrange
+    args = ["list", "--no-fanout"]
+    # Act
+    result = CliRunner().invoke(account, args)
+    # Assert
+    assert "PAUSED" not in result.output, result.output
+
+
+def test_the_default_lists_status_cell_quotes_the_operators_own_reason(
+    paused_account,
+):
+    """"PAUSED" alone leaves him wondering which decision this was.
+
+    ASSERTED ON THE CELL, NOT ON THE TABLE, and that is not a dodge.
+    ``rich`` word-wraps a Status cell that is wider than the column, so
+    the reason genuinely appears in the rendered table split across
+    three lines — a substring assertion there would be measuring the
+    terminal width rather than anything this code decides, which is the
+    same defect that made the first truncation test unable to fail. The
+    cell is the widest thing the application actually controls, so this
+    is where the claim belongs. The CLI test above owns the other half:
+    that the cell reaches the default screen at all.
+    """
+    # Arrange — the real row the default table is built from.
+    rows = build_stored_rows(list(_ACCOUNTS), passive=True)
+    # Act
+    cell = _fmt_status_cell(_group(rows[0]))
+    # Assert
+    assert "quota rest" in cell
+
+
+def test_the_by_host_list_shows_paused(paused_account):
+    """The other fleet shape reaches the renderer through the same builder."""
+    # Arrange
+    args = ["list", "--no-fanout", "--by-host"]
+    # Act
+    result = CliRunner().invoke(account, args)
+    # Assert
+    assert "PAUSED" in result.output, result.output
+
+
+# ---------------------------------------------------------------------------
+# The rendered table, from a real file rather than a hand-rolled row
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_pause_file_reaches_the_rendered_table(paused_account):
+    """Store → builder → renderer, with nothing hand-rolled in between."""
+    # Arrange
+    rows = build_stored_rows(list(_ACCOUNTS), passive=True)
+    # Act
+    table = render_stored_table_to_str(rows, width=160)
+    # Assert
+    assert "PAUSED 1d" in table
+
+
+def test_without_the_file_the_same_table_shows_the_token_ttl(running_account):
+    """The control: the same account, same builder, no pause file."""
+    # Arrange
+    rows = build_stored_rows(list(_ACCOUNTS), passive=True)
+    # Act
+    table = render_stored_table_to_str(rows, width=160)
+    # Assert
+    assert "PAUSED" not in table

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_render_paused_row.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_render_paused_row.py
@@ -1,0 +1,168 @@
+"""A pause the operator cannot SEE is a trap, so the listing has to show it.
+
+He said 「また復活させる」 — he intends to bring these accounts back.
+A pause never expires and nothing nags him about one, so the screen he
+already watches (``sac accounts list``, refreshed every few seconds) is
+the only standing reminder that an account is resting rather than
+broken.
+
+THE TOKEN TTL IS REPLACED, NOT JOINED. The Status cell normally reads
+``VALID +2h26m``, and that ``+2h26m`` belongs to the TOKEN. Printing it
+beside PAUSED — ``PAUSED +6h12m`` — would be read as "the pause expires
+in six hours", which is a lie about the one property that makes a pause
+trustworthy: nothing lifts it but the operator.
+:func:`test_a_paused_row_does_not_show_the_token_ttl` is that rule, and
+:func:`test_an_unpaused_row_still_shows_the_token_ttl` is its control —
+without the second, a bug that dropped the TTL from every row would
+pass the first.
+
+Pure renderer tests: an ``AccountRow`` is hand-rolled and pushed through
+the real table renderer. No CliRunner, no store, no clock patched — the
+dataclass exists precisely so this can be done with nothing
+substituted, and both new fields default so every pre-existing
+hand-rolled row in the suite still constructs.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from scitex_agent_container.cli_pkg._account_list_format import format_ttl_live
+from scitex_agent_container.cli_pkg._account_list_render import (
+    _PAUSE_REASON_CHARS,
+    AccountRow,
+    _fmt_status,
+    render_stored_table_to_str,
+)
+
+_HOURS_LEFT = 6.2
+
+
+def _row(**overrides) -> AccountRow:
+    base = dict(
+        name="beta-example-com",
+        freshness_state="VALID",
+        freshness_hours=_HOURS_LEFT,
+        used_pct_5h=None,
+        used_pct_7d=None,
+        snapshot_as_of=None,
+    )
+    base.update(overrides)
+    return AccountRow(**base)
+
+
+@pytest.fixture
+def paused_table() -> str:
+    """One row for an account the operator rested three days ago."""
+    row = _row(
+        pause_reason="quota rest",
+        pause_since=time.time() - 3 * 86400,
+    )
+    return render_stored_table_to_str([row], width=160)
+
+
+@pytest.fixture
+def unpaused_table() -> str:
+    """The identical row with no pause — the control for every assertion."""
+    return render_stored_table_to_str([_row()], width=160)
+
+
+def test_a_paused_row_says_paused(paused_table: str):
+    # Arrange
+    table = paused_table
+    # Act
+    shown = "PAUSED" in table
+    # Assert
+    assert shown is True
+
+
+def test_an_unpaused_row_does_not_say_paused(unpaused_table: str):
+    """The control: PAUSED must come from the pause, not from the renderer."""
+    # Arrange
+    table = unpaused_table
+    # Act
+    shown = "PAUSED" in table
+    # Assert
+    assert shown is False
+
+
+def test_a_paused_row_quotes_the_operators_reason(paused_table: str):
+    """"PAUSED" alone would leave him wondering which decision this was."""
+    # Arrange
+    table = paused_table
+    # Act
+    shown = "quota rest" in table
+    # Assert
+    assert shown is True
+
+
+def test_a_paused_row_shows_the_age_of_the_decision(paused_table: str):
+    # Arrange
+    table = paused_table
+    # Act
+    shown = "PAUSED 3d" in table
+    # Assert
+    assert shown is True
+
+
+def test_a_paused_row_does_not_show_the_token_ttl(paused_table: str):
+    """``PAUSED +6h12m`` would read as "the pause expires in 6h12m"."""
+    # Arrange
+    ttl = format_ttl_live(_HOURS_LEFT)
+    # Act
+    shown = ttl in paused_table
+    # Assert
+    assert shown is False
+
+
+def test_an_unpaused_row_still_shows_the_token_ttl(unpaused_table: str):
+    """The control for the assertion above."""
+    # Arrange
+    ttl = format_ttl_live(_HOURS_LEFT)
+    # Act
+    shown = ttl in unpaused_table
+    # Assert
+    assert shown is True
+
+
+def test_a_long_reason_is_truncated_rather_than_wrapping_the_table():
+    """The cell has neighbours; an essay in it pushes them off the screen.
+
+    ASSERTED ON THE CELL, AND THIS TEST USED TO BE UNABLE TO FAIL.
+    Reviewed 2026-08-26: it rendered a 200-character reason into a
+    160-column table and asserted ``"x" * 200 not in table``. ``rich``
+    wraps a long cell across lines, so that run of 200 x's can never
+    appear contiguously in a rendered table no matter what this code
+    does — deleting the truncation entirely left the file's seven tests
+    green and the whole list-render suite green (69 passed), while the
+    operator got a Status cell that shoved Identity and Last-update off
+    his screen. The assertion was measuring rich's line breaking.
+
+    :func:`_fmt_status` is what the application controls, so the bound
+    goes there. ``+ 20`` is head-room for the fixed prefix (``PAUSED``,
+    the age, the em-dash and the ellipsis), not slack in the claim: the
+    number that matters is that the cell is bounded by
+    ``_PAUSE_REASON_CHARS`` rather than by the reason's own length.
+    """
+    # Arrange
+    reason = "x" * 200
+    # Act
+    cell = _fmt_status("VALID", _HOURS_LEFT, pause_reason=reason, pause_since=1.0)
+    # Assert
+    assert len(cell) <= _PAUSE_REASON_CHARS + 20
+
+
+def test_a_short_reason_survives_intact(paused_table: str):
+    """The reversing control: truncation must not eat a normal reason.
+
+    Without it, a "fix" that returned a constant would satisfy the
+    bound above and lose the only thing the cell is carrying.
+    """
+    # Arrange
+    expected = "quota rest"
+    # Act
+    shown = expected in paused_table
+    # Assert
+    assert shown is True

--- a/tests/scitex_agent_container/cli_pkg/test__account_pause_cli.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_pause_cli.py
@@ -1,0 +1,435 @@
+"""``sac accounts pause`` / ``resume`` — the operator's own switch.
+
+OPERATOR REQUEST 2026-08-26. He offered 「除外」 (exclusion) and rejected
+it, in the same sentence, for 「休止」 — a PAUSE. These two verbs are
+that word, and 「また復活させる」 is why ``resume`` exists at all: he
+intends to bring the accounts back, so stopping one must cost one
+command and lifting it must cost one command.
+
+WHAT THESE TESTS PIN, beyond "the file gets written":
+
+* ``--reason`` IS REQUIRED, whitespace included. This record has no
+  expiry, so nothing will ever tidy up a pause he has forgotten; the
+  reason is the only thing that distinguishes, months later, a
+  deliberate rest from an abandoned account. The fleet already ruled
+  this way on ``scitex-cards``' ``parked`` field, in nearly the same
+  words: "a park with no stated reason is exactly the abandonment the
+  sweep should still catch."
+
+* THE ``--yes`` GATE CAN FAIL, AND CAN SUCCEED. Pausing the last VALID
+  account leaves the picker with nothing and fails every agent boot, so
+  it is refused; ``--yes`` proceeds. Both directions are tested,
+  because a gate that only ever passes is not a gate.
+
+* ``resume`` STATES THE RESULT RATHER THAN IMPLYING IT. Lifting a pause
+  from an account whose subscription is still cancelled gives you a
+  FORBIDDEN account, not a working one. An operator told "resumed" who
+  then watches it keep failing has been answered about the wrong
+  question.
+
+NO MOCKS (PA-306), no ``monkeypatch``: real account directories on a
+real ``tmp_path``, and click's own ``CliRunner(env=...)`` isolation to
+point the store cascade at them.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._creds._entitlement import (
+    FORBIDDEN,
+    Entitlement,
+    write_entitlement,
+)
+from scitex_agent_container._creds._pause import pause_path, read_pause
+
+ALPHA = "alpha-example-com"
+BETA = "beta-example-com"
+
+
+def _write_account(store: Path, name: str, *, hours_left: float = 8.0) -> Path:
+    account_dir = store / name
+    account_dir.mkdir(parents=True, exist_ok=True)
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "access-not-a-real-token",
+                    "refreshToken": "refresh-not-a-real-token",
+                    "expiresAt": int((time.time() + hours_left * 3600) * 1000),
+                }
+            }
+        )
+    )
+    (account_dir / "account.json").write_text(json.dumps({"name": name}))
+    return account_dir
+
+
+@pytest.fixture
+def pause_cli() -> click.Group:
+    from scitex_agent_container.cli_pkg._account_pause import register_pause_commands
+
+    @click.group()
+    def group():
+        pass
+
+    register_pause_commands(group)
+    return group
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    path = tmp_path / ".scitex" / "agent-container" / "accounts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    return {"HOME": str(tmp_path), "SCITEX_DIR": str(tmp_path / ".scitex")}
+
+
+@pytest.fixture
+def two_accounts(store: Path) -> Path:
+    _write_account(store, ALPHA)
+    _write_account(store, BETA)
+    return store
+
+
+@pytest.fixture
+def one_account(store: Path) -> Path:
+    _write_account(store, ALPHA)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# The reason is required
+# ---------------------------------------------------------------------------
+
+
+def test_pausing_without_a_reason_is_refused(pause_cli, env, two_accounts):
+    """A pause with no reason is the same file on disk as an abandonment."""
+    # Arrange
+    args = ["pause", ALPHA]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_pausing_with_a_whitespace_reason_is_refused(pause_cli, env, two_accounts):
+    """``--reason "   "`` satisfies click and says nothing. Refuse it here."""
+    # Arrange
+    args = ["pause", ALPHA, "--reason", "   "]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_a_whitespace_reason_leaves_no_record_behind(
+    pause_cli, env, two_accounts: Path
+):
+    """The refusal must be total: no half-written pause on disk."""
+    # Arrange
+    args = ["pause", ALPHA, "--reason", "   "]
+    # Act
+    CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert pause_path(two_accounts / ALPHA).exists() is False
+
+
+# ---------------------------------------------------------------------------
+# Pausing a real account
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def paused_result(pause_cli, env, two_accounts: Path):
+    return CliRunner().invoke(
+        pause_cli, ["pause", BETA, "--reason", "quota rest"], env=env
+    )
+
+
+def test_pausing_a_real_account_exits_zero(paused_result):
+    # Arrange
+    result = paused_result
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code == 0
+
+
+def test_pausing_records_the_reason_on_disk(paused_result, two_accounts: Path):
+    # Arrange
+    account_dir = two_accounts / BETA
+    # Act
+    stored = read_pause(BETA, account_dir)
+    # Assert
+    assert stored.reason == "quota rest"
+
+
+def test_pausing_marks_the_account_paused_on_disk(paused_result, two_accounts: Path):
+    # Arrange
+    account_dir = two_accounts / BETA
+    # Act
+    stored = read_pause(BETA, account_dir)
+    # Assert
+    assert stored.active is True
+
+
+def test_pausing_prints_the_path_it_wrote(paused_result, two_accounts: Path):
+    """It is a PER-HOST decision, so the operator must be told which host's
+    file this is — the path says it without a sentence about hosts."""
+    # Arrange
+    expected = str(pause_path(two_accounts / BETA))
+    # Act
+    output = paused_result.output
+    # Assert
+    assert expected in output
+
+
+def test_pausing_names_the_command_that_lifts_it(paused_result):
+    # Arrange
+    output = paused_result.output
+    # Act
+    named = f"sac accounts resume {BETA}" in output
+    # Assert
+    assert named is True
+
+
+def test_pausing_touches_no_credential(paused_result, two_accounts: Path):
+    """Nothing is deleted and no token is rewritten — that is the whole point."""
+    # Arrange
+    creds = two_accounts / BETA / ".credentials.json"
+    # Act
+    payload = json.loads(creds.read_text())
+    # Assert
+    assert payload["claudeAiOauth"]["refreshToken"] == "refresh-not-a-real-token"
+
+
+# ---------------------------------------------------------------------------
+# Unknown names are refused
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def unknown_name_result(pause_cli, env, two_accounts):
+    return CliRunner().invoke(
+        pause_cli, ["pause", "not-an-account", "--reason", "x"], env=env
+    )
+
+
+def test_an_unknown_account_is_refused(unknown_name_result):
+    """The store carries symlink aliases, so a plausible-but-unlisted second
+    spelling of a real account exists. Refusing anything the enumerator does
+    not name keeps the CLI and the listing agreeing."""
+    # Arrange
+    result = unknown_name_result
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code != 0
+
+
+def test_the_refusal_lists_the_accounts_that_do_exist(unknown_name_result):
+    # Arrange
+    output = unknown_name_result.output
+    # Act
+    listed = ALPHA in output and BETA in output
+    # Assert
+    assert listed is True
+
+
+# ---------------------------------------------------------------------------
+# The --yes gate, in both directions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def last_account_without_yes(pause_cli, env, one_account: Path):
+    return CliRunner().invoke(
+        pause_cli, ["pause", ALPHA, "--reason", "resting everything"], env=env
+    )
+
+
+@pytest.fixture
+def last_account_with_yes(pause_cli, env, one_account: Path):
+    return CliRunner().invoke(
+        pause_cli,
+        ["pause", ALPHA, "--reason", "resting everything", "--yes"],
+        env=env,
+    )
+
+
+def test_pausing_the_last_valid_account_is_refused(last_account_without_yes):
+    """An all-paused store fails every agent boot. Say so before it happens."""
+    # Arrange
+    result = last_account_without_yes
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code != 0
+
+
+def test_the_refusal_explains_what_would_break(last_account_without_yes):
+    # Arrange
+    output = last_account_without_yes.output
+    # Act
+    explained = "last stored account" in output
+    # Assert
+    assert explained is True
+
+
+def test_the_refusal_writes_nothing(last_account_without_yes, one_account: Path):
+    # Arrange
+    account_dir = one_account / ALPHA
+    # Act
+    exists = pause_path(account_dir).exists()
+    # Assert
+    assert exists is False
+
+
+def test_yes_pauses_the_last_valid_account_anyway(last_account_with_yes):
+    """The other half of the pair: a gate that cannot succeed is not a gate."""
+    # Arrange
+    result = last_account_with_yes
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code == 0
+
+
+def test_yes_actually_writes_the_record(last_account_with_yes, one_account: Path):
+    # Arrange
+    account_dir = one_account / ALPHA
+    # Act
+    stored = read_pause(ALPHA, account_dir)
+    # Assert
+    assert stored.active is True
+
+
+# ---------------------------------------------------------------------------
+# Resume
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def resumed_result(pause_cli, env, two_accounts: Path):
+    CliRunner().invoke(
+        pause_cli, ["pause", BETA, "--reason", "quota rest"], env=env
+    )
+    return CliRunner().invoke(pause_cli, ["resume", BETA], env=env)
+
+
+def test_resuming_a_paused_account_exits_zero(resumed_result):
+    # Arrange
+    result = resumed_result
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code == 0
+
+
+def test_resuming_removes_the_record(resumed_result, two_accounts: Path):
+    """Absence IS "not paused", so deletion is the whole of resume."""
+    # Arrange
+    account_dir = two_accounts / BETA
+    # Act
+    exists = pause_path(account_dir).exists()
+    # Assert
+    assert exists is False
+
+
+def test_resuming_quotes_the_reason_it_lifted(resumed_result):
+    """So the operator can see WHICH decision he just reversed."""
+    # Arrange
+    output = resumed_result.output
+    # Act
+    quoted = "lifted: quota rest" in output
+    # Assert
+    assert quoted is True
+
+
+def test_resuming_states_the_health_that_results(resumed_result):
+    # Arrange
+    output = resumed_result.output
+    # Act
+    stated = "health now: VALID" in output
+    # Assert
+    assert stated is True
+
+
+@pytest.fixture
+def resumed_still_forbidden_result(pause_cli, env, two_accounts: Path):
+    """Resume an account whose SUBSCRIPTION is still cancelled underneath."""
+    CliRunner().invoke(
+        pause_cli, ["pause", BETA, "--reason", "sub is off"], env=env
+    )
+    write_entitlement(
+        two_accounts / BETA,
+        Entitlement(
+            BETA,
+            FORBIDDEN,
+            checked_at=time.time(),
+            http_status=403,
+            detail="oauth_not_allowed_for_organization",
+        ),
+    )
+    return CliRunner().invoke(pause_cli, ["resume", BETA], env=env)
+
+
+def test_resuming_a_cancelled_account_reports_forbidden(
+    resumed_still_forbidden_result,
+):
+    """"Resumed" must not be heard as "working". The pause was one reason the
+    account was out of service; it may not have been the only one."""
+    # Arrange
+    output = resumed_still_forbidden_result.output
+    # Act
+    stated = "health now: FORBIDDEN" in output
+    # Assert
+    assert stated is True
+
+
+def test_resuming_a_cancelled_account_names_the_real_remedy(
+    resumed_still_forbidden_result,
+):
+    # Arrange
+    output = resumed_still_forbidden_result.output
+    # Act
+    named = "Restore the subscription" in output
+    # Assert
+    assert named is True
+
+
+@pytest.fixture
+def resume_of_a_running_account(pause_cli, env, two_accounts):
+    return CliRunner().invoke(pause_cli, ["resume", BETA], env=env)
+
+
+def test_resuming_an_unpaused_account_is_not_an_error(resume_of_a_running_account):
+    """A no-op the operator is allowed to make."""
+    # Arrange
+    result = resume_of_a_running_account
+    # Act
+    exit_code = result.exit_code
+    # Assert
+    assert exit_code == 0
+
+
+def test_resuming_an_unpaused_account_says_there_was_nothing_to_lift(
+    resume_of_a_running_account,
+):
+    # Arrange
+    output = resume_of_a_running_account.output
+    # Act
+    said = "was not paused" in output
+    # Assert
+    assert said is True

--- a/tests/scitex_agent_container/cli_pkg/test__account_pause_cli_guards.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_pause_cli_guards.py
@@ -1,0 +1,391 @@
+"""``sac accounts pause`` — the four refusals, and what a refusal must not say.
+
+THE COMPANION TO ``test__account_pause_cli.py``, split off it because
+that file passed the repo's 512-line cap. It holds the guards rather
+than the happy path, and every one of them was added or repaired on
+2026-08-26 after review found the same shape twice: a check that was
+RIGHT ABOUT THE FEATURE and wrong about the population it ran on.
+
+* THE LAST-VALID GUARD asked only "is anything ELSE VALID?", so it
+  fired on a target that was not VALID either and then said, as its
+  reason, that the target "currently reads VALID". That is exactly the
+  account class this feature exists for — his FORBIDDEN account is the
+  one he wants to rest — so the real workflow walked into a refusal
+  built for a different situation and had to be talked past with
+  ``--yes``.
+
+* ``_resolve_account_dir`` validated with ``is_dir()``, which is true
+  of the provider dir, the bookkeeping dirs and editor litter. All
+  three paused successfully, wrote a record nothing reads, and left the
+  timer failing while the operator had a command that said "paused".
+
+* ``resume`` called ``clear_pause`` bare. Its refusal to absorb a
+  non-FileNotFoundError is correct — the pause is STILL THERE — but
+  the rendering was missing, so the one verb whose whole promise is
+  that 「また復活させる」 costs one command ended in a stack trace.
+
+* NOTHING PINNED THE ON-DISK KEY NAMES, so a lockstep rename of
+  ``write_pause`` and ``read_pause`` would have kept every test green
+  while every pause file written before the rename became unreadable —
+  and unreadable degrades to "not paused", silently un-pausing every
+  account he had rested.
+
+NO MOCKS (PA-306), no ``monkeypatch``: real account directories on a
+real ``tmp_path``, and click's own ``CliRunner(env=...)`` isolation.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._creds._entitlement import (
+    FORBIDDEN,
+    Entitlement,
+    write_entitlement,
+)
+from scitex_agent_container._creds._pause import pause_path, read_pause
+
+ALPHA = "alpha-example-com"
+BETA = "beta-example-com"
+
+
+def _write_account(store: Path, name: str, *, hours_left: float = 8.0) -> Path:
+    account_dir = store / name
+    account_dir.mkdir(parents=True, exist_ok=True)
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "access-not-a-real-token",
+                    "refreshToken": "refresh-not-a-real-token",
+                    "expiresAt": int((time.time() + hours_left * 3600) * 1000),
+                }
+            }
+        )
+    )
+    (account_dir / "account.json").write_text(json.dumps({"name": name}))
+    return account_dir
+
+
+@pytest.fixture
+def pause_cli() -> click.Group:
+    from scitex_agent_container.cli_pkg._account_pause import register_pause_commands
+
+    @click.group()
+    def group():
+        pass
+
+    register_pause_commands(group)
+    return group
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    path = tmp_path / ".scitex" / "agent-container" / "accounts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    return {"HOME": str(tmp_path), "SCITEX_DIR": str(tmp_path / ".scitex")}
+
+
+@pytest.fixture
+def two_accounts(store: Path) -> Path:
+    _write_account(store, ALPHA)
+    _write_account(store, BETA)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# The guard asks about the TARGET, not only about its neighbours
+# ---------------------------------------------------------------------------
+#
+# Reviewed 2026-08-26. The guard originally asked one question — "is
+# anything ELSE currently VALID?" — and refused whenever the answer was
+# no. So it fired on a target that was not VALID either, and stated as
+# its reason that the target "currently reads VALID". Measured on a
+# store holding one EXPIRED and one FORBIDDEN account: pausing the
+# FORBIDDEN one was refused, both clauses of the refusal false, and the
+# operator had to reach for --yes to do something that could not have
+# broken anything.
+#
+# That is precisely the class this feature exists for. His FORBIDDEN
+# account is the one he wants to rest, and the fleet's others read
+# EXPIRED between keepalive passes, so the real workflow walked
+# straight into a refusal written for a different situation. The
+# existing pair above proves the guard on a VALID target, which is the
+# half that was already right.
+
+
+@pytest.fixture
+def only_a_forbidden_account(store: Path) -> Path:
+    """One account, fresh token, and a measured 403 underneath it.
+
+    The operator's own 2026-08-26 case: ``wyusuuke-gmail-com``'s
+    credential is fine and the API refuses it. Nothing here reads VALID,
+    so pausing it removes nothing from the picker.
+    """
+    account_dir = _write_account(store, ALPHA)
+    write_entitlement(
+        account_dir,
+        Entitlement(
+            name=ALPHA,
+            state=FORBIDDEN,
+            checked_at=time.time(),
+            http_status=403,
+            detail="Your organization has disabled Claude Code",
+        ),
+    )
+    return store
+
+
+@pytest.fixture
+def only_an_expired_account(store: Path) -> Path:
+    """The same shape by the other route — a stale token, no entitlement file."""
+    _write_account(store, ALPHA, hours_left=-5.0)
+    return store
+
+
+def test_pausing_a_forbidden_last_account_is_allowed_without_yes(
+    pause_cli, env, only_a_forbidden_account
+):
+    """It was never pickable, so pausing it strands nothing."""
+    # Arrange
+    args = ["pause", ALPHA, "--reason", "the subscription is stopped"]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_pausing_a_forbidden_last_account_records_the_pause(
+    pause_cli, env, only_a_forbidden_account
+):
+    """Exit 0 is not enough — the decision has to be on disk."""
+    # Arrange
+    args = ["pause", ALPHA, "--reason", "the subscription is stopped"]
+    # Act
+    CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert read_pause(ALPHA, only_a_forbidden_account / ALPHA).active is True
+
+
+def test_pausing_an_expired_last_account_is_allowed_without_yes(
+    pause_cli, env, only_an_expired_account
+):
+    """The other route to the same state: stale token, no verdict file."""
+    # Arrange
+    args = ["pause", ALPHA, "--reason", "resting it while it is stale"]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# Only things the ENUMERATOR names may be paused
+# ---------------------------------------------------------------------------
+#
+# Reviewed 2026-08-26. ``_resolve_account_dir`` validated with
+# ``is_dir()``, which is true of things that are not accounts. Measured
+# against a store carrying the real shape, all three exited 0 saying
+# "paused": the PROVIDER dir ``anthropic/``, the bookkeeping dir
+# ``_backup/``, and editor litter ``.swap-backup-20260815/``. Each wrote
+# a ``pause.json`` where nothing would ever read it — ``list_accounts``
+# skips ``_``/``.`` names and classifies a provider dir as a provider —
+# so the very next keepalive run still enumerated the real accounts and
+# still failed, while the operator had a command that had said "paused".
+#
+# It is reachable in the real store rather than hypothetical: the
+# accounts are symlinked short names, so ``anthropic`` sits among the
+# account names in an ``ls``. The pre-existing refusal test used a name
+# with NO directory at all, which ``is_dir()`` already caught — so it
+# proved the wrong half of the claim its own docstring made.
+
+
+@pytest.fixture
+def store_with_non_accounts(store: Path) -> Path:
+    """A real account beside the three shapes that are not accounts."""
+    _write_account(store, ALPHA)
+    (store / "anthropic" / "some-account").mkdir(parents=True)
+    (store / "_backup").mkdir()
+    (store / ".swap-backup-20260815").mkdir()
+    return store
+
+
+@pytest.mark.parametrize("name", ["anthropic", "_backup", ".swap-backup-20260815"])
+def test_pausing_something_that_is_not_an_account_is_refused(
+    pause_cli, env, store_with_non_accounts, name
+):
+    """A decision recorded where nothing reads it is worse than a refusal."""
+    # Arrange
+    args = ["pause", name, "--reason", "audit probe"]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert result.exit_code != 0, result.output
+
+
+@pytest.mark.parametrize("name", ["anthropic", "_backup", ".swap-backup-20260815"])
+def test_a_refused_non_account_gets_no_pause_file(
+    pause_cli, env, store_with_non_accounts, name
+):
+    """Exit non-zero is not enough; nothing may be left behind either."""
+    # Arrange
+    args = ["pause", name, "--reason", "audit probe"]
+    # Act
+    CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert not pause_path(store_with_non_accounts / name).exists()
+
+
+def test_a_real_account_in_the_same_store_is_still_pausable(
+    pause_cli, env, store_with_non_accounts
+):
+    """The reversing control: the membership check must not refuse everything."""
+    # Arrange
+    args = ["pause", ALPHA, "--reason", "quota rest", "--yes"]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# A store that refuses the unlink
+# ---------------------------------------------------------------------------
+#
+# :func:`._creds._pause.clear_pause` absorbs FileNotFoundError and NOTHING
+# else, deliberately: a permission problem means the pause is STILL THERE,
+# and reporting that as "nothing to lift" would tell the operator he had
+# resumed an account that stays paused. That decision is right and its
+# RENDERING was missing — the call was bare, so the one verb whose whole
+# promise is that 「また復活させる」 costs one command ended in a Python
+# traceback instead of a sentence.
+#
+# The unremovable record here is a DIRECTORY named ``pause.json``, not a
+# chmod: ``Path.unlink`` raises IsADirectoryError, which is an OSError and
+# not FileNotFoundError, on every uid. A permission-based fixture would
+# quietly succeed for root and turn this into a gate that cannot fail on
+# exactly the hosts where it matters least to notice.
+
+
+@pytest.fixture
+def unremovable_record(pause_cli, env, two_accounts: Path) -> Path:
+    """A ``pause.json`` that exists and cannot be unlinked."""
+    pause_path(two_accounts / BETA).mkdir()
+    return two_accounts
+
+
+def test_resume_reports_an_unremovable_record_instead_of_crashing(
+    pause_cli, env, unremovable_record
+):
+    """A ClickException, not a stack trace: exit 1 with a sentence."""
+    # Arrange
+    args = ["resume", BETA]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert result.exit_code == 1, result.output
+
+
+def test_resume_says_the_account_is_still_paused(pause_cli, env, unremovable_record):
+    """The one thing he must not be left believing is that it worked."""
+    # Arrange
+    args = ["resume", BETA]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert "STILL PAUSED" in result.output, result.output
+
+
+def test_resume_does_not_raise_a_bare_oserror(pause_cli, env, unremovable_record):
+    """The failure this replaces: an unhandled IsADirectoryError."""
+    # Arrange
+    args = ["resume", BETA]
+    # Act
+    result = CliRunner().invoke(pause_cli, args, env=env)
+    # Assert
+    assert not isinstance(result.exception, OSError)
+
+
+def test_a_removable_record_is_still_removed(pause_cli, env, two_accounts: Path):
+    """The reversing control: resume must still resume."""
+    # Arrange
+    CliRunner().invoke(pause_cli, ["pause", BETA, "--reason", "quota rest"], env=env)
+    # Act
+    CliRunner().invoke(pause_cli, ["resume", BETA], env=env)
+    # Assert
+    assert not pause_path(two_accounts / BETA).exists()
+
+
+# ---------------------------------------------------------------------------
+# The ON-DISK shape, pinned literally
+# ---------------------------------------------------------------------------
+#
+# Every other test in this file produces a pause with ``write_pause`` and
+# reads it back with ``read_pause``, so renaming the payload key in BOTH
+# would keep them all green while every pause file written before the
+# rename became unreadable — and an unreadable record degrades to "not
+# paused", which silently un-pauses every account the operator had
+# rested. That is the exact failure :mod:`._creds._pause` says it exists
+# to prevent, arriving by the one route the round-trip cannot watch. This
+# is the only assertion here that survives a lockstep rename.
+
+
+def test_the_pause_file_holds_exactly_the_documented_keys(
+    pause_cli, env, two_accounts: Path
+):
+    # Arrange
+    CliRunner().invoke(pause_cli, ["pause", BETA, "--reason", "quota rest"], env=env)
+    # Act
+    payload = json.loads(pause_path(two_accounts / BETA).read_text())
+    # Assert
+    assert set(payload) == {"reason", "since", "by"}
+
+
+def test_the_pause_file_stores_the_reason_under_the_key_reason(
+    pause_cli, env, two_accounts: Path
+):
+    # Arrange
+    CliRunner().invoke(pause_cli, ["pause", BETA, "--reason", "quota rest"], env=env)
+    # Act
+    payload = json.loads(pause_path(two_accounts / BETA).read_text())
+    # Assert
+    assert payload["reason"] == "quota rest"
+
+
+def test_the_audit_field_names_a_real_user_not_the_word_unknown(
+    pause_cli, env, two_accounts: Path
+):
+    """With no expiry, ``by`` and the reason are all that survive the months.
+
+    THE FIXTURE IS THE POINT: every name-carrying environment variable
+    is blanked, which is the state anything launched from systemd, cron
+    or a bare container shell actually runs in. The first cut read only
+    ``$USER`` / ``$LOGNAME`` and fell to the literal string "unknown"
+    there — reliably, and most reliably in exactly the non-interactive
+    contexts where nobody is watching. It now falls through
+    ``getpass.getuser``, which consults ``pwd`` when the environment is
+    silent.
+
+    Without the blanking this test would pass on any interactive shell
+    whatever the code did, i.e. it would be a gate that cannot fail.
+    """
+    # Arrange — the non-interactive environment, made explicit.
+    blind_env = {**env, "USER": "", "LOGNAME": "", "LNAME": "", "USERNAME": ""}
+    CliRunner().invoke(
+        pause_cli, ["pause", BETA, "--reason", "quota rest"], env=blind_env
+    )
+    # Act
+    payload = json.loads(pause_path(two_accounts / BETA).read_text())
+    # Assert
+    assert not payload["by"].startswith("unknown@")

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_paused.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_paused.py
@@ -1,0 +1,320 @@
+"""The OTHER account timer must honour the pause, or the pause half-works.
+
+THERE ARE TWO TIMERS AND THEY SHARE AN ACCOUNT SET.
+``sac accounts send-credentials`` DISTRIBUTES a credential to peers;
+``sac accounts refresh --all --include-active --sync-active-login``
+RENEWS one, on its own schedule. Reviewed 2026-08-26: the first cut of
+the pause change taught the distributor to skip a rested account and
+left the renewer enumerating straight from ``list_accounts``. Measured
+by reading it: no ``read_pause`` anywhere in ``_account_refresh.py``.
+
+Two consequences, and both are the operator's own words:
+
+* A paused account is by construction one whose token is no longer
+  kept alive, so within hours it stops being "skipped, still fresh"
+  and starts being ATTEMPTED on every pass. Each failure feeds
+  ``alert_failed_refreshes``; when he has paused EVERYTHING, every
+  attempt fails and ``all_attempted_failed`` exits 1 on every pass.
+  That is 「休止の間も失敗しないようにしてほしい」 — the requirement
+  the whole change exists for — one timer over from the one that was
+  fixed.
+* Each attempt is a network round-trip against a subscription he asked
+  us to stop touching, which is 「無駄遣いをしないように」 whatever the
+  exit code says.
+
+A half-honoured pause is worse than none, because it teaches him the
+pause works.
+
+WHAT THESE TESTS CAN AND CANNOT MEASURE OFFLINE, stated plainly. A
+real refresh POSTs to Anthropic's token endpoint, which this suite must
+not do, so no test here drives a refresh ATTEMPT of any kind. What
+every test below measures instead is the TARGET SET and the lines the
+run prints about it — which is where the defect was and where a future
+edit would put it back.
+
+THE EXIT CODE IS NOT ASSERTED, and the reason is worth recording
+because the first draft did assert it. ``exit_code == 0`` on an
+all-paused store passed, and its control — the same store without the
+pause files — passed too, both at 0: a token that is still fresh is
+held back by the TTL gate and never attempted, so the 0 was measuring
+the fixture rather than the pause. Reversing that needs STALE tokens,
+and a stale account really does reach for the network. The claim is
+therefore made one step earlier, at the attempt set, where it is both
+true and falsifiable: ``all_attempted_failed`` reads ``bool(attempted)``
+and an empty list is False, which is the whole of why the timer stays
+green through a total pause.
+
+NO MOCKS (PA-306): real account dirs on a real ``tmp_path``, real
+``pause.json`` written by :func:`._creds._pause.write_pause`, and
+click's own ``CliRunner(env=...)`` isolation.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._creds._pause import Pause, write_pause
+from scitex_agent_container.cli_pkg._account_keepalive_pause import (
+    refresh_targets_and_notes,
+)
+
+ALPHA = "alpha-example-com"
+BETA = "beta-example-com"
+REASON = "quota rest — subscription stopped for now"
+
+
+def _write_account(store: Path, name: str, *, hours_left: float = 8.0) -> Path:
+    account_dir = store / name
+    account_dir.mkdir(parents=True, exist_ok=True)
+    (account_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "access-not-a-real-token",
+                    "refreshToken": "refresh-not-a-real-token",
+                    "expiresAt": int((time.time() + hours_left * 3600) * 1000),
+                }
+            }
+        )
+    )
+    (account_dir / "account.json").write_text(json.dumps({"name": name}))
+    return account_dir
+
+
+def _pause(account_dir: Path, name: str) -> None:
+    write_pause(
+        account_dir,
+        Pause(
+            name=name,
+            active=True,
+            reason=REASON,
+            since=time.time() - 86400,
+            by="operator@test-host",
+        ),
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    path = tmp_path / ".scitex" / "agent-container" / "accounts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    return {"HOME": str(tmp_path), "SCITEX_DIR": str(tmp_path / ".scitex")}
+
+
+@pytest.fixture
+def one_paused(store: Path, tmp_path: Path) -> Path:
+    """Two accounts, beta rested. The shape the operator actually runs."""
+    _write_account(store, ALPHA)
+    _pause(_write_account(store, BETA), BETA)
+    return tmp_path
+
+
+@pytest.fixture
+def none_paused(store: Path, tmp_path: Path) -> Path:
+    """The identical store with no pause files — the control for every case."""
+    _write_account(store, ALPHA)
+    _write_account(store, BETA)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# The partition itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_paused_account_is_dropped_from_the_all_target_set(one_paused):
+    """Every network round-trip this run would have made against it."""
+    # Arrange
+    home = one_paused
+    # Act
+    targets, _ = refresh_targets_and_notes(
+        [ALPHA, BETA], all_accounts=True, home=home
+    )
+    # Assert
+    assert targets == [ALPHA]
+
+
+def test_without_the_pause_both_accounts_stay_in_the_target_set(none_paused):
+    """The reversing control: the drop must come from the file."""
+    # Arrange
+    home = none_paused
+    # Act
+    targets, _ = refresh_targets_and_notes(
+        [ALPHA, BETA], all_accounts=True, home=home
+    )
+    # Assert
+    assert targets == [ALPHA, BETA]
+
+
+def test_the_dropped_account_gets_a_skipped_line(one_paused):
+    """A silent skip is indistinguishable from a target list that lost a name."""
+    # Arrange
+    home = one_paused
+    # Act
+    _, notes = refresh_targets_and_notes([ALPHA, BETA], all_accounts=True, home=home)
+    # Assert
+    assert "SKIPPED — paused" in notes[0]
+
+
+def test_the_skipped_line_quotes_the_reason(one_paused):
+    """The reason is what makes a months-old pause liftable."""
+    # Arrange
+    home = one_paused
+    # Act
+    _, notes = refresh_targets_and_notes([ALPHA, BETA], all_accounts=True, home=home)
+    # Assert
+    assert REASON in notes[0]
+
+
+def test_nothing_is_announced_when_nothing_is_paused(none_paused):
+    """The control: a quiet run must stay quiet."""
+    # Arrange
+    home = none_paused
+    # Act
+    _, notes = refresh_targets_and_notes([ALPHA, BETA], all_accounts=True, home=home)
+    # Assert
+    assert notes == []
+
+
+def test_pausing_everything_leaves_nothing_to_attempt(one_paused, store):
+    """Nothing attempted is nothing failed — that IS the exit-0 mechanism."""
+    # Arrange
+    _pause(store / ALPHA, ALPHA)
+    # Act
+    targets, _ = refresh_targets_and_notes(
+        [ALPHA, BETA], all_accounts=True, home=one_paused
+    )
+    # Assert
+    assert targets == []
+
+
+# ---------------------------------------------------------------------------
+# An explicitly named account is a different question
+# ---------------------------------------------------------------------------
+
+
+def test_naming_a_paused_account_still_refreshes_it(one_paused):
+    """A pause silences what enumerates on its own, not what he types."""
+    # Arrange
+    home = one_paused
+    # Act
+    targets, _ = refresh_targets_and_notes([BETA], all_accounts=False, home=home)
+    # Assert
+    assert targets == [BETA]
+
+
+def test_naming_a_paused_account_says_so(one_paused):
+    """Otherwise the two surfaces disagree in silence, which is worse."""
+    # Arrange
+    home = one_paused
+    # Act
+    _, notes = refresh_targets_and_notes([BETA], all_accounts=False, home=home)
+    # Assert
+    assert "is PAUSED" in notes[0]
+
+
+def test_naming_an_unpaused_account_says_nothing(one_paused):
+    """The control for the note above."""
+    # Arrange
+    home = one_paused
+    # Act
+    _, notes = refresh_targets_and_notes([ALPHA], all_accounts=False, home=home)
+    # Assert
+    assert notes == []
+
+
+# ---------------------------------------------------------------------------
+# Through the CLI, which is where the timer meets it
+# ---------------------------------------------------------------------------
+
+
+def _invoke_refresh(env: dict[str, str], *args: str):
+    from scitex_agent_container.cli_pkg.account_group import account
+
+    return CliRunner().invoke(account, ["refresh", *args], env=env)
+
+
+def test_the_refresh_command_announces_the_skip(one_paused, env):
+    """``journalctl`` has to say the same thing the other timer's journal says."""
+    # Arrange
+    args = ("--all",)
+    # Act
+    result = _invoke_refresh(env, *args)
+    # Assert
+    assert f"{BETA}: SKIPPED — paused" in result.output, result.output
+
+
+def test_the_refresh_command_says_nothing_when_nothing_is_paused(none_paused, env):
+    """The reversing control, same store shape, same argv."""
+    # Arrange
+    args = ("--all",)
+    # Act
+    result = _invoke_refresh(env, *args)
+    # Assert
+    assert "SKIPPED — paused" not in result.output, result.output
+
+
+def test_the_refresh_command_leaves_nothing_to_attempt_when_all_are_paused(
+    one_paused, store, env
+):
+    """The operator's requirement, measured where it can honestly be measured.
+
+    THE EXIT CODE IS NOT ASSERTED HERE, AND THAT IS DELIBERATE. The
+    first draft of this test asserted ``exit_code == 0`` with an
+    ``exit_code != 0`` control on the same store minus the pause files.
+    The control came back GREEN-when-it-should-have-been-RED: both runs
+    exited 0, because a token that is still fresh is skipped by the TTL
+    gate and never attempted at all, so the 0 was measuring the fixture,
+    not the pause. Reversing it needs accounts whose tokens are STALE —
+    and a stale account really does POST to Anthropic's token endpoint,
+    which a test may not do.
+
+    So the claim is made one step earlier, where it is both true and
+    falsifiable: the run reports that it has NOTHING to attempt. An
+    empty attempt set is what ``all_attempted_failed`` reads, and
+    ``bool([])`` is False, which is the whole of why the timer stays
+    green through a total pause. The reversing control is
+    :func:`test_without_the_pause_both_accounts_stay_in_the_target_set`,
+    which shows the emptying comes from the pause files.
+    """
+    # Arrange
+    _pause(store / ALPHA, ALPHA)
+    # Act
+    result = _invoke_refresh(env, "--all")
+    # Assert
+    assert f"{ALPHA}: SKIPPED — paused" in result.output, result.output
+
+
+def test_an_all_paused_refresh_attempts_no_account(one_paused, store, env):
+    """The other half: no account line survives the partition.
+
+    ``skipped; token still fresh`` is what an ATTEMPT-less-but-present
+    target prints, so its absence is how we know the target list was
+    emptied rather than merely quiet.
+    """
+    # Arrange
+    _pause(store / ALPHA, ALPHA)
+    # Act
+    result = _invoke_refresh(env, "--all")
+    # Assert
+    assert "token still fresh" not in result.output, result.output
+
+
+def test_without_the_pauses_the_same_store_does_attempt_them(none_paused, env):
+    """The reversing control for the assertion above, same argv, same store."""
+    # Arrange
+    args = ("--all",)
+    # Act
+    result = _invoke_refresh(env, *args)
+    # Assert
+    assert "token still fresh" in result.output, result.output

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -410,6 +410,72 @@ def test_invoking_an_unsupported_delegation_is_refused() -> None:
         _call()
 
 
+def _lay_down(binary_dir: Path) -> Path:
+    """Write a real, executable ``scitex-dev`` and return it."""
+    binary_dir.mkdir(parents=True, exist_ok=True)
+    exe = binary_dir / "scitex-dev"
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+    return exe
+
+
+def test_the_delegate_is_the_sibling_of_our_own_interpreter(tmp_path) -> None:
+    # Arrange — the invariant: EXECUTE the verb in the interpreter that
+    # ANSWERED the questions. Capability is probed in-process and the job name
+    # resolved in-process, so a delegate from anywhere else means sac asked A
+    # and acted on B.
+    #
+    # MEASURED 2026-08-26: in an agent container `shutil.which("scitex-dev")`
+    # found /uvwork/bin/scitex-dev, a shim execing ANOTHER package's venv whose
+    # scitex_dev.jobs group lacks scitex-agent-container. `list` showed 11 sac
+    # timers while `status` said the job did not exist.
+    #
+    # NO PATCHING: both candidates are real files and the resolver is ASKED.
+    ours = _lay_down(tmp_path / "ours" / "bin")
+    _lay_down(tmp_path / "on-path")
+
+    # Act
+    resolved = backend.resolve_scitex_dev(
+        executable=str(tmp_path / "ours" / "bin" / "python"),
+        path=str(tmp_path / "on-path"),
+    )
+
+    # Assert
+    assert resolved == str(ours)
+
+
+def test_the_delegate_falls_back_to_path_when_there_is_no_sibling(tmp_path) -> None:
+    # Arrange — sibling-first must DEGRADE, not demand. Outside a venv there is
+    # no sibling next to the interpreter and PATH is the only answer there is;
+    # refusing would break every such caller to fix none of them.
+    only = _lay_down(tmp_path / "on-path")
+
+    # Act
+    resolved = backend.resolve_scitex_dev(
+        executable=str(tmp_path / "nowhere" / "python"),
+        path=str(tmp_path / "on-path"),
+    )
+
+    # Assert
+    assert resolved == str(only)
+
+
+def test_resolution_returns_none_when_neither_answers(tmp_path) -> None:
+    # Arrange — None is the third value and it must exist: the caller turns it
+    # into a clean ClickException naming what to install, rather than an opaque
+    # FileNotFoundError from deep inside subprocess.
+    (tmp_path / "empty").mkdir()
+
+    # Act
+    resolved = backend.resolve_scitex_dev(
+        executable=str(tmp_path / "nowhere" / "python"),
+        path=str(tmp_path / "empty"),
+    )
+
+    # Assert
+    assert resolved is None
+
+
 def test_the_manual_hint_names_the_timer_unit() -> None:
     # Arrange — the unit filename is derived from JobSpec.name verbatim by
     # scitex-dev's renderer, so the hint must mirror that exactly or it

--- a/tests/scitex_agent_container/cli_pkg/test_account_group_sync_live.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group_sync_live.py
@@ -125,6 +125,51 @@ def test_sync_live_exits_nonzero_when_live_absent(sandbox_home):
     assert result.exit_code == 1
 
 
+def test_poll_exits_zero_when_live_absent(sandbox_home):
+    # Arrange — the two tests above pin the LOUD default and must keep
+    # passing; this pins the other half. A scheduled caller has no human to
+    # tell, and on a host nobody logged into today an absent live credential
+    # is the NORMAL resting state, not an incident.
+    #
+    # MEASURED 2026-08-26: without this flag the 2-minute snapshot timer was
+    # armed on five hosts and failed on three of them (absent, expired 7.9d,
+    # expired 4.6d) — 720 failures a day each. A job that is always red can
+    # never report a NEW problem.
+    (sandbox_home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": "x@y.com"}})
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live", "--poll"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_poll_exits_zero_when_live_expired(sandbox_home):
+    # Arrange — an expired live cred under --poll is "nothing to snapshot",
+    # not a failure. The SAFETY behaviour is unchanged: it is still not saved.
+    _write_live(sandbox_home, "alpha@example.com", int((time.time() - 10_000) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live", "--poll"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_poll_wording_does_not_call_a_no_op_an_error(sandbox_home):
+    # Arrange — the exit code and the words must agree. A line reading
+    # "Error:" beside exit 0 teaches whoever greps the journal that errors
+    # here are ignorable, which is how a real one later gets skipped.
+    (sandbox_home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": "x@y.com"}})
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live", "--poll"])
+    # Assert
+    assert "Error" not in result.output, result.output
+
+
 def test_sync_live_error_message_points_at_login(sandbox_home):
     # Arrange
     _write_live(sandbox_home, "alpha@example.com", int((time.time() - 10_000) * 1_000))

--- a/tests/scitex_agent_container/containers/test_sif_symbol_probe.py
+++ b/tests/scitex_agent_container/containers/test_sif_symbol_probe.py
@@ -131,6 +131,20 @@ def test_probe_checks_the_comment_merge_symbol() -> None:
     assert ("scitex_cards._mirror_rows", "_merge_unseen_comment_rows") in from_imports
 
 
+def test_probe_checks_the_seq_allocation_symbol() -> None:
+    # Arrange - scitex-dev 0.56.6's bounded (origin, seq) oplog-allocation
+    # retry. A bare `import scitex_dev.store` CANNOT catch its absence: 0.56.5
+    # imports perfectly and then loses concurrent same-node writes on the oplog
+    # primary key (7/8 and 5/8 failures, reproduced three times). The module
+    # resolves on both releases and only the ATTRIBUTE differs, so nothing but
+    # the module+symbol pair tells the two apart.
+    source = _probe_source()
+    # Act
+    from_imports = _from_imports(source)
+    # Assert
+    assert ("scitex_dev.store._store", "_SEQ_ALLOCATION_ATTEMPTS") in from_imports
+
+
 def test_probe_fails_loud_on_a_bad_sif() -> None:
     # Arrange — a gate that can only PASS is a hope; the probe must sys.exit()
     # non-zero so a mis-baked SIF is REJECTED, not silently published.
@@ -284,4 +298,28 @@ def test_every_probe_copy_carries_the_comment_merge_symbol(path) -> None:
     assert present, (
         f"{path.name} embeds the symbol probe but not the 0.49.0 "
         "comment-merge check — this copy still passes on a 0.48.0 image"
+    )
+
+
+@pytest.mark.parametrize("path", EMBEDS, ids=lambda p: p.name)
+def test_every_probe_copy_carries_the_seq_allocation_symbol(path) -> None:
+    """The four-copy rule again, for the scitex-dev floor.
+
+    Identical reasoning to the comment-merge check above and a separate test on
+    purpose: the two floors move independently, so one symbol reaching all four
+    copies says nothing about the other. Below scitex-dev 0.56.6, Store._append
+    read MAX(seq) once and inserted, and concurrent writers on a single node
+    collided on the oplog (origin, seq) primary key with no bounded retry. A
+    copy left un-updated keeps baking images that carry that defect while the
+    other copies report a clean gate.
+    Token check, not AST: these are shell heredocs and do not parse as Python.
+    """
+    # Arrange
+    source = path.read_text(encoding="utf-8")
+    # Act
+    present = "_SEQ_ALLOCATION_ATTEMPTS" in source
+    # Assert
+    assert present, (
+        f"{path.name} embeds the symbol probe but not the 0.56.6 "
+        "seq-allocation check - this copy still passes on a 0.56.5 image"
     )

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -17,6 +17,7 @@ assert + STX-TQ003 descriptive names.
 
 from __future__ import annotations
 
+import errno
 import json
 import shutil
 import socket
@@ -43,43 +44,155 @@ _HAS_PORT_DISCOVERY = bool(
     shutil.which("lsof") or shutil.which("ss") or shutil.which("fuser")
 )
 
-def _free_a2a_port() -> int:
-    """An OS-assigned port that is free RIGHT NOW, for the tests that really bind.
 
-    `start_turn_bridge` calls `port_is_free()`, which performs a genuine
-    SO_REUSEADDR bind probe — so these tests need a port nothing holds, not a
-    representative-looking number.
+def _reserve_a2a_port() -> tuple[int, socket.socket | None]:
+    """An a2a port that is free AND STAYS free — held, not merely observed.
 
-    This used to be the literal 19007, chosen (per the old comment) to be "a
-    realistic resolved a2a port". That realism WAS the defect: 19007 is inside
-    the live a2a range [19000, 19999] and is really held by the `figrecipe`
-    agent on the self-hosted `scitex-ci` runner, whose tmux session sits on the
-    same machine the job runs on. So the four `start_turn_bridge` tests passed
-    on GitHub-hosted runners and failed DETERMINISTICALLY on the self-hosted
-    one, with `TurnBridgePortBusyError` naming a real fleet agent:
+    The previous form bound ``("127.0.0.1", 0)``, read ``getsockname()``, and
+    CLOSED the socket, storing the bare int for the whole 5-7 minute session.
+    Its docstring defended the close by arguing a later rebind would succeed
+    (SO_REUSEADDR over TIME_WAIT). That answers "can I rebind it?" The tests
+    depend on "will it still be free when I get there?", and a closed port
+    returns to the kernel's ephemeral pool at once. It was a memory of a fact,
+    not a reservation.
 
-        Holder PID(s): unknown ...; tmux session: tui-figrecipe.
-        Free it, then restart: `fuser -k 19007/tcp; ...`
+    MEASURED on Linux 6.8 (ephemeral range 32768-60999):
+        released the old way -> re-issued to another process after 4,542 draws
+        held as below        -> 0 re-issues in 120,000 draws
+    So the race is real and the hold removes it. Two earlier attempts to
+    reproduce it returned nulls (0 in 4,000 binds; 0/25 at a 10s delay) and
+    both instruments were wrong in the same way: holding thousands of sockets
+    SIMULTANEOUSLY consumes the pool instead of cycling the kernel's rotating
+    allocation cursor, which is what re-issues a released port.
 
-    Which runner picks up a job is not something a PR controls, so the outcome
-    was decided by scheduling rather than by the change under test — a red that
-    tells you nothing and blocks a merge. It stalled PR #1117 twice, and #1117
-    is itself the fix for the audit gate blocking two other PRs.
+    Keeping the socket bound but NEVER ``listen()``-ed is transparent to
+    ``port_is_free`` — that probe is the same SO_REUSEADDR bind — so the gate
+    the tests exercise still passes, while a real rogue LISTENER still trips
+    it. The tests keep their teeth.
 
-    Binding port 0 and reading back the assignment is the standard way to ask
-    the OS for something free. The socket is closed before the test runs, so a
-    later bind of the same port succeeds (SO_REUSEADDR over TIME_WAIT is
-    exactly the case `port_is_free` is documented to treat as free).
+    THE RE-CHECK IS NOT DEFENSIVE CLUTTER. Duplicate-bind-while-not-listening
+    is LINUX semantics; on macOS/BSD a held socket would make ``port_is_free``
+    read False and would fail every ``start_turn_bridge`` test
+    DETERMINISTICALLY. So the helper asks the real probe whether its own hold
+    is transparent, and releases if it is not, degrading to exactly today's
+    behaviour. This fix can never turn a rare Linux flake into a certain
+    non-Linux failure.
+
+    This is the THIRD form of this constant. It was the literal 19007 — inside
+    the live a2a range and genuinely held by the ``figrecipe`` agent on the
+    self-hosted runner — which stalled PR #1117 twice. Commit 811c6a99 traded
+    that DETERMINISTIC collision for a PROBABILISTIC one, and the coin came up
+    tails three times in seven days (ports 35045 / 34121 / 59935), blocking
+    two more unrelated PRs.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-        probe.bind(("127.0.0.1", 0))
-        return int(probe.getsockname()[1])
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    probe.bind(("127.0.0.1", 0))
+    port = int(probe.getsockname()[1])
+    if bridge.port_is_free("127.0.0.1", port):
+        return port, probe
+    probe.close()
+    return port, None
 
 
-# A FREE a2a port + a fake PID for the bridge tests
+# A RESERVED a2a port + a fake PID for the bridge tests
 # (PEP 515 separators satisfy STX-NL001).
-_PORT = _free_a2a_port()
+_PORT, _PORT_RESERVATION = _reserve_a2a_port()
 _PID = 4_242
+
+
+@pytest.mark.skipif(
+    _PORT_RESERVATION is None,
+    reason=(
+        "this platform does not permit a hold that is transparent to "
+        "port_is_free, so the module fell back to the draw-and-release form"
+    ),
+)
+def test_the_reserved_port_still_reads_free_to_the_bridges_own_probe() -> None:
+    """The reservation must not break the gate it exists to stabilise."""
+    # Arrange
+    host = "127.0.0.1"
+    # Act
+    observed = bridge.port_is_free(host, _PORT)
+    # Assert
+    assert observed is True, (
+        "the session reservation made the module port look BUSY to the "
+        "bridge's own probe, which would fail every start_turn_bridge test "
+        "deterministically instead of rarely"
+    )
+
+
+@pytest.mark.skipif(
+    _PORT_RESERVATION is None,
+    reason=(
+        "this platform does not permit a hold that is transparent to "
+        "port_is_free, so the module fell back to the draw-and-release form"
+    ),
+)
+def test_the_module_port_is_reserved_not_merely_observed_free() -> None:
+    """The kernel must genuinely HOLD it, which is what excludes it.
+
+    A plain socket -- no SO_REUSEADDR -- is the honest question "is this port
+    occupied?". An occupied port is excluded from the ephemeral autobind pool,
+    and that exclusion is the only thing stopping a co-tenant process being
+    handed this port minutes after the module was imported.
+
+    FAILS BEFORE THE FIX: the old helper closed its socket, so the port was
+    genuinely unoccupied and this plain bind SUCCEEDED.
+    """
+    # Arrange
+    plain = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # Act
+    try:
+        plain.bind(("127.0.0.1", _PORT))
+        observed = None
+    except OSError as exc:
+        observed = exc.errno
+    finally:
+        plain.close()
+    # Assert
+    assert observed == errno.EADDRINUSE, (
+        "the module port is not actually held, so the kernel may re-issue it "
+        "to another process mid-session -- the exact race this reservation "
+        f"exists to remove (plain bind returned {observed!r})"
+    )
+
+
+def _gate_says_free(_host: str, _port: int) -> bool:
+    """The port gate's answer, supplied by the test instead of by the machine.
+
+    ``start_turn_bridge`` takes ``port_free_fn`` as a first-class parameter
+    precisely so a caller can decide this, and the busy-path tests below
+    already inject the ``False`` half (``port_free_fn=lambda _h, _p: False``).
+    This is the symmetric ``True``: dependency injection through a declared
+    seam, not a mock, so PA-306 is satisfied.
+
+    WHY THE TESTS BELOW MUST NOT ASK THE MACHINE. ``_free_a2a_port`` picks a
+    port by binding 0 and reading the assignment back, then CLOSES the socket
+    at module import. Everything after that is a gap: on a self-hosted runner
+    with N xdist workers, several CI legs and real agents all churning the
+    ephemeral range, something else can take that port before the test bind
+    probe runs. Measured 2026-08-26, worker ``[gw5]``, port 59935 -- two
+    ``start_turn_bridge`` tests red on ``pytest-matrix-on-ubuntu-py3.11``.
+
+    That red was decided by SCHEDULING, not by the change under test. Two PRs
+    with disjoint diffs -- #1222 (``cli_pkg/_dev_jobs_backend.py``) and #1224
+    (``.github/ci/run-in-sif.sh``), neither touching ``runtimes/`` -- both
+    failed the same leg with the same error, which is what a defect neither of
+    them caused looks like.
+
+    This is the SECOND round of the same defect. The port used to be the
+    literal 19007, inside the live a2a range and genuinely held by the
+    ``figrecipe`` agent on the self-hosted runner; that stalled PR #1117
+    twice. Moving to an OS-assigned port turned a DETERMINISTIC collision into
+    a PROBABILISTIC one -- better, but still a coin flip on a busy machine.
+    Injecting the predicate removes the machine from the question entirely.
+
+    The gate itself stays covered, and better than before: the busy path is
+    asserted by injecting ``False``, and ``port_is_free``'s own real-socket
+    behaviour is tested where it belongs, against a socket the test holds open.
+    """
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -319,7 +432,7 @@ def test_start_turn_bridge_passes_resolved_port_to_spawn(
         a2a=SimpleNamespace(port=_PORT), name="figrecipe", config_path=str(spec)
     )
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_gate_says_free)
     # Assert
     assert str(_PORT) in recorded["argv"]
 
@@ -337,7 +450,9 @@ def test_start_turn_bridge_returns_spawned_pid(
     )
     # Act
     pid = bridge.start_turn_bridge(
-        config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID)
+        config,
+        spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
+        port_free_fn=_gate_says_free,
     )
     # Assert
     assert pid == _PID
@@ -404,7 +519,9 @@ def test_start_turn_bridge_returns_none_on_spawn_failure(
         a2a=SimpleNamespace(port=_PORT), name="boom", config_path=str(spec)
     )
     # Act
-    pid = bridge.start_turn_bridge(config, spawn=raising_spawn)
+    pid = bridge.start_turn_bridge(
+        config, spawn=raising_spawn, port_free_fn=_gate_says_free
+    )
     # Assert
     assert pid is None
 
@@ -446,7 +563,11 @@ def test_start_turn_bridge_kills_preexisting_bridge_before_spawn(
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_path.write_text(str(prior.pid), encoding="utf-8")
     # Act — start must SIGTERM the prior bridge before spawning the new one.
-    bridge.start_turn_bridge(config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID))
+    bridge.start_turn_bridge(
+        config,
+        spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
+        port_free_fn=_gate_says_free,
+    )
     # Assert — the prior process received SIGTERM and exited.
     assert prior.wait(timeout=5) is not None
     # (defensive: make sure we never leak the helper if the assert above changes)
@@ -471,7 +592,11 @@ def test_start_turn_bridge_records_new_pid_over_prior(
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_path.write_text("999999", encoding="utf-8")  # dead/stale PID
     # Act
-    bridge.start_turn_bridge(config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID))
+    bridge.start_turn_bridge(
+        config,
+        spawn=lambda argv, **kw: SimpleNamespace(pid=_PID),
+        port_free_fn=_gate_says_free,
+    )
     # Assert — pidfile now holds the new bridge's PID.
     assert pid_path.read_text(encoding="utf-8").strip() == str(_PID)
 
@@ -821,7 +946,7 @@ def test_start_turn_bridge_spawns_with_the_declared_host(
     config = _cfg_with_host(_WILDCARD_HOST)
     config.config_path = str(spec)
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_gate_says_free)
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == _WILDCARD_HOST
 
@@ -843,7 +968,7 @@ def test_start_turn_bridge_spawns_with_loopback_for_an_undeclared_host(
     config = _cfg_with_host(None)
     config.config_path = str(spec)
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    bridge.start_turn_bridge(config, spawn=fake_spawn, port_free_fn=_gate_says_free)
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST
 
@@ -866,7 +991,12 @@ def test_start_turn_bridge_explicit_host_overrides_the_spec(
     config = _cfg_with_host(_WILDCARD_HOST)
     config.config_path = str(spec)
     # Act
-    bridge.start_turn_bridge(config, spawn=fake_spawn, host=DEFAULT_A2A_HOST)
+    bridge.start_turn_bridge(
+        config,
+        spawn=fake_spawn,
+        host=DEFAULT_A2A_HOST,
+        port_free_fn=_gate_says_free,
+    )
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST
 
@@ -976,7 +1106,12 @@ def test_write_bridge_event_names_the_agent(tmp_path: Path) -> None:
     # Act
     with log_path.open("w", encoding="utf-8") as fh:
         bridge.write_bridge_event(
-            fh, "shutdown", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+            fh,
+            "shutdown",
+            agent="figrecipe",
+            host=DEFAULT_A2A_HOST,
+            port=_PORT,
+            pid=_PID,
         )
     # Assert
     assert "agent=figrecipe" in log_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Release **0.27.0**. Thirteen commits since `v0.26.3` (twelve of work, plus the version bump in #1227).

Minor rather than patch: four of them are features.

### Added
- `sac accounts pause` / `resume` (#1226) — an account the operator has deliberately stopped no longer fails the keepalive job on his behalf.
- The credential pool asks whether an account may still RUN, not merely whether its token is fresh (#1217).
- The credential snapshot is declared as a timer, because a daemon has no cron form (#1219).
- CI provisions its own PostgreSQL instead of borrowing the fleet's (#1221).

### Fixed — one theme: gates reporting an outcome unrelated to what they measured
- `pytest -r` REPLACES the reported set rather than appending, so `-rs` had deleted every `FAILED` line from CI summaries (#1224). Now `-rfEs`, with a guard that fails in both directions.
- A PostgreSQL gate that skipped silently read as a pass (#1220).
- The identity drift guard read the RETIRED env name and so skipped 110 of 148 live specs (#1215).
- The turn-bridge port gate no longer depends on a live port (#1225).
- A scheduled snapshotter no longer calls "nothing to do" a failure (#1223).
- dev-jobs delegate to the interpreter we probed, not to whatever `PATH` holds (#1222).
- The image pins `scitex-dev>=0.56.6` and gates it BY SYMBOL (#1214).

### Documentation
- How a BYO machine joins the overlay, and the four traps that cost a day (#1216).

### Gate
`#1227` merged with `mergeState: CLEAN` — 9 checks, 8 success + 1 skipped. Note that one `pytest-matrix-on-ubuntu-py3.13` leg hung on the first attempt (27min against an 8.1–8.7min norm measured across four recent develop runs) and passed normally on rerun; recorded as flake, since the change is a CHANGELOG entry and a version string and py3.11 passed the identical suite on the same commit throughout.

Tag `v0.27.0` from `main` after merge — that is what publishes to PyPI.
