### PR TITLE
fix(cli): give the sac process the SCITEX_STORE_DSN it hands to containers

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -432,6 +432,16 @@ def cli_entry_point() -> None:
 
     warn_once()
 
+    # The fleet defaults this process hands to every container, applied to
+    # ITSELF — sac opens the same Postgres stores its agents do, and until
+    # 2026-08-28 it was the one process in the fleet launching without
+    # ``SCITEX_STORE_DSN``. A variable exported in the operator's shell still
+    # wins; see ``apply_fleet_defaults_to_process`` for the failure this
+    # closes.
+    from ..runtimes._fleet_env import apply_fleet_defaults_to_process
+
+    apply_fleet_defaults_to_process()
+
     # Cheap pre-scan: don't import the heavy ``host_group`` module
     # unless ``--on`` is actually present on the command line. Importing
     # ``host_group`` (state.host_config + subprocess + the full click

--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -51,7 +51,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 
 logger = logging.getLogger(__name__)
 
@@ -378,9 +378,58 @@ def fleet_env_flags(
     ]
 
 
+def apply_fleet_defaults_to_process(
+    environ: "MutableMapping[str, str] | None" = None,
+    *,
+    config_path: Path | None = None,
+) -> dict[str, str]:
+    """Give sac's OWN process the fleet defaults its containers get.
+
+    Everything above renders the defaults into an agent's ``apptainer --env``
+    flags and stops there. But the host-side ``sac`` process opens the SAME
+    stores the containers do — ``persist_acl_policy`` on every start,
+    instances, dispatches, the diary — and it received none of them. On a
+    shell with no ``SCITEX_STORE_DSN``, ``scitex_dev.store.host_store()`` fell
+    through to its UNIX-socket fallback, ``pg_hba`` asked the socket for a
+    password, and ``.pgpass`` — keyed by ``127.0.0.1`` / ``localhost`` /
+    ``scitex-primary``, never by a socket directory — had nothing to offer:
+
+        Cannot connect to Postgres store 'node_comms_policy' ...
+        socket "~/.scitex/pg/run/.s.PGSQL.55432" failed:
+        fe_sendauth: no password supplied
+
+    MEASURED on compute-04, 2026-08-28, on ``sac agents restart``. A
+    ``.pgpass`` row for the socket directory is the WRONG fix: that socket is
+    the local cluster, which is now a streaming STANDBY
+    (``pg_is_in_recovery() = t``), so the row would only trade a loud connect
+    refusal for a quiet read-only write failure. The right store is the one
+    :data:`FLEET_DEFAULT_ENV` already names — the gap was that only the
+    containers were told.
+
+    Same precedence as everything else in this module: a key already present
+    in ``environ`` wins, untouched — a default exists in order to be
+    overridden, and an operator who exported ``SCITEX_STORE_DSN`` in their
+    shell has overridden it. ``environ`` defaults to ``os.environ`` and is an
+    injection seam for tests. Returns the keys it actually set.
+    """
+    import os
+
+    target = os.environ if environ is None else environ
+    injected: dict[str, str] = {}
+    for key, val in declared_fleet_defaults(config_path).items():
+        if key in target:
+            continue
+        target[key] = val
+        injected[key] = val
+    if injected:
+        logger.debug("fleet_env: process env gained %s", sorted(injected))
+    return injected
+
+
 __all__ = [
     "CONFIG_SECTION",
     "FLEET_DEFAULT_ENV",
+    "apply_fleet_defaults_to_process",
     "declared_fleet_defaults",
     "effective_env",
     "fleet_env_flags",

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -23,6 +23,7 @@ import pytest
 from scitex_agent_container.runtimes._fleet_env import (
     CONFIG_SECTION,
     FLEET_DEFAULT_ENV,
+    apply_fleet_defaults_to_process,
     declared_fleet_defaults,
     effective_env,
     fleet_env_flags,
@@ -164,6 +165,148 @@ def test_without_the_injection_the_resolver_goes_somewhere_else() -> None:
     without_injection = _resolved_store_locator(None)
     # Assert
     assert without_injection != with_injection
+
+
+# ----------------------------------------------------------------------
+# The defaults reach sac's OWN process, not only its containers.
+#
+# The gap behind ``fe_sendauth: no password supplied`` on 2026-08-28:
+# ``sac agents restart`` on compute-04 opened ``node_comms_policy`` with NO
+# ``SCITEX_STORE_DSN`` in its own environment — the defaults were only ever
+# rendered into ``apptainer --env`` flags — so scitex-dev's resolver fell
+# through to the local UNIX socket, a streaming standby whose password no
+# ``.pgpass`` row could supply. A real mapping stands in for ``os.environ``
+# below (the seam exists so these tests do not touch the process they run
+# in); the last two go through the real ``os.environ`` with save/restore,
+# the repo idiom (see ``_resolved_store_locator``).
+# ----------------------------------------------------------------------
+
+
+def _bare_process_env(tmp_path: Path) -> dict[str, str]:
+    """A process env that says nothing about the store, defaults applied."""
+    environ: dict[str, str] = {"PATH": "/usr/bin"}
+    apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    return environ
+
+
+def test_the_sac_process_receives_the_store_dsn_it_hands_to_containers(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    environ: dict[str, str] = {"PATH": "/usr/bin"}
+    # Act
+    apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    # Assert
+    assert environ["SCITEX_STORE_DSN"] == FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"]
+
+
+def test_applying_defaults_reports_exactly_the_keys_it_injected(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    environ: dict[str, str] = {"PATH": "/usr/bin"}
+    # Act
+    injected = apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    # Assert
+    assert injected == FLEET_DEFAULT_ENV
+
+
+def test_applying_defaults_leaves_unrelated_process_keys_alone(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    # Act
+    environ = _bare_process_env(tmp_path)
+    # Assert
+    assert environ["PATH"] == "/usr/bin"
+
+
+def test_an_operator_exported_store_dsn_beats_the_fleet_default(
+    tmp_path: Path,
+) -> None:
+    """Same rule as ``spec.env`` over the fleet layer — a default exists in
+    order to be overridden. A host whose Postgres lives elsewhere exports its
+    own DSN, and sac must not silently redirect that host's writes to
+    ``scitex-primary``.
+    """
+    # Arrange
+    environ = {"SCITEX_STORE_DSN": "postgresql://elsewhere:5432/mine"}
+    # Act
+    apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    # Assert
+    assert environ["SCITEX_STORE_DSN"] == "postgresql://elsewhere:5432/mine"
+
+
+def test_the_config_yaml_layer_reaches_the_process_beside_a_kept_override(
+    tmp_path: Path,
+) -> None:
+    """Precedence proven against the FULL declared set, not just sac's
+    constant: the operator's config.yaml key is added, the exported DSN is
+    kept, and the return value names only what was actually injected.
+    """
+    # Arrange
+    cfg = _write_config_yaml(tmp_path / "config.yaml", {"OPERATOR_KEY": "from-yaml"})
+    environ = {"SCITEX_STORE_DSN": "postgresql://elsewhere:5432/mine"}
+    # Act
+    injected = apply_fleet_defaults_to_process(environ, config_path=cfg)
+    # Assert
+    assert injected == {"OPERATOR_KEY": "from-yaml"}
+
+
+def _with_store_dsn_unset(fn):
+    """Run ``fn`` with ``SCITEX_STORE_DSN`` absent from the REAL os.environ."""
+    import os
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    try:
+        os.environ.pop(key, None)
+        return fn(key)
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+def test_the_default_form_writes_to_the_live_process_environment() -> None:
+    """No ``environ`` argument — the way ``cli_entry_point`` calls it."""
+    import os
+
+    # Arrange
+    absent = Path("/nonexistent/config.yaml")
+
+    def act(key: str) -> str:
+        apply_fleet_defaults_to_process(config_path=absent)
+        return os.environ[key]
+
+    # Act
+    seen = _with_store_dsn_unset(act)
+    # Assert
+    assert seen == FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"]
+
+
+def test_a_second_application_finds_the_key_present_and_injects_nothing() -> None:
+    # Arrange
+    absent = Path("/nonexistent/config.yaml")
+
+    def act(_key: str) -> dict[str, str]:
+        apply_fleet_defaults_to_process(config_path=absent)
+        return apply_fleet_defaults_to_process(config_path=absent)
+
+    # Act
+    second = _with_store_dsn_unset(act)
+    # Assert
+    assert second == {}
+
 
 
 def test_declared_defaults_do_not_mutate_the_module_constant(tmp_path: Path) -> None:


### PR DESCRIPTION
## Symptom

`sac agents restart <name>` on scitex-compute-04 (2026-08-28):

```
Error: Cannot connect to Postgres store 'node_comms_policy' at postgres: connection
failed: connection to server on socket "/home/ywatanabe/.scitex/pg/run/.s.PGSQL.55432"
failed: fe_sendauth: no password supplied.
```

## Root cause (measured, not inferred)

`_start.py` → `persist_acl_policy` → `open_policy_store` → `scitex_dev.store.host_store()`, which resolves `SCITEX_STORE_DSN` if set, else the local UNIX-socket DSN.

- The fleet default `SCITEX_STORE_DSN=postgresql://scitex-primary:55432/scitex` (`_fleet_env.FLEET_DEFAULT_ENV`) was only ever rendered into `apptainer --env` flags. **The host-side `sac` process itself never received it**, so the resolver took the socket fallback.
- `pg_hba.conf`: `local all all scram-sha-256` → the socket demands a password.
- `~/.pgpass` is keyed by `127.0.0.1` / `localhost` / `scitex-primary`. libpq matches on the literal host string, which for a non-default socket dir is the directory path → no row → `fe_sendauth: no password supplied`.

Reproduced with psql: socket DSN fails identically; `localhost:55432` as the same role connects.

## Why not a `.pgpass` row for the socket dir

The local `:55432` cluster is a streaming **standby** (`pg_is_in_recovery() = t`; `scitex-primary` reports `f`). A pgpass row would only trade a loud connect refusal for silent read-only write failures — the exact "connects fine, cannot write" failure `_fleet_env.py` already documents.

## Fix

`apply_fleet_defaults_to_process()` in `_fleet_env.py` applies `declared_fleet_defaults()` (sac's constant + the operator's `config.yaml` `spec.fleet_default_env`) to `os.environ` at `cli_entry_point`, **only for keys not already present**. A DSN exported in the operator's shell still wins — the same spec.env-over-fleet precedence the module already has. One source of truth; container behaviour unchanged.

## Verification

- Two-arm live check from the worktree source with `SCITEX_STORE_DSN` unset:
  - without the call: locator `postgres[host=/home/ywatanabe/.scitex/pg/run …]`, `open_policy_store()` raises the reported `StoreTargetError`
  - with the call: locator `postgres[host=scitex-primary db=scitex port=55432]`, `open_policy_store()` connects
- `sac agents restart -y scitex-agent-container` with the DSN present: exit 0, new run verified.
- `tests/…/runtimes/test__fleet_env.py` + `test__pg_identity_env.py`: 58 passed (worktree source on PYTHONPATH). Seven new single-assert tests cover both arms, the config.yaml layer, and idempotence against the real `os.environ`.
- Linter: zero errors on the three files; remaining warnings are pre-existing lines.

## Operator workaround until merged

```bash
SCITEX_STORE_DSN=postgresql://scitex-primary:55432/scitex sac agents restart -y <name>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
