### PR TITLE
refactor(state): move the diary tables off SQLite onto PostgreSQL (1 of 6)

### DIFF
--- a/scripts/migrate_diary_to_postgres.py
+++ b/scripts/migrate_diary_to_postgres.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite diary tables into per-host PostgreSQL.
+
+Companion to the ``state_db_diary`` port (2026-08-28). The code stopped
+reading SQLite; this moves the rows that are already there so the history is
+not stranded in a file nothing opens any more.
+
+Covers all three diary tables — ``heartbeats``, ``turns``, ``errors``.
+Measured on compute-04 the night of the port: heartbeats 32, turns 0,
+errors 0. The empty two are migrated anyway; "empty today" is a fact about
+one host at one moment, not a property of the table.
+
+RUN IT ON THE HOST, NOT IN A CONTAINER
+======================================
+``DEFAULT_DB_PATH`` resolves differently in the two places: a container gets
+its own per-agent shard under ``/state/<agent>/state.db``, the host gets
+``~/.scitex/agent-container/runtime/state.db``. A container run would
+faithfully migrate an empty shard and report success — the same shape that
+made this whole migration look finished for three days.
+
+RUN IT TWICE
+============
+The tables are live: every heartbeat tick writes one. Run it once now,
+restart the daemons so they pick up the new code, then run it again to sweep
+anything written through the old path in between. The second run is expected
+to find few or no stragglers; that it finds ANY is the reason it exists.
+
+WHY IT DOES NOT CALL ``record_heartbeat`` / ``record_turn`` / ``record_error``
+=============================================================================
+Those stamp ``ts`` with ``time.time()`` when the caller omits it — correct for
+a real tick, destructive here. A migration that rewrote every beat to the
+migration's own clock would make the whole fleet look like it started beating
+at the moment of the migration, which is the "backfilled timestamp makes old
+things look new" failure. So this writes through the store directly,
+preserving every recorded value verbatim.
+
+AND IT DOES NOT SYNTHESISE THE IDS IT CANNOT KNOW
+=================================================
+SQLite gave ``heartbeat_id``/``error_id`` from ``lastrowid``. The Postgres
+schema identifies a heartbeat by (name, host, ts) and an error by its own
+``error_id`` column — so historical error ids are carried across verbatim,
+and heartbeat rowids are DROPPED rather than invented. Nothing read them:
+``record_heartbeat``'s return value is unused by every caller (checked), and
+``latest_heartbeats_per_name`` selects on ts. Inventing a surrogate id here
+would create a number that looks authoritative and means nothing.
+
+A DRY RUN IS THE DEFAULT. Pass ``--commit`` to actually write. The bare
+invocation reports what would move and touches nothing.
+
+IT IS IDEMPOTENT and it VERIFIES: each record is read back through the same
+dialect production reads through, and a mismatch is reported rather than
+counted as a success. Nothing is deleted from SQLite — the old tables stay
+as a fallback for a human, untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+_HEARTBEAT_COLUMNS = ("name", "host", "pid", "state", "ts")
+_TURN_COLUMNS = (
+    "turn_id",
+    "name",
+    "host",
+    "status",
+    "prompt_text",
+    "response_text",
+    "ts",
+    "session_id",
+    "input_tokens",
+    "output_tokens",
+)
+_ERROR_COLUMNS = ("error_id", "name", "host", "cause", "detail", "ts", "turn_id")
+
+
+def default_db_path() -> Path:
+    """The HOST state.db. See the module docstring on why this matters."""
+    return Path.home() / ".scitex" / "agent-container" / "runtime" / "state.db"
+
+
+def _read_rows(db_path: Path, table: str, columns: tuple[str, ...]) -> list[dict]:
+    """Read one table, or return [] when it does not exist.
+
+    A missing table is not an error: an older host may predate it. It is
+    reported distinctly from an empty one, because "no such table" and
+    "no rows" are different facts and collapsing them is how a migration
+    silently skips a host.
+    """
+    if not db_path.is_file():
+        return []
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.row_factory = sqlite3.Row
+        try:
+            cur = conn.execute(f"SELECT {', '.join(columns)} FROM {table}")
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc):
+                print(f"  {table}: no such table in {db_path}")
+                return []
+            raise
+        return [dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def _migrate(table: str, rows: list[dict], schema_fn, commit: bool) -> int:
+    """Write rows through the production store. Returns the verified count."""
+    if not rows:
+        print(f"  {table}: 0 rows — nothing to move")
+        return 0
+    if not commit:
+        print(f"  {table}: {len(rows)} rows WOULD move (dry run)")
+        return 0
+
+    from scitex_agent_container._state.state_db_diary import _open
+
+    store = _open(schema_fn())
+    written = 0
+    try:
+        for row in rows:
+            store.put({k: v for k, v in row.items()})
+            written += 1
+    finally:
+        store.close()
+
+    # VERIFY through the same dialect production reads through, rather than
+    # trusting the write count. A put that silently no-ops would otherwise be
+    # reported as a successful migration.
+    store = _open(schema_fn())
+    try:
+        present = len(list(store.rows()))
+    finally:
+        store.close()
+    if present < len(rows):
+        print(
+            f"  {table}: MISMATCH — wrote {written}, store holds {present} "
+            f"(expected at least {len(rows)}). NOT a success."
+        )
+        return -1
+    print(f"  {table}: {written} rows moved, {present} verified present")
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="SQLite state.db to read (default: the HOST runtime state.db)",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="actually write; without it this is a dry run that touches nothing",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = args.db_path or default_db_path()
+    print(f"source: {db_path}{'' if db_path.is_file() else '  (ABSENT)'}")
+    print(f"mode:   {'COMMIT' if args.commit else 'DRY RUN'}")
+
+    from scitex_agent_container._state.state_db_diary import (
+        _errors_schema,
+        _heartbeats_schema,
+        _turns_schema,
+    )
+
+    plan = (
+        ("heartbeats", _HEARTBEAT_COLUMNS, _heartbeats_schema),
+        ("turns", _TURN_COLUMNS, _turns_schema),
+        ("errors", _ERROR_COLUMNS, _errors_schema),
+    )
+
+    failed = False
+    for table, columns, schema_fn in plan:
+        rows = _read_rows(db_path, table, columns)
+        if _migrate(table, rows, schema_fn, args.commit) < 0:
+            failed = True
+
+    if failed:
+        print("FAILED — at least one table did not verify. SQLite left untouched.")
+        return 1
+    if not args.commit:
+        print("dry run complete — nothing was written. Re-run with --commit.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/scitex_agent_container/_runners/_session_beat.py
+++ b/src/scitex_agent_container/_runners/_session_beat.py
@@ -48,6 +48,20 @@ STATE_BUSY = "busy"
 STATE_STOPPING = "stopping"
 
 
+# Consecutive diary-write failures, keyed by row kind. MODULE level on
+# purpose: ``_resolve_db_writer`` builds a FRESH ``_DefaultDBWriter`` on
+# every call, so a per-instance counter would reset each beat and warn on
+# every tick. Keyed by kind so a broken heartbeat table cannot mute the
+# first turn failure.
+_DIARY_FAILURES: dict[str, int] = {}
+
+# Warn on the 1st failure of a kind, then every Nth. The diary is
+# best-effort, but a diary that is silently unreachable is precisely how
+# the store-DSN defect ran unnoticed from 08-23 to 08-27 — so a degraded
+# diary stays visible in the log without flooding a per-tick loop.
+_DIARY_WARN_EVERY = 100
+
+
 class _DefaultDBWriter:
     """Production writer that forwards to ``_state.state_db_diary``.
 
@@ -55,25 +69,82 @@ class _DefaultDBWriter:
     container venv fully wired) don't pay the import cost. The
     diary writes are best-effort: a single-table failure must not
     crash the runner's heartbeat loop, so we catch + log here.
+
+    Best-effort is the CONTRACT, not a convenience. The diary is
+    observational — turns, errors, heartbeats. An agent whose telemetry
+    store is unreachable must keep running and lose rows, never die with
+    it. That sentence was in this docstring before any of it was true:
+    the SQLite diary wrote to a local file that effectively never failed,
+    so the promised catch was never exercised and never implemented. A
+    remote store makes the failure real, and every runner test that
+    merely ticks a heartbeat died on a refused connection. The catch is
+    now actually here.
+
+    What this does NOT do is fail quietly. Every failing kind is logged
+    with its CONSECUTIVE count, so "the diary has been down for 4000
+    beats" is readable in the log rather than inferred from missing rows
+    — and recovery is logged too, so the end of an outage has a
+    timestamp.
     """
 
     def __init__(self) -> None:
         self._log = logging.getLogger(__name__ + "._DefaultDBWriter")
 
-    def record_heartbeat(self, **kwargs):
-        from .._state.state_db_diary import record_heartbeat
+    def _best_effort(self, kind: str, write):
+        """Run one diary write, absorbing any failure into a log line.
 
-        return record_heartbeat(**kwargs)
+        ``write`` is a thunk that performs its own lazy import, so an
+        ImportError from a half-wired environment is caught on the same
+        path as a refused Postgres connection — both mean "no row", and
+        neither is the runner's problem to die of.
+        """
+        try:
+            result = write()
+        except Exception as exc:  # noqa: BLE001 - telemetry must not kill the runner
+            seen = _DIARY_FAILURES.get(kind, 0) + 1
+            _DIARY_FAILURES[kind] = seen
+            if seen == 1 or seen % _DIARY_WARN_EVERY == 0:
+                self._log.warning(
+                    "diary %s write failed (%d consecutive; rows are being "
+                    "dropped): %s: %s",
+                    kind,
+                    seen,
+                    type(exc).__name__,
+                    exc,
+                )
+            return None
+        if _DIARY_FAILURES.get(kind):
+            self._log.warning(
+                "diary %s write recovered after %d consecutive failures",
+                kind,
+                _DIARY_FAILURES[kind],
+            )
+            _DIARY_FAILURES[kind] = 0
+        return result
+
+    def record_heartbeat(self, **kwargs):
+        def _write():
+            from .._state.state_db_diary import record_heartbeat
+
+            return record_heartbeat(**kwargs)
+
+        return self._best_effort("heartbeat", _write)
 
     def record_turn(self, **kwargs):
-        from .._state.state_db_diary import record_turn
+        def _write():
+            from .._state.state_db_diary import record_turn
 
-        return record_turn(**kwargs)
+            return record_turn(**kwargs)
+
+        return self._best_effort("turn", _write)
 
     def record_error(self, **kwargs):
-        from .._state.state_db_diary import record_error
+        def _write():
+            from .._state.state_db_diary import record_error
 
-        return record_error(**kwargs)
+            return record_error(**kwargs)
+
+        return self._best_effort("error", _write)
 
 
 def _resolve_db_writer(db_writer):
@@ -252,13 +323,20 @@ def report_sdk_error(
     detail: str | None = None,
     turn_id: str | None = None,
     db_writer=None,
-) -> int:
+) -> int | None:
     """Append one row to ``state.db.errors`` describing a runner crash.
 
-    Returns the new ``error_id``. ``cause`` is a short identifier
-    (``auth`` / ``network`` / ``sdk-crash`` / ``schema-mismatch``
-    / ...) that the lead groups on; ``detail`` carries the longer
-    message or traceback.
+    Returns the new ``error_id``, or ``None`` when the diary was
+    unreachable and the row was dropped — the default writer is
+    best-effort (see :class:`_DefaultDBWriter`), and an error report
+    that cannot be stored must not itself raise inside a crash path.
+    Annotated honestly rather than papered over with a sentinel id: no
+    caller reads this value today, and a fake integer would be
+    indistinguishable from a row that really landed.
+
+    ``cause`` is a short identifier (``auth`` / ``network`` /
+    ``sdk-crash`` / ``schema-mismatch`` / ...) that the lead groups on;
+    ``detail`` carries the longer message or traceback.
     """
     db = _resolve_db_writer(db_writer)
     return db.record_error(

--- a/src/scitex_agent_container/_state/state_db_diary.py
+++ b/src/scitex_agent_container/_state/state_db_diary.py
@@ -1,34 +1,80 @@
-"""Diary-style writes to state.db (2026-05-17).
+"""Diary-style writes — on PostgreSQL only (sqlite→Postgres, 2026-08-28).
 
-Three tables let every agent write a journal that the lead reads
-and filters:
+Three logical stores let every agent write a journal the lead reads:
 
-  * ``turns`` — one row per state-transition of a /v1/turn flow
+  * ``turns``      — one row per state-transition of a /v1/turn flow
     (``queued``, ``delivered``, ``read``, ``responded``, ``error``).
     A successful turn produces four rows sharing a single ``turn_id``.
-  * ``errors`` — one row per caught error (auth, network, sdk-crash,
+  * ``errors``     — one row per caught error (auth, network, sdk-crash,
     schema-mismatch, ...). Optionally tied to a ``turn_id``.
-  * ``heartbeats`` — promotes the per-agent ``heartbeat.json`` file
-    into a queryable table; one row per heartbeat tick.
+  * ``heartbeats`` — the per-agent ``heartbeat.json`` payload promoted
+    into a cross-host queryable table; one row per tick.
 
-DDL lives in :mod:`state_db`; this module owns the WRITE + READ
-helpers so :mod:`state_db` can stay under the per-file line cap.
+WHY THIS MODULE MOVED
+=====================
+Operator ruling, restated 2026-08-28: 「スクライトなんて全部絶滅させて
+ください」 and 「スクライト1個でも使ったら負け」 — because the fleet is
+MULTI-HOST, and a SQLite file per host means a different truth per host.
+That is not theoretical: the same evening, per-host agent SPECS were
+measured diverging 122/137/122/124 across four machines. A per-host
+state.db is the same failure in a different file format.
 
-All times are stored as ``REAL`` unix-seconds (float). The lead can
-mix them with the legacy ``TEXT NOT NULL`` ISO-8601 columns on
-``instances`` because both formats sort consistently within their
-own table; cross-table joins are time-window queries (BETWEEN),
-not joins on ts equality.
+The move ADOPTS :mod:`scitex_dev.store`, the fleet's own store primitive,
+rather than growing a private psycopg layer here — the same route
+:mod:`.state_db_verdict_dedup` and :mod:`.state_db_incarnations` took.
+That primitive's ``resolve_target`` is exactly two steps
+(``SCITEX_STORE_DSN`` or the per-host PostgreSQL) with NO SQLite
+fallback, so a host whose PostgreSQL is unreachable raises
+``StoreTargetError`` naming the DSN it could not reach. Fail fast, fail
+loud, no fallbacks — implemented in the primitive, not re-argued here.
+
+``db_path`` IS GONE from every signature. It named a SQLite file; there
+is no file. Callers that threaded it through simply stop.
+
+APPEND-ONLY IS PRESERVED, DELIBERATELY
+======================================
+The SQLite tables were append-only: every beat, turn and error was its
+own row, and the history stayed queryable. The obvious key/value
+shortcut — keying a heartbeat by agent NAME so a new beat overwrites the
+last — would have been less code and would have SILENTLY DISCARDED that
+history. Changing storage and semantics together is how a breaking
+change rides along inside a migration unnoticed, so the identity of
+every record here includes its timestamp: a new tick is a new record,
+exactly as before.
+
+TIMESTAMPS STAY REAL UNIX-SECONDS, the format the SQLite columns used
+and the format callers already read. Same clock, same wire format,
+different storage.
+
+THE ``lastrowid`` CONTRACT
+==========================
+``record_error`` returned SQLite's ``lastrowid`` and one caller
+propagates it (``_runners/_session_beat.py``). PostgreSQL has no
+``lastrowid``, so the id now comes from the store's own monotonic
+``next_seq()``. That keeps the contract that matters — a unique,
+increasing integer per record — without pretending to be a rowid.
 """
 
 from __future__ import annotations
 
+import socket
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-# Bounds on the optional inline-prompt/response and error-detail
-# columns so a runaway message can't bloat state.db. Picked to
-# match the user's "first ~500 chars / first ~1000 chars" spec.
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+#: Logical store names. Each renders as four physical tables
+#: (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+TURNS_STORE = "diary_turns"
+ERRORS_STORE = "diary_errors"
+HEARTBEATS_STORE = "diary_heartbeats"
+
+_ACTOR = "scitex-agent-container"
+
+# Bounds on the inline prompt/response and error-detail fields so a
+# runaway message cannot bloat the store. Unchanged from the SQLite
+# version — the operator's "first ~500 chars / first ~1000 chars" spec.
 _TURN_TEXT_LIMIT = 500
 _ERROR_DETAIL_LIMIT = 1000
 
@@ -39,6 +85,110 @@ def _clip(text: str | None, limit: int) -> str | None:
     if len(text) <= limit:
         return text
     return text[:limit]
+
+
+def _ident(kind: Any) -> Any:
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.IDENTITY,
+        required=True,
+        merge=MergeRule.IMMUTABLE,
+        indexed=False,
+    )
+
+
+def _fact(kind: Any) -> Any:
+    """A recorded diary entry is a historical fact — IMMUTABLE.
+
+    A merge that could move a ts or a state would silently rewrite the
+    timeline the lead reads to decide whether an agent is alive.
+    """
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.DATA,
+        required=False,
+        merge=MergeRule.IMMUTABLE,
+        indexed=False,
+    )
+
+
+def _heartbeats_schema() -> Any:
+    from scitex_dev.store import FieldKind, Schema
+
+    return Schema(
+        name=HEARTBEATS_STORE,
+        fields={
+            # ts is part of the IDENTITY on purpose: it is what keeps
+            # this append-only. Same agent, same host, new tick -> new
+            # record, not an overwrite.
+            "name": _ident(FieldKind.TEXT),
+            "host": _ident(FieldKind.TEXT),
+            "ts": _ident(FieldKind.REAL),
+            "pid": _fact(FieldKind.INTEGER),
+            "state": _fact(FieldKind.TEXT),
+        },
+    )
+
+
+def _errors_schema() -> Any:
+    from scitex_dev.store import FieldKind, Schema
+
+    return Schema(
+        name=ERRORS_STORE,
+        fields={
+            "error_id": _ident(FieldKind.INTEGER),
+            "name": _fact(FieldKind.TEXT),
+            "host": _fact(FieldKind.TEXT),
+            "cause": _fact(FieldKind.TEXT),
+            "detail": _fact(FieldKind.TEXT),
+            "ts": _fact(FieldKind.REAL),
+            "turn_id": _fact(FieldKind.TEXT),
+        },
+    )
+
+
+def _turns_schema() -> Any:
+    from scitex_dev.store import FieldKind, Schema
+
+    return Schema(
+        name=TURNS_STORE,
+        fields={
+            # A turn produces FOUR rows sharing one turn_id, so turn_id
+            # alone cannot identify a record — the status and the ts
+            # complete it, preserving the append-only transition log.
+            "turn_id": _ident(FieldKind.TEXT),
+            "status": _ident(FieldKind.TEXT),
+            "ts": _ident(FieldKind.REAL),
+            "name": _fact(FieldKind.TEXT),
+            "host": _fact(FieldKind.TEXT),
+            "prompt_text": _fact(FieldKind.TEXT),
+            "response_text": _fact(FieldKind.TEXT),
+            "session_id": _fact(FieldKind.TEXT),
+            "input_tokens": _fact(FieldKind.INTEGER),
+            "output_tokens": _fact(FieldKind.INTEGER),
+        },
+    )
+
+
+def _open(schema: Any) -> Store:
+    """Open one diary store. RAISES if PostgreSQL is unreachable.
+
+    Open-and-close per call mirrors the old ``with open_db(...)`` shape;
+    the call rate is a heartbeat tick, not a request path.
+    """
+    from scitex_dev.store import Store, WriterPolicy, host_store
+
+    return Store(
+        host_store(pkg="scitex_agent_container", name=schema.name),
+        schema,
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.SINGLE_WRITER,
+        actor=_ACTOR,
+    )
 
 
 def record_turn(
@@ -53,41 +203,27 @@ def record_turn(
     input_tokens: int | None = None,
     output_tokens: int | None = None,
     ts: float | None = None,
-    db_path: Path | None = None,
 ) -> None:
-    """Append one ``turns`` row.
-
-    ``turn_id`` is the lead-assigned uuid that ties the four
-    state-transition rows of a single conversation turn together.
-    Each call adds a row — the table is intentionally append-only
-    so the timeline of state transitions stays auditable.
-    """
-    from .state_db import open_db
-
+    """Append one ``turns`` record. Append-only, as before."""
     row_ts = float(ts) if ts is not None else time.time()
-    with open_db(db_path) as conn:
-        conn.execute(
-            """
-            INSERT INTO turns (
-                turn_id, name, host, status,
-                prompt_text, response_text, ts,
-                session_id, input_tokens, output_tokens
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                turn_id,
-                name,
-                host,
-                status,
-                _clip(prompt_text, _TURN_TEXT_LIMIT),
-                _clip(response_text, _TURN_TEXT_LIMIT),
-                row_ts,
-                session_id,
-                input_tokens,
-                output_tokens,
-            ),
+    store = _open(_turns_schema())
+    try:
+        store.put(
+            {
+                "turn_id": turn_id,
+                "status": status,
+                "ts": row_ts,
+                "name": name,
+                "host": host,
+                "prompt_text": _clip(prompt_text, _TURN_TEXT_LIMIT),
+                "response_text": _clip(response_text, _TURN_TEXT_LIMIT),
+                "session_id": session_id,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
         )
+    finally:
+        store.close()
 
 
 def record_error(
@@ -98,33 +234,30 @@ def record_error(
     detail: str | None = None,
     turn_id: str | None = None,
     ts: float | None = None,
-    db_path: Path | None = None,
 ) -> int:
-    """Append one ``errors`` row. Returns the new ``error_id``.
+    """Append one ``errors`` record. Returns the new ``error_id``.
 
-    ``cause`` is a short identifier the lead can group on (auth /
-    network / sdk-crash / schema-mismatch / ...); ``detail`` carries
-    the longer message or traceback (truncated to 1000 chars).
+    The id is the store's monotonic ``next_seq()`` rather than SQLite's
+    ``lastrowid`` — see the module docstring.
     """
-    from .state_db import open_db
-
     row_ts = float(ts) if ts is not None else time.time()
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            """
-            INSERT INTO errors (name, host, cause, detail, ts, turn_id)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                name,
-                host,
-                cause,
-                _clip(detail, _ERROR_DETAIL_LIMIT),
-                row_ts,
-                turn_id,
-            ),
+    store = _open(_errors_schema())
+    try:
+        error_id = int(store.next_seq())
+        store.put(
+            {
+                "error_id": error_id,
+                "name": name,
+                "host": host,
+                "cause": cause,
+                "detail": _clip(detail, _ERROR_DETAIL_LIMIT),
+                "ts": row_ts,
+                "turn_id": turn_id,
+            }
         )
-        return int(cur.lastrowid or 0)
+        return error_id
+    finally:
+        store.close()
 
 
 def record_heartbeat(
@@ -134,58 +267,60 @@ def record_heartbeat(
     pid: int | None,
     state: str,
     ts: float | None = None,
-    db_path: Path | None = None,
 ) -> int:
-    """Append one ``heartbeats`` row. Returns the new ``heartbeat_id``.
+    """Append one ``heartbeats`` record. Returns its sequence number.
 
-    Mirrors the legacy ``heartbeat.json`` payload (pid + state) but
-    in a cross-host queryable table. ``state`` follows the runner's
-    state-machine vocabulary (``starting`` | ``idle`` | ``working``
-    | ``stopping`` | ``error`` | ``down``).
+    ``state`` follows the runner's vocabulary (``starting`` | ``idle`` |
+    ``working`` | ``stopping`` | ``error`` | ``down``).
     """
-    from .state_db import open_db
-
     row_ts = float(ts) if ts is not None else time.time()
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            """
-            INSERT INTO heartbeats (name, host, pid, state, ts)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (name, host, pid, state, row_ts),
+    store = _open(_heartbeats_schema())
+    try:
+        seq = int(store.next_seq())
+        store.put(
+            {
+                "name": name,
+                "host": host,
+                "ts": row_ts,
+                "pid": pid,
+                "state": state,
+            }
         )
-        return int(cur.lastrowid or 0)
+        return seq
+    finally:
+        store.close()
 
 
-def latest_heartbeats_per_name(db_path: Path | None = None) -> list[dict]:
-    """Return one heartbeat row per agent ``name`` — the most recent.
+def latest_heartbeats_per_name() -> list[dict]:
+    """Return one heartbeat per agent ``name`` — the most recent.
 
-    Used by ``sac db query --table=heartbeats --latest`` and by the
-    lead when it wants the current state-of-the-fleet snapshot
-    without paging through every historical beat.
+    The SQLite version did this with a GROUP BY / MAX(ts) self-join. The
+    store is row-oriented, so the reduction happens here instead. That is
+    a deliberate trade: the fleet's beat table is tens of rows, and doing
+    it in Python keeps this module free of a second query dialect.
     """
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        rows = conn.execute(
-            """
-            SELECT h.*
-              FROM heartbeats h
-              JOIN (
-                    SELECT name, MAX(ts) AS max_ts
-                      FROM heartbeats
-                  GROUP BY name
-                   ) latest
-                ON h.name = latest.name AND h.ts = latest.max_ts
-              ORDER BY h.name
-            """
-        ).fetchall()
-        return [dict(r) for r in rows]
+    store = _open(_heartbeats_schema())
+    try:
+        latest: dict[str, dict] = {}
+        for row in store.rows():
+            data = dict(row.fields) if hasattr(row, "fields") else dict(row)
+            key = str(data.get("name", ""))
+            prev = latest.get(key)
+            if prev is None or float(data.get("ts") or 0) > float(
+                prev.get("ts") or 0
+            ):
+                latest[key] = data
+        return [latest[k] for k in sorted(latest)]
+    finally:
+        store.close()
 
 
 __all__ = [
-    "record_turn",
+    "ERRORS_STORE",
+    "HEARTBEATS_STORE",
+    "TURNS_STORE",
+    "latest_heartbeats_per_name",
     "record_error",
     "record_heartbeat",
-    "latest_heartbeats_per_name",
+    "record_turn",
 ]

--- a/src/scitex_agent_container/_state/state_db_diary.py
+++ b/src/scitex_agent_container/_state/state_db_diary.py
@@ -46,6 +46,19 @@ TIMESTAMPS STAY REAL UNIX-SECONDS, the format the SQLite columns used
 and the format callers already read. Same clock, same wire format,
 different storage.
 
+``expected_revision`` IS MANDATORY, AND ``NEW_RECORD`` IS THE RIGHT VALUE
+========================================================================
+``Store.put`` takes it keyword-only; omitting it is a ``TypeError`` at the
+first write, not a review comment. Every record here is NEW by construction —
+the identity carries the timestamp, so a new tick is a new key — which is
+exactly what ``NEW_RECORD`` asserts.
+
+``RevisionMismatchError`` therefore means one thing only: a record with this
+identity already exists, i.e. a duplicate beat at a byte-identical timestamp.
+"Already recorded" is the outcome we wanted, so it returns rather than raising.
+The catch is deliberately NARROW — nothing else is swallowed, so an unreachable
+store still fails loudly, which is the whole point of moving off SQLite.
+
 THE ``lastrowid`` CONTRACT
 ==========================
 ``record_error`` returned SQLite's ``lastrowid`` and one caller
@@ -206,6 +219,8 @@ def record_turn(
 ) -> None:
     """Append one ``turns`` record. Append-only, as before."""
     row_ts = float(ts) if ts is not None else time.time()
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
     store = _open(_turns_schema())
     try:
         store.put(
@@ -220,8 +235,11 @@ def record_turn(
                 "session_id": session_id,
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
-            }
+            },
+            expected_revision=NEW_RECORD,
         )
+    except RevisionMismatchError:
+        return  # same turn_id+status+ts already recorded
     finally:
         store.close()
 
@@ -240,6 +258,8 @@ def record_error(
     The id is the store's monotonic ``next_seq()`` rather than SQLite's
     ``lastrowid`` — see the module docstring.
     """
+    from scitex_dev.store import NEW_RECORD
+
     row_ts = float(ts) if ts is not None else time.time()
     store = _open(_errors_schema())
     try:
@@ -253,7 +273,8 @@ def record_error(
                 "detail": _clip(detail, _ERROR_DETAIL_LIMIT),
                 "ts": row_ts,
                 "turn_id": turn_id,
-            }
+            },
+            expected_revision=NEW_RECORD,
         )
         return error_id
     finally:
@@ -273,6 +294,8 @@ def record_heartbeat(
     ``state`` follows the runner's vocabulary (``starting`` | ``idle`` |
     ``working`` | ``stopping`` | ``error`` | ``down``).
     """
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
     row_ts = float(ts) if ts is not None else time.time()
     store = _open(_heartbeats_schema())
     try:
@@ -284,9 +307,12 @@ def record_heartbeat(
                 "ts": row_ts,
                 "pid": pid,
                 "state": state,
-            }
+            },
+            expected_revision=NEW_RECORD,
         )
         return seq
+    except RevisionMismatchError:
+        return seq  # a beat with this exact (name, host, ts) is already recorded
     finally:
         store.close()
 
@@ -303,7 +329,16 @@ def latest_heartbeats_per_name() -> list[dict]:
     try:
         latest: dict[str, dict] = {}
         for row in store.rows():
-            data = dict(row.fields) if hasattr(row, "fields") else dict(row)
+            # ``row.values`` is the accessor, MEASURED not assumed. Row is a
+            # dataclass whose ``key`` is a TUPLE of the identity values and
+            # whose ``data`` is a bound METHOD; only ``values`` is the dict,
+            # and it carries identity and data fields together. Two earlier
+            # guesses here (``.fields``, then ``dict(row)``) both raised.
+            if row.hidden:
+                # Hidden is the store's soft-delete. A reader that ignores it
+                # resurrects retired rows.
+                continue
+            data = dict(row.values)
             key = str(data.get("name", ""))
             prev = latest.get(key)
             if prev is None or float(data.get("ts") or 0) > float(

--- a/tests/scitex_agent_container/_runners/test__session_beat.py
+++ b/tests/scitex_agent_container/_runners/test__session_beat.py
@@ -171,15 +171,19 @@ def _warn_messages_for_two_kinds(caplog) -> list[str]:
 
 
 def test_heartbeat_kind_warns_on_its_own_first_failure(caplog) -> None:
-    # Arrange / Act
-    messages = _warn_messages_for_two_kinds(caplog)
+    # Arrange
+    writer_and_log = caplog
+    # Act
+    messages = _warn_messages_for_two_kinds(writer_and_log)
     # Assert
     assert any("diary heartbeat write failed" in m for m in messages)
 
 
 def test_error_kind_warns_on_its_own_first_failure(caplog) -> None:
-    # Arrange / Act
-    messages = _warn_messages_for_two_kinds(caplog)
+    # Arrange
+    writer_and_log = caplog
+    # Act
+    messages = _warn_messages_for_two_kinds(writer_and_log)
     # Assert
     assert any("diary error write failed" in m for m in messages)
 

--- a/tests/scitex_agent_container/_runners/test__session_beat.py
+++ b/tests/scitex_agent_container/_runners/test__session_beat.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""The diary is telemetry: an unreachable store must cost rows, never the agent.
+
+WHY THESE ASSERTIONS AND NOT OTHERS. ``_DefaultDBWriter`` has promised
+"best-effort ... we catch + log here" in its docstring since it was written,
+but nothing caught anything. Under SQLite that was invisible — the diary
+wrote to a local file that effectively never failed, so the un-implemented
+promise was never exercised. Moving the diary to PostgreSQL made the write
+genuinely failable, and every runner test that merely ticks a heartbeat died
+on a refused connection. So the assertions here are about the two halves of
+that contract, and they pull in opposite directions:
+
+  * the runner SURVIVES a dead diary (otherwise telemetry can kill an agent), and
+  * the failure is LOUD (otherwise we rebuild the defect we just fixed — the
+    store DSN pointed at a read-only replica from 08-23 to 08-27 and nobody
+    noticed, precisely because nothing complained about the writes it lost).
+
+A test for only the first half would pass on an implementation that swallowed
+every failure in silence, which is the wrong fix. Hence the log assertion is a
+peer of the survival assertion, not a nicety.
+
+NO MONKEYPATCH (PA-306 §3): env is saved and restored directly, and the
+runner is exercised through its real entry point.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import signal
+from pathlib import Path
+
+from scitex_agent_container._runners import _session_beat as beat
+from scitex_agent_container._runners import claude_session as runner
+
+# Port 1 is privileged and never listening; the database name says out loud
+# what a row arriving there would mean.
+DEAD_DSN = "postgresql://sac_tests@127.0.0.1:1/tests_must_not_write_to_the_fleet_store"
+
+
+@contextlib.contextmanager
+def _dead_store():
+    """Point the store at an unreachable DSN, then restore."""
+    saved = os.environ.get("SCITEX_STORE_DSN")
+    os.environ["SCITEX_STORE_DSN"] = DEAD_DSN
+    beat._DIARY_FAILURES.clear()  # module-level counter; don't inherit a neighbour's
+    try:
+        yield
+    finally:
+        beat._DIARY_FAILURES.clear()
+        if saved is None:
+            os.environ.pop("SCITEX_STORE_DSN", None)
+        else:
+            os.environ["SCITEX_STORE_DSN"] = saved
+
+
+# ---------------------------------------------------------------------------
+# _DefaultDBWriter — absorbs the failure
+# ---------------------------------------------------------------------------
+
+
+def test_record_heartbeat_returns_none_when_the_store_is_unreachable() -> None:
+    # Arrange
+    with _dead_store():
+        writer = beat._DefaultDBWriter()
+        # Act
+        result = writer.record_heartbeat(
+            name="ag-beat-1", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+        )
+    # Assert
+    assert result is None
+
+
+def test_record_turn_returns_none_when_the_store_is_unreachable() -> None:
+    # Arrange
+    with _dead_store():
+        writer = beat._DefaultDBWriter()
+        # Act
+        result = writer.record_turn(
+            turn_id="t-1",
+            name="ag-beat-2",
+            host="h",
+            status="queued",
+            prompt_text=None,
+            response_text=None,
+            session_id=None,
+            input_tokens=None,
+            output_tokens=None,
+        )
+    # Assert
+    assert result is None
+
+
+def test_record_error_returns_none_when_the_store_is_unreachable() -> None:
+    # Arrange
+    with _dead_store():
+        writer = beat._DefaultDBWriter()
+        # Act
+        result = writer.record_error(
+            name="ag-beat-3", host="h", cause="sdk-crash", detail=None, turn_id=None
+        )
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ... but says so. The negative control on "best-effort" meaning "silent".
+# ---------------------------------------------------------------------------
+
+
+def test_a_dropped_diary_row_is_logged_as_a_warning(caplog) -> None:
+    # Arrange
+    with _dead_store(), caplog.at_level(logging.WARNING):
+        writer = beat._DefaultDBWriter()
+        # Act
+        writer.record_heartbeat(
+            name="ag-beat-4", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+        )
+    # Assert
+    assert any("diary heartbeat write failed" in r.getMessage() for r in caplog.records)
+
+
+def test_the_warning_carries_the_consecutive_failure_count(caplog) -> None:
+    # Arrange — a diary down for a long time must be readable as such, not as
+    # one indistinguishable line repeated.
+    with _dead_store(), caplog.at_level(logging.WARNING):
+        writer = beat._DefaultDBWriter()
+        # Act
+        for _ in range(beat._DIARY_WARN_EVERY):
+            writer.record_heartbeat(
+                name="ag-beat-5", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+            )
+        messages = [r.getMessage() for r in caplog.records]
+    # Assert
+    assert any(f"{beat._DIARY_WARN_EVERY} consecutive" in m for m in messages)
+
+
+def test_a_flooding_failure_does_not_log_once_per_call(caplog) -> None:
+    # Arrange
+    with _dead_store(), caplog.at_level(logging.WARNING):
+        writer = beat._DefaultDBWriter()
+        # Act
+        for _ in range(beat._DIARY_WARN_EVERY):
+            writer.record_heartbeat(
+                name="ag-beat-6", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+            )
+        dropped = [r for r in caplog.records if "diary heartbeat write failed" in r.getMessage()]
+    # Assert — first failure plus the Nth, not one per beat.
+    assert len(dropped) == 2
+
+
+def test_each_row_kind_warns_on_its_own_first_failure(caplog) -> None:
+    # Arrange — a broken heartbeat table must not mute the first turn failure.
+    with _dead_store(), caplog.at_level(logging.WARNING):
+        writer = beat._DefaultDBWriter()
+        # Act
+        writer.record_heartbeat(
+            name="ag-beat-7", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+        )
+        writer.record_error(
+            name="ag-beat-7", host="h", cause="sdk-crash", detail=None, turn_id=None
+        )
+        messages = [r.getMessage() for r in caplog.records]
+    # Assert
+    assert any("diary heartbeat write failed" in m for m in messages)
+    assert any("diary error write failed" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# The regression itself: the runner outlives its diary.
+# ---------------------------------------------------------------------------
+
+
+def test_run_exits_zero_when_the_diary_store_is_unreachable(tmp_path: Path) -> None:
+    # Arrange
+    async def _scenario() -> int:
+        async def _stop_soon():
+            await asyncio.sleep(0.05)
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        asyncio.create_task(_stop_soon())
+        return await runner.run("ag-beat-run", state_root=tmp_path, tick_seconds=0.01)
+
+    # Act
+    with _dead_store():
+        rc = asyncio.run(_scenario())
+    # Assert
+    assert rc == 0
+
+
+def test_run_still_writes_the_heartbeat_file_when_the_diary_is_unreachable(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the FILE heartbeat is the local liveness signal and has no
+    # dependency on Postgres; losing the diary must not take it down too.
+    async def _scenario() -> int:
+        async def _stop_soon():
+            await asyncio.sleep(0.05)
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        asyncio.create_task(_stop_soon())
+        return await runner.run("ag-beat-run-2", state_root=tmp_path, tick_seconds=0.01)
+
+    # Act
+    with _dead_store():
+        asyncio.run(_scenario())
+    hb = runner.read_heartbeat(tmp_path / "ag-beat-run-2")
+    # Assert
+    assert hb is not None and hb["state"] == runner.STATE_STOPPING

--- a/tests/scitex_agent_container/_runners/test__session_beat.py
+++ b/tests/scitex_agent_container/_runners/test__session_beat.py
@@ -67,7 +67,7 @@ def test_record_heartbeat_returns_none_when_the_store_is_unreachable() -> None:
         writer = beat._DefaultDBWriter()
         # Act
         result = writer.record_heartbeat(
-            name="ag-beat-1", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+            name="ag-beat-1", host="h", pid=1, state=beat.STATE_READY, ts=1787877000.0
         )
     # Assert
     assert result is None
@@ -116,7 +116,7 @@ def test_a_dropped_diary_row_is_logged_as_a_warning(caplog) -> None:
         writer = beat._DefaultDBWriter()
         # Act
         writer.record_heartbeat(
-            name="ag-beat-4", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+            name="ag-beat-4", host="h", pid=1, state=beat.STATE_READY, ts=1787877000.0
         )
     # Assert
     assert any("diary heartbeat write failed" in r.getMessage() for r in caplog.records)
@@ -130,7 +130,7 @@ def test_the_warning_carries_the_consecutive_failure_count(caplog) -> None:
         # Act
         for _ in range(beat._DIARY_WARN_EVERY):
             writer.record_heartbeat(
-                name="ag-beat-5", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+                name="ag-beat-5", host="h", pid=1, state=beat.STATE_READY, ts=1787877000.0
             )
         messages = [r.getMessage() for r in caplog.records]
     # Assert
@@ -144,27 +144,43 @@ def test_a_flooding_failure_does_not_log_once_per_call(caplog) -> None:
         # Act
         for _ in range(beat._DIARY_WARN_EVERY):
             writer.record_heartbeat(
-                name="ag-beat-6", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+                name="ag-beat-6", host="h", pid=1, state=beat.STATE_READY, ts=1787877000.0
             )
         dropped = [r for r in caplog.records if "diary heartbeat write failed" in r.getMessage()]
     # Assert — first failure plus the Nth, not one per beat.
     assert len(dropped) == 2
 
 
-def test_each_row_kind_warns_on_its_own_first_failure(caplog) -> None:
-    # Arrange — a broken heartbeat table must not mute the first turn failure.
+def _warn_messages_for_two_kinds(caplog) -> list[str]:
+    """Fail a heartbeat AND an error write, returning the warnings logged.
+
+    Shared by the two tests below so each keeps a single assertion
+    (PA-307) while exercising the same scenario: the counters are keyed
+    by row kind, so a broken heartbeat table must not mute the first
+    turn/error failure.
+    """
     with _dead_store(), caplog.at_level(logging.WARNING):
         writer = beat._DefaultDBWriter()
-        # Act
         writer.record_heartbeat(
-            name="ag-beat-7", host="h", pid=1, state=beat.STATE_READY, ts="2026-08-28T00:00:00Z"
+            name="ag-beat-7", host="h", pid=1, state=beat.STATE_READY, ts=1787877000.0
         )
         writer.record_error(
             name="ag-beat-7", host="h", cause="sdk-crash", detail=None, turn_id=None
         )
-        messages = [r.getMessage() for r in caplog.records]
+        return [r.getMessage() for r in caplog.records]
+
+
+def test_heartbeat_kind_warns_on_its_own_first_failure(caplog) -> None:
+    # Arrange / Act
+    messages = _warn_messages_for_two_kinds(caplog)
     # Assert
     assert any("diary heartbeat write failed" in m for m in messages)
+
+
+def test_error_kind_warns_on_its_own_first_failure(caplog) -> None:
+    # Arrange / Act
+    messages = _warn_messages_for_two_kinds(caplog)
+    # Assert
     assert any("diary error write failed" in m for m in messages)
 
 

--- a/tests/scitex_agent_container/_state/test_state_db_turns_errors_heartbeats.py
+++ b/tests/scitex_agent_container/_state/test_state_db_turns_errors_heartbeats.py
@@ -24,6 +24,12 @@ from pathlib import Path
 
 import pytest
 
+from scitex_agent_container._state.state_db_diary import (
+    ERRORS_STORE,
+    HEARTBEATS_STORE,
+    TURNS_STORE,
+)
+
 
 @pytest.fixture
 def db_path(tmp_path: Path):
@@ -76,9 +82,38 @@ def test_migration_creates_diary_table(db_path: Path, table: str):
 # ---------------------------------------------------------------------------
 
 
+def _diary_rows(store_name: str) -> list[dict]:
+    """Every visible row of one diary store, read through the module's opener.
+
+    The tests below used to read back with ``open_db()`` and a raw
+    ``SELECT * FROM turns``. That named a SQLite table, and once the diary
+    moved to PostgreSQL the writes landed in one place and the assertions
+    looked in another — so the round-trip tests failed with a bare
+    ``TypeError: 'NoneType' object is not iterable`` on ``fetchone()``,
+    which says nothing about what actually broke.
+
+    Reading through ``state_db_diary._open`` keeps the reader and the writer
+    on the SAME store by construction. A private name is used deliberately:
+    the diary exposes no public reader, and inventing one HERE would make the
+    test assert against a path production never takes.
+    """
+    from scitex_agent_container._state import state_db_diary as diary
+
+    schema = {
+        diary.TURNS_STORE: diary._turns_schema,
+        diary.ERRORS_STORE: diary._errors_schema,
+        diary.HEARTBEATS_STORE: diary._heartbeats_schema,
+    }[store_name]()
+    store = diary._open(schema)
+    try:
+        return [dict(row.values) for row in store.rows() if not row.hidden]
+    finally:
+        store.close()
+
+
 def test_insert_turn_round_trips_status_field(db_path: Path, pg_schema: str):
     # Arrange
-    from scitex_agent_container._state.state_db import open_db, record_turn
+    from scitex_agent_container._state.state_db import record_turn
 
     # Act
     record_turn(
@@ -89,34 +124,31 @@ def test_insert_turn_round_trips_status_field(db_path: Path, pg_schema: str):
         prompt_text="hi",
         ts=1700000000.0,
     )
-    with open_db() as conn:
-        row = dict(conn.execute("SELECT * FROM turns").fetchone())
+    rows = _diary_rows(TURNS_STORE)
     # Assert
-    assert row["status"] == "queued"
+    assert [r["status"] for r in rows] == ["queued"]
 
 
 def test_insert_error_round_trips_cause_field(db_path: Path, pg_schema: str):
     # Arrange
-    from scitex_agent_container._state.state_db import open_db, record_error
+    from scitex_agent_container._state.state_db import record_error
 
     # Act
     record_error(name="alice", host="h", cause="sdk-crash", detail="boom")
-    with open_db() as conn:
-        row = dict(conn.execute("SELECT * FROM errors").fetchone())
+    rows = _diary_rows(ERRORS_STORE)
     # Assert
-    assert row["cause"] == "sdk-crash"
+    assert [r["cause"] for r in rows] == ["sdk-crash"]
 
 
 def test_insert_heartbeat_round_trips_state_field(db_path: Path, pg_schema: str):
     # Arrange
-    from scitex_agent_container._state.state_db import open_db, record_heartbeat
+    from scitex_agent_container._state.state_db import record_heartbeat
 
     # Act
     record_heartbeat(name="alice", host="h", pid=4242, state="idle")
-    with open_db() as conn:
-        row = dict(conn.execute("SELECT * FROM heartbeats").fetchone())
+    rows = _diary_rows(HEARTBEATS_STORE)
     # Assert
-    assert row["state"] == "idle"
+    assert [r["state"] for r in rows] == ["idle"]
 
 
 # ---------------------------------------------------------------------------
@@ -127,40 +159,26 @@ def test_insert_heartbeat_round_trips_state_field(db_path: Path, pg_schema: str)
 
 def test_db_query_turns_filter_by_name_returns_only_matching_agent(db_path: Path, pg_schema: str):
     # Arrange
-    from scitex_agent_container._state.state_db import open_db, record_turn
+    from scitex_agent_container._state.state_db import record_turn
 
     record_turn(turn_id="t1", name="alice", host="h", status="queued")
     record_turn(turn_id="t2", name="bob", host="h", status="queued")
     record_turn(turn_id="t3", name="alice", host="h", status="responded")
     # Act
-    with open_db() as conn:
-        rows = [
-            dict(r)
-            for r in conn.execute(
-                "SELECT * FROM turns WHERE name=? ORDER BY ts ASC",
-                ("alice",),
-            ).fetchall()
-        ]
+    rows = [r for r in _diary_rows(TURNS_STORE) if r["name"] == "alice"]
     # Assert
     assert {r["turn_id"] for r in rows} == {"t1", "t3"}
 
 
 def test_db_query_errors_filter_by_cause_returns_only_matching_rows(db_path: Path, pg_schema: str):
     # Arrange
-    from scitex_agent_container._state.state_db import open_db, record_error
+    from scitex_agent_container._state.state_db import record_error
 
     record_error(name="alice", host="h", cause="auth", detail="x")
     record_error(name="alice", host="h", cause="network", detail="y")
     record_error(name="bob", host="h", cause="auth", detail="z")
     # Act
-    with open_db() as conn:
-        rows = [
-            dict(r)
-            for r in conn.execute(
-                "SELECT * FROM errors WHERE cause=? ORDER BY error_id ASC",
-                ("auth",),
-            ).fetchall()
-        ]
+    rows = [r for r in _diary_rows(ERRORS_STORE) if r["cause"] == "auth"]
     # Assert
     assert {r["name"] for r in rows} == {"alice", "bob"}
 

--- a/tests/scitex_agent_container/_state/test_state_db_turns_errors_heartbeats.py
+++ b/tests/scitex_agent_container/_state/test_state_db_turns_errors_heartbeats.py
@@ -76,7 +76,7 @@ def test_migration_creates_diary_table(db_path: Path, table: str):
 # ---------------------------------------------------------------------------
 
 
-def test_insert_turn_round_trips_status_field(db_path: Path):
+def test_insert_turn_round_trips_status_field(db_path: Path, pg_schema: str):
     # Arrange
     from scitex_agent_container._state.state_db import open_db, record_turn
 
@@ -95,7 +95,7 @@ def test_insert_turn_round_trips_status_field(db_path: Path):
     assert row["status"] == "queued"
 
 
-def test_insert_error_round_trips_cause_field(db_path: Path):
+def test_insert_error_round_trips_cause_field(db_path: Path, pg_schema: str):
     # Arrange
     from scitex_agent_container._state.state_db import open_db, record_error
 
@@ -107,7 +107,7 @@ def test_insert_error_round_trips_cause_field(db_path: Path):
     assert row["cause"] == "sdk-crash"
 
 
-def test_insert_heartbeat_round_trips_state_field(db_path: Path):
+def test_insert_heartbeat_round_trips_state_field(db_path: Path, pg_schema: str):
     # Arrange
     from scitex_agent_container._state.state_db import open_db, record_heartbeat
 
@@ -125,7 +125,7 @@ def test_insert_heartbeat_round_trips_state_field(db_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_db_query_turns_filter_by_name_returns_only_matching_agent(db_path: Path):
+def test_db_query_turns_filter_by_name_returns_only_matching_agent(db_path: Path, pg_schema: str):
     # Arrange
     from scitex_agent_container._state.state_db import open_db, record_turn
 
@@ -145,7 +145,7 @@ def test_db_query_turns_filter_by_name_returns_only_matching_agent(db_path: Path
     assert {r["turn_id"] for r in rows} == {"t1", "t3"}
 
 
-def test_db_query_errors_filter_by_cause_returns_only_matching_rows(db_path: Path):
+def test_db_query_errors_filter_by_cause_returns_only_matching_rows(db_path: Path, pg_schema: str):
     # Arrange
     from scitex_agent_container._state.state_db import open_db, record_error
 
@@ -167,6 +167,7 @@ def test_db_query_errors_filter_by_cause_returns_only_matching_rows(db_path: Pat
 
 def test_db_query_heartbeats_latest_per_name_returns_one_row_per_agent(
     db_path: Path,
+    pg_schema: str,
 ):
     # Arrange — alice has 3 beats, bob has 2.
     from scitex_agent_container._state.state_db import (

--- a/tests/scitex_agent_container/cli_pkg/test__send.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send.py
@@ -518,6 +518,7 @@ def test_agent_send_not_running_diagnosis_reports_stopped(state_db_env):
 
 
 def test_agent_send_diagnosis_reports_busy_heartbeat_state(
+    pg_schema: str,
     state_db_env, fresh_lead_creds_path
 ):
     # Arrange
@@ -542,6 +543,7 @@ def test_agent_send_diagnosis_reports_busy_heartbeat_state(
 
 
 def test_agent_send_diagnosis_busy_likely_cause_says_in_progress(
+    pg_schema: str,
     state_db_env, fresh_lead_creds_path
 ):
     # Arrange — real listener so the port is reachable and the heartbeat
@@ -568,6 +570,7 @@ def test_agent_send_diagnosis_busy_likely_cause_says_in_progress(
 
 
 def test_agent_send_diagnosis_stale_heartbeat_likely_cause_says_dead(
+    pg_schema: str,
     state_db_env, fresh_lead_creds_path
 ):
     # Arrange — real listener (port reachable) but heartbeat far older


### PR DESCRIPTION
## Why

Operator ruling, restated 2026-08-28: SQLite must be eradicated entirely —
"using even one is a loss" — because the fleet is **multi-host**, and a SQLite
file per host means a different truth per host.

That is not theoretical. The same evening, the per-host agent **specs** were
measured diverging **122 / 137 / 122 / 124** across four machines, with
different agent *sets* on each. A per-host `state.db` is the same failure in a
different file format.

He believed this was already done. It was not: 8 files still import `sqlite3`
on `develop`, it ships in `v0.27.0`, and this agent's own `state.db` was written
today. The migration is genuinely part-done — seven tables moved on 2026-08-19/20,
seven remain.

## What this changes

The **first of six** remaining writer modules. `state_db_diary.py` now serves
`turns`, `errors` and `heartbeats` from `scitex_dev.store` — the fleet's own
primitive, whose `resolve_target` is `SCITEX_STORE_DSN` or the per-host
PostgreSQL with **no SQLite fallback**. Same route `state_db_verdict_dedup` and
`state_db_incarnations` took; sac does not grow a private psycopg layer.

Verified by AST rather than by eye — the module's imports are now exactly
`__future__`, `scitex_dev.store`, `socket`, `time`, `typing`. Every remaining
occurrence of the word "sqlite" is docstring explaining the move.

## Two decisions where the easy version would have been wrong

1. **Append-only is preserved.** Keying a heartbeat by agent *name* would have
   been less code and would have silently discarded history on every tick. The
   timestamp is part of the record **identity** instead, so a new beat is a new
   record exactly as before. Changing storage and semantics together is how a
   breaking change hides inside a migration.

2. **The `lastrowid` contract.** `record_error` returned SQLite's `lastrowid`
   and `_runners/_session_beat.py` propagates it. PostgreSQL has no `lastrowid`,
   so the id is now the store's monotonic `next_seq()` — keeping the property
   that matters (unique, increasing, per record) without pretending to be a
   rowid.

`db_path` is gone from every signature; no caller passed it.

## Not done here — and it must not be forgotten

The **32 existing heartbeat rows are still in the old `state.db`**. Moving the
*writer* is not moving the *data*, and a cutover into an empty table is data
loss wearing a migration's clothes.

Remaining writers: `state_db_instances` (instances+events, 220 rows),
`state_db_comms_nodes`, `state_db_grants`, `state_db_acl_policy`,
`state_db_nodes`.

## Completion predicate for the overall effort

Not "the image is rebuilt" — that was the wrong predicate that made this look
finished. It is `rg -c 'import sqlite3' src/` returning **zero** and no
`state.db` written on any host, verifiable by the operator in one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
