### PR TITLE
refactor(state): delete the comms_grants SQLite residue

### DIFF
--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -98,8 +98,16 @@ KNOWN_TABLES = (
     "channel_events",
     "node_tokens",
     "lineage",
-    "comms_grants",
     "comms_nodes",
+    # ``comms_grants`` left on 2026-08-28 under the same ruling as
+    # ``incarnations`` below. Its CRUD had already moved to the shared
+    # PostgreSQL store (:mod:`.state_db_grants`, which resolves through
+    # ``host_store``); only the DDL and this whitelist entry were left,
+    # and the entry is what kept the GENERIC readers -- ``table_counts``
+    # behind ``sac db show``, ``export_state``/``import_state``, and the
+    # ``click.Choice`` for ``sac db query`` -- pointed at a SQLite table
+    # nothing writes. The 52 live rows were carried into PostgreSQL
+    # before this landed.
     # ``incarnations`` was here until 2026-08-19. It now lives in per-host
     # PostgreSQL via :mod:`.state_db_incarnations`, so it is NOT queryable
     # through `sac db query`. Removed rather than left behind: a whitelisted
@@ -213,8 +221,9 @@ def init_schema(db_path: Path | None = None) -> Path:
         # PostgreSQL; each store creates its own schema on first open
         # (``state_db_pending_approval.open_pending_prompt_store`` /
         # ``state_db_blocks.open_blocks_store``), so there is nothing to run
-        # here for either. What is left of the pair in SQLite is
-        # ``comms_grants``, which lives in ``state_db_nodes`` and has not moved.
+        # here for either. ``comms_grants`` was the last of that pair left
+        # in SQLite; it moved to the shared PostgreSQL store and its DDL
+        # was deleted on 2026-08-28, so nothing of the pair remains here.
         # The ``incarnations`` birth-certificate table used to be created
         # here. It moved to per-host PostgreSQL on 2026-08-19; the promise
         # this comment block used to make — "lives in the EXISTING sqlite

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -74,7 +74,6 @@ def _table_filter_clauses(
         # WI-2 ACL tables — ``created_at`` is the row-mint time.
         "node_tokens": ("WHERE created_at >= ?", (since,)),
         "lineage": ("WHERE created_at >= ?", (since,)),
-        "comms_grants": ("WHERE created_at >= ?", (since,)),
         # ADR-0014 — anti-entropy filter advances on ``updated_at`` so
         # a tombstoned row (``ended_at`` set) still ships on the next
         # pull until both sides converge.

--- a/src/scitex_agent_container/_state/state_db_schema.py
+++ b/src/scitex_agent_container/_state/state_db_schema.py
@@ -181,13 +181,13 @@ CREATE INDEX IF NOT EXISTS idx_channel_events_target_id
 -- derived from lineage: parent + parent's direct children. Schema
 -- stays N-level capable — see derive_group() for the traversal.
 --
--- ``comms_grants`` records explicit cross-group send grants. A row
--- ``(sender, target)`` permits ``sender → target`` even when the
--- two are in different groups. With authenticated identity in force,
--- ``sender`` is the resolved-from-bearer name (administrative caller
--- path: the host-wide bearer honours ``metadata.from_agent`` verbatim
--- — used by cross-host forwarders authenticating with the
--- destination's host bearer pulled from ``peer-tokens/`` registry).
+-- ``comms_grants`` was defined here until 2026-08-28. Its readers had
+-- already moved to the shared PostgreSQL store via
+-- :mod:`.state_db_grants`, which resolves through ``host_store`` and
+-- carries no SQLite path at all, so this DDL was creating a table
+-- nothing read or wrote. A CREATE TABLE with no writer leaves an empty
+-- table that answers "no grants" instead of raising, which is the
+-- reading that turns a migration gap into a silent deny.
 CREATE TABLE IF NOT EXISTS node_tokens (
     name        TEXT PRIMARY KEY,
     token       TEXT NOT NULL UNIQUE,
@@ -201,15 +201,6 @@ CREATE TABLE IF NOT EXISTS lineage (
     created_at   REAL NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_lineage_parent ON lineage(parent_name);
-
-CREATE TABLE IF NOT EXISTS comms_grants (
-    sender_name  TEXT NOT NULL,
-    target_name  TEXT NOT NULL,
-    created_at   REAL NOT NULL,
-    note         TEXT,  -- optional audit annotation
-    PRIMARY KEY (sender_name, target_name)
-);
-CREATE INDEX IF NOT EXISTS idx_comms_grants_target ON comms_grants(target_name);
 
 -- ADR-0014 — symmetric federated comms graph.
 --

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -60,29 +60,17 @@ def test_lineage_table_exists(db_path: Path) -> None:
     assert len(rows) == 1
 
 
-def test_comms_grants_table_exists(db_path: Path) -> None:
-    # Arrange
-    conn_ctx = state_db.open_db(db_path)
-    # Act
-    with conn_ctx as conn:
-        rows = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='comms_grants'"
-        ).fetchall()
-    # Assert
-    assert len(rows) == 1
-
-
-@pytest.mark.parametrize("column", ["sender_name", "target_name", "created_at", "note"])
-def test_comms_grants_has_column(db_path: Path, column: str) -> None:
-    # Arrange
-    conn_ctx = state_db.open_db(db_path)
-    # Act
-    with conn_ctx as conn:
-        cols = {
-            r[1] for r in conn.execute("PRAGMA table_info(comms_grants)").fetchall()
-        }
-    # Assert
-    assert column in cols
+# ``test_comms_grants_table_exists`` and ``test_comms_grants_has_column``
+# were here until 2026-08-28. They asked ``sqlite_master`` and
+# ``PRAGMA table_info`` whether the SQLite ``comms_grants`` table and its four
+# columns existed -- and this commit deletes that DDL, because every reader
+# had already moved to the shared PostgreSQL store. A DDL-presence test
+# outlives its table by exactly one commit; keeping them would mean either a
+# permanently red suite or restoring a table nothing reads.
+#
+# Nothing is lost. They asserted the SHAPE of storage, never a behaviour:
+# what a grant MEANS is covered by test_state_db_grants.py against the store
+# the code actually uses.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`comms_grants` was in exactly the state the diary trio was in before #1240 (delete the diary's SQLite residue): every **reader** had already moved, and only the SQLite scaffolding was left. `state_db_grants._open()` resolves through `host_store` to PostgreSQL and carries no SQLite path at all, so this DDL was creating a table nothing read and nothing wrote.

**Deleted:** the `CREATE TABLE` + its index in `state_db_schema.py`, the `KNOWN_TABLES` entry in `state_db.py`, and the export filter in `state_db_export.py`.

## Why the KNOWN_TABLES entry was the load-bearing one

It is what kept the **generic** readers pointed at SQLite long after the CRUD had moved — `table_counts` behind `sac db show`, `export_state`/`import_state`, and the `click.Choice` for `sac db query`. Same ruling as `incarnations` and the diary trio: a whitelisted name with no writer returns an **empty result**, and for this table empty reads as "this agent has no grants" when the truth is "you are asking the wrong database". An unknown-table error is honest; a silent empty answer on an authorisation table is a deny nobody logged.

Also corrects a comment in `state_db.py` that had gone false — it said `comms_grants` "lives in `state_db_nodes` and has not moved". It had moved.

## The data is already across

52 live rows were carried into the shared store **before** this landed — 34 from compute-04, 17 from compute-03, 1 from compute-01, deduped to 48 distinct `(sender, target)` pairs — and verified through the production predicate: `has_grant()` returns `True` for `figrecipe`/`scitex-ui`/`cards-04`/`business` → `lead`, and `False` for a name that was never granted.

That check is what found the gap in the first place. The code had been merged reading PostgreSQL while PostgreSQL held **zero**, so every grant-dependent cross-group send was being denied with nothing reporting it. This PR removes the dead scaffolding that made that state possible.

## Mixed-version note

Dropping it from `KNOWN_TABLES` means `import_state` stops carrying `comms_grants` from a peer still on old code (it does `tables.get(table, [])` and drops unknown tables silently). Acceptable **here specifically** because the grants already live in the one shared store and the stragglers were carried by hand. Not a precedent for a table whose data still travels by ssh+JSON.

## Verification

- `test_sqlite_footprint_frozen`: **6 passed**. Neither frozen set changes — `state_db_grants` carries no `sqlite3` import, and `state_db_schema` still defines other tables.
- export + grants suites: **18 passed, 13 skipped** (the skips need a writable store; CI has one).
- `ruff` clean on all three changed files.