### PR TITLE
refactor(state): remove the dead attempts table (zero writers)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_rename_db.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_db.py
@@ -10,12 +10,18 @@ the A2A directory still advertises the dead name, and the ACL gate has no
 policy row for the live one.
 
 So: rename EVERY row in state.db that keys on the name, including the
-history (``attempts``, ``channel_events``). A renamed agent is the SAME
-agent — its past must still be findable under the new name. This is the
-``git mv`` position: the name changed, history follows.
+history (``channel_events``). A renamed agent is the SAME agent — its
+past must still be findable under the new name. This is the ``git mv``
+position: the name changed, history follows.
 
 WHAT THIS NO LONGER COVERS, STATED RATHER THAN LEFT AS A DEAD ENTRY
 ===================================================================
+``attempts`` was in :data:`NAME_COLUMNS` until 2026-08-28. It is no
+longer a SQLite table at all — it had zero writers, so its DDL was
+deleted rather than migrated — and the loops below skip a table that does
+not exist, so the entry could only ever match zero rows. Same ruling as
+the trio below: removed, not left as reassuring decoration.
+
 ``turns`` / ``errors`` / ``heartbeats`` were in :data:`NAME_COLUMNS`
 until 2026-08-28. They are no longer SQLite tables — the diary moved to
 per-host PostgreSQL (:mod:`.._state.state_db_diary`) — and the loops
@@ -54,7 +60,9 @@ NAME_COLUMNS: tuple[tuple[str, str], ...] = (
     ("definitions", "name"),
     ("instances", "name"),
     ("instances", "spawned_by"),
-    ("attempts", "agent"),
+    # ("attempts", "agent") was here until 2026-08-28 — the table itself is
+    # gone (zero writers), so the pair named something this code cannot
+    # reach. Same ruling as the trio below; see the module docstring.
     # ("turns", "name") / ("errors", "name") / ("heartbeats", "name") were
     # here until 2026-08-28 — see the module docstring for why removing them
     # is the honest edit and why a store call cannot replace them.

--- a/src/scitex_agent_container/_mcp/_tools/_db.py
+++ b/src/scitex_agent_container/_mcp/_tools/_db.py
@@ -9,7 +9,10 @@ from ._helpers import invoke_cli_json, invoke_cli_text
 
 def db_show() -> dict[str, Any]:
     """Print high-level state-db row counts (definitions, instances,
-    heartbeats, events, attempts). Mirrors ``sac db show --json``."""
+    heartbeats, events, channel_events). Mirrors ``sac db show --json``.
+
+    ``attempts`` was listed here until 2026-08-28, when it left
+    :data:`KNOWN_TABLES`; the counts follow that tuple."""
     return invoke_cli_json(["db", "show", "--json"])
 
 

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -8,9 +8,11 @@ holding tables in two groups:
   * F-CS11 phase 2 — ``instance_heartbeats`` (the legacy
     ``heartbeats`` time series, tied to an ``instances.id``).
 
-The single-file layout makes backup/sync trivial (one ``cp``) and
-keeps the existing ``actions.db`` table (``attempts``) co-located so
-queries can join across action history and instance lifecycle.
+The single-file layout makes backup/sync trivial (one ``cp``). It also
+kept the legacy ``actions.db`` table (``attempts``) co-located so queries
+could join action history against instance lifecycle; that table left on
+2026-08-28 — it never had a writer, so the join it promised had nothing
+on one side. See :mod:`state_db_schema` for the departure note.
 
 THE DIARY GROUP IS GONE FROM SQLite (2026-08-28)
 ================================================
@@ -69,7 +71,6 @@ from .state_db_migrations import (
     migrate_legacy_heartbeats,
 )
 from .state_db_schema import (
-    _SCHEMA_ATTEMPTS,
     _SCHEMA_CHANNEL_AND_ACL,
     _SCHEMA_REGISTRY,
 )
@@ -94,11 +95,16 @@ KNOWN_TABLES = (
     "instances",
     "instance_heartbeats",
     "events",
-    "attempts",
     "channel_events",
     "node_tokens",
     "lineage",
     "comms_nodes",
+    # ``attempts`` left on 2026-08-28 under the same ruling, for the
+    # simplest possible version of the reason: it never had a writer. Its
+    # DDL is gone from :mod:`.state_db_schema`, so keeping the name here
+    # would point every generic reader -- ``table_counts`` behind ``sac db
+    # show``, ``export_state``/``import_state``, and the ``click.Choice``
+    # for ``sac db query`` -- at a table that no longer exists.
     # ``comms_grants`` left on 2026-08-28 under the same ruling as
     # ``incarnations`` below. Its CRUD had already moved to the shared
     # PostgreSQL store (:mod:`.state_db_grants`, which resolves through
@@ -209,7 +215,10 @@ def init_schema(db_path: Path | None = None) -> Path:
         # until 2026-08-28. The table moved to PostgreSQL, so both would
         # now be permanent no-ops against a table SQLite no longer has —
         # dead code claiming a live purpose. Removed with the DDL.
-        conn.executescript(_SCHEMA_ATTEMPTS)
+        # ``_SCHEMA_ATTEMPTS`` ran here until 2026-08-28. The ``attempts``
+        # table had zero writers, so issuing its DDL only produced an empty
+        # table that answered readers with a plausible zero. Existing rows
+        # are untouched — we stop issuing the CREATE, we do not DROP.
         conn.executescript(_SCHEMA_CHANNEL_AND_ACL)
         # ``turns`` / ``errors`` / ``heartbeats`` were created by the
         # constant above (then called ``_SCHEMA_DIARY``) until 2026-08-28.

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -63,7 +63,11 @@ def _table_filter_clauses(
         ),
         "instance_heartbeats": ("WHERE ts >= ?", (since,)),
         "events": ("WHERE ts >= ?", (since,)),
-        "attempts": ("WHERE ts >= ?", (since,)),
+        # ``attempts`` had a ``WHERE ts >= ?`` entry here until 2026-08-28.
+        # It left KNOWN_TABLES that day -- zero writers, DDL deleted -- so
+        # this mapping could never be selected again, and a WHERE clause
+        # naming a table SQLite no longer has reads as "sac still exports
+        # this".
         # ``turns``, ``errors`` and the diary-style ``heartbeats`` each had a
         # ``WHERE ts >= ?`` entry here until 2026-08-28. All three moved to
         # per-host PostgreSQL and left KNOWN_TABLES together, so — exactly as
@@ -103,7 +107,11 @@ def export_state(
     host: str | None = None,
     tables: list[str] | tuple[str, ...] | None = None,
 ) -> dict:
-    """Dump the registry tables (and ``attempts``) into a JSON-able dict.
+    """Dump the registry tables into a JSON-able dict.
+
+    ``attempts`` was named here alongside them until 2026-08-28, when it
+    left :data:`KNOWN_TABLES`; this dump follows that tuple, so it no
+    longer ships an empty ``attempts`` array.
 
     Used by ``sac db export``; an aggregator consumes the result via
     ``sac db import`` (or its own importer).

--- a/src/scitex_agent_container/_state/state_db_schema.py
+++ b/src/scitex_agent_container/_state/state_db_schema.py
@@ -6,13 +6,16 @@ run via ``conn.executescript`` in ``state_db.init_schema``; keeping them
 in a focused sibling mirrors the existing ``state_db_*`` split
 convention (state_db_export / state_db_gc / state_db_instances / ...).
 
-``state_db`` re-imports all three names, so every existing
+``state_db`` re-imports both names, so every existing
 ``from ...state_db import _SCHEMA_*`` / ``executescript(_SCHEMA_*)`` call
 site is unchanged.
 
 WHAT IS NO LONGER HERE: the diary trio (``turns`` / ``errors`` /
 ``heartbeats``). They moved to per-host PostgreSQL on 2026-08-28 and
 :mod:`.state_db_diary` owns them end to end — writers, reader, schema.
+Also gone, same day: ``attempts`` and its ``_SCHEMA_ATTEMPTS`` constant —
+see the departure note below the registry block. That one did not move
+anywhere; it simply never had a writer.
 """
 
 from __future__ import annotations
@@ -101,23 +104,25 @@ CREATE INDEX IF NOT EXISTS idx_events_instance
     ON events(instance_id, ts);
 """
 
-# Attempts predates state.db (lived in actions.db). Bundled here so
-# state.db is self-contained on a fresh host.
-_SCHEMA_ATTEMPTS = """
-CREATE TABLE IF NOT EXISTS attempts (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    ts           TEXT    NOT NULL,
-    agent        TEXT    NOT NULL,
-    action       TEXT    NOT NULL,
-    outcome      TEXT    NOT NULL,
-    elapsed_s    REAL    NOT NULL,
-    pane_before  TEXT,
-    pane_after   TEXT,
-    extras       TEXT
-);
-CREATE INDEX IF NOT EXISTS idx_attempts_ts ON attempts(ts);
-CREATE INDEX IF NOT EXISTS idx_attempts_agent_action ON attempts(agent, action);
-"""
+# ``attempts`` (and its two indexes) was defined here as
+# ``_SCHEMA_ATTEMPTS`` until 2026-08-28. It predated state.db — it lived in
+# ``actions.db`` and was bundled in so state.db was self-contained on a
+# fresh host — and by the time it landed here nothing wrote it: ZERO
+# INSERTs anywhere in ``src/``, only tests. Unlike the tables that left
+# before it, it did not move to PostgreSQL; there was no history to carry,
+# because none was ever recorded.
+#
+# REMOVED rather than left behind, under the same ruling as ``comms_grants``
+# and ``node_comms_policy`` below: a CREATE TABLE with no writer is WORSE
+# than no table. The empty table answers every reader with a plausible-
+# looking zero — ``sac db show`` prints ``attempts 0``, ``sac db query
+# --table=attempts`` prints nothing, ``sac db export`` ships an empty array
+# — and a zero meaning "nobody ever wrote this" is indistinguishable from a
+# zero meaning "this agent did nothing". No table at all raises, which is
+# the honest answer.
+#
+# Deleting this DDL drops NO existing rows: ``CREATE TABLE IF NOT EXISTS``
+# simply stops being issued, so an old state.db keeps whatever it holds.
 
 # Channel-event durability (WI-1) + the WI-2 / ADR-0014 ACL tables.
 #

--- a/src/scitex_agent_container/_store_plugin.py
+++ b/src/scitex_agent_container/_store_plugin.py
@@ -422,9 +422,10 @@ NEVER_SYNCED: dict[str, str] = {
         "thousands of times the cost"
     ),
     "attempts": (
-        "declared in KNOWN_TABLES and exported by sac today, but it has "
-        "ZERO writers anywhere in src/ — replicating a table nothing "
-        "writes moves no information"
+        "a legacy actions.db carry-over with ZERO writers anywhere in src/ "
+        "— replicating a table nothing writes moves no information. Since "
+        "2026-08-28 it is not a SQLite table either: it left KNOWN_TABLES "
+        "and its DDL was deleted, which does not change the ruling"
     ),
     "definitions": (
         "same: in KNOWN_TABLES, FK'd from instances.definition_id, and "
@@ -459,8 +460,9 @@ NEVER_SYNCED: dict[str, str] = {
         "the fleet-relevant content is the latest sample, carried as "
         "sac_instances.last_heartbeat_at"
     ),
-    # The three entries above no longer appear in KNOWN_TABLES — the diary
-    # left SQLite on 2026-08-28. They STAY here for the reason
+    # The three entries above — and ``attempts`` — no longer appear in
+    # KNOWN_TABLES: the diary left SQLite on 2026-08-28 and ``attempts``
+    # left the same day. They STAY here for the reason
     # acl_deny_notify_log stays: the completeness gate only checks that every
     # KNOWN_TABLES name is decided, so a table leaving that tuple must not be
     # read as the refusal being withdrawn. A store that moved backend still

--- a/src/scitex_agent_container/cli_pkg/db_group.py
+++ b/src/scitex_agent_container/cli_pkg/db_group.py
@@ -149,7 +149,9 @@ def db_query(
         "definitions": "first_seen_at DESC",
         "instance_heartbeats": "ts DESC",
         "events": "ts DESC",
-        "attempts": "ts DESC",
+        # ``attempts`` had a ``ts DESC`` entry here until 2026-08-28. It
+        # left KNOWN_TABLES, so ``--table`` can no longer name it and this
+        # key could only ever be dead.
     }.get(table)
     if order_by:
         sql += f" ORDER BY {order_by}"

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -296,21 +296,28 @@ COMMS_NODE_SQL = (
     "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, updated_at) "
     "VALUES (?, ?, ?, ?, ?)"
 )
-ATTEMPT_SQL = "INSERT INTO attempts (ts, agent, action, outcome, elapsed_s) VALUES (?, ?, ?, ?, ?)"
+CHANNEL_EVENT_SQL = (
+    "INSERT INTO channel_events (target, source, kind, content, meta_json, ts) "
+    "VALUES (?, ?, ?, ?, ?, ?)"
+)
 
 
 def seed_identity_and_history(layout: Layout, name: str) -> Path:
-    """One identity row (comms_nodes) + one history row (attempts) for ``name``.
+    """Identity row (comms_nodes) + history row (channel_events) for ``name``.
 
-    Both halves a rename must carry. ``attempts`` replaced ``turns`` here on
-    2026-08-28, when the diary trio left SQLite for per-host PostgreSQL.
+    Both halves a rename must carry. The history half has moved twice: it was
+    ``turns`` until 2026-08-28, when the diary trio left SQLite for per-host
+    PostgreSQL; then ``attempts`` for the rest of that day, until ``attempts``
+    itself was deleted for having zero writers. ``channel_events.target`` is
+    the history column still in ``_rename_db.NAME_COLUMNS`` AND still a real
+    SQLite table — the two properties this fixture needs.
     """
     db_path = make_state_db(layout)
     return seed_db_rows(
         db_path,
         [
             (COMMS_NODE_SQL, (name, "h", 9001, 1.0, 1.0)),
-            (ATTEMPT_SQL, ("t1", name, "run", "ok", 0.5)),
+            (CHANNEL_EVENT_SQL, (name, None, "message", "hi", "{}", 1.0)),
         ],
     )
 

--- a/tests/scitex_agent_container/_lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename.py
@@ -95,7 +95,7 @@ def _db_names(db_path: Path) -> list[str]:
     conn = sqlite3.connect(str(db_path))
     try:
         nodes = conn.execute("SELECT name FROM comms_nodes").fetchall()
-        past = conn.execute("SELECT agent FROM attempts").fetchall()
+        past = conn.execute("SELECT target FROM channel_events").fetchall()
     finally:
         conn.close()
     return sorted([r[0] for r in nodes] + [t[0] for t in past])

--- a/tests/scitex_agent_container/_lifecycle/test__rename_db.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_db.py
@@ -49,15 +49,16 @@ _SEED = [
         "VALUES (?, ?, ?)",
         ("child-a", OLD, 1.0),
     ),
-    # The history half. This was an ``INSERT INTO turns`` until 2026-08-28,
-    # when the diary trio left SQLite for per-host PostgreSQL and stopped
-    # being a table this rename can reach. ``attempts.agent`` is the history
-    # column still in ``_rename_db.NAME_COLUMNS``, so it is what the
-    # history-follows-the-agent tests below now exercise.
+    # The history half. It was ``INSERT INTO turns`` until 2026-08-28, when
+    # the diary trio left SQLite for per-host PostgreSQL; then ``INSERT INTO
+    # attempts`` for the rest of that day, until ``attempts`` was deleted for
+    # having zero writers. ``channel_events.target`` is the history column
+    # still in ``_rename_db.NAME_COLUMNS`` AND still a real SQLite table, so
+    # it is what the history-follows-the-agent tests below now exercise.
     (
-        "INSERT INTO attempts (ts, agent, action, outcome, elapsed_s) "
-        "VALUES (?, ?, ?, ?, ?)",
-        ("t1", OLD, "run", "ok", 0.5),
+        "INSERT INTO channel_events (target, source, kind, content, "
+        "meta_json, ts) VALUES (?, ?, ?, ?, ?, ?)",
+        (OLD, None, "message", "hi", "{}", 1.0),
     ),
 ]
 
@@ -100,7 +101,7 @@ def test_count_rows_counts_the_identity_row(seeded: Path):
 def test_count_rows_counts_the_history_row(seeded: Path):
     """History follows the agent: a renamed agent is the SAME agent."""
     # Arrange
-    key = "attempts.agent"
+    key = "channel_events.target"
     # Act
     counts = count_rows(seeded, OLD)
     # Assert
@@ -168,7 +169,7 @@ def test_rename_moves_the_lineage_parent_edge(seeded: Path):
 
 def test_rename_moves_the_history_rows(seeded: Path):
     # Arrange
-    sql = "SELECT COUNT(*) FROM attempts WHERE agent = ?"
+    sql = "SELECT COUNT(*) FROM channel_events WHERE target = ?"
     # Act
     rename_rows(seeded, OLD, NEW)
     # Assert
@@ -247,13 +248,13 @@ def test_undo_does_not_clobber_a_row_that_already_held_the_new_name(seeded: Path
     conn = sqlite3.connect(str(seeded))
     with conn:
         conn.execute(
-            "INSERT INTO attempts (ts, agent, action, outcome, elapsed_s) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ("t-stranger", NEW, "stranger", "ok", 0.5),
+            "INSERT INTO channel_events (target, source, kind, content, "
+            "meta_json, ts) VALUES (?, ?, ?, ?, ?, ?)",
+            (NEW, None, "stranger", "hi", "{}", 2.0),
         )
     conn.close()
     undo = rename_rows(seeded, OLD, NEW)
-    sql = "SELECT agent FROM attempts WHERE action = 'stranger'"
+    sql = "SELECT target FROM channel_events WHERE kind = 'stranger'"
     # Act
     undo_rename_rows(undo)
     # Assert

--- a/tests/scitex_agent_container/cli_pkg/test__registry_sync.py
+++ b/tests/scitex_agent_container/cli_pkg/test__registry_sync.py
@@ -73,11 +73,11 @@ def _peer_export_payload(*, host: str, name: str, port: int) -> str:
                 # ``heartbeats`` were here until 2026-08-28; the diary left
                 # SQLite and KNOWN_TABLES together, so a peer that still
                 # ships those keys is describing a dump sac no longer makes.
+                # ``attempts`` left the same day for having zero writers.
                 "definitions": [],
                 "instances": [],
                 "instance_heartbeats": [],
                 "events": [],
-                "attempts": [],
                 "channel_events": [],
                 "node_tokens": [],
                 "lineage": [],
@@ -306,7 +306,6 @@ def test_registry_sync_all_invokes_ssh_for_every_static_peer(
                         "instances",
                         "instance_heartbeats",
                         "events",
-                        "attempts",
                         "turns",
                         "errors",
                         "heartbeats",
@@ -351,7 +350,6 @@ def test_registry_sync_all_per_peer_error_continues(
                     "instances",
                     "instance_heartbeats",
                     "events",
-                    "attempts",
                     "turns",
                     "errors",
                     "heartbeats",


### PR DESCRIPTION
## What

Deletes the SQLite table `attempts` from sac. One table, every site that named it.

`attempts` predated `state.db` — it lived in `actions.db` and was bundled into the
single-file layout so a fresh host was self-contained. By the time it landed here,
nothing wrote it: **ZERO INSERTs anywhere in `src/`**, only tests.
`_store_plugin.NEVER_SYNCED` has said exactly that in prose since it was written
("declared in KNOWN_TABLES and exported by sac today, but it has ZERO writers
anywhere in src/").

I re-measured before deleting: `rg` over `src/` finds no `INSERT INTO attempts`, no
`FROM attempts`, no `UPDATE attempts`. The only mentions were the DDL, the
`KNOWN_TABLES` whitelist, the export `--since` filter, a `db query` order-by key, a
`NAME_COLUMNS` rename pair, and the NEVER_SYNCED reason. All six are covered below.

## Why — a CREATE TABLE with no writer is worse than no table

The empty table answers every reader with a **plausible-looking zero**:

- `sac db show` printed `attempts 0`
- `sac db query --table=attempts` printed nothing
- `sac db export` shipped an empty `attempts` array

A zero meaning *"nobody ever wrote this"* is indistinguishable from a zero meaning
*"this agent did nothing"*. An unknown-table error is the honest answer. This is the
same ruling that retired `incarnations` (2026-08-19) and `comms_grants` /
`node_comms_policy` (2026-08-28), and each departure site here carries a comment in
that established house style.

## NO DATA MIGRATION AND NO DATA-LOSS RISK

Nothing is `DROP`ped. `CREATE TABLE IF NOT EXISTS attempts (...)` simply **stops being
issued**. An existing `state.db` on any host keeps every row it already holds — the
table and its contents are untouched; only a *freshly initialised* DB lacks it. There
is no migration step, no backfill, and nothing to run before or after merging.

## Removed

| Site | What went |
| --- | --- |
| `_state/state_db_schema.py` | `_SCHEMA_ATTEMPTS` + `idx_attempts_ts` + `idx_attempts_agent_action` |
| `_state/state_db.py` | the `_SCHEMA_ATTEMPTS` import, its `executescript` call in `init_schema`, and the `KNOWN_TABLES` entry |
| `_state/state_db_export.py` | the `"attempts": ("WHERE ts >= ?", (since,))` filter, and the `export_state` docstring that promised it dumps "the registry tables (and ``attempts``)" |
| `cli_pkg/db_group.py` | the `"attempts": "ts DESC"` order_by key |
| `_lifecycle/_rename_db.py` | the `("attempts", "agent")` pair in `NAME_COLUMNS` |
| `_mcp/_tools/_db.py` | `attempts` in the `db_show` docstring's list of counted tables |

`KNOWN_TABLES` is the tuple every *generic* reader follows — `table_counts` behind
`sac db show`, `export_state` / `import_state`, and the `click.Choice` for
`sac db query --table` — so removing the name there is what makes all four stop
pointing at a table that no longer exists.

## Kept (deliberately): the NEVER_SYNCED refusal

`_store_plugin.py` states its own house rule: *a table leaving `KNOWN_TABLES` must NOT
read as the refusal being withdrawn.* So `NEVER_SYNCED["attempts"]` stays. Its reason
text is **updated**, because it claimed the table is "declared in KNOWN_TABLES and
exported by sac today" — false as of this commit. The zero-writers reasoning is
preserved verbatim in substance. (`test__store_plugin.py` enforces both a completeness
gate and a ≥12-word reason; the new text satisfies both.)

## Tests — what was re-pointed, what was deleted

**Nothing was deleted.** `attempts` was serving as the *"history half"* of the rename
fixtures — a role it had inherited from `turns` earlier the same day, when the diary
trio left SQLite. That property (a renamed agent is the SAME agent; its history follows)
is real and still holds, so every test asserting it was re-pointed at
**`channel_events.target`** — the history column that is still in
`_rename_db.NAME_COLUMNS` *and* still a real SQLite table.

- `tests/.../_helpers/fleet_root.py` — `ATTEMPT_SQL` → `CHANNEL_EVENT_SQL`;
  `seed_identity_and_history` now seeds `comms_nodes` + `channel_events`.
- `tests/.../_lifecycle/test__rename_db.py` — the `_SEED` history row plus the three
  tests that read it, all **re-pointed, none removed**:
  `test_count_rows_counts_the_history_row`, `test_rename_moves_the_history_rows`, and
  `test_undo_does_not_clobber_a_row_that_already_held_the_new_name` (the rowid-scoped
  undo trap — the sharpest test in the file; its "stranger" row is now a
  `channel_events` row with `kind='stranger'`).
- `tests/.../_lifecycle/test__rename.py` — `_db_names` reads
  `SELECT target FROM channel_events` instead of `SELECT agent FROM attempts`.
- `tests/.../cli_pkg/test__registry_sync.py` — dropped the now-extra `attempts` key
  from the three synthetic peer-export payloads. (`import_state` uses
  `tables.get(table, [])`, so these were harmless extras either way; leaving the key
  would have implied `attempts` is still a known table.)

## Verification

**pytest** — `_state` + `_lifecycle` (the directories that own every changed source
module), run against THIS worktree's `src` via `PYTHONPATH`:

```
3272 passed, 407 skipped, 9 warnings in 85.92s
```

Plus the other three touched test files:

```
tests/scitex_agent_container/test__store_plugin.py
tests/scitex_agent_container/cli_pkg/test__registry_sync.py
tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
53 passed, 8 skipped in 2.62s
```

**Fresh DB, built by sac's own `init_schema` (no hand-written DDL), read back through
`sqlite_master`:**

```
package loaded from: .../.worktrees/agent-ac383068612798db8/src/scitex_agent_container
init_schema created: /uvwork/tmp/tmpx64jz26u/state.db

--- sqlite_master of the fresh DB ---
  index  idx_channel_events_target_id
  index  idx_channel_events_target_undelivered
  index  idx_comms_nodes_host
  index  idx_events_instance
  index  idx_instances_active
  index  idx_instances_host
  index  idx_lineage_parent
  index  idx_node_tokens_token
  index  sqlite_autoindex_comms_nodes_1
  index  sqlite_autoindex_definitions_1
  index  sqlite_autoindex_definitions_2
  index  sqlite_autoindex_instance_heartbeats_1
  index  sqlite_autoindex_instances_1
  index  sqlite_autoindex_lineage_1
  index  sqlite_autoindex_node_tokens_1
  index  sqlite_autoindex_node_tokens_2
  table  channel_events
  table  comms_nodes
  table  definitions
  table  events
  table  instance_heartbeats
  table  instances
  table  lineage
  table  node_tokens
  table  sqlite_sequence

PASS: 'attempts' absent from sqlite_master (tables AND indexes)

KNOWN_TABLES = ['definitions', 'instances', 'instance_heartbeats', 'events',
                'channel_events', 'node_tokens', 'lineage', 'comms_nodes']
PASS: every KNOWN_TABLES name exists in the fresh DB
```

**The `sac db` CLI paths do not raise now that the table is missing:**

```
=== sac db show --json ===  exit_code=0
{"store": "...", "tables": {"definitions": 0, "instances": 0,
 "instance_heartbeats": 0, "events": 0, "channel_events": 0, "node_tokens": 0,
 "lineage": 0, "comms_nodes": 0}, ... "counts_are_authoritative": true}

=== sac db query --table=attempts ===  exit_code=2
Error: Invalid value for '--table': 'attempts' is not one of 'definitions',
'instances', 'instance_heartbeats', 'events', 'channel_events', 'node_tokens',
'lineage', 'comms_nodes'.

=== sac db query --table=instances --json ===  exit_code=0  output='[]'

=== export_state(since=...) tables: ['channel_events', 'comms_nodes',
'definitions', 'events', 'instance_heartbeats', 'instances', 'lineage',
'node_tokens']
```

The `--table=attempts` refusal (exit 2, naming the valid set) is the honest error this
change exists to produce, replacing a silent empty result.

**Linter** — `scitex-dev linter validate-files` on all 11 changed files: **zero errors.**
Warnings only, and every warning sits on a line this PR does not touch (`STX-IO015`
`sqlite3.connect` in `state_db.py`, `_rename_db.py`, `fleet_root.py`,
`test__rename_db.py`; `STX-IO006` print/echo in `db_group.py`, `state_db_export.py`;
`STX-EH001` / `STX-I008` in `fleet_root.py`). The one warning on a changed line —
`fleet_root.py:319 STX-NL001`, a numeric literal — replaces an identical warning on the
line it supersedes (`0.5` → `1.0` inside the seed tuple).

## Found while doing this, NOT fixed here

Two pre-existing items I noticed and deliberately left alone rather than widening this
PR. Flagging them rather than quietly fixing or ignoring them:

1. **`_rename_db.NAME_COLUMNS` still lists `("comms_grants", "sender_name")` and
   `("comms_grants", "target_name")`.** `comms_grants` left `KNOWN_TABLES` and had its
   DDL deleted from `state_db_schema.py` on 2026-08-28 — so by that module's own ruling
   (the one this PR follows) those two pairs are now the same "reassuring decoration"
   the module docstring warns about. Unlike `node_comms_policy`, which got a replacement
   step in `_rename.apply_plan`, I found no equivalent `rename_grants` call, so a rename
   may not be carrying grant rows at all. That is a behaviour question, not a
   dead-name-cleanup, and deserves its own card.

2. **`tests/.../cli_pkg/test__registry_sync.py` synthetic payloads still list `turns`,
   `errors`, `heartbeats` and `comms_grants`** — all departed tables. Harmless
   (`import_state` reads `tables.get(...)`), but stale. I removed only `attempts`, the
   table this PR owns.

## Contradictions with the brief

None. Every claim in the brief held up under re-measurement: zero writers, zero readers
in `src/`, all INSERT/SELECT confined to tests, and the NEVER_SYNCED prose saying so.
One detail the brief did not mention: removing the DDL also required dropping the
`_SCHEMA_ATTEMPTS` **import and `executescript` call** in `state_db.init_schema` (the
constant was re-exported), and updating the `_mcp/_tools/_db.py` `db_show` docstring,
which also listed `attempts` among the counted tables.
