### PR TITLE
fix(state): three follow-ups an audit found in the merged SQLite migrations

### DIFF
--- a/src/scitex_agent_container/_store_plugin.py
+++ b/src/scitex_agent_container/_store_plugin.py
@@ -317,8 +317,19 @@ COMMS_GRANTS = Schema.build(
 # the loaded spec. Its content is DERIVED from the spec, so the newest
 # write is genuinely the best answer and LAST_WRITER_WINS is honest here —
 # unlike on a heartbeat, where the newest DELIVERY is not the newest FACT.
-# ``updated_at`` is MAX rather than LWW so the row's own clock cannot be
-# walked backwards by a late-arriving stale replica.
+# ``updated_at`` is LAST_WRITER_WINS too, matching the live store. It was
+# MAX here, to stop a late-arriving stale replica walking the row's clock
+# backwards -- but HLC ordering already delivers that for every other
+# field, and MAX bought it by resolving this one field on a DIFFERENT
+# ordering than the rest of the record. ``_merge.py`` decides
+# LAST_WRITER_WINS on ``incoming_stamp > current_stamp`` (the HLC) and MAX
+# on ``incoming > current`` (the value), and those disagree whenever a
+# node's HLC wall has been pulled forward by a peer's message while its own
+# ``time.time()`` -- which is what ``updated_at`` holds -- has not. MAX then
+# keeps the LOSING write's larger timestamp and the record advertises itself
+# as fresher than the write that supplied its data: a stale ACL reading as
+# current. See ``state_db_acl_policy_store`` for the same argument at the
+# point the value is actually written.
 NODE_COMMS_POLICY = Schema.build(
     "sac_node_comms_policy",
     {
@@ -336,7 +347,7 @@ NODE_COMMS_POLICY = Schema.build(
         # through it.
         "group_name": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
         "group_names": _data(FieldKind.TEXT, MergeRule.LAST_WRITER_WINS, required=True),
-        "updated_at": _data(FieldKind.REAL, MergeRule.MAX, required=True),
+        "updated_at": _data(FieldKind.REAL, MergeRule.LAST_WRITER_WINS, required=True),
     },
 )
 

--- a/tests/develop/test_migrate_scripts_do_not_write_by_default.py
+++ b/tests/develop/test_migrate_scripts_do_not_write_by_default.py
@@ -182,3 +182,88 @@ def test_verdict_delivered_bare_invocation_succeeds(tmp_path):
         rc = module.main(["--state-db", str(empty)])
     # Assert
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# node_comms_policy — the table where a silent no-op is a PRIVILEGE change
+#
+# This script had no coverage here at all, which is the shape that let a
+# sibling script go days unable to write a single row: its dry run returned
+# before the write path, so the default invocation looked healthy and only
+# ``--commit`` was broken. On THIS table the cost is worse than a lost
+# observation. The script's own docstring spells it out: a missing row makes
+# read_comms_policy return the all-allow defaults, so a capsule authored
+# ``inbound.siblings=deny`` becomes reachable with nothing logged, and the
+# same missing row strips the agent of its named groups.
+# ---------------------------------------------------------------------------
+
+
+def _sqlite_with_one_policy(tmp_path) -> Path:
+    """One policy row, with every column the ALTER-TABLE history produced."""
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """CREATE TABLE node_comms_policy (
+               name TEXT PRIMARY KEY, outbound_siblings TEXT NOT NULL,
+               outbound_parent TEXT NOT NULL, inbound_siblings TEXT NOT NULL,
+               inbound_parent TEXT NOT NULL, lineage_group TEXT NOT NULL,
+               may_spawn INTEGER NOT NULL, group_name TEXT NOT NULL,
+               updated_at REAL NOT NULL, group_names TEXT NOT NULL)"""
+    )
+    conn.execute(
+        "INSERT INTO node_comms_policy VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ("agent-x", "allow", "allow", "deny", "allow", "", 1,
+         "developer", 1756339200.0, "developer"),
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _run_node_comms_policy(tmp_path, capsys, extra: list[str]) -> Run:
+    db = _sqlite_with_one_policy(tmp_path)
+    module = _load("migrate_node_comms_policy_to_postgres.py")
+    argv = ["migrate", "--db-path", str(db), *extra]
+    rc: int | None = None
+    err: BaseException | None = None
+    with _dead_store_and_argv(argv):
+        try:
+            rc = module.main()
+        except BaseException as exc:
+            err = exc
+    return Run(rc=rc, out=capsys.readouterr().out, error=err)
+
+
+def test_node_comms_policy_bare_invocation_succeeds(tmp_path, capsys):
+    """A dry run is a success, not an error."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_node_comms_policy(target, capsys, [])
+    # Assert
+    assert run.rc == 0
+
+
+def test_node_comms_policy_bare_invocation_never_reaches_the_store(tmp_path, capsys):
+    """The dead DSN is the detector: a writer could not have stayed silent."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_node_comms_policy(target, capsys, [])
+    # Assert
+    assert run.error is None
+
+
+def test_node_comms_policy_commit_does_reach_for_the_store(tmp_path, capsys):
+    """NEGATIVE CONTROL — the one that matters.
+
+    Without it the two tests above still pass on a script that can never
+    write anything, which is precisely how the diary migration shipped
+    unable to carry a single row. Reaching an unreachable DSN must raise.
+    """
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_node_comms_policy(target, capsys, ["--commit"])
+    # Assert
+    assert run.error is not None

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
@@ -307,7 +307,7 @@ def test_dry_run_moves_no_card(fleet: Layout, board: Path):
     assert len(_owned(OLD, board)) == 3
 
 
-def test_rename_migrates_every_card(fleet: Layout, board: Path):
+def test_rename_migrates_every_card(pg_schema: str, fleet: Layout, board: Path):
     # Arrange
     _seed(board, 3)
     # Act


### PR DESCRIPTION
An audit of the SQLite→PostgreSQL branches against the defect classes measured during today's migration work confirmed three issues now live on `develop`. Each was independently reproduced before being fixed; the audit's other findings were adversarially refuted and are not included.

## 1. The plugin declares the opposite of the live store

`_store_plugin.py` declared `updated_at` as `MergeRule.MAX` while the live store uses `LAST_WRITER_WINS`. **This one is mine**: I changed the store in #1245 (move node_comms_policy off SQLite) and did not change the declaration, so the two now state opposite things about the single field that PR argued about at length.

It is inert *today* only because the plugin names a different logical store (`sac_node_comms_policy` vs the live `node_comms_policy`) — which is itself the two-declarations hazard: whichever a future replicator picks up, one of them is wrong. The rationale comment is replaced with the argument from `state_db_acl_policy_store`, at the point the value is actually written.

## 2. One rename test never got the fixture its siblings got

`test_rename_migrates_every_card` is missing `pg_schema`, which `test_rename_exits_clean`, `test_rename_moves_the_spec_dir` and `test_rename_tells_the_operator_how_to_start_the_agent` all received on the same pass. `rename_agent` now aborts at `STEP_ACL` with a store-connection error and unwinds, so `STEP_CARDS` never runs and the assertion fails — **on any runner that has a database**. Where there is none the fixture skips, so it reads as a flake rather than a break.

## 3. Nothing exercised the node_comms_policy migration's `--commit` path

That is precisely the shape that let the diary migration ship unable to write a single row: its dry run returned before the write path, so the default invocation looked healthy and only `--commit` was broken.

On **this** table the cost is a privilege change in both directions. The script's own docstring says it: a missing row makes `read_comms_policy` return the all-allow defaults — so a capsule authored `inbound.siblings=deny` becomes reachable with nothing logged — and the same missing row strips the agent of its named groups.

Added the three tests the incarnations script already has, including the **negative control** (`test_node_comms_policy_commit_does_reach_for_the_store`) that fails if the commit path ever stops reaching the store. Without it the other two would still pass on a script that can never write.

## Verification

- `tests/develop/test_migrate_scripts_do_not_write_by_default.py`: **8 passed** (5 existing + 3 new).
- `ruff` clean on all three changed files; `scitex_dev linter validate-files` reports no errors on both touched test files.
- No production behaviour changes: item 1 is a declaration + comment, items 2 and 3 are tests.