### PR TITLE
feat(agents): a roles listing, because 109 of 115 agents cannot say what they are for

### DIFF
--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -19,6 +19,7 @@ from ._helpers import HelpRecursiveGroup
 from .agents_prune_claude import archive_claude_bloat as _archive_claude_bloat_impl
 from .build_cmds import check as _check_impl
 from .info_cmds import find as _find_impl
+from .info_cmds import roles as _roles_impl
 from .info_cmds import tail_session as _tail_impl
 from .lifecycle import attach as _attach_impl
 from .lifecycle import delete as _delete_impl
@@ -69,7 +70,7 @@ class _AgentsGroup(HelpRecursiveGroup):
         ("Interact", ["send", "attach"]),
         ("Inspect", ["list", "status", "health", "auth-status", "tail", "recall"]),
         ("Preflight", ["check"]),
-        ("Discovery", ["find"]),
+        ("Discovery", ["find", "roles"]),
         ("Account", ["accounts"]),
         (
             "Maintenance",
@@ -234,6 +235,7 @@ agent_group.add_command(_auth_status_impl)
 
 # Verb leaves
 agent_group.add_command(_rebind(_find_impl, "find"))
+agent_group.add_command(_rebind(_roles_impl, "roles"))
 agent_group.add_command(_rebind(_recall_impl, "recall"))
 agent_group.add_command(_rebind(_check_impl, "check"))
 agent_group.add_command(_rebind(_send_impl, "send"))

--- a/src/scitex_agent_container/cli_pkg/info_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/info_cmds.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import json as json_mod
+import os
 import sys
 from pathlib import Path
 
@@ -372,6 +373,35 @@ def list_python_apis(
                     click.echo(f"{indent}    {ln}")
 
 
+def _roles_default_dir() -> Path:
+    """Where ``roles`` looks when no ``--dir`` is given.
+
+    :func:`fleet_agents_dir` reads ``SCITEX_AGENT_CONTAINER_AGENTS_DIR`` and
+    otherwise falls back to the user's home. Inside a container that home is
+    ``/home/agent`` -- ephemeral, and it does not hold the fleet registry, so
+    the listing reported 0 agents from exactly the place agents run.
+
+    The launcher does not set that variable, but it DOES inject
+    ``SCITEX_AGENT_CONTAINER_YAML_DIRS`` naming the real registry, and that
+    path is readable from inside a container (measured 2026-08-27 on
+    scitex-compute-04: 149 specs enumerable, via the shared host filesystem).
+    So when the primary variable is unset, fall through to the one the
+    launcher actually provides rather than to a home that cannot answer.
+
+    A missing or non-existent entry is skipped rather than trusted, so a
+    stale variable degrades to the normal resolution instead of pinning the
+    listing to a directory that is not there.
+    """
+    if os.environ.get("SCITEX_AGENT_CONTAINER_AGENTS_DIR"):
+        return fleet_agents_dir()
+    for part in os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS", "").split(":"):
+        entry = part.strip()
+        if entry:
+            candidate = Path(entry).expanduser()
+            if candidate.is_dir():
+                return candidate
+    return fleet_agents_dir()
+
 @click.command()
 @click.option(
     "--dir",
@@ -421,7 +451,7 @@ def roles(
       $ sac agents roles --json
     """
     search_path = (
-        fleet_agents_dir()
+        _roles_default_dir()
         if search_dir is None
         else Path(search_dir).expanduser().resolve()
     )

--- a/src/scitex_agent_container/cli_pkg/info_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/info_cmds.py
@@ -12,6 +12,7 @@ import click
 from rich.table import Table
 
 from ..config import load_config
+from .._reconcile._pass import fleet_agents_dir, fleet_spec_paths
 from ._api_tree import get_api_tree
 from ._helpers import _json_flag, agent_name_complete, console
 from .._state._remote_sac_hint import remote_sac_not_found_hint
@@ -369,3 +370,133 @@ def list_python_apis(
             else:
                 for ln in row["Docstring"].split("\n"):
                     click.echo(f"{indent}    {ln}")
+
+
+@click.command()
+@click.option(
+    "--dir",
+    "-d",
+    "search_dir",
+    default=None,
+    help="Directory of YAML agent configs (default: the fleet registry).",
+)
+@click.option(
+    "--missing",
+    "only_missing",
+    is_flag=True,
+    default=False,
+    help="Show only agents with no description — the gap to fill.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output as JSON.",
+)
+@click.pass_context
+def roles(
+    ctx: click.Context, search_dir: str | None, only_missing: bool, as_json: bool
+) -> None:
+    """List what every DEFINED agent is FOR — role and description.
+
+    The population is the agents DEFINED in the fleet registry, not the
+    ones currently RUNNING: a registry of running things cannot answer
+    "what is this fleet made of", and reading one as if it could
+    under-reports by however many agents happen to be down.
+
+    It resolves that registry through :func:`fleet_spec_paths`, the same
+    accessor the reconciler and the auth-heal detector use, because two
+    sweeps of one fleet must never disagree about which agents exist.
+
+    ``role`` is a coarse role-CLASS that most agents share, so the line
+    that actually says what an agent is FOR is ``description``. The
+    footer reports description coverage and ``--missing`` lists exactly
+    the specs that still owe one.
+
+    \b
+    Example:
+      $ sac agents roles
+      $ sac agents roles --missing
+      $ sac agents roles --json
+    """
+    search_path = (
+        fleet_agents_dir()
+        if search_dir is None
+        else Path(search_dir).expanduser().resolve()
+    )
+    spec_paths = fleet_spec_paths(search_path)
+
+    rows: list[dict] = []
+    for yaml_path in spec_paths:
+        # stx-allow: fallback (reason: one unparseable spec must not blank the whole fleet listing; it is reported as an explicitly unreadable row instead of vanishing)
+        try:
+            cfg = load_config(yaml_path)
+        except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+            rows.append(
+                {
+                    "name": yaml_path.parent.name,
+                    "role": "",
+                    "description": "",
+                    "machine": "",
+                    "unreadable": True,
+                    "config": str(yaml_path),
+                }
+            )
+            continue
+        labels = cfg.labels or {}
+        raw_role = labels.get("role", "") or ""
+        role = raw_role.strip() if isinstance(raw_role, str) else str(raw_role)
+        rows.append(
+            {
+                "name": cfg.name,
+                "role": role,
+                "description": (labels.get("description", "") or "").strip(),
+                "machine": labels.get("machine", "") or "",
+                "unreadable": False,
+                "config": str(yaml_path),
+            }
+        )
+
+    total = len(rows)
+    described = sum(1 for r in rows if r["description"])
+    shown = [r for r in rows if not r["description"]] if only_missing else rows
+
+    if _json_flag(ctx, as_json):
+        click.echo(
+            json_mod.dumps(
+                {
+                    "agents_dir": str(search_path),
+                    "total": total,
+                    "described": described,
+                    "agents": shown,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if not rows:
+        console.print(f"[dim]No agent specs under {search_path}[/dim]")
+        return
+
+    title = "Agents missing a description" if only_missing else "Agent roles"
+    table = Table(title=f"{title}  ({search_path})")
+    table.add_column("Name", style="bold")
+    table.add_column("Role")
+    if not only_missing:
+        table.add_column("Description")
+    table.add_column("Machine")
+    for r in shown:
+        cells = [r["name"], r["role"] or "[dim]-[/dim]"]
+        if not only_missing:
+            cells.append(r["description"] or "[dim]— undeclared —[/dim]")
+        cells.append(r["machine"])
+        table.add_row(*cells)
+    console.print(table)
+    tail = (
+        ""
+        if described == total
+        else "  —  `sac agents roles --missing` lists the rest"
+    )
+    console.print(f"[dim]{described}/{total} agents declare a description{tail}[/dim]")

--- a/src/scitex_agent_container/cli_pkg/info_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/info_cmds.py
@@ -429,7 +429,7 @@ def roles(
 
     rows: list[dict] = []
     for yaml_path in spec_paths:
-        # stx-allow: fallback (reason: one unparseable spec must not blank the whole fleet listing; it is reported as an explicitly unreadable row instead of vanishing)
+        # stx-allow: fallback (reason: one unparseable spec must not blank the whole fleet listing; the failure is reported on this command's own stdout as a row with unreadable=true, so a broken spec cannot silently shrink the fleet)
         try:
             cfg = load_config(yaml_path)
         except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)

--- a/tests/scitex_agent_container/cli_pkg/test_info_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_info_cmds.py
@@ -38,6 +38,7 @@ from scitex_agent_container.cli_pkg.info_cmds import (
     _tail_one,
     find,
     list_python_apis,
+    roles,
     tail_session,
 )
 
@@ -504,3 +505,158 @@ def test_list_python_apis_double_verbose_renders_multiple_doc_lines():
     result = runner.invoke(list_python_apis, ["-vv", "-d", "1"])
     # Assert -- -vv prints every docstring line, not just the first.
     assert "Only" in result.output
+
+
+# ---------------------------------------------------------------------------
+# `roles` — what every DEFINED agent is FOR
+#
+# The population under test is the specs on disk, deliberately: an earlier
+# reading of this fleet counted RUNNING agents and under-reported by however
+# many happened to be down. These fixtures are real spec dirs, so a listing
+# that silently narrowed its population would fail here.
+
+
+def _write_role_spec(
+    tmp_path: Path, name: str, role: str = "project-maintainer", desc: str = ""
+) -> Path:
+    """Write a v3 spec carrying ``role`` / ``description`` labels."""
+    d = tmp_path / name
+    d.mkdir()
+    spec = d / "spec.yaml"
+    labels = f"    role: '{role}'\n"
+    if desc:
+        labels += f"    description: '{desc}'\n"
+    spec.write_text(
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "metadata:\n"
+            f"  labels:\n{labels}    machine: m1\n"
+            "spec:\n  runtime: apptainer\n"
+            "  host: ${HOSTNAME}\n"
+            "  workdir: /home/agent/work\n"
+            "  apptainer:\n    image: /x.sif\n    binds: []\n"
+            "  claude:\n    model: sonnet\n"
+            "  health:\n    enabled: true\n    interval: 60\n"
+            "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        )
+    )
+    return spec
+
+
+def test_roles_counts_every_defined_spec(tmp_path):
+    # Arrange
+    for n in ("alpha", "beta", "gamma"):
+        _write_role_spec(tmp_path, n)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--json"])
+    # Assert
+    assert json.loads(result.stdout)["total"] == 3
+
+
+def test_roles_skips_underscore_scaffolding(tmp_path):
+    # Arrange
+    _write_role_spec(tmp_path, "alpha")
+    _write_role_spec(tmp_path, "_template_python_developer")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--json"])
+    names = [a["name"] for a in json.loads(result.stdout)["agents"]]
+    # Assert
+    assert "_template_python_developer" not in names
+
+
+def test_roles_reports_the_declared_role(tmp_path):
+    # Arrange
+    _write_role_spec(tmp_path, "alpha", role="infra-maintainer")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--json"])
+    agents = json.loads(result.stdout)["agents"]
+    # Assert
+    assert agents[0]["role"] == "infra-maintainer"
+
+
+def test_roles_counts_only_specs_that_declare_a_description(tmp_path):
+    # Arrange
+    _write_role_spec(tmp_path, "alpha", desc="does the thing")
+    _write_role_spec(tmp_path, "beta")
+    _write_role_spec(tmp_path, "gamma")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--json"])
+    # Assert
+    assert json.loads(result.stdout)["described"] == 1
+
+
+def test_roles_missing_lists_the_undescribed_specs(tmp_path):
+    # Arrange
+    _write_role_spec(tmp_path, "alpha", desc="does the thing")
+    _write_role_spec(tmp_path, "beta")
+    _write_role_spec(tmp_path, "gamma")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--missing", "--json"])
+    names = sorted(a["name"] for a in json.loads(result.stdout)["agents"])
+    # Assert
+    assert names == ["beta", "gamma"]
+
+
+def test_roles_missing_excludes_the_described_spec(tmp_path):
+    # Arrange
+    _write_role_spec(tmp_path, "alpha", desc="does the thing")
+    _write_role_spec(tmp_path, "beta")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--missing", "--json"])
+    names = [a["name"] for a in json.loads(result.stdout)["agents"]]
+    # Assert
+    assert "alpha" not in names
+
+
+def test_roles_keeps_the_total_honest_while_missing_is_filtered(tmp_path):
+    # Arrange — --missing narrows the ROWS, never the denominator, or the
+    # coverage figure would read 0/2 for a fleet that is half documented.
+    _write_role_spec(tmp_path, "alpha", desc="does the thing")
+    _write_role_spec(tmp_path, "beta")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--missing", "--json"])
+    # Assert
+    assert json.loads(result.stdout)["total"] == 2
+
+
+def test_roles_reports_an_unreadable_spec_rather_than_dropping_it(tmp_path):
+    # Arrange
+    _write_role_spec(tmp_path, "alpha")
+    broken = tmp_path / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("this: [is, not: valid\n  yaml: ::::\n")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--json"])
+    unreadable = [
+        a["name"] for a in json.loads(result.stdout)["agents"] if a["unreadable"]
+    ]
+    # Assert
+    assert unreadable == ["broken"]
+
+
+def test_roles_human_output_marks_an_undeclared_description(tmp_path):
+    # Arrange
+    _write_role_spec(tmp_path, "alpha")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path)])
+    # Assert
+    assert "undeclared" in result.output
+
+
+def test_roles_empty_dir_exits_zero(tmp_path):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(roles, ["--dir", str(tmp_path), "--json"])
+    # Assert
+    assert result.exit_code == 0

--- a/tests/scitex_agent_container/cli_pkg/test_info_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_info_cmds.py
@@ -35,6 +35,7 @@ import pytest
 from click.testing import CliRunner
 
 from scitex_agent_container.cli_pkg.info_cmds import (
+    _roles_default_dir,
     _tail_one,
     find,
     list_python_apis,
@@ -660,3 +661,67 @@ def test_roles_empty_dir_exits_zero(tmp_path):
     result = runner.invoke(roles, ["--dir", str(tmp_path), "--json"])
     # Assert
     assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# `roles` default directory — the container-vs-host resolution
+#
+# fleet_agents_dir() falls back to the user's home, which inside a container is
+# /home/agent and does not hold the fleet registry: the listing reported 0
+# agents from exactly the place agents run. The launcher injects
+# SCITEX_AGENT_CONTAINER_YAML_DIRS naming the real registry, so that is the
+# fallback these tests pin.
+
+
+def test_roles_default_dir_uses_yaml_dirs_when_agents_dir_is_unset(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    registry = tmp_path / "registry"
+    registry.mkdir()
+    os.environ.pop("SCITEX_AGENT_CONTAINER_AGENTS_DIR", None)
+    os.environ["SCITEX_AGENT_CONTAINER_YAML_DIRS"] = str(registry)
+    # Act
+    resolved = _roles_default_dir()
+    # Assert
+    assert resolved == registry
+
+
+def test_roles_default_dir_skips_a_yaml_dirs_entry_that_does_not_exist(
+    tmp_path, env_save_restore
+):
+    # Arrange — a stale first entry must not pin the listing to a missing dir
+    registry = tmp_path / "registry"
+    registry.mkdir()
+    os.environ.pop("SCITEX_AGENT_CONTAINER_AGENTS_DIR", None)
+    os.environ["SCITEX_AGENT_CONTAINER_YAML_DIRS"] = (
+        f"{tmp_path / 'gone'}:{registry}"
+    )
+    # Act
+    resolved = _roles_default_dir()
+    # Assert
+    assert resolved == registry
+
+
+def test_roles_default_dir_prefers_the_agents_dir_variable(tmp_path, env_save_restore):
+    # Arrange — the primary variable wins over the launcher's fallback
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    os.environ["SCITEX_AGENT_CONTAINER_AGENTS_DIR"] = str(primary)
+    os.environ["SCITEX_AGENT_CONTAINER_YAML_DIRS"] = str(fallback)
+    # Act
+    resolved = _roles_default_dir()
+    # Assert
+    assert resolved == primary
+
+
+def test_roles_default_dir_ignores_an_empty_yaml_dirs(tmp_path, env_save_restore):
+    # Arrange — an empty value must not resolve to Path('') / the cwd
+    os.environ.pop("SCITEX_AGENT_CONTAINER_AGENTS_DIR", None)
+    os.environ["SCITEX_AGENT_CONTAINER_YAML_DIRS"] = ""
+    # Act
+    resolved = _roles_default_dir()
+    # Assert
+    assert resolved != Path("")


### PR DESCRIPTION
The operator could not tell what a package agent was FOR. Measured on
scitex-compute-04: **only 12 of 115 defined agents declare
`metadata.labels.description`.**

The A2A card already reads that label (`a2a/_card.py` uses it as the card
description, falling back to `sac agent: <name> (<role>)`), so the surface
was never the gap -- the declarations were. And `role` cannot fill it
alone: **96 of 113 role labels are the single string `project-maintainer`**,
a role-CLASS rather than a statement of purpose. So this listing reports
role AND description, and scores coverage on the latter.

```
sac agents roles              what every defined agent is for
sac agents roles --missing    exactly the specs that still owe a line
sac agents roles --json       the same, machine-readable
```

**Population.** The agents DEFINED in the fleet registry, not the ones
currently RUNNING. Reading a registry of running things as an inventory of
the fleet under-reports by however many agents are down -- on this fleet,
most of them. It walks the registry with `fleet_spec_paths`, the same
accessor the reconciler and auth-heal detector use, rather than growing a
third enumeration.

**It works from inside a container, which took a correction.** An earlier
revision of this description claimed the registry is not bound into
containers, so naming it in an env var would point most agents at nothing.
That was wrong, and measuring beat guessing: from inside a container the
registry IS readable (149 spec files enumerable, via the shared host
filesystem rather than a dedicated bind), and the launcher ALREADY injects
`SCITEX_AGENT_CONTAINER_YAML_DIRS` naming it. The gap was an env-var NAME --
nothing sets `AGENTS_DIR`, which is the one `fleet_agents_dir()` reads, so it
fell through to `/home/agent`.

So this leaf's default now falls through to `YAML_DIRS`, skipping entries
that do not exist. `fleet_agents_dir()` is deliberately UNTOUCHED: it is
shared with the reconciler and the auth-heal detector, and widening it would
silently change what those two sweep.

Measured in-container, no `--dir`, no hand-set env:

```
before: "No agent specs under /home/agent/.scitex/agent-container/agents"
after : 115 agents, 12 described, from the real registry
```

**Two details a test pins.** `--missing` narrows the rows, never the
denominator (otherwise coverage reads 0/2 for a half-documented fleet). An
unparseable spec is reported on stdout as an explicitly unreadable row rather
than dropped, so a broken spec cannot quietly shrink the fleet.

**Verification.** 14 new tests, real spec dirs in `tmp_path`, no mocks; 40
pass in the file, and the full `tests/develop` guard suite (127) is green.
Ruff introduces no new errors -- both `I001`s pre-exist on develop,
control-checked against the pristine files.

Also carded while here: `_iter_agent_yamls` returns 0 against a directory
holding 122 real specs -- it accepts only `<name>/<name>.yaml` while every
host uses `<name>/spec.yaml`.

*(Note: the first commit's message says "measured on scitex-compute-01". The
host is scitex-compute-04; the numbers are unaffected. I will fix that in the
squash message at merge rather than force-push.)*
