### PR TITLE
fix(lifecycle): read the spec layout every host actually writes

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
@@ -357,9 +357,12 @@ def materialize_cold_start(
 def _dir_has_agents_default(p: Path) -> bool:
     """Fallback bulk-dir detector: any ``<child>/spec.yaml`` under ``p``.
 
-    The command injects the production ``_iter_agent_yamls`` (which also
-    accepts the ``<name>/<name>.yaml`` layout); this default keeps the helper
-    usable + unit-testable without importing the command (no import cycle).
+    The command injects the production ``_iter_agent_yamls``, which accepts
+    BOTH ``<name>/spec.yaml`` and ``<name>/<name>.yaml``; this default keeps
+    the helper usable + unit-testable without importing the command (no
+    import cycle). NOTE the two are not equivalent -- this default sees only
+    ``spec.yaml``, so a caller that does NOT inject will not recognise a
+    self-named agents-root.
     """
     try:
         return any((c / "spec.yaml").is_file() for c in p.iterdir() if c.is_dir())

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
@@ -229,6 +229,22 @@ def _singleton_skip_reason(
     )
 
 
+def _is_self_peer_spec(spec_path: "Path") -> bool:
+    """Reuse the canonical self-peer-marker predicate.
+
+    Imported lazily: the list-view helpers pull in the click surface, and
+    a module-level import here would close a cycle. Tolerant by design --
+    if the predicate cannot be reached, treat the file as a normal spec
+    rather than silently dropping an agent from a start/stop expansion.
+    """
+    # stx-allow: fallback (reason: an unavailable predicate must not drop an agent from a bulk start/stop; the miscount is reported on this command's own stdout as the agent simply appearing, never as a silent omission)
+    try:
+        from .._helpers._agent_list_discover import _is_self_peer_marker
+    except Exception:  # stx-allow: fallback (reason: see comment above)
+        return False
+    return bool(_is_self_peer_marker(spec_path))
+
+
 def _iter_agent_yamls(agents_dir: "Path") -> "list[tuple[str, str]]":
     """Yield ``(name, yaml_path)`` for each agent subdir in ``agents_dir``.
 
@@ -245,11 +261,24 @@ def _iter_agent_yamls(agents_dir: "Path") -> "list[tuple[str, str]]":
             continue
         if d.name in _SKIP_DIR_NAMES:
             continue
-        for ext in (".yaml", ".yml"):
-            candidate = d / f"{d.name}{ext}"
-            if candidate.exists():
-                results.append((d.name, str(candidate)))
+        # ``<name>/spec.yaml`` FIRST: that is what every registry writer
+        # emits, and reading only ``<name>/<name>.yaml`` made this helper
+        # return 0 against a registry holding 122 specs. ``<name>/<name>.yaml``
+        # stays as a fallback because `sac fleet materialize` and
+        # render_contributor_spec still write it -- alias first, remove after
+        # those writers move (see the follow-up card).
+        for candidate in (d / "spec.yaml", d / f"{d.name}.yaml", d / f"{d.name}.yml"):
+            if not candidate.exists():
+                continue
+            # ``agents/self/spec.yaml`` registers the running listen's own
+            # identity and is deliberately NOT a launchable Agent. It was
+            # invisible here only by accident, because this helper could not
+            # see spec.yaml at all; now that it can, skip it explicitly using
+            # the SAME predicate the listen merge and the list view use.
+            if _is_self_peer_spec(candidate):
                 break
+            results.append((d.name, str(candidate)))
+            break
     return results
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -357,8 +357,21 @@ def start(
             dry_run=dry_run,
             force=force,
             # Use the SAME bulk-dir detector the classifier below uses, so an
-            # agents-root dir (``<name>/<name>.yaml`` layout) is treated as an
-            # existing bulk target, not cold-started.
+            # agents-root dir is treated as an existing bulk target, not
+            # cold-started. This override is WIDER than the resolver's own
+            # _dir_has_agents_default, which sees only <child>/spec.yaml:
+            # _iter_agent_yamls accepts BOTH <name>/spec.yaml (what every
+            # registry writer emits) and <name>/<name>.yaml (what `sac fleet
+            # materialize` still emits), so both kinds of agents-root are
+            # recognised.
+            #
+            # Until 2026-08-27 the helper matched ONLY <name>/<name>.yaml, so a
+            # real registry of 122 spec.yaml agents read as EMPTY here and fell
+            # through to COLD-START -- materializing a phantom agent named after
+            # the directory while starting none of the real ones. The defect was
+            # the helper's layout blindness, NOT this injection: removing the
+            # injection instead makes the SELF-NAMED layout cold-start, which is
+            # the same bug pointed the other way (8 tests in this file catch it).
             dir_has_agents=lambda p: bool(_iter_agent_yamls(p)),
         )
     except (ColdStartParseError, ColdStartConflictError) as exc:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start.py
@@ -21,9 +21,11 @@ from scitex_agent_container.cli_pkg.lifecycle._cold_start import (
     ColdStartParseError,
     ColdStartTarget,
     parse_start_target,
+    resolve_cold_start_targets,
 )
+from scitex_agent_container.cli_pkg.lifecycle._common import _iter_agent_yamls
 
-CALLER = "ywata-note-win"
+CALLER = "scitex-laptop-01"  # retired spelling was ywata-note-win
 
 
 # --- plain agent name → not a cold-start form (existing flow) ----------------
@@ -188,3 +190,91 @@ def test_returns_cold_start_target_type():
     t = parse_start_target(arg, caller_host=CALLER)
     # Assert
     assert isinstance(t, ColdStartTarget)
+
+
+# --- an agents-root is an EXISTING bulk target, never a cold-start -----------
+#
+# REGRESSION. `sac agents start <registry>` used to inject _iter_agent_yamls as
+# the bulk-dir detector; that helper matched only <name>/<name>.yaml, so a real
+# registry of <name>/spec.yaml agents read as EMPTY and fell through to
+# cold-start. Measured 2026-08-27 before the fix: plans=1, action='would-create',
+# label = the directory's own basename, and targets=[] -- a phantom agent
+# materialised into the registry while none of the real agents started.
+
+
+def _registry(tmp_path, *names, layout="spec"):
+    """Build a registry-shaped dir.
+
+    ``layout="spec"`` -> <name>/spec.yaml, what every registry writer emits.
+    ``layout="self"`` -> <name>/<name>.yaml, what `sac fleet materialize` emits.
+    """
+    reg = tmp_path / "agents"
+    reg.mkdir()
+    for n in names:
+        (reg / n).mkdir()
+        fname = "spec.yaml" if layout == "spec" else f"{n}.yaml"
+        (reg / n / fname).write_text("x")
+    return reg
+
+
+def _resolve(reg, base):
+    """Call the resolver the way `sac agents start` actually calls it.
+
+    _start.py injects this exact detector. Using the resolver's DEFAULT here
+    instead would exercise a path production never takes -- and would pass
+    whether or not the bug is present.
+    """
+    return resolve_cold_start_targets(
+        [str(reg)],
+        caller_host=CALLER,
+        dry_run=True,
+        base_dir=base,
+        dir_has_agents=lambda p: bool(_iter_agent_yamls(p)),
+    )
+
+
+def test_a_spec_yaml_registry_dir_produces_no_cold_start_plan(tmp_path):
+    # Arrange
+    reg = _registry(tmp_path, "alpha", "beta")
+    base = tmp_path / "base"
+    base.mkdir()
+    # Act
+    _targets, plans = _resolve(reg, base)
+    # Assert
+    assert plans == []
+
+
+def test_a_spec_yaml_registry_dir_is_passed_through_as_a_target(tmp_path):
+    # Arrange
+    reg = _registry(tmp_path, "alpha", "beta")
+    base = tmp_path / "base"
+    base.mkdir()
+    # Act
+    targets, _plans = _resolve(reg, base)
+    # Assert -- the real agents must survive as a target, not be replaced by a label
+    assert targets == [str(reg)]
+
+
+def test_no_phantom_agent_dir_is_created_inside_the_registry(tmp_path):
+    # Arrange
+    reg = _registry(tmp_path, "alpha")
+    base = tmp_path / "base"
+    base.mkdir()
+    # Act
+    _resolve(reg, base)
+    # Assert -- nothing named after the directory itself appeared
+    assert not (reg / reg.name).exists()
+
+
+def test_a_self_named_registry_dir_is_also_not_cold_started(tmp_path):
+    # Arrange -- `sac fleet materialize` still writes <name>/<name>.yaml. The
+    # first attempt at this fix DELETED the detector injection, which made this
+    # layout cold-start instead: the same bug pointed the other way. Eight
+    # tests in test__start.py caught it; this one states the invariant here.
+    reg = _registry(tmp_path, "alpha", "beta", layout="self")
+    base = tmp_path / "base"
+    base.mkdir()
+    # Act
+    targets, plans = _resolve(reg, base)
+    # Assert
+    assert (plans, targets) == ([], [str(reg)])

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
@@ -534,6 +534,71 @@ class TestIterAgentYamls:
         # Assert
         assert [n for n, _ in result] == ["bar", "foo"]
 
+    # -- the layout that actually exists on every host ----------------------
+    #
+    # Until 2026-08-27 this helper matched ONLY <name>/<name>.yaml, so it
+    # returned 0 against a registry holding 122 <name>/spec.yaml agents. Every
+    # fixture above uses the self-named layout, which is why the suite stayed
+    # green over a shape no host produces. These tests pin the real one.
+
+    def test_discovers_the_spec_yaml_layout_every_host_uses(self, tmp_path):
+        # Arrange
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "alpha" / "spec.yaml").write_text("x")
+        # Act
+        result = _iter_agent_yamls(tmp_path)
+        # Assert
+        assert [n for n, _ in result] == ["alpha"]
+
+    def test_returns_the_spec_yaml_path_not_a_self_named_guess(self, tmp_path):
+        # Arrange
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "alpha" / "spec.yaml").write_text("x")
+        # Act
+        result = _iter_agent_yamls(tmp_path)
+        # Assert
+        assert result[0][1].endswith("/alpha/spec.yaml")
+
+    def test_prefers_spec_yaml_when_both_layouts_are_present(self, tmp_path):
+        # Arrange
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "alpha" / "spec.yaml").write_text("x")
+        (tmp_path / "alpha" / "alpha.yaml").write_text("x")
+        # Act
+        result = _iter_agent_yamls(tmp_path)
+        # Assert
+        assert result[0][1].endswith("/alpha/spec.yaml")
+
+    def test_still_finds_the_self_named_layout_the_materializers_write(
+        self, tmp_path
+    ):
+        # Arrange -- `sac fleet materialize` and render_contributor_spec still
+        # emit <name>/<name>.yaml; the fallback is the alias half of the
+        # migration and must not regress while they do.
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "alpha" / "spec.yaml").write_text("x")
+        (tmp_path / "beta").mkdir()
+        (tmp_path / "beta" / "beta.yaml").write_text("x")
+        # Act
+        result = _iter_agent_yamls(tmp_path)
+        # Assert
+        assert [n for n, _ in result] == ["alpha", "beta"]
+
+    def test_skips_the_self_peer_marker(self, tmp_path):
+        # Arrange -- agents/self/spec.yaml registers the running listen's own
+        # identity and is NOT a launchable agent. It was invisible here only
+        # because this helper could not see spec.yaml at all.
+        (tmp_path / "self").mkdir()
+        (tmp_path / "self" / "spec.yaml").write_text(
+            "name: scitex-compute-04\nlisten_url: http://127.0.0.1:7878\n"
+        )
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "alpha" / "spec.yaml").write_text("x")
+        # Act
+        result = _iter_agent_yamls(tmp_path)
+        # Assert
+        assert [n for n, _ in result] == ["alpha"]
+
 
 # ---------------------------------------------------------------------------
 # _discover_all_agents — uses the injected project_local_dirs callable.


### PR DESCRIPTION
`_iter_agent_yamls` matched only `<name>/<name>.yaml`. Measured on
scitex-compute-04: the fleet registry holds **122 `<name>/spec.yaml` and 0
`<name>/<name>.yaml`** — so the helper returned **0 against 122 real agents**.
`sac agents create` writes `spec.yaml`, and cold-start's own materialize writes
`spec.yaml`. The layout it recognised is one sac itself stopped emitting.

## Two consequences, both on documented recipes

**1. `sac agents start <agents-root>` cold-starts a phantom.** `_start.py`
injects this helper as the bulk-dir detector. With 0 matches the registry read
as EMPTY, failed the existing-target and empty-dir branches, and fell through
to cold-start as a *workdir*. The label is the sanitized basename, which passes
`_VALID_LABEL`, so nothing failed loud: it would materialize an agent named
after the directory and start none of the real ones.

**2. Directory-target bulk start/stop silently expanded to nothing** — `sac
agents stop <registry>` exited 0 having stopped nothing.

## The fix is one line of behaviour

The helper tries `<name>/spec.yaml` first, keeping `<name>/<name>.yaml` as a
fallback. Both defects follow from the same blindness and both clear with it.

```
before:  spec.yaml registry  -> helper=0  plans=1  action='would-create'
after :  spec.yaml registry  -> helper=3  plans=0  targets=1
         self-named registry -> helper=2  plans=0  targets=1
```
(pure function call, `base_dir` redirected to a temp dir — nothing touched the
live registry.)

## The injection is deliberately KEPT — and that took a wrong turn to learn

My first attempt **deleted** it, reasoning that the resolver's own
`_dir_has_agents_default` already tests `spec.yaml`. That inverted the bug: the
default sees ONLY `spec.yaml`, so a **self-named** agents-root then cold-started
instead. Eight tests in `test__start.py` caught it. With the helper fixed the
injection is strictly *wider* than the default (both layouts vs one), which is
what a bulk-dir detector should be.

The fallback stays until `sac fleet materialize` and `render_contributor_spec`
move to `spec.yaml` — alias first, remove after. Narrowing now would turn their
output into a fresh silent no-op. Follow-up card tracks it.

## A bug this fix would otherwise have introduced

Teaching the helper to see `spec.yaml` newly exposes `agents/self/spec.yaml`,
which registers the running listen's own identity and is **not** a launchable
agent — invisible here before only because the helper couldn't see `spec.yaml`
at all. Guarded with the same predicate the listen merge and list view use,
imported lazily to avoid the cycle `_dir_has_agents_default` exists to dodge.

## Verification

**9 new tests.** The five layout tests were **calibrated against the unfixed
package** — there they return `[]` and fail — so they pin the fix rather than
restate it. Four cold-start regressions assert no plan, passthrough of the real
target, no directory named after the registry, and that the self-named layout
is equally not cold-started. They call the resolver through **the same
injection `_start.py` uses**; an earlier draft used the resolver's default and
would have passed with or without the bug.

**158 passed** across `test__common`, `test__cold_start`, `test__stop`,
`test__cold_start_materialize`.

**`test__start.py`: 49 passed / 3 failed — all three PRE-EXISTING**, verified by
running the same class against a checkout confirmed identical to
`origin/develop`:

```
BASELINE pristine develop: 3 failed, 5 passed in 361.39s
WORKTREE with this fix   : 3 failed, 5 passed in 361.36s
```

Same three tests, same counts. They are timeouts, not assertion failures — 0
`E …assert` lines — blocking on `time.sleep(pause)` in `run_parallel_targets`
(`_start_parallel.py:149`), a stack that never touches `_iter_agent_yamls`.
Carded separately.

Also corrected: `_cold_start.py` described the injected helper as one "which
ALSO accepts the `<name>/<name>.yaml` layout". It accepted ONLY that. The
sentence is true after this change; the caveat that the *default* is narrower is
now stated, because that asymmetry is what my first attempt tripped on.

Tidied where touched: `test__cold_start.py`'s `CALLER` was the retired hostname
`ywata-note-win`.

Ruff: no new errors (the one `I001` pre-exists on develop, control-checked).
