### PR TITLE
refactor(state): finish the diary move — delete its SQLite residue (2 of 6)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_rename_db.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_db.py
@@ -9,10 +9,29 @@ at the old name produces an agent that starts but cannot be addressed:
 the A2A directory still advertises the dead name, and the ACL gate has no
 policy row for the live one.
 
-So: rename EVERY row that keys on the name, including the history
-(``turns`` / ``errors`` / ``heartbeats`` / ``attempts``). A renamed agent
-is the SAME agent — ``sac agents recall <new>`` must still find its past.
-This is the ``git mv`` position: the name changed, history follows.
+So: rename EVERY row in state.db that keys on the name, including the
+history (``attempts``, ``channel_events``). A renamed agent is the SAME
+agent — its past must still be findable under the new name. This is the
+``git mv`` position: the name changed, history follows.
+
+WHAT THIS NO LONGER COVERS, STATED RATHER THAN LEFT AS A DEAD ENTRY
+===================================================================
+``turns`` / ``errors`` / ``heartbeats`` were in :data:`NAME_COLUMNS`
+until 2026-08-28. They are no longer SQLite tables — the diary moved to
+per-host PostgreSQL (:mod:`.._state.state_db_diary`) — and the loops
+below skip a table that does not exist, so those three entries could
+only ever match zero rows. They are REMOVED rather than left as
+reassuring decoration: a list naming a table this code cannot reach
+reads as coverage that is not there.
+
+The diary history therefore does NOT follow a rename today, and it
+cannot be made to follow one by adding a store call here. ``name`` is an
+IDENTITY field of the heartbeats store (changing it names a different
+record, not the same one renamed) and an ``IMMUTABLE`` data field of the
+turns and errors stores, so the store REFUSES the write by design. Making
+diary history follow a rename means hiding each record and re-writing it
+under a new identity — a decision about append-only history, not a line
+of config, and deliberately not smuggled into this migration.
 
 Reversibility: we capture the ``rowid`` of every row we are about to
 touch, BEFORE touching it. The undo is then a rowid-scoped UPDATE back to
@@ -36,9 +55,9 @@ NAME_COLUMNS: tuple[tuple[str, str], ...] = (
     ("instances", "name"),
     ("instances", "spawned_by"),
     ("attempts", "agent"),
-    ("turns", "name"),
-    ("errors", "name"),
-    ("heartbeats", "name"),
+    # ("turns", "name") / ("errors", "name") / ("heartbeats", "name") were
+    # here until 2026-08-28 — see the module docstring for why removing them
+    # is the honest edit and why a store call cannot replace them.
     ("channel_events", "target"),
     ("channel_events", "source"),
     ("node_tokens", "name"),

--- a/src/scitex_agent_container/_state/dispatch_ledger.py
+++ b/src/scitex_agent_container/_state/dispatch_ledger.py
@@ -11,8 +11,9 @@ A ``dispatch_id`` is orthogonal to the other ids already in the system:
   * the a2a ``conversation_id`` correlates many messages in one
     conversation,
   * the a2a ``message_id`` identifies one message,
-  * the receiver-side ``turn_id`` (``state_db.turns``) tracks the
-    ``/v1/turn`` state machine.
+  * the receiver-side ``turn_id`` (the diary's ``turns`` store — on
+    per-host PostgreSQL since 2026-08-28, NOT in this database) tracks
+    the ``/v1/turn`` state machine.
 
 The ledger row is the identity of one outbound *send action*. One
 conversation produces many dispatches. The optional ``conversation_id``

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -1,25 +1,37 @@
-"""SQLite-backed state for scitex-agent-container (F-CS11 + diary tables).
+"""SQLite-backed state for scitex-agent-container (F-CS11).
 
 Replaces the per-agent JSON files under
 ``~/.scitex/agent-container/runtime/registry/`` with a single ``state.db``
-holding tables in three groups:
+holding tables in two groups:
 
   * F-CS11 registry — ``definitions``, ``instances``, ``events``.
   * F-CS11 phase 2 — ``instance_heartbeats`` (the legacy
     ``heartbeats`` time series, tied to an ``instances.id``).
-  * Diary (2026-05-17) — ``turns``, ``errors``, ``heartbeats``. Each
-    agent writes here continuously, like a journal; the lead reads
-    + filters when it wants cross-host visibility. ``heartbeats``
-    promotes the per-agent ``heartbeat.json`` file into a queryable
-    table keyed by ``(name, host, pid, state, ts)``.
 
 The single-file layout makes backup/sync trivial (one ``cp``) and
 keeps the existing ``actions.db`` table (``attempts``) co-located so
 queries can join across action history and instance lifecycle.
 
+THE DIARY GROUP IS GONE FROM SQLite (2026-08-28)
+================================================
+``turns`` / ``errors`` / ``heartbeats`` were a third group here: each
+agent appended rows like a journal and the lead read them back. The
+WRITERS moved to per-host PostgreSQL first; this module was the residue
+— the DDL that kept creating the three empty tables, and the
+``KNOWN_TABLES`` entries that kept ``sac db show`` and ``sac db query``
+reading them.
+
+Empty is the dangerous shape. ``sac db show`` reporting ``turns 0``
+while PostgreSQL holds the rows is not a missing feature, it is a WRONG
+ANSWER that looks like a right one — the failure the ``incarnations``
+removal named on 2026-08-19. So the names are removed rather than left
+whitelisted, and asking for one now fails loudly instead of answering
+zero. :mod:`state_db_diary` owns the trio end to end.
+
 NOTE: The original F-CS11 ``heartbeats`` table is renamed to
 ``instance_heartbeats`` on first open (idempotent migration in
-``init_schema``) so the diary-style ``heartbeats`` can own the name.
+``init_schema``). That migration STAYS: it is what an old state.db
+still needs, and nothing creates the bare name here any more.
 
 Large helper groups live in sibling modules, all re-exported from THIS
 module so ``from ...state_db import X`` imports keep working:
@@ -27,8 +39,10 @@ module so ``from ...state_db import X`` imports keep working:
   * :mod:`state_db_export` — export_state / import_state / import_legacy_registry.
   * :mod:`state_db_gc` — gc_dead_instances / _proc_btime.
   * :mod:`state_db_diary` — record_turn / record_error / record_heartbeat /
-    latest_heartbeats_per_name.
+    latest_heartbeats_per_name. On PostgreSQL, NOT in this database.
   * :mod:`state_db_heartbeats` — update_heartbeat / latest_instance_heartbeat.
+    ``instance_heartbeats``, which is a different table from the diary's
+    ``heartbeats`` and has NOT moved.
   * :mod:`state_db_migrations` — idempotent schema migrations.
 """
 
@@ -58,7 +72,7 @@ from .state_db_migrations import (
 )
 from .state_db_schema import (
     _SCHEMA_ATTEMPTS,
-    _SCHEMA_DIARY,
+    _SCHEMA_CHANNEL_AND_ACL,
     _SCHEMA_REGISTRY,
 )
 
@@ -83,9 +97,6 @@ KNOWN_TABLES = (
     "instance_heartbeats",
     "events",
     "attempts",
-    "turns",
-    "errors",
-    "heartbeats",
     "channel_events",
     "node_tokens",
     "lineage",
@@ -98,6 +109,15 @@ KNOWN_TABLES = (
     # name with no table returns an EMPTY result, and an empty result reads
     # as "this agent has no incarnations" when the truth is "you are asking
     # the wrong database". An unknown-table error is the honest answer.
+    #
+    # ``turns``, ``errors`` and ``heartbeats`` left on 2026-08-28 under the
+    # SAME ruling, and the three go together because they share
+    # :mod:`.state_db_diary` and the loops below. Every reader of this tuple
+    # is generic — :func:`table_counts`, ``export_state``, ``import_state``,
+    # and the ``--table`` choice list — so one name left behind here would
+    # have kept `sac db show` printing ``turns 0`` while the rows sat in
+    # PostgreSQL, and a half-migrated trio is a split brain that raises
+    # nothing: some readers see a row, others do not.
 )
 
 
@@ -189,7 +209,12 @@ def init_schema(db_path: Path | None = None) -> Path:
         # whose spec lists several groups was reduced to its FIRST one).
         migrate_node_comms_policy_add_group_names(conn)
         conn.executescript(_SCHEMA_ATTEMPTS)
-        conn.executescript(_SCHEMA_DIARY)
+        conn.executescript(_SCHEMA_CHANNEL_AND_ACL)
+        # ``turns`` / ``errors`` / ``heartbeats`` were created by the
+        # constant above (then called ``_SCHEMA_DIARY``) until 2026-08-28.
+        # All three moved to per-host PostgreSQL; each diary store creates
+        # its own schema on first open (``state_db_diary._open``), so there
+        # is nothing to run here for them.
         # Task #27's two ACL tables were both created here until 2026-08-20.
         # ``pending_prompts`` and ``comms_blocks`` have BOTH moved to per-host
         # PostgreSQL; each store creates its own schema on first open

--- a/src/scitex_agent_container/_state/state_db_channel.py
+++ b/src/scitex_agent_container/_state/state_db_channel.py
@@ -28,9 +28,13 @@ Three primitives, each operating on the ``channel_events`` table in
     ids. Idempotent (we only update rows where
     ``delivered_at IS NULL``); subsequent calls are no-ops.
 
-All times stored as ``REAL`` unix-seconds (float). Matches the diary
-tables (turns / errors / heartbeats) so cross-table time-window
-queries work without format conversion.
+All times stored as ``REAL`` unix-seconds (float). This module owns
+``channel_events`` and nothing else — it does NOT read the diary trio
+(turns / errors / heartbeats), which named this format when it lived in
+the same SQLite file. Since 2026-08-28 the diary is per-host PostgreSQL,
+so a single cross-table time-window query over both is no longer
+possible; the shared wire format is kept anyway, because comparing two
+timestamps across the two stores should not need a conversion.
 """
 
 from __future__ import annotations

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -62,11 +62,15 @@ def _table_filter_clauses(
             (since, since),
         ),
         "instance_heartbeats": ("WHERE ts >= ?", (since,)),
-        "heartbeats": ("WHERE ts >= ?", (since,)),
         "events": ("WHERE ts >= ?", (since,)),
         "attempts": ("WHERE ts >= ?", (since,)),
-        "turns": ("WHERE ts >= ?", (since,)),
-        "errors": ("WHERE ts >= ?", (since,)),
+        # ``turns``, ``errors`` and the diary-style ``heartbeats`` each had a
+        # ``WHERE ts >= ?`` entry here until 2026-08-28. All three moved to
+        # per-host PostgreSQL and left KNOWN_TABLES together, so — exactly as
+        # for acl_deny_notify_log below — these mappings could never be
+        # selected again, and a WHERE clause naming a table SQLite no longer
+        # has reads as "sac still exports this". Note ``instance_heartbeats``
+        # above is a DIFFERENT table and has not moved.
         # WI-2 ACL tables — ``created_at`` is the row-mint time.
         "node_tokens": ("WHERE created_at >= ?", (since,)),
         "lineage": ("WHERE created_at >= ?", (since,)),

--- a/src/scitex_agent_container/_state/state_db_schema.py
+++ b/src/scitex_agent_container/_state/state_db_schema.py
@@ -4,19 +4,26 @@ Extracted verbatim from :mod:`state_db` (which grew past the 512-line
 module cap). These are pure ``CREATE TABLE`` / ``CREATE INDEX`` scripts
 run via ``conn.executescript`` in ``state_db.init_schema``; keeping them
 in a focused sibling mirrors the existing ``state_db_*`` split
-convention (state_db_export / state_db_gc / state_db_diary / ...).
+convention (state_db_export / state_db_gc / state_db_instances / ...).
 
 ``state_db`` re-imports all three names, so every existing
 ``from ...state_db import _SCHEMA_*`` / ``executescript(_SCHEMA_*)`` call
 site is unchanged.
+
+WHAT IS NO LONGER HERE: the diary trio (``turns`` / ``errors`` /
+``heartbeats``). They moved to per-host PostgreSQL on 2026-08-28 and
+:mod:`.state_db_diary` owns them end to end — writers, reader, schema.
 """
 
 from __future__ import annotations
 
 # Registry tables (F-CS11) — definitions, instances, events.
 # The legacy ``heartbeats`` table (instance_id, ts, ...) is now
-# created under the name ``instance_heartbeats``. See _SCHEMA_DIARY
-# below for the new diary-style ``heartbeats``.
+# created under the name ``instance_heartbeats``. Nothing in this file
+# competes for the bare name any more: the diary-style ``heartbeats``
+# left SQLite on 2026-08-28 (see :mod:`.state_db_diary`), so the rename
+# migration in :func:`.state_db_migrations.migrate_legacy_heartbeats`
+# is now the ONLY thing that ever writes that name here.
 _SCHEMA_REGISTRY = """
 CREATE TABLE IF NOT EXISTS definitions (
     id              TEXT PRIMARY KEY,
@@ -112,46 +119,23 @@ CREATE INDEX IF NOT EXISTS idx_attempts_ts ON attempts(ts);
 CREATE INDEX IF NOT EXISTS idx_attempts_agent_action ON attempts(agent, action);
 """
 
-# Diary tables (2026-05-17): turns / errors / heartbeats. Each
-# agent appends rows like a journal; the lead reads + filters.
-_SCHEMA_DIARY = """
-CREATE TABLE IF NOT EXISTS turns (
-    turn_id        TEXT NOT NULL,
-    name           TEXT NOT NULL,
-    host           TEXT NOT NULL,
-    status         TEXT NOT NULL,
-    prompt_text    TEXT,
-    response_text  TEXT,
-    ts             REAL NOT NULL,
-    session_id     TEXT,
-    input_tokens   INTEGER,
-    output_tokens  INTEGER
-);
-CREATE INDEX IF NOT EXISTS idx_turns_turn_id ON turns(turn_id);
-CREATE INDEX IF NOT EXISTS idx_turns_name_ts ON turns(name, ts);
-
-CREATE TABLE IF NOT EXISTS errors (
-    error_id   INTEGER PRIMARY KEY AUTOINCREMENT,
-    name       TEXT NOT NULL,
-    host       TEXT NOT NULL,
-    cause      TEXT NOT NULL,
-    detail     TEXT,
-    ts         REAL NOT NULL,
-    turn_id    TEXT
-);
-CREATE INDEX IF NOT EXISTS idx_errors_name_ts ON errors(name, ts);
-CREATE INDEX IF NOT EXISTS idx_errors_cause ON errors(cause);
-
-CREATE TABLE IF NOT EXISTS heartbeats (
-    heartbeat_id  INTEGER PRIMARY KEY AUTOINCREMENT,
-    name          TEXT NOT NULL,
-    host          TEXT NOT NULL,
-    pid           INTEGER,
-    state         TEXT NOT NULL,
-    ts            REAL NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_heartbeats_name_ts ON heartbeats(name, ts);
-
+# Channel-event durability (WI-1) + the WI-2 / ADR-0014 ACL tables.
+#
+# THIS CONSTANT WAS ``_SCHEMA_DIARY`` UNTIL 2026-08-28. It was named for
+# the three tables it opened with — ``turns``, ``errors``, ``heartbeats``
+# — and those moved to per-host PostgreSQL that day (:mod:`.state_db_diary`
+# holds both the writers and the reader now). The DDL went with them, and
+# so did the name: a constant still called ``_SCHEMA_DIARY`` while
+# defining only channel and ACL tables is a lie no grep can see through,
+# and the next reader asking "where does the diary live" would land here
+# and find ``channel_events``.
+#
+# The DDL is REMOVED rather than left behind, for the reason
+# ``incarnations`` was removed from ``KNOWN_TABLES`` on 2026-08-19: a
+# SQLite table that exists and is never written returns an EMPTY result
+# to every reader, and an empty result reads as "this agent recorded no
+# turns" when the truth is "you are asking the wrong database".
+_SCHEMA_CHANNEL_AND_ACL = """
 -- WI-1 channel-event durability (handoff §4 "Durability /
 -- replay-on-reconnect"): persist every channel-bus event so a POST
 -- with no subscriber is delivered on connect, and a kill+reconnect

--- a/src/scitex_agent_container/_store_plugin.py
+++ b/src/scitex_agent_container/_store_plugin.py
@@ -415,24 +415,31 @@ NEVER_SYNCED: dict[str, str] = {
     ),
     "turns": (
         "the agent conversation diary — prompt_text and response_text, i.e. "
-        "the full content of what agents were asked and answered. It has NO "
-        "primary key at all, so today's importer duplicates every row on "
-        "every re-import. High-volume per-host diagnostics whose content is "
-        "the most sensitive thing in the DB: it should not leave its host "
-        "as a side effect of a directory sync"
+        "the full content of what agents were asked and answered. Since "
+        "2026-08-28 a per-host PostgreSQL store rather than a SQLite table, "
+        "which does not change the ruling: high-volume per-host diagnostics "
+        "whose content is the most sensitive thing sac records, and it "
+        "should not leave its host as a side effect of a directory sync"
     ),
     "errors": (
-        "per-host error journal keyed by an autoincrement error_id. Useful "
-        "to READ across hosts, but that is a query concern; replicating it "
-        "puts an unbounded diagnostic stream on the sync path and its ids "
-        "collide between hosts"
+        "per-host error journal, since 2026-08-28 a per-host PostgreSQL "
+        "store rather than a SQLite table. Useful to READ across hosts, but "
+        "that is a query concern; replicating it puts an unbounded "
+        "diagnostic stream on the sync path"
     ),
     "heartbeats": (
         "the diary-style heartbeat stream (name, host, pid, state, ts), "
-        "append-only with an autoincrement id and no uniqueness. Same "
-        "argument as instance_heartbeats: the fleet-relevant content is the "
-        "latest sample, carried as sac_instances.last_heartbeat_at"
+        "append-only, and since 2026-08-28 a per-host PostgreSQL store "
+        "rather than a SQLite table. Same argument as instance_heartbeats: "
+        "the fleet-relevant content is the latest sample, carried as "
+        "sac_instances.last_heartbeat_at"
     ),
+    # The three entries above no longer appear in KNOWN_TABLES — the diary
+    # left SQLite on 2026-08-28. They STAY here for the reason
+    # acl_deny_notify_log stays: the completeness gate only checks that every
+    # KNOWN_TABLES name is decided, so a table leaving that tuple must not be
+    # read as the refusal being withdrawn. A store that moved backend still
+    # must not replicate, and deleting the reason would lose why.
 }
 
 

--- a/src/scitex_agent_container/cli_pkg/db_group.py
+++ b/src/scitex_agent_container/cli_pkg/db_group.py
@@ -137,8 +137,7 @@ def db_query(
     \b
     Example:
       $ sac db query --table=instances --limit=20
-      $ sac db query --table=heartbeats --where="agent='head-nas'"
-      $ sac db query --table=events --json
+      $ sac db query --table=instance_heartbeats --where="iter > 100" --json
     """
     sql = f"SELECT * FROM {table}"  # table is whitelisted via click.Choice
     if where:
@@ -149,11 +148,8 @@ def db_query(
         "instances": "started_at DESC",
         "definitions": "first_seen_at DESC",
         "instance_heartbeats": "ts DESC",
-        "heartbeats": "ts DESC",
         "events": "ts DESC",
         "attempts": "ts DESC",
-        "turns": "ts DESC",
-        "errors": "ts DESC",
     }.get(table)
     if order_by:
         sql += f" ORDER BY {order_by}"

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -296,21 +296,21 @@ COMMS_NODE_SQL = (
     "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, updated_at) "
     "VALUES (?, ?, ?, ?, ?)"
 )
-TURN_SQL = "INSERT INTO turns (turn_id, name, host, status, ts) VALUES (?, ?, ?, ?, ?)"
+ATTEMPT_SQL = "INSERT INTO attempts (ts, agent, action, outcome, elapsed_s) VALUES (?, ?, ?, ?, ?)"
 
 
 def seed_identity_and_history(layout: Layout, name: str) -> Path:
-    """Give ``name`` one identity row (comms_nodes) and one history row (turns).
+    """One identity row (comms_nodes) + one history row (attempts) for ``name``.
 
-    The two halves the rename must both carry: the live A2A directory entry,
-    and the agent's past.
+    Both halves a rename must carry. ``attempts`` replaced ``turns`` here on
+    2026-08-28, when the diary trio left SQLite for per-host PostgreSQL.
     """
     db_path = make_state_db(layout)
     return seed_db_rows(
         db_path,
         [
             (COMMS_NODE_SQL, (name, "h", 9001, 1.0, 1.0)),
-            (TURN_SQL, ("t1", name, "h", "ok", 1.0)),
+            (ATTEMPT_SQL, ("t1", name, "run", "ok", 0.5)),
         ],
     )
 

--- a/tests/scitex_agent_container/_lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename.py
@@ -95,10 +95,10 @@ def _db_names(db_path: Path) -> list[str]:
     conn = sqlite3.connect(str(db_path))
     try:
         nodes = conn.execute("SELECT name FROM comms_nodes").fetchall()
-        turns = conn.execute("SELECT name FROM turns").fetchall()
+        past = conn.execute("SELECT agent FROM attempts").fetchall()
     finally:
         conn.close()
-    return sorted([r[0] for r in nodes] + [t[0] for t in turns])
+    return sorted([r[0] for r in nodes] + [t[0] for t in past])
 
 
 def _raise_at(step_to_fail: str):

--- a/tests/scitex_agent_container/_lifecycle/test__rename_db.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_db.py
@@ -53,10 +53,15 @@ _SEED = [
         "VALUES (?, ?, ?)",
         ("child-a", OLD, 1.0),
     ),
+    # The history half. This was an ``INSERT INTO turns`` until 2026-08-28,
+    # when the diary trio left SQLite for per-host PostgreSQL and stopped
+    # being a table this rename can reach. ``attempts.agent`` is the history
+    # column still in ``_rename_db.NAME_COLUMNS``, so it is what the
+    # history-follows-the-agent tests below now exercise.
     (
-        "INSERT INTO turns (turn_id, name, host, status, ts) "
+        "INSERT INTO attempts (ts, agent, action, outcome, elapsed_s) "
         "VALUES (?, ?, ?, ?, ?)",
-        ("t1", OLD, "h", "ok", 1.0),
+        ("t1", OLD, "run", "ok", 0.5),
     ),
 ]
 
@@ -99,7 +104,7 @@ def test_count_rows_counts_the_identity_row(seeded: Path):
 def test_count_rows_counts_the_history_row(seeded: Path):
     """History follows the agent: a renamed agent is the SAME agent."""
     # Arrange
-    key = "turns.name"
+    key = "attempts.agent"
     # Act
     counts = count_rows(seeded, OLD)
     # Assert
@@ -161,7 +166,7 @@ def test_rename_moves_the_lineage_parent_edge(seeded: Path):
 
 def test_rename_moves_the_history_rows(seeded: Path):
     # Arrange
-    sql = "SELECT COUNT(*) FROM turns WHERE name = ?"
+    sql = "SELECT COUNT(*) FROM attempts WHERE agent = ?"
     # Act
     rename_rows(seeded, OLD, NEW)
     # Assert
@@ -240,13 +245,13 @@ def test_undo_does_not_clobber_a_row_that_already_held_the_new_name(seeded: Path
     conn = sqlite3.connect(str(seeded))
     with conn:
         conn.execute(
-            "INSERT INTO turns (turn_id, name, host, status, ts) "
+            "INSERT INTO attempts (ts, agent, action, outcome, elapsed_s) "
             "VALUES (?, ?, ?, ?, ?)",
-            ("t-stranger", NEW, "h", "ok", 0.5),
+            ("t-stranger", NEW, "stranger", "ok", 0.5),
         )
     conn.close()
     undo = rename_rows(seeded, OLD, NEW)
-    sql = "SELECT name FROM turns WHERE turn_id = 't-stranger'"
+    sql = "SELECT agent FROM attempts WHERE action = 'stranger'"
     # Act
     undo_rename_rows(undo)
     # Assert

--- a/tests/scitex_agent_container/_state/test_state_db_export_tables.py
+++ b/tests/scitex_agent_container/_state/test_state_db_export_tables.py
@@ -14,6 +14,8 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from scitex_agent_container._state.state_db import KNOWN_TABLES
+
 
 @pytest.fixture
 def db_path(tmp_path: Path):
@@ -41,24 +43,14 @@ def db_path(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "table",
-    [
-        "definitions",
-        "instances",
-        "instance_heartbeats",
-        "events",
-        "attempts",
-        "turns",
-        "errors",
-        "heartbeats",
-        "channel_events",
-        "node_tokens",
-        "lineage",
-        "comms_grants",
-        "comms_nodes",
-    ],
-)
+# Parametrized over KNOWN_TABLES ITSELF, not over a copy of it. This was a
+# hand-written literal list until 2026-08-28, and by then it had drifted: it
+# still named ``turns`` / ``errors`` / ``heartbeats`` after the diary moved to
+# PostgreSQL and those names left KNOWN_TABLES, so the test failed asserting
+# the export SHOULD contain tables sac no longer has. A literal copy of a
+# constant is a second source of truth that nothing keeps honest; reading the
+# constant means this test tracks the whitelist for free, in both directions.
+@pytest.mark.parametrize("table", sorted(KNOWN_TABLES))
 def test_export_state_no_tables_filter_includes_table(
     db_path: Path, table: str
 ) -> None:

--- a/tests/scitex_agent_container/_state/test_state_db_turns_errors_heartbeats.py
+++ b/tests/scitex_agent_container/_state/test_state_db_turns_errors_heartbeats.py
@@ -1,9 +1,16 @@
-"""Tests for the diary tables: turns / errors / heartbeats (2026-05-17).
+"""Tests for the diary stores: turns / errors / heartbeats (2026-05-17).
 
 Foundation for fleet-wide visibility before fanout: every agent
-writes timestamped state-transition rows to state.db like a journal;
-the lead reads + filters them. Three new tables — ``turns``,
-``errors``, ``heartbeats`` — plus runner write-paths.
+writes timestamped state-transition rows like a journal; the lead
+reads + filters them. Three logical stores — ``turns``, ``errors``,
+``heartbeats`` — plus runner write-paths.
+
+They lived in ``state.db`` until 2026-08-28 and are now per-host
+PostgreSQL (:mod:`scitex_agent_container._state.state_db_diary`). The
+SQLite half of this file was INVERTED rather than deleted: the first
+group below now asserts the tables are absent, unqueryable, and refused
+by ``sac db query``, because a table that still exists and is never
+written answers every reader with a confident zero.
 
 Conventions:
 
@@ -55,16 +62,28 @@ def db_path(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# Migration — the three new tables exist on a fresh DB.
+# The SQLite tables are GONE, and asking for one must SAY so.
+#
+# These three tests were ONE test asserting the exact opposite — that
+# ``init_schema`` created ``turns`` / ``errors`` / ``heartbeats`` in state.db.
+# The writers moved to PostgreSQL first, which left DDL creating three tables
+# nothing would ever write again. An always-empty table is the worst shape
+# available: every reader still gets an answer, the answer is zero rows, and
+# zero rows reads as "this agent recorded no turns" when the truth is "you are
+# asking the wrong database". That is the ruling ``incarnations`` established
+# on 2026-08-19, applied to the trio on 2026-08-28.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("table", ["turns", "errors", "heartbeats"])
-def test_migration_creates_diary_table(db_path: Path, table: str):
-    # Arrange
+def test_init_schema_no_longer_creates_the_diary_table_in_sqlite(
+    db_path: Path, table: str
+):
+    # Arrange — POSITIVE CONTROL. A fixture that never ran the schema would
+    # leave ``names`` empty and pass this test for entirely the wrong reason,
+    # so the precondition is an explicit raise rather than a second assertion.
     from scitex_agent_container._state.state_db import init_schema
 
-    # Act
     init_schema()
     with sqlite3.connect(db_path) as conn:
         names = {
@@ -73,8 +92,50 @@ def test_migration_creates_diary_table(db_path: Path, table: str):
                 "SELECT name FROM sqlite_master WHERE type='table'"
             ).fetchall()
         }
+    if "instances" not in names:
+        raise RuntimeError(
+            f"init_schema() left no `instances` table in {db_path}, so the "
+            f"schema never ran and the absence of `{table}` proves nothing."
+        )
+    # Act
+    created = table in names
     # Assert
-    assert table in names
+    assert not created
+
+
+@pytest.mark.parametrize("table", ["turns", "errors", "heartbeats"])
+def test_the_diary_table_is_no_longer_a_sqlite_known_table(table: str):
+    # Arrange — while the name stayed whitelisted, ``sac db show`` reported
+    # ``turns 0`` and ``sac db query --table=turns`` returned an empty array,
+    # both of them confident and both of them wrong.
+    from scitex_agent_container._state.state_db import KNOWN_TABLES
+
+    known = set(KNOWN_TABLES)
+    if "instances" not in known:
+        raise RuntimeError(
+            "KNOWN_TABLES does not contain `instances`; it is not the "
+            "whitelist this test means to inspect."
+        )
+    # Act
+    whitelisted = table in known
+    # Assert
+    assert not whitelisted
+
+
+@pytest.mark.parametrize("table", ["turns", "errors", "heartbeats"])
+def test_sac_db_query_refuses_the_moved_diary_table(db_path: Path, table: str):
+    # Arrange — the end-to-end half. Removing the name from KNOWN_TABLES is
+    # only useful if the CLI turns the request into a usage ERROR; exit code 2
+    # is what click raises for a rejected ``--table`` choice.
+    from click.testing import CliRunner
+
+    from scitex_agent_container.cli_pkg.db_group import db_query
+
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(db_query, [f"--table={table}"])
+    # Assert
+    assert result.exit_code == 2, result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_state/test_state_db_turns_errors_heartbeats.py
+++ b/tests/scitex_agent_container/_state/test_state_db_turns_errors_heartbeats.py
@@ -75,28 +75,76 @@ def db_path(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("table", ["turns", "errors", "heartbeats"])
-def test_init_schema_no_longer_creates_the_diary_table_in_sqlite(
-    db_path: Path, table: str
-):
-    # Arrange — POSITIVE CONTROL. A fixture that never ran the schema would
-    # leave ``names`` empty and pass this test for entirely the wrong reason,
-    # so the precondition is an explicit raise rather than a second assertion.
-    from scitex_agent_container._state.state_db import init_schema
+def _table_names(db_path: Path) -> set[str]:
+    """Read ``sqlite_master`` and hand back the names, closing the connection.
 
-    init_schema()
-    with sqlite3.connect(db_path) as conn:
-        names = {
+    A PLAIN FUNCTION rather than part of the fixture below: STX-TQ005 forbids a
+    fixture that acquires an external resource and ``return``\\ s instead of
+    ``yield``\\ ing, and it reads the fixture body syntactically. Keeping the
+    ``connect`` here means the fixture hands back a ``set``, which owns nothing
+    and needs no teardown — which is the rule's actual point.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
             r[0]
             for r in conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
             ).fetchall()
         }
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def sqlite_table_names(db_path: Path) -> set[str]:
+    """Every table a fresh ``state.db`` really has, after ``init_schema``.
+
+    THE POSITIVE CONTROL LIVES HERE, not in the tests below. A fixture that
+    never ran the schema would hand them an empty set, and "the diary table is
+    absent" would pass for exactly the wrong reason — absence of evidence
+    reading as evidence of absence, which is the failure this whole file is
+    about. The guard is a ``raise`` rather than an assertion so each test keeps
+    one assertion (STX-TQ007), and it sits in a fixture rather than in a
+    parametrized body (STX-TQ006).
+    """
+    from scitex_agent_container._state.state_db import init_schema
+
+    init_schema()
+    names = _table_names(db_path)
     if "instances" not in names:
         raise RuntimeError(
-            f"init_schema() left no `instances` table in {db_path}, so the "
-            f"schema never ran and the absence of `{table}` proves nothing."
+            f"init_schema() left no `instances` table in {db_path}; the schema "
+            "never ran, so an absent diary table would prove nothing."
         )
+    return names
+
+
+@pytest.fixture
+def known_tables() -> set[str]:
+    """``KNOWN_TABLES`` as a set, with the same control applied to it.
+
+    ``instances`` must be in there for this to be the whitelist the tests below
+    mean to inspect; an empty or wrong tuple would otherwise make every
+    "not whitelisted" assertion pass on its own.
+    """
+    from scitex_agent_container._state.state_db import KNOWN_TABLES
+
+    known = set(KNOWN_TABLES)
+    if "instances" not in known:
+        raise RuntimeError(
+            "KNOWN_TABLES does not contain `instances`; it is not the "
+            "whitelist these tests mean to inspect."
+        )
+    return known
+
+
+@pytest.mark.parametrize("table", ["turns", "errors", "heartbeats"])
+def test_init_schema_no_longer_creates_the_diary_table_in_sqlite(
+    sqlite_table_names: set[str], table: str
+):
+    # Arrange — the fixture ran init_schema and cleared its own control.
+    names = sqlite_table_names
     # Act
     created = table in names
     # Assert
@@ -104,18 +152,13 @@ def test_init_schema_no_longer_creates_the_diary_table_in_sqlite(
 
 
 @pytest.mark.parametrize("table", ["turns", "errors", "heartbeats"])
-def test_the_diary_table_is_no_longer_a_sqlite_known_table(table: str):
+def test_the_diary_table_is_no_longer_a_sqlite_known_table(
+    known_tables: set[str], table: str
+):
     # Arrange — while the name stayed whitelisted, ``sac db show`` reported
     # ``turns 0`` and ``sac db query --table=turns`` returned an empty array,
     # both of them confident and both of them wrong.
-    from scitex_agent_container._state.state_db import KNOWN_TABLES
-
-    known = set(KNOWN_TABLES)
-    if "instances" not in known:
-        raise RuntimeError(
-            "KNOWN_TABLES does not contain `instances`; it is not the "
-            "whitelist this test means to inspect."
-        )
+    known = known_tables
     # Act
     whitelisted = table in known
     # Assert

--- a/tests/scitex_agent_container/cli_pkg/test__registry_sync.py
+++ b/tests/scitex_agent_container/cli_pkg/test__registry_sync.py
@@ -69,15 +69,15 @@ def _peer_export_payload(*, host: str, name: str, port: int) -> str:
             "tables": {
                 # Only comms_nodes carries data — every other known table
                 # has to be present-but-empty so import_state's
-                # KNOWN_TABLES loop doesn't trip.
+                # KNOWN_TABLES loop doesn't trip. ``turns`` / ``errors`` /
+                # ``heartbeats`` were here until 2026-08-28; the diary left
+                # SQLite and KNOWN_TABLES together, so a peer that still
+                # ships those keys is describing a dump sac no longer makes.
                 "definitions": [],
                 "instances": [],
                 "instance_heartbeats": [],
                 "events": [],
                 "attempts": [],
-                "turns": [],
-                "errors": [],
-                "heartbeats": [],
                 "channel_events": [],
                 "node_tokens": [],
                 "lineage": [],


### PR DESCRIPTION
## What

dc4a8bab (#1233) moved the **writers** of `turns` / `errors` / `heartbeats` to per-host PostgreSQL. It left the SQLite half standing. This deletes that residue — all three tables in one change.

## Why one PR and not three

Every remaining reader of these tables is **generic**, driven by `state_db.KNOWN_TABLES`:

| reader | surface |
|---|---|
| `table_counts()` | `sac db show` |
| `export_state()` / `import_state()` | `sac db export` / `import`, `sac registry sync` |
| `click.Choice(KNOWN_TABLES)` | `sac db query --table=` |

So a table left whitelisted with no writer does not fail — it **answers zero**. `sac db show` printed `turns 0` with total confidence while the rows sat in PostgreSQL. That is the failure the `incarnations` removal named on 2026-08-19:

> a whitelisted name with no table returns an EMPTY result, and an empty result reads as "this agent has no incarnations" when the truth is "you are asking the wrong database".

Splitting the trio would leave that wrong answer alive for the tables not yet done — a split brain that raises nothing, some readers seeing a row and others not.

## Changes

| file | change |
|---|---|
| `_state/state_db_schema.py` | the three `CREATE TABLE` blocks deleted; the constant that held them renamed `_SCHEMA_DIARY` → `_SCHEMA_CHANNEL_AND_ACL` (what is left in it is `channel_events` + the ACL tables) |
| `_state/state_db.py` | the three names leave `KNOWN_TABLES`; `init_schema` no longer runs their DDL |
| `_state/state_db_export.py` | their `--since` filter entries removed, following the `acl_deny_notify_log` precedent directly above them |
| `cli_pkg/db_group.py` | their `ORDER BY` defaults and the stale `--table=heartbeats` example removed |
| `_store_plugin.py` | the three `NEVER_SYNCED` refusals **stay**, reasons updated to say they are PostgreSQL stores now |
| `_lifecycle/_rename_db.py` | the three entries leave `NAME_COLUMNS` |
| `_state/state_db_channel.py`, `_state/dispatch_ledger.py` | docstrings that claimed cross-table queries against the diary — corrected. Confirmed by AST + SQL walk: **neither module touches the trio**, they only named it. |

## The one behaviour change worth naming

`sac agents rename` no longer carries diary history, and this PR does **not** restore it. It cannot be restored by adding a store call: `name` is an IDENTITY field of the heartbeats store and an `IMMUTABLE` data field of the turns and errors stores, so the store refuses the write **by design**. Making diary history follow a rename means hiding each record and re-writing it under a new identity — a decision about append-only history, not a line of config. `_rename_db.py`'s docstring states this where the next reader will look.

## Not versioned up, deliberately

`EXPORT_SCHEMA_VERSION` stays at 1. Both directions use `.get(table, [])`, so an older peer's dump carrying the three keys still imports and a newer dump without them still parses. Same backward-compatible shape `incarnations` and `acl_deny_notify_log` used when they left. Bumping it would make a mixed-version fleet refuse every `sac registry sync`.

## Tests

`test_state_db_turns_errors_heartbeats.py` had one test asserting `init_schema` **created** the three tables. It is **inverted rather than deleted**, into three parametrized groups:

1. the table is absent from a fresh `state.db` — with an explicit positive control (`raise` if `instances` is missing), so an un-run schema cannot pass it vacuously;
2. the name is absent from `KNOWN_TABLES`;
3. `sac db query --table=turns` exits 2 instead of printing `[]` — the end-to-end half of the ruling.

The rename fixtures seeded their "history" row into `turns`; they now use `attempts`, the history table a rename can still reach.

```
248 passed, 7 skipped  (test_state_db, test_state_db_turns_errors_heartbeats,
                        test__rename_db, test__rename, test__store_plugin,
                        test_sqlite_footprint_frozen, test__registry_sync)
```

The 7 skips are the pre-existing PostgreSQL-fixture skips (this host's loopback is a read-only replica of the fleet cluster) plus one federation-absent skip. `ruff check` clean on every changed file.

## Scope held

`instances` and its 11 modules are untouched, as are `state_db_export.py` / `db_group.py` beyond the specific turns/errors/heartbeats reads. `state_db_heartbeats.py` was **checked and deliberately left alone**: it owns `instance_heartbeats` + `instances`, which is the instances group, not the diary.
