### PR TITLE
fix(scripts): the diary migration could never write a row, and the relocation check could never fail

### DIFF
--- a/scripts/migrate_diary_to_postgres.py
+++ b/scripts/migrate_diary_to_postgres.py
@@ -115,16 +115,45 @@ def _migrate(table: str, rows: list[dict], schema_fn, commit: bool) -> int:
         print(f"  {table}: {len(rows)} rows WOULD move (dry run)")
         return 0
 
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
     from scitex_agent_container._state.state_db_diary import _open
 
-    store = _open(schema_fn())
+    # `expected_revision` is KEYWORD-ONLY WITH NO DEFAULT
+    # (Store.put(self, values, *, expected_revision, owner=None, actor=None)).
+    # This loop used to call `store.put({...})` with no revision, so `--commit`
+    # raised TypeError on its FIRST row and this script had never carried a
+    # single row on any host. The dry-run path returns above, so the failure
+    # was invisible to anyone who ran the default.
+    #
+    # NEW_RECORD, not ANY_REVISION: a migration must never overwrite a row that
+    # is already there. These tables order by their timestamps, so re-running
+    # with ANY_REVISION would silently re-stamp history. Skipping a present key
+    # makes the script IDEMPOTENT — safe to re-run after a partial move, which
+    # is exactly what you want in the middle of a cutover.
+    schema = schema_fn()
+    identity = list(schema.identity_fields)
+    store = _open(schema)
     written = 0
+    already = 0
     try:
         for row in rows:
-            store.put({k: v for k, v in row.items()})
-            written += 1
+            values = {k: v for k, v in row.items()}
+            key = {k: values[k] for k in identity}
+            if store.get(key, include_hidden=True) is not None:
+                already += 1
+                continue
+            try:
+                store.put(values, expected_revision=NEW_RECORD)
+                written += 1
+            except RevisionMismatchError:
+                # Another writer won the race between the get and the put.
+                # The row exists, which is the goal — not an error.
+                already += 1
     finally:
         store.close()
+    if already:
+        print(f"  {table}: {already} row(s) already present, left untouched")
 
     # VERIFY through the same dialect production reads through, rather than
     # trusting the write count. A put that silently no-ops would otherwise be

--- a/scripts/migrate_relocation_to_postgres.py
+++ b/scripts/migrate_relocation_to_postgres.py
@@ -188,8 +188,20 @@ def _migrate_journal(rows: list[dict], v1_rows: list[dict], commit: bool) -> int
     return len(payload)
 
 
-def _verify() -> int:
-    """Read back through the PRODUCTION path. Returns the record count seen."""
+def _verify(expected: "dict[str, int] | None" = None) -> int:
+    """Read back through the PRODUCTION path and COMPARE against the source.
+
+    This used to count `len(store.rows())`, print it, and return the total —
+    with nothing to compare it against. A control that cannot fail is not a
+    control: an empty store printed "0 record(s) readable" and the run still
+    reported success, which is indistinguishable from a migration that moved
+    everything. `expected` supplies the SQLite-side count per table so a short
+    read is an ERROR rather than a number nobody checks.
+
+    `expected=None` keeps the old count-only behaviour for callers that have no
+    source to compare against, and SAYS SO in the output rather than implying a
+    verdict it did not reach.
+    """
     from scitex_agent_container._state.relocation_pg import (
         _journal_store,
         _lease_store,
@@ -197,6 +209,7 @@ def _verify() -> int:
     )
 
     total = 0
+    short: list[str] = []
     for label, opener in (
         ("agent_residency", _residency_store),
         ("relocation_leases", _lease_store),
@@ -207,8 +220,20 @@ def _verify() -> int:
             seen = len(store.rows())
         finally:
             store.close()
-        print(f"  verify {label}: {seen} record(s) readable")
+        want = None if expected is None else expected.get(label, 0)
+        if want is None:
+            print(f"  verify {label}: {seen} record(s) readable (NOT COMPARED)")
+        elif seen < want:
+            print(f"  verify {label}: {seen} readable but source held {want} — SHORT")
+            short.append(f"{label} ({seen} < {want})")
+        else:
+            print(f"  verify {label}: {seen} record(s) readable, source had {want} — OK")
         total += seen
+    if short:
+        raise SystemExit(
+            "verification FAILED — the store holds fewer records than the "
+            "SQLite source for: " + ", ".join(short)
+        )
     return total
 
 
@@ -282,7 +307,19 @@ def main() -> int:
         print(f"\nDRY RUN — {moved} record(s) would move. Re-run with --commit.")
         return 0
     print(f"\nmoved {moved} record(s); verifying through the production path")
-    _verify()
+    # LOWER BOUNDS, deliberately, so the check cannot cry wolf. Every modern
+    # source row must arrive; `journal` therefore excludes `v1`, because
+    # _migrate_journal DEDUPES a v1 row against a modern attempt-1 row for the
+    # same agent, so `len(journal) + len(v1)` would flag a correct dedup as a
+    # short read. A check that fires on correct behaviour gets ignored, which
+    # is how it ends up as useless as no check at all.
+    _verify(
+        {
+            "agent_residency": len(residency),
+            "relocation_leases": len(leases),
+            "relocation_journal": len(journal),
+        }
+    )
     print("SQLite untouched — the old tables remain as a fallback.")
     return 0
 


### PR DESCRIPTION
Two data-carry scripts, two defects that both hid behind a passing dry run.

1. migrate_diary_to_postgres.py called `store.put({...})` with no revision.
   `Store.put(self, values, *, expected_revision, owner=None, actor=None)` —
   expected_revision is KEYWORD-ONLY WITH NO DEFAULT, so `--commit` raised
   TypeError on its FIRST row. This script has never carried a single row on
   any host. The dry-run path returns before the loop, so the default
   invocation looked healthy.

   The irony is worth keeping: the lines immediately below the broken call are
   a careful verify guarding against "a put that silently no-ops". The guard
   was right; the put never reached it.

   Now uses expected_revision=NEW_RECORD with a get-first skip and
   RevisionMismatchError treated as "already present" — the idiom
   migrate_comms_grants_to_postgres.py already uses. NEW_RECORD rather than
   ANY_REVISION because a migration must not overwrite an existing row: these
   tables order by their timestamps, so a re-run under ANY_REVISION would
   silently re-stamp history. Skipping present keys also makes the script
   idempotent, which is what you want when resuming a partial cutover.

2. migrate_relocation_to_postgres.py::_verify() counted len(store.rows()),
   printed it, and returned — with nothing to compare against. An empty store
   printed "0 record(s) readable" and the run still reported success, which is
   indistinguishable from a migration that moved everything. A control that
   cannot fail is not a control.

   It now takes the per-table source counts and raises SystemExit on a short
   read. The counts passed are LOWER BOUNDS on purpose: `relocation_journal`
   excludes the v1 rows, because _migrate_journal dedupes a v1 row against a
   modern attempt-1 row for the same agent, and counting them would flag a
   correct dedup as data loss. A check that fires on correct behaviour gets
   ignored. `expected=None` keeps the old count-only behaviour and prints
   "NOT COMPARED" rather than implying a verdict it did not reach.

VERIFIED: both files parse; both dry runs complete cleanly on this host; the
Store.put signature was read from the installed package rather than assumed
(expected_revision: KEYWORD_ONLY, no default).

NOT VERIFIED, and it needs a host with rows: the --commit path end to end.
This host holds 0 rows in every affected table, so the fix removes a proven
TypeError but the successful write has not been observed. Run it on a host
with data before trusting the migration, and read the verify line.

Found by an adversarial pass over the remaining SQLite tables; two independent
refuters flagged the put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)