### PR TITLE
fix(runtime): tell the container where heartbeats live

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from .._runtime_paths import runtime_base_dir
 from ..config import AgentConfig
 from ..config._harness_registry import (
     CLAUDE_AGENT_SDK,
@@ -225,6 +226,30 @@ def build_run_argv(
         # writable home automatically.
         "--env",
         "SCITEX_AGENT_CONTAINER_STATE_DB=/state/state.db",
+        # AND ITS SIBLING, which was missing and blinded fleet liveness.
+        #
+        # `beat_is_recent(name)` resolves `runtime_base_dir() / name /
+        # heartbeat.json`, and `runtime_base_dir()` honours this env var
+        # before falling back to `~/.scitex/agent-container/runtime`. Inside a
+        # container `~` is /home/agent — ephemeral, and no agent ever writes a
+        # beat there — so the fallback made the lookup answer None for EVERY
+        # name. Measured 2026-08-27 from a live container: a beat file 30
+        # seconds old, and beat_is_recent returning None for this agent, for a
+        # real peer, and for a name that does not exist alike. Live, dead and
+        # nonexistent were indistinguishable, which is
+        # `sac-agent-liveness-undetectable-and-no-autoheal-20260823`.
+        #
+        # The HOST runtime root, not /state: /state binds THIS agent only
+        # (measured: 1 entry), so it answers self-liveness and nothing else.
+        # The host root carries every agent (measured: 79 dirs, 29 with a live
+        # beat) and is already reachable wherever the spec declares a
+        # whole-home bind.
+        #
+        # Setting it where that bind is ABSENT costs nothing: the reader then
+        # finds no file and returns None, which is what it returns today. This
+        # can make the answer better and cannot make it worse.
+        "--env",
+        f"SCITEX_AGENT_CONTAINER_RUNTIME_DIR={runtime_base_dir()}",
         "--pwd",
         str(Path(config.workdir).expanduser()),
     ]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -1365,3 +1365,59 @@ def test_build_run_argv_openai_harness_refusal_names_the_v4_card(
         raised = exc
     # Assert
     assert raised is not None and V4_HARNESS_DISPATCH_CARD in str(raised)
+
+
+# ---------------------------------------------------------------------------
+# SCITEX_AGENT_CONTAINER_RUNTIME_DIR — telling the container where beats live
+# ---------------------------------------------------------------------------
+
+
+def test_the_runtime_dir_env_is_passed_into_the_container(tui_config, tmp_path):
+    """Without this flag the container cannot see ANY agent's heartbeat.
+
+    `beat_is_recent` resolves `runtime_base_dir() / name / heartbeat.json`, and
+    `runtime_base_dir()` falls back to `~/.scitex/agent-container/runtime` when
+    this variable is unset. Inside a container `~` is /home/agent — ephemeral,
+    and no agent writes a beat there — so the fallback answered None for EVERY
+    name. Measured 2026-08-27 from a live container: a beat file 30s old, and
+    the reader returning None for this agent, a real peer, and a nonexistent
+    name alike (sac-agent-liveness-undetectable-and-no-autoheal-20260823).
+
+    THIS TEST IS THE LAUNCHER HALF and it is deliberately separate from the
+    reader tests in test__apptainer_runtime_dir_env.py. Those prove the reader
+    works when told where to look; this proves the launcher tells it. Either
+    one alone passes while the pair is broken — a reader nothing configures, or
+    a variable nothing reads.
+    """
+    # Arrange
+    from scitex_agent_container._runtime_paths import runtime_base_dir
+
+    expected = f"SCITEX_AGENT_CONTAINER_RUNTIME_DIR={runtime_base_dir()}"
+    # Act
+    argv = build_run_argv(
+        tui_config, state_dir=tmp_path / "state", sif_path=tmp_path / "img.sif"
+    )
+    # Assert
+    assert expected in argv
+
+
+def test_the_runtime_dir_env_carries_a_usable_path(tui_config, tmp_path):
+    """CONTROL on the VALUE, not just the key.
+
+    `--env FOO=` is emitted, deduped and asserted-present exactly like a real
+    one, and it points the reader at nothing. The flag being present is not
+    evidence the value can be used.
+    """
+    # Arrange
+    argv = build_run_argv(
+        tui_config, state_dir=tmp_path / "state", sif_path=tmp_path / "img.sif"
+    )
+    # Act
+    flag = next(
+        a for a in argv if a.startswith("SCITEX_AGENT_CONTAINER_RUNTIME_DIR=")
+    )
+    # Assert
+    assert flag.split("=", 1)[1].startswith("/")
+
+
+# EOF

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime_dir_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime_dir_env.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The container must be told where beats live, or liveness is undetectable.
+
+THE DEFECT THIS PINS, measured 2026-08-27 from inside a live agent container:
+
+    beat_is_recent('scitex-agent-container')  -> None   # me, beat file 30s old
+    beat_is_recent('paper-scitex-clew')       -> None   # a real peer
+    beat_is_recent('definitely-not-an-agent') -> None   # does not exist
+
+Live, dead and nonexistent were indistinguishable — the whole of
+`sac-agent-liveness-undetectable-and-no-autoheal-20260823`, in three lines.
+
+The cause is not the reader. `beat_is_recent` resolves
+`runtime_base_dir() / name / heartbeat.json`, and `runtime_base_dir()` falls
+back to `~/.scitex/agent-container/runtime` when its env var is unset. Inside
+a container `~` is /home/agent, which is ephemeral and where no agent ever
+writes a beat, so the lookup finds nothing and answers None HONESTLY. The
+container was simply never told where the beats are.
+
+WHY THE OBVIOUS TEST WOULD NOT HAVE CAUGHT IT. A test asserting the flag
+appears in the argv passes whether or not the value is usable, and a test run
+on the HOST passes either way — there `~` already IS the runtime root, so the
+fallback is correct and the bug is invisible. That is how this survived long
+enough to blind 107 of 123 agents.
+
+So these drive the REAL reader against a REAL beat file on disk, with HOME
+pointed at an empty directory the way a container has it. No mocks and no
+monkeypatch (PA-306 / STX-NM002): the `environment` fixture sets os.environ
+and restores it on teardown, which is the real variable the real resolver
+reads.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._runtime_paths import runtime_base_dir
+from scitex_agent_container.cli_pkg._helpers._agent_list_beat import beat_is_recent
+
+_AGENT = "an-agent-that-is-beating"
+_RUNTIME_ENV = "SCITEX_AGENT_CONTAINER_RUNTIME_DIR"
+
+
+@pytest.fixture
+def environment():
+    """Set/unset real env vars, restoring exactly what was there before.
+
+    A yield fixture rather than monkeypatch: the resolver reads os.environ, so
+    the test should write os.environ. Teardown restores the prior value —
+    including its ABSENCE, which a naive save/restore that stores "" would get
+    wrong, and the resolver treats "" and unset differently.
+    """
+    saved: dict[str, str | None] = {}
+
+    def apply(**pairs: str | None) -> None:
+        for key, value in pairs.items():
+            if key not in saved:
+                saved[key] = os.environ.get(key)
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    try:
+        yield apply
+    finally:
+        for key, prior in saved.items():
+            if prior is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prior
+
+
+@pytest.fixture
+def beating_agent(tmp_path):
+    """A real runtime root holding one agent whose beat was written just now."""
+    agent_dir = tmp_path / "runtime" / _AGENT
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "heartbeat.json").write_text("{}")
+    return tmp_path / "runtime"
+
+
+def test_the_reader_is_blind_when_home_is_the_containers_own(
+    beating_agent, tmp_path, environment
+):
+    """THE DEFECT. Container HOME holds no beats, so the fallback finds none.
+
+    This assertion fails on a fixed container and passes on a broken one — it
+    pins the SYMPTOM, so a fix has to change something real rather than move a
+    string around in the argv.
+    """
+    # Arrange
+    empty_home = tmp_path / "container-home"
+    (empty_home / ".scitex" / "agent-container" / "runtime").mkdir(parents=True)
+    # Act
+    environment(HOME=str(empty_home), **{_RUNTIME_ENV: None})
+    # Assert — None, not False: no evidence either way (three-valued contract).
+    assert beat_is_recent(_AGENT) is None
+
+
+def test_the_env_var_makes_the_same_reader_see_the_beat(
+    beating_agent, tmp_path, environment
+):
+    """THE FIX. Same reader, same beat file, told where to look."""
+    # Arrange
+    empty_home = tmp_path / "container-home-2"
+    empty_home.mkdir()
+    # Act
+    environment(HOME=str(empty_home), **{_RUNTIME_ENV: str(beating_agent)})
+    # Assert
+    assert beat_is_recent(_AGENT) is True
+
+
+def test_a_name_with_no_beat_file_stays_unknown(beating_agent, environment):
+    """CONTROL. Without this, the test above could pass by always saying True."""
+    # Arrange
+    environment(**{_RUNTIME_ENV: str(beating_agent)})
+    # Act
+    verdict = beat_is_recent("a-name-that-was-never-an-agent")
+    # Assert
+    assert verdict is None
+
+
+def test_a_stale_beat_reads_false_rather_than_unknown(beating_agent, environment):
+    """The other pole, so `None` and `False` are not being conflated.
+
+    `False` means "the file is old"; `None` means "there is no file". A reader
+    returning None for both would satisfy every other test in this file.
+    """
+    # Arrange
+    beat = beating_agent / _AGENT / "heartbeat.json"
+    a_day_ago = time.time() - 86_400
+    os.utime(beat, (a_day_ago, a_day_ago))
+    # Act
+    environment(**{_RUNTIME_ENV: str(beating_agent)})
+    # Assert
+    assert beat_is_recent(_AGENT) is False
+
+
+def test_the_resolver_honours_the_variable_the_launcher_sets(
+    beating_agent, environment
+):
+    """The launcher writes this variable; the resolver must read THAT one.
+
+    Named separately because the two halves live in different modules, and a
+    launcher setting a variable nothing reads is this card's own failure one
+    level up.
+    """
+    # Arrange
+    environment(**{_RUNTIME_ENV: str(beating_agent)})
+    # Act
+    resolved = runtime_base_dir()
+    # Assert
+    assert resolved == Path(str(beating_agent))
+
+
+# EOF


### PR DESCRIPTION
Closes the mechanism behind **`sac-agent-liveness-undetectable-and-no-autoheal-20260823`** (P1, open since 08-23: *107 of 123 agents down and no alarm fired*).

## The reader was never at fault

`beat_is_recent(name)` resolves `runtime_base_dir() / name / heartbeat.json`, and `runtime_base_dir()` falls back to `~/.scitex/agent-container/runtime` when its env var is unset. Inside a container `~` is `/home/agent` — ephemeral, and **no agent ever writes a beat there** — so the lookup finds nothing and returns `None`.

Measured from a live container, with this agent's own beat file **30 seconds old** at the time:

```
beat_is_recent('scitex-agent-container')  -> None   # me, beating right now
beat_is_recent('paper-scitex-clew')       -> None   # a real peer
beat_is_recent('definitely-not-an-agent') -> None   # does not exist
```

Live, dead and nonexistent — indistinguishable. That is the card's "byte-identical records", reproduced at the function level.

`_apptainer_build_argv` already injects `SCITEX_AGENT_CONTAINER_STATE_DB`; it never injected the sibling pointing at the runtime tree. This adds it.

## Why the host runtime root, not `/state`

Measured, not preferred:

| target | agents visible | answers |
|---|---|---|
| `/state` | 1 (this agent) | self-liveness only |
| host runtime root | **79 dirs, 29 with a live beat** | the fleet |

Setting it where no whole-home bind exists costs nothing — the reader finds no file and returns `None`, exactly what it returns today. **This can make the answer better and cannot make it worse.**

## Tested in both halves, deliberately separate

Either half alone passes while the pair is broken — a reader nothing configures, or a variable nothing reads. I shipped the second gap in my own first draft and caught it on review, which is why they are split:

- **Reader** — drives the real function against a real beat file with `HOME` pointed at an empty directory, the way a container has it. The first test asserts the reader is **blind there without the variable**: it fails on a fixed container and passes on a broken one, so a fix must change something real rather than move a string around in the argv.
- **Launcher** — asserts the flag is emitted, plus a control on the **value** rather than the key, because `--env FOO=` is emitted, deduped and asserted-present exactly like a real one while pointing at nothing.

Controls both ways on the reader: a name with no beat stays `None`, a stale beat reads `False` — so `None` ("no file") and `False` ("old file") are not conflated, which is what the three-valued contract exists to prevent.

No mocks, no `monkeypatch` (PA-306 / STX-NM002): the env fixture sets real `os.environ` and restores the prior value **including its absence**, since the resolver treats `""` and unset differently.

## Not fixed here

`gc_dead_instances`' stale sweep selects on `instances.last_heartbeat_at`, whose only writer (`update_heartbeat`) has **no production caller** — so the *reaper* stays blind for an unrelated reason. Two distinct defects; this PR is the listing. Tracked on the same card.

**Verification:** 88 passed / 2 skipped across `build_argv`, `env_dedup`, `argv_guard` and the new tests; ruff and format clean on everything touched (both modified files are unformatted on `develop` too, so that is left alone).
