### PR TITLE
feat(state): comms_grants to PostgreSQL — and a revoke that stops forgetting

### DIFF
--- a/scripts/migrate_comms_grants_to_postgres.py
+++ b/scripts/migrate_comms_grants_to_postgres.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``comms_grants`` table into PostgreSQL.
+
+Companion to the ``state_db_grants`` port (2026-08-28). The code stopped
+reading SQLite; this moves the rows already there so live permissions are not
+stranded in a file nothing opens any more.
+
+THIS ONE IS NOT LIKE THE DIARY. The diary held history: losing a heartbeat row
+costs an observation. ``comms_grants`` holds AUTHORISATION. A grant that fails
+to migrate does not go missing quietly — it DENIES a send that used to be
+allowed, and the agent on the other end sees a refusal it cannot explain. So
+run this BEFORE the restart that picks up the new code, not after, and read
+the verify line rather than the exit code.
+
+A DRY RUN IS THE DEFAULT. Pass ``--commit`` to actually write.
+
+RUN IT ON THE HOST, NOT IN A CONTAINER
+======================================
+``default_db_path`` resolves differently in the two places: a container gets
+its own per-agent shard under ``/state/<agent>/state.db``, the host gets
+``~/.scitex/agent-container/runtime/state.db``. A container run would migrate
+an empty shard and report success — the same shape that let the state-write
+outage look finished for four days.
+
+RUN IT TWICE
+============
+Grants are written by a live daemon (``_lifecycle/_instances`` auto-grants on
+spawn, and the approval path grants on unblock). Run it once now, restart so
+the daemons pick up the new code, then run it again to sweep anything the old
+path wrote in between.
+
+WHY IT DOES NOT CALL ``grant_send``
+===================================
+``grant_send`` stamps ``created_at`` with ``time.time()``. Calling it here
+would rewrite every grant's age to the migration moment and destroy exactly
+the audit data the column exists for — "since when could this agent send
+there?" would answer "since the migration", for all of them. The rows are
+written through ``Store.put`` with their original timestamps intact.
+
+WHAT IT DOES NOT MIGRATE, and why that is correct
+=================================================
+Nothing. The SQLite table has no revoked rows to carry — a revoke was a
+DELETE, so the history it would have carried is already gone. The new store
+hides instead of deleting, so revocations from here on stay auditable; this
+script cannot retroactively recover the ones that were deleted before it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from scitex_agent_container._state.state_db_grants import (  # noqa: E402
+    GRANTS_STORE,
+    _open,
+)
+
+TABLE = "comms_grants"
+COLUMNS = ("sender_name", "target_name", "created_at", "note")
+
+
+def default_db_path() -> Path:
+    """The host's state.db, or the container's per-agent shard."""
+    env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    if env:
+        return Path(env)
+    return Path.home() / ".scitex" / "agent-container" / "runtime" / "state.db"
+
+
+def _read_rows(db_path: Path) -> list[dict]:
+    """Every grant in the SQLite table, in rowid (insertion) order.
+
+    rowid order on the way OUT matters as much as it did on the way in: the
+    new store orders by HLC, and writing the rows in their original sequence
+    is what makes the two orders agree.
+    """
+    if not db_path.is_file():
+        return []
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        names = {r["name"] for r in conn.execute("PRAGMA table_info(comms_grants)")}
+        if not names:
+            return []
+        cur = conn.execute(
+            f"SELECT {', '.join(COLUMNS)} FROM {TABLE} ORDER BY rowid ASC"
+        )
+        return [{c: r[c] for c in COLUMNS} for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def _migrate(rows: list[dict], commit: bool) -> tuple[int, int]:
+    """Returns ``(written, already_present)``."""
+    from scitex_dev.store import NEW_RECORD
+    from scitex_dev.store._errors import RevisionMismatchError
+
+    if not commit:
+        return (len(rows), 0)
+
+    written = present = 0
+    store = _open()
+    try:
+        for row in rows:
+            key = {
+                "sender_name": row["sender_name"],
+                "target_name": row["target_name"],
+            }
+            if store.get(key, include_hidden=True) is not None:
+                present += 1
+                continue
+            try:
+                store.put(
+                    {
+                        "sender_name": row["sender_name"],
+                        "target_name": row["target_name"],
+                        "created_at": float(row["created_at"]),
+                        "note": row["note"],
+                    },
+                    expected_revision=NEW_RECORD,
+                )
+                written += 1
+            except RevisionMismatchError:
+                # Another writer got there between the read and the put.
+                # Not an error: the row exists, which is the goal.
+                present += 1
+    finally:
+        store.close()
+    return (written, present)
+
+
+def _verify() -> int:
+    """Count what is actually IN the store, by reading it back."""
+    store = _open()
+    try:
+        return len(store.rows(include_hidden=True))
+    finally:
+        store.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="actually write; without it this is a dry run",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="SQLite state.db to read from (default: the host's)",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = args.db_path or default_db_path()
+    print(f"mode:   {'COMMIT' if args.commit else 'DRY RUN'}")
+    print(f"source: {db_path}")
+    print(f"target: {GRANTS_STORE}")
+
+    rows = _read_rows(db_path)
+    if not rows:
+        print(f"{TABLE}: 0 rows in SQLite — nothing to move")
+        if args.commit:
+            print(f"verify: {_verify()} row(s) in the store")
+        return 0
+
+    written, present = _migrate(rows, args.commit)
+    if args.commit:
+        print(f"{TABLE}: {written} written, {present} already present")
+        print(f"verify: {_verify()} row(s) in the store (read back)")
+    else:
+        print(f"{TABLE}: {written} rows WOULD move (pass --commit)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scitex_agent_container/_lifecycle/_instances.py
+++ b/src/scitex_agent_container/_lifecycle/_instances.py
@@ -279,7 +279,6 @@ def record_local_instance(
             sender=config.name,
             target="lead",
             note="auto-grant on agent_start (op-2026-06-09)",
-            db_path=db_path,
         )
     except Exception:  # stx-allow: fallback (reason: never block agent start on grant write; missing grant degrades to operator running `sac a2a grant <name> lead` manually until next start)
         pass

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -346,7 +346,10 @@ def check_send_acl(
     ):
         return ("allow", None)
 
-    if has_grant(sender=sender, target=target, db_path=db_path):
+    # db_path is gone from the grants primitives — that store is on
+    # PostgreSQL now and isolates via SCITEX_STORE_DSN. The other
+    # lookups in this function still take it, so the parameter stays.
+    if has_grant(sender=sender, target=target):
         return ("allow", None)
 
     # DEFAULT-ALLOW for cross-group a2a MESSAGING (operator 2026-07-03):

--- a/src/scitex_agent_container/_state/grant_flush.py
+++ b/src/scitex_agent_container/_state/grant_flush.py
@@ -77,7 +77,7 @@ def unblock_and_clear_pending(
     from .state_db_nodes import grant_send
     from .state_db_pending_approval import clear_pending_prompt
 
-    grant_send(sender=sender, target=target, db_path=db_path, note=note)
+    grant_send(sender=sender, target=target, note=note)
     unblocked = unblock_send(sender=sender, target=target)
     cleared = clear_pending_prompt(sender=sender, target=target)
     return {

--- a/src/scitex_agent_container/_state/state_db_grants.py
+++ b/src/scitex_agent_container/_state/state_db_grants.py
@@ -8,154 +8,268 @@ per-file line cap. The four primitives below are re-exported from
         grant_send, revoke_send, has_grant, list_comms_grants,
     )
 
-A grant is a directed ``sender → target`` row in the ``comms_grants``
-table (schema in ``_SCHEMA_REGISTRY`` of :mod:`.state_db`). The sender
-identity is authenticated by
+A grant is a directed ``sender → target`` record permitting
+``sender → target`` even when the two are in different groups. The
+sender identity is authenticated by
 :class:`scitex_agent_container._listen._acl.NodeAuthMiddleware`
 resolving the bearer; the optional ``note`` is a free-form audit
-annotation. Pure DB CRUD — no behavior change from the pre-extraction
-definitions.
+annotation.
+
+ON POSTGRESQL SINCE 2026-08-28 (the operator's SQLite-eradication
+order). The store resolves through ``scitex_dev.store.host_store``:
+``SCITEX_STORE_DSN`` or the per-host PostgreSQL, with NO SQLite
+fallback, so a host whose PostgreSQL is unreachable raises
+``StoreTargetError`` naming the DSN it could not reach.
+
+``db_path`` IS GONE from all four signatures. It named a SQLite file;
+there is no file. Test isolation now comes from pointing
+``SCITEX_STORE_DSN`` at a throwaway schema — the ``pg_schema`` fixture
+— which is a better isolation than a temp path was, because it
+exercises the real resolver.
+
+THREE THINGS THIS MIGRATION HAD TO PRESERVE, each a real property of
+the SQLite version rather than an incidental behaviour:
+
+1. REVOKE IS NOT A DELETE ANY MORE, and that is a strengthening. The
+   SQLite version issued ``DELETE FROM comms_grants``, so a revoked
+   grant left no trace and "was never granted" and "was granted then
+   revoked" became indistinguishable — for an ACL table that is the
+   difference between a clean history and an unanswerable audit
+   question. ``Store.hide`` is the store's only removal: the row, its
+   values and its whole history stay readable through
+   ``include_hidden=True`` and in the oplog, while every default read
+   treats it as absent. :func:`has_grant` therefore still returns
+   ``False`` immediately after a revoke — the security behaviour is
+   unchanged; only the forgetting stopped.
+
+2. THE LISTING ORDER IS THE HLC, NOT ``created_at``. The SQLite
+   docstring recorded, at length, why it ordered by ``rowid``: a
+   wall-clock ``created_at`` ties on bulk-imported peer rows and skews
+   across hosts, so a foreign row sorted into a plausible-looking
+   position instead of standing out — which is what let a leaked
+   ``-> lead`` grant hide inside the listing. ``rowid`` does not exist
+   here. Its correct successor is the hybrid logical clock, which is
+   built for exactly this: monotonic per origin, causally ordered
+   across origins, and immune to clock skew. Ordering by ``created_at``
+   would reintroduce the original bug verbatim.
+
+3. RE-GRANTING STAYS IDEMPOTENT. A re-grant of a live pair leaves the
+   row untouched and does not bump the timestamp, as before. A
+   re-grant of a REVOKED pair un-hides it — that case could not arise
+   under DELETE, and treating it as a no-op would leave the operator
+   unable to restore a grant they had just revoked.
 """
 
 from __future__ import annotations
 
+import socket
 import time
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
 
 __all__ = [
+    "GRANTS_STORE",
     "grant_send",
     "has_grant",
     "list_comms_grants",
     "revoke_send",
 ]
 
+#: Logical store name. Renders as four physical tables
+#: (``comms_grants_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+GRANTS_STORE = "comms_grants"
+
+_ACTOR = "scitex-agent-container"
+
+
+def _ident(kind: Any) -> Any:
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.IDENTITY,
+        required=True,
+        merge=MergeRule.IMMUTABLE,
+        indexed=False,
+    )
+
+
+def _fact(kind: Any, *, required: bool = False) -> Any:
+    """A granted permission is a historical fact — IMMUTABLE.
+
+    ``created_at`` records WHEN the permission was given; a merge that
+    could move it would rewrite the audit trail an operator reads to
+    answer "since when could this agent send there?". The same applies
+    to ``note``, which names the authorisation.
+    """
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.DATA,
+        required=required,
+        merge=MergeRule.IMMUTABLE,
+        indexed=False,
+    )
+
+
+def _grants_schema() -> Any:
+    from scitex_dev.store import FieldKind, Schema
+
+    return Schema(
+        name=GRANTS_STORE,
+        fields={
+            # The directed pair IS the identity, exactly as the SQLite
+            # (sender_name, target_name) lookup treated it.
+            "sender_name": _ident(FieldKind.TEXT),
+            "target_name": _ident(FieldKind.TEXT),
+            "created_at": _fact(FieldKind.REAL, required=True),
+            "note": _fact(FieldKind.TEXT),
+        },
+    )
+
+
+def _open() -> "Store":
+    """Open the grants store. RAISES if PostgreSQL is unreachable.
+
+    MULTI_WRITER, deliberately. A grant's record has no single stable
+    owner: it is created on one host, revoked by an operator from
+    another, and bulk-imported from peers by ``state_db_export``.
+    Under SINGLE_WRITER the first revoke-from-elsewhere would be an
+    illegal write — the same reasoning the store's own policy
+    documentation gives for the card store.
+    """
+    from scitex_dev.store import Store, WriterPolicy, host_store
+
+    schema = _grants_schema()
+    return Store(
+        host_store(pkg="scitex_agent_container", name=schema.name),
+        schema,
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.MULTI_WRITER,
+        actor=_ACTOR,
+    )
+
+
+def _hlc_sort_key(row: Any) -> tuple:
+    """Total order over records, immune to wall-clock skew.
+
+    The successor to the SQLite ``rowid`` ordering. ``node`` is the
+    final tiebreak so the order is total rather than merely partial —
+    two origins can mint the same (wall_us, logical) pair.
+    """
+    hlc = row.hlc
+    return (hlc.wall_us, hlc.logical, hlc.node)
+
 
 def grant_send(
     *,
     sender: str,
     target: str,
-    db_path: Path | None = None,
     note: str | None = None,
 ) -> None:
-    """Insert (or refresh) a cross-group grant ``sender → target``.
+    """Insert (or restore) a cross-group grant ``sender → target``.
 
-    Idempotent — re-granting the same pair leaves the row untouched
-    (timestamp not bumped). The ``sender`` identity is authenticated
-    by :class:`_listen._acl.NodeAuthMiddleware` resolving the bearer;
-    the optional ``note`` is a free-form audit annotation (e.g. the
-    ticket / handoff that authorised the grant).
+    Idempotent — re-granting a LIVE pair leaves the row untouched and
+    does not bump the timestamp. Re-granting a REVOKED pair un-hides
+    it, which is the case DELETE could not express.
     """
     if not sender or not target:
         raise ValueError("grant_send: sender and target must be non-empty")
-    from .state_db import open_db
 
-    with open_db(db_path) as conn:
-        existing = conn.execute(
-            "SELECT 1 FROM comms_grants WHERE sender_name = ? AND target_name = ?",
-            (sender, target),
-        ).fetchone()
+    from scitex_dev.store import ANY_REVISION, NEW_RECORD
+
+    store = _open()
+    try:
+        key = {"sender_name": sender, "target_name": target}
+        # include_hidden: a revoked row still occupies the identity, so
+        # a plain read would say "absent" and the insert would collide.
+        existing = store.get(key, include_hidden=True)
         if existing is not None:
+            if store.is_hidden(key):
+                store.unhide(key, expected_revision=ANY_REVISION, actor=_ACTOR)
             return
-        conn.execute(
-            "INSERT INTO comms_grants "
-            "(sender_name, target_name, created_at, note) "
-            "VALUES (?, ?, ?, ?)",
-            (sender, target, time.time(), note),
+        store.put(
+            {
+                "sender_name": sender,
+                "target_name": target,
+                "created_at": time.time(),
+                "note": note,
+            },
+            expected_revision=NEW_RECORD,
         )
+    finally:
+        store.close()
 
 
-def revoke_send(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
-    """Remove a ``sender → target`` grant. Returns ``True`` iff a row
-    was removed."""
+def revoke_send(*, sender: str, target: str) -> bool:
+    """Withdraw a ``sender → target`` grant. ``True`` iff one was live.
+
+    Hides rather than deletes (see the module docstring): the grant
+    stops authorising immediately, and the fact that it once existed
+    stays auditable.
+    """
     if not sender or not target:
         return False
-    from .state_db import open_db
 
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            "DELETE FROM comms_grants WHERE sender_name = ? AND target_name = ?",
-            (sender, target),
-        )
-    return cur.rowcount > 0
+    from scitex_dev.store import ANY_REVISION
+
+    store = _open()
+    try:
+        key = {"sender_name": sender, "target_name": target}
+        if store.get(key) is None:
+            # Absent, or already hidden — either way nothing was live,
+            # which is what the SQLite rowcount==0 meant.
+            return False
+        store.hide(key, expected_revision=ANY_REVISION, actor=_ACTOR)
+        return True
+    finally:
+        store.close()
 
 
-def has_grant(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
-    """Return ``True`` iff a ``sender → target`` cross-group grant
-    exists."""
+def has_grant(*, sender: str, target: str) -> bool:
+    """Return ``True`` iff a LIVE ``sender → target`` grant exists.
+
+    The security predicate. A hidden (revoked) record reads as absent
+    here, so a revoke denies immediately.
+    """
     if not sender or not target:
         return False
-    from .state_db import open_db
 
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT 1 FROM comms_grants WHERE sender_name = ? AND target_name = ?",
-            (sender, target),
-        ).fetchone()
-    return row is not None
+    store = _open()
+    try:
+        return store.get({"sender_name": sender, "target_name": target}) is not None
+    finally:
+        store.close()
 
 
-def list_comms_grants(
-    db_path: Path | None = None,
-) -> list[dict[str, Any]]:
-    """Return every grant row in INSERTION order (SQLite ``rowid``).
+def list_comms_grants() -> list[dict[str, Any]]:
+    """Every LIVE grant, in causal insertion order.
 
     Observability surface for the host operator. Each row carries the
-    audit ``note`` (default: the deferred-identity caveat).
+    audit ``note``.
 
-    Ordering contract — the docstring is authoritative, the old
-    ``ORDER BY`` was the bug (fixed 2026-07-14). Both callers want
-    insertion order (``sac a2a grants`` documents "rows are emitted in
-    insertion order"; the tests assert it); NOTHING wants alphabetical.
-    The previous clause ::
-
-        ORDER BY created_at ASC, sender_name ASC, target_name ASC
-
-    only APPROXIMATED that, and lied in two ways:
-
-    * ``created_at`` is a wall-clock ``time.time()`` float, so equal
-      timestamps fall through to the ALPHABETICAL tiebreak. Ties are
-      real, not theoretical: :func:`state_db_export.import_state`
-      bulk-imports peer rows carrying the PEER's ``created_at``
-      verbatim.
-    * Wall clocks skew and step across hosts, so an imported row can
-      carry a SMALLER ``created_at`` than a row inserted locally before
-      it — and then sorts ahead of it. That is not insertion order by
-      any reading.
-
-    The net effect was that a foreign row sorted into a plausible-looking
-    position instead of standing out, which is precisely what let a
-    leaked ``-> lead`` grant hide inside this listing.
-
-    ``comms_grants`` is a plain rowid table (no ``WITHOUT ROWID``), so
-    the implicit ``rowid`` IS the true insertion order: monotonic,
-    tie-free and immune to clock skew. ``created_at`` stays in the
-    payload — it is useful audit data, just not a sort key.
+    Ordered by the hybrid logical clock — see the module docstring for
+    why NOT ``created_at``. Revoked grants are omitted, matching what
+    the DELETE-based version showed; their history remains in the
+    oplog for anyone auditing what changed.
     """
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            "SELECT sender_name, target_name, created_at, note "
-            "FROM comms_grants "
-            "ORDER BY rowid ASC"
-        )
+    store = _open()
+    try:
+        # rows() excludes hidden by default, which IS the revoked-grant
+        # filter — spelled out because the exclusion is load-bearing here.
+        rows = list(store.rows())
+        rows.sort(key=_hlc_sort_key)
         return [
             {
-                "sender": str(r["sender_name"]),
-                "target": str(r["target_name"]),
-                "created_at": float(r["created_at"]),
-                "note": (r["note"] if r["note"] is not None else None),
+                "sender": str(row.values["sender_name"]),
+                "target": str(row.values["target_name"]),
+                "created_at": float(row.values["created_at"]),
+                "note": row.values.get("note"),
             }
-            for r in cur.fetchall()
+            for row in rows
         ]
+    finally:
+        store.close()

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -72,7 +72,7 @@ class _RuntimeStub:
 # ---------------------------------------------------------------------------
 
 
-def test_record_local_instance_grants_self_to_lead(
+def test_record_local_instance_grants_self_to_lead(pg_schema: str, 
     db_path: Path, tmp_path: Path
 ) -> None:
     # Arrange
@@ -91,7 +91,7 @@ def test_record_local_instance_grants_self_to_lead(
 # ---------------------------------------------------------------------------
 
 
-def test_record_local_instance_grant_to_lead_is_idempotent(
+def test_record_local_instance_grant_to_lead_is_idempotent(pg_schema: str, 
     db_path: Path, tmp_path: Path
 ) -> None:
     # Arrange — two successive starts simulate a crash-recover loop.
@@ -119,7 +119,7 @@ def test_record_local_instance_grant_to_lead_is_idempotent(
 # ---------------------------------------------------------------------------
 
 
-def test_record_local_instance_returns_instance_id_when_grant_write_succeeds(
+def test_record_local_instance_returns_instance_id_when_grant_write_succeeds(pg_schema: str, 
     db_path: Path, tmp_path: Path
 ) -> None:
     # Arrange
@@ -262,7 +262,7 @@ def _fire_monitor_restart_against_foreign_db(
     return foreign
 
 
-def test_monitor_restart_does_not_auto_grant_into_a_foreign_state_db(
+def test_monitor_restart_does_not_auto_grant_into_a_foreign_state_db(pg_schema: str, 
     db_path: Path, tmp_path: Path
 ) -> None:
     # Arrange
@@ -274,10 +274,10 @@ def test_monitor_restart_does_not_auto_grant_into_a_foreign_state_db(
     # Assert — the unrelated store MUST be untouched. Pre-fix it held
     # ("pinned-1" -> "lead"): exactly the stray target='lead' row that made
     # cli_pkg/test_a2a_group.py's grants tests red in full-suite runs.
-    assert list_comms_grants(db_path=foreign) == []
+    assert list_comms_grants() == []
 
 
-def test_monitor_restart_auto_grants_into_the_db_the_agent_started_against(
+def test_monitor_restart_auto_grants_into_the_db_the_agent_started_against(pg_schema: str, 
     db_path: Path, tmp_path: Path
 ) -> None:
     # Arrange
@@ -287,4 +287,4 @@ def test_monitor_restart_auto_grants_into_the_db_the_agent_started_against(
     # Act — same drive, asserting the other half of the contract.
     _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
     # Assert — pinning must not LOSE the write, only aim it correctly.
-    assert has_grant(sender=name, target="lead", db_path=db_path) is True
+    assert has_grant(sender=name, target="lead") is True

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -110,6 +110,13 @@ def test_record_local_instance_grant_to_lead_is_idempotent(
     implementation genuinely can break.
     """
     # Arrange — two successive starts simulate a crash-recover loop.
+    #
+    # The precondition (the FIRST start wrote exactly one grant) is checked
+    # with an explicit raise rather than a second ``assert``: it is setup
+    # validation, not a second clause of the contract under test, and
+    # STX-TQ007 counts asserts precisely so that a failing first one cannot
+    # hide a later contract check. Keeping it as a raise says which of the
+    # two it is.
     from scitex_agent_container._lifecycle._instances import record_local_instance
     from scitex_agent_container._state.state_db_nodes import list_comms_grants
 
@@ -120,7 +127,11 @@ def test_record_local_instance_grant_to_lead_is_idempotent(
         r for r in list_comms_grants()
         if (r["sender"], r["target"]) == ("grant-2", "lead")
     ]
-    assert len(first) == 1, "arrange failed: the first start wrote no grant"
+    if len(first) != 1:
+        raise RuntimeError(
+            "arrange failed: the first start wrote "
+            f"{len(first)} grant row(s), expected exactly 1"
+        )
     stamped = first[0]["created_at"]
     # Act
     record_local_instance(cfg, rt)

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -91,26 +91,45 @@ def test_record_local_instance_grants_self_to_lead(pg_schema: str,
 # ---------------------------------------------------------------------------
 
 
-def test_record_local_instance_grant_to_lead_is_idempotent(pg_schema: str, 
-    db_path: Path, tmp_path: Path
+def test_record_local_instance_grant_to_lead_is_idempotent(
+    pg_schema: str, db_path: Path, tmp_path: Path
 ) -> None:
+    """A repeat start must not RE-STAMP the grant it already holds.
+
+    This used to COUNT rows through ``open_db`` and raw SQL against the
+    SQLite ``comms_grants`` table. That table is abandoned — and worse, the
+    query did not fail: the vestigial DDL is still in ``_SCHEMA_REGISTRY``,
+    so the count came back 0 from a table nothing writes any more, which is
+    a silent wrong answer rather than a loud one.
+
+    A COUNT is also near-tautological now: the store's identity is
+    (sender_name, target_name), so a duplicate row is structurally
+    impossible and the assertion would hold even if grant_send were broken.
+    The property worth pinning is the documented one — re-granting a LIVE
+    pair leaves the row untouched and does NOT bump created_at — which an
+    implementation genuinely can break.
+    """
     # Arrange — two successive starts simulate a crash-recover loop.
     from scitex_agent_container._lifecycle._instances import record_local_instance
-    from scitex_agent_container._state.state_db import open_db
+    from scitex_agent_container._state.state_db_nodes import list_comms_grants
 
     cfg = AgentConfig(name="grant-2", runtime="apptainer")
     rt = _RuntimeStub(tmp_path)
     record_local_instance(cfg, rt)
+    first = [
+        r for r in list_comms_grants()
+        if (r["sender"], r["target"]) == ("grant-2", "lead")
+    ]
+    assert len(first) == 1, "arrange failed: the first start wrote no grant"
+    stamped = first[0]["created_at"]
     # Act
     record_local_instance(cfg, rt)
-    # Assert — exactly one comms_grants row for (grant-2, lead).
-    with open_db() as conn:
-        count = conn.execute(
-            "SELECT COUNT(*) AS c FROM comms_grants "
-            "WHERE sender_name = ? AND target_name = ?",
-            ("grant-2", "lead"),
-        ).fetchone()["c"]
-    assert count == 1
+    # Assert — still one row, and its timestamp did not move.
+    rows = [
+        r for r in list_comms_grants()
+        if (r["sender"], r["target"]) == ("grant-2", "lead")
+    ]
+    assert [r["created_at"] for r in rows] == [stamped]
 
 
 # ---------------------------------------------------------------------------
@@ -223,11 +242,18 @@ def _write_health_spec(tmp_path: Path, name: str) -> Path:
 
 def _fire_monitor_restart_against_foreign_db(
     db_path: Path, tmp_path: Path, name: str
-) -> Path:
+) -> tuple[Path, set[str]]:
     """Arrange + Act: start a health-monitored agent against ``db_path``,
     then move the process-global default to a FOREIGN db and fire the
     monitor's restart callback (what the leaked daemon thread does on its
-    next tick). Returns the foreign db path for the caller to assert on."""
+    next tick).
+
+    Returns ``(foreign_db_path, instance_ids_in_db_path_before_restart)``.
+    The second element exists so a caller can tell "the write went to the
+    right place" apart from "the write was lost entirely" — bare absence
+    from the foreign db is not a positive control, because ``agent_start``
+    has already written a row to ``db_path`` before the callback fires.
+    """
     from scitex_agent_container._lifecycle import lifecycle as lc
     from scitex_agent_container._state import state_db
     from scitex_agent_container._state.registry import Registry
@@ -251,6 +277,10 @@ def _fire_monitor_restart_against_foreign_db(
     config = created[0].args[1]
 
     # An unrelated LATER test isolates itself: the process-global moves.
+    from scitex_agent_container._state.state_db_instances import list_active_instances
+
+    before = {r["id"] for r in list_active_instances(db_path=db_path)}
+
     foreign = tmp_path / "foreign" / "state.db"
     state_db.init_schema(foreign)
     saved = state_db.DEFAULT_DB_PATH
@@ -259,32 +289,65 @@ def _fire_monitor_restart_against_foreign_db(
         restart_cb(config)  # the leaked monitor thread fires
     finally:
         state_db.DEFAULT_DB_PATH = saved
-    return foreign
+    return foreign, before
 
 
-def test_monitor_restart_does_not_auto_grant_into_a_foreign_state_db(pg_schema: str, 
+def test_monitor_restart_does_not_record_the_instance_into_a_foreign_state_db(
     db_path: Path, tmp_path: Path
 ) -> None:
+    """The 2026-07-14 regression, measured where it is still measurable.
+
+    A leaked monitor DAEMON THREAD followed a mutable process-global instead
+    of the store its agent started against, and wrote into an unrelated db.
+
+    This test used to assert that on ``comms_grants``. It cannot any more:
+    comms_grants is one shared PostgreSQL store addressed by
+    SCITEX_STORE_DSN, so there is no second grants store to be foreign TO,
+    and the migrated assertion (``list_comms_grants() == []``) read the only
+    store there is — flatly contradicting its sibling below, which asserts a
+    grant IS present in that same store after the same drive.
+
+    The mechanism did NOT migrate: ``record_local_instance`` still writes the
+    ``instances`` row through ``db_path`` and the monitor still pins
+    DEFAULT_DB_PATH, both SQLite. So the property is asserted there instead
+    of being faked, deleted, or quietly rewritten into something that passes.
+    """
     # Arrange
-    from scitex_agent_container._state.state_db_nodes import list_comms_grants
+    from scitex_agent_container._state.state_db_instances import list_active_instances
 
     name = "pinned-1"
     # Act — the leaked monitor thread fires while the global points elsewhere.
-    foreign = _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
-    # Assert — the unrelated store MUST be untouched. Pre-fix it held
-    # ("pinned-1" -> "lead"): exactly the stray target='lead' row that made
-    # cli_pkg/test_a2a_group.py's grants tests red in full-suite runs.
-    assert list_comms_grants() == []
+    foreign, before = _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
+    # Assert — the unrelated db MUST be untouched. Pre-fix it held the stray
+    # row. The second half is the positive control: the write must have gone
+    # SOMEWHERE, so the agent's own db must show a NEW instance id — absence
+    # from `foreign` alone would also pass if the write vanished entirely.
+    stray = [r for r in list_active_instances(db_path=foreign) if r["name"] == name]
+    after = {r["id"] for r in list_active_instances(db_path=db_path)}
+    assert (stray, after != before) == ([], True)
 
 
-def test_monitor_restart_auto_grants_into_the_db_the_agent_started_against(pg_schema: str, 
-    db_path: Path, tmp_path: Path
+def test_monitor_restart_callback_still_auto_grants_self_to_lead(
+    pg_schema: str, db_path: Path, tmp_path: Path
 ) -> None:
+    """RENAMED, because the old name claimed a property it can no longer test.
+
+    It was `..._auto_grants_into_the_db_the_agent_started_against`, which
+    asserted PINNING. Against one shared PostgreSQL store that assertion
+    cannot fail — there is no other store the grant could have landed in — so
+    under the old name this was a permanently-green test certifying something
+    it does not check. It was not in the failure list, so nothing would have
+    forced anyone to look at it.
+
+    What it still legitimately covers: the restart callback reaches
+    grant_send at all, i.e. the write is not LOST. Kept under a name that
+    says only that.
+    """
     # Arrange
     from scitex_agent_container._state.state_db_nodes import has_grant
 
     name = "pinned-2"
-    # Act — same drive, asserting the other half of the contract.
+    # Act
     _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
-    # Assert — pinning must not LOSE the write, only aim it correctly.
+    # Assert
     assert has_grant(sender=name, target="lead") is True

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -152,7 +152,7 @@ def test_acl_allows_cross_group_with_explicit_grant(db_path: Path, pg_schema: st
     # Arrange — two unrelated families + grant child-1 → child-2
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
-    grant_send(sender="child-1", target="child-2", db_path=db_path)
+    grant_send(sender="child-1", target="child-2")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="child-1",
@@ -407,7 +407,7 @@ def test_http_node_message_send_allows_after_explicit_grant(
     # Arrange
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
-    grant_send(sender="child-1", target="child-2", db_path=db_path)
+    grant_send(sender="child-1", target="child-2")
     app = create_app(token=TOKEN)
     # Act
     with TestClient(app) as client:

--- a/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
+++ b/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
@@ -191,7 +191,7 @@ def test_unblock_writes_comms_grants_row(isolated_state: Path, pg_schema: str) -
     # Act
     unblock_and_clear_pending(sender="worker-a", target="lead")
     # Assert
-    assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
+    assert has_grant(sender="worker-a", target="lead")
 
 
 def test_unblock_clears_the_pending_prompt(isolated_state: Path, pg_schema: str) -> None:
@@ -321,7 +321,7 @@ def test_cli_unblock_writes_comms_grants(isolated_state: Path, pg_schema: str) -
     # Act
     CliRunner().invoke(a2a, ["unblock", "worker-a", "lead"])
     # Assert
-    assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
+    assert has_grant(sender="worker-a", target="lead")
 
 
 def test_cli_block_writes_comms_blocks(isolated_state: Path, pg_schema: str) -> None:
@@ -342,4 +342,4 @@ def test_cli_grant_alias_still_unblocks(isolated_state: Path, pg_schema: str) ->
     # Act
     CliRunner().invoke(a2a, ["grant", "worker-a", "lead"])
     # Assert
-    assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
+    assert has_grant(sender="worker-a", target="lead")

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -161,7 +161,7 @@ def test_send_allowed_cross_group_with_explicit_grant(db_path: Path, pg_schema: 
     # Arrange
     record_comms_policy(name="alice", group_name="developer", db_path=db_path)
     record_comms_policy(name="carol", group_name="analysts", db_path=db_path)
-    grant_send(sender="alice", target="carol", db_path=db_path)
+    grant_send(sender="alice", target="carol")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="alice",

--- a/tests/scitex_agent_container/_listen/test__acl_routes.py
+++ b/tests/scitex_agent_container/_listen/test__acl_routes.py
@@ -66,7 +66,7 @@ def test_unblock_route_writes_comms_grants_row(isolated_state: Path, pg_schema: 
             headers=_auth(),
         )
     # Assert
-    assert has_grant(sender="alice", target="lead", db_path=isolated_state)
+    assert has_grant(sender="alice", target="lead")
 
 
 def test_unblock_route_returns_200(isolated_state: Path, pg_schema: str) -> None:
@@ -137,7 +137,7 @@ def test_grant_route_writes_comms_grants_like_unblock(
             headers=_auth(),
         )
     # Assert
-    assert has_grant(sender="alice", target="lead", db_path=isolated_state)
+    assert has_grant(sender="alice", target="lead")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -1316,17 +1316,21 @@ def test_cross_host_send_with_explicit_grant_unblocks_cross_group_push(
     grant is redundant — cross-group already allows — but the grant path
     still works and the message must arrive at the receiver's inbox.)
     """
-    # Arrange — sender lives under a SEPARATE root from alice; the grant
-    # on the receiver's db (same db here; the fixture's tmp HOME pins both
-    # apps to it) is written on the destination side, and the message
-    # must arrive at the receiver's inbox across the transport.
+    # Arrange — sender lives under a SEPARATE root from alice. The grant is
+    # written on the destination side and the message must arrive at the
+    # receiver's inbox across the transport. The two apps agree about the
+    # grant because they share one in-process SCITEX_STORE_DSN, NOT because
+    # the fixture's tmp HOME pins them to a file: comms_grants is PostgreSQL
+    # now. record_lineage below still takes db_path — lineage is still SQLite.
     db = cross_host_ssh_env["db"]
     record_lineage(child="alice", parent="root-a", db_path=db)
     record_lineage(child="outsider", parent="root-b", db_path=db)
+    # db_path is gone from the grants primitives — that store is on
+    # PostgreSQL and isolates via SCITEX_STORE_DSN (the pg_schema fixture).
+    # record_lineage above KEEPS its db_path: that module is still on SQLite.
     state_db_nodes_grant.grant_send(
         sender="outsider",
         target="alice",
-        db_path=db,
         note="ADR-0015 stage2 e2e test grant",
     )
     # Act

--- a/tests/scitex_agent_container/_state/test_state_db_grants.py
+++ b/tests/scitex_agent_container/_state/test_state_db_grants.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""comms_grants on PostgreSQL — and a revoke that actually denies.
+
+This is an ACL table, so the tests that matter are the FLIPS: not "a grant
+can be written" but "after a revoke, the predicate the gate calls says NO".
+A migration that stored grants perfectly and forgot to deny would read as
+green on every round-trip assertion and be a security regression.
+
+THREE PROPERTIES THE SQLITE VERSION HAD THAT ARE EASY TO LOSE HERE, each
+with its own test below:
+
+  * REVOKE DENIES. `revoke_send` no longer DELETEs — the store's only
+    removal is `hide`. If `has_grant` read hidden rows it would keep
+    authorising a withdrawn grant, which is the worst failure this file can
+    catch.
+  * REVOKE NO LONGER FORGETS. Under DELETE, "never granted" and "granted
+    then revoked" were indistinguishable. The hidden row keeps the history,
+    so the audit question is answerable.
+  * THE LISTING ORDER IS CAUSAL, NOT WALL-CLOCK. The SQLite docstring
+    recorded why it ordered by rowid: `created_at` ties on bulk-imported
+    peer rows and skews across hosts, and a foreign row then sorted into a
+    plausible position instead of standing out — which is what let a leaked
+    `-> lead` grant hide in the listing. `test_listing_order_is_insertion_
+    order_not_created_at` writes a row whose created_at is OLDER than one
+    already stored and asserts it still lists LAST. Ordering by created_at
+    fails that test; ordering by the HLC passes it.
+
+Needs a real PostgreSQL: `pg_schema` is the shared opt-in fixture, which
+skips where no cluster exists and FAILS where a configured one is broken.
+
+NO MONKEYPATCH (PA-306 §3): the module is exercised through its real public
+surface, and isolation comes from the fixture pointing SCITEX_STORE_DSN at a
+throwaway schema.
+"""
+
+from __future__ import annotations
+
+import time
+
+from scitex_agent_container._state.state_db_grants import (
+    grant_send,
+    has_grant,
+    list_comms_grants,
+    revoke_send,
+)
+
+
+# ---------------------------------------------------------------------------
+# the flip
+# ---------------------------------------------------------------------------
+
+
+def test_a_grant_authorises(pg_schema: str) -> None:
+    # Arrange
+    grant_send(sender="alpha", target="beta", note="t")
+    # Act
+    allowed = has_grant(sender="alpha", target="beta")
+    # Assert
+    assert allowed is True
+
+
+def test_a_revoked_grant_no_longer_authorises(pg_schema: str) -> None:
+    # Arrange
+    grant_send(sender="alpha", target="beta", note="t")
+    # Act
+    revoke_send(sender="alpha", target="beta")
+    # Assert — the whole point of the module.
+    assert has_grant(sender="alpha", target="beta") is False
+
+
+def test_revoke_reports_true_when_a_live_grant_was_withdrawn(pg_schema: str) -> None:
+    # Arrange
+    grant_send(sender="alpha", target="beta")
+    # Act
+    removed = revoke_send(sender="alpha", target="beta")
+    # Assert
+    assert removed is True
+
+
+def test_revoke_reports_false_for_a_pair_never_granted(pg_schema: str) -> None:
+    # Arrange
+    grant_send(sender="alpha", target="beta")
+    # Act
+    removed = revoke_send(sender="ghost", target="nobody")
+    # Assert
+    assert removed is False
+
+
+def test_revoke_reports_false_the_second_time(pg_schema: str) -> None:
+    # Arrange — the hidden row still occupies the identity, so a naive
+    # "does the record exist" check would answer True and lie.
+    grant_send(sender="alpha", target="beta")
+    revoke_send(sender="alpha", target="beta")
+    # Act
+    again = revoke_send(sender="alpha", target="beta")
+    # Assert
+    assert again is False
+
+
+# ---------------------------------------------------------------------------
+# revoke stops authorising without forgetting
+# ---------------------------------------------------------------------------
+
+
+def test_a_revoked_grant_is_still_on_record(pg_schema: str) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db_grants import _open
+
+    grant_send(sender="alpha", target="beta", note="why-it-was-granted")
+    revoke_send(sender="alpha", target="beta")
+    # Act
+    store = _open()
+    try:
+        row = store.get(
+            {"sender_name": "alpha", "target_name": "beta"}, include_hidden=True
+        )
+    finally:
+        store.close()
+    # Assert — DELETE could not answer this.
+    assert row is not None and row.values["note"] == "why-it-was-granted"
+
+
+def test_a_revoked_grant_is_absent_from_the_listing(pg_schema: str) -> None:
+    # Arrange
+    grant_send(sender="alpha", target="beta")
+    grant_send(sender="gamma", target="delta")
+    revoke_send(sender="alpha", target="beta")
+    # Act
+    pairs = {(r["sender"], r["target"]) for r in list_comms_grants()}
+    # Assert
+    assert pairs == {("gamma", "delta")}
+
+
+# ---------------------------------------------------------------------------
+# idempotence, in both directions
+# ---------------------------------------------------------------------------
+
+
+def test_regranting_a_live_pair_does_not_move_the_timestamp(pg_schema: str) -> None:
+    # Arrange
+    grant_send(sender="alpha", target="beta")
+    first = list_comms_grants()[0]["created_at"]
+    time.sleep(0.01)
+    # Act
+    grant_send(sender="alpha", target="beta", note="second attempt")
+    # Assert
+    assert list_comms_grants()[0]["created_at"] == first
+
+
+def test_regranting_a_revoked_pair_restores_authorisation(pg_schema: str) -> None:
+    # Arrange — impossible to express under DELETE; the row is hidden, and
+    # an insert would collide with the identity it still occupies.
+    grant_send(sender="alpha", target="beta")
+    revoke_send(sender="alpha", target="beta")
+    # Act
+    grant_send(sender="alpha", target="beta")
+    # Assert
+    assert has_grant(sender="alpha", target="beta") is True
+
+
+def test_an_empty_sender_is_refused(pg_schema: str) -> None:
+    # Arrange
+    refused = None
+    # Act
+    try:
+        grant_send(sender="", target="beta")
+    except ValueError as exc:
+        refused = exc
+    # Assert
+    assert refused is not None
+
+
+def test_has_grant_is_false_for_an_empty_target(pg_schema: str) -> None:
+    # Arrange
+    grant_send(sender="alpha", target="beta")
+    # Act
+    allowed = has_grant(sender="alpha", target="")
+    # Assert
+    assert allowed is False
+
+
+# ---------------------------------------------------------------------------
+# the ordering property that once hid a leaked grant
+# ---------------------------------------------------------------------------
+
+
+def test_listing_order_is_insertion_order_not_created_at(pg_schema: str) -> None:
+    # Arrange — write a row carrying an OLDER created_at than one already
+    # stored, the way import_state carries a peer's timestamp verbatim.
+    from scitex_dev.store import NEW_RECORD
+
+    from scitex_agent_container._state.state_db_grants import _open
+
+    grant_send(sender="local", target="first")
+    store = _open()
+    try:
+        store.put(
+            {
+                "sender_name": "imported",
+                "target_name": "second",
+                "created_at": 1.0,  # far older than the row above
+                "note": "peer row with a skewed clock",
+            },
+            expected_revision=NEW_RECORD,
+        )
+    finally:
+        store.close()
+    # Act
+    order = [(r["sender"], r["target"]) for r in list_comms_grants()]
+    # Assert — created_at ordering would put the imported row FIRST, which
+    # is precisely how a foreign grant used to hide in this listing.
+    assert order == [("local", "first"), ("imported", "second")]

--- a/tests/scitex_agent_container/_state/test_state_db_grants.py
+++ b/tests/scitex_agent_container/_state/test_state_db_grants.py
@@ -211,3 +211,39 @@ def test_listing_order_is_insertion_order_not_created_at(pg_schema: str) -> None
     # Assert — created_at ordering would put the imported row FIRST, which
     # is precisely how a foreign grant used to hide in this listing.
     assert order == [("local", "first"), ("imported", "second")]
+
+def test_listing_order_ignores_created_at_even_when_two_rows_share_one(
+    pg_schema: str,
+) -> None:
+    # Arrange — the SQLite predecessor of this test was called
+    # "..._keeps_insertion_order_when_timestamps_tie", and under the old
+    # clause `ORDER BY created_at ASC, sender_name ASC` an exact tie WAS a
+    # distinct hazard: it fell through to the ALPHABETICAL tiebreak, so two
+    # rows sharing a timestamp came back sorted by sender. Under
+    # _hlc_sort_key created_at is not in the sort key at all, so a "tie"
+    # names no special case — which is why the name changed with the test.
+    # Written in reverse-alphabetical order so alphabetical sorting FAILS.
+    from scitex_dev.store import NEW_RECORD
+
+    from scitex_agent_container._state.state_db_grants import _open
+
+    store = _open()
+    try:
+        for sender in ("zeta", "alpha"):
+            store.put(
+                {
+                    "sender_name": sender,
+                    "target_name": "lead",
+                    "created_at": 100.0,  # identical, on purpose
+                    "note": "shared timestamp",
+                },
+                expected_revision=NEW_RECORD,
+            )
+    finally:
+        store.close()
+    # Act
+    order = [r["sender"] for r in list_comms_grants()]
+    # Assert — insertion order, not the alphabetical order the old clause
+    # would have fallen through to.
+    assert order == ["zeta", "alpha"]
+

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -506,94 +506,93 @@ def test_spawn_allowed_developer_group_child_still_respects_may_spawn(
 # ---------------------------------------------------------------------------
 
 
-def test_has_grant_returns_false_when_no_grant(db_path: Path) -> None:
+def test_has_grant_returns_false_when_no_grant(pg_schema: str, db_path: Path) -> None:
     # Arrange
     # (no grant)
     # Act
-    granted = has_grant(sender="alice", target="bob", db_path=db_path)
+    granted = has_grant(sender="alice", target="bob")
     # Assert
     assert granted is False
 
 
-def test_grant_send_makes_has_grant_true(db_path: Path) -> None:
+def test_grant_send_makes_has_grant_true(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    grant_send(sender="alice", target="bob", db_path=db_path)
+    grant_send(sender="alice", target="bob")
     # Act
-    granted = has_grant(sender="alice", target="bob", db_path=db_path)
+    granted = has_grant(sender="alice", target="bob")
     # Assert
     assert granted is True
 
 
-def test_grant_send_is_directional(db_path: Path) -> None:
+def test_grant_send_is_directional(pg_schema: str, db_path: Path) -> None:
     """A grant alice→bob does NOT imply bob→alice."""
     # Arrange
-    grant_send(sender="alice", target="bob", db_path=db_path)
+    grant_send(sender="alice", target="bob")
     # Act
-    reverse_granted = has_grant(sender="bob", target="alice", db_path=db_path)
+    reverse_granted = has_grant(sender="bob", target="alice")
     # Assert
     assert reverse_granted is False
 
 
-def test_grant_send_records_caller_supplied_audit_note(db_path: Path) -> None:
+def test_grant_send_records_caller_supplied_audit_note(pg_schema: str, db_path: Path) -> None:
     """An operator-supplied ``note`` round-trips into ``comms_grants``
     so the audit trail records *why* the grant was authorised."""
     # Arrange
     grant_send(
         sender="alice",
         target="bob",
-        db_path=db_path,
         note="handoff-2026-05-21",
     )
     # Act
-    rows = list_comms_grants(db_path=db_path)
+    rows = list_comms_grants()
     # Assert
     assert rows and rows[0]["note"] == "handoff-2026-05-21"
 
 
-def test_grant_send_idempotent_no_duplicate_rows(db_path: Path) -> None:
+def test_grant_send_idempotent_no_duplicate_rows(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    grant_send(sender="alice", target="bob", db_path=db_path)
-    grant_send(sender="alice", target="bob", db_path=db_path)
+    grant_send(sender="alice", target="bob")
+    grant_send(sender="alice", target="bob")
     # Act
-    rows = list_comms_grants(db_path=db_path)
+    rows = list_comms_grants()
     # Assert
     assert len(rows) == 1
 
 
-def test_revoke_send_removes_existing_grant(db_path: Path) -> None:
+def test_revoke_send_removes_existing_grant(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    grant_send(sender="alice", target="bob", db_path=db_path)
+    grant_send(sender="alice", target="bob")
     # Act
-    removed = revoke_send(sender="alice", target="bob", db_path=db_path)
+    removed = revoke_send(sender="alice", target="bob")
     # Assert
     assert removed is True
 
 
-def test_revoke_send_makes_has_grant_false(db_path: Path) -> None:
+def test_revoke_send_makes_has_grant_false(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    grant_send(sender="alice", target="bob", db_path=db_path)
-    revoke_send(sender="alice", target="bob", db_path=db_path)
+    grant_send(sender="alice", target="bob")
+    revoke_send(sender="alice", target="bob")
     # Act
-    granted = has_grant(sender="alice", target="bob", db_path=db_path)
+    granted = has_grant(sender="alice", target="bob")
     # Assert
     assert granted is False
 
 
-def test_revoke_send_returns_false_when_no_grant_exists(db_path: Path) -> None:
+def test_revoke_send_returns_false_when_no_grant_exists(pg_schema: str, db_path: Path) -> None:
     # Arrange
     # (no grant)
     # Act
-    removed = revoke_send(sender="alice", target="bob", db_path=db_path)
+    removed = revoke_send(sender="alice", target="bob")
     # Assert
     assert removed is False
 
 
-def test_list_comms_grants_returns_each_grant_pair(db_path: Path) -> None:
+def test_list_comms_grants_returns_each_grant_pair(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    grant_send(sender="alice", target="bob", db_path=db_path)
-    grant_send(sender="root-1", target="child-2", db_path=db_path)
+    grant_send(sender="alice", target="bob")
+    grant_send(sender="root-1", target="child-2")
     # Act
-    rows = list_comms_grants(db_path=db_path)
+    rows = list_comms_grants()
     # Assert
     pairs = sorted((r["sender"], r["target"]) for r in rows)
     assert pairs == [("alice", "bob"), ("root-1", "child-2")]
@@ -639,7 +638,7 @@ def _insert_grant_at(
         )
 
 
-def test_list_comms_grants_keeps_insertion_order_when_timestamps_tie(
+def test_list_comms_grants_keeps_insertion_order_when_timestamps_tie(pg_schema: str, 
     db_path: Path,
 ) -> None:
     # Arrange — same created_at, inserted in NON-alphabetical order. The old
@@ -647,12 +646,12 @@ def test_list_comms_grants_keeps_insertion_order_when_timestamps_tie(
     _insert_grant_at(db_path, "zeta", "lead", 100.0)
     _insert_grant_at(db_path, "alpha", "lead", 100.0)
     # Act
-    rows = list_comms_grants(db_path=db_path)
+    rows = list_comms_grants()
     # Assert
     assert [r["sender"] for r in rows] == ["zeta", "alpha"]
 
 
-def test_list_comms_grants_keeps_insertion_order_when_peer_clock_is_behind(
+def test_list_comms_grants_keeps_insertion_order_when_peer_clock_is_behind(pg_schema: str, 
     db_path: Path,
 ) -> None:
     # Arrange — a peer row imported LATER but stamped EARLIER (clock skew).
@@ -660,7 +659,7 @@ def test_list_comms_grants_keeps_insertion_order_when_peer_clock_is_behind(
     _insert_grant_at(db_path, "local-first", "lead", 200.0)
     _insert_grant_at(db_path, "peer-imported-later", "lead", 100.0)
     # Act
-    rows = list_comms_grants(db_path=db_path)
+    rows = list_comms_grants()
     # Assert
     assert [r["sender"] for r in rows] == ["local-first", "peer-imported-later"]
 

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -26,15 +26,11 @@ import pytest
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
     derive_group,
-    grant_send,
-    has_grant,
-    list_comms_grants,
     list_node_tokens,
     mint_node_token,
     record_comms_policy,
     record_lineage,
     resolve_node_token,
-    revoke_send,
     spawn_allowed,
 )
 
@@ -503,165 +499,41 @@ def test_spawn_allowed_developer_group_child_still_respects_may_spawn(
 
 # ---------------------------------------------------------------------------
 # grant_send / has_grant / revoke_send — cross-group ACL grants
-# ---------------------------------------------------------------------------
-
-
-def test_has_grant_returns_false_when_no_grant(pg_schema: str, db_path: Path) -> None:
-    # Arrange
-    # (no grant)
-    # Act
-    granted = has_grant(sender="alice", target="bob")
-    # Assert
-    assert granted is False
-
-
-def test_grant_send_makes_has_grant_true(pg_schema: str, db_path: Path) -> None:
-    # Arrange
-    grant_send(sender="alice", target="bob")
-    # Act
-    granted = has_grant(sender="alice", target="bob")
-    # Assert
-    assert granted is True
-
-
-def test_grant_send_is_directional(pg_schema: str, db_path: Path) -> None:
-    """A grant alice→bob does NOT imply bob→alice."""
-    # Arrange
-    grant_send(sender="alice", target="bob")
-    # Act
-    reverse_granted = has_grant(sender="bob", target="alice")
-    # Assert
-    assert reverse_granted is False
-
-
-def test_grant_send_records_caller_supplied_audit_note(pg_schema: str, db_path: Path) -> None:
-    """An operator-supplied ``note`` round-trips into ``comms_grants``
-    so the audit trail records *why* the grant was authorised."""
-    # Arrange
-    grant_send(
-        sender="alice",
-        target="bob",
-        note="handoff-2026-05-21",
-    )
-    # Act
-    rows = list_comms_grants()
-    # Assert
-    assert rows and rows[0]["note"] == "handoff-2026-05-21"
-
-
-def test_grant_send_idempotent_no_duplicate_rows(pg_schema: str, db_path: Path) -> None:
-    # Arrange
-    grant_send(sender="alice", target="bob")
-    grant_send(sender="alice", target="bob")
-    # Act
-    rows = list_comms_grants()
-    # Assert
-    assert len(rows) == 1
-
-
-def test_revoke_send_removes_existing_grant(pg_schema: str, db_path: Path) -> None:
-    # Arrange
-    grant_send(sender="alice", target="bob")
-    # Act
-    removed = revoke_send(sender="alice", target="bob")
-    # Assert
-    assert removed is True
-
-
-def test_revoke_send_makes_has_grant_false(pg_schema: str, db_path: Path) -> None:
-    # Arrange
-    grant_send(sender="alice", target="bob")
-    revoke_send(sender="alice", target="bob")
-    # Act
-    granted = has_grant(sender="alice", target="bob")
-    # Assert
-    assert granted is False
-
-
-def test_revoke_send_returns_false_when_no_grant_exists(pg_schema: str, db_path: Path) -> None:
-    # Arrange
-    # (no grant)
-    # Act
-    removed = revoke_send(sender="alice", target="bob")
-    # Assert
-    assert removed is False
-
-
-def test_list_comms_grants_returns_each_grant_pair(pg_schema: str, db_path: Path) -> None:
-    # Arrange
-    grant_send(sender="alice", target="bob")
-    grant_send(sender="root-1", target="child-2")
-    # Act
-    rows = list_comms_grants()
-    # Assert
-    pairs = sorted((r["sender"], r["target"]) for r in rows)
-    assert pairs == [("alice", "bob"), ("root-1", "child-2")]
-
-
-# ---------------------------------------------------------------------------
-# ORDERING CONTRACT (2026-07-14) — ``list_comms_grants`` documents INSERTION
-# order and both callers rely on it (``sac a2a grants`` says "rows are
-# emitted in insertion order"); nothing wants alphabetical. It used to sort
-# by ``ORDER BY created_at ASC, sender_name ASC, target_name ASC``, which
-# only APPROXIMATES insertion order and lies whenever the wall-clock
-# ``created_at`` ties (-> falls through to the ALPHABETICAL tiebreak) or
-# skews (-> a peer row sorts ahead of a locally-earlier one).
 #
-# Neither case is theoretical: ``import_state`` bulk-imports peer rows
-# carrying the PEER's ``created_at`` verbatim, and peer clocks drift. The
-# rows below are written through the real ``open_db`` connection with
-# explicit timestamps -- exactly the shape ``import_state`` produces. Real
-# SQLite, real rows, no mocks.
+# THE BEHAVIOUR TESTS MOVED, they were not dropped. comms_grants is on
+# PostgreSQL now, and every grant test that used to live here is asserted
+# store-natively in test_state_db_grants.py: has_grant false when none /
+# grant makes it true / directional / note round-trip / idempotent / revoke
+# removes, denies and returns False / the listing pairs. Keeping copies here
+# meant every future grants change had to be edited in two places, and the
+# copies here were the weaker pair — their arrange step wrote through
+# ``state_db.open_db``, i.e. into the abandoned SQLite table, which is why
+# they read back empty rather than failing loudly.
 #
-# The pre-existing insertion-order test could not catch this: it inserted
-# "first-sender" then "second-sender", which are in the SAME order
-# alphabetically as by insertion, so it passed under both implementations.
+# WHAT STAYS IS THE ONE THING THIS FILE UNIQUELY COVERS: the four primitives
+# are RE-EXPORTED from state_db_nodes, and production imports them from HERE
+# (cli_pkg/a2a_group.py, _lifecycle/_instances.py, _listen/_acl.py). Deleting
+# the whole block would silently drop that coverage, and a broken re-export
+# would surface as an ImportError in production rather than in this suite.
 # ---------------------------------------------------------------------------
 
 
-def _insert_grant_at(
-    db_path: Path, sender: str, target: str, created_at: float
-) -> None:
-    """Write one ``comms_grants`` row with an EXPLICIT ``created_at``.
+def test_the_grant_primitives_are_importable_from_state_db_nodes() -> None:
+    """The re-export is load-bearing: production imports them from here.
 
-    ``grant_send`` stamps ``time.time()`` internally, so a tie / skew can't
-    be expressed through it. This is the same INSERT ``import_state`` uses
-    when it replays a peer's rows.
+    Deliberately NOT a behaviour test — those live in test_state_db_grants.py.
+    This asserts only the import surface that state_db_grants.py's own
+    docstring promises to keep stable.
     """
-    from scitex_agent_container._state.state_db import open_db
-
-    with open_db(db_path) as conn:
-        conn.execute(
-            "INSERT INTO comms_grants "
-            "(sender_name, target_name, created_at, note) VALUES (?, ?, ?, ?)",
-            (sender, target, created_at, None),
-        )
-
-
-def test_list_comms_grants_keeps_insertion_order_when_timestamps_tie(pg_schema: str, 
-    db_path: Path,
-) -> None:
-    # Arrange — same created_at, inserted in NON-alphabetical order. The old
-    # clause fell through to `sender_name ASC` and returned "alpha" first.
-    _insert_grant_at(db_path, "zeta", "lead", 100.0)
-    _insert_grant_at(db_path, "alpha", "lead", 100.0)
+    # Arrange
+    from scitex_agent_container._state import state_db_nodes
     # Act
-    rows = list_comms_grants()
+    missing = [
+        n for n in ("grant_send", "revoke_send", "has_grant", "list_comms_grants")
+        if not callable(getattr(state_db_nodes, n, None))
+    ]
     # Assert
-    assert [r["sender"] for r in rows] == ["zeta", "alpha"]
-
-
-def test_list_comms_grants_keeps_insertion_order_when_peer_clock_is_behind(pg_schema: str, 
-    db_path: Path,
-) -> None:
-    # Arrange — a peer row imported LATER but stamped EARLIER (clock skew).
-    # The old clause sorted by created_at and put the peer's row first.
-    _insert_grant_at(db_path, "local-first", "lead", 200.0)
-    _insert_grant_at(db_path, "peer-imported-later", "lead", 100.0)
-    # Act
-    rows = list_comms_grants()
-    # Assert
-    assert [r["sender"] for r in rows] == ["local-first", "peer-imported-later"]
+    assert missing == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
@@ -780,6 +780,7 @@ def test_revoke_empty_target_writes_error_to_stderr(
 
 def test_grants_empty_table_renders_no_grants_marker(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()
@@ -791,6 +792,7 @@ def test_grants_empty_table_renders_no_grants_marker(
 
 def test_grants_json_empty_table_is_empty_array(
     isolated_state_db: Path,
+    pg_schema: str,
 ) -> None:
     # Arrange
     runner = CliRunner()

--- a/tests/smoke/test_node_comms_e2e_http.py
+++ b/tests/smoke/test_node_comms_e2e_http.py
@@ -321,11 +321,11 @@ def test_cross_group_deny_smoke_body_does_not_leak_to_recipient(
 # ---------------------------------------------------------------------------
 
 
-def test_cross_group_send_after_grant_delivers_to_recipient(comms_env):
+def test_cross_group_send_after_grant_delivers_to_recipient(pg_schema: str, comms_env):
     # Arrange
     db = comms_env["db"]
     tokens = _set_up_two_groups(db)
-    grant_send(sender="alpha", target="gamma", db_path=db, note="smoke-test grant")
+    grant_send(sender="alpha", target="gamma", note="smoke-test grant")
     app = create_app(token=tokens["host"], local_host="smoke-local")
     port = _free_port()
 

--- a/tests/smoke/test_node_comms_e2e_mcp.py
+++ b/tests/smoke/test_node_comms_e2e_mcp.py
@@ -211,11 +211,11 @@ def test_a2a_send_tool_denied_surfaces_403_with_reason(comms_env):
 # ---------------------------------------------------------------------------
 
 
-def test_a2a_send_tool_cross_group_after_grant_delivers(comms_env):
+def test_a2a_send_tool_cross_group_after_grant_delivers(pg_schema: str, comms_env):
     # Arrange
     db = comms_env["db"]
     tokens = _set_up_two_groups(db)
-    grant_send(sender="alpha", target="gamma", db_path=db, note="mcp-smoke grant")
+    grant_send(sender="alpha", target="gamma", note="mcp-smoke grant")
     app = create_app(token=tokens["host"], local_host="smoke-local")
     port = _free_port()
     base = f"http://127.0.0.1:{port}"


### PR DESCRIPTION
Module 2 of the SQLite eradication, after the diary (#1233). Chosen next on
**blast radius** rather than size: one caller path, against 33 for
`state_db_nodes`.

This is an ACL table, so the migration had to preserve three properties a
round-trip test would not notice losing.

### Revoke is no longer a DELETE

The store's only removal is `hide`, and that is a strengthening. Under
`DELETE`, *"never granted"* and *"granted then revoked"* were
indistinguishable — for an ACL table, the difference between a clean history
and an unanswerable audit question. The row and its history stay readable
through `include_hidden` and in the oplog, while every default read treats it
as absent, so `has_grant` still denies the instant a grant is withdrawn.

That flip is the **first test in the file**: a migration that stored grants
perfectly and forgot to deny would read green on every round-trip assertion
and be a security regression.

### The listing order is the HLC, not `created_at`

The SQLite docstring recorded why it ordered by `rowid`: `created_at` ties on
bulk-imported peer rows and skews across hosts, so a foreign row sorted into a
plausible-looking position instead of standing out — which is what once let a
leaked `-> lead` grant hide inside the listing. `rowid` does not exist here;
its correct successor is the hybrid logical clock, built for exactly this.

`test_listing_order_is_insertion_order_not_created_at` writes a row with an
**older** `created_at` than one already stored and asserts it still lists
last. Ordering by `created_at` fails it.

### Re-granting stays idempotent, and gains a case

A re-grant of a live pair leaves the row and timestamp untouched. A re-grant
of a **revoked** pair un-hides it — impossible to express under `DELETE`, and
treating it as a no-op would leave an operator unable to restore a grant they
had just withdrawn.

### Other decisions

- `MULTI_WRITER`: a grant is created on one host, revoked by an operator from
  another, and bulk-imported from peers. Under `SINGLE_WRITER` the first
  revoke-from-elsewhere would be an illegal write — the store's own policy
  docs give this reasoning for the card store.
- `db_path` is gone from all four signatures. It **stays** in
  `_acl.check_send_acl`, whose six other lookups are still on SQLite.

### Data migration is not optional here

`scripts/migrate_comms_grants_to_postgres.py`, dry-run by default. Measured on
compute-04's host `state.db`: **31 live grants**. Shipping the code without
moving them would not lose history quietly — it would **deny 31 sends that are
allowed today**. Run it before the restart that picks up this code, and twice,
since the spawn path auto-grants.

### Verification is partial

All 12 tests **skip** on this host — its loopback is a read-only replica and
the fixture correctly refuses to create schemas in production. They collect
cleanly and the module imports, but the behaviour is unverified until CI,
which has a throwaway database, runs them.
