### PR TITLE
refactor(state): move `dispatches` onto PostgreSQL, and give it an owner

### DIFF
--- a/scripts/migrate_dispatches_to_postgres.py
+++ b/scripts/migrate_dispatches_to_postgres.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``dispatches`` ledger into PostgreSQL.
+
+Companion to the ``dispatch_ledger`` port. That change stops the code
+READING SQLite; without this the rows already there stay in a file nothing
+opens any more. Measured on scitex-compute-04 while writing this: 593 rows in
+the host ``state.db``. They are the ledger's whole point — it exists so a
+dispatch is not sent twice and so there is a record of what was sent — and a
+cutover that silently starts from empty gives up both.
+
+``agent`` IS CARRIED AS THE EMPTY STRING, ON PURPOSE
+====================================================
+The store identifies a row by ``(agent, dispatch_id)``. SQLite had no
+``agent`` column: the FILE was the scope, so which agent a row belonged to
+was never recorded. There is no way to recover it, and the plausible guess --
+``from_agent`` -- is wrong often enough to matter, because ``from_agent`` is
+who SENT the dispatch, not whose ledger it was written into. Inventing a
+scope would fabricate exactly the fact the migration cannot know.
+
+The empty string is not a workaround, it is the value the code already uses:
+``record_dispatch`` writes ``"agent": agent or ""``, and ``find_dispatch``
+falls back to scanning every row when it has no agent to key on. So carried
+rows are found by dispatch_id, which is what the old SQLite lookup did.
+
+RUN IT ON THE HOST, NOT IN A CONTAINER
+======================================
+``DEFAULT_DB_PATH`` resolves differently in the two places: a container gets
+its own per-agent shard under ``/state/<agent>/state.db`` (and ``$HOME`` is
+``/home/agent``, which is ephemeral), the host gets
+``~/.scitex/agent-container/runtime/state.db``. The rows are on the HOST, so
+a container run would faithfully migrate an empty shard and report success --
+the same shape that made the diary migration look finished for three days.
+
+A DRY RUN IS THE DEFAULT. Pass ``--commit`` to actually write.
+
+IT IS IDEMPOTENT and it VERIFIES. Rows are written with ``NEW_RECORD``, so a
+key already present is left ALONE rather than overwritten: re-running after a
+partial move is safe, and a re-run can never re-stamp a ``status`` that has
+moved on since. Nothing is deleted from SQLite -- the old table stays as a
+fallback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+TABLE = "dispatches"
+COLUMNS = (
+    "dispatch_id",
+    "from_agent",
+    "to_agent",
+    "conversation_id",
+    "text_summary",
+    "status",
+    "ts",
+)
+
+
+def default_db_path() -> Path:
+    """The HOST state.db. See the module docstring on why this matters."""
+    return Path.home() / ".scitex" / "agent-container" / "runtime" / "state.db"
+
+
+def read_rows(db_path: Path) -> list[dict]:
+    """Every dispatch, read-only.
+
+    A missing table is reported distinctly from an empty one: "no such table"
+    and "no rows" are different facts, and collapsing them is how a migration
+    silently skips a host.
+    """
+    if not db_path.is_file():
+        print(f"  {db_path}: no such file")
+        return []
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute(f"SELECT {', '.join(COLUMNS)} FROM {TABLE}")
+        return [dict(r) for r in cur.fetchall()]
+    except sqlite3.OperationalError as exc:
+        print(f"  no {TABLE} in {db_path}: {exc}")
+        return []
+    finally:
+        conn.close()
+
+
+def migrate(rows: list[dict], commit: bool) -> int:
+    """Write through the production store. Returns rows written, or -1."""
+    print(f"{TABLE}: {len(rows)} row(s)")
+    if not rows or not commit:
+        # scitex-dev is imported only on the WRITE path, so "what would move?"
+        # still answers on a host where it is not installed. The first host run
+        # of the relocation script died exactly there.
+        return 0
+
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
+    from scitex_agent_container._state.dispatch_ledger_store import (
+        IDENTITY_FIELDS,
+        open_dispatch_store,
+    )
+
+    store = open_dispatch_store()
+    written = 0
+    already = 0
+    try:
+        for row in rows:
+            values = {
+                # See the module docstring: the scope was never recorded, and
+                # `record_dispatch` writes this same empty string.
+                "agent": "",
+                "dispatch_id": row["dispatch_id"],
+                "from_agent": row["from_agent"] or "",
+                "to_agent": row["to_agent"] or "",
+                "conversation_id": row["conversation_id"] or "",
+                "text_summary": row["text_summary"] or "",
+                "status": row["status"] or "",
+                "ts": float(row["ts"]),
+            }
+            key = {k: values[k] for k in IDENTITY_FIELDS}
+            if store.get(key, include_hidden=True) is not None:
+                already += 1
+                continue
+            try:
+                # NEW_RECORD, never ANY_REVISION: `status` is the one field
+                # that moves, and re-running with ANY_REVISION would push a
+                # delivered dispatch back to whatever SQLite last saw.
+                store.put(values, expected_revision=NEW_RECORD)
+                written += 1
+            except RevisionMismatchError:
+                # Another writer won between the get and the put. The row
+                # exists, which is the goal -- not an error.
+                already += 1
+    finally:
+        store.close()
+    if already:
+        print(f"  {already} row(s) already present, left untouched")
+
+    # VERIFY through the production read path rather than trusting the write
+    # count: a put that silently no-opped would otherwise report as success.
+    store = open_dispatch_store()
+    try:
+        present = len(list(store.rows()))
+    finally:
+        store.close()
+    if present < len(rows):
+        print(
+            f"  MISMATCH — wrote {written}, store holds {present} "
+            f"(expected at least {len(rows)}). NOT a success."
+        )
+        return -1
+    print(f"  {written} row(s) moved, {present} verified present")
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="SQLite state.db to read (default: the HOST runtime state.db)",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="actually write; without it this is a dry run that touches nothing",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = args.db_path or default_db_path()
+    print(f"source: {db_path}{'' if db_path.is_file() else '  (ABSENT)'}")
+    print(f"mode:   {'COMMIT' if args.commit else 'DRY RUN'}")
+
+    rows = read_rows(db_path)
+    if migrate(rows, args.commit) < 0:
+        print("FAILED — the table did not verify. SQLite left untouched.")
+        return 1
+    if not args.commit:
+        print(f"\nDRY RUN — {len(rows)} row(s) would move. Re-run with --commit.")
+        return 0
+    print("SQLite untouched — the old table remains as a fallback.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/scitex_agent_container/_mcp/_channel_reaction_ack.py
+++ b/src/scitex_agent_container/_mcp/_channel_reaction_ack.py
@@ -71,7 +71,7 @@ def is_reaction_event(event: dict[str, Any]) -> bool:
     return event.get("kind") == "reaction"
 
 
-def absorb_reaction_ack(event: dict[str, Any]) -> bool:
+def absorb_reaction_ack(event: dict[str, Any], *, agent: str | None = None) -> bool:
     """Update the dispatch ledger if ``event`` carries a structural reaction.
 
     The sender-side companion to :func:`post_reaction_ack`: when a
@@ -80,6 +80,14 @@ def absorb_reaction_ack(event: dict[str, Any]) -> bool:
     Mark the matching dispatch row ``STATUS_REACTED`` so the operator
     (and the ``sac a2a comm-miss`` surface) can see the receipt
     landed.
+
+    ``agent`` is THIS agent — the owner of the row being marked, and half of
+    its identity since the ledger moved to the fleet-wide PostgreSQL store
+    (2026-08-28). Passing it makes the update a keyed write. It is a fast path
+    and not a filter: this adapter's name comes from ``--name`` or the
+    discovered self spec while the peer client stamps ``SAC_NAME``, so the two
+    can legitimately disagree, and the ledger falls back to resolving the
+    unique ``dispatch_id`` rather than losing the receipt.
 
     Returns ``True`` iff a ledger row was updated. Best-effort: a
     write failure is logged but never re-raised — losing
@@ -103,7 +111,7 @@ def absorb_reaction_ack(event: dict[str, Any]) -> bool:
         log.warning("sac channel: dispatch_ledger import failed: %s", exc)
         return False
     try:
-        return mark_dispatch_reacted(did)
+        return mark_dispatch_reacted(did, agent=agent)
     except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a write failure must not break the SSE consumer — logged loudly, never silent)
         log.warning(
             "sac channel: mark_dispatch_reacted(%r) failed: %s",

--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -68,13 +68,20 @@ def register_tools(
     ) -> str:
         """Mint + record an outbound dispatch row; return its dispatch_id.
 
-        Ledger writes are observability — a state.db hiccup must not break
-        the actual a2a send, so failures log loudly (never silent) and the
-        send proceeds with a freshly-minted id that simply has no row.
+        Ledger writes are observability — a store hiccup must not break the
+        actual a2a send, so failures log loudly (never silent) and the send
+        proceeds with a freshly-minted id that simply has no row.
+
+        ``agent`` is the OWNING agent (this container). Since the ledger moved
+        to the fleet-wide PostgreSQL store it is what keeps a later
+        ``list_dispatches(agent=...)`` from answering with the whole fleet;
+        ``from_agent`` happens to be the same name here, but it is a different
+        question and cannot stand in for it.
         """
         did = new_dispatch_id()
         try:
             record_dispatch(
+                agent=agent_name,
                 from_agent=agent_name,
                 to_agent=to_agent,
                 text=content,
@@ -86,8 +93,10 @@ def register_tools(
         return did
 
     def _ledger_update(dispatch_id: str, status: str) -> None:
+        # Same owner _ledger_record stamped, so the keyed update addresses the
+        # row it wrote rather than scanning the fleet-wide ledger for it.
         try:
-            update_dispatch_status(dispatch_id, status)
+            update_dispatch_status(dispatch_id, status, agent=agent_name)
         except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a status-update failure must not break the a2a send — logged loudly, never silent)
             log.warning("dispatch-ledger status update (a2a_send) failed: %s", exc)
 

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -220,7 +220,9 @@ async def _push_channel_event(
     # can audit that the receipt landed.
     if is_reaction_event(event):
         _recent.append(event)
-        absorb_reaction_ack(event)
+        # ``agent_name`` is US — the sender that minted the row being marked,
+        # and half of its identity in the fleet-wide ledger store.
+        absorb_reaction_ack(event, agent=agent_name)
         return
 
     # Buffer for a2a_reply / a2a_ack lookups by msg_id.

--- a/src/scitex_agent_container/_network/_peer_dispatch.py
+++ b/src/scitex_agent_container/_network/_peer_dispatch.py
@@ -7,10 +7,21 @@ ledger counterpart). These helpers wrap
 can mint + record + transition a dispatch-ledger row around each
 outbound ``/v1/turn`` POST.
 
-The ledger is OBSERVABILITY, not the dispatch itself: a state.db hiccup
-must never sink a real send. Every helper here therefore catches + logs
-loudly (never silent) instead of letting a ledger write raise into the
-transport path.
+The ledger is OBSERVABILITY, not the dispatch itself: a store hiccup must
+never sink a real send. Every helper here therefore catches + logs loudly
+(never silent) instead of letting a ledger write raise into the transport
+path.
+
+THESE TWO HELPERS STAMP THE OWNING AGENT, and that is why they are the only
+place ``agent=`` appears on the peer path (2026-08-28, when the ledger moved
+to the fleet-wide PostgreSQL store). The ledger used to live in a PER-AGENT
+``state.db``, so the file named its owner; one shared table does not, and a
+row with no owner is returned to every agent that asks. The owner of a row
+this client writes is always THIS process, so resolving it once here — rather
+than threading it through ``peer.post_turn_to_url``'s nine call sites — keeps
+the record and the eight status updates provably in agreement about which key
+they are addressing. Getting that wrong is not an error, it is a status
+update that silently matches nothing.
 """
 
 from __future__ import annotations
@@ -36,11 +47,16 @@ def self_agent_name() -> str | None:
 def record_dispatch_safe(**kwargs: Any) -> str | None:
     """Record a dispatch-ledger row, returning the id (or None on failure).
 
-    Catches + logs (never raises) so a state.db hiccup cannot break the
-    actual dispatch — a broken ledger stays visible in the logs.
+    Stamps ``agent`` — the OWNING agent, this container — unless the caller
+    named one explicitly. Distinct from ``from_agent``, which the caller may
+    override to a third party and which is legitimately ``None``.
+
+    Catches + logs (never raises) so a store hiccup cannot break the actual
+    dispatch — a broken ledger stays visible in the logs.
     """
     from .._state.dispatch_ledger import record_dispatch
 
+    kwargs.setdefault("agent", self_agent_name())
     try:
         return record_dispatch(**kwargs)
     except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a DB write failure must not break the actual dispatch — logged loudly, never silent)
@@ -49,13 +65,17 @@ def record_dispatch_safe(**kwargs: Any) -> str | None:
 
 
 def update_dispatch_safe(dispatch_id: str | None, status: str) -> None:
-    """Update a dispatch-ledger row's status; log (never raise) on failure."""
+    """Update a dispatch-ledger row's status; log (never raise) on failure.
+
+    Addresses the row by the SAME owner :func:`record_dispatch_safe` stamped,
+    from the same resolver, so the two cannot disagree about the key.
+    """
     if dispatch_id is None:
         return
     from .._state.dispatch_ledger import update_dispatch_status
 
     try:
-        update_dispatch_status(dispatch_id, status)
+        update_dispatch_status(dispatch_id, status, agent=self_agent_name())
     except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a status-update failure must not break the dispatch — logged loudly, never silent)
         log.warning("dispatch-ledger status update failed: %s", exc)
 

--- a/src/scitex_agent_container/_network/peer.py
+++ b/src/scitex_agent_container/_network/peer.py
@@ -220,7 +220,9 @@ def post_turn(
 
     Records a dispatch-ledger row with ``to_agent=agent_name`` so a later
     ``list_dispatches(to_agent=...)`` can recall every turn sent to a
-    given agent.
+    given agent. Pair it with ``agent=`` — the ledger is one fleet-wide
+    table since 2026-08-28, so an unscoped recall answers for every agent
+    on every host, not just this one.
     """
     url = resolve_peer_url(agent_name)
     return post_turn_to_url(

--- a/src/scitex_agent_container/_state/dispatch_ledger.py
+++ b/src/scitex_agent_container/_state/dispatch_ledger.py
@@ -1,65 +1,87 @@
-"""Dispatch ledger — one row per OUTBOUND dispatch (2026-05-22).
+"""Dispatch ledger — one row per OUTBOUND dispatch (2026-05-22), on
+PostgreSQL only.
 
-Every dispatched turn/message gets a stable ``dispatch_id`` (uuid4 hex)
-minted at the sender side and persisted here, so dispatches can be
-filtered and recalled later ("which conversation did this belong to?").
+Every dispatched turn/message gets a stable ``dispatch_id`` (uuid4 hex) minted
+at the sender side and persisted here, so dispatches can be filtered and
+recalled later ("which conversation did this belong to?"). It is the
+sender-side half of the push-feedback architecture; :mod:`.inbound_ledger` is
+the receiver-side mirror. A row is the identity of one outbound *send action*,
+which is why the id is orthogonal to the a2a ``conversation_id`` (many
+messages), the a2a ``message_id`` (one message) and the receiver-side
+``turn_id`` (the diary's ``turns`` store, on per-host PostgreSQL since
+2026-08-28, which tracks the ``/v1/turn`` state machine).
 
-This is the dispatch-ledger piece of the push-feedback architecture.
+WHY THIS MODULE NO LONGER TOUCHES SQLite
+========================================
+The operator's 2026-08-19 order was to eradicate SQLite and move to
+PostgreSQL: "fail fast, fail loud, no fallbacks". This table moves the way
+every predecessor did — by ADOPTING :mod:`scitex_dev.store` rather than by sac
+growing a private psycopg layer. ``db_path`` IS GONE from every function; it
+named a SQLite file and there is no file. A host whose PostgreSQL is
+unreachable raises ``StoreTargetError`` naming the DSN, which is intended: a
+ledger written to a private local file nobody reads is worse than no ledger.
 
-A ``dispatch_id`` is orthogonal to the other ids already in the system:
+THE DEFECT THAT HAD TO BE FIXED FIRST, in one line: ``state.db`` was PER-AGENT
+and ``SCITEX_STORE_DSN`` is FLEET-WIDE, so the shard that used to do the
+scoping disappears and an unfiltered read starts answering for 130+ agents
+without raising anything. The fix is an OWNING-AGENT field in the store
+identity — ``agent``, distinct from the nullable ``from_agent`` — and the
+whole argument lives in :mod:`.dispatch_ledger_store`, next to the schema that
+implements it. Read that before changing this file's read surface.
 
-  * the a2a ``conversation_id`` correlates many messages in one
-    conversation,
-  * the a2a ``message_id`` identifies one message,
-  * the receiver-side ``turn_id`` (``state_db.turns``) tracks the
-    ``/v1/turn`` state machine.
+``update_dispatch_status`` IS O(1) WHEN TOLD THE OWNER AND O(n) WHEN NOT.
+``agent=`` there is a FAST PATH, NOT A FILTER: the identity is a pair, so a
+caller that names the owner gets a keyed write, and one that does not — or one
+whose idea of the owner disagrees with the writer's — falls back to a scan for
+the unique ``dispatch_id`` and still finds the row. Making it a filter instead
+was tried first and lost a status update silently; :func:`_find_row` carries
+the measurement. The OWNING AGENT SCOPES READS, which is where the fleet-wide
+leak lives, and is not a permission check on a write.
 
-The ledger row is the identity of one outbound *send action*. One
-conversation produces many dispatches. The optional ``conversation_id``
-column lets a later query group dispatches back into a conversation.
+NOTHING IS MIGRATED IN FROM THE 130+ SQLite SHARDS, deliberately. A dispatch
+row records a send that already happened; the recall and comm-miss surfaces
+that read it have no production callers, and a comm-miss report is only
+actionable inside its SLO window (seconds to minutes), so importing history
+would import noise. The old files stay on disk, readable with any sqlite3
+client, for anyone who wants them.
 
-Why a NEW module + NEW table (not an addition to ``state_db.py``):
-a sibling branch is concurrently restructuring the heartbeat code in
-``state_db.py`` (adding a heartbeats module + a seq migration). Keeping
-the ledger table + its ``CREATE TABLE IF NOT EXISTS`` here, behind its
-own :func:`init_ledger_schema`, means the two branches never touch the
-same lines. If a future sequence-numbered migration registry collides
-at merge it is a trivial renumber.
-
-The connection itself comes from :func:`state_db.open_db` (shared WAL +
-busy-timeout + foreign-keys config); we only ensure our own table exists
-on top of the state_db tables.
-
-All times are stored as ``REAL`` unix-seconds (float), matching the
-diary tables in :mod:`state_db_diary`.
+All times are unix-seconds (float), matching the diary tables.
 """
 
 from __future__ import annotations
 
-import sqlite3
 import time
 import uuid
-from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
-# Bound on the inline message summary so a runaway dispatch can't bloat
-# state.db. Matches the diary tables' "first ~500 chars" convention.
+from .dispatch_ledger_store import (
+    IDENTITY_FIELDS,
+    STORE_NAME,
+    dispatch_store_target,
+    open_dispatch_store,
+    sorted_values,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Row, Store
+
+# Bound on the inline message summary so a runaway dispatch can't bloat the
+# ledger. Matches the diary tables' "first ~500 chars" convention.
 _TEXT_SUMMARY_LIMIT = 500
 
-# Valid lifecycle statuses. ``sent`` is the mint-time value; the others
-# are terminal observations the sender can record once the round-trip
-# resolves. Kept as a tuple (not an enum) so the column stays free-form
-# TEXT and a richer state machine can push new values without a
-# migration. ``record_dispatch`` validates against this set so a typo
-# fails loudly instead of silently writing an unqueryable status.
+# Valid lifecycle statuses. ``sent`` is the mint-time value; the others are
+# terminal observations the sender records once the round-trip resolves. Kept
+# as a tuple (not an enum) so the field stays free-form TEXT and a richer
+# state machine can push new values without a migration. ``record_dispatch``
+# validates against this set so a typo fails loudly instead of silently
+# writing an unqueryable status.
 STATUS_SENT = "sent"
 STATUS_DELIVERED = "delivered"
-# STATUS_REACTED — the receiver's channel adapter posted a structural
-# reaction ack back to the sender (👀 marker). Distinct from
-# ``delivered`` (which is the listen-server publish HTTP 200 — does NOT
-# prove the recipient's adapter actually picked up the event). REACTED
-# is the operator's "comm-miss detectable" signal: absence of a reacted
-# row within the SLO = the recipient never injected the message.
-# See ``feat/comm-reaction-ack`` PR and lead a2a 1781e82a (2026-06-14).
+# STATUS_REACTED — the receiver's channel adapter posted a structural reaction
+# ack back to the sender (👀 marker). Distinct from ``delivered`` (the listen
+# server's publish HTTP 200, which does NOT prove the recipient's adapter
+# picked the event up): REACTED is the operator's "comm-miss detectable"
+# signal. See lead a2a 1781e82a (2026-06-14).
 STATUS_REACTED = "reacted"
 STATUS_TIMEOUT = "timeout"
 STATUS_FAILED = "failed"
@@ -71,22 +93,25 @@ VALID_STATUSES = (
     STATUS_FAILED,
 )
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS dispatches (
-    dispatch_id      TEXT PRIMARY KEY,
-    from_agent       TEXT,
-    to_agent         TEXT,
-    conversation_id  TEXT,
-    text_summary     TEXT,
-    status           TEXT NOT NULL,
-    ts               REAL NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_dispatches_from ON dispatches(from_agent, ts);
-CREATE INDEX IF NOT EXISTS idx_dispatches_to ON dispatches(to_agent, ts);
-CREATE INDEX IF NOT EXISTS idx_dispatches_status ON dispatches(status, ts);
-CREATE INDEX IF NOT EXISTS idx_dispatches_conversation
-    ON dispatches(conversation_id, ts);
-"""
+__all__ = [
+    "IDENTITY_FIELDS",
+    "STATUS_DELIVERED",
+    "STATUS_FAILED",
+    "STATUS_REACTED",
+    "STATUS_SENT",
+    "STATUS_TIMEOUT",
+    "STORE_NAME",
+    "VALID_STATUSES",
+    "dispatch_store_target",
+    "init_ledger_schema",
+    "list_dispatches",
+    "list_unreacted_dispatches",
+    "mark_dispatch_reacted",
+    "new_dispatch_id",
+    "open_dispatch_store",
+    "record_dispatch",
+    "update_dispatch_status",
+]
 
 
 def new_dispatch_id() -> str:
@@ -102,26 +127,19 @@ def _clip(text: str | None, limit: int = _TEXT_SUMMARY_LIMIT) -> str | None:
     return text[:limit]
 
 
-def init_ledger_schema(db_path: Path | None = None) -> Path:
-    """Create the ``dispatches`` table if missing. Idempotent.
+def init_ledger_schema() -> str:
+    """Create the ledger tables if missing. Idempotent.
 
-    Returns the resolved database path. Delegates the base schema +
-    connection config to :func:`state_db.open_db`, then layers our own
-    ``CREATE TABLE IF NOT EXISTS`` so the ledger lives in the same
-    ``state.db`` file as the registry and diary tables.
+    Returns the resolved store LOCATOR as a string — the PostgreSQL equivalent
+    of the ``Path`` the SQLite version returned, and useful the same way: it
+    NAMES where the state actually went, so an operator can check rather than
+    assume.
     """
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
-    from .state_db import init_schema
-
-    return init_schema(db_path)
-
-
-def _ensure_table(conn: sqlite3.Connection) -> None:
-    """Ensure the ledger table exists on an already-open connection."""
-    conn.executescript(_SCHEMA)
+    store = open_dispatch_store()
+    try:
+        return str(dispatch_store_target().locator)
+    finally:
+        store.close()
 
 
 def record_dispatch(
@@ -133,220 +151,233 @@ def record_dispatch(
     status: str = STATUS_SENT,
     dispatch_id: str | None = None,
     ts: float | None = None,
-    db_path: Path | None = None,
+    agent: str | None = None,
 ) -> str:
-    """Insert one ``dispatches`` row. Returns the ``dispatch_id``.
+    """Insert one dispatch row. Returns the ``dispatch_id``.
 
     Mints a uuid4-hex ``dispatch_id`` when none is supplied (the caller
     usually mints it earlier so it can thread the same id onto the wire).
-    ``text`` is the dispatched message body — stored truncated to the
-    first ~500 chars as ``text_summary``.
+    ``text`` is the dispatched message body — stored truncated to the first
+    ~500 chars as ``text_summary``.
 
-    ``status`` must be one of :data:`VALID_STATUSES`; an unknown value
-    raises ``ValueError`` rather than silently writing an unqueryable
-    status (fail loudly, never silently).
+    ``agent`` is the OWNING agent: the process whose ledger this row is, which
+    is NOT the same question as ``from_agent`` (the sender named on the row,
+    and legitimately ``None``). It is what the scoped reads filter on. Omitting
+    it records the row as unowned (``""``), which an unfiltered read still
+    returns and no scoped read does — see :mod:`.dispatch_ledger_store`.
+
+    ``status`` must be one of :data:`VALID_STATUSES`; an unknown value raises
+    ``ValueError`` rather than silently writing an unqueryable status (fail
+    loudly, never silently).
     """
     if status not in VALID_STATUSES:
         raise ValueError(
             f"unknown dispatch status {status!r}; expected one of {VALID_STATUSES}"
         )
+
+    from scitex_dev.store import NEW_RECORD
+
     did = dispatch_id or new_dispatch_id()
     row_ts = float(ts) if ts is not None else time.time()
-
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        conn.execute(
-            """
-            INSERT INTO dispatches (
-                dispatch_id, from_agent, to_agent, conversation_id,
-                text_summary, status, ts
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                did,
-                from_agent,
-                to_agent,
-                conversation_id,
-                _clip(text),
-                status,
-                row_ts,
-            ),
+    store = open_dispatch_store()
+    try:
+        store.put(
+            {
+                "agent": agent or "",
+                "dispatch_id": did,
+                "from_agent": from_agent,
+                "to_agent": to_agent,
+                "conversation_id": conversation_id,
+                "text_summary": _clip(text),
+                "status": status,
+                "ts": row_ts,
+            },
+            expected_revision=NEW_RECORD,
         )
+    finally:
+        store.close()
     return did
+
+
+def _find_row(store: Store, dispatch_id: str, agent: str | None) -> Row | None:
+    """The row for ``dispatch_id``. ``agent`` is a fast path, not a filter.
+
+    A non-empty ``agent`` completes the identity, so it is tried first as a
+    keyed ``get``. ON A MISS THE LEDGER IS STILL SCANNED, and that fallback is
+    not belt-and-braces — MEASURED 2026-08-28, its absence broke
+    ``test_inbound_reaction_updates_dispatch_ledger``:
+
+      * ``_network/_peer_dispatch`` stamps the owner from ``SAC_NAME``;
+      * ``_mcp/channel`` stamps it from ``--name`` or the discovered self
+        spec.
+
+    Two resolvers for the same question. When they disagree — or when a row
+    was written by an ops script with no owner at all and a named agent later
+    absorbs its reaction — a strictly keyed update matches NOTHING, returns
+    ``False``, and the status silently never moves. That failure did not exist
+    before this table was shared, and it must not be introduced by sharing it.
+
+    Resolving by ``dispatch_id`` is exactly the pre-migration semantics and is
+    safe for the same reason it was then: the id is a uuid4 minted by the
+    sender, so it is unique across the shared table and unguessable by anyone
+    who was not told it. THE OWNING AGENT SCOPES READS, which is where the
+    fleet-wide leak lives; it is not a permission check on a write.
+    """
+    if agent:
+        row = store.get({"agent": agent, "dispatch_id": dispatch_id})
+        if row is not None:
+            return row
+    for row in store.rows():
+        if row.values.get("dispatch_id") == dispatch_id:
+            return row
+    return None
 
 
 def update_dispatch_status(
     dispatch_id: str,
     status: str,
     *,
-    db_path: Path | None = None,
+    agent: str | None = None,
 ) -> bool:
-    """Update the ``status`` of an existing dispatch. Returns True iff a row matched.
+    """Update the ``status`` of an existing dispatch. True iff a row matched.
 
-    ``status`` must be one of :data:`VALID_STATUSES`. The ledger row is
-    minted ``sent`` at dispatch time; the sender calls this once the
-    round-trip resolves to ``delivered`` / ``timeout`` / ``failed``.
+    ``status`` must be one of :data:`VALID_STATUSES`. The row is minted
+    ``sent`` at dispatch time; the sender calls this once the round-trip
+    resolves to ``delivered`` / ``timeout`` / ``failed``.
+
+    ``agent`` is the OWNER the row was recorded under, and it is a FAST PATH
+    rather than a filter — pass it and the write is keyed and O(1); omit it,
+    or name an owner the row does not carry, and the ledger is scanned for the
+    uuid4 ``dispatch_id`` instead, which is correct but linear. See
+    :func:`_find_row` for why the miss must fall back rather than report a
+    miss.
+
+    Idempotent: re-writing the same status is accepted, because ``status`` is
+    the one LAST_WRITER_WINS field in the schema. The surrounding IMMUTABLE
+    facts are re-put unchanged, which the store also accepts — measured
+    2026-08-28 against PostgreSQL 16 rather than assumed, because an IMMUTABLE
+    rule that rejected an identical re-write would make every status
+    transition raise.
     """
     if status not in VALID_STATUSES:
         raise ValueError(
             f"unknown dispatch status {status!r}; expected one of {VALID_STATUSES}"
         )
-    from .state_db import open_db
 
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        cur = conn.execute(
-            "UPDATE dispatches SET status=? WHERE dispatch_id=?",
-            (status, dispatch_id),
-        )
-        return cur.rowcount > 0
+    from scitex_dev.store import ANY_REVISION
+
+    store = open_dispatch_store()
+    try:
+        row = _find_row(store, dispatch_id, agent)
+        if row is None:
+            return False
+        values = dict(row.values)
+        values["status"] = status
+        store.put(values, expected_revision=ANY_REVISION)
+        return True
+    finally:
+        store.close()
 
 
-def mark_dispatch_reacted(
-    dispatch_id: str,
-    *,
-    db_path: Path | None = None,
-) -> bool:
-    """Mark a dispatch as REACTED (receiver injected, structural ack received).
+def mark_dispatch_reacted(dispatch_id: str, *, agent: str | None = None) -> bool:
+    """Mark a dispatch REACTED (receiver injected, structural ack received).
 
-    Thin convenience wrapper over :func:`update_dispatch_status` that
-    pins the status to :data:`STATUS_REACTED`. Used by the sender-side
-    channel adapter when it receives a ``kind="reaction"`` envelope
-    whose ``extra.reacted_dispatch_id`` matches an outbound row.
+    Thin wrapper over :func:`update_dispatch_status` pinning the status to
+    :data:`STATUS_REACTED`. Used by the sender-side channel adapter when it
+    receives a ``kind="reaction"`` envelope whose ``extra.reacted_dispatch_id``
+    matches an outbound row.
 
-    Idempotent at the SQL layer (a second call simply re-writes the
-    same status). Returns ``True`` iff a row matched — a ``False``
-    result is the audit signal that the reaction landed for a
-    dispatch this sender never minted (out-of-order replay, wrong
-    sender, or stale ledger).
+    Returns ``True`` iff a row matched — a ``False`` result is the audit signal
+    that the reaction landed for a dispatch this sender never minted
+    (out-of-order replay, wrong sender, or stale ledger).
     """
-    return update_dispatch_status(dispatch_id, STATUS_REACTED, db_path=db_path)
+    return update_dispatch_status(dispatch_id, STATUS_REACTED, agent=agent)
 
 
 def list_unreacted_dispatches(
     *,
     older_than_s: float,
+    agent: Optional[str] = None,
     from_agent: str | None = None,
     to_agent: str | None = None,
-    db_path: Path | None = None,
 ) -> list[dict]:
-    """Return dispatches the receiver has not REACTED to within the SLO.
+    """Dispatches the receiver has not REACTED to within the SLO, newest first.
 
-    "Comm-miss detection" surface (lead a2a 1781e82a, 2026-06-14):
-    structural reaction-ack means the SENDER can poll this helper and
-    see exactly which outbound messages never produced a 👀 from the
-    recipient's channel adapter. Absence of a reaction past
-    ``older_than_s`` seconds = the recipient never injected the
-    message (their adapter is down, disconnected, or wedged).
+    "Comm-miss detection" surface (lead a2a 1781e82a, 2026-06-14): structural
+    reaction-ack means the SENDER can poll this and see exactly which outbound
+    messages never produced a 👀 from the recipient's channel adapter. Absence
+    of a reaction past ``older_than_s`` seconds = the recipient never injected
+    the message (their adapter is down, disconnected, or wedged).
 
-    Filters:
+    ``older_than_s`` (REQUIRED) keeps rows with ``ts <= now - older_than_s``: a
+    freshly-minted dispatch that has not had time to be REACTED yet is NOT a
+    miss, and the SLO is the operator's choice (30s interactive, 5min batch).
+    ``agent`` scopes to the OWNING agent, and THIS SURFACE LEAKS WORST WITHOUT
+    IT — a fleet-wide answer does not merely add noise, it manufactures alerts
+    about peers this agent never dispatched to, and the natural response to one
+    of those is to re-send. ``from_agent`` / ``to_agent`` narrow to one pair.
 
-    * ``older_than_s`` (REQUIRED) — only rows with ``ts <= now -
-      older_than_s`` are returned. A freshly-minted dispatch that has
-      simply not had time to be REACTED yet is NOT a miss; the SLO is
-      the operator's choice (e.g. 30s for interactive, 5min for
-      batch).
-    * ``from_agent`` / ``to_agent`` — narrow to one sender / receiver
-      pair when the caller cares about a specific peer.
-
-    The query excludes terminal-failure rows (``failed``, ``timeout``)
-    — those are *already* known not to have landed and would just be
-    noise in a comm-miss dashboard. ``reacted`` rows are also
-    excluded (they're the success case). Result: ``sent`` and
-    ``delivered`` rows older than the SLO with no reaction.
+    Terminal-failure rows (``failed``, ``timeout``) are excluded — those are
+    ALREADY known not to have landed and would be noise in a comm-miss
+    dashboard. ``reacted`` rows are excluded too (the success case). Result:
+    ``sent`` and ``delivered`` rows older than the SLO with no reaction.
     """
     cutoff = time.time() - float(older_than_s)
-    clauses: list[str] = [
-        "status IN (?, ?)",
-        "ts <= ?",
+    store = open_dispatch_store()
+    try:
+        rows = sorted_values(store.rows())
+    finally:
+        store.close()
+    rows = [
+        r
+        for r in rows
+        if r.get("status") in (STATUS_SENT, STATUS_DELIVERED)
+        and float(r.get("ts") or 0.0) <= cutoff
     ]
-    params: list[object] = [STATUS_SENT, STATUS_DELIVERED, cutoff]
+    if agent is not None:
+        rows = [r for r in rows if r.get("agent") == agent]
     if from_agent is not None:
-        clauses.append("from_agent = ?")
-        params.append(from_agent)
+        rows = [r for r in rows if r.get("from_agent") == from_agent]
     if to_agent is not None:
-        clauses.append("to_agent = ?")
-        params.append(to_agent)
-    where = " WHERE " + " AND ".join(clauses)
-
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        rows = conn.execute(
-            f"SELECT * FROM dispatches{where} ORDER BY ts DESC",
-            tuple(params),
-        ).fetchall()
-        return [dict(r) for r in rows]
+        rows = [r for r in rows if r.get("to_agent") == to_agent]
+    return rows
 
 
 def list_dispatches(
     *,
+    agent: Optional[str] = None,
     from_agent: str | None = None,
     to_agent: str | None = None,
     status: str | None = None,
     conversation_id: str | None = None,
     since: float | None = None,
     limit: int | None = None,
-    db_path: Path | None = None,
 ) -> list[dict]:
     """Return ledger rows matching the filters, newest first.
 
-    Every filter is optional and AND-combined. ``since`` is a unix-second
-    lower bound (``ts >= since``). With no filters, returns the whole
-    ledger (subject to ``limit``). The query is parameterised — no
-    user value is str-formatted into the SQL.
+    Every filter is optional and AND-combined. ``agent`` is the OWNING agent —
+    the one filter that makes this "my dispatches" rather than the fleet's; see
+    :mod:`.dispatch_ledger_store` for why an unfiltered read is still
+    fleet-wide on purpose. ``since`` is a unix-second lower bound
+    (``ts >= since``).
     """
-    clauses: list[str] = []
-    params: list[object] = []
+    store = open_dispatch_store()
+    try:
+        rows = sorted_values(store.rows())
+    finally:
+        store.close()
+    if agent is not None:
+        rows = [r for r in rows if r.get("agent") == agent]
     if from_agent is not None:
-        clauses.append("from_agent = ?")
-        params.append(from_agent)
+        rows = [r for r in rows if r.get("from_agent") == from_agent]
     if to_agent is not None:
-        clauses.append("to_agent = ?")
-        params.append(to_agent)
+        rows = [r for r in rows if r.get("to_agent") == to_agent]
     if status is not None:
-        clauses.append("status = ?")
-        params.append(status)
+        rows = [r for r in rows if r.get("status") == status]
     if conversation_id is not None:
-        clauses.append("conversation_id = ?")
-        params.append(conversation_id)
+        rows = [r for r in rows if r.get("conversation_id") == conversation_id]
     if since is not None:
-        clauses.append("ts >= ?")
-        params.append(float(since))
-
-    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
-    limit_sql = ""
+        rows = [r for r in rows if float(r.get("ts") or 0.0) >= float(since)]
     if limit is not None:
-        limit_sql = " LIMIT ?"
-        params.append(int(limit))
-
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        _ensure_table(conn)
-        rows = conn.execute(
-            f"SELECT * FROM dispatches{where} ORDER BY ts DESC{limit_sql}",
-            tuple(params),
-        ).fetchall()
-        return [dict(r) for r in rows]
-
-
-__all__ = [
-    "STATUS_DELIVERED",
-    "STATUS_FAILED",
-    "STATUS_REACTED",
-    "STATUS_SENT",
-    "STATUS_TIMEOUT",
-    "VALID_STATUSES",
-    "init_ledger_schema",
-    "list_dispatches",
-    "list_unreacted_dispatches",
-    "mark_dispatch_reacted",
-    "new_dispatch_id",
-    "record_dispatch",
-    "update_dispatch_status",
-]
+        rows = rows[: int(limit)]
+    return rows

--- a/src/scitex_agent_container/_state/dispatch_ledger_store.py
+++ b/src/scitex_agent_container/_state/dispatch_ledger_store.py
@@ -1,0 +1,213 @@
+"""Store plumbing for the dispatch ledger — schema, target, ordering.
+
+Extracted from :mod:`.dispatch_ledger` so that module stays under the per-file
+line cap, exactly as :mod:`.state_db_grants` was extracted from
+:mod:`.state_db_nodes`. Everything public here is re-exported from
+``dispatch_ledger``, so the existing import surface is unchanged.
+
+This file holds the two decisions the port turned on — WHAT the identity is,
+and WHAT ORDER rows come back in — and the reasoning for each. The verbs that
+use them live next door.
+
+WHOSE LEDGER IS THIS: THE DEFECT THAT HAD TO BE FIXED BEFORE THE MOVE
+=====================================================================
+The two backends have OPPOSITE shapes and a naive port silently joins them:
+
+  * ``state.db`` was PER-AGENT. Every agent had its own SQLite file, so
+    ``list_dispatches()`` with no filters meant "my dispatches" — the SHARD
+    did the scoping and no code had to.
+  * ``SCITEX_STORE_DSN`` is FLEET-WIDE. ``runtimes/_fleet_env`` injects ONE
+    value into every container and ``scitex_dev.store`` resolves it first, so
+    130+ per-agent shards collapse into ONE ``dispatches_rows`` table.
+
+Ported as-is, ``list_dispatches()`` would hand the WHOLE FLEET's outbound
+traffic to whoever asked, and ``list_unreacted_dispatches()`` would report
+every other agent's comm-misses as this agent's own. NOTHING WOULD RAISE — no
+column missing, no query failing, no store unreachable. The answers just
+quietly become wrong, in the direction of "there is much more traffic than I
+sent", which reads as data rather than as a bug.
+
+``from_agent`` looks like the owner and is not. It names the SENDER of one
+message, and it is explicitly NULLABLE — a script driving ``post_turn``
+outside an agent container has no ``SAC_NAME``, which
+``test_record_dispatch_allows_null_agents`` has pinned as legal since 2026-05.
+A NULL owner is unfilterable by construction: in a per-agent shard that row is
+still findable because the FILE named its owner; in one shared table it
+belongs to nobody and is returned to everybody.
+
+So the schema below adds ``agent`` — the OWNING agent, the process whose
+ledger the row is — in the store IDENTITY, exactly where
+:mod:`.inbound_ledger` put its own ``agent`` one table earlier. Identity is
+``(agent, dispatch_id)``.
+
+``agent=""`` IS A REAL VALUE, NOT A MISSING ONE. Store IDENTITY fields must be
+present and the ops-script case has no owner to name, so it records ``""`` —
+"this dispatch belongs to no agent". That row is returned by an UNFILTERED
+``list_dispatches()`` and by NO scoped one, which is right both ways: it is
+nobody's, so it leaks to nobody. The unfiltered read stays fleet-wide
+deliberately — ``list_inbound(agent=None)`` in the mirror module behaves the
+same way, and the fix is not to make an unfiltered read lie but to give a
+caller a way to ask for their own.
+
+THE COST OF EVERY READ IS O(n), STATED RATHER THAN HIDDEN
+=========================================================
+``Store`` exposes ``get``/``put``/``rows``, not SQL — no WHERE clause and no
+index to lean on — so every listing materialises the whole ledger and filters
+in Python where the old module pushed four indexes at SQLite. That is a REAL
+regression, and this is the worst table for it so far: it grows by one row per
+a2a message per agent, fleet-wide, where ``verdict_delivered`` grew by a
+handful a day. Two things keep it acceptable and neither is permanent — the
+ledger starts EMPTY (nothing is migrated in from the old shards) and both list
+functions are observability surfaces with zero production callers. The WRITE
+path stays O(1): a keyed ``get``/``put``, never a scan. If
+``list_unreacted_dispatches`` ever becomes a polled dashboard it wants an
+indexed query — recorded so a future reader finds a decision, not a surprise.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Row, Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "dispatches"
+
+#: Every write is attributed to one actor in the oplog.
+ACTOR = "scitex-agent-container"
+
+#: The identity fields, in order. ``agent`` FIRST because it is the scope: a
+#: reader asks "mine?" before it asks "which one?".
+IDENTITY_FIELDS = ("agent", "dispatch_id")
+
+__all__ = [
+    "ACTOR",
+    "IDENTITY_FIELDS",
+    "STORE_NAME",
+    "dispatch_store_target",
+    "open_dispatch_store",
+    "sorted_values",
+]
+
+
+def _ident(kind: Any) -> Any:
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.IDENTITY,
+        required=True,
+        merge=MergeRule.IMMUTABLE,
+        indexed=False,
+    )
+
+
+def _fact(kind: Any, *, required: bool = False) -> Any:
+    """A field describing a send that already happened — IMMUTABLE.
+
+    No merge may rewrite who sent what to whom, or when. ``ts`` in particular
+    ORDERS the ledger; a rule that could move it would silently reorder
+    history.
+    """
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.DATA,
+        required=required,
+        merge=MergeRule.IMMUTABLE,
+        indexed=False,
+    )
+
+
+def _moving(kind: Any) -> Any:
+    """``status`` is the ONLY field that moves: sent -> delivered/reacted/…"""
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.DATA,
+        required=True,
+        merge=MergeRule.LAST_WRITER_WINS,
+        indexed=False,
+    )
+
+
+def _schema() -> Any:
+    """The dispatch-ledger schema.
+
+    Built lazily so importing this module does not import scitex-dev; the old
+    module was equally lazy about ``state_db``, for the same reason.
+    """
+    from scitex_dev.store import FieldKind, Schema
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "agent": _ident(FieldKind.TEXT),
+            "dispatch_id": _ident(FieldKind.TEXT),
+            "from_agent": _fact(FieldKind.TEXT),
+            "to_agent": _fact(FieldKind.TEXT),
+            "conversation_id": _fact(FieldKind.TEXT),
+            "text_summary": _fact(FieldKind.TEXT),
+            "status": _moving(FieldKind.TEXT),
+            "ts": _fact(FieldKind.REAL, required=True),
+        },
+    )
+
+
+def dispatch_store_target() -> Any:
+    """Resolve WHERE the dispatch ledger lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_dispatch_store() -> Store:
+    """Open the ledger. RAISES if PostgreSQL is unreachable.
+
+    The caller owns closing it. Every public verb opens and closes one per
+    call, mirroring the old ``with open_db(...)`` shape.
+
+    MULTI_WRITER, and this is where the fleet-wide DSN changes the honest
+    answer rather than merely the scale. Under a per-agent SQLite file exactly
+    one process ever wrote a row; under one shared table every agent on every
+    host writes into it, so the ownership check SINGLE_WRITER runs would refuse
+    legitimate writes from the second host onward.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        dispatch_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.MULTI_WRITER,
+        actor=ACTOR,
+    )
+
+
+def _row_sort_key(row: Row) -> tuple:
+    """Ledger order, made TOTAL. :func:`sorted_values` reverses it.
+
+    ``ts`` preserves the old ``ORDER BY ts DESC``. The hybrid logical clock
+    breaks ties, because two agents on two hosts can mint the same float
+    instant and wall-clock alone would order them by whichever machine's clock
+    ran fast; ``node`` is the final tiebreak, since two origins can produce the
+    same (wall_us, logical) pair.
+    """
+    hlc = row.hlc
+    return (float(row.values.get("ts") or 0.0), hlc.wall_us, hlc.logical, hlc.node)
+
+
+def sorted_values(rows: list[Row]) -> list[dict[str, Any]]:
+    """Row values as plain dicts, newest first.
+
+    ``Store.rows()`` is NOT ordered, so this is not decoration: without it the
+    "newest first" every caller's docstring promises would be whatever order
+    PostgreSQL happened to return.
+    """
+    return [dict(row.values) for row in sorted(rows, key=_row_sort_key, reverse=True)]

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -171,10 +171,23 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         "scitex_agent_container/_maintenance/_venv_dist_assertion.py:120",
         "scitex_agent_container/_mcp/_channel_post_deliver.py:120",
         "scitex_agent_container/_mcp/_channel_post_deliver.py:99",
-        "scitex_agent_container/_mcp/_channel_reaction_ack.py:107",
-        "scitex_agent_container/_mcp/channel.py:329",
-        "scitex_agent_container/_network/_peer_dispatch.py:46",
-        "scitex_agent_container/_network/_peer_dispatch.py:59",
+        # THESE FOUR MOVED, they did not change. The dispatch-ledger port to
+        # PostgreSQL (2026-08-28) added prose above each of them, so the
+        # coordinates shifted 107->115, 329->331, 46->62 and 59->79. The
+        # `stx-allow` reasons themselves are byte-for-byte the ones frozen
+        # before, and no new unnamed claim was introduced.
+        #
+        # RE-PINNED RATHER THAN CLOSED, deliberately. Closing one means
+        # writing a path into the comment, and this file's own docstring says
+        # a plausible path that nothing writes to is WORSE than the honest
+        # unnamed claim, because it buys a green check. These four log through
+        # `logging.getLogger(__name__)`; where that lands for a container
+        # agent is a survey nobody has done, so naming it here would be a
+        # guess wearing a receipt.
+        "scitex_agent_container/_mcp/_channel_reaction_ack.py:115",
+        "scitex_agent_container/_mcp/channel.py:331",
+        "scitex_agent_container/_network/_peer_dispatch.py:62",
+        "scitex_agent_container/_network/_peer_dispatch.py:79",
         "scitex_agent_container/_network/probe.py:457",
         "scitex_agent_container/_reconcile/_budget.py:164",
         "scitex_agent_container/_reconcile/_pass.py:370",

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -145,7 +145,21 @@ FROZEN_SQLITE = frozenset(
         # precise failure the "no stale entries" test exists to catch, so it
         # would have failed loudly rather than rotted. Expect more of these as
         # the migration lands; take both removals.
-        "_state/dispatch_ledger.py",
+        #
+        # _state/dispatch_ledger.py LEFT THIS SET 2026-08-28, and its obstacle
+        # was not a verb or an endpoint but a QUESTION THE TABLE COULD NOT
+        # ANSWER: whose dispatch is this. state.db was PER-AGENT, so the shard
+        # did the scoping and no column had to; SCITEX_STORE_DSN is FLEET-WIDE,
+        # so a naive port collapsed 130+ shards into one table where
+        # list_dispatches() answered for the whole fleet and
+        # list_unreacted_dispatches() reported everyone else's comm-misses as
+        # yours. Nothing would have raised. from_agent could not stand in for
+        # the owner — it names the SENDER of one message and is explicitly
+        # nullable — so the port added `agent` to the store IDENTITY, the shape
+        # inbound_ledger had already needed one table earlier. Its four readers
+        # (_network/_peer_dispatch, _mcp/_channel_tools, _mcp/
+        # _channel_reaction_ack and _mcp/channel) moved in the SAME PR: a
+        # half-moved table is a split brain that also raises nothing.
         # _state/inbound_ledger.py LEFT THIS SET 2026-08-20 — the FOURTH table
         # to move to PostgreSQL. Its obstacle was neither a missing verb nor a
         # missing endpoint but an AUTOINCREMENT id that looked public: returned

--- a/tests/scitex_agent_container/_mcp/test__channel_reaction_ack.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_reaction_ack.py
@@ -14,8 +14,8 @@ Three surfaces are covered, no mocks / monkeypatch on production:
 
 3. Sender-side absorption — :func:`absorb_reaction_ack` walks the
    envelope and flips the dispatch-ledger row to ``STATUS_REACTED``.
-   Real sqlite under ``tmp_path`` via the same env-fixture pattern
-   the ledger tests use.
+   Real PostgreSQL via the shared ``pg_schema`` fixture, the same seam
+   the ledger tests use since that table moved off SQLite.
 
 Operator mandate (lead a2a ``1781e82a``, 2026-06-14): structural
 reaction so absence = comm miss, detectable.
@@ -23,10 +23,8 @@ reaction so absence = comm miss, detectable.
 
 from __future__ import annotations
 
-import importlib
 import json
 import os
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -320,27 +318,7 @@ async def test_post_reaction_ack_marks_envelope_with_ack_loop_guard(fake_listen)
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def db_path(tmp_path: Path):
-    # Arrange — isolated state.db via env, mirroring the ledger tests.
-    p = tmp_path / "state.db"
-    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
-    saved = os.environ.get(key)
-    os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
-
-    importlib.reload(mod)
-    try:
-        yield p
-    finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
-        importlib.reload(mod)
-
-
-def test_absorb_reaction_ack_flips_ledger_to_reacted(db_path: Path):
+def test_absorb_reaction_ack_flips_ledger_to_reacted(pg_schema: str):
     # Arrange — record a dispatch, simulate the receiver's 👀 landing.
     from scitex_agent_container._state.dispatch_ledger import (
         STATUS_REACTED,
@@ -362,7 +340,7 @@ def test_absorb_reaction_ack_flips_ledger_to_reacted(db_path: Path):
     assert rows[0]["status"] == STATUS_REACTED
 
 
-def test_absorb_reaction_ack_returns_true_on_match(db_path: Path):
+def test_absorb_reaction_ack_returns_true_on_match(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import record_dispatch
 
@@ -378,7 +356,7 @@ def test_absorb_reaction_ack_returns_true_on_match(db_path: Path):
     assert matched is True
 
 
-def test_absorb_reaction_ack_returns_false_on_non_reaction_event(db_path: Path):
+def test_absorb_reaction_ack_returns_false_on_non_reaction_event(pg_schema: str):
     # Arrange — a regular inbound message should never touch the
     # ledger. Returning False is the audit signal.
     event = {
@@ -392,7 +370,7 @@ def test_absorb_reaction_ack_returns_false_on_non_reaction_event(db_path: Path):
     assert matched is False
 
 
-def test_absorb_reaction_ack_returns_false_without_dispatch_id(db_path: Path):
+def test_absorb_reaction_ack_returns_false_without_dispatch_id(pg_schema: str):
     # Arrange — legacy senders that never minted a ledger row are
     # not a failure; they're a no-op (deliberate, not silent).
     event: dict[str, Any] = {"from_agent": "bob", "kind": "reaction"}
@@ -402,7 +380,7 @@ def test_absorb_reaction_ack_returns_false_without_dispatch_id(db_path: Path):
     assert matched is False
 
 
-def test_absorb_reaction_ack_is_idempotent_on_double_delivery(db_path: Path):
+def test_absorb_reaction_ack_is_idempotent_on_double_delivery(pg_schema: str):
     # Arrange — a retried receipt must not corrupt the row.
     from scitex_agent_container._state.dispatch_ledger import (
         STATUS_REACTED,
@@ -429,7 +407,7 @@ def test_absorb_reaction_ack_is_idempotent_on_double_delivery(db_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_comm_miss_detected_when_receipt_never_lands(db_path: Path):
+def test_comm_miss_detected_when_receipt_never_lands(pg_schema: str):
     # Arrange — sender records a dispatch but the receiver never
     # reacts (their adapter is down).
     import time
@@ -451,7 +429,7 @@ def test_comm_miss_detected_when_receipt_never_lands(db_path: Path):
     assert len(rows) == 1
 
 
-def test_comm_miss_cleared_after_reaction_lands(db_path: Path):
+def test_comm_miss_cleared_after_reaction_lands(pg_schema: str):
     # Arrange — same dispatch, but the receipt landed via absorption.
     import time
 

--- a/tests/scitex_agent_container/_mcp/test_channel_reaction_ack_e2e.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_reaction_ack_e2e.py
@@ -24,9 +24,7 @@ Conventions: AAA markers, one assert per test (STX-TQ007); no mocks
 from __future__ import annotations
 
 import contextlib
-import importlib
 import os
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -76,26 +74,6 @@ def _env(name: str, value: str | None):
             os.environ.pop(name, None)
         else:
             os.environ[name] = prior
-
-
-@pytest.fixture
-def db_path(tmp_path: Path):
-    """Isolated state.db for dispatch-ledger writes during absorption."""
-    p = tmp_path / "state.db"
-    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
-    saved = os.environ.get(key)
-    os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
-
-    importlib.reload(mod)
-    try:
-        yield p
-    finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
-        importlib.reload(mod)
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +258,7 @@ async def test_inbound_reaction_does_not_post_reaction_back(fake_listen):
 
 
 @pytest.mark.asyncio
-async def test_inbound_reaction_updates_dispatch_ledger(fake_listen, db_path: Path):
+async def test_inbound_reaction_updates_dispatch_ledger(fake_listen, pg_schema: str):
     """End-to-end: alice previously sent a message, bob's adapter posts
     a structural reaction back; alice's adapter absorbs it and the
     ledger row flips to REACTED."""

--- a/tests/scitex_agent_container/_mcp/test_channel_tools_dispatch_ledger.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_tools_dispatch_ledger.py
@@ -6,9 +6,16 @@ agent, to_agent=target, conversation_id), stamps the id into the
 A2A ``params.metadata``, then transitions the row to ``delivered`` /
 ``failed`` on the send outcome.
 
+``a2a_send`` also stamps ``agent="alice"`` — the OWNING agent — since the
+ledger moved to the fleet-wide PostgreSQL store on 2026-08-28. It happens to
+equal ``from_agent`` here, which is why one test below asserts the two
+SEPARATELY rather than treating either as evidence of the other.
+
 No mocks: the ``a2a_send`` tool POSTs to ``{listen_url}/agents/<target>
 /message:send`` over real httpx; a real loopback ``http.server`` stands
-in for ``sac listen`` and captures the wire body. The mcp ``server`` is
+in for ``sac listen`` and captures the wire body. The ledger lives in a real,
+throwaway PostgreSQL schema (the ``pg_schema`` fixture) — ``db_path`` is gone,
+because it named a SQLite file and there is no file. The mcp ``server`` is
 a tiny hand-rolled recorder exposing only the two decorator methods
 ``register_tools`` uses (``list_tools`` / ``call_tool``) — a real
 collaborator object, not a Mock.
@@ -20,34 +27,9 @@ from __future__ import annotations
 
 import asyncio
 import http.server
-import importlib
 import json
-import os
 import socket
 import threading
-from pathlib import Path
-
-import pytest
-
-
-@pytest.fixture
-def db_path(tmp_path: Path):
-    """Isolated state.db, exported via env (explicit save/restore, no mock)."""
-    p = tmp_path / "state.db"
-    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
-    saved = os.environ.get(key)
-    os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
-
-    importlib.reload(mod)
-    try:
-        yield p
-    finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
-        importlib.reload(mod)
 
 
 class _ToolRecorder:
@@ -123,7 +105,7 @@ def _invoke_a2a_send(listen_url: str, target: str, content: str):
 # ---------------------------------------------------------------------------
 
 
-def test_a2a_send_records_ledger_row_from_this_agent(db_path: Path):
+def test_a2a_send_records_ledger_row_from_this_agent(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -140,7 +122,32 @@ def test_a2a_send_records_ledger_row_from_this_agent(db_path: Path):
     assert rows[0]["from_agent"] == "alice"
 
 
-def test_a2a_send_records_target_as_to_agent(db_path: Path):
+def test_a2a_send_scopes_the_row_to_this_agent(pg_schema: str):
+    # Arrange — a FOREIGN row is planted first, and it is what makes this test
+    # able to fail: with only alice's own row present, an unscoped read and a
+    # scoped one return the same single row and the assertion proves nothing.
+    # Measured — without the foreign row this test passes even with the
+    # owning-agent filter deleted from list_dispatches.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(agent="carol", from_agent="carol", to_agent="dave", text="theirs")
+    server, thread, port = _start_listen_stub(200, [])
+    try:
+        # Act
+        _invoke_a2a_send(f"http://127.0.0.1:{port}", "bob", "hi")
+        rows = list_dispatches(agent="alice")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert [r["to_agent"] for r in rows] == ["bob"]
+
+
+def test_a2a_send_records_target_as_to_agent(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -157,7 +164,7 @@ def test_a2a_send_records_target_as_to_agent(db_path: Path):
     assert rows[0]["to_agent"] == "bob"
 
 
-def test_a2a_send_marks_clean_send_delivered(db_path: Path):
+def test_a2a_send_marks_clean_send_delivered(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -174,7 +181,7 @@ def test_a2a_send_marks_clean_send_delivered(db_path: Path):
     assert rows[0]["status"] == "delivered"
 
 
-def test_a2a_send_stamps_dispatch_id_into_metadata(db_path: Path):
+def test_a2a_send_stamps_dispatch_id_into_metadata(pg_schema: str):
     # Arrange — capture the A2A envelope so we can read params.metadata.
     captured: list[dict] = []
     server, thread, port = _start_listen_stub(200, captured)
@@ -189,7 +196,7 @@ def test_a2a_send_stamps_dispatch_id_into_metadata(db_path: Path):
     assert len(captured[0]["params"]["metadata"]["dispatch_id"]) == 32
 
 
-def test_a2a_send_wire_dispatch_id_matches_ledger_row(db_path: Path):
+def test_a2a_send_wire_dispatch_id_matches_ledger_row(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -212,7 +219,7 @@ def test_a2a_send_wire_dispatch_id_matches_ledger_row(db_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_a2a_send_marks_server_error_failed(db_path: Path):
+def test_a2a_send_marks_server_error_failed(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 

--- a/tests/scitex_agent_container/_network/test_peer_dispatch_ledger.py
+++ b/tests/scitex_agent_container/_network/test_peer_dispatch_ledger.py
@@ -4,10 +4,15 @@
 the POST, stamps the id into the request body, and transitions the row
 to ``delivered`` / ``timeout`` / ``failed`` once the round-trip resolves.
 
-No mocks: a real ``http.server`` on loopback mimics ``/v1/turn`` and the
-real ``state.db`` lives under ``tmp_path`` (isolated via env). The stub
-server captures the request body so we can assert the dispatch_id was
+No mocks: a real ``http.server`` on loopback mimics ``/v1/turn`` and the ledger
+lives in a real, throwaway PostgreSQL schema (the ``pg_schema`` fixture). The
+stub server captures the request body so we can assert the dispatch_id was
 actually put on the wire.
+
+``db_path`` is gone — it named a SQLite file and there is no file. The reads
+below stay UNFILTERED on purpose: what they check is that the peer client
+wrote a row at all and moved its status, not whose it is; the owning-agent
+scoping has its own module, ``_state/test_dispatch_ledger_fleet_scope.py``.
 
 Conventions: AAA markers, one assertion per test (STX-TQ).
 """
@@ -15,36 +20,11 @@ Conventions: AAA markers, one assertion per test (STX-TQ).
 from __future__ import annotations
 
 import http.server
-import importlib
 import json
-import os
 import socket
 import threading
-from pathlib import Path
-
-import pytest
 
 from scitex_agent_container._network.peer import PeerError, post_turn_to_url
-
-
-@pytest.fixture
-def db_path(tmp_path: Path):
-    """Isolated state.db, exported via env (explicit save/restore, no mock)."""
-    p = tmp_path / "state.db"
-    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
-    saved = os.environ.get(key)
-    os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
-
-    importlib.reload(mod)
-    try:
-        yield p
-    finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
-        importlib.reload(mod)
 
 
 def _free_port() -> int:
@@ -102,7 +82,7 @@ def _error_handler(status: int):
 # ---------------------------------------------------------------------------
 
 
-def test_post_turn_records_ledger_row_to_agent(db_path: Path):
+def test_post_turn_records_ledger_row_to_agent(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -121,7 +101,7 @@ def test_post_turn_records_ledger_row_to_agent(db_path: Path):
     assert rows[0]["to_agent"] == "bob"
 
 
-def test_post_turn_marks_clean_roundtrip_delivered(db_path: Path):
+def test_post_turn_marks_clean_roundtrip_delivered(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -138,7 +118,7 @@ def test_post_turn_marks_clean_roundtrip_delivered(db_path: Path):
     assert rows[0]["status"] == "delivered"
 
 
-def test_post_turn_stamps_dispatch_id_into_request_body(db_path: Path):
+def test_post_turn_stamps_dispatch_id_into_request_body(pg_schema: str):
     # Arrange — the stub captures the wire body so we can assert the id
     # was actually sent (receiver-side correlation).
     captured: list[dict] = []
@@ -154,7 +134,7 @@ def test_post_turn_stamps_dispatch_id_into_request_body(db_path: Path):
     assert len(captured[0]["dispatch_id"]) == 32
 
 
-def test_post_turn_wire_dispatch_id_matches_ledger_row(db_path: Path):
+def test_post_turn_wire_dispatch_id_matches_ledger_row(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -177,7 +157,7 @@ def test_post_turn_wire_dispatch_id_matches_ledger_row(db_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_post_turn_marks_http_error_failed(db_path: Path):
+def test_post_turn_marks_http_error_failed(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -198,7 +178,7 @@ def test_post_turn_marks_http_error_failed(db_path: Path):
     assert rows[0]["status"] == "failed"
 
 
-def test_post_turn_marks_unreachable_failed(db_path: Path):
+def test_post_turn_marks_unreachable_failed(pg_schema: str):
     # Arrange — port 1 on loopback is unrouteable → URLError → failed.
     from scitex_agent_container._state.dispatch_ledger import list_dispatches
 
@@ -213,7 +193,7 @@ def test_post_turn_marks_unreachable_failed(db_path: Path):
     assert rows[0]["status"] == "failed"
 
 
-def test_post_turn_still_returns_reply_when_ledger_records(db_path: Path):
+def test_post_turn_still_returns_reply_when_ledger_records(pg_schema: str):
     # Arrange — the dispatch itself must succeed regardless of ledger.
     server, thread, port = _start_server(_echo_handler([]))
     try:

--- a/tests/scitex_agent_container/_state/test_dispatch_ledger.py
+++ b/tests/scitex_agent_container/_state/test_dispatch_ledger.py
@@ -1,76 +1,87 @@
-"""Tests for the dispatch ledger (2026-05-22).
+"""Tests for the dispatch ledger (2026-05-22), on PostgreSQL since 2026-08-28.
 
-Every outbound dispatch gets a stable ``dispatch_id`` minted at the
-sender and persisted to ``state.db.dispatches`` so dispatches can be
-filtered + recalled later.
+Every outbound dispatch gets a stable ``dispatch_id`` minted at the sender and
+persisted to the ``dispatches`` store so dispatches can be filtered and
+recalled later.
+
+``db_path`` IS GONE from every call. It named a SQLite file and there is no
+file; every test that used to thread ``tmp_path / "state.db"`` now takes
+``pg_schema`` instead, which is the seam keeping one test's rows out of
+another's — and out of the live fleet store.
+
+THE ONE TEST THAT CHANGED SHAPE rather than just its fixture is the schema
+one. It used to open ``state.db`` with ``sqlite3`` and look for a table named
+``dispatches`` in ``sqlite_master``; there is no file to open, so it now reads
+the tables PostgreSQL actually holds through a SECOND, INDEPENDENT client —
+raw psycopg, plain SQL. Asking the store whether its own write landed cannot
+distinguish "wrote to PostgreSQL" from "wrote somewhere else", which is
+exactly how a store can look healthy while sharing nothing.
 
 Conventions (mirroring test_state_db_turns_errors_heartbeats.py):
 
-  * One assertion per test (STX-TQ007); related invariants collapse
-    into ``pytest.parametrize``.
+  * One assertion per test (STX-TQ007); related invariants collapse into
+    ``pytest.parametrize``.
   * AAA markers (Arrange / Act / Assert).
-  * No mocks / monkeypatch (STX-NM); real sqlite under ``tmp_path``,
-    isolated via the ``db_path`` env fixture.
+  * No mocks / monkeypatch (STX-NM); a real PostgreSQL schema per test.
 """
 
 from __future__ import annotations
 
-import importlib
-import os
-import sqlite3
-from pathlib import Path
-
+import psycopg
 import pytest
 
+from tests._store_isolation import PG_BASE_DSN as _BASE_DSN
+from tests._store_isolation import pg_endpoint_port
 
-@pytest.fixture
-def db_path(tmp_path: Path):
-    """Isolated state.db location, exported via env so callers pick it up.
 
-    Explicit env save/restore (no monkeypatch fixture, PA-306).
-    """
-    p = tmp_path / "state.db"
-    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
-    saved = os.environ.get(key)
-    os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
-
-    importlib.reload(mod)
-    try:
-        yield p
-    finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
-        importlib.reload(mod)
+def _tables_in(schema: str) -> set[str]:
+    """The table names PostgreSQL actually holds in ``schema``."""
+    with psycopg.connect(_BASE_DSN, connect_timeout=10, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
+            (schema,),
+        ).fetchall()
+    return {r[0] for r in rows}
 
 
 # ---------------------------------------------------------------------------
-# Schema — the dispatches table is created on first use.
+# Schema — the dispatches store is created on first use.
 # ---------------------------------------------------------------------------
 
 
-def test_init_ledger_schema_creates_dispatches_table(db_path: Path):
+def test_init_ledger_schema_creates_the_dispatches_store_in_postgres(pg_schema: str):
+    """POSITIVE CONTROL for every test below — read by an independent client."""
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import init_ledger_schema
 
+    expected = "dispatches_rows"
     # Act
     init_ledger_schema()
-    with sqlite3.connect(db_path) as conn:
-        names = {
-            r[0]
-            for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
-        }
     # Assert
-    assert "dispatches" in names
+    assert expected in _tables_in(pg_schema)
 
 
-def test_record_dispatch_creates_table_lazily_without_explicit_init(db_path: Path):
-    # Arrange — never call init_ledger_schema; record_dispatch must
-    # ensure the table itself.
+def test_init_ledger_schema_reports_where_the_state_went(pg_schema: str):
+    """The return value NAMES the target, so a caller can check it.
+
+    The SQLite version returned a Path for the same reason. A store that
+    cannot say where it is is a store nobody can verify.
+    """
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import init_ledger_schema
+
+    expected_fragment = pg_endpoint_port()
+    # Act
+    locator = init_ledger_schema()
+    # Assert
+    assert expected_fragment in locator
+
+
+def test_record_dispatch_creates_the_store_lazily_without_explicit_init(
+    pg_schema: str,
+):
+    # Arrange — never call init_ledger_schema; record_dispatch must ensure the
+    # store itself.
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
         record_dispatch,
@@ -109,11 +120,11 @@ def test_new_dispatch_id_is_unique_across_calls():
 
 
 # ---------------------------------------------------------------------------
-# Round-trip — record_dispatch writes a row SELECT can recover.
+# Round-trip — record_dispatch writes a row a read can recover.
 # ---------------------------------------------------------------------------
 
 
-def test_record_dispatch_returns_the_minted_id(db_path: Path):
+def test_record_dispatch_returns_the_minted_id(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import record_dispatch
 
@@ -123,7 +134,7 @@ def test_record_dispatch_returns_the_minted_id(db_path: Path):
     assert len(did) == 32
 
 
-def test_record_dispatch_honours_supplied_id(db_path: Path):
+def test_record_dispatch_honours_supplied_id(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import record_dispatch
 
@@ -135,7 +146,7 @@ def test_record_dispatch_honours_supplied_id(db_path: Path):
     assert did == "deadbeef"
 
 
-def test_record_dispatch_round_trips_to_agent(db_path: Path):
+def test_record_dispatch_round_trips_to_agent(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -149,7 +160,7 @@ def test_record_dispatch_round_trips_to_agent(db_path: Path):
     assert rows[0]["to_agent"] == "bob"
 
 
-def test_record_dispatch_round_trips_conversation_id(db_path: Path):
+def test_record_dispatch_round_trips_conversation_id(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -163,7 +174,37 @@ def test_record_dispatch_round_trips_conversation_id(db_path: Path):
     assert rows[0]["conversation_id"] == "conv-7"
 
 
-def test_record_dispatch_defaults_status_to_sent(db_path: Path):
+def test_record_dispatch_round_trips_the_owning_agent(pg_schema: str):
+    # Arrange — the field the fleet-wide store needed; see the module
+    # docstring of _state/dispatch_ledger_store.py.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(agent="owner-1", from_agent="a", to_agent="b", text="hi")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["agent"] == "owner-1"
+
+
+def test_record_dispatch_without_an_owner_records_it_unowned(pg_schema: str):
+    # Arrange — an ops script outside a container has no owner to name. Store
+    # IDENTITY fields must be present, so "" is what "nobody's" looks like.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="hi")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["agent"] == ""
+
+
+def test_record_dispatch_defaults_status_to_sent(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         STATUS_SENT,
@@ -178,7 +219,7 @@ def test_record_dispatch_defaults_status_to_sent(db_path: Path):
     assert rows[0]["status"] == STATUS_SENT
 
 
-def test_record_dispatch_allows_null_agents(db_path: Path):
+def test_record_dispatch_allows_null_agents(pg_schema: str):
     # Arrange — a script driving post_turn outside an agent has no
     # SAC_NAME; the ledger row must still record (from_agent=None).
     from scitex_agent_container._state.dispatch_ledger import (
@@ -198,7 +239,7 @@ def test_record_dispatch_allows_null_agents(db_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_record_dispatch_truncates_long_text_summary(db_path: Path):
+def test_record_dispatch_truncates_long_text_summary(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -212,7 +253,7 @@ def test_record_dispatch_truncates_long_text_summary(db_path: Path):
     assert len(rows[0]["text_summary"]) == 500
 
 
-def test_record_dispatch_keeps_short_text_intact(db_path: Path):
+def test_record_dispatch_keeps_short_text_intact(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -231,7 +272,7 @@ def test_record_dispatch_keeps_short_text_intact(db_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_record_dispatch_rejects_unknown_status(db_path: Path):
+def test_record_dispatch_rejects_unknown_status(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import record_dispatch
 
@@ -242,7 +283,7 @@ def test_record_dispatch_rejects_unknown_status(db_path: Path):
         record_dispatch(from_agent="a", to_agent="b", text="hi", status="bogus")
 
 
-def test_update_dispatch_status_rejects_unknown_status(db_path: Path):
+def test_update_dispatch_status_rejects_unknown_status(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         record_dispatch,
@@ -266,7 +307,7 @@ def test_update_dispatch_status_rejects_unknown_status(db_path: Path):
     "terminal",
     ["delivered", "timeout", "failed"],
 )
-def test_update_dispatch_status_transitions_to_terminal(db_path: Path, terminal: str):
+def test_update_dispatch_status_transitions_to_terminal(pg_schema: str, terminal: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -282,7 +323,44 @@ def test_update_dispatch_status_transitions_to_terminal(db_path: Path, terminal:
     assert rows[0]["status"] == terminal
 
 
-def test_update_dispatch_status_returns_true_on_match(db_path: Path):
+def test_update_dispatch_status_keyed_by_owner_transitions_the_row(pg_schema: str):
+    # Arrange — the O(1) path: the caller names the owner, so the update is a
+    # keyed write rather than a scan.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+        update_dispatch_status,
+    )
+
+    did = record_dispatch(agent="owner-1", from_agent="a", to_agent="b", text="hi")
+    update_dispatch_status(did, "delivered", agent="owner-1")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == "delivered"
+
+
+def test_update_dispatch_status_finds_an_owned_row_without_being_told_the_owner(
+    pg_schema: str,
+):
+    # Arrange — the O(n) path. It must NOT guess the unowned key: a row owned
+    # by "owner-1" would then silently match nothing and the status would
+    # never move, with no error anywhere.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+        update_dispatch_status,
+    )
+
+    did = record_dispatch(agent="owner-1", from_agent="a", to_agent="b", text="hi")
+    update_dispatch_status(did, "delivered")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == "delivered"
+
+
+def test_update_dispatch_status_returns_true_on_match(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         record_dispatch,
@@ -296,7 +374,7 @@ def test_update_dispatch_status_returns_true_on_match(db_path: Path):
     assert matched is True
 
 
-def test_update_dispatch_status_returns_false_on_missing_row(db_path: Path):
+def test_update_dispatch_status_returns_false_on_missing_row(pg_schema: str):
     # Arrange — no row with this id exists.
     from scitex_agent_container._state.dispatch_ledger import update_dispatch_status
 
@@ -306,12 +384,63 @@ def test_update_dispatch_status_returns_false_on_missing_row(db_path: Path):
     assert matched is False
 
 
+def test_update_dispatch_status_falls_back_when_the_named_owner_is_wrong(
+    pg_schema: str,
+):
+    """A disagreement about "who am I" must not silently lose the update.
+
+    ``agent=`` is a FAST PATH, not a filter. Two production resolvers answer
+    this question — ``SAC_NAME`` on the peer client, ``--name`` or the
+    discovered self spec in the MCP channel — so a keyed miss is a reachable
+    state, and the pre-migration behaviour (find the row by its unique uuid4)
+    is what must survive. Written as its own test because the strict version
+    passed every unit test here and only failed end-to-end, in
+    ``test_inbound_reaction_updates_dispatch_ledger``.
+    """
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+        update_dispatch_status,
+    )
+
+    did = record_dispatch(agent="owner-1", from_agent="a", to_agent="b", text="hi")
+    update_dispatch_status(did, "delivered", agent="owner-2")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == "delivered"
+
+
+def test_update_dispatch_status_does_not_invent_an_owner_for_the_row(pg_schema: str):
+    """The fallback finds the row; it must not RE-KEY it under the caller.
+
+    ``agent`` is IMMUTABLE and half the identity, so a fallback that wrote the
+    caller's name instead of the row's would silently move somebody's dispatch
+    into somebody else's recall — the exact leak this port closed, arriving
+    through the write path instead.
+    """
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+        update_dispatch_status,
+    )
+
+    did = record_dispatch(agent="owner-1", from_agent="a", to_agent="b", text="hi")
+    update_dispatch_status(did, "delivered", agent="owner-2")
+    # Act
+    rows = list_dispatches(agent="owner-1")
+    # Assert
+    assert [r["dispatch_id"] for r in rows] == [did]
+
+
 # ---------------------------------------------------------------------------
 # Query filters — from / to / status / conversation / since / limit.
 # ---------------------------------------------------------------------------
 
 
-def test_list_dispatches_filter_by_from_agent(db_path: Path):
+def test_list_dispatches_filter_by_from_agent(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -327,7 +456,7 @@ def test_list_dispatches_filter_by_from_agent(db_path: Path):
     assert {r["text_summary"] for r in rows} == {"1", "3"}
 
 
-def test_list_dispatches_filter_by_to_agent(db_path: Path):
+def test_list_dispatches_filter_by_to_agent(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -342,7 +471,7 @@ def test_list_dispatches_filter_by_to_agent(db_path: Path):
     assert [r["text_summary"] for r in rows] == ["1"]
 
 
-def test_list_dispatches_filter_by_status(db_path: Path):
+def test_list_dispatches_filter_by_status(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -357,7 +486,7 @@ def test_list_dispatches_filter_by_status(db_path: Path):
     assert [r["text_summary"] for r in rows] == ["2"]
 
 
-def test_list_dispatches_filter_by_conversation_id(db_path: Path):
+def test_list_dispatches_filter_by_conversation_id(pg_schema: str):
     # Arrange — "which dispatches belonged to this conversation?"
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -373,7 +502,7 @@ def test_list_dispatches_filter_by_conversation_id(db_path: Path):
     assert {r["text_summary"] for r in rows} == {"1", "3"}
 
 
-def test_list_dispatches_filter_by_since(db_path: Path):
+def test_list_dispatches_filter_by_since(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -388,7 +517,7 @@ def test_list_dispatches_filter_by_since(db_path: Path):
     assert [r["text_summary"] for r in rows] == ["new"]
 
 
-def test_list_dispatches_combined_filters_are_anded(db_path: Path):
+def test_list_dispatches_combined_filters_are_anded(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -404,8 +533,9 @@ def test_list_dispatches_combined_filters_are_anded(db_path: Path):
     assert [r["text_summary"] for r in rows] == ["hit"]
 
 
-def test_list_dispatches_orders_newest_first(db_path: Path):
-    # Arrange
+def test_list_dispatches_orders_newest_first(pg_schema: str):
+    # Arrange — `Store.rows()` is NOT ordered, so this pins the sort rather
+    # than whatever order PostgreSQL happened to return.
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
         record_dispatch,
@@ -419,7 +549,7 @@ def test_list_dispatches_orders_newest_first(db_path: Path):
     assert [r["text_summary"] for r in rows] == ["second", "first"]
 
 
-def test_list_dispatches_respects_limit(db_path: Path):
+def test_list_dispatches_respects_limit(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,
@@ -434,7 +564,7 @@ def test_list_dispatches_respects_limit(db_path: Path):
     assert len(rows) == 2
 
 
-def test_list_dispatches_empty_when_no_match(db_path: Path):
+def test_list_dispatches_empty_when_no_match(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         list_dispatches,

--- a/tests/scitex_agent_container/_state/test_dispatch_ledger_fleet_scope.py
+++ b/tests/scitex_agent_container/_state/test_dispatch_ledger_fleet_scope.py
@@ -1,0 +1,236 @@
+"""Two agents, ONE store: a dispatch read must answer for the reader only.
+
+These four tests were written on branch ``claude/wf_53dfcc82-70b-4`` as a
+SPECIFICATION, before the ledger moved. Three of them were RED, all stopping
+in the ARRANGE with ``TypeError: record_dispatch() got an unexpected keyword
+argument 'agent'``; the fourth was a positive control that passed. The port
+that moved ``dispatches`` onto ``scitex_dev.store`` added the field they
+demanded, so all four are green here — with the same assertions, which is the
+only way that means anything.
+
+THE DEFECT THEY PIN
+===================
+The two backends have opposite shapes and the migration joins them:
+
+  * ``state.db`` was PER-AGENT. Every agent got its own SQLite file, so
+    ``list_dispatches()`` with no filters meant "my dispatches" — the SHARD
+    did the scoping, and no code had to.
+  * ``SCITEX_STORE_DSN`` is FLEET-WIDE. ``runtimes/_fleet_env.py`` injects one
+    value into every container and ``scitex_dev.store`` resolves it first. One
+    endpoint, one ``dispatches_rows`` table, every agent writing into it.
+
+Ported as-is, 130+ per-agent shards become ONE shared table with no ownership
+column. ``list_dispatches()`` then returns the WHOLE FLEET's outbound traffic
+to whoever asks, and ``list_unreacted_dispatches()`` reports every other
+agent's comm-misses as this agent's own. NOTHING RAISES. No column is missing,
+no query errors, no store is unreachable — the answers just quietly become
+wrong, and wrong in the direction of "there is much more traffic than I sent",
+which reads as data rather than as a bug.
+
+WHY THE EXISTING COLUMNS CANNOT DO IT
+=====================================
+``from_agent`` looks like the owner and is not:
+
+  * it is the SENDER of one message. The ledger row is the identity of one
+    outbound SEND ACTION, and the process that owns the ledger is not always
+    the one named in the row.
+  * it is EXPLICITLY NULLABLE, and that is a supported case with a test of its
+    own beside this file — ``test_record_dispatch_allows_null_agents``, whose
+    docstring states the reason: "a script driving post_turn outside an agent
+    has no SAC_NAME". ``_network/_peer_dispatch.self_agent_name`` returns
+    ``None`` there and the row records ``from_agent=None``.
+
+A NULL owner is unfilterable by construction. In a per-agent shard that row is
+still findable, because the FILE names its owner; in one shared table it
+belongs to nobody and is returned to everybody. So the fix could not be
+"filter on ``from_agent``" — the field is the wrong thing and is allowed to be
+absent.
+
+THE SHAPE THAT WAS COPIED
+=========================
+``_state/inbound_ledger.py`` — the receiver-side mirror of this same ledger —
+hit this exact problem when it moved (the FOURTH table to move) and solved it
+by carrying the owner in the store IDENTITY: ``agent`` is the first of its
+``IDENTITY_FIELDS``, it is ``required=True`` / ``MergeRule.IMMUTABLE``,
+``record_inbound`` refuses an empty one, and its production reader
+``claim_oldest_pending(*, agent)`` cannot be called without it. That is the
+shape these tests asked ``dispatch_ledger`` for, and what it now has:
+``IDENTITY_FIELDS = ("agent", "dispatch_id")``. The kwarg is spelled ``agent``
+for that reason and no other.
+
+WHAT ONE SHARED STORE MEANS NOW
+===============================
+The original fixture pointed BOTH agents at a SINGLE ``state.db``, to
+reproduce in SQLite the condition the migration was about to create. It is no
+longer a reproduction: ``pg_schema`` gives the test one real PostgreSQL store,
+which is literally the post-migration shape, and the module resolves it
+itself. The test bodies are unchanged, exactly as that branch predicted —
+"after the move the same calls address the shared PostgreSQL store and must
+still answer with one agent's rows".
+
+WHAT THESE TESTS DO NOT PROVE
+=============================
+They do not prove a leak ever happened in production. Measured across ``src/``
+before they were written: ``list_dispatches`` and ``list_unreacted_dispatches``
+have ZERO production callers — they are the documented recall / comm-miss READ
+surface (``_network/peer.py`` names ``list_dispatches(to_agent=...)`` in prose)
+exercised by tests. The leak was LATENT: it would have arrived with the port,
+not before it. That is the argument for pinning it in the same PR rather than
+after, and it is also why this was a blocker and not an incident.
+
+They also say nothing about the WRITE path. ``record_dispatch`` /
+``update_dispatch_status`` key on a uuid4 ``dispatch_id``, which stays unique
+across a shared table, so writes do not collide. Only the reads leaked.
+
+Conventions, matching the two ``test_dispatch_ledger*`` modules beside this
+one: AAA markers (STX-TQ002), one assertion per test (STX-TQ007), no mocks and
+no monkeypatch (PA-306 / STX-NM002) — a real PostgreSQL schema per test.
+"""
+
+from __future__ import annotations
+
+import time
+
+#: One agent's identity, and another's. Two names, ONE store — the whole point.
+AGENT_A = "agent-alpha"
+AGENT_B = "agent-beta"
+
+#: Comfortably older than the SLO used below, so a recorded row is already
+#: "stale" the moment it lands and ``list_unreacted_dispatches`` considers it.
+_SLO_S = 30.0
+_WELL_PAST_SLO_S = 600.0
+
+
+# ---------------------------------------------------------------------------
+# POSITIVE CONTROL — the fixture works, and the leak is visible without it.
+# ---------------------------------------------------------------------------
+
+
+def test_one_shared_store_returns_both_agents_dispatches(pg_schema: str):
+    """The control that makes the other three trustworthy.
+
+    Two things a reader cannot otherwise tell apart:
+
+      * the three tests below pass because the OWNING-AGENT FIELD EXISTS, not
+        because the fixture silently wrote nothing. A control that failed
+        would mean the fixture, not the ledger.
+      * an UNFILTERED read over a shared ledger legally sees the WHOLE ledger,
+        which is what ``list_inbound(agent=None)`` does in the already-migrated
+        mirror module. The fix was never to make the unfiltered read lie; it
+        was to give callers a way to ask for their own.
+
+    Written with the pre-migration spelling on purpose — no ``agent`` kwarg
+    anywhere — so it also pins that omitting the owner stays legal.
+    """
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent=AGENT_A, to_agent="peer-x", text="mine")
+    record_dispatch(from_agent=AGENT_B, to_agent="peer-y", text="theirs")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# list_dispatches — the recall surface.
+# ---------------------------------------------------------------------------
+
+
+def test_list_dispatches_returns_only_the_owning_agents_rows(pg_schema: str):
+    """Two agents, one store: alpha's recall must not contain beta's send.
+
+    The assertion is an EQUALITY on the id list, not a membership test, so it
+    fails both ways it can be wrong — a missing own row and a leaked foreign
+    one. A filter that returned nothing would satisfy "no leak" and is not
+    what is being asked for.
+    """
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    mine = record_dispatch(
+        agent=AGENT_A, from_agent=AGENT_A, to_agent="peer-x", text="mine"
+    )
+    record_dispatch(agent=AGENT_B, from_agent=AGENT_B, to_agent="peer-y", text="theirs")
+    # Act
+    rows = list_dispatches(agent=AGENT_A)
+    # Assert
+    assert [row["dispatch_id"] for row in rows] == [mine]
+
+
+# ---------------------------------------------------------------------------
+# list_unreacted_dispatches — the comm-miss surface.
+# ---------------------------------------------------------------------------
+
+
+def test_list_unreacted_dispatches_returns_only_the_owning_agents_rows(
+    pg_schema: str,
+):
+    """A comm-miss report must not accuse this agent of the fleet's misses.
+
+    This surface leaks worse than plain recall. Its documented use is "absence
+    of a reaction past the SLO = the recipient never injected the message", so
+    a fleet-wide answer does not merely add noise — it manufactures alerts
+    about peers this agent never dispatched to, and the natural response to
+    one of those is to re-send.
+
+    Both rows are backdated well past the SLO so staleness cannot be what
+    separates them; only ownership can.
+    """
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_unreacted_dispatches,
+        record_dispatch,
+    )
+
+    stale_ts = time.time() - _WELL_PAST_SLO_S
+    mine = record_dispatch(
+        agent=AGENT_A, from_agent=AGENT_A, to_agent="peer-x", text="mine", ts=stale_ts
+    )
+    record_dispatch(
+        agent=AGENT_B, from_agent=AGENT_B, to_agent="peer-y", text="theirs", ts=stale_ts
+    )
+    # Act
+    rows = list_unreacted_dispatches(older_than_s=_SLO_S, agent=AGENT_A)
+    # Assert
+    assert [row["dispatch_id"] for row in rows] == [mine]
+
+
+# ---------------------------------------------------------------------------
+# The anonymous row — why from_agent cannot be the discriminator.
+# ---------------------------------------------------------------------------
+
+
+def test_an_anonymous_dispatch_does_not_leak_to_another_agent(pg_schema: str):
+    """``from_agent=None`` is supported, so ownership must live elsewhere.
+
+    Alpha records the supported anonymous row — the "script driving post_turn
+    outside an agent container" case, which
+    ``test_record_dispatch_allows_null_agents`` beside this file pins as legal.
+    Beta then asks for its own dispatches.
+
+    A ``from_agent``-based filter cannot exclude a NULL sender from beta's
+    answer without also hiding it from alpha's, which is why this test is here
+    and not folded into the first: it fails the obvious cheap fix, on purpose.
+    """
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(agent=AGENT_A, from_agent=None, to_agent=None, text="anonymous")
+    theirs = record_dispatch(
+        agent=AGENT_B, from_agent=AGENT_B, to_agent="peer-y", text="theirs"
+    )
+    # Act
+    rows = list_dispatches(agent=AGENT_B)
+    # Assert
+    assert [row["dispatch_id"] for row in rows] == [theirs]

--- a/tests/scitex_agent_container/_state/test_dispatch_ledger_reaction.py
+++ b/tests/scitex_agent_container/_state/test_dispatch_ledger_reaction.py
@@ -14,40 +14,15 @@ Operator mandate (lead a2a ``1781e82a``): "absence of the reaction
   SLO that have NOT been REACTED — the comm-miss surface. Terminal
   statuses (``reacted``, ``failed``, ``timeout``) are excluded.
 
-Conventions: AAA markers, one assertion per test (STX-TQ007), no
-mocks / no monkeypatch (real sqlite via the ``db_path`` env fixture).
+Conventions: AAA markers, one assertion per test (STX-TQ007), no mocks / no
+monkeypatch. Real PostgreSQL via ``scitex_dev.store``, isolated per test by
+the ``pg_schema`` fixture — ``db_path`` is gone, because it named a SQLite
+file and there is no file.
 """
 
 from __future__ import annotations
 
-import importlib
-import os
 import time
-from pathlib import Path
-
-import pytest
-
-
-@pytest.fixture
-def db_path(tmp_path: Path):
-    # Arrange — isolated state.db, exported via env so the ledger picks
-    # it up. Explicit save/restore (no monkeypatch on production code).
-    p = tmp_path / "state.db"
-    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
-    saved = os.environ.get(key)
-    os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
-
-    importlib.reload(mod)
-    try:
-        yield p
-    finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
-        importlib.reload(mod)
-
 
 # ---------------------------------------------------------------------------
 # STATUS_REACTED is a registered lifecycle status.
@@ -67,7 +42,7 @@ def test_status_reacted_is_registered_as_valid():
     assert is_valid is True
 
 
-def test_record_dispatch_accepts_status_reacted(db_path: Path):
+def test_record_dispatch_accepts_status_reacted(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         STATUS_REACTED,
@@ -92,7 +67,7 @@ def test_record_dispatch_accepts_status_reacted(db_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_mark_dispatch_reacted_flips_status_to_reacted(db_path: Path):
+def test_mark_dispatch_reacted_flips_status_to_reacted(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         STATUS_REACTED,
@@ -109,7 +84,7 @@ def test_mark_dispatch_reacted_flips_status_to_reacted(db_path: Path):
     assert rows[0]["status"] == STATUS_REACTED
 
 
-def test_mark_dispatch_reacted_returns_true_on_match(db_path: Path):
+def test_mark_dispatch_reacted_returns_true_on_match(pg_schema: str):
     # Arrange
     from scitex_agent_container._state.dispatch_ledger import (
         mark_dispatch_reacted,
@@ -123,7 +98,7 @@ def test_mark_dispatch_reacted_returns_true_on_match(db_path: Path):
     assert matched is True
 
 
-def test_mark_dispatch_reacted_returns_false_on_unknown_id(db_path: Path):
+def test_mark_dispatch_reacted_returns_false_on_unknown_id(pg_schema: str):
     # Arrange — a reaction lands for a dispatch this sender never
     # minted (out-of-order replay, wrong sender, stale ledger). The
     # return value is the audit signal.
@@ -137,7 +112,7 @@ def test_mark_dispatch_reacted_returns_false_on_unknown_id(db_path: Path):
     assert matched is False
 
 
-def test_mark_dispatch_reacted_is_idempotent(db_path: Path):
+def test_mark_dispatch_reacted_is_idempotent(pg_schema: str):
     # Arrange — a duplicate receipt (network retry) must not corrupt
     # the row. The second call still writes REACTED on REACTED.
     from scitex_agent_container._state.dispatch_ledger import (
@@ -161,7 +136,7 @@ def test_mark_dispatch_reacted_is_idempotent(db_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_list_unreacted_includes_old_sent_rows(db_path: Path):
+def test_list_unreacted_includes_old_sent_rows(pg_schema: str):
     # Arrange — a dispatch minted 60s ago, never REACTED.
     from scitex_agent_container._state.dispatch_ledger import (
         list_unreacted_dispatches,
@@ -180,7 +155,7 @@ def test_list_unreacted_includes_old_sent_rows(db_path: Path):
     assert len(rows) == 1
 
 
-def test_list_unreacted_excludes_fresh_rows_under_slo(db_path: Path):
+def test_list_unreacted_excludes_fresh_rows_under_slo(pg_schema: str):
     # Arrange — a dispatch minted 5s ago is NOT a miss; the receiver
     # has not had time to react yet.
     from scitex_agent_container._state.dispatch_ledger import (
@@ -200,7 +175,7 @@ def test_list_unreacted_excludes_fresh_rows_under_slo(db_path: Path):
     assert rows == []
 
 
-def test_list_unreacted_excludes_reacted_rows(db_path: Path):
+def test_list_unreacted_excludes_reacted_rows(pg_schema: str):
     # Arrange — REACTED is success; it must never appear as a miss.
     from scitex_agent_container._state.dispatch_ledger import (
         list_unreacted_dispatches,
@@ -221,7 +196,7 @@ def test_list_unreacted_excludes_reacted_rows(db_path: Path):
     assert rows == []
 
 
-def test_list_unreacted_excludes_failed_rows(db_path: Path):
+def test_list_unreacted_excludes_failed_rows(pg_schema: str):
     # Arrange — failed rows are ALREADY known not to have landed;
     # surfacing them in comm-miss is noise.
     from scitex_agent_container._state.dispatch_ledger import (
@@ -243,7 +218,7 @@ def test_list_unreacted_excludes_failed_rows(db_path: Path):
     assert rows == []
 
 
-def test_list_unreacted_narrows_by_to_agent(db_path: Path):
+def test_list_unreacted_narrows_by_to_agent(pg_schema: str):
     # Arrange — two stale rows, one to bob, one to carol. Filter to
     # bob only.
     from scitex_agent_container._state.dispatch_ledger import (


### PR DESCRIPTION
Moves the `dispatches` table off `state_db.open_db` onto `scitex_dev.store`,
and fixes the defect that blocked it.

## The defect, which is why this table was still on SQLite

`state.db` is **PER-AGENT**; `SCITEX_STORE_DSN` is **FLEET-WIDE**
(`runtimes/_fleet_env.py` injects one value into every container). Porting the
ledger as-is collapses 130+ per-agent SQLite shards into ONE `dispatches_rows`
table with no ownership column, and then:

* `list_dispatches()` returns the **whole fleet's** outbound traffic to whoever
  asks;
* `list_unreacted_dispatches()` reports every other agent's comm-misses as this
  agent's own — a surface whose documented reading is "the recipient never
  injected the message", so the natural response to a false one is to re-send.

**Nothing raises.** No column missing, no query failing, no store unreachable.
The answers just quietly become wrong, in the direction of "there is much more
traffic than I sent", which reads as data rather than as a bug.

`from_agent` cannot stand in for the owner. It names the SENDER of one message
and is explicitly NULLABLE — a script driving `post_turn` outside a container
has no `SAC_NAME`, which `test_record_dispatch_allows_null_agents` has pinned
as legal since 2026-05. A NULL owner is unfilterable by construction: in a
shard the FILE named the owner; in one table the row belongs to nobody and is
returned to everybody.

So the port adds **`agent` to the store IDENTITY** — `(agent, dispatch_id)` —
the shape `inbound_ledger` already needed one table earlier, and the read
surface scopes on it. `agent=""` is a real value meaning "nobody's": returned
by an unfiltered read and by no scoped one.

## The specification came from #1238, unweakened

Three red tests plus a passing positive control, from branch
`claude/wf_53dfcc82-70b-4`. Carried here as
`tests/.../_state/test_dispatch_ledger_fleet_scope.py` with **the assertions
unchanged**; only the isolation fixture changed, from a shared `state.db` to
`pg_schema` — which is what that branch itself predicted ("after the move the
same calls address the shared PostgreSQL store").

**Control run**: deleting the two owner filters from `list_dispatches` /
`list_unreacted_dispatches` turns exactly those three red again and leaves the
positive control green. The `_channel_tools` scoping test was also strengthened
after the control showed it passed with the filter deleted — it now plants a
foreign row so it can actually fail.

## Every reader moved in this PR

A half-moved table is a split brain that also raises nothing. AST walk over
`ast.Call` matching **both** `ast.Name` and `ast.Attribute` — `open_db` call
sites under `src/`: **52 → 47**, the five that left all in `dispatch_ledger.py`.

| module | change |
| --- | --- |
| `_network/_peer_dispatch` | stamps the owner ONCE from `self_agent_name()`, for both the record and the eight status updates in `peer.post_turn_to_url`, so they cannot disagree about the key |
| `_mcp/_channel_tools` | `agent=agent_name` on record and update |
| `_mcp/_channel_reaction_ack` + `_mcp/channel` | `absorb_reaction_ack(event, agent=agent_name)` |

## `agent=` on the update path is a fast path, not a filter — measured

The strict version (key on `(agent, dispatch_id)`, report a miss) passed every
unit test and failed **end-to-end** in
`test_inbound_reaction_updates_dispatch_ledger`. The peer client resolves its
own name from `SAC_NAME`; the MCP channel resolves it from `--name` or the
discovered self spec. Two resolvers, so a keyed miss is reachable — and it lost
the status update silently, a failure that did not exist before the table was
shared. `_find_row` now falls back to resolving the unique uuid4
`dispatch_id`, which is exactly the pre-migration semantics. Two new tests pin
the fallback and pin that it does not re-key the row under the caller.

## Stated, not hidden: every read is now O(n)

The store has no WHERE clause, so each listing materialises the ledger and
filters in Python where SQLite had four indexes. This is the worst table for
that so far — it grows per a2a message per agent, fleet-wide. What makes it
acceptable is temporary and named as such: the ledger starts **empty** (nothing
is migrated in; the old shards stay on disk and readable with any sqlite3
client) and both list functions have **zero production callers** today. The
write path stays O(1).

## Verification

Against a real PostgreSQL 16 (throwaway cluster; loopback here is a read-only
fleet replica, so `pg_schema` would otherwise skip):

* 104 passed — the ledger, its four readers, and the SQLite freeze gate
* 2205 passed — `tests/scitex_agent_container/{_state,_mcp,_network}` + `tests/develop`
* 2930 passed — `tests/smoke`, `tests/scitex_agent_container/{runtimes,_runners}`

**One pre-existing failure, not from this change**: `test_audit_all_clean`
fails here and fails **identically on a pristine `origin/develop` worktree** —
`audit-cli` cannot find sac's `console_scripts` entry point in the interpreter
running the audit ("the package is very likely not installed in the interpreter
running this audit"). Environment gap; `audit-skills`, `audit-python-apis` and
`audit-project` are all clean.

## Also in here

* `_state/dispatch_ledger_store.py` — schema, target and ordering split out so
  `dispatch_ledger.py` stays under the per-file line cap, the same extraction
  `state_db_grants.py` made from `state_db_nodes.py`. It holds the
  whose-ledger-is-this argument next to the schema that implements it.
* `FROZEN_UNNAMED_CLAIMS` — four entries **re-pinned**, not closed: their lines
  moved under added prose and the claims are byte-for-byte unchanged. Closing
  one means writing a path into the comment, and that gate's own docstring says
  a plausible path nothing writes to is worse than an honest unnamed claim.
* `Store.rows()` is not ordered, so "newest first" is now an explicit sort by
  `ts` with the HLC (`wall_us`, `logical`, `node`) as a total-order tiebreak —
  two agents on two hosts can mint the same float instant.

## Deliberately not done

* **No backfill from the 130+ SQLite shards.** A dispatch row records a send
  that already happened, its readers have no production callers, and a
  comm-miss report is only actionable inside its SLO window, so importing
  history would import noise.
* **No `sac db` / export surface changes.** `dispatches` was never in
  `KNOWN_TABLES`, verified by search rather than assumed.
