### PR TITLE
fix(cli): module entry point gets the process identity, and the cli name slot is actually reserved

### DIFF
--- a/src/scitex_agent_container/__main__.py
+++ b/src/scitex_agent_container/__main__.py
@@ -3,6 +3,11 @@
 
 """Allow running as: python -m scitex_agent_container"""
 
-from .cli import main
+# Must be cli_entry_point, NOT the bare Click group: the entry point is where
+# the process's ONLY host-side store identity (fleet DSN + PGUSER) is injected
+# (apply_fleet_defaults_to_process) — a bare-group call leaves store-opening
+# subcommands roleless, dying with "fe_sendauth: no password supplied".
+from .cli import cli_entry_point
 
-main()
+if __name__ == "__main__":
+    cli_entry_point()

--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -299,6 +299,16 @@ def create(
             "digits, '-', and '_' only (dir-as-SSoT convention)."
         )
 
+    # Reserved slots (the host-process role name) are refused at the front
+    # door, before anything is written — the collision story lives in
+    # config/_reserved_names.py. Imported lazily for the same cold-start
+    # budget reason as _default_base_dir (config is a heavy package).
+    from ..config._reserved_names import reserved_agent_name_error
+
+    reserved_msg = reserved_agent_name_error(name)
+    if reserved_msg is not None:
+        raise click.UsageError(reserved_msg)
+
     base = base_dir if base_dir is not None else _default_base_dir()
     agent_dir = base / name
     spec_path = agent_dir / "spec.yaml"

--- a/src/scitex_agent_container/config/_reserved_names.py
+++ b/src/scitex_agent_container/config/_reserved_names.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Reserved agent names — slots sac's own machinery already occupies.
+
+:data:`~scitex_agent_container.runtimes._fleet_env.HOST_PROCESS_AGENT_NAME`
+is the agent-name slot sac's host-side process uses in the per-agent
+PostgreSQL role scheme: :func:`..runtimes._pg_identity_env.derive_pg_role`
+composes ``<host_user>__<name>`` for agents and for the host process alike,
+so an AGENT with that name would authenticate with a role byte-identical to
+the host process's own — silently collapsing the per-agent audit trail into
+the host role and inheriting every grant made to it. The same string is
+also the ``spawned_by`` lineage sentinel recorded for bare CLI/operator
+launches (``_lifecycle/_instances.py``), so the agent's lineage rows would
+be indistinguishable from operator activity — the same slot, twice over.
+
+Until 2026-08-28 the reservation existed only as a comment beside the
+constant; nothing refused the name. This module is the enforcement, called
+from both chokepoints an agent name enters the system through:
+
+  * CREATION — ``sac agents create`` (``cli_pkg/_create.py``), right after
+    the charset check, before anything is written;
+  * SPEC VALIDATION — :func:`..config._validation.validate_raw`, which both
+    ``sac agents check`` / ``validate_config`` and every ``load_config``
+    run, so a hand-written or host-broker-materialised
+    ``agents/<reserved>/spec.yaml`` is refused before it can start.
+
+The import from ``runtimes._fleet_env`` is lazy on purpose: ``config`` must
+not pull the ``runtimes`` package at import time (``runtimes.base`` imports
+``config`` back — a module-level import here would re-enter a partially
+initialised package).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def reserved_agent_name_error(name: str) -> str | None:
+    """Return the refusal message when ``name`` is reserved, else ``None``.
+
+    The message names the offending value, the collision (why the slot is
+    reserved), and the next step — an error the operator can act on.
+    """
+    from ..runtimes._fleet_env import HOST_PROCESS_AGENT_NAME
+    from ..runtimes._pg_identity_env import derive_pg_role
+
+    if name != HOST_PROCESS_AGENT_NAME:
+        return None
+    return (
+        f"Agent name {name!r} is reserved for sac's own host-side process: "
+        f"the per-agent Postgres role scheme would give this agent "
+        f"PGUSER={derive_pg_role(name)!r} — byte-identical to the role the "
+        f"host process authenticates with (HOST_PROCESS_AGENT_NAME in "
+        f"runtimes/_fleet_env.py) — collapsing the per-agent audit trail "
+        f"and inheriting the host role's grants. {name!r} is also the "
+        f"spawned_by lineage sentinel for bare CLI launches "
+        f"(_lifecycle/_instances.py) — the same slot again. "
+        f"Pick a different name."
+    )
+
+
+def reserved_spec_path_errors(path: str) -> list[str]:
+    """dir-as-SSoT adapter for ``validate_raw``.
+
+    The agent name IS the spec's parent-directory name
+    (:func:`.._loaders._name_from_path`), so a spec at
+    ``.../<reserved>/spec.yaml`` declares the reserved name by position
+    alone — the YAML content never carries it.
+    """
+    msg = reserved_agent_name_error(Path(path).parent.name)
+    return [] if msg is None else [msg]

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -43,6 +43,7 @@ from ._harness_types import (
     is_known_harness,
     list_harnesses,
 )
+from ._reserved_names import reserved_spec_path_errors
 from ._residency_types import residency_coupling_error, residency_value_error
 from ._shape_validation import validate_autonomous, validate_proxy_coupling
 from ._startup_command_validation import validate_startup_commands
@@ -193,6 +194,11 @@ def validate_raw(raw: dict, path: str) -> list[str]:
 
     if not isinstance(raw, dict):
         return [f"Config file is not a YAML mapping: {path}"]
+
+    # dir-as-SSoT: the agent name is the spec's parent directory, so a
+    # reserved name (the host-process role slot) is refused by PATH here —
+    # this runs under check, list-discovery, AND every load_config/start.
+    errors.extend(reserved_spec_path_errors(path))
 
     # Unknown top-level keys
     unknown_top = set(raw.keys()) - _KNOWN_TOP_LEVEL_KEYS

--- a/tests/scitex_agent_container/cli_pkg/test__create.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create.py
@@ -841,3 +841,53 @@ def test_create_rejects_unknown_template_still_lists_choices(tmp_path: Path) -> 
     )
     # Assert
     assert "developer" in result.output and result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Reserved names — the host-process role slot must be refused at CREATION.
+# HOST_PROCESS_AGENT_NAME ("cli") passes the charset check, and until
+# 2026-08-28 nothing else stood in the way: `sac agents create cli` scaffolded
+# an agent whose derived PGUSER role is byte-identical to the host-side sac
+# process's own, collapsing the per-agent audit trail (audit of #1250).
+# ---------------------------------------------------------------------------
+
+
+def test_create_refuses_the_reserved_host_process_name(tmp_path: Path) -> None:
+    # Arrange — the reserved name comes from the SSOT constant, not a
+    # restated string literal.
+    from scitex_agent_container.runtimes._fleet_env import HOST_PROCESS_AGENT_NAME
+
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    result = runner.invoke(
+        create_cmd, [HOST_PROCESS_AGENT_NAME, "--base-dir", str(base)]
+    )
+    # Assert — refused loudly, naming the reason (the role collision).
+    assert "reserved" in result.output and result.exit_code != 0
+
+
+def test_create_reserved_name_writes_nothing(tmp_path: Path) -> None:
+    # Arrange — the refusal must land BEFORE any filesystem write: a
+    # half-scaffolded reserved agent dir would still be startable by hand.
+    from scitex_agent_container.runtimes._fleet_env import HOST_PROCESS_AGENT_NAME
+
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(create_cmd, [HOST_PROCESS_AGENT_NAME, "--base-dir", str(base)])
+    # Assert
+    assert not (base / HOST_PROCESS_AGENT_NAME).exists()
+
+
+def test_create_accepts_a_name_merely_containing_the_reserved_one(
+    tmp_path: Path,
+) -> None:
+    # Arrange — CONTROL: the reservation is an exact match, not a substring
+    # or prefix rule; "cli-agent" must scaffold normally.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(create_cmd, ["cli-agent", "--base-dir", str(base)])
+    # Assert
+    assert (base / "cli-agent" / "spec.yaml").is_file()

--- a/tests/scitex_agent_container/config/test__validation.py
+++ b/tests/scitex_agent_container/config/test__validation.py
@@ -1224,3 +1224,50 @@ def test_omitting_to_home_layers_is_not_an_error():
     errors = validate_raw(raw, path="<test>")
     # Assert
     assert not [e for e in errors if "to_home_layers" in e]
+
+
+# ---------------------------------------------------------------------------
+# Reserved agent names — dir-as-SSoT means the name arrives via the PATH,
+# never via the YAML body: a spec at .../<reserved>/spec.yaml declares the
+# host-process role slot by position alone. validate_raw is the chokepoint
+# both `sac agents check` / validate_config AND every load_config run
+# through, so this refusal also gates agent START for a hand-written or
+# host-broker-materialised spec (audit of #1250, 2026-08-28).
+# ---------------------------------------------------------------------------
+
+
+def test_reserved_dir_name_is_refused_at_validation():
+    # Arrange — legal YAML content; only the PATH carries the reserved name
+    # (SSOT constant, not a restated literal).
+    from scitex_agent_container.runtimes._fleet_env import HOST_PROCESS_AGENT_NAME
+
+    path = f"/agents/{HOST_PROCESS_AGENT_NAME}/spec.yaml"
+    # Act
+    errors = validate_raw(_BASE, path=path)
+    bad = [e for e in errors if "reserved" in e]
+    # Assert — the refusal names the offending value (the role collision
+    # message quotes the name itself).
+    assert HOST_PROCESS_AGENT_NAME in bad[0]
+
+
+def test_reserved_name_refusal_states_the_role_collision():
+    # Arrange — the message must carry the REASON, not just "reserved":
+    # the derived Postgres role is the host process's own.
+    from scitex_agent_container.runtimes._fleet_env import HOST_PROCESS_AGENT_NAME
+
+    path = f"/agents/{HOST_PROCESS_AGENT_NAME}/spec.yaml"
+    # Act
+    errors = validate_raw(_BASE, path=path)
+    bad = [e for e in errors if "reserved" in e]
+    # Assert
+    assert "PGUSER" in bad[0]
+
+
+def test_normal_dir_name_gets_no_reserved_error():
+    # Arrange — CONTROL: the refusal keys on the dir name alone; a normal
+    # agent path must not trip it (else the check rejects every spec).
+    path = "/agents/figrecipe/spec.yaml"
+    # Act
+    errors = validate_raw(_BASE, path=path)
+    # Assert
+    assert not [e for e in errors if "reserved" in e]

--- a/tests/scitex_agent_container/test___main__.py
+++ b/tests/scitex_agent_container/test___main__.py
@@ -1,0 +1,82 @@
+"""Tests for ``python -m scitex_agent_container`` (``__main__.py``).
+
+The module entry point must route through ``cli_entry_point`` — the ONE
+place the host-side process is handed its store identity (fleet DSN +
+``PGUSER``, via ``apply_fleet_defaults_to_process``). The 2026-08-28
+post-merge audit found it calling the bare Click group instead, which
+reproduces the ``fe_sendauth: no password supplied`` failure class for any
+store-opening subcommand launched as ``python -m scitex_agent_container
+...`` — and ``runtimes/a2a_sidecar.py`` spawns exactly that form in
+production.
+
+No mocks: one subprocess run of the real module entry with a scrubbed
+env, plus a source-level routing assertion whose limits are stated
+inline.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import scitex_agent_container
+
+_PKG_DIR = Path(scitex_agent_container.__file__).resolve().parent
+_MAIN_PY = _PKG_DIR / "__main__.py"
+
+
+def _scrubbed_env(tmp_path: Path) -> dict[str, str]:
+    """A bare-host-shell env: no SAC_* / store-identity variables.
+
+    ``PYTHONPATH`` is pinned to the package under test because pytest's
+    ``pythonpath = ["src"]`` mutates only THIS process's ``sys.path`` —
+    a child interpreter would otherwise import the installed copy, not
+    the one these tests cover. Coverage keys pass through so the child
+    is counted (see tests/conftest.py's subprocess-coverage wiring).
+    """
+    env = {
+        "HOME": str(tmp_path),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PYTHONPATH": str(_PKG_DIR.parent),
+    }
+    for key in ("COVERAGE_PROCESS_START", "COVERAGE_FILE"):
+        if key in os.environ:
+            env[key] = os.environ[key]
+    return env
+
+
+def test_module_entry_help_exits_zero_from_a_bare_env(tmp_path: Path) -> None:
+    # Arrange — the exact production spelling (a2a_sidecar launches
+    # `sys.executable -m scitex_agent_container ...`), from a shell that
+    # carries no store identity — the environment the audit's repro used.
+    env = _scrubbed_env(tmp_path)
+    # Act
+    result = subprocess.run(
+        [sys.executable, "-m", "scitex_agent_container", "--help"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    # Assert
+    assert result.returncode == 0, result.stderr
+
+
+def test_module_entry_routes_through_cli_entry_point() -> None:
+    # Arrange — source-level assertion, deliberately: proving the DSN+PGUSER
+    # injection END-TO-END needs a live Postgres store this suite does not
+    # have, and `--help` exits 0 with or without it. LIMIT: this pins only
+    # the ROUTING (__main__ calls cli_entry_point()); cli_entry_point's own
+    # call to apply_fleet_defaults_to_process is pinned separately by
+    # tests/scitex_agent_container/runtimes/test__fleet_env.py — together
+    # the two cover the chain without a mock.
+    source = _MAIN_PY.read_text(encoding="utf-8")
+    # Act
+    calls_entry_point = "cli_entry_point()" in source
+    # Assert
+    assert calls_entry_point, (
+        "__main__.py must invoke cli_entry_point() — the bare Click group "
+        "skips the process's store-identity injection (fe_sendauth class)"
+    )


### PR DESCRIPTION
Fixes the two confirmed defects from the 2026-08-28 post-merge audit of #1250 (card `audit-1249-1250-followups-20260828`).

## Defect A — `python -m scitex_agent_container` bypassed the identity injection

`src/scitex_agent_container/__main__.py` called the bare Click group (`.cli:main`) directly, skipping `cli_entry_point` — the one place `apply_fleet_defaults_to_process` hands the host-side process its store identity (fleet DSN + `PGUSER`). A store-opening subcommand run as `python -m scitex_agent_container ...` from a host shell therefore reproduced the exact `fe_sendauth: no password supplied` failure class #1250 closed — and `runtimes/a2a_sidecar.py` spawns exactly that form (`sys.executable -m scitex_agent_container a2a serve ...`) in production.

`__main__.py` now routes through `cli_entry_point` (with a `__name__` guard so an accidental import no longer launches the CLI), and carries a comment saying WHY the entry point must be `cli_entry_point`.

## Defect B — the `cli` agent name was reserved by comment only

`HOST_PROCESS_AGENT_NAME = "cli"` (`runtimes/_fleet_env.py`) called itself reserved, but nothing refused the name: `_is_valid_agent_name` is charset-only and config validation derived names with no reserved check. An agent named `cli` would derive `PGUSER=<host_user>__cli` — byte-identical to the host-process role — silently collapsing the per-agent audit trail and inheriting the host role's grants; the same string is the `spawned_by` lineage sentinel for bare CLI launches (`_lifecycle/_instances.py`), so its lineage rows would be unattributable too.

New `src/scitex_agent_container/config/_reserved_names.py` enforces the reservation. The reserved string is imported from `_fleet_env` (SSOT — never restated); the concrete colliding role in the message is composed by `derive_pg_role`, the one module that knows the `<host_user>__<name>` shape. Enforced at the two chokepoints an agent name enters the system through:

- **Creation** — `cli_pkg/_create.py` (`sac agents create`, which the `agent_create` MCP tool also drives): refused right after the charset check, before anything is written.
- **Spec validation** — `config/_validation.py: validate_raw`, keyed on the spec path's parent dir (dir-as-SSoT: the directory IS the name; the YAML body never carries it). `validate_raw` is what `sac agents check` / `validate_config`, agent-list discovery, AND every `load_config` run — so a hand-written or host-broker-materialised `agents/cli/spec.yaml` (the `agent_spawn` inline-spec path) is refused before the agent can start.

The refusal names the offending value, both collision mechanisms (role + lineage sentinel), and the next step:

```
Error: Agent name 'cli' is reserved for sac's own host-side process: the per-agent
Postgres role scheme would give this agent PGUSER='ywatanabe__cli' — byte-identical
to the role the host process authenticates with (HOST_PROCESS_AGENT_NAME in
runtimes/_fleet_env.py) — collapsing the per-agent audit trail and inheriting the
host role's grants. 'cli' is also the spawned_by lineage sentinel for bare CLI
launches (_lifecycle/_instances.py) — the same slot again. Pick a different name.
```

## Note on the audit's `validate_specs` pointer

The audit named `validate_specs` as a validation chokepoint; that function (`_agentstate/_spec.py`) validates agent-STATE signal specs, not agent config specs — verified with rg. The real config-validation chokepoint is `validate_raw`, which is where the check landed.

## Not touched

`sac agents rename` could still rename an existing agent's dir to `cli` without hitting the creation check (`_lifecycle/_rename_db.py` is owned by other agents right now, per the task constraints) — but the very next `load_config`/`check`/`list`/`start` of the renamed agent refuses through `validate_raw`, so the name cannot actually run.

## Tests (no mocks)

- `tests/scitex_agent_container/test___main__.py` (new): a subprocess run of the real module entry (`sys.executable -m scitex_agent_container --help`) from a scrubbed env asserting exit 0, plus a source-level assertion that `__main__` invokes `cli_entry_point()` (limits stated inline: the routing is pinned here; `cli_entry_point → apply_fleet_defaults_to_process` is pinned by `runtimes/test__fleet_env.py`).
- `cli_pkg/test__create.py`: reserved name refused with the reason; nothing written to disk; exact-match control (`cli-agent` still scaffolds).
- `config/test__validation.py`: reserved dir name refused naming the offending value; message states the role collision (`PGUSER`); normal-dir control.

Verification: `pytest tests/scitex_agent_container/test___main__.py cli_pkg/test__create.py config/test__validation.py runtimes/` → **2266 passed, 28 skipped, 0 failed**; full `cli_pkg/` + `config/` + `develop/` dirs re-run green (counts in PR conversation). `scitex-dev linter validate-files` clean on every changed file (the only warnings are pre-existing `yaml.safe_load` STX-IO010 hits on untouched lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
