### PR TITLE
fix(cli): host-side PGUSER completes the fleet-DSN identity (contains #1248)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -435,9 +435,10 @@ def cli_entry_point() -> None:
     # The fleet defaults this process hands to every container, applied to
     # ITSELF — sac opens the same Postgres stores its agents do, and until
     # 2026-08-28 it was the one process in the fleet launching without
-    # ``SCITEX_STORE_DSN``. A variable exported in the operator's shell still
-    # wins; see ``apply_fleet_defaults_to_process`` for the failure this
-    # closes.
+    # ``SCITEX_STORE_DSN``, and without the ``PGUSER`` that DSN is roleless
+    # in order to leave room for. A variable exported in the operator's shell
+    # still wins; see ``apply_fleet_defaults_to_process`` for both halves and
+    # the failure they close.
     from ..runtimes._fleet_env import apply_fleet_defaults_to_process
 
     apply_fleet_defaults_to_process()

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -432,6 +432,16 @@ def cli_entry_point() -> None:
 
     warn_once()
 
+    # The fleet defaults this process hands to every container, applied to
+    # ITSELF — sac opens the same Postgres stores its agents do, and until
+    # 2026-08-28 it was the one process in the fleet launching without
+    # ``SCITEX_STORE_DSN``. A variable exported in the operator's shell still
+    # wins; see ``apply_fleet_defaults_to_process`` for the failure this
+    # closes.
+    from ..runtimes._fleet_env import apply_fleet_defaults_to_process
+
+    apply_fleet_defaults_to_process()
+
     # Cheap pre-scan: don't import the heavy ``host_group`` module
     # unless ``--on`` is actually present on the command line. Importing
     # ``host_group`` (state.host_config + subprocess + the full click

--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -51,7 +51,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 
 logger = logging.getLogger(__name__)
 
@@ -378,9 +378,58 @@ def fleet_env_flags(
     ]
 
 
+def apply_fleet_defaults_to_process(
+    environ: "MutableMapping[str, str] | None" = None,
+    *,
+    config_path: Path | None = None,
+) -> dict[str, str]:
+    """Give sac's OWN process the fleet defaults its containers get.
+
+    Everything above renders the defaults into an agent's ``apptainer --env``
+    flags and stops there. But the host-side ``sac`` process opens the SAME
+    stores the containers do — ``persist_acl_policy`` on every start,
+    instances, dispatches, the diary — and it received none of them. On a
+    shell with no ``SCITEX_STORE_DSN``, ``scitex_dev.store.host_store()`` fell
+    through to its UNIX-socket fallback, ``pg_hba`` asked the socket for a
+    password, and ``.pgpass`` — keyed by ``127.0.0.1`` / ``localhost`` /
+    ``scitex-primary``, never by a socket directory — had nothing to offer:
+
+        Cannot connect to Postgres store 'node_comms_policy' ...
+        socket "~/.scitex/pg/run/.s.PGSQL.55432" failed:
+        fe_sendauth: no password supplied
+
+    MEASURED on compute-04, 2026-08-28, on ``sac agents restart``. A
+    ``.pgpass`` row for the socket directory is the WRONG fix: that socket is
+    the local cluster, which is now a streaming STANDBY
+    (``pg_is_in_recovery() = t``), so the row would only trade a loud connect
+    refusal for a quiet read-only write failure. The right store is the one
+    :data:`FLEET_DEFAULT_ENV` already names — the gap was that only the
+    containers were told.
+
+    Same precedence as everything else in this module: a key already present
+    in ``environ`` wins, untouched — a default exists in order to be
+    overridden, and an operator who exported ``SCITEX_STORE_DSN`` in their
+    shell has overridden it. ``environ`` defaults to ``os.environ`` and is an
+    injection seam for tests. Returns the keys it actually set.
+    """
+    import os
+
+    target = os.environ if environ is None else environ
+    injected: dict[str, str] = {}
+    for key, val in declared_fleet_defaults(config_path).items():
+        if key in target:
+            continue
+        target[key] = val
+        injected[key] = val
+    if injected:
+        logger.debug("fleet_env: process env gained %s", sorted(injected))
+    return injected
+
+
 __all__ = [
     "CONFIG_SECTION",
     "FLEET_DEFAULT_ENV",
+    "apply_fleet_defaults_to_process",
     "declared_fleet_defaults",
     "effective_env",
     "fleet_env_flags",

--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -59,6 +59,16 @@ logger = logging.getLogger(__name__)
 # fleet defaults. Same file + cascade as ``spec.hostname_aliases``.
 CONFIG_SECTION = "fleet_default_env"
 
+# The agent-name slot sac's OWN host-side process occupies in the per-agent
+# PostgreSQL role scheme. It is not an agent and has no agent name, so it uses
+# the reserved name ``cli`` — the cluster holds the role, and compute-04's
+# ``.pgpass`` holds its rows. ONLY THE SLOT LIVES HERE: the role name is
+# composed by :func:`._pg_identity_env.derive_pg_role`, which is the one place
+# that knows the ``<host_user>__<name>`` shape, and the variable it lands in is
+# that module's ``PG_USER_ENV``. See
+# :func:`apply_fleet_defaults_to_process` for why the host process needs one.
+HOST_PROCESS_AGENT_NAME = "cli"
+
 # --------------------------------------------------------------------------
 # THE DATA. Fleet-wide environment defaults, declared once, inherited by every
 # agent that does not override the key in its own ``spec.env``.
@@ -411,8 +421,63 @@ def apply_fleet_defaults_to_process(
     overridden, and an operator who exported ``SCITEX_STORE_DSN`` in their
     shell has overridden it. ``environ`` defaults to ``os.environ`` and is an
     injection seam for tests. Returns the keys it actually set.
+
+    ``PGUSER`` — THE OTHER HALF OF THE SAME IDENTITY (2026-08-28)
+    ------------------------------------------------------------
+    The DSN above is ROLELESS on purpose. ``scitex-primary:55432/scitex``
+    names a host, a port and a database and NO user, because in this fleet the
+    login identity is per-agent and travels in a SECOND variable: containers
+    receive the roleless DSN *and* ``PGUSER=<host_user>__<agent>``, injected by
+    :mod:`._pg_identity_env` (see that module for why specs stopped carrying
+    DSN userinfo at all). Two halves, one scheme.
+
+    Giving the host process only the FIRST half fixed which server it talked
+    to and left it unable to say who it was:
+
+        Cannot connect to Postgres store 'node_comms_policy' ...
+        connection to server at "100.64.0.5", port 55432 failed:
+        fe_sendauth: no password supplied
+
+    With no ``PGUSER``, libpq falls back to the OS user — bare ``ywatanabe``
+    — and ``.pgpass`` matches on (host, port, database, USER). compute-04's
+    file holds 522 rows and NOT ONE names the bare OS user: every row is a
+    service role or a per-agent ``<host_user>__<agent>``. So the OS-user
+    fallback can never authenticate, whichever host the DSN names — the
+    password lookup fails before the server is ever asked. MEASURED on
+    compute-04 2026-08-28 against this branch: with the DSN alone, the read
+    above; with ``PGUSER=ywatanabe__cli`` beside it, the same read returns
+    the policy. COST while it was missing: every ``sac agents start`` that
+    publishes ACL policy died, taking scitex-hub (compute-03) and business
+    (compute-01) down.
+
+    THE ROLE IS DELIBERATELY NOT PUT IN THE DSN, and that constraint is the
+    whole reason this lives here rather than in :data:`FLEET_DEFAULT_ENV`.
+    That mapping is the CONTAINERS' baseline too, so userinfo in its DSN — or
+    a ``PGUSER`` key in it — would reach all 132 agent containers and override
+    every per-agent role, collapsing 132 distinct logins into one shared
+    identity and taking the per-agent audit trail and the ``pg_hba`` grant
+    structure with it. The host process gets its own half of the pair
+    injected HERE, in the one function nothing container-bound calls.
+
+    ``cli`` (:data:`HOST_PROCESS_AGENT_NAME`) is the agent-name slot; the
+    composition is :func:`._pg_identity_env.derive_pg_role`'s, so exactly one
+    module knows the ``<host_user>__<name>`` shape and the libpq variable
+    name. ``ywatanabe__cli`` is verified to authenticate against
+    scitex-primary from compute-01, compute-03, compute-04 and nas-03.
+    compute-02 was NOT tested — it carries neither psycopg nor any agent
+    specs — and is no worse off than before, where it had no host-side login
+    either.
+
+    Declared-anywhere wins here too, and the check runs AFTER the cascade
+    above so all three declaring layers are covered by one lookup: a
+    ``PGUSER`` exported in the operator's shell, one in
+    :data:`FLEET_DEFAULT_ENV`, and one in ``config.yaml``'s
+    ``spec.fleet_default_env`` each land in ``target`` first and suppress the
+    injection.
     """
     import os
+
+    from ._pg_identity_env import PG_USER_ENV, derive_pg_role
 
     target = os.environ if environ is None else environ
     injected: dict[str, str] = {}
@@ -421,6 +486,10 @@ def apply_fleet_defaults_to_process(
             continue
         target[key] = val
         injected[key] = val
+    if PG_USER_ENV not in target:
+        role = derive_pg_role(HOST_PROCESS_AGENT_NAME)
+        target[PG_USER_ENV] = role
+        injected[PG_USER_ENV] = role
     if injected:
         logger.debug("fleet_env: process env gained %s", sorted(injected))
     return injected
@@ -429,6 +498,7 @@ def apply_fleet_defaults_to_process(
 __all__ = [
     "CONFIG_SECTION",
     "FLEET_DEFAULT_ENV",
+    "HOST_PROCESS_AGENT_NAME",
     "apply_fleet_defaults_to_process",
     "declared_fleet_defaults",
     "effective_env",

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -23,6 +23,7 @@ import pytest
 from scitex_agent_container.runtimes._fleet_env import (
     CONFIG_SECTION,
     FLEET_DEFAULT_ENV,
+    apply_fleet_defaults_to_process,
     declared_fleet_defaults,
     effective_env,
     fleet_env_flags,
@@ -164,6 +165,148 @@ def test_without_the_injection_the_resolver_goes_somewhere_else() -> None:
     without_injection = _resolved_store_locator(None)
     # Assert
     assert without_injection != with_injection
+
+
+# ----------------------------------------------------------------------
+# The defaults reach sac's OWN process, not only its containers.
+#
+# The gap behind ``fe_sendauth: no password supplied`` on 2026-08-28:
+# ``sac agents restart`` on compute-04 opened ``node_comms_policy`` with NO
+# ``SCITEX_STORE_DSN`` in its own environment — the defaults were only ever
+# rendered into ``apptainer --env`` flags — so scitex-dev's resolver fell
+# through to the local UNIX socket, a streaming standby whose password no
+# ``.pgpass`` row could supply. A real mapping stands in for ``os.environ``
+# below (the seam exists so these tests do not touch the process they run
+# in); the last two go through the real ``os.environ`` with save/restore,
+# the repo idiom (see ``_resolved_store_locator``).
+# ----------------------------------------------------------------------
+
+
+def _bare_process_env(tmp_path: Path) -> dict[str, str]:
+    """A process env that says nothing about the store, defaults applied."""
+    environ: dict[str, str] = {"PATH": "/usr/bin"}
+    apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    return environ
+
+
+def test_the_sac_process_receives_the_store_dsn_it_hands_to_containers(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    environ: dict[str, str] = {"PATH": "/usr/bin"}
+    # Act
+    apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    # Assert
+    assert environ["SCITEX_STORE_DSN"] == FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"]
+
+
+def test_applying_defaults_reports_exactly_the_keys_it_injected(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    environ: dict[str, str] = {"PATH": "/usr/bin"}
+    # Act
+    injected = apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    # Assert
+    assert injected == FLEET_DEFAULT_ENV
+
+
+def test_applying_defaults_leaves_unrelated_process_keys_alone(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    # Act
+    environ = _bare_process_env(tmp_path)
+    # Assert
+    assert environ["PATH"] == "/usr/bin"
+
+
+def test_an_operator_exported_store_dsn_beats_the_fleet_default(
+    tmp_path: Path,
+) -> None:
+    """Same rule as ``spec.env`` over the fleet layer — a default exists in
+    order to be overridden. A host whose Postgres lives elsewhere exports its
+    own DSN, and sac must not silently redirect that host's writes to
+    ``scitex-primary``.
+    """
+    # Arrange
+    environ = {"SCITEX_STORE_DSN": "postgresql://elsewhere:5432/mine"}
+    # Act
+    apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    # Assert
+    assert environ["SCITEX_STORE_DSN"] == "postgresql://elsewhere:5432/mine"
+
+
+def test_the_config_yaml_layer_reaches_the_process_beside_a_kept_override(
+    tmp_path: Path,
+) -> None:
+    """Precedence proven against the FULL declared set, not just sac's
+    constant: the operator's config.yaml key is added, the exported DSN is
+    kept, and the return value names only what was actually injected.
+    """
+    # Arrange
+    cfg = _write_config_yaml(tmp_path / "config.yaml", {"OPERATOR_KEY": "from-yaml"})
+    environ = {"SCITEX_STORE_DSN": "postgresql://elsewhere:5432/mine"}
+    # Act
+    injected = apply_fleet_defaults_to_process(environ, config_path=cfg)
+    # Assert
+    assert injected == {"OPERATOR_KEY": "from-yaml"}
+
+
+def _with_store_dsn_unset(fn):
+    """Run ``fn`` with ``SCITEX_STORE_DSN`` absent from the REAL os.environ."""
+    import os
+
+    key = "SCITEX_STORE_DSN"
+    saved = os.environ.get(key)
+    try:
+        os.environ.pop(key, None)
+        return fn(key)
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+def test_the_default_form_writes_to_the_live_process_environment() -> None:
+    """No ``environ`` argument — the way ``cli_entry_point`` calls it."""
+    import os
+
+    # Arrange
+    absent = Path("/nonexistent/config.yaml")
+
+    def act(key: str) -> str:
+        apply_fleet_defaults_to_process(config_path=absent)
+        return os.environ[key]
+
+    # Act
+    seen = _with_store_dsn_unset(act)
+    # Assert
+    assert seen == FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"]
+
+
+def test_a_second_application_finds_the_key_present_and_injects_nothing() -> None:
+    # Arrange
+    absent = Path("/nonexistent/config.yaml")
+
+    def act(_key: str) -> dict[str, str]:
+        apply_fleet_defaults_to_process(config_path=absent)
+        return apply_fleet_defaults_to_process(config_path=absent)
+
+    # Act
+    second = _with_store_dsn_unset(act)
+    # Assert
+    assert second == {}
+
 
 
 def test_declared_defaults_do_not_mutate_the_module_constant(tmp_path: Path) -> None:

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -23,12 +23,23 @@ import pytest
 from scitex_agent_container.runtimes._fleet_env import (
     CONFIG_SECTION,
     FLEET_DEFAULT_ENV,
+    HOST_PROCESS_AGENT_NAME,
     apply_fleet_defaults_to_process,
     declared_fleet_defaults,
     effective_env,
     fleet_env_flags,
     merge_fleet_env,
 )
+from scitex_agent_container.runtimes._pg_identity_env import (
+    PG_USER_ENV,
+    derive_pg_role,
+)
+
+# The host process's expected role, composed by the SAME primitive the
+# production code uses. Spelling ``ywatanabe__cli`` literally here would make
+# these tests pass on the operator's laptop and fail for anyone else — and
+# would quietly stop testing the composition the moment it changed.
+HOST_PROCESS_ROLE = derive_pg_role(HOST_PROCESS_AGENT_NAME)
 
 
 def _write_config_yaml(path: Path, mapping: dict) -> Path:
@@ -213,8 +224,8 @@ def test_applying_defaults_reports_exactly_the_keys_it_injected(
     injected = apply_fleet_defaults_to_process(
         environ, config_path=tmp_path / "no-such-config.yaml"
     )
-    # Assert
-    assert injected == FLEET_DEFAULT_ENV
+    # Assert — the declared cascade PLUS the host-side half of the pg identity
+    assert injected == {**FLEET_DEFAULT_ENV, PG_USER_ENV: HOST_PROCESS_ROLE}
 
 
 def test_applying_defaults_leaves_unrelated_process_keys_alone(
@@ -258,23 +269,33 @@ def test_the_config_yaml_layer_reaches_the_process_beside_a_kept_override(
     # Act
     injected = apply_fleet_defaults_to_process(environ, config_path=cfg)
     # Assert
-    assert injected == {"OPERATOR_KEY": "from-yaml"}
+    assert injected == {"OPERATOR_KEY": "from-yaml", PG_USER_ENV: HOST_PROCESS_ROLE}
 
 
 def _with_store_dsn_unset(fn):
-    """Run ``fn`` with ``SCITEX_STORE_DSN`` absent from the REAL os.environ."""
+    """Run ``fn`` with the injected keys absent from the REAL os.environ.
+
+    ``PGUSER`` is saved and cleared alongside ``SCITEX_STORE_DSN`` because the
+    process-level injection now sets BOTH. Clearing it makes the two tests
+    below exercise the injection rather than an inherited value (inside an
+    agent container ``PGUSER`` is always already set), and restoring it stops
+    a test from leaving a role name behind in the live environment it borrowed.
+    """
     import os
 
     key = "SCITEX_STORE_DSN"
-    saved = os.environ.get(key)
+    keys = (key, PG_USER_ENV)
+    saved = {k: os.environ.get(k) for k in keys}
     try:
-        os.environ.pop(key, None)
+        for k in keys:
+            os.environ.pop(k, None)
         return fn(key)
     finally:
-        if saved is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved
+        for k, previous in saved.items():
+            if previous is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = previous
 
 
 def test_the_default_form_writes_to_the_live_process_environment() -> None:
@@ -306,6 +327,126 @@ def test_a_second_application_finds_the_key_present_and_injects_nothing() -> Non
     second = _with_store_dsn_unset(act)
     # Assert
     assert second == {}
+
+
+# ----------------------------------------------------------------------
+# ``PGUSER`` — the OTHER half of the same identity.
+#
+# The fleet's DSN is roleless on purpose and the login travels separately, so
+# a process holding only the DSN can reach the right server and still not say
+# who it is. libpq then falls back to the OS user, and ``.pgpass`` matches on
+# (host, port, database, USER) — compute-04's 522 rows contain no entry for
+# the bare OS user, so that fallback cannot authenticate at all:
+# ``fe_sendauth: no password supplied``. Containers were never exposed to this
+# because ``_pg_identity_env`` gives each one ``<host_user>__<agent>``; the
+# host-side process had no equivalent until it got ``<host_user>__cli``.
+# ----------------------------------------------------------------------
+
+
+def test_a_bare_process_env_gains_both_halves_of_the_pg_identity(
+    tmp_path: Path,
+) -> None:
+    """One assert on the PAIR, because either half alone cannot connect."""
+    # Arrange
+    environ: dict[str, str] = {"PATH": "/usr/bin"}
+    # Act
+    apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    # Assert
+    assert (environ["SCITEX_STORE_DSN"], environ[PG_USER_ENV]) == (
+        FLEET_DEFAULT_ENV["SCITEX_STORE_DSN"],
+        HOST_PROCESS_ROLE,
+    )
+
+
+def test_the_injected_role_is_composed_by_the_shared_primitive(
+    tmp_path: Path,
+) -> None:
+    """SSOT: ``<host_user>__<name>`` is built in exactly one place.
+
+    ``derive_pg_role`` is what every container's ``PGUSER`` already comes
+    from, so asserting against it — rather than against a literal — is what
+    keeps a second copy of the string logic from appearing here later.
+    """
+    # Arrange
+    # Act
+    environ = _bare_process_env(tmp_path)
+    # Assert
+    assert environ[PG_USER_ENV] == derive_pg_role(HOST_PROCESS_AGENT_NAME)
+
+
+def test_a_process_that_already_declares_a_role_keeps_it_verbatim(
+    tmp_path: Path,
+) -> None:
+    """Declared-anywhere wins, same rule as the DSN above.
+
+    An operator debugging as another role, or a wrapper that already resolved
+    an identity, must not have it silently swapped for ``__cli`` — a
+    connection made under the wrong login is worse than one that fails.
+    """
+    # Arrange
+    environ = {PG_USER_ENV: "ywatanabe__deliberately-someone-else"}
+    # Act
+    apply_fleet_defaults_to_process(
+        environ, config_path=tmp_path / "no-such-config.yaml"
+    )
+    # Assert
+    assert environ[PG_USER_ENV] == "ywatanabe__deliberately-someone-else"
+
+
+def test_a_config_yaml_role_beats_the_host_process_default(tmp_path: Path) -> None:
+    """The third declaring layer: the operator's ``spec.fleet_default_env``.
+
+    The injection is checked AFTER the config cascade precisely so this layer
+    is covered by the same lookup, rather than by a second special case that
+    could disagree with it.
+    """
+    # Arrange
+    cfg = _write_config_yaml(
+        tmp_path / "config.yaml", {PG_USER_ENV: "ywatanabe__from-yaml"}
+    )
+    environ: dict[str, str] = {"PATH": "/usr/bin"}
+    # Act
+    apply_fleet_defaults_to_process(environ, config_path=cfg)
+    # Assert
+    assert environ[PG_USER_ENV] == "ywatanabe__from-yaml"
+
+
+def test_the_injected_dsn_names_no_role_of_its_own(tmp_path: Path) -> None:
+    """The DSN must stay ROLELESS — the guard on a 132-way identity collapse.
+
+    Putting the role in the DSN would "fix" the host process in one line, and
+    :data:`FLEET_DEFAULT_ENV` is the CONTAINERS' baseline too: apptainer would
+    hand that userinfo to all 132 agents, where libpq prefers it over each
+    agent's own ``PGUSER``, and every distinct per-agent login would become
+    one shared role. Userinfo lives before an ``@`` in the authority, so that
+    is what this looks at — not the whole string, which legitimately contains
+    ``:`` and ``/``.
+    """
+    # Arrange
+    environ = _bare_process_env(tmp_path)
+    # Act
+    authority = environ["SCITEX_STORE_DSN"].split("://", 1)[1].split("/", 1)[0]
+    # Assert
+    assert "@" not in authority
+
+
+def test_the_host_process_role_never_reaches_a_container(tmp_path: Path) -> None:
+    """The other side of the same guard, at the layer that renders containers.
+
+    ``cli`` is injected into the PROCESS, never into the declared defaults, so
+    an agent still launches as itself. If someone ever "simplifies" this by
+    adding ``PGUSER`` to :data:`FLEET_DEFAULT_ENV`, that key would win over
+    ``_pg_identity_env``'s per-agent injection (declared-anywhere-wins cuts
+    both ways) and this goes red.
+    """
+    # Arrange
+    config = SimpleNamespace(name="some-agent", env={}, apptainer=None)
+    # Act
+    env = effective_env(config, defaults=FLEET_DEFAULT_ENV)
+    # Assert
+    assert env[PG_USER_ENV] == derive_pg_role("some-agent")
 
 
 


### PR DESCRIPTION
**This PR contains and supersedes #1248.** It is branched from that PR's head, so
its commit is included here verbatim; merging this one merges both. #1248 can be
closed once this lands.

## The problem

#1248 gives sac's own host-side process
`SCITEX_STORE_DSN=postgresql://scitex-primary:55432/scitex`. That is the correct
value and it is **roleless by design** — it names a host, a port and a database
and no user — because in this fleet the login identity is per-agent and travels
in a *second* variable.

Containers get both halves. `runtimes/_pg_identity_env.py` injects
`PGUSER=<host_user>__<agent>` alongside the roleless DSN, which is exactly why
specs stopped carrying DSN userinfo at all.

**The host process got only the first half.** With no `PGUSER`, libpq falls back
to the OS user — bare `ywatanabe` — and `.pgpass` matches on
(host, port, database, **USER**). compute-04's file holds **522 rows and not one
names the bare OS user**: every row is a service role or a per-agent
`ywatanabe__<agent>`. So the OS-user fallback can never authenticate, whichever
host the DSN names — the password lookup fails before the server is asked:

```
Cannot connect to Postgres store 'node_comms_policy' ...
connection to server at "100.64.0.5", port 55432 failed:
fe_sendauth: no password supplied
```

Measured on compute-04, 2026-08-28: every `sac agents start` that publishes ACL
policy died here. It took scitex-hub (compute-03) and business (compute-01) down.

## Why the role is NOT put in the DSN

Adding userinfo to the DSN would be a one-line "fix" and would be a much worse
bug. `FLEET_DEFAULT_ENV` is the **containers'** baseline too, so that userinfo —
or a `PGUSER` key added to the same mapping — would be handed to all 132 agent
containers, where it overrides each agent's own per-agent role. 132 distinct
logins collapse into one shared identity, taking the per-agent audit trail and
the `pg_hba` grant structure with them. (This was the objection raised, withdrawn
and then refined on #1248; comment 5451408466 carries the measurement.)

## The fix

`apply_fleet_defaults_to_process` injects `PGUSER=<host_user>__cli` into the
**process** only, after the existing default/config cascade, and only when
nothing else declared it.

* **Declared-anywhere wins, via one lookup.** The check runs *after* the cascade
  has copied the declared layers into the target env, so an exported `PGUSER`, a
  `PGUSER` in `FLEET_DEFAULT_ENV`, and a `PGUSER` in `config.yaml`'s
  `spec.fleet_default_env` are all covered by the same `if PG_USER_ENV not in
  target` — no second special case that could disagree with the first.
* **SSOT.** The name is composed by `_pg_identity_env.derive_pg_role` and lands
  in that module's `PG_USER_ENV`. One place knows the `<host_user>__<name>`
  shape; one constant names the libpq variable. Only the agent-name *slot*
  (`HOST_PROCESS_AGENT_NAME = "cli"`) is new, and it lives next to the function
  that uses it.
* `ywatanabe__cli` is verified to authenticate against scitex-primary from
  compute-01, compute-03, compute-04 and nas-03. **compute-02 is untested** — it
  carries neither psycopg nor any agent specs — and is no worse off there than
  today, where it has no working host-side login either.

## Functional proof on the compute-04 HOST (read-only, nothing written)

Both arms run this branch's `apply_fleet_defaults_to_process(os.environ)` from
the worktree's `src` via `PYTHONPATH`, then read through the production reader
`read_comms_policy(name="scitex-agent-container")`. Control first.

**Control — the code as it stands on #1248 (DSN only, no PGUSER):**

```
injected_keys: ['PGPASSFILE', 'SCITEX_AGENT_CONTAINER_CONFIG', 'SCITEX_CARDS_DB', 'SCITEX_STORE_DSN']
PGUSER: <unset>
SCITEX_STORE_DSN: postgresql://scitex-primary:55432/scitex
READ_COMMS_POLICY: FAILED StoreTargetError Cannot connect to Postgres store
  'node_comms_policy' at postgres[host=scitex-primary db=scitex port=55432]:
  connection failed: connection to server at "100.64.0.5", port 55432 failed:
  fe_sendauth: no password supplied.
```

**With this PR (same DSN, PGUSER injected):**

```
injected_keys: ['PGPASSFILE', 'PGUSER', 'SCITEX_AGENT_CONTAINER_CONFIG', 'SCITEX_CARDS_DB', 'SCITEX_STORE_DSN']
PGUSER: ywatanabe__cli
SCITEX_STORE_DSN: postgresql://scitex-primary:55432/scitex
HOST_STORE_TARGET: StoreTarget(backend=Backend.POSTGRES,
  locator=PostgresDsn(dsn='postgresql://scitex-primary:55432/scitex'),
  pkg='scitex_agent_container', name='node_comms_policy')
READ_COMMS_POLICY: OK {'group_name': 'developer', 'group_names': ('active', 'app',
  'developer', 'infra'), 'inbound_parent': 'allow', 'inbound_siblings': 'allow',
  'lineage_group': '', 'may_spawn': True, 'outbound_parent': 'allow',
  'outbound_siblings': 'allow'}
```

The returned row is the live policy, not `DEFAULT_COMMS_POLICY` — a real read
reached a real row.

## Tests

Six new tests in `tests/scitex_agent_container/runtimes/test__fleet_env.py`,
following the file's existing no-mock idiom (explicit `environ` dicts and real
`config.yaml` files on `tmp_path`):

1. a bare process env gains **both** halves, and the role is compared against
   `derive_pg_role(HOST_PROCESS_AGENT_NAME)` — never a literal, which would pass
   only on the operator's own account and would stop testing the composition;
2. the role is composed by the shared primitive (the SSOT guard);
3. an env that already declares `PGUSER` keeps it verbatim;
4. a `config.yaml` `spec.fleet_default_env` `PGUSER` wins;
5. the DSN authority carries no `@` — the direct guard on the 132-identity
   collapse;
6. `effective_env` still gives a *container* `derive_pg_role("some-agent")`, the
   other side of the same guard: if anyone ever "simplifies" this by moving
   `PGUSER` into `FLEET_DEFAULT_ENV`, it goes red.

**Two assertions from #1248 are widened**, not weakened: both pinned the exact
set of injected keys, and the function now legitimately injects a second one, so
they name it. They still assert exactness, which is the property their comments
care about. `_with_store_dsn_unset` now saves/restores `PGUSER` too — otherwise
those two tests would inherit the container's own role instead of exercising the
injection, and would leak a role name into the live environment.

```
tests/scitex_agent_container/runtimes/test__fleet_env.py    55 passed
tests/scitex_agent_container/runtimes/  (full dir)          2088 passed, 28 skipped
```

`scitex-dev linter validate-files` on all three changed files: **0 errors**; the
warnings that remain (`STX-I007`, `STX-I008`, `STX-IO010`) are pre-existing on
untouched lines.
