### PR TITLE
fix(create): new agents are born session:resume, not null or continue

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_create_templates.py
+++ b/src/scitex_agent_container/cli_pkg/_create_templates.py
@@ -75,8 +75,18 @@ spec:
       - --dangerously-skip-permissions
     channels: []
     raw_options: {{}}
-    # null = role-derived (continue for coordinator roles, fresh otherwise)
-    session: null
+    # resume, always. OPERATOR RULING 2026-08-28: fresh is wrong, continue is
+    # wrong, resume-with-an-id is the only correct value — an agent that
+    # restarts must continue the SAME conversation, not a fresh one and not
+    # merely the latest one. `null` used to role-derive to continue-or-fresh,
+    # which is how 374 live specs across the fleet ended up losing every
+    # agent's memory on every restart.
+    #
+    # Safe with an empty resume_id: the runner warns and falls back to
+    # --continue (_runners/_tmux/claude_code.py), so a brand-new agent with no
+    # session yet is never blocked — and it upgrades itself the moment an id
+    # is pinned below.
+    session: resume
     continue_max_age_minutes: null
     resume_id: ""
     auto_accept: true
@@ -268,7 +278,8 @@ spec:
     model: opus[1m]
     flags:
       - --dangerously-skip-permissions
-    session: continue
+    # resume, always — see the note on the other template above.
+    session: resume
     auto_accept: true
 
     # Fleet push channels: sac control bus + shared scitex-todo store + the


### PR DESCRIPTION
## Why

Tonight 374 live specs and 148 versioned ones were migrated to
`session: resume` — agents had been losing their conversation on every restart
because nothing pinned a session. Without this change `sac agents create` would
keep emitting the broken default, and every agent created after the migration
would be born with the same defect.

Operator ruling, 2026-08-28: fresh is wrong, continue is wrong, resume-with-an-id
is the only correct value.

## Two template blocks, and the second is the interesting one

| block | was | now |
|---|---|---|
| first | `session: null` (role-derived → continue-or-fresh) | `session: resume` |
| second | `session: continue` | `session: resume` |

My first pass **missed the second one**, because I searched for the value I
expected (`session: null`) instead of enumerating the field. The check that
caught it enumerates:

```
every session value in the file now: ['resume']
```

Search the field, not the value you expect to find.

## Safe for a brand-new agent

Verified in `_runners/_tmux/claude_code.py` rather than assumed: `resume` with
an empty `resume_id` warns and falls back to `--continue`, so a first start is
never blocked, and the spec upgrades itself the moment an id is pinned.

## Proven behaviourally, not just structurally

On `sdk-canary-20260814` (a declared throwaway): starting it with
`session: resume` + a pinned id grew the **existing** transcript
95,770 → 105,244 bytes with **no new session file**. A resumed session appends;
a fresh one creates a new UUID — the two are visibly different on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
