### PR TITLE
refactor(state): move node_comms_policy off SQLite, and fix the tests that could not fail

### DIFF
--- a/scripts/migrate_node_comms_policy_to_postgres.py
+++ b/scripts/migrate_node_comms_policy_to_postgres.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``node_comms_policy`` table into PostgreSQL.
+
+Companion to the ``state_db_acl_policy`` port (2026-08-28). The code stopped
+reading SQLite; this moves the rows already there so live ACL policy is not
+stranded in a file nothing opens any more.
+
+THIS IS THE ONE WHERE A MISSED ROW IS A PRIVILEGE CHANGE
+=======================================================
+The diary held history: losing a heartbeat row costs an observation.
+``comms_grants`` held authorisation, and a missed grant DENIES a send.
+``node_comms_policy`` is worse than either, because it fails in BOTH
+directions and one of them is silent:
+
+  * A missing row makes ``read_comms_policy`` return the all-allow defaults,
+    so a capsule authored ``spec.comms.inbound.siblings=deny`` becomes
+    REACHABLE by its siblings. Nothing logs. Nothing 403s. The isolation
+    simply is not there.
+  * A missing row also resolves to NO named group, so an agent whose spec
+    says ``groups: [developer]`` is refused ``host_exec``, ``check_spawn``
+    and agent CRUD — the exact 2026-08-09 escalation, where three agents
+    were denied and spent fifteen minutes reading their own labels.
+
+So run this BEFORE the restart that picks up the new code, and read the
+verify line rather than the exit code.
+
+A DRY RUN IS THE DEFAULT. Pass ``--commit`` to actually write.
+
+RUN IT ON THE HOST, NOT IN A CONTAINER
+======================================
+``default_db_path`` resolves differently in the two places: a container gets
+its own per-agent shard under ``/state/<agent>/state.db``, the host gets
+``~/.scitex/agent-container/runtime/state.db``. This table is the one that
+was MEASURED empty in a container and full on the host (scitex-compute-04,
+2026-08-11), so a container run would migrate nothing and report success.
+
+RUN IT TWICE
+============
+Policy rows are written by a live daemon: every ``agent_start`` upserts one
+through ``persist_acl_policy``. Run it once now, restart so the daemons pick
+up the new code, then run it again to sweep anything the old path wrote in
+between.
+
+WHY IT DOES NOT CALL ``record_comms_policy``
+============================================
+``record_comms_policy`` stamps ``updated_at`` with ``time.time()``. Calling
+it here would rewrite every row's age to the migration moment and destroy
+the only evidence of WHEN a policy last came from a spec — which is what
+``sac agents refresh-acl`` staleness is diagnosed from. It would also run
+the validators against values that are already in the table, so one
+historically out-of-domain row would abort a migration rather than move.
+The rows go through ``Store.put`` with their original stamps intact.
+
+WHAT IT DOES NOT MIGRATE, and why that is correct
+=================================================
+Nothing is skipped, and nothing is retired. The SQLite table had no
+tombstones — a policy was only ever upserted, never deleted — so there is no
+retired history to carry. From here on ``retire_comms_policy`` hides rather
+than deletes, and those retirements stay auditable; this script cannot
+retroactively recover retirements that were never recorded.
+
+IT NEVER TOUCHES THE SQLITE SIDE. The old table is left exactly as found, so
+a re-run is safe and a rollback is "point the code back at SQLite".
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from scitex_agent_container._state.state_db_acl_policy import (  # noqa: E402
+    POLICY_STORE,
+    _open,
+)
+
+TABLE = "node_comms_policy"
+COLUMNS = (
+    "name",
+    "outbound_siblings",
+    "outbound_parent",
+    "inbound_siblings",
+    "inbound_parent",
+    "lineage_group",
+    "may_spawn",
+    "group_name",
+    "group_names",
+    "updated_at",
+)
+
+
+def default_db_path() -> Path:
+    """The host's state.db, or the container's per-agent shard."""
+    env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    if env:
+        return Path(env)
+    return Path.home() / ".scitex" / "agent-container" / "runtime" / "state.db"
+
+
+def _read_rows(db_path: Path) -> list[dict]:
+    """Every policy row in the SQLite table, in rowid (insertion) order.
+
+    Columns are read through ``PRAGMA table_info`` rather than assumed: this
+    table grew ``group_name`` and then ``group_names`` by ALTER TABLE, so a
+    host that never ran those migrations has a narrower table and a literal
+    SELECT of all ten columns would raise instead of migrating what is there.
+    A missing column falls back to the same default its DDL declared.
+    """
+    if not db_path.is_file():
+        return []
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        present = [
+            r["name"] for r in conn.execute(f"PRAGMA table_info({TABLE})")  # noqa: S608
+        ]
+        if not present:
+            return []
+        selected = [c for c in COLUMNS if c in present]
+        cur = conn.execute(
+            f"SELECT {', '.join(selected)} FROM {TABLE} ORDER BY rowid ASC"  # noqa: S608
+        )
+        return [{c: r[c] for c in selected} for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def _record(row: dict) -> dict:
+    """One SQLite row as the store's record, defaults filled for absent cols."""
+    return {
+        "name": str(row["name"]),
+        "outbound_siblings": str(row.get("outbound_siblings") or "allow"),
+        "outbound_parent": str(row.get("outbound_parent") or "allow"),
+        "inbound_siblings": str(row.get("inbound_siblings") or "allow"),
+        "inbound_parent": str(row.get("inbound_parent") or "allow"),
+        "lineage_group": str(row.get("lineage_group") or ""),
+        # SQLite stored 0/1; the store's field is a real BOOL.
+        "may_spawn": bool(row.get("may_spawn", 1)),
+        "group_name": str(row.get("group_name") or ""),
+        "group_names": str(row.get("group_names") or ""),
+        "updated_at": float(row.get("updated_at") or 0.0),
+    }
+
+
+def _migrate(rows: list[dict], commit: bool) -> tuple[int, int]:
+    """Returns ``(written, already_present)``.
+
+    Run-twice safe by READING FIRST: a name already in the store is left
+    exactly as it stands. That direction is deliberate — the store's copy may
+    have been written by a live ``agent_start`` since the first pass, and
+    that copy is NEWER than the SQLite one. Overwriting it would roll a
+    fresh spec back to whatever the abandoned file remembers.
+    """
+    from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
+    if not commit:
+        return (len(rows), 0)
+
+    written = present = 0
+    store = _open()
+    try:
+        for row in rows:
+            key = {"name": str(row["name"])}
+            if store.get(key, include_hidden=True) is not None:
+                present += 1
+                continue
+            try:
+                store.put(_record(row), expected_revision=NEW_RECORD)
+                written += 1
+            except RevisionMismatchError:
+                # Another writer arrived between the read and the put. Not an
+                # error: the record exists, which is the goal.
+                present += 1
+    finally:
+        store.close()
+    return (written, present)
+
+
+def _verify() -> int:
+    """Count what is actually IN the store, by reading it back."""
+    store = _open()
+    try:
+        return len(store.rows(include_hidden=True))
+    finally:
+        store.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="actually write; without it this is a dry run",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="SQLite state.db to read from (default: the host's)",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = args.db_path or default_db_path()
+    print(f"mode:   {'COMMIT' if args.commit else 'DRY RUN'}")
+    print(f"source: {db_path}")
+    print(f"target: {POLICY_STORE}")
+
+    rows = _read_rows(db_path)
+    if not rows:
+        print(f"{TABLE}: 0 rows in SQLite — nothing to move")
+        if args.commit:
+            print(f"verify: {_verify()} record(s) in the store")
+        return 0
+
+    written, present = _migrate(rows, args.commit)
+    if args.commit:
+        print(f"{TABLE}: {written} written, {present} already present")
+        print(f"verify: {_verify()} record(s) in the store (read back)")
+    else:
+        print(f"{TABLE}: {written} rows WOULD move (pass --commit)")
+        for row in rows:
+            groups = row.get("group_names") or row.get("group_name") or "(ungrouped)"
+            print(f"  {row['name']}: groups={groups}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scitex_agent_container/_lifecycle/_rename.py
+++ b/src/scitex_agent_container/_lifecycle/_rename.py
@@ -38,6 +38,7 @@ import shutil
 from pathlib import Path
 from typing import Callable
 
+from .._state.state_db_acl_policy import rename_comms_policy
 from ._rename_cards import CardMigration, CardMigrationError, find_owned_cards
 from ._rename_cards import migrate_cards, undo_migrate_cards
 from ._rename_db import DbUndo, count_rows, rename_rows, undo_rename_rows
@@ -60,6 +61,7 @@ STEP_OVERLAY_DIR = "overlay-dir"
 STEP_RUNTIME_DIR = "runtime-dir"
 STEP_REGISTRY = "registry"
 STEP_STATE_DB = "state-db"
+STEP_ACL = "acl-policy"
 STEP_CARDS = "cards"
 STEP_VERIFY = "verify"
 
@@ -70,6 +72,7 @@ STEPS: tuple[str, ...] = (
     STEP_RUNTIME_DIR,
     STEP_REGISTRY,
     STEP_STATE_DB,
+    STEP_ACL,
     STEP_CARDS,
     STEP_VERIFY,
 )
@@ -136,12 +139,31 @@ def apply_plan(
         db_undo: DbUndo = rename_rows(layout.state_db, old, new)
         undo.append((STEP_STATE_DB, lambda: undo_rename_rows(db_undo)))
 
-        # 7. The board. LAST — see the module docstring.
+        # 7. The ACL policy record — PostgreSQL, so its own step.
+        #
+        # It used to ride along in step 6: ``node_comms_policy.name`` was one
+        # more (table, column) pair in ``NAME_COLUMNS``. The table moved to
+        # PostgreSQL on 2026-08-28 and ``rename_rows`` skips tables absent
+        # from ``sqlite_master``, so leaving it there would have made this a
+        # SILENT no-op — the rename reporting success while the policy stayed
+        # under the old name. The renamed agent then resolves to NO named
+        # group and every authority gate denies it.
+        #
+        # ``name`` is the record IDENTITY in the store, so this is a copy +
+        # retire rather than an update; the inverse is the same verb with the
+        # arguments swapped. It raises rather than degrades when PostgreSQL
+        # is unreachable: half a rename is recoverable, an agent running
+        # under a name no gate has a policy for is not.
+        _step(STEP_ACL)
+        if rename_comms_policy(old=old, new=new):
+            undo.append((STEP_ACL, _undo_acl_policy(old, new)))
+
+        # 8. The board. LAST — see the module docstring.
         _step(STEP_CARDS)
         if plan.cards_enabled:
             _migrate_cards_step(old, new, store, by, undo)
 
-        # 8. Postcondition. "I ran the steps" is not the same claim as "the
+        # 9. Postcondition. "I ran the steps" is not the same claim as "the
         # world is now correct", and this verb exists because the second one
         # is what an operator actually needs. Anything still standing under
         # the old name means a step silently did not take — roll back rather
@@ -246,6 +268,20 @@ def _undo_move(move: Move) -> Callable[[], None]:
     return lambda: _move(Move(move.dst, move.src))
 
 
+def _undo_acl_policy(old: str, new: str) -> Callable[[], None]:
+    """Put the policy record back under ``old``.
+
+    The same verb with the arguments swapped — it copies the values back and
+    retires the name the forward step created, so an unwound rename leaves
+    exactly one live policy, under the name the agent actually has.
+    """
+
+    def _undo() -> None:
+        rename_comms_policy(old=new, new=old)
+
+    return _undo
+
+
 def _rewrite_spec_file(
     spec_path: Path,
     old: str,
@@ -342,6 +378,7 @@ def _rollback_message(
 
 __all__ = [
     "STEPS",
+    "STEP_ACL",
     "STEP_CARDS",
     "STEP_OVERLAY_DIR",
     "STEP_REGISTRY",

--- a/src/scitex_agent_container/_lifecycle/_rename_db.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_db.py
@@ -66,7 +66,14 @@ NAME_COLUMNS: tuple[tuple[str, str], ...] = (
     ("comms_grants", "sender_name"),
     ("comms_grants", "target_name"),
     ("comms_nodes", "name"),
-    ("node_comms_policy", "name"),
+    # ("node_comms_policy", "name") was here until 2026-08-28. That table
+    # moved to PostgreSQL, and leaving the pair would have been WORSE than
+    # a crash: ``rename_rows`` skips tables absent from sqlite_master, so
+    # the rename would have reported success while the policy stayed under
+    # the OLD name. The renamed agent then resolves to NO named group and
+    # every authority gate denies it. The move is done by
+    # ``state_db_acl_policy.rename_comms_policy``, called as its own step
+    # in :mod:`._rename` with its own inverse on the undo stack.
 )
 
 # (table, column) pairs holding a PATH that embeds the agent name as a

--- a/src/scitex_agent_container/_lifecycle/_spawn_gate.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_gate.py
@@ -61,7 +61,7 @@ __all__ = [
 ]
 
 
-def persist_acl_policy(config: Any, db_path: Path | None = None) -> None:
+def persist_acl_policy(config: Any) -> None:
     """Write the loaded spec's Phase-3 ACL policy into ``node_comms_policy``.
 
     Idempotent upsert keyed by ``config.name``. Called from core
@@ -100,7 +100,6 @@ def persist_acl_policy(config: Any, db_path: Path | None = None) -> None:
         may_spawn=lineage.may_spawn,
         group_name=group_name,
         group_names=group_names,
-        db_path=db_path,
     )
 
 

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -217,7 +217,18 @@ def agent_start(
     # becomes live without manual state.db surgery. Defaults preserve
     # pre-Phase-3 behaviour, so an existing YAML with no spec.comms /
     # spec.lineage blocks writes the all-allow / may_spawn=True row.
-    persist_acl_policy(config)
+    #
+    # NOT ON A DRY RUN. This publish was a write to the host's own
+    # state.db, where a dry run doing it was untidy but contained. The
+    # policy now lives in ONE store shared by the whole fleet, so the same
+    # line makes `sac agents start --dry-run` mutate fleet-wide ACL state
+    # for an agent it is not starting -- and makes the dry run fail
+    # outright wherever that store is unreachable, which is how CI found
+    # it: the smoke test drives the real CLI against the isolation DSN and
+    # got `exit=1 ... Cannot connect to Postgres store 'node_comms_policy'`.
+    # A dry run answers "would this start?" and must not write to do it.
+    if not dry_run:
+        persist_acl_policy(config)
 
     # Resolve spec.a2a.port BEFORE the runtime builds argv. ``"auto"``
     # gets a fresh allocator claim; an explicit int is recorded so

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -120,7 +120,7 @@ def check_lineage_acl(
     # delete / status / tail), not just its lineage descendants. Checked
     # before the descendant walk so developer-group CRUD never depends on
     # a lineage edge to the target.
-    if is_developer(name=caller, db_path=db_path):
+    if is_developer(name=caller):
         return ("allow", None)
     from .._state._lineage import descendants_of
 
@@ -138,8 +138,8 @@ def check_lineage_acl(
     # is NOT meshed and stays unmanageable cross-group, preserving the
     # solid isolation scientific rigor requires.
     if groups_mesh(
-        resolve_group_name(name=caller, db_path=db_path),
-        resolve_group_name(name=target, db_path=db_path),
+        resolve_group_name(name=caller),
+        resolve_group_name(name=target),
     ):
         return ("allow", None)
     return (
@@ -328,7 +328,7 @@ def check_send_acl(
     # address every other ``developer``-group agent with no per-pair
     # grant. Additive: an ungrouped fleet shares no named group and
     # falls through to the explicit-grant check below, unchanged.
-    if same_named_group(sender=sender, target=target, db_path=db_path):
+    if same_named_group(sender=sender, target=target):
         return ("allow", None)
 
     # Cross-group mesh (operator 2026-06-27): the three STANDARD fleet
@@ -341,8 +341,8 @@ def check_send_acl(
     # NOT meshed and falls through to the grant check below, preserving
     # the solid isolation scientific rigor requires.
     if groups_mesh(
-        resolve_group_name(name=sender, db_path=db_path),
-        resolve_group_name(name=target, db_path=db_path),
+        resolve_group_name(name=sender),
+        resolve_group_name(name=target),
     ):
         return ("allow", None)
 
@@ -400,7 +400,7 @@ def _phase3_relationship_deny(
     """
     rel = sender_target_relationship(sender=sender, target=target, db_path=db_path)
     if rel in ("parent", "sibling"):
-        sender_policy = read_comms_policy(name=sender, db_path=db_path)
+        sender_policy = read_comms_policy(name=sender)
         if rel == "parent" and sender_policy["outbound_parent"] == "deny":
             return (
                 "deny",
@@ -420,7 +420,7 @@ def _phase3_relationship_deny(
                 ),
             )
     if rel in ("child", "sibling"):
-        target_policy = read_comms_policy(name=target, db_path=db_path)
+        target_policy = read_comms_policy(name=target)
         if rel == "child" and target_policy["inbound_parent"] == "deny":
             return (
                 "deny",
@@ -476,7 +476,7 @@ def check_spawn(
     named-group set, never primary-group equality — see
     :mod:`..._state.state_db_groups` (incident 2026-08-10, grant).
     """
-    if caller and is_developer(name=caller, db_path=db_path):
+    if caller and is_developer(name=caller):
         return ("allow", None)
     allowed, reason = spawn_allowed(caller=caller, db_path=db_path)
     if allowed:

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -67,8 +67,6 @@ from .state_db_migrations import (
     migrate_instance_heartbeats_add_seq,
     migrate_instances_add_family_tree_cols,
     migrate_legacy_heartbeats,
-    migrate_node_comms_policy_add_group_name,
-    migrate_node_comms_policy_add_group_names,
 )
 from .state_db_schema import (
     _SCHEMA_ATTEMPTS,
@@ -102,7 +100,6 @@ KNOWN_TABLES = (
     "lineage",
     "comms_grants",
     "comms_nodes",
-    "node_comms_policy",
     # ``incarnations`` was here until 2026-08-19. It now lives in per-host
     # PostgreSQL via :mod:`.state_db_incarnations`, so it is NOT queryable
     # through `sac db query`. Removed rather than left behind: a whitelisted
@@ -200,14 +197,10 @@ def init_schema(db_path: Path | None = None) -> Path:
         # DB (with the family-tree columns) but is a no-op on an
         # existing one; the migration ADD COLUMNs them onto a pre-cols DB.
         migrate_instances_add_family_tree_cols(conn)
-        # Same idempotent ADD COLUMN for the group-based-ACL ``group_name``
-        # column on a pre-existing ``node_comms_policy`` (operator
-        # 2026-06-25). No-op on a fresh DB (DDL already has the column).
-        migrate_node_comms_policy_add_group_name(conn)
-        # Same idempotent ADD COLUMN for the MULTI-value ``group_names``
-        # column the authority gates read (incident 2026-08-10 — an agent
-        # whose spec lists several groups was reduced to its FIRST one).
-        migrate_node_comms_policy_add_group_names(conn)
+        # The two ``node_comms_policy`` ADD COLUMN migrations ran here
+        # until 2026-08-28. The table moved to PostgreSQL, so both would
+        # now be permanent no-ops against a table SQLite no longer has —
+        # dead code claiming a live purpose. Removed with the DDL.
         conn.executescript(_SCHEMA_ATTEMPTS)
         conn.executescript(_SCHEMA_CHANNEL_AND_ACL)
         # ``turns`` / ``errors`` / ``heartbeats`` were created by the

--- a/src/scitex_agent_container/_state/state_db_acl_policy.py
+++ b/src/scitex_agent_container/_state/state_db_acl_policy.py
@@ -1,81 +1,101 @@
-"""Phase-3 capsule-isolation policy persistence (ADR-0010 Step 2).
+"""Phase-3 capsule-isolation policy — on PostgreSQL only (2026-08-28).
 
-Lives in a sibling module so :mod:`.state_db_nodes` stays under the
-per-file line cap. The functions below are re-exported from
-``state_db_nodes`` so the existing import surface stays:
+The per-agent ACL record :func:`.._listen._acl.check_send_acl` and
+:func:`.._listen._acl.check_spawn` consult on every gated call. Written
+at ``agent_start`` from the loaded ``spec.comms`` / ``spec.lineage``
+blocks (:func:`.._lifecycle._spawn_gate.persist_acl_policy`) and
+re-published by ``sac agents refresh-acl``. The verbs below are
+re-exported from :mod:`.state_db_nodes`, so the existing import surface
+is unchanged::
 
     from scitex_agent_container._state.state_db_nodes import (
         record_comms_policy, read_comms_policy, sender_target_relationship,
     )
 
-Schema (see ``_SCHEMA_REGISTRY`` in :mod:`.state_db`):
+WHY THIS MODULE MOVED
+=====================
+Operator ruling, restated 2026-08-28: 「スクライトなんて全部絶滅させて
+ください」. The fleet is MULTI-HOST and a SQLite file per host means a
+different ACL per host — measured on scitex-compute-04 2026-08-11, where
+the in-container per-agent shard held NO policy row for anybody while the
+bare-host file held them all, so every authority gate resolved the empty
+set and answered 403. A per-host state.db is that outage's storage layer.
 
-    CREATE TABLE node_comms_policy (
-        name              TEXT PRIMARY KEY,
-        outbound_siblings TEXT NOT NULL DEFAULT 'allow',
-        outbound_parent   TEXT NOT NULL DEFAULT 'allow',
-        inbound_siblings  TEXT NOT NULL DEFAULT 'allow',
-        inbound_parent    TEXT NOT NULL DEFAULT 'allow',
-        lineage_group     TEXT NOT NULL DEFAULT '',
-        may_spawn         INTEGER NOT NULL DEFAULT 1,
-        group_name        TEXT NOT NULL DEFAULT '',
-        group_names       TEXT NOT NULL DEFAULT '',
-        updated_at        REAL NOT NULL
-    );
+The move ADOPTS :mod:`scitex_dev.store`, the fleet's own primitive, whose
+``resolve_target`` is exactly two steps (``SCITEX_STORE_DSN`` or the
+per-host PostgreSQL) with NO SQLite fallback. A host whose PostgreSQL is
+unreachable raises ``StoreTargetError`` naming the DSN it could not
+reach. Fail fast, fail loud, no fallbacks.
 
-Row written at ``agent_start`` from the loaded ``spec.comms`` /
-``spec.lineage`` blocks; read at ACL-check time by
-:func:`scitex_agent_container._listen._acl.check_send_acl` and
-:func:`scitex_agent_container._listen._acl.check_spawn`. Defaults match
-the dataclass defaults so a missing row is byte-equivalent to the
-pre-Phase-3 group-default ACL.
+THAT LOUDNESS IS THE SECURITY PROPERTY, and it is why this table is not
+"just another migration". A lost write in the diary costs an
+OBSERVATION. A lost write here is a DENIAL or a WRONGFUL ALLOW: the gate
+reads whatever record it finds, and :func:`read_comms_policy` answers
+with all-allow defaults when it finds none. Silence is indistinguishable
+from permission, so the store must raise rather than return empty.
+
+``db_path`` IS GONE from every policy signature. It named a SQLite file;
+there is no file. Test isolation now comes from pointing
+``SCITEX_STORE_DSN`` at a throwaway schema — the ``pg_schema`` fixture —
+which is better isolation than a temp path was, because it exercises the
+real resolver.
+
+ONE FUNCTION HERE DID NOT MOVE, AND KEEPS ``db_path``
+=====================================================
+:func:`sender_target_relationship` reads ``lineage``, a DIFFERENT table
+with a different owner and its own migration ahead of it. It now lives in
+:mod:`.state_db_lineage_rel` and is re-exported here so no import
+changes. See that module for the full argument.
+
+REMOVAL IS ``hide``, NEVER A DELETE
+===================================
+The SQLite table had no delete — but the rename path did
+``UPDATE node_comms_policy SET name = ?``, which under an IDENTITY field
+is not an update at all: it is one record ending and another beginning.
+:func:`rename_comms_policy` therefore copies the values onto the new name
+and RETIRES the old one with :meth:`Store.hide`. Hiding keeps the retired
+record and its whole history readable through ``include_hidden=True`` and
+in the oplog, so "this agent never had a policy" and "this agent's policy
+was retired at a rename" stay different answers. For an ACL that
+difference is the whole audit.
+
+The schema, the store factory, the ``group_names`` codec and the
+validators live in :mod:`.state_db_acl_policy_store` — same reason the
+lineage reader has its own file, the per-file line cap.
 """
 
 from __future__ import annotations
 
 import time
-from pathlib import Path
 from typing import Any
+
+from .state_db_acl_policy_store import (
+    ACTOR as _ACTOR,
+)
+from .state_db_acl_policy_store import (
+    POLICY_STORE,
+    decode_policy,
+    join_group_names,
+    policy_schema,
+    split_group_names,
+    validate_policy,
+)
+from .state_db_acl_policy_store import (
+    open_policy_store as _open,
+)
+from .state_db_lineage_rel import sender_target_relationship
 
 __all__ = [
     "DEFAULT_COMMS_POLICY",
+    "POLICY_STORE",
     "apply_may_spawn_gate",
+    "comms_policy_row_exists",
     "read_comms_policy",
     "record_comms_policy",
+    "rename_comms_policy",
+    "retire_comms_policy",
     "sender_target_relationship",
 ]
-
-
-def apply_may_spawn_gate(
-    *,
-    caller: str | None,
-    base: tuple[bool, str | None],
-    db_path: Path | None,
-) -> tuple[bool, str | None]:
-    """Layer ``spec.lineage.may_spawn=false`` on top of the global policy.
-
-    Evaluated AFTER the global policy result: a deny stays a deny
-    (existing reason preserved). If the global path allowed but the
-    caller has ``may_spawn=False`` in its persisted policy, the allow
-    flips to a per-spec deny with a clear reason. Admin path
-    (``caller=None``) has no name to look up — kept untouched, so
-    operator-launched starts never trip this.
-    """
-    if not base[0]:
-        return base
-    if not caller:
-        return base
-    policy = read_comms_policy(name=caller, db_path=db_path)
-    if not policy["may_spawn"]:
-        return (
-            False,
-            (
-                f"spawn denied: caller {caller!r} has "
-                "spec.lineage.may_spawn=false in its agent definition; "
-                "the per-spec deny survives global-policy relaxation."
-            ),
-        )
-    return base
 
 
 DEFAULT_COMMS_POLICY: dict[str, Any] = {
@@ -93,55 +113,42 @@ DEFAULT_COMMS_POLICY: dict[str, Any] = {
     # EVERY named group the spec's ``metadata.labels`` lists (incident
     # 2026-08-10). The AUTHORITY gates read this set, not the primary
     # above, so an agent authored as ``groups: [generalist, developer]``
-    # is a developer regardless of list order. Empty tuple on a row
-    # written before the column existed — ``resolve_group_names`` unions
-    # it with ``group_name``, so that row keeps its old meaning exactly.
+    # is a developer regardless of list order. Empty tuple on a record
+    # written before the field existed — ``resolve_group_names`` unions
+    # it with ``group_name``, so that record keeps its old meaning.
     "group_names": (),
 }
 
 
-def _split_group_names(raw: str) -> tuple[str, ...]:
-    """Decode the comma-separated ``group_names`` column into a tuple.
+def apply_may_spawn_gate(
+    *,
+    caller: str | None,
+    base: tuple[bool, str | None],
+) -> tuple[bool, str | None]:
+    """Layer ``spec.lineage.may_spawn=false`` on top of the global policy.
 
-    Blank / whitespace-only members are dropped, so ``""`` decodes to the
-    empty tuple and a trailing comma is harmless.
+    Evaluated AFTER the global policy result: a deny stays a deny
+    (existing reason preserved). If the global path allowed but the
+    caller has ``may_spawn=False`` in its persisted policy, the allow
+    flips to a per-spec deny with a clear reason. Admin path
+    (``caller=None``) has no name to look up — kept untouched, so
+    operator-launched starts never trip this.
     """
-    return tuple(part.strip() for part in str(raw or "").split(",") if part.strip())
-
-
-def _join_group_names(groups) -> str:
-    """Encode an iterable of group names for the ``group_names`` column.
-
-    De-duplicated and SORTED, so the stored string is deterministic for a
-    given set (the column answers a MEMBERSHIP question — order carries
-    no meaning, and a stable encoding keeps diffs and denial messages
-    readable). Blank members are dropped.
-
-    Raises :class:`ValueError` on a name containing a comma: the encoding
-    is comma-separated, so accepting one would silently split a single
-    group into two. Fail loudly rather than corrupt an ACL input.
-    """
-    if groups is None:
-        return ""
-    if isinstance(groups, str):
-        raise ValueError(
-            "group_names must be an iterable of group names, not a bare "
-            f"string ({groups!r}) — pass e.g. ['developer']"
+    if not base[0]:
+        return base
+    if not caller:
+        return base
+    policy = read_comms_policy(name=caller)
+    if not policy["may_spawn"]:
+        return (
+            False,
+            (
+                f"spawn denied: caller {caller!r} has "
+                "spec.lineage.may_spawn=false in its agent definition; "
+                "the per-spec deny survives global-policy relaxation."
+            ),
         )
-    out: set[str] = set()
-    for item in groups:
-        if item is None:
-            continue
-        trimmed = str(item).strip()
-        if not trimmed:
-            continue
-        if "," in trimmed:
-            raise ValueError(
-                f"group name {trimmed!r} contains a comma; the group_names "
-                "column is comma-separated and cannot encode it"
-            )
-        out.add(trimmed)
-    return ",".join(sorted(out))
+    return base
 
 
 def record_comms_policy(
@@ -155,14 +162,21 @@ def record_comms_policy(
     may_spawn: bool = True,
     group_name: str = "",
     group_names=None,
-    db_path: Path | None = None,
 ) -> None:
     """Upsert the Phase-3 per-spec ACL policy for ``name``.
 
     Called from core ``agent_start`` after the spawn-gate runs, so the
-    row always reflects the *current* ``spec.comms`` / ``spec.lineage``
-    blocks on disk. A re-start refreshes the row in place (a spec edit
-    becomes live on the next start without manual state.db surgery).
+    record always reflects the *current* ``spec.comms`` /
+    ``spec.lineage`` blocks on disk. A re-start refreshes it in place (a
+    spec edit becomes live on the next start without manual surgery).
+
+    EVERY field is written on every call, including the ones the caller
+    left at their defaults. ``Store.put`` is a PARTIAL update — absent
+    fields are left alone — so writing the full record is what preserves
+    the SQLite ``INSERT ... ON CONFLICT DO UPDATE SET <all columns>``
+    semantics. Dropping to a partial write would let a previous
+    ``outbound_siblings="deny"`` survive a spec edit that removed it,
+    which is a stale ACL wearing a fresh timestamp.
 
     ``group_name`` is the PRIMARY group (the default-ACL mesh bucket);
     ``group_names`` is EVERY group the spec names (the authority set).
@@ -171,135 +185,101 @@ def record_comms_policy(
     defaults to ``None``, which stores the PRIMARY alone, so an existing
     caller that passes only ``group_name`` keeps its exact old meaning.
 
+    A record RETIRED by :func:`retire_comms_policy` (or by a rename) is
+    un-hidden here: re-publishing a policy for a name is exactly the
+    operation that should bring it back, and leaving it hidden would deny
+    an agent that had just been re-registered.
+
     Raises :class:`ValueError` on an empty name or out-of-domain values
     (the parser/validator already reject these — defence-in-depth).
     """
-    if not name:
-        raise ValueError("record_comms_policy: name must be non-empty")
-    if outbound_siblings not in ("allow", "deny"):
-        raise ValueError(
-            f"outbound_siblings must be 'allow' or 'deny', got {outbound_siblings!r}"
-        )
-    if outbound_parent not in ("allow", "deny"):
-        raise ValueError(
-            f"outbound_parent must be 'allow' or 'deny', got {outbound_parent!r}"
-        )
-    if inbound_siblings not in ("allow", "deny"):
-        raise ValueError(
-            f"inbound_siblings must be 'allow' or 'deny', got {inbound_siblings!r}"
-        )
-    if inbound_parent not in ("allow", "deny"):
-        raise ValueError(
-            f"inbound_parent must be 'allow' or 'deny', got {inbound_parent!r}"
-        )
-    if lineage_group not in ("", "solitary"):
-        raise ValueError(
-            f"lineage_group must be '' or 'solitary', got {lineage_group!r}"
-        )
-    if not isinstance(may_spawn, bool):
-        raise ValueError(f"may_spawn must be a bool, got {type(may_spawn).__name__}")
-    if not isinstance(group_name, str):
-        raise ValueError(f"group_name must be a str, got {type(group_name).__name__}")
+    validate_policy(
+        name=name,
+        outbound_siblings=outbound_siblings,
+        outbound_parent=outbound_parent,
+        inbound_siblings=inbound_siblings,
+        inbound_parent=inbound_parent,
+        lineage_group=lineage_group,
+        may_spawn=may_spawn,
+        group_name=group_name,
+    )
     primary = group_name.strip()
     # A caller that names only the primary keeps its old meaning: the
     # stored set is {primary}. A caller that names the full set gets it
     # stored verbatim, with the primary folded in so the set is never a
     # strict subset of what the mesh already resolves.
     if group_names is None:
-        encoded_groups = _join_group_names([primary])
+        encoded_groups = join_group_names([primary])
     elif isinstance(group_names, str):
         # Reject BEFORE the splat below, which would silently expand a
         # string into its characters and store those as group names.
-        encoded_groups = _join_group_names(group_names)
+        encoded_groups = join_group_names(group_names)
     else:
-        encoded_groups = _join_group_names([*group_names, primary])
-    from .state_db import open_db
+        encoded_groups = join_group_names([*group_names, primary])
 
-    now = time.time()
-    with open_db(db_path) as conn:
-        conn.execute(
-            "INSERT INTO node_comms_policy ("
-            "name, outbound_siblings, outbound_parent, "
-            "inbound_siblings, inbound_parent, lineage_group, "
-            "may_spawn, group_name, group_names, updated_at"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
-            "ON CONFLICT(name) DO UPDATE SET "
-            "outbound_siblings=excluded.outbound_siblings, "
-            "outbound_parent=excluded.outbound_parent, "
-            "inbound_siblings=excluded.inbound_siblings, "
-            "inbound_parent=excluded.inbound_parent, "
-            "lineage_group=excluded.lineage_group, "
-            "may_spawn=excluded.may_spawn, "
-            "group_name=excluded.group_name, "
-            "group_names=excluded.group_names, "
-            "updated_at=excluded.updated_at",
-            (
-                name,
-                outbound_siblings,
-                outbound_parent,
-                inbound_siblings,
-                inbound_parent,
-                lineage_group,
-                1 if may_spawn else 0,
-                primary,
-                encoded_groups,
-                now,
-            ),
+    from scitex_dev.store import ANY_REVISION
+
+    store = _open()
+    try:
+        key = {"name": name}
+        if store.is_hidden(key):
+            store.unhide(key, expected_revision=ANY_REVISION, actor=_ACTOR)
+        store.put(
+            {
+                "name": name,
+                "outbound_siblings": outbound_siblings,
+                "outbound_parent": outbound_parent,
+                "inbound_siblings": inbound_siblings,
+                "inbound_parent": inbound_parent,
+                "lineage_group": lineage_group,
+                "may_spawn": bool(may_spawn),
+                "group_name": primary,
+                "group_names": encoded_groups,
+                "updated_at": time.time(),
+            },
+            # ANY_REVISION, not NEW_RECORD: this verb is an UPSERT by
+            # contract — every agent_start re-publishes the same identity,
+            # and NEW_RECORD would raise on the second start of every
+            # agent in the fleet.
+            expected_revision=ANY_REVISION,
         )
+    finally:
+        store.close()
 
 
-def read_comms_policy(
-    *,
-    name: str,
-    db_path: Path | None = None,
-) -> dict[str, Any]:
+def read_comms_policy(*, name: str) -> dict[str, Any]:
     """Return the per-spec ACL policy for ``name``, or defaults if absent.
 
-    A missing row yields :data:`DEFAULT_COMMS_POLICY` so the
+    A missing record yields :data:`DEFAULT_COMMS_POLICY` so the
     "no-row" vs "row-with-default-values" distinction is invisible to
     callers. Defaults are byte-equivalent to pre-Phase-3 behaviour.
 
+    A RETIRED (hidden) record also reads as absent — the same answer for
+    the same reason: the gate wants the policy in force NOW, and a
+    retired policy is not in force.
+
     That invisibility is correct for POLICY EVALUATION — a caller asking
-    "may this agent spawn?" wants an answer, not a lecture about rows.
+    "may this agent spawn?" wants an answer, not a lecture about records.
     It is wrong for DIAGNOSIS: when an ACL refuses, "this agent is
-    registered and ungrouped" and "this host has never heard of this
+    registered and ungrouped" and "this store has never heard of this
     agent" are different facts and the operator needs to know which.
     Use :func:`comms_policy_row_exists` for that; do NOT infer it from
-    a returned value equal to the defaults, which is ambiguous by
-    design.
+    a returned value equal to the defaults, which is ambiguous by design.
     """
     if not name:
         return dict(DEFAULT_COMMS_POLICY)
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT outbound_siblings, outbound_parent, "
-            "inbound_siblings, inbound_parent, lineage_group, may_spawn, "
-            "group_name, group_names "
-            "FROM node_comms_policy WHERE name = ?",
-            (name,),
-        ).fetchone()
+    store = _open()
+    try:
+        row = store.get({"name": name})
+    finally:
+        store.close()
     if row is None:
         return dict(DEFAULT_COMMS_POLICY)
-    return {
-        "outbound_siblings": str(row["outbound_siblings"]),
-        "outbound_parent": str(row["outbound_parent"]),
-        "inbound_siblings": str(row["inbound_siblings"]),
-        "inbound_parent": str(row["inbound_parent"]),
-        "lineage_group": str(row["lineage_group"]),
-        "may_spawn": bool(row["may_spawn"]),
-        "group_name": str(row["group_name"]),
-        "group_names": _split_group_names(row["group_names"]),
-    }
+    return decode_policy(row.values)
 
 
-def comms_policy_row_exists(
-    *,
-    name: str,
-    db_path: Path | None = None,
-) -> bool:
-    """True iff THIS store holds a policy row for ``name``.
+def comms_policy_row_exists(*, name: str) -> bool:
+    """True iff THIS store holds a LIVE policy record for ``name``.
 
     The narrow question :func:`read_comms_policy` deliberately hides, and
     the one a denial message needs.
@@ -317,62 +297,98 @@ def comms_policy_row_exists(
     This does NOT change any decision. Both cases still deny, and deny
     for the same reason. It exists so the denial can say which one it
     was.
+
+    LIVE, not merely present: a retired record answers ``False`` here,
+    matching what :func:`read_comms_policy` does with it. The retired
+    record stays readable with ``include_hidden=True`` for anyone
+    auditing what changed — that is what hiding is for — but a policy
+    that is not in force must not make a denial claim the agent is
+    registered.
     """
     if not name:
         return False
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT 1 FROM node_comms_policy WHERE name = ?",
-            (name,),
-        ).fetchone()
-    return row is not None
+    store = _open()
+    try:
+        return store.get({"name": name}) is not None
+    finally:
+        store.close()
 
 
-def sender_target_relationship(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> str:
-    """Classify the ``sender → target`` lineage relationship.
+def retire_comms_policy(*, name: str) -> bool:
+    """Withdraw ``name``'s policy record. ``True`` iff one was live.
 
-    Returns one of:
-
-    * ``"self"``    — same node (trivial self-send).
-    * ``"parent"``  — target is sender's parent in the lineage table.
-    * ``"child"``   — target is one of sender's direct children.
-    * ``"sibling"`` — sender and target share the same parent.
-    * ``"other"``   — no lineage path (cross-group or unrelated).
-
-    Used by :func:`scitex_agent_container._listen._acl.check_send_acl`
-    to apply the per-spec outbound/inbound policy on the right edge.
-    Pure read of the ``lineage`` table — no policy state consulted.
+    Hides rather than deletes — the store's only removal. The record,
+    its values and its whole history stay readable through
+    ``include_hidden=True`` and in the oplog, while every default read
+    treats it as absent. So an ACL audit can still answer "did this agent
+    ever hold a policy, and what was in it?" after the agent is gone,
+    which a ``DELETE`` could not.
     """
-    if not sender or not target:
-        return "other"
-    if sender == target:
-        return "self"
-    from .state_db import open_db
+    if not name:
+        return False
 
-    with open_db(db_path) as conn:
-        sender_parent_row = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name = ?", (sender,)
-        ).fetchone()
-        target_parent_row = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name = ?", (target,)
-        ).fetchone()
-    sender_parent = str(sender_parent_row["parent_name"]) if sender_parent_row else None
-    target_parent = str(target_parent_row["parent_name"]) if target_parent_row else None
-    if sender_parent == target:
-        return "parent"
-    if target_parent == sender:
-        return "child"
-    if (
-        sender_parent is not None
-        and target_parent is not None
-        and sender_parent == target_parent
-    ):
-        return "sibling"
-    return "other"
+    from scitex_dev.store import ANY_REVISION
+
+    store = _open()
+    try:
+        key = {"name": name}
+        if store.get(key) is None:
+            # Absent, or already retired — either way nothing was live.
+            return False
+        store.hide(key, expected_revision=ANY_REVISION, actor=_ACTOR)
+        return True
+    finally:
+        store.close()
+
+
+def rename_comms_policy(*, old: str, new: str) -> bool:
+    """Move ``old``'s policy onto ``new``. ``True`` iff a record moved.
+
+    ``name`` is the record IDENTITY, so a rename is not an update: it is
+    one record ending and another beginning. This copies every stored
+    value onto the new identity and RETIRES the old one.
+
+    Called from the agent-rename flow, which used to do this with
+    ``UPDATE node_comms_policy SET name = ?`` across the SQLite table.
+    Miss it and the ACL gate holds no policy for the live name, so the
+    renamed agent resolves to NO named group and every authority gate
+    denies it — the 2026-08-10 shape reached by a different route.
+    Retiring the old name matters just as much in the other direction: a
+    live policy under a name that no longer exists is a standing
+    authorisation nobody owns.
+
+    Idempotent in the useful sense: with nothing live under ``old`` it
+    returns ``False`` and writes nothing, so a re-run after a partial
+    rename does not clobber the record already sitting under ``new``.
+    """
+    if not old or not new or old == new:
+        return False
+
+    from scitex_dev.store import ANY_REVISION
+
+    store = _open()
+    try:
+        row = store.get({"name": old})
+        if row is None:
+            return False
+        # Filtered to the SCHEMA's own fields rather than passed straight
+        # through: ``put`` looks every key up in ``schema.fields``, so any
+        # future bookkeeping key appearing in ``row.values`` would turn a
+        # rename into a KeyError at the worst possible moment.
+        fields = policy_schema().fields
+        moved = {k: v for k, v in row.values.items() if k in fields}
+        moved["name"] = new
+        moved["updated_at"] = time.time()
+        if store.is_hidden({"name": new}):
+            store.unhide({"name": new}, expected_revision=ANY_REVISION, actor=_ACTOR)
+        store.put(moved, expected_revision=ANY_REVISION)
+        store.hide({"name": old}, expected_revision=ANY_REVISION, actor=_ACTOR)
+        return True
+    finally:
+        store.close()
+
+
+# Kept importable from here because the migration script and the tests
+# reach for them by the same names the grants/diary ports established.
+_split_group_names = split_group_names
+_join_group_names = join_group_names

--- a/src/scitex_agent_container/_state/state_db_acl_policy_store.py
+++ b/src/scitex_agent_container/_state/state_db_acl_policy_store.py
@@ -1,0 +1,253 @@
+"""The ``node_comms_policy`` store — schema, connection, codec, validators.
+
+Split out of :mod:`.state_db_acl_policy` (which stays the import surface
+everything else uses) to keep both files under the per-file line cap.
+This half holds nothing a caller outside ``_state`` should reach for: the
+schema declaration, the ``Store`` factory, the ``group_names`` encoding,
+and the two pure translation helpers the public verbs share.
+
+WRITER POLICY: ``MULTI_WRITER``, DELIBERATELY
+=============================================
+A policy record has no single stable owner. It is written at
+``agent_start`` on whichever host is running the agent — and the fleet
+relocates agents between hosts — re-published fleet-wide by ``sac agents
+refresh-acl`` from wherever the operator happens to be, and bulk-imported
+from peers by :func:`.state_db_export.import_state`. Under
+``SINGLE_WRITER`` the first refresh-acl issued from another host would be
+refused, and a refused ACL write is a STALE ACL row: the agent keeps the
+groups it used to have, or loses the ones it just gained. Both directions
+are privilege bugs, and neither raises anywhere a human is looking.
+
+(:mod:`.._store_plugin` declared ``SINGLE_WRITER`` for this table before
+the move, back when the row was modelled as owned by the agent's own
+host. That declaration is updated in the same commit rather than left to
+disagree with the live store.)
+
+UPSERT, NOT APPEND — SO THE FIELDS ARE ``LAST_WRITER_WINS``, NOT IMMUTABLE
+=========================================================================
+The diary and the grants stores hold historical facts and their fields
+are ``IMMUTABLE``. This record is not a fact about an event; it is a
+PROJECTION of ``spec.yaml`` (ADR-0022: "both writers derive it from the
+spec"), and re-publishing it after a spec edit is the entire reason it
+exists. ``IMMUTABLE`` here would make a spec edit unpublishable — the
+newest write really is the best answer, so ``LAST_WRITER_WINS`` is
+honest.
+
+``updated_at`` is the exception: ``MergeRule.MAX``, so a late-arriving
+stale replica cannot walk the record's own clock backwards.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Store
+
+__all__ = [
+    "ACTOR",
+    "POLICY_STORE",
+    "open_policy_store",
+]
+
+#: Logical store name. Renders as four physical tables
+#: (``node_comms_policy_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+POLICY_STORE = "node_comms_policy"
+
+ACTOR = "scitex-agent-container"
+
+#: The domains the validators enforce, named once so the error messages
+#: and the schema cannot drift apart.
+ALLOW_DENY = ("allow", "deny")
+LINEAGE_GROUPS = ("", "solitary")
+
+
+def _ident(kind: Any) -> Any:
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.IDENTITY,
+        required=True,
+        merge=MergeRule.IMMUTABLE,
+        indexed=False,
+    )
+
+
+def _setting(kind: Any) -> Any:
+    """A projection of the spec — the newest write IS the best answer.
+
+    See the module docstring for why this is ``LAST_WRITER_WINS`` where
+    the diary and grants stores are ``IMMUTABLE``.
+    """
+    from scitex_dev.store import FieldPolicy, FieldRole, MergeRule
+
+    return FieldPolicy(
+        kind=kind,
+        role=FieldRole.DATA,
+        required=True,
+        merge=MergeRule.LAST_WRITER_WINS,
+        indexed=False,
+    )
+
+
+def policy_schema() -> Any:
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
+
+    return Schema(
+        name=POLICY_STORE,
+        fields={
+            # The agent name IS the identity, exactly as the SQLite
+            # PRIMARY KEY treated it.
+            "name": _ident(FieldKind.TEXT),
+            "outbound_siblings": _setting(FieldKind.TEXT),
+            "outbound_parent": _setting(FieldKind.TEXT),
+            "inbound_siblings": _setting(FieldKind.TEXT),
+            "inbound_parent": _setting(FieldKind.TEXT),
+            "lineage_group": _setting(FieldKind.TEXT),
+            # BOOL, not the SQLite 0/1 INTEGER. The column was a boolean
+            # wearing an integer's clothes; the store has the type.
+            "may_spawn": _setting(FieldKind.BOOL),
+            "group_name": _setting(FieldKind.TEXT),
+            # Still the comma-separated encoding, deliberately. JSON would
+            # be tidier and would change the wire format of an ACL input
+            # inside a storage migration, which is how a breaking change
+            # rides along unnoticed. Same encoding, same validators, same
+            # comma rejection.
+            "group_names": _setting(FieldKind.TEXT),
+            "updated_at": FieldPolicy(
+                kind=FieldKind.REAL,
+                role=FieldRole.DATA,
+                required=True,
+                # MAX, not LAST_WRITER_WINS: a stale replica arriving late
+                # must not walk this record's clock backwards.
+                merge=MergeRule.MAX,
+                indexed=False,
+            ),
+        },
+    )
+
+
+def open_policy_store() -> "Store":
+    """Open the policy store. RAISES if PostgreSQL is unreachable.
+
+    Open-and-close per call mirrors the old ``with open_db(...)`` shape.
+    Raising is the security property: :func:`.read_comms_policy` answers
+    with all-allow defaults when it finds no record, so a store that
+    returned empty instead of raising would read as PERMISSION.
+    """
+    from scitex_dev.store import Store, WriterPolicy, host_store
+
+    schema = policy_schema()
+    return Store(
+        host_store(pkg="scitex_agent_container", name=schema.name),
+        schema,
+        node=socket.gethostname(),
+        # MULTI_WRITER — see the module docstring. A refused ACL write is
+        # a stale ACL record, and a stale ACL record is a privilege bug.
+        writer_policy=WriterPolicy.MULTI_WRITER,
+        actor=ACTOR,
+    )
+
+
+def split_group_names(raw: str) -> tuple[str, ...]:
+    """Decode the comma-separated ``group_names`` value into a tuple.
+
+    Blank / whitespace-only members are dropped, so ``""`` decodes to the
+    empty tuple and a trailing comma is harmless.
+    """
+    return tuple(part.strip() for part in str(raw or "").split(",") if part.strip())
+
+
+def join_group_names(groups) -> str:
+    """Encode an iterable of group names for the ``group_names`` value.
+
+    De-duplicated and SORTED, so the stored string is deterministic for a
+    given set (the value answers a MEMBERSHIP question — order carries
+    no meaning, and a stable encoding keeps diffs and denial messages
+    readable). Blank members are dropped.
+
+    Raises :class:`ValueError` on a name containing a comma: the encoding
+    is comma-separated, so accepting one would silently split a single
+    group into two. Fail loudly rather than corrupt an ACL input.
+    """
+    if groups is None:
+        return ""
+    if isinstance(groups, str):
+        raise ValueError(
+            "group_names must be an iterable of group names, not a bare "
+            f"string ({groups!r}) — pass e.g. ['developer']"
+        )
+    out: set[str] = set()
+    for item in groups:
+        if item is None:
+            continue
+        trimmed = str(item).strip()
+        if not trimmed:
+            continue
+        if "," in trimmed:
+            raise ValueError(
+                f"group name {trimmed!r} contains a comma; the group_names "
+                "value is comma-separated and cannot encode it"
+            )
+        out.add(trimmed)
+    return ",".join(sorted(out))
+
+
+def validate_policy(
+    *,
+    name: str,
+    outbound_siblings: str,
+    outbound_parent: str,
+    inbound_siblings: str,
+    inbound_parent: str,
+    lineage_group: str,
+    may_spawn: bool,
+    group_name: str,
+) -> None:
+    """Reject out-of-domain values BEFORE any store is opened.
+
+    Defence-in-depth — the YAML parser/validator already rejects these.
+    Hoisted out of :func:`.record_comms_policy` so a bad value costs no
+    connection, and so the refusal is identical whether or not
+    PostgreSQL happens to be reachable.
+    """
+    if not name:
+        raise ValueError("record_comms_policy: name must be non-empty")
+    for field, value in (
+        ("outbound_siblings", outbound_siblings),
+        ("outbound_parent", outbound_parent),
+        ("inbound_siblings", inbound_siblings),
+        ("inbound_parent", inbound_parent),
+    ):
+        if value not in ALLOW_DENY:
+            raise ValueError(f"{field} must be 'allow' or 'deny', got {value!r}")
+    if lineage_group not in LINEAGE_GROUPS:
+        raise ValueError(
+            f"lineage_group must be '' or 'solitary', got {lineage_group!r}"
+        )
+    if not isinstance(may_spawn, bool):
+        raise ValueError(f"may_spawn must be a bool, got {type(may_spawn).__name__}")
+    if not isinstance(group_name, str):
+        raise ValueError(f"group_name must be a str, got {type(group_name).__name__}")
+
+
+def decode_policy(values: Any) -> dict[str, Any]:
+    """Turn one stored record's values into the caller-facing dict.
+
+    Every field is read through a ``get`` carrying the pre-Phase-3
+    default, so a record written before a field existed reads exactly as
+    it did under the SQLite column default rather than raising a
+    ``KeyError`` inside an ACL gate.
+    """
+    return {
+        "outbound_siblings": str(values.get("outbound_siblings") or "allow"),
+        "outbound_parent": str(values.get("outbound_parent") or "allow"),
+        "inbound_siblings": str(values.get("inbound_siblings") or "allow"),
+        "inbound_parent": str(values.get("inbound_parent") or "allow"),
+        "lineage_group": str(values.get("lineage_group") or ""),
+        "may_spawn": bool(values.get("may_spawn", True)),
+        "group_name": str(values.get("group_name") or ""),
+        "group_names": split_group_names(values.get("group_names") or ""),
+    }

--- a/src/scitex_agent_container/_state/state_db_acl_policy_store.py
+++ b/src/scitex_agent_container/_state/state_db_acl_policy_store.py
@@ -33,8 +33,20 @@ exists. ``IMMUTABLE`` here would make a spec edit unpublishable — the
 newest write really is the best answer, so ``LAST_WRITER_WINS`` is
 honest.
 
-``updated_at`` is the exception: ``MergeRule.MAX``, so a late-arriving
-stale replica cannot walk the record's own clock backwards.
+``updated_at`` is ``LAST_WRITER_WINS`` too, and deliberately so. It was
+``MergeRule.MAX``, to stop a late-arriving stale replica walking the
+record's clock backwards -- but HLC ordering already delivers exactly
+that for every other field, and MAX bought the guarantee at the price of
+resolving this one field by a DIFFERENT ordering than the rest of the
+record. ``_merge.py`` decides LAST_WRITER_WINS on ``incoming_stamp >
+current_stamp`` (the HLC) and MAX on ``incoming > current`` (the value),
+so the two disagree whenever a node's HLC wall has been pulled forward
+by a peer's message while its own ``time.time()`` has not. In that case
+MAX keeps the LOSING write's larger timestamp, and the record advertises
+itself as fresher than the write that actually supplied its data -- a
+stale ACL that reads as current, which is the exact failure this module
+says it exists to prevent. One ordering for the whole record is both
+simpler and safer.
 """
 
 from __future__ import annotations
@@ -120,9 +132,13 @@ def policy_schema() -> Any:
                 kind=FieldKind.REAL,
                 role=FieldRole.DATA,
                 required=True,
-                # MAX, not LAST_WRITER_WINS: a stale replica arriving late
-                # must not walk this record's clock backwards.
-                merge=MergeRule.MAX,
+                # LAST_WRITER_WINS, like every other field -- see the module
+                # docstring. A stale replica arriving late loses the HLC
+                # comparison, so its clock cannot win here either; MAX only
+                # differed when the value order and the HLC order disagreed,
+                # and in exactly that case it detached this timestamp from the
+                # data it is supposed to describe.
+                merge=MergeRule.LAST_WRITER_WINS,
                 indexed=False,
             ),
         },

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -79,10 +79,10 @@ def _table_filter_clauses(
         # a tombstoned row (``ended_at`` set) still ships on the next
         # pull until both sides converge.
         "comms_nodes": ("WHERE updated_at >= ?", (since,)),
-        # Phase-3 ACL table (ADR-0010 Step 2). Uses ``updated_at`` since
-        # the row is upserted on every agent_start with no historical
-        # tail (latest write wins).
-        "node_comms_policy": ("WHERE updated_at >= ?", (since,)),
+        # node_comms_policy's entry lived here until 2026-08-28. The table
+        # moved to PostgreSQL and left KNOWN_TABLES, so this mapping could
+        # never be selected again — and a WHERE clause naming a table SQLite
+        # no longer has reads as "sac still exports this".
         # acl_deny_notify_log's entry lived here until 2026-08-20. The table
         # moved to per-host PostgreSQL and left KNOWN_TABLES, so this mapping
         # could never be selected again — and a WHERE clause naming a table

--- a/src/scitex_agent_container/_state/state_db_groups.py
+++ b/src/scitex_agent_container/_state/state_db_groups.py
@@ -54,7 +54,12 @@ about what the spec said.
 
 from __future__ import annotations
 
-from pathlib import Path
+# ``db_path`` IS GONE from every reader below (2026-08-28). It named a
+# SQLite file, and the only thing any of them did with it was hand it to
+# ``read_comms_policy`` — which now reads ``node_comms_policy`` from
+# PostgreSQL. Leaving the parameter would have been worse than removing
+# it: a caller passing a ``tmp_path`` would believe it had isolated the
+# read, and it would silently have been reading the live fleet store.
 
 __all__ = [
     "in_named_group",
@@ -70,7 +75,6 @@ __all__ = [
 def resolve_group_name(
     *,
     name: str,
-    db_path: Path | None = None,
 ) -> str:
     """Return ``name``'s PRIMARY named group, or ``""`` if ungrouped.
 
@@ -97,7 +101,7 @@ def resolve_group_name(
         return from_spec
     from .state_db_acl_policy import read_comms_policy
 
-    policy = read_comms_policy(name=name, db_path=db_path)
+    policy = read_comms_policy(name=name)
     return str(policy.get("group_name", "") or "")
 
 
@@ -105,7 +109,6 @@ def same_named_group(
     *,
     sender: str,
     target: str,
-    db_path: Path | None = None,
 ) -> bool:
     """Return ``True`` iff ``sender`` and ``target`` share a NAMED group.
 
@@ -114,17 +117,16 @@ def same_named_group(
     the pre-group-name behaviour (an ungrouped fleet falls through to
     the lineage-mesh + explicit-grant ACL exactly as before).
     """
-    sender_group = resolve_group_name(name=sender, db_path=db_path)
+    sender_group = resolve_group_name(name=sender)
     if not sender_group:
         return False
-    target_group = resolve_group_name(name=target, db_path=db_path)
+    target_group = resolve_group_name(name=target)
     return target_group == sender_group
 
 
 def resolve_group_names(
     *,
     name: str,
-    db_path: Path | None = None,
 ) -> frozenset[str]:
     """Return EVERY named group ``name``'s persisted policy row holds.
 
@@ -183,7 +185,7 @@ def resolve_group_names(
         return from_spec
     from .state_db_acl_policy import read_comms_policy
 
-    policy = read_comms_policy(name=name, db_path=db_path)
+    policy = read_comms_policy(name=name)
     out = {str(g).strip() for g in policy.get("group_names", ()) if str(g).strip()}
     primary = str(policy.get("group_name", "") or "").strip()
     if primary:
@@ -195,7 +197,6 @@ def in_named_group(
     *,
     name: str,
     group: str,
-    db_path: Path | None = None,
 ) -> bool:
     """Return ``True`` iff ``name``'s persisted groups include ``group``.
 
@@ -209,14 +210,13 @@ def in_named_group(
         return False
     return any(
         g.strip().lower() == wanted
-        for g in resolve_group_names(name=name, db_path=db_path)
+        for g in resolve_group_names(name=name)
     )
 
 
 def is_developer(
     *,
     name: str,
-    db_path: Path | None = None,
 ) -> bool:
     """Return ``True`` iff ``developer`` is among ``name``'s named groups.
 
@@ -233,13 +233,12 @@ def is_developer(
     """
     from ..config._group_resolver import DEVELOPER_GROUP
 
-    return in_named_group(name=name, group=DEVELOPER_GROUP, db_path=db_path)
+    return in_named_group(name=name, group=DEVELOPER_GROUP)
 
 
 def is_researcher(
     *,
     name: str,
-    db_path: Path | None = None,
 ) -> bool:
     """Return ``True`` iff ``researcher`` is among ``name``'s named groups.
 
@@ -253,13 +252,12 @@ def is_researcher(
     """
     from ..config._group_resolver import RESEARCHER_GROUP
 
-    return in_named_group(name=name, group=RESEARCHER_GROUP, db_path=db_path)
+    return in_named_group(name=name, group=RESEARCHER_GROUP)
 
 
 def is_privileged(
     *,
     name: str,
-    db_path: Path | None = None,
 ) -> bool:
     """Return ``True`` iff ``privileged`` is among ``name``'s named groups.
 
@@ -269,4 +267,4 @@ def is_privileged(
     """
     from ..config._group_resolver import PRIVILEGED_GROUP
 
-    return in_named_group(name=name, group=PRIVILEGED_GROUP, db_path=db_path)
+    return in_named_group(name=name, group=PRIVILEGED_GROUP)

--- a/src/scitex_agent_container/_state/state_db_lineage_rel.py
+++ b/src/scitex_agent_container/_state/state_db_lineage_rel.py
@@ -1,0 +1,74 @@
+"""``sender → target`` lineage classification — STILL ON SQLITE.
+
+Extracted from :mod:`.state_db_acl_policy` on 2026-08-28, when the policy
+table moved to PostgreSQL and this function did not.
+
+IT DID NOT MOVE BECAUSE IT READS A DIFFERENT TABLE. ``lineage`` is owned
+by :mod:`.state_db_nodes` (``record_lineage`` / ``derive_group``) and has
+its own migration ahead of it. This function only ever lived beside the
+policy code because ``state_db_nodes`` was over the per-file line cap,
+and carrying its storage along as a side effect of the policy move would
+have been a second migration smuggled inside the first.
+
+So it keeps ``db_path``, and keeps reading SQLite, until ``lineage``
+itself moves. Its own file is what makes that visible: a reader looking
+for "what is left on SQLite here" finds a module, not a stray function at
+the bottom of a PostgreSQL one.
+
+Re-exported from :mod:`.state_db_acl_policy` (and thence from
+:mod:`.state_db_nodes`) so every existing import path keeps working.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["sender_target_relationship"]
+
+
+def sender_target_relationship(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> str:
+    """Classify the ``sender → target`` lineage relationship.
+
+    Returns one of:
+
+    * ``"self"``    — same node (trivial self-send).
+    * ``"parent"``  — target is sender's parent in the lineage table.
+    * ``"child"``   — target is one of sender's direct children.
+    * ``"sibling"`` — sender and target share the same parent.
+    * ``"other"``   — no lineage path (cross-group or unrelated).
+
+    Used by :func:`scitex_agent_container._listen._acl.check_send_acl`
+    to apply the per-spec outbound/inbound policy on the right edge.
+    Pure read of the ``lineage`` table — no policy state consulted.
+    """
+    if not sender or not target:
+        return "other"
+    if sender == target:
+        return "self"
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        sender_parent_row = conn.execute(
+            "SELECT parent_name FROM lineage WHERE child_name = ?", (sender,)
+        ).fetchone()
+        target_parent_row = conn.execute(
+            "SELECT parent_name FROM lineage WHERE child_name = ?", (target,)
+        ).fetchone()
+    sender_parent = str(sender_parent_row["parent_name"]) if sender_parent_row else None
+    target_parent = str(target_parent_row["parent_name"]) if target_parent_row else None
+    if sender_parent == target:
+        return "parent"
+    if target_parent == sender:
+        return "child"
+    if (
+        sender_parent is not None
+        and target_parent is not None
+        and sender_parent == target_parent
+    ):
+        return "sibling"
+    return "other"

--- a/src/scitex_agent_container/_state/state_db_migrations.py
+++ b/src/scitex_agent_container/_state/state_db_migrations.py
@@ -15,12 +15,6 @@ every :func:`state_db.init_schema`.
   * :func:`migrate_instances_add_family_tree_cols` — ADD COLUMN the
     sac-agent-spawn family-tree columns (``bound_port``, ``remote``,
     ``spawned_by``) onto a pre-existing ``instances`` table.
-  * :func:`migrate_node_comms_policy_add_group_name` — ADD COLUMN the
-    ``group_name`` column (group-based ACL, operator 2026-06-25) onto a
-    pre-existing ``node_comms_policy`` table.
-  * :func:`migrate_node_comms_policy_add_group_names` — ADD COLUMN the
-    MULTI-value ``group_names`` column (authority-is-membership,
-    incident 2026-08-10) onto a pre-existing ``node_comms_policy``.
 """
 
 from __future__ import annotations
@@ -145,77 +139,11 @@ def migrate_instances_add_family_tree_cols(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE instances ADD COLUMN spawned_by TEXT")
 
 
-def migrate_node_comms_policy_add_group_name(conn: sqlite3.Connection) -> None:
-    """ADD the ``group_name`` column to ``node_comms_policy``.
-
-    Group-based ACL (operator 2026-06-25): the per-agent NAMED group,
-    resolved at ``agent_start`` from ``metadata.labels.group`` (else
-    role-derived). A fresh DB gets the column from the ``CREATE TABLE``
-    DDL in :mod:`state_db`; this migration is for an EXISTING
-    ``node_comms_policy`` table created before the column existed.
-
-    ``ALTER TABLE ... ADD COLUMN`` with a ``DEFAULT ''`` backfills every
-    pre-existing row to "ungrouped", which is byte-equivalent to the
-    pre-group-name behaviour (the ACL same-group allow requires a
-    NON-EMPTY match).
-
-    Detection: ``node_comms_policy`` exists AND lacks ``group_name``.
-    Idempotent: a no-op once the column is present (or the table is
-    absent).
-    """
-    existing = {
-        r[0]
-        for r in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        ).fetchall()
-    }
-    if "node_comms_policy" not in existing:
-        return
-    cols = {
-        r[1] for r in conn.execute("PRAGMA table_info(node_comms_policy)").fetchall()
-    }
-    if "group_name" in cols:
-        return
-    conn.execute(
-        "ALTER TABLE node_comms_policy ADD COLUMN group_name TEXT NOT NULL DEFAULT ''"
-    )
-
-
-def migrate_node_comms_policy_add_group_names(conn: sqlite3.Connection) -> None:
-    """ADD the MULTI-value ``group_names`` column to ``node_comms_policy``.
-
-    Authority-is-membership (incident 2026-08-10): ``group_name`` holds
-    only the FIRST group a spec's ``metadata.labels.groups`` list names,
-    so an agent authored as ``groups: [generalist, developer]`` was not a
-    developer to any ACL gate. ``group_names`` holds the WHOLE set
-    (comma-separated, sorted, written from the same labels), and the
-    authority predicates read it.
-
-    ``ALTER TABLE ... ADD COLUMN`` with ``DEFAULT ''`` leaves every
-    pre-existing row with an empty set. That is deliberately NOT a
-    regression: :func:`.state_db_groups.resolve_group_names` unions the
-    set with ``group_name``, so an un-refreshed row still resolves to
-    ``{primary}`` — exactly the pre-migration behaviour. Running
-    ``sac agents refresh-acl`` (or restarting the agent) re-publishes the
-    full set from the on-disk spec.
-
-    Detection: ``node_comms_policy`` exists AND lacks ``group_names``.
-    Idempotent: a no-op once the column is present (or the table is
-    absent).
-    """
-    existing = {
-        r[0]
-        for r in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        ).fetchall()
-    }
-    if "node_comms_policy" not in existing:
-        return
-    cols = {
-        r[1] for r in conn.execute("PRAGMA table_info(node_comms_policy)").fetchall()
-    }
-    if "group_names" in cols:
-        return
-    conn.execute(
-        "ALTER TABLE node_comms_policy ADD COLUMN group_names TEXT NOT NULL DEFAULT ''"
-    )
+# ``migrate_node_comms_policy_add_group_name`` and
+# ``migrate_node_comms_policy_add_group_names`` lived here until
+# 2026-08-28. Both ALTERed ``node_comms_policy``, which moved to
+# PostgreSQL in the same commit — so both were already written to
+# return early when the table is absent, and would have run as
+# permanent no-ops for the rest of time. A migration that can never
+# fire is not a safety net; it is a claim that a schema step still
+# happens. Deleted with the DDL rather than left to be read as live.

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -184,7 +184,7 @@ def derive_group(
         raise ValueError("derive_group: name must be non-empty")
     # Phase-3 solitary override — short-circuits to the singleton group
     # without touching the lineage table.
-    policy = read_comms_policy(name=name, db_path=db_path)
+    policy = read_comms_policy(name=name)
     if policy["lineage_group"] == "solitary":
         return {name}
     from .state_db import open_db
@@ -293,7 +293,7 @@ def spawn_allowed(
     if caller is None or caller == "":
         # Admin / human operator. Skips the global root-only check;
         # per-spec may_spawn (Phase-3 Gap-5) layers on top.
-        return apply_may_spawn_gate(caller=caller, base=(True, None), db_path=db_path)
+        return apply_may_spawn_gate(caller=caller, base=(True, None))
     # The three spawn-authorised groups, checked as MEMBERSHIP over the
     # caller's whole named-group set. Hoisted above the lineage lookup
     # because the authority is lineage-independent: a developer- /
@@ -302,11 +302,11 @@ def spawn_allowed(
     # 2026-07-06 ACL incident). The per-spec may_spawn gate still layers
     # on top, exactly like the root path above.
     if (
-        is_developer(name=caller, db_path=db_path)
-        or is_researcher(name=caller, db_path=db_path)
-        or is_privileged(name=caller, db_path=db_path)
+        is_developer(name=caller)
+        or is_researcher(name=caller)
+        or is_privileged(name=caller)
     ):
-        return apply_may_spawn_gate(caller=caller, base=(True, None), db_path=db_path)
+        return apply_may_spawn_gate(caller=caller, base=(True, None))
     from .state_db import open_db
 
     with open_db(db_path) as conn:
@@ -314,15 +314,11 @@ def spawn_allowed(
             "SELECT parent_name FROM lineage WHERE child_name = ?", (caller,)
         ).fetchone()
     if parent_row is None:
-        return apply_may_spawn_gate(caller=caller, base=(True, None), db_path=db_path)
-    return (False, _spawn_denied_reason(caller, parent_row["parent_name"], db_path))
+        return apply_may_spawn_gate(caller=caller, base=(True, None))
+    return (False, _spawn_denied_reason(caller, parent_row["parent_name"]))
 
 
-def _spawn_denied_reason(
-    caller: str,
-    parent: str,
-    db_path: Path | None,
-) -> str:
+def _spawn_denied_reason(caller: str, parent: str) -> str:
     """Compose the spawn-deny reason, naming the groups ACTUALLY resolved.
 
     The message this replaces asserted the caller "is in none of the
@@ -342,13 +338,13 @@ def _spawn_denied_reason(
     """
     from .state_db_acl_policy import comms_policy_row_exists
 
-    groups = sorted(resolve_group_names(name=caller, db_path=db_path))
+    groups = sorted(resolve_group_names(name=caller))
     if groups:
         seen = (
             f"the groups this host resolved for it are {groups}, none of "
             "which grant spawn authority"
         )
-    elif comms_policy_row_exists(name=caller, db_path=db_path):
+    elif comms_policy_row_exists(name=caller):
         seen = "it IS registered on this host but resolved to NO named group at all"
     else:
         seen = (

--- a/src/scitex_agent_container/_state/state_db_schema.py
+++ b/src/scitex_agent_container/_state/state_db_schema.py
@@ -241,29 +241,16 @@ CREATE TABLE IF NOT EXISTS comms_nodes (
 );
 CREATE INDEX IF NOT EXISTS idx_comms_nodes_host ON comms_nodes(host);
 
--- Phase-3 ACL: per-spec capsule-isolation policy (ADR-0010 Step 2).
--- Row written at agent_start from the loaded spec.comms/spec.lineage
--- blocks. Read at ACL-check time by check_send_acl / check_spawn /
--- derive_group so policy lookups stay synchronous with no YAML re-parse.
--- Defaults match the dataclass defaults (everything "allow", may_spawn=1,
--- lineage_group=""), so absence of a row is byte-equivalent to the
--- pre-Phase-3 group-default ACL.
--- ``group_name`` (operator 2026-06-25): the agent's NAMED group, resolved
--- at agent_start from metadata.labels.group (else role-derived; the
--- developer-ish roles default to 'developer'). Read at ACL-check time so
--- a same-named-group send is allowed (full mesh within a group) and the
--- 'developer' group gets full agent-CRUD authority. Default '' (ungrouped)
--- keeps absence byte-equivalent to the pre-group-name behaviour.
-CREATE TABLE IF NOT EXISTS node_comms_policy (
-    name              TEXT PRIMARY KEY,
-    outbound_siblings TEXT NOT NULL DEFAULT 'allow',
-    outbound_parent   TEXT NOT NULL DEFAULT 'allow',
-    inbound_siblings  TEXT NOT NULL DEFAULT 'allow',
-    inbound_parent    TEXT NOT NULL DEFAULT 'allow',
-    lineage_group     TEXT NOT NULL DEFAULT '',
-    may_spawn         INTEGER NOT NULL DEFAULT 1,
-    group_name        TEXT NOT NULL DEFAULT '',
-    group_names       TEXT NOT NULL DEFAULT '',
-    updated_at        REAL NOT NULL
-);
+-- The Phase-3 ACL table ``node_comms_policy`` was defined here until
+-- 2026-08-28. It moved to PostgreSQL via scitex_dev.store; its schema is
+-- created on first open by ``state_db_acl_policy_store.open_policy_store``,
+-- so there is nothing to create here.
+--
+-- REMOVED rather than left behind, which for an ACL matters more than for
+-- the tables that went before it. A CREATE TABLE with no writer leaves an
+-- EMPTY table, and an empty ACL table does not read as "wrong database" —
+-- ``read_comms_policy`` answers a missing row with all-allow defaults, so a
+-- stale reader querying the abandoned table would have been handed
+-- PERMISSION, silently, with no error anywhere. No table at all is the
+-- honest answer.
 """

--- a/src/scitex_agent_container/_store_plugin.py
+++ b/src/scitex_agent_container/_store_plugin.py
@@ -329,6 +329,12 @@ NODE_COMMS_POLICY = Schema.build(
         "inbound_parent": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
         "lineage_group": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
         "may_spawn": _data(FieldKind.BOOL, MergeRule.LAST_WRITER_WINS, required=True),
+        # BOTH group projections. They are written together by
+        # ``record_comms_policy`` from one ``metadata.labels``, and
+        # declaring only ``group_names`` here let the primary drift out
+        # of the replication contract while the mesh still resolved
+        # through it.
+        "group_name": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
         "group_names": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
         "updated_at": _data(FieldKind.REAL, MergeRule.MAX, required=True),
     },
@@ -339,10 +345,18 @@ NODE_COMMS_POLICY = Schema.build(
 CLASSIFIED: dict[str, tuple[Schema, Truth, WriterPolicy]] = {
     "sac_comms_nodes": (COMMS_NODES, Truth.FLEET, WriterPolicy.SINGLE_WRITER),
     "sac_comms_grants": (COMMS_GRANTS, Truth.FLEET, WriterPolicy.MULTI_WRITER),
+    # MULTI_WRITER since 2026-08-28, when the table moved to PostgreSQL
+    # and this declaration stopped being a plan and started describing a
+    # live store. SINGLE_WRITER modelled the record as owned by the host
+    # running the agent, which it is not: ``sac agents refresh-acl``
+    # re-publishes the whole fleet from wherever the operator is, agents
+    # relocate between hosts, and ``import_state`` bulk-imports peer rows.
+    # A refused ACL write is a STALE ACL row, and a stale ACL row denies
+    # an agent its groups or leaves it holding groups its spec dropped.
     "sac_node_comms_policy": (
         NODE_COMMS_POLICY,
         Truth.FLEET,
-        WriterPolicy.SINGLE_WRITER,
+        WriterPolicy.MULTI_WRITER,
     ),
     "sac_lineage": (LINEAGE, Truth.HISTORY, WriterPolicy.MULTI_WRITER),
     "sac_instances": (INSTANCES, Truth.PER_HOST, WriterPolicy.SINGLE_WRITER),

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -198,7 +198,17 @@ FROZEN_SQLITE_DDL = frozenset(
         # `test_the_ddl_freeze_list_has_no_stale_entries` reported. A ratchet
         # that only checks one direction would have gone green on a half-done
         # migration.
-        "_state/state_db_acl_policy.py",
+        #
+        # _state/state_db_acl_policy.py LEFT THIS SET 2026-08-28 — the Phase-3
+        # per-spec ACL table, and the first move where a lost write is a
+        # PRIVILEGE change rather than a lost observation: read_comms_policy
+        # answers a missing record with all-allow defaults, so an unreachable
+        # store that returned empty instead of raising would read as
+        # PERMISSION. It is also the first to leave this set on the strength
+        # of its DOCSTRING: the module never executed DDL, it quoted the
+        # CREATE TABLE in its prose, and this scan reads file text — so the
+        # entry went stale the moment the prose was rewritten, exactly as the
+        # two-directional rule intends.
         # _state/state_db_blocks.py LEFT THIS SET 2026-08-20 — the FOURTH table
         # to move to PostgreSQL, and the first where the migration's own
         # PREDICTION was wrong in the safe direction. It was scoped as "a

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -697,6 +697,7 @@ def test_agent_start_forwards_assume_yes_to_broker_body(
 
 
 def test_agent_start_not_in_sif_uses_local_runtime(
+    pg_schema: str,
     isolated_state, sif_env, listen_env, tmp_path
 ) -> None:
     # Arrange — NO in-SIF env vars set → regression guard: local flow intact.

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -304,6 +304,7 @@ def _fire_monitor_restart_against_foreign_db(
 
 
 def test_monitor_restart_does_not_record_the_instance_into_a_foreign_state_db(
+    pg_schema: str,
     db_path: Path, tmp_path: Path
 ) -> None:
     """The 2026-07-14 regression, measured where it is still measurable.

--- a/tests/scitex_agent_container/_lifecycle/test__layers_preflight.py
+++ b/tests/scitex_agent_container/_lifecycle/test__layers_preflight.py
@@ -353,7 +353,7 @@ class TestReportedOncePerStart:
     report. Before the move this same start produced two."""
 
     def test_start_reports_undeclared_layers_exactly_once(
-        self, tmp_path, isolated_home, caplog
+        self, pg_schema: str, tmp_path, isolated_home, caplog
     ):
         # Arrange
         spec = _write_undeclared_spec(tmp_path)
@@ -372,7 +372,7 @@ class TestReportedOncePerStart:
         assert len(hits) == 1
 
     def test_start_still_reaches_the_runtime_while_not_enforcing(
-        self, tmp_path, isolated_home
+        self, pg_schema: str, tmp_path, isolated_home
     ):
         # Arrange
         spec = _write_undeclared_spec(tmp_path)

--- a/tests/scitex_agent_container/_lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename.py
@@ -320,7 +320,7 @@ def test_no_cards_mode_warns_that_the_cards_will_be_orphaned(world: World):
 # ---------------------------------------------------------------------------
 
 
-def test_rename_moves_the_spec_dir(renamed: World):
+def test_rename_moves_the_spec_dir(pg_schema: str, renamed: World):
     # Arrange
     spec = renamed.layout.spec_file(NEW)
     # Act
@@ -329,7 +329,7 @@ def test_rename_moves_the_spec_dir(renamed: World):
     assert exists
 
 
-def test_rename_removes_the_old_spec_dir(renamed: World):
+def test_rename_removes_the_old_spec_dir(pg_schema: str, renamed: World):
     # Arrange
     old_dir = renamed.layout.spec_dir(OLD)
     # Act
@@ -338,7 +338,7 @@ def test_rename_removes_the_old_spec_dir(renamed: World):
     assert not exists
 
 
-def test_rename_rewrites_the_board_identity_in_the_spec(renamed: World):
+def test_rename_rewrites_the_board_identity_in_the_spec(pg_schema: str, renamed: World):
     # Arrange
     expected = f"SCITEX_TODO_AGENT_ID={NEW}"
     # Act
@@ -347,7 +347,7 @@ def test_rename_rewrites_the_board_identity_in_the_spec(renamed: World):
     assert expected in text
 
 
-def test_rename_rewrites_the_state_db_path_in_the_spec(renamed: World):
+def test_rename_rewrites_the_state_db_path_in_the_spec(pg_schema: str, renamed: World):
     # Arrange
     expected = f"SCITEX_AGENT_CONTAINER_STATE_DB=/state/{NEW}/state.db"
     # Act
@@ -356,7 +356,7 @@ def test_rename_rewrites_the_state_db_path_in_the_spec(renamed: World):
     assert expected in text
 
 
-def test_rename_moves_the_overlay_dir_with_its_contents(renamed: World):
+def test_rename_moves_the_overlay_dir_with_its_contents(pg_schema: str, renamed: World):
     # Arrange
     marker = renamed.layout.overlay_dir(NEW) / "upper" / "home" / "agent" / "marker"
     # Act
@@ -365,7 +365,7 @@ def test_rename_moves_the_overlay_dir_with_its_contents(renamed: World):
     assert content == OLD  # the file MOVED; its bytes are untouched
 
 
-def test_rename_moves_the_runtime_dir(renamed: World):
+def test_rename_moves_the_runtime_dir(pg_schema: str, renamed: World):
     # Arrange
     session = renamed.layout.runtime_dir(NEW) / "session.jsonl"
     # Act
@@ -374,7 +374,7 @@ def test_rename_moves_the_runtime_dir(renamed: World):
     assert exists
 
 
-def test_rename_repoints_the_registry_entry_name(renamed: World):
+def test_rename_repoints_the_registry_entry_name(pg_schema: str, renamed: World):
     # Arrange
     path = renamed.layout.registry_json(NEW)
     # Act
@@ -383,7 +383,7 @@ def test_rename_repoints_the_registry_entry_name(renamed: World):
     assert entry["name"] == NEW
 
 
-def test_rename_repoints_the_registry_config_path(renamed: World):
+def test_rename_repoints_the_registry_config_path(pg_schema: str, renamed: World):
     # Arrange
     expected = str(renamed.layout.spec_file(NEW))
     # Act
@@ -392,7 +392,7 @@ def test_rename_repoints_the_registry_config_path(renamed: World):
     assert entry["config"] == expected
 
 
-def test_rename_moves_the_state_db_rows(renamed: World):
+def test_rename_moves_the_state_db_rows(pg_schema: str, renamed: World):
     # Arrange
     expected = [NEW, NEW]
     # Act
@@ -401,7 +401,7 @@ def test_rename_moves_the_state_db_rows(renamed: World):
     assert names == expected
 
 
-def test_rename_keeps_the_operators_spec_comments(renamed: World):
+def test_rename_keeps_the_operators_spec_comments(pg_schema: str, renamed: World):
     # Arrange
     marker = "# This comment block is LOAD-BEARING"
     # Act
@@ -410,7 +410,7 @@ def test_rename_keeps_the_operators_spec_comments(renamed: World):
     assert marker in text
 
 
-def test_a_renamed_agent_can_be_renamed_back(world: World):
+def test_a_renamed_agent_can_be_renamed_back(pg_schema: str, world: World):
     """The rename is not a one-way door."""
     # Arrange
     agent_rename(OLD, NEW, layout=world.layout, cards=False)

--- a/tests/scitex_agent_container/_lifecycle/test__rename_db.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_db.py
@@ -45,10 +45,6 @@ _SEED = [
         (OLD, "h", 9001, 1.0, 1.0),
     ),
     (
-        "INSERT INTO node_comms_policy (name, updated_at) VALUES (?, ?)",
-        (OLD, 1.0),
-    ),
-    (
         "INSERT INTO lineage (child_name, parent_name, created_at) "
         "VALUES (?, ?, ?)",
         ("child-a", OLD, 1.0),
@@ -145,14 +141,20 @@ def test_rename_moves_the_comms_node_row(seeded: Path):
     assert _one(seeded, sql, NEW) == 1
 
 
-def test_rename_moves_the_acl_policy_row(seeded: Path):
-    """Miss this and the ACL gate has no policy for the live name."""
-    # Arrange
-    sql = "SELECT COUNT(*) FROM node_comms_policy WHERE name = ?"
-    # Act
-    rename_rows(seeded, OLD, NEW)
-    # Assert
-    assert _one(seeded, sql, NEW) == 1
+# ``test_rename_moves_the_acl_policy_row`` was here until 2026-08-28. It
+# asserted that ``rename_rows`` UPDATEs ``node_comms_policy.name``, and the
+# migration of that table to PostgreSQL killed the premise outright: SQLite
+# no longer has the table, and ``rename_rows`` SKIPS tables absent from
+# sqlite_master. Left in place it would have passed forever while reaching
+# nothing — a green test whose name claims a property it can no longer test,
+# which is worse than a red one because nothing forces anyone to look.
+#
+# DELETED, NOT EDITED UNTIL IT PASSED. The property it named is real and
+# still holds; it is measured where it now lives —
+# ``_state/test_state_db_acl_policy.py::test_rename_carries_the_policy_to_
+# the_new_name`` and ``::test_rename_retires_the_old_name``, against the
+# store that actually holds the row. ``_rename.apply_plan`` runs that move
+# as its own ``acl-policy`` step, with its inverse on the undo stack.
 
 
 def test_rename_moves_the_lineage_parent_edge(seeded: Path):

--- a/tests/scitex_agent_container/_lifecycle/test__restart_preflight_integration.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_preflight_integration.py
@@ -224,6 +224,7 @@ def test_agent_restart_launches_no_successor_on_abort(
 
 
 def test_agent_restart_healthy_successor_still_stops_then_starts(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — the pre-flight passes (returns None): normal restart proceeds.
@@ -244,6 +245,7 @@ def test_agent_restart_healthy_successor_still_stops_then_starts(
 
 
 def test_agent_restart_runs_preflight_before_the_stop(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — record ordering: the check must fire BEFORE the stop.
@@ -276,6 +278,7 @@ def test_agent_restart_runs_preflight_before_the_stop(
 
 
 def test_agent_start_force_raises_abort_on_unusable_successor(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — a live agent, force-restart, pre-flight will REJECT.
@@ -299,6 +302,7 @@ def test_agent_start_force_raises_abort_on_unusable_successor(
 
 
 def test_agent_start_force_leaves_running_container_up_on_abort(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -324,6 +328,7 @@ def test_agent_start_force_leaves_running_container_up_on_abort(
 
 
 def test_agent_start_force_healthy_successor_still_restarts(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — pre-flight passes: a normal force-restart must still work.

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
@@ -117,7 +117,7 @@ def test_gate_allows_admin_caller_when_sac_name_unset(db_path, sac_name) -> None
     assert caller is None
 
 
-def test_gate_allows_root_caller_to_spawn(db_path, sac_name) -> None:
+def test_gate_allows_root_caller_to_spawn(pg_schema: str, db_path, sac_name) -> None:
     # Arrange — "root" has no parent in lineage → root → allowed.
     sac_name("root")
     # Act
@@ -131,7 +131,7 @@ def test_gate_allows_root_caller_to_spawn(db_path, sac_name) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_gate_records_lineage_edge_for_root_caller(db_path, sac_name) -> None:
+def test_gate_records_lineage_edge_for_root_caller(pg_schema: str, db_path, sac_name) -> None:
     # Arrange — a root caller spawning a child writes the lineage edge.
     sac_name("root")
     # Act
@@ -140,7 +140,7 @@ def test_gate_records_lineage_edge_for_root_caller(db_path, sac_name) -> None:
     assert "root" in derive_group(name="child-c")
 
 
-def test_gate_does_not_record_lineage_for_admin_caller(db_path, sac_name) -> None:
+def test_gate_does_not_record_lineage_for_admin_caller(pg_schema: str, db_path, sac_name) -> None:
     # Arrange — admin spawn (no SAC_NAME) must leave the child unattached.
     sac_name(None)
     # Act
@@ -149,7 +149,7 @@ def test_gate_does_not_record_lineage_for_admin_caller(db_path, sac_name) -> Non
     assert derive_group(name="child-d") == {"child-d"}
 
 
-def test_gate_lineage_record_is_idempotent_on_same_parent(db_path, sac_name) -> None:
+def test_gate_lineage_record_is_idempotent_on_same_parent(pg_schema: str, db_path, sac_name) -> None:
     # Arrange — root spawns the same child twice (e.g. a --force restart).
     sac_name("root")
     enforce_spawn_gate("child-e")
@@ -164,7 +164,7 @@ def test_gate_lineage_record_is_idempotent_on_same_parent(db_path, sac_name) -> 
 # ---------------------------------------------------------------------------
 
 
-def test_gate_denies_child_caller_under_root_only_policy(db_path, sac_name) -> None:
+def test_gate_denies_child_caller_under_root_only_policy(pg_schema: str, db_path, sac_name) -> None:
     # Arrange — "worker-a" is a child of "root" → not a root → may not spawn.
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     sac_name("worker-a")
@@ -175,7 +175,7 @@ def test_gate_denies_child_caller_under_root_only_policy(db_path, sac_name) -> N
         enforce_spawn_gate("grandchild")
 
 
-def test_gate_allows_restart_keeps_existing_parent(db_path, sac_name) -> None:
+def test_gate_allows_restart_keeps_existing_parent(pg_schema: str, db_path, sac_name) -> None:
     # Arrange — child-f already parented to "root-1"; a restart by a
     # different-lineage caller must SUCCEED in-place (no re-parent, no
     # SpawnDeniedError) — the 409 the ACL previously raised is now gone,
@@ -193,7 +193,7 @@ def test_gate_allows_restart_keeps_existing_parent(db_path, sac_name) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_explicit_caller_arg_overrides_sac_name_env(db_path, sac_name) -> None:
+def test_explicit_caller_arg_overrides_sac_name_env(pg_schema: str, db_path, sac_name) -> None:
     # Arrange — env says "env-parent" but the explicit arg wins.
     sac_name("env-parent")
     # Act

--- a/tests/scitex_agent_container/_lifecycle/test__stale_lease.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stale_lease.py
@@ -454,6 +454,7 @@ def _drive_dead_runtime_start_scenario(
 
 
 def test_agent_start_clears_dead_pid_from_active_zombie_rows(
+    pg_schema: str,
     db_path: Path, tmp_path: Path
 ) -> None:
     # Arrange
@@ -468,6 +469,7 @@ def test_agent_start_clears_dead_pid_from_active_zombie_rows(
 
 
 def test_agent_start_reaches_runtime_start_after_clearing_zombie_lease(
+    pg_schema: str,
     db_path: Path, tmp_path: Path
 ) -> None:
     # Arrange

--- a/tests/scitex_agent_container/_lifecycle/test__start_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_drift.py
@@ -213,7 +213,7 @@ def test_refusal_names_the_named_override(tmp_path, registry, capsys):
     assert "--allow-stale-spec" in capsys.readouterr().err
 
 
-def test_allow_stale_spec_starts_the_agent(tmp_path, registry):
+def test_allow_stale_spec_starts_the_agent(pg_schema: str, tmp_path, registry):
     # Arrange — the escape hatch, passed the way --allow-stale-spec passes it.
     spec = _make_spec_repo(tmp_path, drifted=True)
     runtime = _FakeRuntime()
@@ -223,7 +223,7 @@ def test_allow_stale_spec_starts_the_agent(tmp_path, registry):
     assert len(runtime.started) == 1
 
 
-def test_allow_stale_spec_env_starts_the_agent(tmp_path, registry, env_save_restore):
+def test_allow_stale_spec_env_starts_the_agent(pg_schema: str, tmp_path, registry, env_save_restore):
     # Arrange — same override, env transport (what the parallel path inherits).
     env_save_restore.set("SAC_ALLOW_STALE_SPEC", "1")
     spec = _make_spec_repo(tmp_path, drifted=True)
@@ -234,7 +234,7 @@ def test_allow_stale_spec_env_starts_the_agent(tmp_path, registry, env_save_rest
     assert len(runtime.started) == 1
 
 
-def test_unpushed_local_commits_still_start(tmp_path, registry):
+def test_unpushed_local_commits_still_start(pg_schema: str, tmp_path, registry):
     # Arrange — AHEAD is not staleness: the spec here IS the newest that
     # exists. Hosts like spartan legitimately carry local commits.
     spec = _make_spec_repo(tmp_path, drifted=False)
@@ -248,7 +248,7 @@ def test_unpushed_local_commits_still_start(tmp_path, registry):
     assert len(runtime.started) == 1
 
 
-def test_unpushed_local_commits_still_warn(tmp_path, registry, capsys):
+def test_unpushed_local_commits_still_warn(pg_schema: str, tmp_path, registry, capsys):
     # Arrange — not refusing is not the same as staying quiet.
     spec = _make_spec_repo(tmp_path, drifted=False)
     (spec.parent / "local.txt").write_text("local only")
@@ -261,7 +261,7 @@ def test_unpushed_local_commits_still_warn(tmp_path, registry, capsys):
     assert "sac-drift WARNING" in capsys.readouterr().err
 
 
-def test_clean_source_starts_normally(tmp_path, registry):
+def test_clean_source_starts_normally(pg_schema: str, tmp_path, registry):
     # Arrange
     spec = _make_spec_repo(tmp_path, drifted=False)
     runtime = _FakeRuntime()

--- a/tests/scitex_agent_container/_lifecycle/test__start_retracts_marker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_retracts_marker.py
@@ -184,6 +184,7 @@ def _seed_marker(runtime_dir: Path) -> None:
 
 
 def test_the_already_running_noop_returns_the_already_running_outcome(
+    pg_schema: str,
     tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -205,6 +206,7 @@ def test_the_already_running_noop_returns_the_already_running_outcome(
 
 
 def test_the_already_running_noop_retracts_an_existing_marker(
+    pg_schema: str,
     tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -227,6 +229,7 @@ def test_the_already_running_noop_retracts_an_existing_marker(
 
 
 def test_the_already_running_noop_leaves_the_retracted_copy(
+    pg_schema: str,
     tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -249,6 +252,7 @@ def test_the_already_running_noop_leaves_the_retracted_copy(
 
 
 def test_the_already_running_noop_with_no_marker_does_not_raise(
+    pg_schema: str,
     tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
 ) -> None:
     # Arrange — no marker on disk at all; retract_marker_for must be a
@@ -278,6 +282,7 @@ def test_the_already_running_noop_with_no_marker_does_not_raise(
 
 
 def test_a_launch_that_merely_returned_keeps_the_marker(
+    pg_schema: str,
     tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
 ) -> None:
     # Arrange — nothing vouches for liveness (no registry row, no
@@ -307,6 +312,7 @@ def test_a_launch_that_merely_returned_keeps_the_marker(
 
 
 def test_a_dry_run_on_an_alive_agent_keeps_the_marker(
+    pg_schema: str,
     tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
 ) -> None:
     # Arrange — ALIVE verdict (registry + running + verifier), but
@@ -337,6 +343,7 @@ def test_a_dry_run_on_an_alive_agent_keeps_the_marker(
 
 
 def test_a_failed_start_keeps_the_marker(
+    pg_schema: str,
     tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
 ) -> None:
     # Arrange — runtime.start() returns False -> raise_start_failure raises

--- a/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
@@ -162,6 +162,7 @@ def _write_spec(yaml_root: Path, name: str) -> Path:
 
 
 def test_core_start_writes_lineage_row_for_parent_caller(
+    pg_schema: str,
     isolated_state, sac_name, tmp_path
 ) -> None:
     # Arrange — a root parent agent spawns a child via core agent_start.
@@ -182,6 +183,7 @@ def test_core_start_writes_lineage_row_for_parent_caller(
 
 
 def test_admin_start_records_no_lineage_edge(
+    pg_schema: str,
     isolated_state, sac_name, tmp_path
 ) -> None:
     # Arrange — no SAC_NAME → admin / operator / lead launch.

--- a/tests/scitex_agent_container/_lifecycle/test__start_verdict.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_verdict.py
@@ -202,7 +202,7 @@ def test_legacy_verifier_missing_registry_row_is_unknown(tmp_path, registry):
 # --------------------------------------------------------------------------
 
 
-def test_an_unknown_agent_is_started_rather_than_no_opped(tmp_path, registry):
+def test_an_unknown_agent_is_started_rather_than_no_opped(pg_schema: str, tmp_path, registry):
     """THE unfalsifiable-row regression.
 
     The agent looks running to every proxy (registry row present, runtime says
@@ -230,7 +230,7 @@ def test_an_unknown_agent_is_started_rather_than_no_opped(tmp_path, registry):
     assert len(runtime.start_calls) == 1
 
 
-def test_an_unknown_agent_is_started_without_force(tmp_path, registry):
+def test_an_unknown_agent_is_started_without_force(pg_schema: str, tmp_path, registry):
     """And it does so WITHOUT --force — i.e. without stopping anything."""
     # Arrange
     spec = _write_spec(tmp_path)
@@ -253,7 +253,7 @@ def test_an_unknown_agent_is_started_without_force(tmp_path, registry):
     assert runtime.stop_calls == []
 
 
-def test_a_dead_agent_is_started(tmp_path, registry):
+def test_a_dead_agent_is_started(pg_schema: str, tmp_path, registry):
     # Arrange
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
@@ -279,7 +279,7 @@ def test_a_dead_agent_is_started(tmp_path, registry):
 # --------------------------------------------------------------------------
 
 
-def test_an_alive_agent_still_no_ops(tmp_path, registry):
+def test_an_alive_agent_still_no_ops(pg_schema: str, tmp_path, registry):
     """Positive evidence of life still pins the no-op — we did not just delete it."""
     # Arrange
     spec = _write_spec(tmp_path)
@@ -309,7 +309,7 @@ def test_an_alive_agent_still_no_ops(tmp_path, registry):
     assert runtime.start_calls == []
 
 
-def test_an_alive_agent_no_op_returns_success(tmp_path, registry):
+def test_an_alive_agent_no_op_returns_success(pg_schema: str, tmp_path, registry):
     # Arrange
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
@@ -347,6 +347,7 @@ def test_an_alive_agent_no_op_returns_success(tmp_path, registry):
 
 
 def test_an_alive_no_op_announces_agent_and_session_loudly(
+    pg_schema: str,
     tmp_path, registry, caplog
 ):
     """The no-op branch must EMIT what it found — never exit 0 in silence.

--- a/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
@@ -607,6 +607,7 @@ def _restart(tmp_path: Path, runtime: Any, *, name: str = "alpha") -> bool:
 
 
 def test_restart_kills_the_runtime_that_ignored_sigterm(
+    pg_schema: str,
     tmp_path: Path, deaf_proc: subprocess.Popen
 ) -> None:
     # Arrange — the neurovista shape: a REAL process that ignores SIGTERM.
@@ -619,6 +620,7 @@ def test_restart_kills_the_runtime_that_ignored_sigterm(
 
 
 def test_restart_starts_the_replacement_after_escalating(
+    pg_schema: str,
     tmp_path: Path, deaf_proc: subprocess.Popen
 ) -> None:
     # Arrange

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -382,6 +382,7 @@ def test_fire_forget_hook_swallows_run_hook_exceptions() -> None:
 
 
 def test_agent_start_happy_path_returns_true(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -402,6 +403,7 @@ def test_agent_start_happy_path_returns_true(
 
 
 def test_agent_start_happy_path_calls_runtime_start_once(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -421,6 +423,7 @@ def test_agent_start_happy_path_calls_runtime_start_once(
 
 
 def test_agent_start_happy_path_registers_agent(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -440,6 +443,7 @@ def test_agent_start_happy_path_registers_agent(
 
 
 def test_agent_start_happy_path_invokes_handover(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -459,6 +463,7 @@ def test_agent_start_happy_path_invokes_handover(
 
 
 def test_agent_start_idempotent_when_already_running(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange: registry knows the agent, runtime reports it running,
@@ -496,6 +501,7 @@ def test_agent_start_idempotent_when_already_running(
 
 
 def test_agent_start_force_restarts_when_already_running(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -527,6 +533,7 @@ def test_agent_start_force_restarts_when_already_running(
 
 
 def test_agent_start_launches_when_liveness_verifier_returns_false(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — registry says exists, runtime PID-check says running,
@@ -666,6 +673,7 @@ def _force_restart_running_agent(
 
 
 def test_agent_start_force_restart_records_single_active_instance_row(
+    pg_schema: str,
     tmp_path: Path, registry: Registry, isolated_state_db: Path
 ) -> None:
     # Arrange
@@ -679,6 +687,7 @@ def test_agent_start_force_restart_records_single_active_instance_row(
 
 
 def test_agent_start_force_restart_records_non_none_a2a_port(
+    pg_schema: str,
     tmp_path: Path, registry: Registry, isolated_state_db: Path
 ) -> None:
     """Regression: before the fix, the ``--force`` ``agent_stop`` released
@@ -697,6 +706,7 @@ def test_agent_start_force_restart_records_non_none_a2a_port(
 
 
 def test_agent_start_force_restart_instances_port_matches_claim(
+    pg_schema: str,
     tmp_path: Path, registry: Registry, isolated_state_db: Path
 ) -> None:
     """After a force restart the ``instances`` row a2a_port must equal the
@@ -714,6 +724,7 @@ def test_agent_start_force_restart_instances_port_matches_claim(
 
 
 def test_agent_start_force_clears_stale_registry_entry(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange: registered but runtime says not running → stale entry.
@@ -735,6 +746,7 @@ def test_agent_start_force_clears_stale_registry_entry(
 
 
 def test_agent_start_session_override_mutates_claude_session(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -761,6 +773,7 @@ def test_agent_start_session_override_mutates_claude_session(
 
 
 def test_agent_start_continue_override_beats_spec_fresh(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — spec explicitly says fresh; the CLI --continue maps to a
@@ -787,6 +800,7 @@ def test_agent_start_continue_override_beats_spec_fresh(
 
 
 def test_agent_start_fresh_override_beats_spec_continue(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — spec explicitly says continue; the CLI --fresh maps to a
@@ -813,6 +827,7 @@ def test_agent_start_fresh_override_beats_spec_continue(
 
 
 def test_agent_start_resume_id_override_mutates_resume_id(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -839,6 +854,7 @@ def test_agent_start_resume_id_override_mutates_resume_id(
 
 
 def test_agent_start_runtime_failure_raises_runtime_error(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -878,6 +894,7 @@ def _start_with_failing_runtime(spec: Path, registry: Registry) -> None:
 
 
 def test_agent_start_runtime_failure_persists_diag_file(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange -- a false-negative start whose only evidence must survive
@@ -896,6 +913,7 @@ def test_agent_start_runtime_failure_persists_diag_file(
 
 
 def test_agent_start_runtime_failure_diag_names_the_reason(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -911,6 +929,7 @@ def test_agent_start_runtime_failure_diag_names_the_reason(
 
 
 def test_agent_start_dry_run_does_not_register(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -931,6 +950,7 @@ def test_agent_start_dry_run_does_not_register(
 
 
 def test_agent_start_dry_run_passes_dry_run_kwarg_to_runtime(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -951,6 +971,7 @@ def test_agent_start_dry_run_passes_dry_run_kwarg_to_runtime(
 
 
 def test_agent_start_dry_run_typeerror_raises_helpful_runtime_error(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange: a runtime whose ``start`` refuses ``dry_run`` (older runtime).
@@ -973,6 +994,7 @@ def test_agent_start_dry_run_typeerror_raises_helpful_runtime_error(
 
 
 def test_agent_start_hydrate_failure_does_not_block_start(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange: hydrate_from_hub raises but agent_start must still succeed.
@@ -993,6 +1015,7 @@ def test_agent_start_hydrate_failure_does_not_block_start(
 
 
 def test_agent_start_starts_health_monitor_thread_when_enabled(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange: health.enabled=true in the spec → production must spawn a thread.
@@ -1019,6 +1042,7 @@ def test_agent_start_starts_health_monitor_thread_when_enabled(
 
 
 def test_agent_start_failback_poller_failure_is_swallowed(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -1039,6 +1063,7 @@ def test_agent_start_failback_poller_failure_is_swallowed(
 
 
 def test_agent_start_cli_no_preflight_propagates_to_runtime(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     """WI-6 removed ``RemoteSpec`` and the
@@ -1369,6 +1394,7 @@ def test_agent_stop_all_without_force_aborts_on_first_failure(
 
 
 def test_agent_restart_calls_runtime_stop_then_start(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -1389,6 +1415,7 @@ def test_agent_restart_calls_runtime_stop_then_start(
 
 
 def test_agent_restart_clears_dead_session_marker(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — a runtime state dir holding a DEAD resume marker + history
@@ -1425,6 +1452,7 @@ def test_agent_restart_clears_dead_session_marker(
 
 
 def test_agent_restart_clears_dead_session_history(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — the dead uuid lives in the append-only history that the
@@ -1461,6 +1489,7 @@ def test_agent_restart_clears_dead_session_history(
 
 
 def test_agent_restart_backs_up_dead_session_history(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — clearing the dead history must preserve it as an audit
@@ -1516,6 +1545,7 @@ def test_agent_restart_unknown_raises(tmp_path: Path, registry: Registry) -> Non
 
 
 def test_agent_restart_no_row_falls_back_to_spec_and_starts(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — NO registry row for "alpha" (ad-hoc / pre-autorecord
@@ -1538,6 +1568,7 @@ def test_agent_restart_no_row_falls_back_to_spec_and_starts(
 
 
 def test_agent_restart_no_row_force_stops_before_start(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — no registry row; a runtime whose stop() raises. The
@@ -1560,6 +1591,7 @@ def test_agent_restart_no_row_force_stops_before_start(
 
 
 def test_agent_restart_no_row_uses_default_resolver_discovery_chain(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange — no registry row, NO injected resolver: the real default
@@ -1745,6 +1777,7 @@ def _restart_alpha(runtime: _StaggeredRuntime, registry: Registry) -> bool:
 
 
 def test_agent_restart_returns_true_after_waiting_for_previous_to_stop(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -1758,6 +1791,7 @@ def test_agent_restart_returns_true_after_waiting_for_previous_to_stop(
 
 
 def test_agent_restart_calls_runtime_start_exactly_once_after_waiting_for_stop(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -1771,6 +1805,7 @@ def test_agent_restart_calls_runtime_start_exactly_once_after_waiting_for_stop(
 
 
 def test_agent_restart_does_not_call_start_while_previous_runtime_is_still_running(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange
@@ -1786,6 +1821,7 @@ def test_agent_restart_does_not_call_start_while_previous_runtime_is_still_runni
 
 
 def test_agent_restart_polls_is_running_until_false(
+    pg_schema: str,
     tmp_path: Path, registry: Registry
 ) -> None:
     # Arrange

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -249,7 +249,7 @@ def test_acl_denies_when_target_missing(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_spawn_allows_root_caller(db_path: Path) -> None:
+def test_spawn_allows_root_caller(pg_schema: str, db_path: Path) -> None:
     """A node with no parent in lineage is allowed to spawn."""
     # Arrange
     caller = "root"
@@ -269,7 +269,7 @@ def test_spawn_allows_admin_caller_when_caller_is_none(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_spawn_denies_child_caller(db_path: Path) -> None:
+def test_spawn_denies_child_caller(pg_schema: str, db_path: Path) -> None:
     """A node with a parent (child) is NOT allowed to spawn."""
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
@@ -279,7 +279,7 @@ def test_spawn_denies_child_caller(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_spawn_deny_reason_explains_root_only_policy(db_path: Path) -> None:
+def test_spawn_deny_reason_explains_root_only_policy(pg_schema: str, db_path: Path) -> None:
     """The 403 body names the groups that WOULD authorise the spawn.
 
     It no longer asserts the caller holds none of them — that claim was
@@ -367,7 +367,7 @@ def test_http_node_message_send_403_body_carries_per_spec_reason(
     # Arrange — siblings so the per-spec inbound-sibling deny applies.
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     record_lineage(child="worker-b", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-b", inbound_siblings="deny", db_path=db_path)
+    record_comms_policy(name="worker-b", inbound_siblings="deny")
     app = create_app(token=TOKEN)
     # Act
     with TestClient(app) as client:
@@ -500,6 +500,7 @@ def test_http_per_node_bearer_403_body_explains_spoof(
 
 
 def test_http_agents_start_denies_child_caller_with_403(
+    pg_schema: str,
     isolated_listen_env, db_path: Path
 ) -> None:
     """Root-only spawn (current policy): a child caller → 403."""
@@ -519,6 +520,7 @@ def test_http_agents_start_denies_child_caller_with_403(
 
 
 def test_http_agents_start_403_carries_role_policy_text(
+    pg_schema: str,
     isolated_listen_env, db_path: Path
 ) -> None:
     # Arrange
@@ -578,7 +580,7 @@ def cross_group_deny_scenario(isolated_listen_env, db_path: Path, pg_schema: str
     the sibling relationship applies."""
     record_lineage(child="child-1", parent="root", db_path=db_path)
     record_lineage(child="child-2", parent="root", db_path=db_path)
-    record_comms_policy(name="child-2", inbound_siblings="deny", db_path=db_path)
+    record_comms_policy(name="child-2", inbound_siblings="deny")
     app = create_app(token=TOKEN)
     with TestClient(app) as client:
         resp = client.post(
@@ -667,7 +669,7 @@ def body_leak_scenario(isolated_listen_env, db_path: Path, pg_schema: str) -> di
     deny path under messaging default-allow)."""
     record_lineage(child="child-1", parent="root", db_path=db_path)
     record_lineage(child="child-2", parent="root", db_path=db_path)
-    record_comms_policy(name="child-2", inbound_siblings="deny", db_path=db_path)
+    record_comms_policy(name="child-2", inbound_siblings="deny")
     app = create_app(token=TOKEN)
     with TestClient(app) as client:
         resp = client.post(
@@ -728,7 +730,7 @@ def fanout_scope_scenario(isolated_listen_env, db_path: Path, pg_schema: str) ->
     """
     record_lineage(child="child-1", parent="root", db_path=db_path)
     record_lineage(child="child-2", parent="root", db_path=db_path)
-    record_comms_policy(name="child-2", inbound_siblings="deny", db_path=db_path)
+    record_comms_policy(name="child-2", inbound_siblings="deny")
     record_lineage(child="bystander", parent="root-3", db_path=db_path)
     app = create_app(token=TOKEN)
     with TestClient(app) as client:
@@ -852,7 +854,7 @@ def live_broker_event(isolated_listen_env, db_path: Path, pg_schema: str) -> dic
 
     record_lineage(child="child-1", parent="root", db_path=db_path)
     record_lineage(child="child-2", parent="root", db_path=db_path)
-    record_comms_policy(name="child-2", inbound_siblings="deny", db_path=db_path)
+    record_comms_policy(name="child-2", inbound_siblings="deny")
     app = create_app(token=TOKEN)
 
     async def driver() -> dict:

--- a/tests/scitex_agent_container/_listen/test__acl_check_lineage.py
+++ b/tests/scitex_agent_container/_listen/test__acl_check_lineage.py
@@ -68,7 +68,7 @@ def test_self_management_is_allowed(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_direct_child_is_allowed(db_path: Path) -> None:
+def test_direct_child_is_allowed(pg_schema: str, db_path: Path) -> None:
     # Arrange — root → child edge.
     record_lineage(child="kid", parent="root", db_path=db_path)
     # Act
@@ -77,7 +77,7 @@ def test_direct_child_is_allowed(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_transitive_descendant_is_allowed(db_path: Path) -> None:
+def test_transitive_descendant_is_allowed(pg_schema: str, db_path: Path) -> None:
     # Arrange — root → alice → ada (grandchild).
     record_lineage(child="alice", parent="root", db_path=db_path)
     record_lineage(child="ada", parent="alice", db_path=db_path)
@@ -92,7 +92,7 @@ def test_transitive_descendant_is_allowed(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_deny_when_caller_has_no_lineage_to_target(db_path: Path) -> None:
+def test_deny_when_caller_has_no_lineage_to_target(pg_schema: str, db_path: Path) -> None:
     # Arrange — alice and bob are unrelated roots.
     # (no lineage records: both are independent root nodes)
     # Act
@@ -101,7 +101,7 @@ def test_deny_when_caller_has_no_lineage_to_target(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_deny_for_sibling_target(db_path: Path) -> None:
+def test_deny_for_sibling_target(pg_schema: str, db_path: Path) -> None:
     # Arrange — alice + bob share a parent but are siblings.
     # Lineage gate denies sibling control (only descendants).
     record_lineage(child="alice", parent="root", db_path=db_path)
@@ -112,7 +112,7 @@ def test_deny_for_sibling_target(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_deny_for_ancestor_target(db_path: Path) -> None:
+def test_deny_for_ancestor_target(pg_schema: str, db_path: Path) -> None:
     # Arrange — child cannot operate on its parent (the gate is
     # downward only).
     record_lineage(child="kid", parent="root", db_path=db_path)
@@ -122,7 +122,7 @@ def test_deny_for_ancestor_target(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_deny_reason_names_caller_and_target(db_path: Path) -> None:
+def test_deny_reason_names_caller_and_target(pg_schema: str, db_path: Path) -> None:
     # Arrange — the deny reason must identify both names so the
     # 403 body lets the operator diagnose without guessing.
     record_lineage(child="alice", parent="root", db_path=db_path)
@@ -145,7 +145,7 @@ def test_returns_allow_tuple_with_none_reason(db_path: Path) -> None:
     assert (decision, reason) == ("allow", None)
 
 
-def test_returns_deny_tuple_with_string_reason(db_path: Path) -> None:
+def test_returns_deny_tuple_with_string_reason(pg_schema: str, db_path: Path) -> None:
     # Arrange
     # Act
     decision, reason = check_lineage_acl(caller="alice", target="bob", db_path=db_path)

--- a/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
+++ b/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
@@ -44,7 +44,16 @@ _TOKEN = "test-token-acl-deny-synthetic-notify"
 
 
 @pytest.fixture
-def isolated_state(tmp_path: Path) -> Iterator[Path]:
+def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
+    """The deny scenario, seeded across BOTH stores.
+
+    ``pg_schema`` is a dependency of the FIXTURE rather than only of the
+    tests because the seed below calls ``record_comms_policy``, which since
+    2026-08-28 writes to PostgreSQL. A test that lists ``pg_schema`` after
+    ``isolated_state`` gets them set up in that order, so the seed would run
+    against the deliberately unreachable DSN and ERROR before the skip could
+    fire — which is exactly what happened.
+    """
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
     saved_default = state_db.DEFAULT_DB_PATH
@@ -72,7 +81,7 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
         # so ``worker-a → lead`` is denied.
         record_lineage(child="worker-a", parent="root", db_path=db)
         record_lineage(child="lead", parent="root", db_path=db)
-        record_comms_policy(name="lead", inbound_siblings="deny", db_path=db)
+        record_comms_policy(name="lead", inbound_siblings="deny")
         yield db
     finally:
         state_db.DEFAULT_DB_PATH = saved_default

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -76,7 +76,6 @@ def _seed_child_from_labels(
         group_name=group_from_labels(labels),
         group_names=all_named_groups(labels),
         may_spawn=may_spawn,
-        db_path=db_path,
     )
 
 
@@ -107,8 +106,8 @@ def db_path(tmp_path: Path):
 def test_send_allowed_within_same_named_group(db_path: Path, pg_schema: str) -> None:
     """Same named group, no lineage edge, no grant → allow (full mesh)."""
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
-    record_comms_policy(name="bob", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
+    record_comms_policy(name="bob", group_name="developer")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="alice",
@@ -125,8 +124,8 @@ def test_send_allowed_cross_group_by_default(db_path: Path, pg_schema: str) -> N
     groups, no lineage, no grant → ALLOW. Cross-group messaging is
     collaboration, not a security boundary."""
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
-    record_comms_policy(name="carol", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
+    record_comms_policy(name="carol", group_name="analysts")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="alice",
@@ -142,8 +141,8 @@ def test_send_blocked_sender_still_denied_cross_group(db_path: Path, pg_schema: 
     """Override preserved: an explicit block still denies even though the
     cross-group default is now allow."""
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
-    record_comms_policy(name="carol", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
+    record_comms_policy(name="carol", group_name="analysts")
     block_send(sender="alice", target="carol")
     # Act
     decision, _reason = check_send_acl(
@@ -159,8 +158,8 @@ def test_send_blocked_sender_still_denied_cross_group(db_path: Path, pg_schema: 
 def test_send_allowed_cross_group_with_explicit_grant(db_path: Path, pg_schema: str) -> None:
     """An explicit grant still flips a cross-group deny to allow."""
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
-    record_comms_policy(name="carol", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
+    record_comms_policy(name="carol", group_name="analysts")
     grant_send(sender="alice", target="carol")
     # Act
     decision, _reason = check_send_acl(
@@ -199,8 +198,8 @@ def test_ungrouped_pair_allowed_by_default(db_path: Path, pg_schema: str) -> Non
 def test_send_allowed_developer_to_researcher(db_path: Path, pg_schema: str) -> None:
     """Cross-group mesh: developer → researcher, no grant → allow."""
     # Arrange
-    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
-    record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
+    record_comms_policy(name="dev-1", group_name="developer")
+    record_comms_policy(name="res-1", group_name="researcher")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="dev-1",
@@ -215,8 +214,8 @@ def test_send_allowed_developer_to_researcher(db_path: Path, pg_schema: str) -> 
 def test_send_allowed_researcher_to_generalist(db_path: Path, pg_schema: str) -> None:
     """Cross-group mesh: researcher → generalist, no grant → allow."""
     # Arrange
-    record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
-    record_comms_policy(name="gen-1", group_name="generalist", db_path=db_path)
+    record_comms_policy(name="res-1", group_name="researcher")
+    record_comms_policy(name="gen-1", group_name="generalist")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="res-1",
@@ -231,8 +230,8 @@ def test_send_allowed_researcher_to_generalist(db_path: Path, pg_schema: str) ->
 def test_send_allowed_generalist_to_developer_all_directions(db_path: Path, pg_schema: str) -> None:
     """Mesh is bidirectional: generalist → developer, no grant → allow."""
     # Arrange
-    record_comms_policy(name="gen-1", group_name="generalist", db_path=db_path)
-    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
+    record_comms_policy(name="gen-1", group_name="generalist")
+    record_comms_policy(name="dev-1", group_name="developer")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="gen-1",
@@ -250,8 +249,8 @@ def test_send_allowed_mesh_group_to_non_mesh_group(db_path: Path, pg_schema: str
     still gates PRIVILEGED actions via check_lineage_acl; a solver that must
     reject inbound messages uses per-spec spec.comms.inbound=deny.)"""
     # Arrange
-    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
-    record_comms_policy(name="solver-1", group_name="solver", db_path=db_path)
+    record_comms_policy(name="dev-1", group_name="developer")
+    record_comms_policy(name="solver-1", group_name="solver")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="dev-1",
@@ -268,8 +267,8 @@ def test_send_allowed_non_mesh_group_to_mesh_group(db_path: Path, pg_schema: str
     now ALLOWS (the exact cross-group case PR #12/#524's mesh could not
     cover for paper-group agents a2a-ing developer agents)."""
     # Arrange
-    record_comms_policy(name="solver-1", group_name="solver", db_path=db_path)
-    record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
+    record_comms_policy(name="solver-1", group_name="solver")
+    record_comms_policy(name="res-1", group_name="researcher")
     # Act
     decision, _reason = check_send_acl(
         authenticated_node="solver-1",
@@ -286,22 +285,22 @@ def test_send_allowed_non_mesh_group_to_mesh_group(db_path: Path, pg_schema: str
 # ---------------------------------------------------------------------------
 
 
-def test_developer_child_may_spawn(db_path: Path) -> None:
+def test_developer_child_may_spawn(pg_schema: str, db_path: Path) -> None:
     """A developer-group caller may spawn even as a (non-root) child."""
     # Arrange
     record_lineage(child="dev-1", parent="root", db_path=db_path)
-    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
+    record_comms_policy(name="dev-1", group_name="developer")
     # Act
     decision, _reason = check_spawn(caller="dev-1", db_path=db_path)
     # Assert
     assert decision == "allow"
 
 
-def test_non_developer_child_still_denied_spawn(db_path: Path) -> None:
+def test_non_developer_child_still_denied_spawn(pg_schema: str, db_path: Path) -> None:
     """Backward-compatible: a non-developer child is still root-only denied."""
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="worker-a", group_name="analysts")
     # Act
     decision, _reason = check_spawn(caller="worker-a", db_path=db_path)
     # Assert
@@ -326,7 +325,7 @@ GRANT_LABELS = {
 }
 
 
-def test_child_with_developer_late_in_its_groups_may_spawn(db_path: Path) -> None:
+def test_child_with_developer_late_in_its_groups_may_spawn(pg_schema: str, db_path: Path) -> None:
     """THE reported bug, end-to-end from grant's real spec labels."""
     # Arrange
     _seed_child_from_labels("grant", GRANT_LABELS, db_path=db_path)
@@ -337,6 +336,7 @@ def test_child_with_developer_late_in_its_groups_may_spawn(db_path: Path) -> Non
 
 
 def test_child_with_developer_late_in_its_groups_may_manage_peers(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The same membership question on the MANAGE gate (tail / stop /
@@ -351,7 +351,7 @@ def test_child_with_developer_late_in_its_groups_may_manage_peers(
     assert decision == "allow"
 
 
-def test_child_with_researcher_late_in_its_groups_may_spawn(db_path: Path) -> None:
+def test_child_with_researcher_late_in_its_groups_may_spawn(pg_schema: str, db_path: Path) -> None:
     # Arrange
     labels = {"role": "worker", "groups": ["generalist", "researcher"]}
     _seed_child_from_labels("nv", labels, db_path=db_path)
@@ -361,7 +361,7 @@ def test_child_with_researcher_late_in_its_groups_may_spawn(db_path: Path) -> No
     assert decision == "allow"
 
 
-def test_child_with_privileged_late_in_its_groups_may_spawn(db_path: Path) -> None:
+def test_child_with_privileged_late_in_its_groups_may_spawn(pg_schema: str, db_path: Path) -> None:
     # Arrange
     labels = {"role": "worker", "groups": ["generalist", "privileged"]}
     _seed_child_from_labels("dotfiles", labels, db_path=db_path)
@@ -372,6 +372,7 @@ def test_child_with_privileged_late_in_its_groups_may_spawn(db_path: Path) -> No
 
 
 def test_multi_group_child_with_no_authorising_group_is_still_denied(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The gate must still SHUT — a set-valued read that stopped denying
@@ -396,7 +397,7 @@ def test_multi_group_child_with_no_authorising_group_is_still_denied(
 # ---------------------------------------------------------------------------
 
 
-def test_labelled_researcher_child_may_spawn(db_path: Path) -> None:
+def test_labelled_researcher_child_may_spawn(pg_schema: str, db_path: Path) -> None:
     """Explicit ``groups: [researcher]`` child may spawn (regression pin)."""
     # Arrange
     _seed_child_from_labels(
@@ -408,7 +409,7 @@ def test_labelled_researcher_child_may_spawn(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_role_derived_researcher_child_may_spawn(db_path: Path) -> None:
+def test_role_derived_researcher_child_may_spawn(pg_schema: str, db_path: Path) -> None:
     """``role: researcher`` with NO groups label may spawn.
 
     The half of the operator's ruling that was missing: only developer-ish
@@ -423,11 +424,11 @@ def test_role_derived_researcher_child_may_spawn(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_role_derived_researcher_child_may_manage_peer(db_path: Path) -> None:
+def test_role_derived_researcher_child_may_manage_peer(pg_schema: str, db_path: Path) -> None:
     """``role: researcher`` child may RESTART a developer peer (the incident)."""
     # Arrange
     _seed_child_from_labels("res-by-role", {"role": "research-agent"}, db_path=db_path)
-    record_comms_policy(name="scitex-clew", group_name="developer", db_path=db_path)
+    record_comms_policy(name="scitex-clew", group_name="developer")
     # Act
     decision, _reason = check_lineage_acl(
         caller="res-by-role", target="scitex-clew", db_path=db_path
@@ -436,7 +437,7 @@ def test_role_derived_researcher_child_may_manage_peer(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_role_derived_developer_child_may_spawn(db_path: Path) -> None:
+def test_role_derived_developer_child_may_spawn(pg_schema: str, db_path: Path) -> None:
     """The other half of the ruling: ``role: project-maintainer`` may spawn."""
     # Arrange
     _seed_child_from_labels(
@@ -448,7 +449,7 @@ def test_role_derived_developer_child_may_spawn(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_worker_role_child_still_denied_spawn(db_path: Path) -> None:
+def test_worker_role_child_still_denied_spawn(pg_schema: str, db_path: Path) -> None:
     """NEGATIVE: a ``role: worker`` child derives no group → still denied.
 
     Guards against the fix over-reaching: role-derivation must promote the
@@ -463,7 +464,7 @@ def test_worker_role_child_still_denied_spawn(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_isolated_solver_child_still_denied_spawn(db_path: Path) -> None:
+def test_isolated_solver_child_still_denied_spawn(pg_schema: str, db_path: Path) -> None:
     """NEGATIVE: an explicit non-mesh ``groups: [solver]`` child stays denied.
 
     Even when its role says ``researcher``: the explicit label wins, so a
@@ -479,7 +480,7 @@ def test_isolated_solver_child_still_denied_spawn(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_researcher_child_with_may_spawn_false_is_denied(db_path: Path) -> None:
+def test_researcher_child_with_may_spawn_false_is_denied(pg_schema: str, db_path: Path) -> None:
     """NEGATIVE: per-spec ``lineage.may_spawn=false`` still overrides the group.
 
     The group grants authority; the spec can still revoke it. Without this,
@@ -500,10 +501,10 @@ def test_researcher_child_with_may_spawn_false_is_denied(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_developer_may_manage_unrelated_agent(db_path: Path) -> None:
+def test_developer_may_manage_unrelated_agent(pg_schema: str, db_path: Path) -> None:
     """Developer-group caller manages a target with NO lineage edge."""
     # Arrange
-    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
+    record_comms_policy(name="dev-1", group_name="developer")
     record_lineage(child="victim", parent="someone-else", db_path=db_path)
     # Act
     decision, _reason = check_lineage_acl(
@@ -513,10 +514,10 @@ def test_developer_may_manage_unrelated_agent(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_non_developer_cannot_manage_unrelated_agent(db_path: Path) -> None:
+def test_non_developer_cannot_manage_unrelated_agent(pg_schema: str, db_path: Path) -> None:
     """Backward-compatible: non-developer with no lineage edge → deny."""
     # Arrange
-    record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="worker-a", group_name="analysts")
     record_lineage(child="victim", parent="someone-else", db_path=db_path)
     # Act
     decision, _reason = check_lineage_acl(
@@ -535,11 +536,11 @@ def test_non_developer_cannot_manage_unrelated_agent(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_researcher_may_manage_developer_target_via_mesh(db_path: Path) -> None:
+def test_researcher_may_manage_developer_target_via_mesh(pg_schema: str, db_path: Path) -> None:
     """Researcher → developer, no lineage, no grant → allow (manage mesh)."""
     # Arrange — neurovista (researcher) restarts scitex-todo (developer).
-    record_comms_policy(name="neurovista", group_name="researcher", db_path=db_path)
-    record_comms_policy(name="scitex-todo", group_name="developer", db_path=db_path)
+    record_comms_policy(name="neurovista", group_name="researcher")
+    record_comms_policy(name="scitex-todo", group_name="developer")
     # Act
     decision, _reason = check_lineage_acl(
         caller="neurovista", target="scitex-todo", db_path=db_path
@@ -548,7 +549,7 @@ def test_researcher_may_manage_developer_target_via_mesh(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_mesh_caller_cannot_manage_isolated_solver_target(db_path: Path) -> None:
+def test_mesh_caller_cannot_manage_isolated_solver_target(pg_schema: str, db_path: Path) -> None:
     """A non-mesh target (isolated solver) stays unmanageable cross-group.
 
     Uses a RESEARCHER caller (not developer): the developer group has
@@ -556,8 +557,8 @@ def test_mesh_caller_cannot_manage_isolated_solver_target(db_path: Path) -> None
     isolation must be probed by a mesh-but-non-developer caller.
     """
     # Arrange — researcher caller, solver target (outside the mesh).
-    record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
-    record_comms_policy(name="solver-1", group_name="solver", db_path=db_path)
+    record_comms_policy(name="res-1", group_name="researcher")
+    record_comms_policy(name="solver-1", group_name="solver")
     record_lineage(child="solver-1", parent="someone-else", db_path=db_path)
     # Act
     decision, _reason = check_lineage_acl(

--- a/tests/scitex_agent_container/_listen/test__acl_phase3.py
+++ b/tests/scitex_agent_container/_listen/test__acl_phase3.py
@@ -53,7 +53,7 @@ def test_outbound_siblings_deny_blocks_sibling_send(db_path: Path, pg_schema: st
     # Arrange
     record_lineage(child="cap-a", parent="root", db_path=db_path)
     record_lineage(child="cap-b", parent="root", db_path=db_path)
-    record_comms_policy(name="cap-a", outbound_siblings="deny", db_path=db_path)
+    record_comms_policy(name="cap-a", outbound_siblings="deny")
     # Act
     decision, _ = check_send_acl(
         authenticated_node="cap-a",
@@ -69,7 +69,7 @@ def test_outbound_parent_deny_blocks_send_to_parent(db_path: Path, pg_schema: st
     """Gap-1: child with outbound.parent=deny cannot send to its parent."""
     # Arrange
     record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_comms_policy(name="cap-a", outbound_parent="deny", db_path=db_path)
+    record_comms_policy(name="cap-a", outbound_parent="deny")
     # Act
     decision, _ = check_send_acl(
         authenticated_node="cap-a",
@@ -109,7 +109,7 @@ def test_inbound_siblings_deny_rejects_sibling_inbound(db_path: Path, pg_schema:
     # Arrange
     record_lineage(child="cap-a", parent="root", db_path=db_path)
     record_lineage(child="cap-b", parent="root", db_path=db_path)
-    record_comms_policy(name="cap-b", inbound_siblings="deny", db_path=db_path)
+    record_comms_policy(name="cap-b", inbound_siblings="deny")
     # Act
     decision, _ = check_send_acl(
         authenticated_node="cap-a",
@@ -126,7 +126,7 @@ def test_inbound_parent_deny_rejects_send_from_parent(db_path: Path, pg_schema: 
     send (the parent appears as ``rel='child'`` from sender's POV)."""
     # Arrange
     record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_comms_policy(name="cap-a", inbound_parent="deny", db_path=db_path)
+    record_comms_policy(name="cap-a", inbound_parent="deny")
     # Act
     decision, _ = check_send_acl(
         authenticated_node="root",
@@ -143,18 +143,18 @@ def test_inbound_parent_deny_rejects_send_from_parent(db_path: Path, pg_schema: 
 # ---------------------------------------------------------------------------
 
 
-def test_may_spawn_false_denies_root_spawn(db_path: Path) -> None:
+def test_may_spawn_false_denies_root_spawn(pg_schema: str, db_path: Path) -> None:
     """Gap-5: a root caller that globally-passes the spawn ACL is still
     denied when its persisted policy carries ``may_spawn=False``."""
     # Arrange
-    record_comms_policy(name="root", may_spawn=False, db_path=db_path)
+    record_comms_policy(name="root", may_spawn=False)
     # Act
     decision, _ = check_spawn(caller="root", db_path=db_path)
     # Assert
     assert decision == "deny"
 
 
-def test_may_spawn_default_preserves_root_allow(db_path: Path) -> None:
+def test_may_spawn_default_preserves_root_allow(pg_schema: str, db_path: Path) -> None:
     """Default-preservation: a root with no per-spec policy row keeps the
     legacy root-only allow."""
     # Arrange — no lineage row (caller is a root) and no policy row.

--- a/tests/scitex_agent_container/_listen/test__host_exec.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec.py
@@ -155,7 +155,7 @@ def test_host_exec_denies_when_no_caller_resolves():
     assert resp.status_code == 403
 
 
-def test_host_exec_denies_when_group_is_not_eligible():
+def test_host_exec_denies_when_group_is_not_eligible(pg_schema: str):
     # Arrange — hand-rolled resolver that reports a non-eligible group.
     req = _FakeRequest({"argv": ["echo", "hi"]}, authenticated_node="some-agent")
     # Act
@@ -200,7 +200,7 @@ def test_host_exec_allows_the_privileged_group():
     assert resp.status_code == 200
 
 
-def test_host_exec_denies_unlabeled_privileged_style_caller_helpfully():
+def test_host_exec_denies_unlabeled_privileged_style_caller_helpfully(pg_schema: str):
     # Arrange — an agent that has NOT been labeled into the privileged group
     # resolves to the ungrouped "" (or any non-eligible group) and is refused
     # with a structured 403 that names the eligible groups.

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -1357,7 +1357,7 @@ def test_cross_host_send_without_grant_returns_403_from_target_listen(
     record_lineage(child="alice", parent="root", db_path=db)
     record_lineage(child="outsider", parent="root", db_path=db)
     state_db_nodes_grant.record_comms_policy(
-        name="alice", inbound_siblings="deny", db_path=db
+        name="alice", inbound_siblings="deny"
     )
     state_db.record_instance_start(name="alice", host="host-a", a2a_port=0, db_path=db)
     with state_db.open_db(db) as conn:

--- a/tests/scitex_agent_container/_listen/test_server_inline_spec_bind_translate.py
+++ b/tests/scitex_agent_container/_listen/test_server_inline_spec_bind_translate.py
@@ -144,6 +144,7 @@ def _child_body(name: str, caller: str | None, binds: list) -> dict:
 
 
 def test_child_with_work_prefix_bind_is_accepted_after_translate(
+    pg_schema: str,
     client, auth_headers, isolated_env, tmp_path
 ):
     # Arrange — parent maps its host $HOME/proj/foo at /work; child
@@ -170,6 +171,7 @@ def test_child_with_work_prefix_bind_is_accepted_after_translate(
 
 
 def test_translated_bind_is_what_gets_written_to_disk(
+    pg_schema: str,
     client, auth_headers, isolated_env, tmp_path
 ):
     # Arrange — same setup as above, but inspect the materialised
@@ -229,6 +231,7 @@ def test_no_caller_means_no_translate_so_pr1_still_rejects_work_path(
 
 
 def test_unknown_caller_falls_back_to_pr1_rejection(
+    pg_schema: str,
     client, auth_headers, isolated_env, tmp_path
 ):
     # Arrange — caller string doesn't resolve to any registered
@@ -251,6 +254,7 @@ def test_unknown_caller_falls_back_to_pr1_rejection(
 
 
 def test_translate_passthrough_for_non_work_bind_still_caught_by_pr1(
+    pg_schema: str,
     client, auth_headers, isolated_env, tmp_path
 ):
     # Arrange — caller IS known but the child requested a bind
@@ -278,6 +282,7 @@ def test_translate_passthrough_for_non_work_bind_still_caught_by_pr1(
 
 
 def test_mixed_binds_translate_only_work_prefix_others_pass_through(
+    pg_schema: str,
     client, auth_headers, isolated_env, tmp_path
 ):
     # Arrange — child requests two binds: one /work-prefixed

--- a/tests/scitex_agent_container/_listen/test_server_lineage_acl.py
+++ b/tests/scitex_agent_container/_listen/test_server_lineage_acl.py
@@ -97,7 +97,7 @@ def test_delete_with_host_bearer_does_not_403(client, isolated_env):
 # ---------------------------------------------------------------------------
 
 
-def test_delete_unrelated_caller_returns_403(client, isolated_env):
+def test_delete_unrelated_caller_returns_403(pg_schema: str, client, isolated_env):
     # Arrange — alice is a known node with no lineage edge to
     # ``unrelated-target``.
     headers = _node_headers("alice")
@@ -107,7 +107,7 @@ def test_delete_unrelated_caller_returns_403(client, isolated_env):
     assert response.status_code == 403
 
 
-def test_delete_unrelated_caller_body_has_kind_acl_deny(client, isolated_env):
+def test_delete_unrelated_caller_body_has_kind_acl_deny(pg_schema: str, client, isolated_env):
     # Arrange
     headers = _node_headers("alice")
     # Act
@@ -117,7 +117,7 @@ def test_delete_unrelated_caller_body_has_kind_acl_deny(client, isolated_env):
     assert body["kind"] == "acl_deny"
 
 
-def test_delete_unrelated_caller_body_has_error_acl_deny(client, isolated_env):
+def test_delete_unrelated_caller_body_has_error_acl_deny(pg_schema: str, client, isolated_env):
     # Arrange
     headers = _node_headers("alice")
     # Act
@@ -127,7 +127,7 @@ def test_delete_unrelated_caller_body_has_error_acl_deny(client, isolated_env):
     assert body["error"] == "ACL deny"
 
 
-def test_delete_unrelated_caller_body_has_reason_naming_target(client, isolated_env):
+def test_delete_unrelated_caller_body_has_reason_naming_target(pg_schema: str, client, isolated_env):
     # Arrange — the deny reason must name the target for diagnosability.
     headers = _node_headers("alice")
     # Act
@@ -153,7 +153,7 @@ def test_delete_caller_can_target_self(client, isolated_env):
     assert response.status_code != 403
 
 
-def test_delete_caller_can_target_direct_child(client, isolated_env):
+def test_delete_caller_can_target_direct_child(pg_schema: str, client, isolated_env):
     # Arrange — alice has child ``kid`` via the lineage table.
     headers = _node_headers("alice")
     record_lineage(child="kid", parent="alice")
@@ -182,7 +182,7 @@ def test_tail_with_host_bearer_does_not_403(client, isolated_env):
 # ---------------------------------------------------------------------------
 
 
-def test_tail_unrelated_caller_returns_403(client, isolated_env):
+def test_tail_unrelated_caller_returns_403(pg_schema: str, client, isolated_env):
     # Arrange
     headers = _node_headers("alice")
     # Act
@@ -191,7 +191,7 @@ def test_tail_unrelated_caller_returns_403(client, isolated_env):
     assert response.status_code == 403
 
 
-def test_tail_unrelated_caller_body_has_kind_acl_deny(client, isolated_env):
+def test_tail_unrelated_caller_body_has_kind_acl_deny(pg_schema: str, client, isolated_env):
     # Arrange
     headers = _node_headers("alice")
     # Act
@@ -215,7 +215,7 @@ def test_tail_caller_can_target_self(client, isolated_env):
     assert response.status_code != 403
 
 
-def test_tail_caller_can_target_descendant(client, isolated_env):
+def test_tail_caller_can_target_descendant(pg_schema: str, client, isolated_env):
     # Arrange — root → alice → ada (grandchild).
     headers = _node_headers("root")
     record_lineage(child="alice", parent="root")

--- a/tests/scitex_agent_container/_listen/test_server_restart_route.py
+++ b/tests/scitex_agent_container/_listen/test_server_restart_route.py
@@ -85,7 +85,7 @@ def _host_headers() -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def test_restart_unrelated_caller_returns_403(client, isolated_env):
+def test_restart_unrelated_caller_returns_403(pg_schema: str, client, isolated_env):
     # Arrange — alice has no lineage edge and no group mesh to the target.
     headers = _node_headers("alice")
     # Act
@@ -94,7 +94,7 @@ def test_restart_unrelated_caller_returns_403(client, isolated_env):
     assert response.status_code == 403
 
 
-def test_restart_unrelated_caller_body_has_kind_acl_deny(client, isolated_env):
+def test_restart_unrelated_caller_body_has_kind_acl_deny(pg_schema: str, client, isolated_env):
     # Arrange
     headers = _node_headers("alice")
     # Act
@@ -124,7 +124,7 @@ def test_restart_with_host_bearer_does_not_403(client, isolated_env):
 # ---------------------------------------------------------------------------
 
 
-def test_restart_researcher_to_developer_not_403(client, isolated_env):
+def test_restart_researcher_to_developer_not_403(pg_schema: str, client, isolated_env):
     # Arrange — neurovista (researcher) restarts scitex-todo (developer):
     # the manage mesh allows it with no lineage edge. The target has no
     # row so the bare-host shell fails, but NOT via a 403 ACL deny.
@@ -329,7 +329,7 @@ def test_admin_restart_caller_none_does_not_self_schedule(client, isolated_env):
     assert recorder.calls == [] and "self_restart" not in body
 
 
-def test_node_caller_restarting_peer_does_not_self_schedule(client, isolated_env):
+def test_node_caller_restarting_peer_does_not_self_schedule(pg_schema: str, client, isolated_env):
     # Arrange — neurovista restarts scitex-todo (mesh-allowed, caller != name):
     # the self-restart branch must be skipped, sync path taken.
     record_comms_policy(name="neurovista", group_name="researcher")

--- a/tests/scitex_agent_container/_state/test_fleet_template.py
+++ b/tests/scitex_agent_container/_state/test_fleet_template.py
@@ -348,7 +348,7 @@ def cli_dry_run_result(tmp_path: Path, env_save_restore):
     return result, out_dir
 
 
-def test_start_params_file_dry_run_exits_zero(cli_dry_run_result):
+def test_start_params_file_dry_run_exits_zero(pg_schema: str, cli_dry_run_result):
     # Arrange
     result, _ = cli_dry_run_result
     # Act

--- a/tests/scitex_agent_container/_state/test_state_db_acl_policy.py
+++ b/tests/scitex_agent_container/_state/test_state_db_acl_policy.py
@@ -1,264 +1,424 @@
-"""Phase-3 (ADR-0010 Step 2) — per-spec ACL policy persistence + the
-state-DB primitives that surface it to the listen-server's
-``check_send_acl``.
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""node_comms_policy on PostgreSQL — and gates that actually flip.
 
-Tests cover:
+This is the table ``check_send_acl`` and ``check_spawn`` read, so the tests
+that matter are the FLIPS: not "a policy can be written" but "after the spec
+says deny, the thing the gate calls says NO — and after it says allow again,
+the same call says YES". A migration that stored policies perfectly and
+forgot to flip would read as green on every round-trip assertion and be a
+security regression in both directions at once.
 
-* ``record_comms_policy`` upserts and is idempotent on conflict.
-* ``read_comms_policy`` returns the persisted row or the legacy default.
-* ``sender_target_relationship`` classifies parent / child / sibling /
-  other from the ``lineage`` table.
-* ``derive_group`` honours ``lineage_group='solitary'`` (Gap-4) by
-  returning the singleton group regardless of lineage edges.
+FOUR PROPERTIES THAT ARE EASY TO LOSE HERE, each with its own test below:
 
-AAA, one assertion per test, no mocks (real SQLite).
+  * A DENY DENIES, AND ITS REMOVAL UN-DENIES. ``Store.put`` is a PARTIAL
+    update — absent fields are left alone — so a ``record_comms_policy``
+    that wrote only the caller's non-default arguments would let a previous
+    ``inbound_siblings="deny"`` survive the spec edit that removed it.
+    ``test_re_publishing_without_the_deny_flips_it_back_to_allow`` writes the
+    deny, re-publishes with defaults, and asserts the deny is GONE. A partial
+    write fails that test; the full-record write passes it.
+  * DROPPING A GROUP REVOKES IT. Same hazard, higher stakes: ``group_names``
+    is what ``is_developer`` reads, so a stale value is a standing privilege.
+  * RETIREMENT DENIES WITHOUT FORGETTING. ``retire_comms_policy`` does not
+    DELETE — the store's only removal is ``hide``. If ``read_comms_policy``
+    read hidden records it would keep enforcing a withdrawn policy; if
+    hiding lost the record, "never registered" and "registered then retired"
+    would become indistinguishable, and for an ACL that is the whole audit.
+  * A RETIRED POLICY RE-OPENS THE GATE, and that is worth an explicit test
+    rather than a footnote: a missing record reads as the all-allow
+    defaults, so retiring a ``may_spawn=false`` policy RESTORES the spawn.
+    Silence is permission here, which is exactly why the store must raise
+    rather than return empty when PostgreSQL is unreachable.
+
+WHICH TESTS NEED POSTGRESQL, AND WHICH DELIBERATELY DO NOT. The validators
+run BEFORE any store is opened, so the rejection tests exercise real
+behaviour on a host with no database and stay green there. That is a
+property, not a convenience: a bad ACL value must be refused identically
+whether or not the store happens to be reachable. Everything that reads or
+writes takes ``pg_schema``, the shared opt-in fixture, which skips where no
+cluster exists and FAILS where a configured one is broken.
+
+``sender_target_relationship`` used to be tested here. It reads ``lineage``,
+which is still SQLite, so it moved to
+``test_state_db_lineage_rel.py`` alongside the module it moved to — rather
+than staying in a file whose name now promises PostgreSQL.
+
+NO MONKEYPATCH (PA-306 §3): the module is exercised through its real public
+surface, and isolation comes from the fixture pointing SCITEX_STORE_DSN at a
+throwaway schema.
 """
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
 import pytest
 
-from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_acl_policy import (
+    _open,
+    comms_policy_row_exists,
+    rename_comms_policy,
+    retire_comms_policy,
+)
 from scitex_agent_container._state.state_db_nodes import (
-    derive_group,
+    apply_may_spawn_gate,
     read_comms_policy,
     record_comms_policy,
-    record_lineage,
-    sender_target_relationship,
 )
 
-
-@pytest.fixture
-def db_path(tmp_path: Path):
-    db = tmp_path / "state.db"
-    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
-    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
-    try:
-        yield db
-    finally:
-        state_db.DEFAULT_DB_PATH = saved_default
-        if saved_env is None:
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
-        else:
-            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
-
-
 # ---------------------------------------------------------------------------
-# record_comms_policy / read_comms_policy
+# the per-spec deny flips, in BOTH directions
 # ---------------------------------------------------------------------------
 
 
-def test_read_comms_policy_returns_defaults_when_row_absent(
-    db_path: Path,
-) -> None:
-    """No row → byte-equivalent to pre-Phase-3 (everything allow)."""
-    # Arrange — no record_comms_policy call.
+def test_a_recorded_deny_is_in_force(pg_schema: str) -> None:
+    # Arrange
+    record_comms_policy(name="cap-a", inbound_siblings="deny")
     # Act
-    policy = read_comms_policy(name="never-recorded", db_path=db_path)
+    policy = read_comms_policy(name="cap-a")
+    # Assert
+    assert policy["inbound_siblings"] == "deny"
+
+
+def test_re_publishing_without_the_deny_flips_it_back_to_allow(
+    pg_schema: str,
+) -> None:
+    # Arrange — the spec-edit path: agent_start re-publishes on every start,
+    # and the second call names no deny at all.
+    record_comms_policy(name="cap-a", inbound_siblings="deny")
+    # Act
+    record_comms_policy(name="cap-a")
+    # Assert — a partial write would leave "deny" standing here.
+    assert read_comms_policy(name="cap-a")["inbound_siblings"] == "allow"
+
+
+def test_dropping_a_group_from_the_spec_revokes_it(pg_schema: str) -> None:
+    # Arrange — an agent whose spec listed developer, then stopped.
+    record_comms_policy(name="cap-a", group_names=["generalist", "developer"])
+    # Act
+    record_comms_policy(name="cap-a", group_names=["generalist"])
+    # Assert — a stale group_names is a standing privilege.
+    assert "developer" not in read_comms_policy(name="cap-a")["group_names"]
+
+
+# ---------------------------------------------------------------------------
+# the spawn gate — the one that turns a policy value into a decision
+# ---------------------------------------------------------------------------
+
+
+def test_may_spawn_false_denies_a_spawn_the_global_policy_allowed(
+    pg_schema: str,
+) -> None:
+    # Arrange
+    record_comms_policy(name="cap-a", may_spawn=False)
+    # Act
+    allowed, _reason = apply_may_spawn_gate(caller="cap-a", base=(True, None))
+    # Assert
+    assert allowed is False
+
+
+def test_re_publishing_may_spawn_true_restores_the_spawn(pg_schema: str) -> None:
+    # Arrange
+    record_comms_policy(name="cap-a", may_spawn=False)
+    record_comms_policy(name="cap-a", may_spawn=True)
+    # Act
+    allowed, _reason = apply_may_spawn_gate(caller="cap-a", base=(True, None))
+    # Assert
+    assert allowed is True
+
+
+def test_may_spawn_never_rescues_an_already_denied_spawn(pg_schema: str) -> None:
+    # Arrange
+    record_comms_policy(name="cap-a", may_spawn=True)
+    # Act
+    allowed, _reason = apply_may_spawn_gate(caller="cap-a", base=(False, "no"))
+    # Assert
+    assert allowed is False
+
+
+def test_may_spawn_round_trips_as_a_real_bool(pg_schema: str) -> None:
+    # Arrange — the SQLite column was 0/1; the store field is BOOL.
+    record_comms_policy(name="cap-a", may_spawn=False)
+    # Act
+    value = read_comms_policy(name="cap-a")["may_spawn"]
+    # Assert
+    assert value is False
+
+
+# ---------------------------------------------------------------------------
+# retirement — hide, never delete
+# ---------------------------------------------------------------------------
+
+
+def test_retire_reports_true_when_a_live_policy_was_withdrawn(
+    pg_schema: str,
+) -> None:
+    # Arrange
+    record_comms_policy(name="cap-a", may_spawn=False)
+    # Act
+    withdrawn = retire_comms_policy(name="cap-a")
+    # Assert
+    assert withdrawn is True
+
+
+def test_retire_reports_false_the_second_time(pg_schema: str) -> None:
+    # Arrange — the hidden record still occupies the identity, so a naive
+    # "does the record exist" check would answer True and lie.
+    record_comms_policy(name="cap-a")
+    retire_comms_policy(name="cap-a")
+    # Act
+    again = retire_comms_policy(name="cap-a")
+    # Assert
+    assert again is False
+
+
+def test_a_retired_policy_is_absent_from_the_diagnostic(pg_schema: str) -> None:
+    # Arrange
+    record_comms_policy(name="cap-a")
+    retire_comms_policy(name="cap-a")
+    # Act
+    registered = comms_policy_row_exists(name="cap-a")
+    # Assert
+    assert registered is False
+
+
+def test_retiring_a_may_spawn_deny_reopens_the_spawn(pg_schema: str) -> None:
+    # Arrange — the surprising direction, asserted on purpose: a missing
+    # record reads as the all-allow defaults, so withdrawing a policy grants
+    # rather than revokes. Silence is permission in this table.
+    record_comms_policy(name="cap-a", may_spawn=False)
+    retire_comms_policy(name="cap-a")
+    # Act
+    allowed, _reason = apply_may_spawn_gate(caller="cap-a", base=(True, None))
+    # Assert
+    assert allowed is True
+
+
+def test_a_retired_policy_is_still_on_record(pg_schema: str) -> None:
+    # Arrange
+    record_comms_policy(name="cap-a", group_names=["developer"])
+    retire_comms_policy(name="cap-a")
+    # Act
+    store = _open()
+    try:
+        row = store.get({"name": "cap-a"}, include_hidden=True)
+    finally:
+        store.close()
+    # Assert — DELETE could not answer "what groups did it hold?".
+    assert row is not None and row.values["group_names"] == "developer"
+
+
+def test_re_recording_a_retired_policy_restores_it(pg_schema: str) -> None:
+    # Arrange — impossible to express under DELETE; the record is hidden and
+    # an insert would collide with the identity it still occupies.
+    record_comms_policy(name="cap-a", inbound_siblings="deny")
+    retire_comms_policy(name="cap-a")
+    # Act
+    record_comms_policy(name="cap-a", inbound_siblings="deny")
+    # Assert
+    assert read_comms_policy(name="cap-a")["inbound_siblings"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# rename — an IDENTITY change, so a copy + retire rather than an update
+# ---------------------------------------------------------------------------
+
+
+def test_rename_carries_the_policy_to_the_new_name(pg_schema: str) -> None:
+    # Arrange — miss this and the ACL gate has no policy for the live name.
+    record_comms_policy(name="scitex-todo", group_names=["developer"])
+    # Act
+    rename_comms_policy(old="scitex-todo", new="scitex-cards")
+    # Assert
+    assert "developer" in read_comms_policy(name="scitex-cards")["group_names"]
+
+
+def test_rename_retires_the_old_name(pg_schema: str) -> None:
+    # Arrange — a live policy under a name that no longer exists is a
+    # standing authorisation nobody owns.
+    record_comms_policy(name="scitex-todo", group_names=["developer"])
+    # Act
+    rename_comms_policy(old="scitex-todo", new="scitex-cards")
+    # Assert
+    assert comms_policy_row_exists(name="scitex-todo") is False
+
+
+def test_rename_keeps_the_old_name_on_record(pg_schema: str) -> None:
+    # Arrange
+    record_comms_policy(name="scitex-todo", group_names=["developer"])
+    rename_comms_policy(old="scitex-todo", new="scitex-cards")
+    # Act
+    store = _open()
+    try:
+        row = store.get({"name": "scitex-todo"}, include_hidden=True)
+    finally:
+        store.close()
+    # Assert
+    assert row is not None and row.hidden is True
+
+
+def test_rename_reports_false_when_nothing_is_live(pg_schema: str) -> None:
+    # Arrange — the re-run-after-a-partial-rename case: it must not clobber
+    # whatever already sits under the new name.
+    record_comms_policy(name="scitex-cards", group_names=["developer"])
+    # Act
+    moved = rename_comms_policy(old="scitex-todo", new="scitex-cards")
+    # Assert
+    assert moved is False
+
+
+# ---------------------------------------------------------------------------
+# the diagnostic distinction the 2026-08-09 escalation needed
+# ---------------------------------------------------------------------------
+
+
+def test_row_exists_is_false_for_a_name_this_store_never_saw(
+    pg_schema: str,
+) -> None:
+    # Arrange
+    record_comms_policy(name="cap-a")
+    # Act
+    registered = comms_policy_row_exists(name="never-recorded")
+    # Assert
+    assert registered is False
+
+
+def test_row_exists_is_true_for_a_registered_but_ungrouped_agent(
+    pg_schema: str,
+) -> None:
+    # Arrange — the OTHER cause of an empty group set, and the one the
+    # denial message used to assert without checking.
+    record_comms_policy(name="cap-a")
+    # Act
+    registered = comms_policy_row_exists(name="cap-a")
+    # Assert
+    assert registered is True
+
+
+def test_read_returns_the_legacy_defaults_when_no_record_exists(
+    pg_schema: str,
+) -> None:
+    # Arrange — no record_comms_policy call for this name.
+    record_comms_policy(name="someone-else")
+    # Act
+    policy = read_comms_policy(name="never-recorded")
     # Assert
     assert policy["outbound_siblings"] == "allow"
 
 
-def test_record_comms_policy_persists_outbound_siblings_deny(
-    db_path: Path,
+def test_the_primary_group_is_folded_into_the_authority_set(
+    pg_schema: str,
 ) -> None:
-    """Round-trip through state.db preserves the deny flag."""
-    # Arrange
-    record_comms_policy(name="cap-a", outbound_siblings="deny", db_path=db_path)
+    # Arrange — the two projections are written together so the stored set
+    # is never a strict subset of what the mesh already resolves.
+    record_comms_policy(name="cap-a", group_name="infra", group_names=["developer"])
     # Act
-    policy = read_comms_policy(name="cap-a", db_path=db_path)
+    groups = read_comms_policy(name="cap-a")["group_names"]
     # Assert
-    assert policy["outbound_siblings"] == "deny"
-
-
-def test_record_comms_policy_upsert_refreshes_on_restart(db_path: Path) -> None:
-    """A spec edit at restart re-publishes the row in place (no manual
-    state.db surgery)."""
-    # Arrange
-    record_comms_policy(name="cap-a", inbound_parent="deny", db_path=db_path)
-    record_comms_policy(name="cap-a", inbound_parent="allow", db_path=db_path)
-    # Act
-    policy = read_comms_policy(name="cap-a", db_path=db_path)
-    # Assert
-    assert policy["inbound_parent"] == "allow"
-
-
-def test_record_comms_policy_rejects_unknown_outbound_value(db_path: Path) -> None:
-    """Out-of-domain values are rejected (defence-in-depth — parser also
-    rejects them at YAML-load time)."""
-    # Arrange — about to call with a bad value.
-    # Act
-    # Assert
-    with pytest.raises(ValueError):
-        record_comms_policy(name="cap-a", outbound_siblings="maybe", db_path=db_path)
+    assert set(groups) == {"developer", "infra"}
 
 
 # ---------------------------------------------------------------------------
-# sender_target_relationship
+# refusals — these run BEFORE any store is opened, so they need no database
 # ---------------------------------------------------------------------------
 
 
-def test_sender_target_relationship_sibling(db_path: Path) -> None:
-    """Two children of the same parent classify as siblings."""
+def test_an_empty_name_is_refused() -> None:
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    refused = None
     # Act
-    rel = sender_target_relationship(sender="cap-a", target="cap-b", db_path=db_path)
+    try:
+        record_comms_policy(name="")
+    except ValueError as exc:
+        refused = exc
     # Assert
-    assert rel == "sibling"
+    assert refused is not None
 
 
-def test_sender_target_relationship_parent(db_path: Path) -> None:
-    """Sender → its parent classifies as 'parent'."""
-    # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    # Act
-    rel = sender_target_relationship(sender="cap-a", target="root", db_path=db_path)
-    # Assert
-    assert rel == "parent"
-
-
-def test_sender_target_relationship_child(db_path: Path) -> None:
-    """Sender → its direct child classifies as 'child'."""
-    # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    # Act
-    rel = sender_target_relationship(sender="root", target="cap-a", db_path=db_path)
-    # Assert
-    assert rel == "child"
-
-
-def test_sender_target_relationship_other(db_path: Path) -> None:
-    """Unrelated nodes (no shared parent, no direct edge) → 'other'."""
-    # Arrange — no lineage edges.
-    # Act
-    rel = sender_target_relationship(sender="cap-a", target="cap-z", db_path=db_path)
-    # Assert
-    assert rel == "other"
-
-
-# ---------------------------------------------------------------------------
-# derive_group — Gap-4 solitary override
-# ---------------------------------------------------------------------------
-
-
-def test_derive_group_solitary_returns_singleton_despite_siblings(
-    db_path: Path,
-) -> None:
-    """Gap-4: a child whose policy sets ``lineage_group='solitary'`` has
-    a singleton group regardless of the lineage table — no transitive
-    parent-group inheritance, so a sibling capsule can never address
-    it via the group-default ACL."""
-    # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
-    record_comms_policy(name="cap-a", lineage_group="solitary", db_path=db_path)
-    # Act
-    group = derive_group(name="cap-a", db_path=db_path)
-    # Assert
-    assert group == {"cap-a"}
-
-
-def test_derive_group_default_includes_siblings(db_path: Path) -> None:
-    """Default-preservation: with no policy row, derive_group keeps the
-    legacy parent + direct-children semantics."""
-    # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
-    # Act
-    group = derive_group(name="cap-a", db_path=db_path)
-    # Assert
-    assert "cap-b" in group
-
-
-# ---------------------------------------------------------------------------
-# record_comms_policy — per-field out-of-domain rejection (defence-in-depth)
-# ---------------------------------------------------------------------------
-
-
-def test_record_comms_policy_rejects_unknown_outbound_parent(db_path: Path) -> None:
-    """A bad ``outbound_parent`` is rejected."""
+def test_an_unknown_outbound_siblings_value_is_refused() -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError):
-        record_comms_policy(name="cap-a", outbound_parent="maybe", db_path=db_path)
+        record_comms_policy(name="cap-a", outbound_siblings="maybe")
 
 
-def test_record_comms_policy_rejects_unknown_inbound_siblings(db_path: Path) -> None:
-    """A bad ``inbound_siblings`` is rejected."""
+def test_an_unknown_outbound_parent_value_is_refused() -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError):
-        record_comms_policy(name="cap-a", inbound_siblings="maybe", db_path=db_path)
+        record_comms_policy(name="cap-a", outbound_parent="maybe")
 
 
-def test_record_comms_policy_rejects_unknown_inbound_parent(db_path: Path) -> None:
-    """A bad ``inbound_parent`` is rejected."""
+def test_an_unknown_inbound_siblings_value_is_refused() -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError):
-        record_comms_policy(name="cap-a", inbound_parent="maybe", db_path=db_path)
+        record_comms_policy(name="cap-a", inbound_siblings="maybe")
 
 
-def test_record_comms_policy_rejects_unknown_lineage_group(db_path: Path) -> None:
-    """A bad ``lineage_group`` is rejected."""
+def test_an_unknown_inbound_parent_value_is_refused() -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError):
-        record_comms_policy(name="cap-a", lineage_group="cluster", db_path=db_path)
+        record_comms_policy(name="cap-a", inbound_parent="maybe")
 
 
-def test_record_comms_policy_rejects_non_bool_may_spawn(db_path: Path) -> None:
-    """A non-boolean ``may_spawn`` is rejected."""
+def test_an_unknown_lineage_group_is_refused() -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError):
-        record_comms_policy(name="cap-a", may_spawn="nope", db_path=db_path)
+        record_comms_policy(name="cap-a", lineage_group="cluster")
 
 
-def test_record_comms_policy_rejects_empty_name(db_path: Path) -> None:
-    """An empty agent name is rejected."""
+def test_a_non_bool_may_spawn_is_refused() -> None:
     # Arrange
     # Act
     # Assert
     with pytest.raises(ValueError):
-        record_comms_policy(name="", db_path=db_path)
+        record_comms_policy(name="cap-a", may_spawn="nope")
 
 
-def test_read_comms_policy_empty_name_yields_defaults(db_path: Path) -> None:
-    """An empty name short-circuits to the legacy all-allow default."""
+def test_a_group_name_containing_a_comma_is_refused() -> None:
+    # Arrange — the encoding is comma-separated, so accepting one would
+    # silently split a single group into two.
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        record_comms_policy(name="cap-a", group_names=["dev,ops"])
+
+
+def test_a_bare_string_group_names_is_refused() -> None:
+    # Arrange — without this it would splat into its characters and store
+    # each letter as a group name.
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        record_comms_policy(name="cap-a", group_names="developer")
+
+
+def test_an_empty_name_reads_the_defaults_without_touching_the_store() -> None:
     # Arrange
     # Act
-    policy = read_comms_policy(name="", db_path=db_path)
+    policy = read_comms_policy(name="")
     # Assert
     assert policy["may_spawn"] is True
 
 
-def test_sender_target_relationship_self(db_path: Path) -> None:
-    """A node addressing itself classifies as 'self'."""
+def test_row_exists_is_false_for_an_empty_name_without_touching_the_store() -> None:
     # Arrange
     # Act
-    rel = sender_target_relationship(sender="cap-a", target="cap-a", db_path=db_path)
+    registered = comms_policy_row_exists(name="")
     # Assert
-    assert rel == "self"
+    assert registered is False
 
 
-def test_sender_target_relationship_empty_sender_is_other(db_path: Path) -> None:
-    """A missing sender/target classifies as 'other' (no edge to read)."""
+def test_renaming_a_name_onto_itself_is_refused_without_touching_the_store() -> None:
     # Arrange
     # Act
-    rel = sender_target_relationship(sender="", target="cap-a", db_path=db_path)
+    moved = rename_comms_policy(old="cap-a", new="cap-a")
     # Assert
-    assert rel == "other"
+    assert moved is False

--- a/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
+++ b/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
@@ -75,7 +75,6 @@ def _record_grant_like(name: str, groups: list[str], db: Path) -> None:
         name=name,
         group_name=groups[0],
         group_names=groups,
-        db_path=db,
     )
 
 
@@ -85,35 +84,36 @@ def _record_grant_like(name: str, groups: list[str], db: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_developer_not_first_in_the_list_is_still_a_developer(db_path: Path) -> None:
+def test_developer_not_first_in_the_list_is_still_a_developer(pg_schema: str, db_path: Path) -> None:
     """``groups: [generalist, developer]`` IS a developer."""
     # Arrange
     _record_grant_like("alice", ["generalist", "developer"], db_path)
     # Act
-    result = is_developer(name="alice", db_path=db_path)
+    result = is_developer(name="alice")
     # Assert
     assert result is True
 
 
-def test_researcher_not_first_in_the_list_is_still_a_researcher(db_path: Path) -> None:
+def test_researcher_not_first_in_the_list_is_still_a_researcher(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("alice", ["generalist", "researcher"], db_path)
     # Act
-    result = is_researcher(name="alice", db_path=db_path)
+    result = is_researcher(name="alice")
     # Assert
     assert result is True
 
 
-def test_privileged_not_first_in_the_list_is_still_privileged(db_path: Path) -> None:
+def test_privileged_not_first_in_the_list_is_still_privileged(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("alice", ["generalist", "privileged"], db_path)
     # Act
-    result = is_privileged(name="alice", db_path=db_path)
+    result = is_privileged(name="alice")
     # Assert
     assert result is True
 
 
 def test_grant_child_with_developer_in_its_groups_passes_check_spawn(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """THE reported bug: grant, a child of scitex-agent-container, denied
@@ -128,6 +128,7 @@ def test_grant_child_with_developer_in_its_groups_passes_check_spawn(
 
 
 def test_child_with_only_researcher_in_its_groups_passes_check_spawn(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The researcher half of the operator's ruling, on the same footing."""
@@ -141,6 +142,7 @@ def test_child_with_only_researcher_in_its_groups_passes_check_spawn(
 
 
 def test_child_with_only_privileged_in_its_groups_passes_check_spawn(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     # Arrange
@@ -158,7 +160,7 @@ def test_child_with_only_privileged_in_its_groups_passes_check_spawn(
 # ---------------------------------------------------------------------------
 
 
-def test_child_in_no_authorising_group_is_still_denied(db_path: Path) -> None:
+def test_child_in_no_authorising_group_is_still_denied(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("worker", ["generalist", "active"], db_path)
     record_lineage(child="worker", parent="lead", db_path=db_path)
@@ -168,9 +170,9 @@ def test_child_in_no_authorising_group_is_still_denied(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_ungrouped_child_is_still_denied(db_path: Path) -> None:
+def test_ungrouped_child_is_still_denied(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="worker", db_path=db_path)
+    record_comms_policy(name="worker")
     record_lineage(child="worker", parent="lead", db_path=db_path)
     # Act
     decision, _reason = check_spawn(caller="worker", db_path=db_path)
@@ -178,7 +180,7 @@ def test_ungrouped_child_is_still_denied(db_path: Path) -> None:
     assert decision == "deny"
 
 
-def test_isolated_solver_group_gets_no_spawn_authority(db_path: Path) -> None:
+def test_isolated_solver_group_gets_no_spawn_authority(pg_schema: str, db_path: Path) -> None:
     """A deliberately-isolated solver must not gain authority from the
     set-valued read."""
     # Arrange
@@ -196,20 +198,20 @@ def test_isolated_solver_group_gets_no_spawn_authority(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_primary_group_is_still_the_first_authored_group(db_path: Path) -> None:
+def test_primary_group_is_still_the_first_authored_group(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("grant", GRANT_GROUPS, db_path)
     # Act
-    primary = resolve_group_name(name="grant", db_path=db_path)
+    primary = resolve_group_name(name="grant")
     # Assert
     assert primary == "generalist"
 
 
-def test_resolve_group_names_returns_every_authored_group(db_path: Path) -> None:
+def test_resolve_group_names_returns_every_authored_group(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("grant", GRANT_GROUPS, db_path)
     # Act
-    groups = resolve_group_names(name="grant", db_path=db_path)
+    groups = resolve_group_names(name="grant")
     # Assert
     assert groups == frozenset(GRANT_GROUPS)
 
@@ -221,19 +223,20 @@ def test_resolve_group_names_returns_every_authored_group(db_path: Path) -> None
 
 
 def test_legacy_row_without_a_set_still_resolves_to_its_primary(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     # Arrange — group_names omitted, exactly like a pre-migration caller.
-    record_comms_policy(name="legacy", group_name="developer", db_path=db_path)
+    record_comms_policy(name="legacy", group_name="developer")
     # Act
-    groups = resolve_group_names(name="legacy", db_path=db_path)
+    groups = resolve_group_names(name="legacy")
     # Assert
     assert groups == frozenset({"developer"})
 
 
-def test_legacy_developer_row_still_passes_check_spawn(db_path: Path) -> None:
+def test_legacy_developer_row_still_passes_check_spawn(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="legacy", group_name="developer", db_path=db_path)
+    record_comms_policy(name="legacy", group_name="developer")
     record_lineage(child="legacy", parent="lead", db_path=db_path)
     # Act
     decision, _reason = check_spawn(caller="legacy", db_path=db_path)
@@ -241,10 +244,10 @@ def test_legacy_developer_row_still_passes_check_spawn(db_path: Path) -> None:
     assert decision == "allow"
 
 
-def test_unknown_agent_resolves_to_no_groups(db_path: Path) -> None:
+def test_unknown_agent_resolves_to_no_groups(pg_schema: str, db_path: Path) -> None:
     # Arrange — no row at all.
     # Act
-    groups = resolve_group_names(name="ghost", db_path=db_path)
+    groups = resolve_group_names(name="ghost")
     # Assert
     assert groups == frozenset()
 
@@ -254,21 +257,22 @@ def test_unknown_agent_resolves_to_no_groups(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_group_names_round_trip_through_the_policy_row(db_path: Path) -> None:
+def test_group_names_round_trip_through_the_policy_row(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("grant", GRANT_GROUPS, db_path)
     # Act
-    policy = read_comms_policy(name="grant", db_path=db_path)
+    policy = read_comms_policy(name="grant")
     # Assert
     assert set(policy["group_names"]) == set(GRANT_GROUPS)
 
 
 def test_group_names_defaults_to_empty_for_an_unrecorded_agent(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     # Arrange — no record_comms_policy call.
     # Act
-    policy = read_comms_policy(name="never-recorded", db_path=db_path)
+    policy = read_comms_policy(name="never-recorded")
     # Assert
     assert policy["group_names"] == ()
 
@@ -282,7 +286,7 @@ def test_a_group_name_containing_a_comma_is_rejected(db_path: Path) -> None:
     raises = pytest.raises(ValueError)
     # Assert
     with raises:
-        record_comms_policy(name="alice", group_names=bad, db_path=db_path)
+        record_comms_policy(name="alice", group_names=bad)
 
 
 def test_a_bare_string_group_names_is_rejected(db_path: Path) -> None:
@@ -294,7 +298,7 @@ def test_a_bare_string_group_names_is_rejected(db_path: Path) -> None:
     raises = pytest.raises(ValueError)
     # Assert
     with raises:
-        record_comms_policy(name="alice", group_names=bad, db_path=db_path)
+        record_comms_policy(name="alice", group_names=bad)
 
 
 # ---------------------------------------------------------------------------
@@ -303,7 +307,7 @@ def test_a_bare_string_group_names_is_rejected(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_denial_names_the_groups_the_gate_actually_resolved(db_path: Path) -> None:
+def test_denial_names_the_groups_the_gate_actually_resolved(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("worker", ["generalist", "active"], db_path)
     record_lineage(child="worker", parent="lead", db_path=db_path)
@@ -314,6 +318,7 @@ def test_denial_names_the_groups_the_gate_actually_resolved(db_path: Path) -> No
 
 
 def test_denial_no_longer_claims_the_caller_holds_none_of_the_groups(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The old sentence was flatly false against the same server's own
@@ -327,7 +332,7 @@ def test_denial_no_longer_claims_the_caller_holds_none_of_the_groups(
     assert "is in none of the" not in reason
 
 
-def test_denial_spells_researcher_in_full(db_path: Path) -> None:
+def test_denial_spells_researcher_in_full(pg_schema: str, db_path: Path) -> None:
     """The old text said "research", which cost a reader a wrong
     hypothesis about a string mismatch. Name the real group."""
     # Arrange
@@ -340,6 +345,7 @@ def test_denial_spells_researcher_in_full(db_path: Path) -> None:
 
 
 def test_denial_points_at_refresh_acl_when_the_row_may_be_stale(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     # Arrange
@@ -352,6 +358,7 @@ def test_denial_points_at_refresh_acl_when_the_row_may_be_stale(
 
 
 def test_denial_distinguishes_an_absent_row_from_an_ungrouped_agent(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The 2026-08-09 host_exec lesson, applied to the spawn gate: both

--- a/tests/scitex_agent_container/_state/test_state_db_lineage_rel.py
+++ b/tests/scitex_agent_container/_state/test_state_db_lineage_rel.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``sender_target_relationship`` — the SQLite half that did NOT move.
+
+These tests lived in ``test_state_db_acl_policy.py`` until 2026-08-28, when
+``node_comms_policy`` moved to PostgreSQL and this function did not. They are
+here, not there, for the reason the function itself moved modules: it reads
+``lineage``, a different table with a different owner, still on SQLite and
+still taking ``db_path``.
+
+MEASURED WHERE THE PROPERTY STILL LIVES, which is the point. Leaving them in
+a file whose subject is now a PostgreSQL store would have made them read as
+coverage of the migrated code; they are not. They cover the table that stayed
+behind, and they will move again when it moves.
+
+Real SQLite, no mocks — the same isolation these tests always had.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    record_lineage,
+    sender_target_relationship,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+def test_two_children_of_one_parent_are_siblings(db_path: Path) -> None:
+    # Arrange
+    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    # Act
+    rel = sender_target_relationship(sender="cap-a", target="cap-b", db_path=db_path)
+    # Assert
+    assert rel == "sibling"
+
+
+def test_a_child_addressing_its_parent_is_parent(db_path: Path) -> None:
+    # Arrange
+    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    # Act
+    rel = sender_target_relationship(sender="cap-a", target="root", db_path=db_path)
+    # Assert
+    assert rel == "parent"
+
+
+def test_a_parent_addressing_its_child_is_child(db_path: Path) -> None:
+    # Arrange
+    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    # Act
+    rel = sender_target_relationship(sender="root", target="cap-a", db_path=db_path)
+    # Assert
+    assert rel == "child"
+
+
+def test_unrelated_nodes_are_other(db_path: Path) -> None:
+    # Arrange — no lineage edges.
+    # Act
+    rel = sender_target_relationship(sender="cap-a", target="cap-z", db_path=db_path)
+    # Assert
+    assert rel == "other"
+
+
+def test_a_node_addressing_itself_is_self(db_path: Path) -> None:
+    # Arrange
+    # Act
+    rel = sender_target_relationship(sender="cap-a", target="cap-a", db_path=db_path)
+    # Assert
+    assert rel == "self"
+
+
+def test_an_empty_sender_is_other(db_path: Path) -> None:
+    # Arrange
+    # Act
+    rel = sender_target_relationship(sender="", target="cap-a", db_path=db_path)
+    # Assert
+    assert rel == "other"

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -144,7 +144,7 @@ def test_record_lineage_re_parent_keeps_existing_parent(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_derive_group_of_root_with_no_children_is_self_only(db_path: Path) -> None:
+def test_derive_group_of_root_with_no_children_is_self_only(pg_schema: str, db_path: Path) -> None:
     # Arrange
     name = "root"
     # Act
@@ -153,7 +153,7 @@ def test_derive_group_of_root_with_no_children_is_self_only(db_path: Path) -> No
     assert group == {"root"}
 
 
-def test_derive_group_of_parent_includes_direct_children(db_path: Path) -> None:
+def test_derive_group_of_parent_includes_direct_children(pg_schema: str, db_path: Path) -> None:
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     record_lineage(child="worker-b", parent="root", db_path=db_path)
@@ -163,7 +163,7 @@ def test_derive_group_of_parent_includes_direct_children(db_path: Path) -> None:
     assert group == {"root", "worker-a", "worker-b"}
 
 
-def test_derive_group_of_child_includes_parent_and_siblings(db_path: Path) -> None:
+def test_derive_group_of_child_includes_parent_and_siblings(pg_schema: str, db_path: Path) -> None:
     """Sibling sees the same group as the parent does — bidirectional."""
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
@@ -174,7 +174,7 @@ def test_derive_group_of_child_includes_parent_and_siblings(db_path: Path) -> No
     assert group == {"root", "worker-a", "worker-b"}
 
 
-def test_derive_group_excludes_cross_group_nodes(db_path: Path) -> None:
+def test_derive_group_excludes_cross_group_nodes(pg_schema: str, db_path: Path) -> None:
     """A different root's children are not in this group."""
     # Arrange — two unrelated families
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
@@ -185,7 +185,7 @@ def test_derive_group_excludes_cross_group_nodes(db_path: Path) -> None:
     assert group == {"root-1", "child-1"}
 
 
-def test_derive_group_of_unknown_node_is_singleton(db_path: Path) -> None:
+def test_derive_group_of_unknown_node_is_singleton(pg_schema: str, db_path: Path) -> None:
     """A fresh, unattached node is its own singleton group."""
     # Arrange
     name = "fresh"
@@ -193,6 +193,48 @@ def test_derive_group_of_unknown_node_is_singleton(db_path: Path) -> None:
     group = derive_group(name=name, db_path=db_path)
     # Assert
     assert group == {"fresh"}
+
+
+# ---------------------------------------------------------------------------
+# derive_group — the Gap-4 solitary override.
+#
+# These two moved here from test_state_db_acl_policy.py on 2026-08-28. They
+# are about derive_group, which now STRADDLES two databases: the policy read
+# is PostgreSQL and the lineage walk is still SQLite, so they take both
+# ``pg_schema`` and ``db_path``. Left in the acl-policy file they would have
+# read as coverage of the migrated module, which they are not.
+# ---------------------------------------------------------------------------
+
+
+def test_derive_group_solitary_returns_a_singleton_despite_siblings(
+    pg_schema: str, db_path: Path
+) -> None:
+    """Gap-4: ``lineage_group='solitary'`` isolates a capsule from its
+    siblings AND its parent, without depending on the lineage table being
+    empty — so a sibling capsule can never address it via the group-default
+    ACL even though they share a parent edge."""
+    # Arrange
+    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    record_comms_policy(name="cap-a", lineage_group="solitary")
+    # Act
+    group = derive_group(name="cap-a", db_path=db_path)
+    # Assert
+    assert group == {"cap-a"}
+
+
+def test_derive_group_without_a_policy_keeps_the_legacy_siblings(
+    pg_schema: str, db_path: Path
+) -> None:
+    """Default-preservation: with no policy record, derive_group keeps the
+    legacy parent + direct-children semantics."""
+    # Arrange
+    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    # Act
+    group = derive_group(name="cap-a", db_path=db_path)
+    # Assert
+    assert "cap-b" in group
 
 
 # ---------------------------------------------------------------------------
@@ -210,7 +252,7 @@ def test_spawn_allowed_returns_true_for_admin_caller(db_path: Path) -> None:
     assert allowed is True
 
 
-def test_spawn_allowed_returns_true_for_root_node(db_path: Path) -> None:
+def test_spawn_allowed_returns_true_for_root_node(pg_schema: str, db_path: Path) -> None:
     """A node with no parent → root → allowed."""
     # Arrange
     caller = "root"
@@ -220,7 +262,7 @@ def test_spawn_allowed_returns_true_for_root_node(db_path: Path) -> None:
     assert allowed is True
 
 
-def test_spawn_allowed_returns_false_for_child_node(db_path: Path) -> None:
+def test_spawn_allowed_returns_false_for_child_node(pg_schema: str, db_path: Path) -> None:
     """A node with a parent → child → denied under current policy."""
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
@@ -231,6 +273,7 @@ def test_spawn_allowed_returns_false_for_child_node(db_path: Path) -> None:
 
 
 def test_spawn_allowed_deny_reason_explains_role_policy(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The reason names the groups that WOULD have authorised the spawn.
@@ -249,6 +292,7 @@ def test_spawn_allowed_deny_reason_explains_role_policy(
 
 
 def test_spawn_deny_reason_for_unregistered_caller_says_it_has_no_row(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """No policy row and "registered but ungrouped" both resolve to an
@@ -262,12 +306,13 @@ def test_spawn_deny_reason_for_unregistered_caller_says_it_has_no_row(
 
 
 def test_spawn_allowed_returns_true_for_developer_group_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """A developer-group child may spawn even though it has a parent."""
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-a", group_name="developer", db_path=db_path)
+    record_comms_policy(name="worker-a", group_name="developer")
     # Act
     allowed, _reason = spawn_allowed(caller="worker-a", db_path=db_path)
     # Assert
@@ -275,12 +320,13 @@ def test_spawn_allowed_returns_true_for_developer_group_child(
 
 
 def test_spawn_allowed_returns_true_for_researcher_group_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """A researcher-group child may spawn even though it has a parent."""
     # Arrange
     record_lineage(child="neurovista", parent="scitex-cv", db_path=db_path)
-    record_comms_policy(name="neurovista", group_name="researcher", db_path=db_path)
+    record_comms_policy(name="neurovista", group_name="researcher")
     # Act
     allowed, _reason = spawn_allowed(caller="neurovista", db_path=db_path)
     # Assert
@@ -288,6 +334,7 @@ def test_spawn_allowed_returns_true_for_researcher_group_child(
 
 
 def test_spawn_allowed_returns_true_for_privileged_group_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """A privileged-group child may spawn (operator ruling 2026-07-16).
@@ -298,7 +345,7 @@ def test_spawn_allowed_returns_true_for_privileged_group_child(
     """
     # Arrange
     record_lineage(child="dotfiles", parent="root", db_path=db_path)
-    record_comms_policy(name="dotfiles", group_name="privileged", db_path=db_path)
+    record_comms_policy(name="dotfiles", group_name="privileged")
     # Act
     allowed, _reason = spawn_allowed(caller="dotfiles", db_path=db_path)
     # Assert
@@ -306,12 +353,13 @@ def test_spawn_allowed_returns_true_for_privileged_group_child(
 
 
 def test_spawn_allowed_returns_false_for_non_dev_research_group_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """A child in an unrelated named group is still denied."""
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="worker-a", group_name="analysts")
     # Act
     allowed, _reason = spawn_allowed(caller="worker-a", db_path=db_path)
     # Assert
@@ -319,6 +367,7 @@ def test_spawn_allowed_returns_false_for_non_dev_research_group_child(
 
 
 def test_spawn_allowed_deny_reason_for_non_dev_research_group_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The deny reason reports the group the gate ACTUALLY resolved.
@@ -329,7 +378,7 @@ def test_spawn_allowed_deny_reason_for_non_dev_research_group_child(
     """
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="worker-a", group_name="analysts")
     # Act
     _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
     # Assert
@@ -337,6 +386,7 @@ def test_spawn_allowed_deny_reason_for_non_dev_research_group_child(
 
 
 def test_spawn_allowed_may_spawn_false_still_denies_developer_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """Per-spec may_spawn=false overrides the developer-group allow."""
@@ -346,7 +396,6 @@ def test_spawn_allowed_may_spawn_false_still_denies_developer_child(
         name="worker-a",
         group_name="developer",
         may_spawn=False,
-        db_path=db_path,
     )
     # Act
     allowed, _reason = spawn_allowed(caller="worker-a", db_path=db_path)
@@ -355,6 +404,7 @@ def test_spawn_allowed_may_spawn_false_still_denies_developer_child(
 
 
 def test_spawn_allowed_may_spawn_false_reason_for_developer_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The deny reason names the per-spec may_spawn=false override."""
@@ -364,7 +414,6 @@ def test_spawn_allowed_may_spawn_false_reason_for_developer_child(
         name="worker-a",
         group_name="developer",
         may_spawn=False,
-        db_path=db_path,
     )
     # Act
     _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
@@ -373,6 +422,7 @@ def test_spawn_allowed_may_spawn_false_reason_for_developer_child(
 
 
 def test_spawn_allowed_may_spawn_false_still_denies_researcher_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """Per-spec may_spawn=false overrides the researcher-group allow."""
@@ -382,7 +432,6 @@ def test_spawn_allowed_may_spawn_false_still_denies_researcher_child(
         name="neurovista",
         group_name="researcher",
         may_spawn=False,
-        db_path=db_path,
     )
     # Act
     allowed, _reason = spawn_allowed(caller="neurovista", db_path=db_path)
@@ -391,6 +440,7 @@ def test_spawn_allowed_may_spawn_false_still_denies_researcher_child(
 
 
 def test_spawn_allowed_may_spawn_false_reason_for_researcher_child(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The deny reason names the per-spec may_spawn=false override."""
@@ -400,7 +450,6 @@ def test_spawn_allowed_may_spawn_false_reason_for_researcher_child(
         name="neurovista",
         group_name="researcher",
         may_spawn=False,
-        db_path=db_path,
     )
     # Act
     _allowed, reason = spawn_allowed(caller="neurovista", db_path=db_path)
@@ -415,40 +464,40 @@ def test_spawn_allowed_may_spawn_false_reason_for_researcher_child(
 # ---------------------------------------------------------------------------
 
 
-def test_spawn_allowed_allows_developer_group_child(db_path: Path) -> None:
+def test_spawn_allowed_allows_developer_group_child(pg_schema: str, db_path: Path) -> None:
     """A child in the developer group may spawn (group short-circuit)."""
     # Arrange
     record_lineage(child="worker-dev", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-dev", group_name="developer", db_path=db_path)
+    record_comms_policy(name="worker-dev", group_name="developer")
     # Act
     allowed, _reason = spawn_allowed(caller="worker-dev", db_path=db_path)
     # Assert
     assert allowed is True
 
 
-def test_spawn_allowed_allows_research_group_child(db_path: Path) -> None:
+def test_spawn_allowed_allows_research_group_child(pg_schema: str, db_path: Path) -> None:
     """A child in the researcher group may spawn (the incident's case)."""
     # Arrange
     record_lineage(child="neurovista", parent="scitex-cv", db_path=db_path)
-    record_comms_policy(name="neurovista", group_name="researcher", db_path=db_path)
+    record_comms_policy(name="neurovista", group_name="researcher")
     # Act
     allowed, _reason = spawn_allowed(caller="neurovista", db_path=db_path)
     # Assert
     assert allowed is True
 
 
-def test_spawn_allowed_denies_child_in_neither_group(db_path: Path) -> None:
+def test_spawn_allowed_denies_child_in_neither_group(pg_schema: str, db_path: Path) -> None:
     """A child in NEITHER the developer nor research group stays denied."""
     # Arrange
     record_lineage(child="worker-gen", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-gen", group_name="generalist", db_path=db_path)
+    record_comms_policy(name="worker-gen", group_name="generalist")
     # Act
     allowed, _reason = spawn_allowed(caller="worker-gen", db_path=db_path)
     # Assert
     assert allowed is False
 
 
-def test_spawn_allowed_deny_reason_names_group_policy(db_path: Path) -> None:
+def test_spawn_allowed_deny_reason_names_group_policy(pg_schema: str, db_path: Path) -> None:
     """The neither-group deny reason states the group-scoped policy.
 
     Spelled ``researcher`` in full. The old text said "research", and a
@@ -458,7 +507,7 @@ def test_spawn_allowed_deny_reason_names_group_policy(db_path: Path) -> None:
     """
     # Arrange
     record_lineage(child="worker-gen", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-gen", group_name="generalist", db_path=db_path)
+    record_comms_policy(name="worker-gen", group_name="generalist")
     # Act
     _allowed, reason = spawn_allowed(caller="worker-gen", db_path=db_path)
     # Assert
@@ -466,13 +515,14 @@ def test_spawn_allowed_deny_reason_names_group_policy(db_path: Path) -> None:
 
 
 def test_spawn_deny_reason_points_at_refresh_acl_for_a_stale_row(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """A denial whose group list disagrees with the spec means a STALE
     row; the message must name the command that re-publishes it."""
     # Arrange
     record_lineage(child="worker-gen", parent="root", db_path=db_path)
-    record_comms_policy(name="worker-gen", group_name="generalist", db_path=db_path)
+    record_comms_policy(name="worker-gen", group_name="generalist")
     # Act
     _allowed, reason = spawn_allowed(caller="worker-gen", db_path=db_path)
     # Assert
@@ -480,6 +530,7 @@ def test_spawn_deny_reason_points_at_refresh_acl_for_a_stale_row(
 
 
 def test_spawn_allowed_developer_group_child_still_respects_may_spawn(
+    pg_schema: str,
     db_path: Path,
 ) -> None:
     """The per-spec may_spawn=false deny survives the group short-circuit."""
@@ -489,7 +540,6 @@ def test_spawn_allowed_developer_group_child_still_respects_may_spawn(
         name="worker-dev",
         group_name="developer",
         may_spawn=False,
-        db_path=db_path,
     )
     # Act
     allowed, _reason = spawn_allowed(caller="worker-dev", db_path=db_path)

--- a/tests/scitex_agent_container/_state/test_state_db_nodes_group.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes_group.py
@@ -53,40 +53,40 @@ def db_path(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_read_comms_policy_group_name_defaults_empty(db_path: Path) -> None:
+def test_read_comms_policy_group_name_defaults_empty(pg_schema: str, db_path: Path) -> None:
     """A node with no policy row reports the ungrouped default."""
     # Arrange — no record_comms_policy call.
     # Act
-    policy = read_comms_policy(name="never-recorded", db_path=db_path)
+    policy = read_comms_policy(name="never-recorded")
     # Assert
     assert policy["group_name"] == ""
 
 
-def test_record_comms_policy_persists_group_name(db_path: Path) -> None:
+def test_record_comms_policy_persists_group_name(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
     # Act
-    policy = read_comms_policy(name="alice", db_path=db_path)
+    policy = read_comms_policy(name="alice")
     # Assert
     assert policy["group_name"] == "developer"
 
 
-def test_record_comms_policy_group_name_is_trimmed(db_path: Path) -> None:
+def test_record_comms_policy_group_name_is_trimmed(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="alice", group_name="  analysts  ", db_path=db_path)
+    record_comms_policy(name="alice", group_name="  analysts  ")
     # Act
-    policy = read_comms_policy(name="alice", db_path=db_path)
+    policy = read_comms_policy(name="alice")
     # Assert
     assert policy["group_name"] == "analysts"
 
 
-def test_record_comms_policy_group_name_upsert_refreshes(db_path: Path) -> None:
+def test_record_comms_policy_group_name_upsert_refreshes(pg_schema: str, db_path: Path) -> None:
     """A re-record (e.g. a restart after a spec edit) updates the group."""
     # Arrange
-    record_comms_policy(name="alice", group_name="analysts", db_path=db_path)
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="analysts")
+    record_comms_policy(name="alice", group_name="developer")
     # Act
-    policy = read_comms_policy(name="alice", db_path=db_path)
+    policy = read_comms_policy(name="alice")
     # Assert
     assert policy["group_name"] == "developer"
 
@@ -98,7 +98,7 @@ def test_record_comms_policy_rejects_non_str_group_name(db_path: Path) -> None:
     raises = pytest.raises(ValueError)
     # Assert
     with raises:
-        record_comms_policy(name="alice", group_name=bad_group, db_path=db_path)
+        record_comms_policy(name="alice", group_name=bad_group)
 
 
 # ---------------------------------------------------------------------------
@@ -106,19 +106,19 @@ def test_record_comms_policy_rejects_non_str_group_name(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_group_name_returns_persisted_group(db_path: Path) -> None:
+def test_resolve_group_name_returns_persisted_group(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
     # Act
-    group = resolve_group_name(name="alice", db_path=db_path)
+    group = resolve_group_name(name="alice")
     # Assert
     assert group == "developer"
 
 
-def test_resolve_group_name_unknown_node_is_empty(db_path: Path) -> None:
+def test_resolve_group_name_unknown_node_is_empty(pg_schema: str, db_path: Path) -> None:
     # Arrange — no row.
     # Act
-    group = resolve_group_name(name="ghost", db_path=db_path)
+    group = resolve_group_name(name="ghost")
     # Assert
     assert group == ""
 
@@ -128,33 +128,33 @@ def test_resolve_group_name_unknown_node_is_empty(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_same_named_group_true_for_equal_nonempty(db_path: Path) -> None:
+def test_same_named_group_true_for_equal_nonempty(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
-    record_comms_policy(name="bob", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
+    record_comms_policy(name="bob", group_name="developer")
     # Act
-    result = same_named_group(sender="alice", target="bob", db_path=db_path)
+    result = same_named_group(sender="alice", target="bob")
     # Assert
     assert result is True
 
 
-def test_same_named_group_false_for_different_groups(db_path: Path) -> None:
+def test_same_named_group_false_for_different_groups(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
-    record_comms_policy(name="bob", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
+    record_comms_policy(name="bob", group_name="analysts")
     # Act
-    result = same_named_group(sender="alice", target="bob", db_path=db_path)
+    result = same_named_group(sender="alice", target="bob")
     # Assert
     assert result is False
 
 
-def test_same_named_group_false_when_both_ungrouped(db_path: Path) -> None:
+def test_same_named_group_false_when_both_ungrouped(pg_schema: str, db_path: Path) -> None:
     """Two ungrouped agents must NOT match — absence is a no-op."""
     # Arrange — neither has a group_name.
-    record_comms_policy(name="alice", db_path=db_path)
-    record_comms_policy(name="bob", db_path=db_path)
+    record_comms_policy(name="alice")
+    record_comms_policy(name="bob")
     # Act
-    result = same_named_group(sender="alice", target="bob", db_path=db_path)
+    result = same_named_group(sender="alice", target="bob")
     # Assert
     assert result is False
 
@@ -164,19 +164,19 @@ def test_same_named_group_false_when_both_ungrouped(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_is_developer_true_for_developer_group_member(db_path: Path) -> None:
+def test_is_developer_true_for_developer_group_member(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
     # Act
-    result = is_developer(name="alice", db_path=db_path)
+    result = is_developer(name="alice")
     # Assert
     assert result is True
 
 
-def test_is_developer_false_for_other_group_member(db_path: Path) -> None:
+def test_is_developer_false_for_other_group_member(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_comms_policy(name="alice", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="alice", group_name="analysts")
     # Act
-    result = is_developer(name="alice", db_path=db_path)
+    result = is_developer(name="alice")
     # Assert
     assert result is False

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
@@ -142,7 +142,7 @@ def test_dry_run_leaves_the_spec_dir_where_it_was(dry_run, fleet: Layout):
 # ---------------------------------------------------------------------------
 
 
-def test_rename_exits_clean(applied):
+def test_rename_exits_clean(pg_schema: str, applied):
     # Arrange
     expected = 0
     # Act
@@ -151,7 +151,7 @@ def test_rename_exits_clean(applied):
     assert code == expected, applied.output
 
 
-def test_rename_moves_the_spec_dir(applied, fleet: Layout):
+def test_rename_moves_the_spec_dir(pg_schema: str, applied, fleet: Layout):
     # Arrange
     new_spec = fleet.spec_file(NEW)
     # Act
@@ -160,7 +160,7 @@ def test_rename_moves_the_spec_dir(applied, fleet: Layout):
     assert exists
 
 
-def test_rename_tells_the_operator_how_to_start_the_agent(applied):
+def test_rename_tells_the_operator_how_to_start_the_agent(pg_schema: str, applied):
     # Arrange
     needle = f"sac agents start {NEW}"
     # Act

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
@@ -1036,7 +1036,7 @@ class TestGroupOption:
         # Assert
         assert "nonexistent-group" in result.output
 
-    def test_matching_group_reaches_singleton_skip(self, tmp_path, env_save_restore):
+    def test_matching_group_reaches_singleton_skip(self, pg_schema: str, tmp_path, env_save_restore):
         # Arrange — group-resolved agent is a singleton pinned to a host
         # with a live registry row, so the run short-circuits cleanly
         # (no real apptainer needed) at the SAME skip gate the plain
@@ -1058,7 +1058,7 @@ class TestGroupOption:
         assert result.exit_code == 0
 
     def test_matching_group_skip_message_names_resolved_agent(
-        self, tmp_path, env_save_restore
+        self, pg_schema: str, tmp_path, env_save_restore
     ):
         # Arrange
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
@@ -1077,7 +1077,7 @@ class TestGroupOption:
         # Assert
         assert "Skipping 'mini'" in result.output
 
-    def test_explicit_target_plus_group_both_queued(self, tmp_path, env_save_restore):
+    def test_explicit_target_plus_group_both_queued(self, pg_schema: str, tmp_path, env_save_restore):
         # Arrange — one explicit-by-path target, one group-resolved target;
         # a genuine TWO-name invocation routes to the serialized multi-start
         # queue (_start_parallel.py), which dispatches each target as its

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_force_clears_session.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_force_clears_session.py
@@ -230,6 +230,7 @@ def _seed_session_id(runtime_root: Path, name: str, sid: str) -> Path:
 
 
 def test_force_removes_persisted_session_id_file(
+    pg_schema: str,
     tmp_path: Path,
     runtime_root: Path,
     isolated_home: Path,
@@ -256,6 +257,7 @@ def test_force_removes_persisted_session_id_file(
 
 
 def test_force_leaves_other_runtime_state_alone(
+    pg_schema: str,
     tmp_path: Path,
     runtime_root: Path,
     isolated_home: Path,
@@ -292,6 +294,7 @@ def test_force_leaves_other_runtime_state_alone(
 
 
 def test_no_force_leaves_session_id(
+    pg_schema: str,
     tmp_path: Path,
     runtime_root: Path,
     isolated_home: Path,
@@ -317,6 +320,7 @@ def test_no_force_leaves_session_id(
 
 
 def test_missing_session_id_file_under_force_is_no_op(
+    pg_schema: str,
     tmp_path: Path,
     runtime_root: Path,
     isolated_home: Path,

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_group_filter.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_group_filter.py
@@ -84,7 +84,7 @@ class TestResolveGroupTargets:
         # Assert
         assert result == []
 
-    def test_single_group_matches_agent(self, isolated_agents_root):
+    def test_single_group_matches_agent(self, pg_schema: str, isolated_agents_root):
         # Arrange
         _write_agent_spec(isolated_agents_root, "alpha", groups_yaml="[developer]")
         # Act
@@ -92,7 +92,7 @@ class TestResolveGroupTargets:
         # Assert
         assert result == ["alpha"]
 
-    def test_non_matching_agent_is_excluded(self, isolated_agents_root):
+    def test_non_matching_agent_is_excluded(self, pg_schema: str, isolated_agents_root):
         # Arrange
         _write_agent_spec(isolated_agents_root, "alpha", groups_yaml="[developer]")
         _write_agent_spec(isolated_agents_root, "beta", groups_yaml="[researcher]")
@@ -101,7 +101,7 @@ class TestResolveGroupTargets:
         # Assert
         assert result == ["alpha"]
 
-    def test_matching_is_case_insensitive(self, isolated_agents_root):
+    def test_matching_is_case_insensitive(self, pg_schema: str, isolated_agents_root):
         # Arrange
         _write_agent_spec(isolated_agents_root, "alpha", groups_yaml="[developer]")
         # Act
@@ -118,7 +118,7 @@ class TestResolveGroupTargets:
         assert result == []
 
     def test_agent_with_multiple_groups_matches_non_first_element(
-        self, isolated_agents_root
+        self, pg_schema: str, isolated_agents_root
     ):
         # Arrange — grant-style spec: developer is NOT the first element,
         # so the ACL-effective group_from_labels would miss it; the
@@ -133,7 +133,7 @@ class TestResolveGroupTargets:
         # Assert
         assert result == ["grant"]
 
-    def test_multiple_wanted_groups_union_across_agents(self, isolated_agents_root):
+    def test_multiple_wanted_groups_union_across_agents(self, pg_schema: str, isolated_agents_root):
         # Arrange
         _write_agent_spec(isolated_agents_root, "alpha", groups_yaml="[developer]")
         _write_agent_spec(isolated_agents_root, "beta", groups_yaml="[researcher]")
@@ -143,7 +143,7 @@ class TestResolveGroupTargets:
         # Assert
         assert result == ["alpha", "beta"]
 
-    def test_result_is_sorted(self, isolated_agents_root):
+    def test_result_is_sorted(self, pg_schema: str, isolated_agents_root):
         # Arrange
         _write_agent_spec(isolated_agents_root, "zeta", groups_yaml="[developer]")
         _write_agent_spec(isolated_agents_root, "alpha", groups_yaml="[developer]")
@@ -160,7 +160,7 @@ class TestResolveGroupTargets:
         # Assert
         assert result == []
 
-    def test_broken_spec_is_excluded_not_raised(self, isolated_agents_root):
+    def test_broken_spec_is_excluded_not_raised(self, pg_schema: str, isolated_agents_root):
         # Arrange — a spec missing every required field must not crash
         # resolution; it is simply excluded from every group.
         broken = isolated_agents_root / "broken"
@@ -172,7 +172,7 @@ class TestResolveGroupTargets:
         # Assert
         assert result == ["alpha"]
 
-    def test_ungrouped_agent_never_matches(self, isolated_agents_root):
+    def test_ungrouped_agent_never_matches(self, pg_schema: str, isolated_agents_root):
         # Arrange — spec with no groups label at all.
         d = isolated_agents_root / "ungrouped"
         d.mkdir()
@@ -242,7 +242,7 @@ class TestApplyGroupTargets:
         assert "nonexistent" in capsys.readouterr().err
 
     def test_matching_group_resolves_with_no_explicit_targets(
-        self, isolated_agents_root
+        self, pg_schema: str, isolated_agents_root
     ):
         # Arrange
         _write_agent_spec(isolated_agents_root, "alpha", groups_yaml="[developer]")
@@ -251,7 +251,7 @@ class TestApplyGroupTargets:
         # Assert
         assert result == ("alpha",)
 
-    def test_explicit_targets_and_group_are_unioned(self, isolated_agents_root):
+    def test_explicit_targets_and_group_are_unioned(self, pg_schema: str, isolated_agents_root):
         # Arrange
         _write_agent_spec(isolated_agents_root, "alpha", groups_yaml="[developer]")
         # Act
@@ -259,7 +259,7 @@ class TestApplyGroupTargets:
         # Assert
         assert result == ("other-agent", "alpha")
 
-    def test_union_is_de_duplicated(self, isolated_agents_root):
+    def test_union_is_de_duplicated(self, pg_schema: str, isolated_agents_root):
         # Arrange — "alpha" is both an explicit target AND group-resolved.
         _write_agent_spec(isolated_agents_root, "alpha", groups_yaml="[developer]")
         # Act

--- a/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
+++ b/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
@@ -107,63 +107,63 @@ def registry(tmp_path: Path):
             os.environ[env_key] = saved
 
 
-def test_refresh_writes_resolved_group_for_stale_agent(db_path, registry):
+def test_refresh_writes_resolved_group_for_stale_agent(pg_schema: str, db_path, registry):
     """A spec with groups:[researcher] whose persisted group is stale →
     after the command read_comms_policy returns ``researcher``."""
     # Arrange — spec says researcher; DB still holds the stale developer.
     _write_spec(registry, "alice", {"groups": ["researcher"]})
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
     # Act
     CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
     # Assert
     assert read_comms_policy(name="alice")["group_name"] == "researcher"
 
 
-def test_diff_output_shows_the_change(db_path, registry):
+def test_diff_output_shows_the_change(pg_schema: str, db_path, registry):
     """The printed per-agent diff shows old -> new for a changed group."""
     # Arrange
     _write_spec(registry, "alice", {"groups": ["researcher"]})
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
     # Act
     result = CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
     # Assert
     assert "alice: developer -> researcher" in result.output
 
 
-def test_unchanged_agent_marked_unchanged(db_path, registry):
+def test_unchanged_agent_marked_unchanged(pg_schema: str, db_path, registry):
     """An agent already at its resolved group prints ``(unchanged)``."""
     # Arrange
     _write_spec(registry, "alice", {"groups": ["researcher"]})
-    record_comms_policy(name="alice", group_name="researcher", db_path=db_path)
+    record_comms_policy(name="alice", group_name="researcher")
     # Act
     result = CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
     # Assert
     assert "(unchanged)" in result.output
 
 
-def test_dry_run_does_not_mutate_the_db(db_path, registry):
+def test_dry_run_does_not_mutate_the_db(pg_schema: str, db_path, registry):
     """--dry-run shows the diff WITHOUT writing — DB stays stale."""
     # Arrange
     _write_spec(registry, "alice", {"groups": ["researcher"]})
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
     # Act
     CliRunner().invoke(refresh_acl, ["--dry-run"], catch_exceptions=False)
     # Assert
     assert read_comms_policy(name="alice")["group_name"] == "developer"
 
 
-def test_dry_run_still_previews_the_new_group(db_path, registry):
+def test_dry_run_still_previews_the_new_group(pg_schema: str, db_path, registry):
     """--dry-run previews the would-be group in the diff output."""
     # Arrange
     _write_spec(registry, "alice", {"groups": ["researcher"]})
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
     # Act
     result = CliRunner().invoke(refresh_acl, ["--dry-run"], catch_exceptions=False)
     # Assert
     assert "alice: developer -> researcher" in result.output
 
 
-def test_underscore_dirs_are_skipped(db_path, registry):
+def test_underscore_dirs_are_skipped(pg_schema: str, db_path, registry):
     """``_shared`` / ``_template_*`` dirs are NOT treated as fleet agents."""
     # Arrange — a real agent plus two underscore scaffolding dirs.
     _write_spec(registry, "alice", {"groups": ["researcher"]})
@@ -175,7 +175,7 @@ def test_underscore_dirs_are_skipped(db_path, registry):
     assert "_shared" not in result.output and "_template_dev" not in result.output
 
 
-def test_malformed_spec_reported_with_nonzero_exit(db_path, registry):
+def test_malformed_spec_reported_with_nonzero_exit(pg_schema: str, db_path, registry):
     """A malformed spec is reported + non-zero exit, but the others still
     refresh."""
     # Arrange — one good agent, one spec.yaml that fails validation.
@@ -189,11 +189,11 @@ def test_malformed_spec_reported_with_nonzero_exit(db_path, registry):
     assert result.exit_code == 1
 
 
-def test_malformed_spec_does_not_abort_the_others(db_path, registry):
+def test_malformed_spec_does_not_abort_the_others(pg_schema: str, db_path, registry):
     """The good agent is still refreshed despite the sibling failure."""
     # Arrange
     _write_spec(registry, "alice", {"groups": ["researcher"]})
-    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer")
     bad_dir = registry / "broken"
     bad_dir.mkdir()
     (bad_dir / "spec.yaml").write_text("this: is: not: a: valid: v3 spec\n")

--- a/tests/scitex_agent_container/config/test__group_authority.py
+++ b/tests/scitex_agent_container/config/test__group_authority.py
@@ -125,7 +125,6 @@ def relocate_case(spec_root, tmp_path) -> RelocateCase:
         may_spawn=True,
         group_name="developer",
         group_names=frozenset({"developer", "infra"}),
-        db_path=host_db,
     )
     return RelocateCase(name=name, host_db=host_db, container_db=container_db)
 
@@ -135,20 +134,20 @@ def relocate_case(spec_root, tmp_path) -> RelocateCase:
 # ---------------------------------------------------------------------------
 
 
-def test_host_store_holds_the_policy_row(relocate_case):
+def test_host_store_holds_the_policy_row(pg_schema: str, relocate_case):
     # Arrange
     case = relocate_case
     # Act
-    policy = read_comms_policy(name=case.name, db_path=case.host_db)
+    policy = read_comms_policy(name=case.name)
     # Assert
     assert policy["group_name"] == "developer"
 
 
-def test_container_store_holds_no_policy_row(relocate_case):
+def test_container_store_holds_no_policy_row(pg_schema: str, relocate_case):
     # Arrange
     case = relocate_case
     # Act
-    policy = read_comms_policy(name=case.name, db_path=case.container_db)
+    policy = read_comms_policy(name=case.name)
     # Assert
     assert policy["group_name"] == ""
 
@@ -158,41 +157,41 @@ def test_container_store_holds_no_policy_row(relocate_case):
 # ---------------------------------------------------------------------------
 
 
-def test_group_set_is_identical_from_container_and_host(relocate_case):
+def test_group_set_is_identical_from_container_and_host(pg_schema: str, relocate_case):
     # Arrange
     case = relocate_case
     # Act
-    from_host = resolve_group_names(name=case.name, db_path=case.host_db)
-    from_container = resolve_group_names(name=case.name, db_path=case.container_db)
+    from_host = resolve_group_names(name=case.name)
+    from_container = resolve_group_names(name=case.name)
     # Assert
     assert from_host == from_container
 
 
-def test_group_set_from_the_container_is_the_spec_answer(relocate_case):
+def test_group_set_from_the_container_is_the_spec_answer(pg_schema: str, relocate_case):
     # Arrange
     case = relocate_case
     # Act
-    from_container = resolve_group_names(name=case.name, db_path=case.container_db)
+    from_container = resolve_group_names(name=case.name)
     # Assert
     assert from_container == frozenset({"developer", "infra"})
 
 
-def test_primary_group_is_identical_from_container_and_host(relocate_case):
+def test_primary_group_is_identical_from_container_and_host(pg_schema: str, relocate_case):
     # Arrange
     case = relocate_case
     # Act
-    from_host = resolve_group_name(name=case.name, db_path=case.host_db)
-    from_container = resolve_group_name(name=case.name, db_path=case.container_db)
+    from_host = resolve_group_name(name=case.name)
+    from_container = resolve_group_name(name=case.name)
     # Assert
     assert from_host == from_container
 
 
-def test_developer_authority_holds_from_the_container_store(relocate_case):
+def test_developer_authority_holds_from_the_container_store(pg_schema: str, relocate_case):
     """The gate itself agrees — this is what the 403 actually turned on."""
     # Arrange
     case = relocate_case
     # Act
-    allowed = is_developer(name=case.name, db_path=case.container_db)
+    allowed = is_developer(name=case.name)
     # Assert
     assert allowed is True
 
@@ -351,35 +350,34 @@ def stale_row_case(spec_root, tmp_path) -> RelocateCase:
         may_spawn=True,
         group_name="developer",
         group_names=frozenset({"developer"}),
-        db_path=db,
     )
     return RelocateCase(name=name, host_db=db, container_db=db)
 
 
-def test_stale_row_still_records_the_revoked_group(stale_row_case):
+def test_stale_row_still_records_the_revoked_group(pg_schema: str, stale_row_case):
     # Arrange
     case = stale_row_case
     # Act
-    policy = read_comms_policy(name=case.name, db_path=case.host_db)
+    policy = read_comms_policy(name=case.name)
     # Assert
     assert policy["group_name"] == "developer"
 
 
-def test_spec_revocation_beats_the_stale_row(stale_row_case):
+def test_spec_revocation_beats_the_stale_row(pg_schema: str, stale_row_case):
     """Deleting a group from the spec actually revokes it."""
     # Arrange
     case = stale_row_case
     # Act
-    groups = resolve_group_names(name=case.name, db_path=case.host_db)
+    groups = resolve_group_names(name=case.name)
     # Assert
     assert groups == frozenset({"generalist"})
 
 
-def test_revoked_developer_authority_is_actually_denied(stale_row_case):
+def test_revoked_developer_authority_is_actually_denied(pg_schema: str, stale_row_case):
     # Arrange
     case = stale_row_case
     # Act
-    allowed = is_developer(name=case.name, db_path=case.host_db)
+    allowed = is_developer(name=case.name)
     # Assert
     assert allowed is False
 
@@ -399,12 +397,11 @@ def foreign_node_case(spec_root, tmp_path) -> RelocateCase:
         may_spawn=True,
         group_name="researcher",
         group_names=frozenset({"researcher"}),
-        db_path=db,
     )
     return RelocateCase(name=name, host_db=db, container_db=db)
 
 
-def test_foreign_node_has_no_visible_spec(foreign_node_case):
+def test_foreign_node_has_no_visible_spec(pg_schema: str, foreign_node_case):
     # Arrange
     case = foreign_node_case
     # Act
@@ -413,19 +410,19 @@ def test_foreign_node_has_no_visible_spec(foreign_node_case):
     assert groups is None
 
 
-def test_foreign_node_falls_back_to_its_policy_row(foreign_node_case):
+def test_foreign_node_falls_back_to_its_policy_row(pg_schema: str, foreign_node_case):
     # Arrange
     case = foreign_node_case
     # Act
-    groups = resolve_group_names(name=case.name, db_path=case.host_db)
+    groups = resolve_group_names(name=case.name)
     # Assert
     assert groups == frozenset({"researcher"})
 
 
-def test_foreign_node_primary_group_falls_back_to_its_row(foreign_node_case):
+def test_foreign_node_primary_group_falls_back_to_its_row(pg_schema: str, foreign_node_case):
     # Arrange
     case = foreign_node_case
     # Act
-    primary = resolve_group_name(name=case.name, db_path=case.host_db)
+    primary = resolve_group_name(name=case.name)
     # Assert
     assert primary == "researcher"

--- a/tests/scitex_agent_container/config/test__group_authority.py
+++ b/tests/scitex_agent_container/config/test__group_authority.py
@@ -2,21 +2,31 @@
 # -*- coding: utf-8 -*-
 """Tests for spec-sourced group authority.
 
-The headline is the ``identical_from_both_stores`` pair — one caller,
-one spec, two genuinely different stores, one answer. That is the
-assertion that would have caught the 2026-08-11 relocation incident
-(nine ``403 ACL deny`` probes at once, because the target host held no
+This file used to be built around an ``identical_from_both_stores``
+pair — one caller, one spec, two genuinely different SQLite stores, one
+answer. It was written for the 2026-08-11 relocation incident (nine
+``403 ACL deny`` probes at once, because the target host held no
 ``node_comms_policy`` row for the caller) and the 2026-08-09 escalation
 (three agents read an empty per-agent shard and concluded the fleet
 registry had been wiped, while the host DB was healthy).
 
-Real SQLite files and real spec files throughout — no mocks, and no
-fixture that rewrites production internals. The "container" store is a
-genuinely empty database, which is exactly what ``/state/<agent>/state.db``
-is inside a SIF; the "bare host" store is a genuinely populated one. Two
-tests below assert that the stores really do still differ, so the
-equality tests can never quietly decay into comparing one store with
-itself and proving nothing.
+THAT SHAPE IS GONE, and this docstring no longer claims otherwise. Both
+incidents were caused by the per-agent SQLite shard, and moving
+``node_comms_policy`` to one shared PostgreSQL store removes the shard
+rather than testing around it. There is no longer a second store for a
+caller to disagree with, so the equality the old headline asserted is
+now true BY CONSTRUCTION and cannot be tested — a test for it can only
+call the same function twice.
+
+The old docstring promised the opposite: that "two tests below assert
+that the stores really do still differ, so the equality tests can never
+quietly decay into comparing one store with itself and proving
+nothing." That guard is exactly what decayed. The tests it protected
+became ``x == x``, and one of them — a container store holding no row —
+asserted an emptiness that the shared store cannot produce, so it was
+green only where nothing could write. They are deleted below rather
+than left passing under names that promise coverage this file no longer
+provides.
 """
 
 from __future__ import annotations
@@ -94,27 +104,32 @@ def spec_root(tmp_path):
 
 @dataclass(frozen=True)
 class RelocateCase:
-    """One agent, its spec, and the two stores that used to disagree."""
+    """One agent and its spec.
+
+    It carried ``host_db`` and ``container_db`` until the policy table
+    moved to PostgreSQL. Nothing read them after that -- ``record_comms_policy``
+    stopped taking a ``db_path`` -- but they kept the file LOOKING like it
+    still exercised two stores, which is how three tests went on claiming a
+    container/host comparison they no longer made.
+    """
 
     name: str
-    host_db: Path
-    container_db: Path
 
 
 @pytest.fixture()
 def relocate_case(spec_root, tmp_path) -> RelocateCase:
-    """An agent whose spec is visible but whose policy row is host-only.
+    """An agent whose spec is visible and whose policy row is published.
 
-    ``host_db`` stands for the bare host's populated
-    ``~/.scitex/agent-container/runtime/state.db``; ``container_db``
-    stands for the private ``/state/<agent>/state.db`` shard a SIF gets,
-    which holds no ``node_comms_policy`` row for anybody. This is the
-    exact shape of the relocation 403.
+    It used to build two SQLite files: a populated one standing for the bare
+    host's ``~/.scitex/agent-container/runtime/state.db``, and an empty one
+    standing for the private ``/state/<agent>/state.db`` shard a SIF gets --
+    the exact shape of the relocation 403. The shard is what caused that
+    incident, and it no longer exists: the policy row lives in one shared
+    PostgreSQL store that every caller reads. The two paths are not built any
+    more because nothing could read them.
     """
     name = "t-auth-relocate"
     _write_spec(spec_root, name, groups="developer, infra")
-    host_db = tmp_path / "host-state.db"
-    container_db = tmp_path / "container-state.db"
     record_comms_policy(
         name=name,
         outbound_siblings="allow",
@@ -126,15 +141,28 @@ def relocate_case(spec_root, tmp_path) -> RelocateCase:
         group_name="developer",
         group_names=frozenset({"developer", "infra"}),
     )
-    return RelocateCase(name=name, host_db=host_db, container_db=container_db)
+    return RelocateCase(name=name)
 
 
 # ---------------------------------------------------------------------------
-# the two stores really do differ — the fault condition, asserted
+# the published row is readable
+#
+# This section asserted the FAULT CONDITION: that a populated host store and
+# an empty container shard really did disagree, so the equality tests further
+# down could not decay into comparing one store with itself.
+#
+# `test_container_store_holds_no_policy_row` is deleted. It made the IDENTICAL
+# call as the test below -- `read_comms_policy(name=case.name)`, no store
+# argument, because there is no longer one to pass -- and asserted the
+# OPPOSITE result. Against the shared store that row exists, so the read
+# returns "developer" and the assertion of "" is simply false; it passed only
+# where nothing could write, which made it green here and red on any writable
+# primary. Two tests cannot both be right about one call, and the one that is
+# right is the one that is kept.
 # ---------------------------------------------------------------------------
 
 
-def test_host_store_holds_the_policy_row(pg_schema: str, relocate_case):
+def test_the_published_policy_row_is_readable(pg_schema: str, relocate_case):
     # Arrange
     case = relocate_case
     # Act
@@ -143,28 +171,9 @@ def test_host_store_holds_the_policy_row(pg_schema: str, relocate_case):
     assert policy["group_name"] == "developer"
 
 
-def test_container_store_holds_no_policy_row(pg_schema: str, relocate_case):
-    # Arrange
-    case = relocate_case
-    # Act
-    policy = read_comms_policy(name=case.name)
-    # Assert
-    assert policy["group_name"] == ""
-
-
 # ---------------------------------------------------------------------------
 # the headline — one caller, two stores, one answer
 # ---------------------------------------------------------------------------
-
-
-def test_group_set_is_identical_from_container_and_host(pg_schema: str, relocate_case):
-    # Arrange
-    case = relocate_case
-    # Act
-    from_host = resolve_group_names(name=case.name)
-    from_container = resolve_group_names(name=case.name)
-    # Assert
-    assert from_host == from_container
 
 
 def test_group_set_from_the_container_is_the_spec_answer(pg_schema: str, relocate_case):
@@ -174,16 +183,6 @@ def test_group_set_from_the_container_is_the_spec_answer(pg_schema: str, relocat
     from_container = resolve_group_names(name=case.name)
     # Assert
     assert from_container == frozenset({"developer", "infra"})
-
-
-def test_primary_group_is_identical_from_container_and_host(pg_schema: str, relocate_case):
-    # Arrange
-    case = relocate_case
-    # Act
-    from_host = resolve_group_name(name=case.name)
-    from_container = resolve_group_name(name=case.name)
-    # Assert
-    assert from_host == from_container
 
 
 def test_developer_authority_holds_from_the_container_store(pg_schema: str, relocate_case):
@@ -339,7 +338,6 @@ def stale_row_case(spec_root, tmp_path) -> RelocateCase:
     """A spec that has DROPPED developer, over a row that still grants it."""
     name = "t-auth-revoked"
     _write_spec(spec_root, name, groups="generalist")
-    db = tmp_path / "stale.db"
     record_comms_policy(
         name=name,
         outbound_siblings="allow",
@@ -351,7 +349,7 @@ def stale_row_case(spec_root, tmp_path) -> RelocateCase:
         group_name="developer",
         group_names=frozenset({"developer"}),
     )
-    return RelocateCase(name=name, host_db=db, container_db=db)
+    return RelocateCase(name=name)
 
 
 def test_stale_row_still_records_the_revoked_group(pg_schema: str, stale_row_case):
@@ -386,7 +384,6 @@ def test_revoked_developer_authority_is_actually_denied(pg_schema: str, stale_ro
 def foreign_node_case(spec_root, tmp_path) -> RelocateCase:
     """A node with a policy row but NO spec — a remote / federated peer."""
     name = "t-auth-foreign"
-    db = tmp_path / "foreign.db"
     record_comms_policy(
         name=name,
         outbound_siblings="allow",
@@ -398,7 +395,7 @@ def foreign_node_case(spec_root, tmp_path) -> RelocateCase:
         group_name="researcher",
         group_names=frozenset({"researcher"}),
     )
-    return RelocateCase(name=name, host_db=db, container_db=db)
+    return RelocateCase(name=name)
 
 
 def test_foreign_node_has_no_visible_spec(pg_schema: str, foreign_node_case):

--- a/tests/smoke/_node_comms.py
+++ b/tests/smoke/_node_comms.py
@@ -172,7 +172,7 @@ def _set_up_denied_send(db: Path) -> dict[str, str]:
     """
     record_lineage(child="alpha", parent="parent_a", db_path=db)
     record_lineage(child="gamma", parent="parent_a", db_path=db)
-    record_comms_policy(name="gamma", inbound_siblings="deny", db_path=db)
+    record_comms_policy(name="gamma", inbound_siblings="deny")
     return {
         "host": "smoke-host-token",
         "parent_a": mint_node_token(name="parent_a", db_path=db),


### PR DESCRIPTION
Moves `node_comms_policy` — the ACL policy table — onto `scitex_dev.store`/PostgreSQL, and includes a rename path that stops silently denying.

## Review findings addressed

This branch sat finished-but-unpushed. A review of it raised three things, all fixed here:

**1. A test that was green here and RED on any writable primary (the blocker).**
`test_container_store_holds_no_policy_row` made the *identical* call as the test above it — `read_comms_policy(name=case.name)`, no store argument, because there is no longer one to pass — and asserted the opposite result. Against the shared store the row exists, so the read returns `"developer"` and the assertion of `""` is false. It passed only where nothing could write. Deleted; the correct one is kept.

**2. Two assertions that had decayed to `x == x`.**
`test_group_set_is_identical_from_container_and_host` and `test_primary_group_is_identical_from_container_and_host` called one function twice and compared the results, under names promising a container/host equivalence the code can no longer express.

The cause of all three is the same: both incidents that file was written for were caused by the per-agent SQLite shard, and moving the table to one shared store removes the shard rather than testing around it. The equality is now true by construction. `RelocateCase` still carried `host_db`/`container_db` fields that nothing read — both surviving fixtures passed the *same* path for the two — and those fields are what kept the file looking like it still exercised two stores. They, their dead assignments, and the module docstring's claim to a decay-guard that had already failed, all go.

**3. `updated_at` was resolved by a different ordering than every other field.**
`_merge.py` decides `LAST_WRITER_WINS` on `incoming_stamp > current_stamp` (the HLC) and `MAX` on `incoming > current` (the value). Under `MULTI_WRITER` those disagree whenever a node's HLC wall has been pulled forward by a peer's message while its own `time.time()` has not — and `updated_at` is written as `time.time()`. In that window MAX keeps the *losing* write's larger timestamp, so the record advertises itself as fresher than the write that supplied its data: a stale ACL reading as current, which this module's docstring names as the failure it exists to prevent. MAX was there to stop a late replica walking the clock backwards; HLC ordering already does that for every other field.

## Rebase

Rebased onto current develop (was 5 behind). Two conflicts, both from `comms_grants` having migrated underneath:
- `test__acl_group.py` — neither side verbatim: develop dropped `db_path` from `grant_send`, this branch drops it from `record_comms_policy`. Resolved to the intersection, verified against both signatures.
- `test__instances_auto_grant.py` — took develop's newer test names; one of them documents in its own docstring that it was renamed *away from* the name this branch still carried.