### PR TITLE
feat(state): move lineage to the shared store

### DIFF
--- a/scripts/migrate_lineage_to_postgres.py
+++ b/scripts/migrate_lineage_to_postgres.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``lineage`` table into PostgreSQL.
+
+Companion to the ``state_db_lineage_store`` port (2026-08-28). The code
+stopped reading SQLite; this moves the edges already there so the spawn DAG
+is not stranded in a file nothing opens any more.
+
+THIS IS THE ONE WHERE A MISSED ROW GRANTS AUTHORITY
+===================================================
+The three migrations before this each failed in a direction. A missed
+``comms_nodes`` row made an agent unroutable. A missed ``comms_grants`` row
+DENIED a send. A missed ``node_comms_policy`` row could deny OR silently
+un-isolate. ``lineage`` fails one way only, and it is the wrong way:
+
+    an agent with no lineage edge is a ROOT, and a root MAY SPAWN.
+
+``spawn_allowed`` reads exactly one fact — "does this caller have a
+parent?" — and answers "allowed" when it does not. So a row this script
+fails to move does not degrade into a denial that someone notices and
+reports; it degrades into PERMISSION, silently. The same absence collapses
+``derive_group`` to a singleton (isolating agents that should mesh) and
+``descendants_of`` to nothing (so a parent loses ``check_lineage_acl``
+authority over agents it actually spawned).
+
+So run this BEFORE the restart that picks up the new code, and read the
+verify line rather than the exit code.
+
+IT REFUSES TO PICK A WINNER, AND ON THIS FLEET THAT IS NOT HYPOTHETICAL
+======================================================================
+Every host migrates its OWN SQLite file into ONE shared store, and those
+files were never synced with each other, so the same child can carry
+different parents on different machines. That was MEASURED across all four
+hosts on 2026-08-28, before a line of this script was written:
+
+    scitex-compute-01   0 edges
+    scitex-compute-03   7 edges
+    scitex-compute-04  16 edges
+    scitex-nas-03       0 edges          (23 total)
+
+and exactly one child disagreed::
+
+    scitex-cards -> proj-scitex-hub          (scitex-compute-03)
+    scitex-cards -> scitex-agent-container   (scitex-compute-04)
+
+"Skip what is already there" would resolve that in favour of whichever
+host ran the script first — an arbitrary winner, chosen by run order,
+invisible in the output, and a silent edit to the ACL, since
+``derive_group`` puts ``scitex-cards`` in a different group under each
+answer. So a name already in the store with a DIFFERENT parent is a
+COLLISION: it is reported, it makes the run exit non-zero, and nothing is
+written for that name. The house rule from the ``comms_nodes`` rollout,
+where it fired correctly on its first real run.
+
+The operator resolves it by deciding which parent is true and, if the
+stored one is wrong, correcting it deliberately — there is no way to do it
+by accident, because ``parent_name`` is IMMUTABLE in the store and the
+first value is kept forever.
+
+``created_at`` IS CARRIED VERBATIM, never re-stamped. It is IMMUTABLE in
+the store, so re-stamping would both destroy the record of when the spawn
+happened and make the first genuine collision unreportable — the same
+argument ``registered_at`` carries in the ``comms_nodes`` migration.
+
+Nothing is deleted from SQLite; the old table stays as a fallback.
+
+RUN IT TWICE. Edges are written by live daemons: every ``sac agents
+start`` funnels through ``check_spawn`` and every brokered spawn through
+the host listen. Run it once now, restart so the daemons pick up the new
+code, then run it again to sweep whatever the old path wrote in between.
+
+A DRY RUN IS THE DEFAULT and it must be RUN ON THE HOST — ``_migrate_lib``
+owns both rules and the ``$HOME`` trap behind the second one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from _migrate_lib import SqliteSource, run_migration  # noqa: E402
+
+from scitex_agent_container._state.state_db_lineage_store import (  # noqa: E402
+    ACTOR,
+    LINEAGE_STORE,
+    new_lineage_store,
+    read_edges,
+)
+
+SOURCE = SqliteSource(
+    table="lineage",
+    columns=("child_name", "parent_name", "created_at"),
+    # ``child_name`` rather than rowid: it is the identity, so a listing
+    # ordered by it is the one an operator reads the DAG by, and it stays
+    # stable across a re-run.
+    order_by="child_name ASC",
+)
+
+
+def _record(row: Mapping[str, Any]) -> dict[str, Any]:
+    """One SQLite row as the store's three-field record."""
+    return {
+        "child_name": str(row["child_name"]),
+        "parent_name": str(row["parent_name"]),
+        "created_at": float(row["created_at"]),
+    }
+
+
+def _key(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {"child_name": record["child_name"]}
+
+
+def _collides_with(existing: Any, row: Mapping[str, Any]) -> "str | None":
+    """Does the stored edge disagree with this file about WHO THE PARENT IS?
+
+    Compares ``parent_name`` only. ``created_at`` deliberately does NOT
+    participate: two hosts can hold the same edge stamped at different
+    moments (each recorded it when it observed the spawn), and that is
+    agreement about the thing the ACL reads, not a conflict.
+    """
+    stored_parent = str(existing.values["parent_name"])
+    incoming_parent = str(row["parent_name"])
+    if stored_parent == incoming_parent:
+        return None
+    child = str(row["child_name"])
+    return (
+        f"the store already says {child}'s parent is {stored_parent!r} "
+        f"(written by {str(existing.origin)!r}); this file says "
+        f"{incoming_parent!r}. These put {child} in DIFFERENT ACL groups, so "
+        f"there is no safe default. Decide which parent is true; the stored "
+        f"one cannot be overwritten (parent_name is IMMUTABLE) and both "
+        f"values remain in the oplog."
+    )
+
+
+def _describe(row: Mapping[str, Any]) -> str:
+    return f"{row['child_name']} -> {row['parent_name']}"
+
+
+def _verify_factory(rows: list[Mapping[str, Any]]):
+    """Build a verifier that asserts THIS HOST's edges are readable.
+
+    NOT a global row count, and that distinction is a bug found during the
+    ``comms_nodes`` rollout rather than a preference. ``_migrate_lib``
+    compares ``verify() < len(rows)``, so a verifier returning "how many
+    records does the store hold" is VACUOUSLY TRUE the moment a second host
+    migrates: the shared store already holds the first host's rows, the
+    count exceeds this host's row count no matter what happened, and a run
+    that wrote nothing at all still verifies green.
+
+    So this counts how many of THE ROWS THIS RUN READ are visible through
+    the production reader (:func:`read_edges`, the same index the ACL
+    walks), which is the question the operator is actually asking.
+    """
+
+    def _verify() -> int:
+        edges = read_edges()
+        return sum(
+            1
+            for row in rows
+            if edges.parent(str(row["child_name"])) == str(row["parent_name"])
+        )
+
+    return _verify
+
+
+def main(argv: list[str] | None = None) -> int:
+    # ``run_migration`` reads the rows itself, and the verifier needs the
+    # same list. Reading them twice is cheap (23 rows fleet-wide) and keeps
+    # the library's single-source-of-truth read path unchanged.
+    captured: list[Mapping[str, Any]] = []
+
+    class _CapturingSource(SqliteSource):
+        def read(self, db_path: Path, *, log: Any = print) -> list[dict]:
+            rows = super().read(db_path, log=log)
+            captured.clear()
+            captured.extend(rows)
+            return rows
+
+    source = _CapturingSource(
+        table=SOURCE.table, columns=SOURCE.columns, order_by=SOURCE.order_by
+    )
+    return run_migration(
+        argv=argv,
+        description=__doc__,
+        source=source,
+        store_name=LINEAGE_STORE,
+        # ``new_...``, not the shared ``open_...``: the library closes the
+        # handle it is given, and closing the process-wide one would leave
+        # the verification read below holding a dead connection.
+        open_store=new_lineage_store,
+        to_record=_record,
+        key_of=_key,
+        verify=_verify_factory(captured),
+        describe_row=_describe,
+        collides_with=_collides_with,
+        actor=ACTOR,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/scitex_agent_container/_lifecycle/_ci_deliver.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_deliver.py
@@ -92,7 +92,6 @@ def deliver_verdict(
     record: Any = None,
     failure_streak: Any = None,
     failing_checks: Any = None,
-    db_path: Any = None,
     agents_dir: Any = None,
     pr_body: str | None = None,
 ) -> dict:
@@ -138,9 +137,10 @@ def deliver_verdict(
 
         failure_streak = failures_since_last_success
 
-    # No `db_path`: the delivered-set moved to PostgreSQL via
-    # scitex_dev.store, which resolves its own target. `db_path` still
-    # reaches `ancestors` below, whose lineage table is still SQLite.
+    # No `db_path` anywhere in this function any more. The delivered-set
+    # moved to PostgreSQL first; `lineage` followed on 2026-08-28, so the
+    # `ancestors` walk below resolves its own target too and the parameter
+    # that used to reach it is gone rather than left inert.
     if already_delivered(
         repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion
     ):
@@ -167,7 +167,7 @@ def deliver_verdict(
     if not owner:
         return {"delivered": [], "skipped": True, "reason": "no-owner"}
 
-    targets = [owner, *ancestors(name=owner, db_path=db_path)]
+    targets = [owner, *ancestors(name=owner)]
     if escalating:
         # One extra gh call, on the rare escalation tick only — never on the
         # hot path. Fail-soft: an unnamed escalation still beats no escalation.

--- a/src/scitex_agent_container/_lifecycle/_rename.py
+++ b/src/scitex_agent_container/_lifecycle/_rename.py
@@ -47,6 +47,7 @@ from typing import Callable
 
 from .._state.state_db_acl_policy import rename_comms_policy
 from .._state.state_db_comms_nodes import rename_comms_node
+from .._state.state_db_lineage_rename import rename_lineage
 from ._rename_cards import CardMigration, CardMigrationError, find_owned_cards
 from ._rename_cards import migrate_cards, undo_migrate_cards
 from ._rename_db import DbUndo, count_rows, rename_rows, undo_rename_rows
@@ -71,6 +72,7 @@ STEP_REGISTRY = "registry"
 STEP_STATE_DB = "state-db"
 STEP_ACL = "acl-policy"
 STEP_DIRECTORY = "comms-directory"
+STEP_LINEAGE = "lineage"
 STEP_CARDS = "cards"
 STEP_VERIFY = "verify"
 
@@ -83,6 +85,7 @@ STEPS: tuple[str, ...] = (
     STEP_STATE_DB,
     STEP_ACL,
     STEP_DIRECTORY,
+    STEP_LINEAGE,
     STEP_CARDS,
     STEP_VERIFY,
 )
@@ -185,7 +188,31 @@ def apply_plan(
         if rename_comms_node(old=old, new=new):
             undo.append((STEP_DIRECTORY, _undo_comms_node(old, new)))
 
-        # 9. The board. LAST — see the module docstring.
+        # 9. The spawn DAG — PostgreSQL since 2026-08-28, so its own step
+        # for the same reason steps 7 and 8 are.
+        #
+        # It used to ride along in step 6 as the ``lineage.child_name`` and
+        # ``lineage.parent_name`` pairs in ``NAME_COLUMNS``, and leaving
+        # them there would have been the PRIVILEGE version of the two bugs
+        # above: ``rename_rows`` skips a table absent from
+        # ``sqlite_master``, so the rename reports success while the edge
+        # stays under the old name — and an agent with no edge is a ROOT,
+        # which may spawn.
+        #
+        # THIS STEP CAN REFUSE, and unlike its two neighbours that refusal
+        # is expected rather than exceptional. ``parent_name`` is IMMUTABLE
+        # in the store, so an edge naming ``old`` as a PARENT cannot be
+        # re-pointed at all; :func:`rename_lineage` raises rather than
+        # leaving or hiding it (both of which grant spawn authority), and
+        # the raise propagates into the unwind below. Renaming an agent
+        # that has spawned children is therefore refused outright — see
+        # :mod:`..._state.state_db_lineage_rename` for why that is the
+        # least-bad of the three available answers.
+        _step(STEP_LINEAGE)
+        if rename_lineage(old=old, new=new):
+            undo.append((STEP_LINEAGE, _undo_lineage(old, new)))
+
+        # 10. The board. LAST — see the module docstring.
         _step(STEP_CARDS)
         if plan.cards_enabled:
             _migrate_cards_step(old, new, store, by, undo)
@@ -305,6 +332,20 @@ def _undo_acl_policy(old: str, new: str) -> Callable[[], None]:
 
     def _undo() -> None:
         rename_comms_policy(old=new, new=old)
+
+    return _undo
+
+
+def _undo_lineage(old: str, new: str) -> Callable[[], None]:
+    """Move the lineage edge back. The same verb, arguments swapped.
+
+    Cannot itself hit the parent-side refusal: this only runs when the
+    forward call SUCCEEDED, which means nothing named ``old`` as a parent,
+    and the forward call did not create such an edge.
+    """
+
+    def _undo() -> None:
+        rename_lineage(old=new, new=old)
 
     return _undo
 

--- a/src/scitex_agent_container/_lifecycle/_rename_db.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_db.py
@@ -7,8 +7,8 @@ are no real FKs on it). A rename that moves the spec dir but leaves
 ``comms_nodes.name`` / ``node_comms_policy.name`` / ``lineage`` pointing
 at the old name produces an agent that starts but cannot be addressed:
 the A2A directory still advertises the dead name, and the ACL gate has no
-policy row for the live one. Two of those three now live in PostgreSQL and
-are renamed by :mod:`._rename` as their own steps — see below.
+policy row for the live one. All three now live in PostgreSQL and are
+renamed by :mod:`._rename` as their own steps — see below.
 
 So: rename EVERY row in state.db that keys on the name, including the
 history (``channel_events``). A renamed agent is the SAME agent — its
@@ -83,8 +83,24 @@ NAME_COLUMNS: tuple[tuple[str, str], ...] = (
     # empty on every host, so there was never a row to miss. Removed all
     # the same: a pair here asserts that renaming an agent must carry its
     # credential across, and there is no credential.
-    ("lineage", "child_name"),
-    ("lineage", "parent_name"),
+    # ("lineage", "child_name") / ("lineage", "parent_name") were here
+    # until 2026-08-28. The spawn DAG moved to PostgreSQL, and leaving the
+    # pairs would have been the PRIVILEGE version of the two cases below:
+    # ``rename_rows`` skips tables absent from sqlite_master, so the rename
+    # would have reported success while the edge stayed under the OLD name
+    # — and an agent with no lineage edge is a ROOT, which MAY SPAWN. The
+    # renamed agent, and every agent it had spawned, would have silently
+    # gained spawn authority as a side effect of a rename.
+    #
+    # The move is done by ``state_db_lineage_rename.rename_lineage``,
+    # called as its own step in :mod:`._rename` with its own inverse on the
+    # undo stack. That verb carries a restriction these pairs did not: it
+    # can move an agent's OWN edge (``child_name`` is the store identity,
+    # so a rename is a copy + retire) but NOT the edges that name it as a
+    # PARENT, because ``parent_name`` is IMMUTABLE and the first value is
+    # kept forever. It refuses the rename rather than leaving or hiding
+    # those edges — both of which would grant the spawn authority described
+    # above. See that module for why refusing is the least-bad answer.
     ("comms_grants", "sender_name"),
     ("comms_grants", "target_name"),
     # ("comms_nodes", "name") was here until 2026-08-28. The ADR-0014

--- a/src/scitex_agent_container/_lifecycle/_spawn_gate.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_gate.py
@@ -50,7 +50,6 @@ row. The ``spec.acl`` schema (Step 2) and ``child ⊆ parent`` clamp
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 __all__ = [
@@ -137,7 +136,6 @@ def enforce_spawn_gate(
     child_name: str,
     *,
     caller: str | None = None,
-    db_path: Path | None = None,
 ) -> str | None:
     """Gate a spawn of ``child_name`` and record its lineage edge.
 
@@ -160,7 +158,6 @@ def enforce_spawn_gate(
             the parent's ``SAC_NAME`` env via :func:`resolve_spawn_caller`.
             An explicit ``caller`` (e.g. the server handler's request
             ``caller`` field) overrides the env.
-        db_path: Optional isolated state.db (tests). ``None`` → default.
 
     Returns the resolved caller (``None`` for the admin path), so a
     diagnostic / log line can attribute the spawn.
@@ -176,7 +173,7 @@ def enforce_spawn_gate(
     if caller is None:
         caller = resolve_spawn_caller()
 
-    decision, reason = check_spawn(caller=caller, db_path=db_path)
+    decision, reason = check_spawn(caller=caller)
     if decision == "deny":
         raise SpawnDeniedError(reason or f"spawn of {child_name!r} denied")
 
@@ -185,7 +182,7 @@ def enforce_spawn_gate(
     # would make every operator-launched agent a child of "").
     if caller:
         try:
-            record_lineage(child=child_name, parent=caller, db_path=db_path)
+            record_lineage(child=child_name, parent=caller)
         except ValueError as exc:
             # record_lineage keeps the existing parent on a re-parent
             # attempt (restart-in-place) rather than raising; this except

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -37,7 +37,6 @@ forwarder's side — see :mod:`_listen.peer_tokens`).
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Literal
 
 from starlette.responses import JSONResponse
@@ -69,7 +68,6 @@ def check_lineage_acl(
     *,
     caller: str | None,
     target: str,
-    db_path: Path | None = None,
 ) -> AclDecision:
     """Decide whether ``caller`` may operate on ``target`` via lineage.
 
@@ -120,8 +118,13 @@ def check_lineage_acl(
     suitable for inclusion in :func:`deny_response` (which now
     wraps it with ``kind="acl_deny"`` per the 5-kind contract).
 
-    ``db_path`` is exposed so tests can isolate from the global
-    state.db.
+    ``db_path`` is GONE (2026-08-28). It was "exposed so tests can
+    isolate from the global state.db", and after the ``lineage`` move
+    there is no state.db behind this gate to isolate from: the descendant
+    walk reads the shared PostgreSQL store, which isolates via
+    ``SCITEX_STORE_DSN`` (the ``pg_schema`` fixture). A parameter that
+    still promised SQLite isolation would promise something no lookup
+    under it can deliver.
     """
     if caller is None or caller == "":
         return ("allow", None)
@@ -136,7 +139,7 @@ def check_lineage_acl(
         return ("allow", None)
     from .._state._lineage import descendants_of
 
-    descendants = descendants_of(name=caller, db_path=db_path)
+    descendants = descendants_of(name=caller)
     if target in descendants:
         return ("allow", None)
     # Standard-fleet manage mesh (operator 2026-06-29: "agents manage
@@ -175,7 +178,6 @@ def check_send_acl(
     *,
     claimed_from_agent: str | None,
     target: str,
-    db_path: Path | None = None,
 ) -> AclDecision:
     """Decide whether a ``message:send`` should be admitted.
 
@@ -259,13 +261,11 @@ def check_send_acl(
     # BEFORE the group check so a sibling-deny on either side fires even
     # when sender and target share a group. Default policies (everything
     # ``allow``) leave the legacy group ACL semantics untouched.
-    phase3_decision = _phase3_relationship_deny(
-        sender=sender, target=target, db_path=db_path
-    )
+    phase3_decision = _phase3_relationship_deny(sender=sender, target=target)
     if phase3_decision is not None:
         return phase3_decision
 
-    sender_group = derive_group(name=sender, db_path=db_path)
+    sender_group = derive_group(name=sender)
     if target in sender_group:
         return ("allow", None)
 
@@ -295,9 +295,12 @@ def check_send_acl(
     ):
         return ("allow", None)
 
-    # db_path is gone from the grants primitives — that store is on
-    # PostgreSQL now and isolates via SCITEX_STORE_DSN. The other
-    # lookups in this function still take it, so the parameter stays.
+    # Every lookup this function makes is now a PostgreSQL store read
+    # isolating via SCITEX_STORE_DSN — the grants primitives since their
+    # own move, and the lineage ones since 2026-08-28. The sentence that
+    # stood here ("the other lookups in this function still take it, so
+    # the parameter stays") was the last thing keeping ``db_path`` alive;
+    # with it false, the parameter went too.
     if has_grant(sender=sender, target=target):
         return ("allow", None)
 
@@ -318,7 +321,6 @@ def _phase3_relationship_deny(
     *,
     sender: str,
     target: str,
-    db_path: Path | None,
 ) -> AclDecision | None:
     """Per-spec ACL deny based on the sender↔target lineage relationship.
 
@@ -347,7 +349,7 @@ def _phase3_relationship_deny(
     Defaults preserve current behaviour: every comb in the matrix
     starts ``"allow"`` so absence of ``spec.comms`` is a no-op here.
     """
-    rel = sender_target_relationship(sender=sender, target=target, db_path=db_path)
+    rel = sender_target_relationship(sender=sender, target=target)
     if rel in ("parent", "sibling"):
         sender_policy = read_comms_policy(name=sender)
         if rel == "parent" and sender_policy["outbound_parent"] == "deny":
@@ -394,7 +396,6 @@ def _phase3_relationship_deny(
 def check_spawn(
     *,
     caller: str | None,
-    db_path: Path | None = None,
 ) -> AclDecision:
     """Wrap :func:`spawn_allowed` in the same allow/deny tuple shape
     as :func:`check_send_acl` so the listen-server handler can branch
@@ -427,7 +428,7 @@ def check_spawn(
     """
     if caller and is_developer(name=caller):
         return ("allow", None)
-    allowed, reason = spawn_allowed(caller=caller, db_path=db_path)
+    allowed, reason = spawn_allowed(caller=caller)
     if allowed:
         return ("allow", None)
     return ("deny", reason)

--- a/src/scitex_agent_container/_mcp/_tools/_db.py
+++ b/src/scitex_agent_container/_mcp/_tools/_db.py
@@ -8,15 +8,20 @@ from ._helpers import invoke_cli_json, invoke_cli_text
 
 
 def db_show() -> dict[str, Any]:
-    """Print high-level state-db row counts (instances, channel_events,
-    lineage). Mirrors ``sac db show --json``.
+    """Print high-level state-db row counts (instances, channel_events).
+    Mirrors ``sac db show --json``.
 
     The counts follow :data:`KNOWN_TABLES`, and that tuple is what this
     docstring must track — it enumerated ``definitions, instances,
     heartbeats, events, channel_events`` and had been stale for a while by
     2026-08-28 (``heartbeats`` moved to PostgreSQL, ``attempts`` was
     deleted, then ``definitions`` / ``instance_heartbeats`` / ``events``
-    went the same day). Three names is the whole list now."""
+    went the same day). ``lineage`` followed on 2026-08-28 when the spawn
+    DAG moved to the shared PostgreSQL store, leaving TWO names — and this
+    docstring is updated with it rather than after it, because a count
+    this tool reports for a table sac no longer keeps here is the
+    wrong-answer-that-looks-right the tuple has been shedding names to
+    avoid."""
     return invoke_cli_json(["db", "show", "--json"])
 
 

--- a/src/scitex_agent_container/_state/_lineage.py
+++ b/src/scitex_agent_container/_state/_lineage.py
@@ -65,6 +65,16 @@ def descendants_of(
     as a parent) — same shape as a leaf node, so callers don't
     need to disambiguate.
 
+    ONE BEHAVIOUR CHANGED IN THE CYCLE CASE, stated rather than left to
+    be discovered. The SQLite version guarded only on the ``seen`` set, so
+    given the edges ``a → b`` and ``b → a`` it returned ``{b, a}`` —
+    including ``a`` itself, which contradicts the "does NOT include
+    ``name``" promise three paragraphs up. The ``child == name`` guard
+    below makes the code keep that promise. Nothing downstream shifts:
+    :func:`~.._listen._acl.check_lineage_acl` answers ``caller == target``
+    before it ever walks, so self was never reachable through this set,
+    and a cycle is a malformed edge set in the first place.
+
     Args:
         name: the agent whose descendants we want.
         max_depth: BFS depth ceiling. Default 64 (= safety bound,

--- a/src/scitex_agent_container/_state/_lineage.py
+++ b/src/scitex_agent_container/_state/_lineage.py
@@ -1,11 +1,22 @@
-"""Lineage-table walk helpers (PR-3 — transitive descendants).
+"""Lineage walk helpers (PR-3 — transitive descendants and ancestors).
 
-Extracted from :mod:`._state.state_db_nodes` (which hit the
-per-file line cap) so the PR-3 lineage-scoped ACL gate has a
-focused module to import from. The ``lineage`` table itself
-(``child_name``, ``parent_name``, ``created_at``) is created and
-mutated by :func:`._state.state_db_nodes.record_lineage`; this
-module is read-only.
+Extracted from :mod:`._state.state_db_nodes` (which hit the per-file line
+cap) so the PR-3 lineage-scoped ACL gate has a focused module to import
+from. The edges themselves (``child_name``, ``parent_name``,
+``created_at``) are written by
+:func:`._state.state_db_lineage_group.record_lineage`; this module is
+read-only.
+
+ON POSTGRESQL SINCE 2026-08-28. ``db_path`` is gone from both signatures —
+it named a SQLite file and there is no file. What changed for the walks
+themselves is the number of round-trips, and it went DOWN: each function
+now reads the edge set ONCE through
+:func:`.state_db_lineage_store.read_edges` and walks it in memory, where
+:func:`descendants_of` previously issued one ``SELECT ... WHERE parent_name
+IN (...)`` PER BFS LEVEL and :func:`ancestors_to_root` one per ancestor.
+The cycle guards are unchanged and still do the work described below —
+they guard the WALK, not the storage, so a contradictory edge set is
+bounded here whatever produced it.
 
 The PR-3 lineage-scoped ACL contract (clew checkpoint 3):
 
@@ -21,15 +32,12 @@ helpers in :mod:`._listen._acl`; this module provides the third
 
 from __future__ import annotations
 
-from pathlib import Path
-
 __all__ = ["ancestors_to_root", "descendants_of"]
 
 
 def descendants_of(
     *,
     name: str,
-    db_path: Path | None = None,
     max_depth: int = 64,
 ) -> set[str]:
     """Return the set of transitive descendants of ``name``.
@@ -39,18 +47,18 @@ def descendants_of(
     is yes when ``target ∈ descendants(caller)`` (transitively,
     not just direct children).
 
-    The walk is breadth-first over the ``lineage`` table; the
-    return set does NOT include ``name`` itself (callers checking
-    self-management should do so before calling this). Cycles in
-    the lineage table (which :func:`record_lineage` prevents but
-    a hand-edited DB could introduce) are guarded by both the
+    The walk is breadth-first over the lineage edges; the return set does
+    NOT include ``name`` itself (callers checking self-management should do
+    so before calling this). Cycles (which
+    :func:`~.state_db_lineage_group.record_lineage` prevents, but which a
+    contradictory edge set could still contain) are guarded by both the
     seen set AND a depth ceiling — a runaway walk is bounded to
     ``max_depth`` levels deep.
 
     The default ``max_depth=64`` is deeper than any realistic SAC
     deployment (cohort sizes top out at ~50 capsules; a 64-deep
     chain would be a degenerate tree) and is here purely to
-    prevent a malformed DB from infinitely looping the listen
+    prevent a malformed edge set from infinitely looping the listen
     server.
 
     A non-existent ``name`` returns the empty set (nothing has it
@@ -59,8 +67,6 @@ def descendants_of(
 
     Args:
         name: the agent whose descendants we want.
-        db_path: optional override for the state.db path; tests
-            pass a tmp file so the global DB stays clean.
         max_depth: BFS depth ceiling. Default 64 (= safety bound,
             never reached in practice).
 
@@ -69,42 +75,35 @@ def descendants_of(
     """
     if not name:
         return set()
-    from .state_db import open_db
 
+    from .state_db_lineage_store import read_edges
+
+    edges = read_edges()
     out: set[str] = set()
-    with open_db(db_path) as conn:
-        # BFS by levels so we hit max_depth as a real depth bound
-        # rather than a queue-size bound. ``frontier`` carries the
-        # current depth's nodes; we batch-query their children with
-        # an IN clause to avoid one round-trip per node.
-        frontier = {name}
-        depth = 0
-        while frontier and depth < max_depth:
-            placeholders = ",".join("?" * len(frontier))
-            rows = conn.execute(
-                f"SELECT child_name FROM lineage WHERE parent_name IN ({placeholders})",
-                tuple(frontier),
-            ).fetchall()
-            next_frontier: set[str] = set()
-            for r in rows:
-                child = str(r["child_name"])
-                if child in out:
-                    # Already seen — cycle guard (a hand-edited DB
-                    # could have it; record_lineage never produces
-                    # one but the listen server cannot trust the DB
-                    # blindly).
+    # BFS by levels so ``max_depth`` is a real DEPTH bound rather than a
+    # queue-size bound. ``frontier`` carries the current depth's nodes.
+    frontier = {name}
+    depth = 0
+    while frontier and depth < max_depth:
+        next_frontier: set[str] = set()
+        for parent in frontier:
+            for child in edges.children(parent):
+                if child in out or child == name:
+                    # Already seen — cycle guard. ``record_lineage`` never
+                    # produces one, but the listen server cannot trust the
+                    # edge set blindly, and ``child == name`` catches the
+                    # shortest cycle of all (a node reaching itself).
                     continue
                 out.add(child)
                 next_frontier.add(child)
-            frontier = next_frontier
-            depth += 1
+        frontier = next_frontier
+        depth += 1
     return out
 
 
 def ancestors_to_root(
     *,
     name: str,
-    db_path: Path | None = None,
     max_depth: int = 64,
 ) -> list[str]:
     """Return the lineage chain from ``name``'s parent up to the root.
@@ -118,14 +117,12 @@ def ancestors_to_root(
     parent — or an unknown ``name`` — returns ``[]``.
 
     Cycle guard: a ``seen`` set plus the ``max_depth`` ceiling bound the
-    walk so a hand-edited DB with a parent cycle (which
-    :func:`record_lineage` never produces) cannot loop the listen
-    server — same rationale as :func:`descendants_of`.
+    walk so a parent cycle (which
+    :func:`~.state_db_lineage_group.record_lineage` never produces) cannot
+    loop the listen server — same rationale as :func:`descendants_of`.
 
     Args:
         name: the agent whose ancestor chain we want (the pusher).
-        db_path: optional override for the state.db path; tests pass a
-            tmp file so the global DB stays clean.
         max_depth: walk depth ceiling. Default 64 (safety bound).
 
     Returns:
@@ -134,25 +131,24 @@ def ancestors_to_root(
     """
     if not name:
         return []
-    from .state_db import open_db
 
+    from .state_db_lineage_store import read_edges
+
+    edges = read_edges()
     chain: list[str] = []
     seen: set[str] = {name}
-    with open_db(db_path) as conn:
-        current = name
-        depth = 0
-        while depth < max_depth:
-            row = conn.execute(
-                "SELECT parent_name FROM lineage WHERE child_name = ?",
-                (current,),
-            ).fetchone()
-            if row is None:
-                break
-            parent = str(row["parent_name"])
-            if parent in seen:
-                break  # cycle guard (hand-edited DB; record_lineage never loops)
-            chain.append(parent)
-            seen.add(parent)
-            current = parent
-            depth += 1
+    current = name
+    depth = 0
+    while depth < max_depth:
+        parent = edges.parent(current)
+        if parent is None:
+            break
+        if parent in seen:
+            break  # cycle guard; record_lineage never loops
+        chain.append(parent)
+        seen.add(parent)
+        current = parent
+        depth += 1
     return chain
+
+# EOF

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -3,10 +3,15 @@
 Replaces the per-agent JSON files under
 ``~/.scitex/agent-container/runtime/registry/`` with a single ``state.db``.
 
-WHAT IT HOLDS TODAY IS THREE TABLES: ``instances`` (the F-CS11 registry)
-plus ``channel_events`` and ``lineage`` (WI-1 durability and the WI-2
-spawn DAG). :data:`KNOWN_TABLES` is the list, and it is the list every
-generic reader walks.
+WHAT IT HOLDS TODAY IS TWO TABLES: ``instances`` (the F-CS11 registry)
+plus ``channel_events`` (WI-1 durability). :data:`KNOWN_TABLES` is the
+list, and it is the list every generic reader walks.
+
+The WI-2 spawn DAG, ``lineage``, was the third until 2026-08-28. It moved
+to the shared PostgreSQL store (:mod:`.state_db_lineage_store`), which is
+the one departure from this file where an empty leftover would have been
+worse than a crash: every reader treats "no row for this child" as ROOT,
+and a root MAY SPAWN. See the departure note in :mod:`.state_db_schema`.
 
 The F-CS11 registry was ``definitions`` / ``instances`` / ``events``, with
 ``instance_heartbeats`` (the legacy ``heartbeats`` time series, tied to an
@@ -97,7 +102,22 @@ DEFAULT_DB_PATH = Path(
 KNOWN_TABLES = (
     "instances",
     "channel_events",
-    "lineage",
+    # ``lineage`` left on 2026-08-28, when the spawn DAG moved to the
+    # shared PostgreSQL store (:mod:`.state_db_lineage_store`). Its DDL is
+    # gone from :mod:`.state_db_schema`, which carries the departure note,
+    # and its ``export_state`` filter is gone from
+    # :mod:`.state_db_export` -- so keeping the name here would aim every
+    # generic reader (``table_counts`` behind ``sac db show``,
+    # ``export_state`` / ``import_state``, and the ``click.Choice`` for
+    # ``sac db query``) at a table that no longer exists.
+    #
+    # The empty-is-dangerous argument this tuple has been shedding names
+    # over is at its sharpest here, and it is worth naming once: an empty
+    # ``lineage`` does not read as "wrong database", it reads as "every
+    # agent is a ROOT" -- and a root may spawn. ``sac db show`` answering
+    # ``lineage 0`` while the store holds the fleet's 23 edges would be a
+    # wrong answer that looks like a right one about the table the whole
+    # ACL is derived from.
     # ``definitions``, ``instance_heartbeats`` and ``events`` left on
     # 2026-08-28, in one change, taking this tuple from six names to three.
     # Their DDL is gone from :mod:`.state_db_schema`, where each carries its

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -97,7 +97,13 @@ def _table_filter_clauses(
         # is given. A filter naming it would read as "sac still exports
         # this", which for this one table would have been a description of
         # a credential leak rather than of a stale sync.
-        "lineage": ("WHERE created_at >= ?", (since,)),
+        # ``lineage`` had a ``WHERE created_at >= ?`` entry here until
+        # 2026-08-28. The spawn DAG moved to the shared PostgreSQL store and
+        # left KNOWN_TABLES, so this mapping could never be selected again.
+        # Deleted rather than kept: on the shared store every host reads and
+        # writes ONE set of edges, so there is no longer a peer to ship them
+        # to -- an incremental filter here would describe a sync that has
+        # nothing left to converge.
         # ``comms_nodes`` had a ``WHERE updated_at >= ?`` entry here until
         # 2026-08-28 — the ADR-0014 anti-entropy filter, written so a
         # tombstoned row still shipped on the next pull until both sides

--- a/src/scitex_agent_container/_state/state_db_lineage_group.py
+++ b/src/scitex_agent_container/_state/state_db_lineage_group.py
@@ -1,0 +1,203 @@
+"""The lineage WRITER and the group it derives — on PostgreSQL.
+
+Extracted from :mod:`.state_db_nodes` on 2026-08-28, when ``lineage`` moved
+off SQLite and the store-shaped writer no longer fit under that module's
+line cap. It is the same split, for the same reason, that already gave
+:mod:`.state_db_lineage_rel` its own file: ``state_db_nodes`` is the import
+surface, not the implementation.
+
+The pair here is the whole default-ACL mechanism. :func:`record_lineage`
+writes ONE parent → child edge, at spawn time, from the two chokepoints
+every spawn funnels through (:mod:`.._lifecycle._spawn_gate` locally,
+:mod:`.._listen._agent_exec` for a brokered one). :func:`derive_group`
+turns those edges into "who may talk to whom by default". Everything else
+in the ACL reads one of the two.
+
+Re-exported from :mod:`.state_db_nodes`, so every existing
+``from ..._state.state_db_nodes import record_lineage`` keeps resolving.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from .state_db_acl_policy import read_comms_policy
+
+_logger = logging.getLogger(__name__)
+
+__all__ = ["derive_group", "record_lineage"]
+
+
+def record_lineage(
+    *,
+    child: str,
+    parent: str,
+) -> None:
+    """Record ``parent`` as ``child``'s parent (keep-first-parent).
+
+    Idempotent; a child's parent is set once and immutable. A DIFFERENT
+    parent KEEPS the existing one (logged, NEVER raised) so a restart by a
+    non-original-parent caller works in-place without re-parenting;
+    identity drift stays impossible. Permission is gated upstream by
+    ``check_spawn``.
+
+    ON POSTGRESQL SINCE 2026-08-28, AND THE CONTRACT SURVIVED THE MOVE
+    ==================================================================
+    ``parent_name`` is IMMUTABLE in the store, which is the same rule this
+    function has always enforced by hand — with one difference worth
+    stating, because getting it wrong would turn the loud case silent:
+    **IMMUTABLE keeps the first value and does NOT raise.** A differing
+    write comes back in ``PutResult.conflicts`` as a ``MergeConflict``
+    carrying ``kept`` / ``rejected`` / ``reason``. So the read-then-warn
+    branch below is not the whole story, and the result of the ``put`` IS
+    inspected rather than discarded: that is the path a concurrent writer
+    or a replicated peer op takes, and it is exactly the case a "keeps
+    first" contract exists to report.
+
+    Both values stay in the oplog either way, so the contradiction is
+    recoverable rather than merely logged.
+
+    ``db_path`` is GONE. It named a SQLite file; there is no file.
+    """
+    if not child or not parent:
+        raise ValueError("record_lineage: child and parent must be non-empty")
+
+    from scitex_dev.store import ANY_REVISION
+
+    from .state_db_lineage_store import ACTOR, run_with_reconnect
+
+    def _write(store: Any) -> None:
+        # ``include_hidden`` so a RETIRED edge is seen rather than written
+        # over blind. The rename flow hides a child's old identity; a later
+        # spawn reusing that name must not land a live-looking record on
+        # top of a withdrawn one without anybody noticing.
+        existing = store.get({"child_name": child}, include_hidden=True)
+        if existing is not None:
+            stored = str(existing.values["parent_name"])
+            if stored != parent:
+                _logger.warning(
+                    "record_lineage: child %r keeps parent %r "
+                    "(ignored re-parent to %r)",
+                    child,
+                    stored,
+                    parent,
+                )
+                return
+            if existing.hidden:
+                # Same parent, same child, previously retired: this name is
+                # genuinely back. Unhiding restores the edge WITH its
+                # history rather than writing a second one. Only ever done
+                # when the parent AGREES — resurrecting an edge whose
+                # parent is contradicted would be the silent privilege
+                # change the IMMUTABLE rule exists to prevent.
+                store.unhide(
+                    {"child_name": child},
+                    expected_revision=ANY_REVISION,
+                    actor=ACTOR,
+                )
+            return  # idempotent no-op
+        result = store.put(
+            {
+                "child_name": child,
+                "parent_name": parent,
+                "created_at": time.time(),
+            },
+            expected_revision=ANY_REVISION,
+            actor=ACTOR,
+        )
+        _log_lineage_conflicts(result, child=child, parent=parent)
+
+    run_with_reconnect(_write)
+
+
+def _log_lineage_conflicts(result: Any, *, child: str, parent: str) -> None:
+    """Report what an IMMUTABLE field refused, at the severity it deserves.
+
+    ``parent_name`` is the privilege-bearing one: a rejected value means two
+    writers disagree about who spawned ``child``, and the ACL derives group
+    membership from the answer. It gets a WARNING naming both values.
+
+    ``created_at`` losing is ordinary: it can only differ when two writers
+    raced on the same edge, and the winner is whichever got there first,
+    which is the correct historical answer. Logged at debug, so the record
+    exists without dressing a race up as a contradiction.
+    """
+    for conflict in getattr(result, "conflicts", ()):
+        if conflict.field == "parent_name":
+            _logger.warning(
+                "record_lineage: child %r keeps parent %r (store rejected %r "
+                "as a second, differing claim; both remain in the oplog)",
+                child,
+                conflict.kept,
+                conflict.rejected,
+            )
+        else:
+            _logger.debug(
+                "record_lineage: child %r kept %s=%r over %r (concurrent "
+                "write of the same edge; parent %r agreed)",
+                child,
+                conflict.field,
+                conflict.kept,
+                conflict.rejected,
+                parent,
+            )
+
+
+def derive_group(
+    *,
+    name: str,
+) -> set[str]:
+    """Return the set of nodes inside ``name``'s default-ACL group.
+
+    A *group* is a parent together with its direct children
+    (handoff §2). Concretely:
+
+    * If ``name`` is a parent (any edge with ``parent_name = name``):
+      group = {name} ∪ {its direct children}.
+    * If ``name`` is a child (an edge with ``child_name = name``):
+      group = {its parent} ∪ {parent's other children}.
+    * If ``name`` has no edges at all: group = {name} (singleton —
+      a fresh registration starts unattached).
+
+    The derivation is intentionally local — it never walks the full
+    lineage tree. That keeps the default-ACL semantics simple and
+    matches handoff §2: "the group is the unit of default ACL" (one
+    parent + its direct children, not the entire ancestry).
+
+    Phase-3 (ADR-0010 Step 2): if ``name``'s ``node_comms_policy`` row
+    sets ``lineage_group = 'solitary'``, the group is forced to
+    ``{name}`` and the lineage walk is skipped. That isolates a capsule
+    from its siblings AND its parent without depending on the lineage
+    table being empty — clew capsule children adopt this so a sibling
+    capsule can never address them through the group-default ACL even
+    though they share a parent edge.
+
+    THE SOLITARY SHORT-CIRCUIT STILL RETURNS BEFORE THE STORE IS TOUCHED,
+    and that is now load-bearing in a way it was not against SQLite. The
+    lineage import sits BELOW the branch on purpose: a solitary capsule
+    must resolve its own singleton group without a PostgreSQL round-trip,
+    so an unreachable primary cannot turn "isolated" into an exception on
+    a path that never needed an edge in the first place.
+    """
+    if not name:
+        raise ValueError("derive_group: name must be non-empty")
+    # Phase-3 solitary override — short-circuits to the singleton group
+    # without touching the lineage store. Keep the import below this line.
+    policy = read_comms_policy(name=name)
+    if policy["lineage_group"] == "solitary":
+        return {name}
+
+    from .state_db_lineage_store import read_edges
+
+    edges = read_edges()
+    children = edges.children(name)
+    if children:
+        return {name} | children
+    parent = edges.parent(name)
+    if parent is None:
+        return {name}
+    return {parent} | edges.children(parent)
+
+# EOF

--- a/src/scitex_agent_container/_state/state_db_lineage_rel.py
+++ b/src/scitex_agent_container/_state/state_db_lineage_rel.py
@@ -1,27 +1,23 @@
-"""``sender → target`` lineage classification — STILL ON SQLITE.
+"""``sender → target`` lineage classification — ON POSTGRESQL.
 
 Extracted from :mod:`.state_db_acl_policy` on 2026-08-28, when the policy
-table moved to PostgreSQL and this function did not.
+table moved to PostgreSQL and this function did not: it reads a DIFFERENT
+table, ``lineage``, which had its own migration ahead of it. That migration
+landed the same day, so the note this module used to carry — "STILL ON
+SQLITE ... it keeps ``db_path``, and keeps reading SQLite, until ``lineage``
+itself moves" — is now discharged rather than merely stale. ``db_path`` is
+gone; there is no file to point it at.
 
-IT DID NOT MOVE BECAUSE IT READS A DIFFERENT TABLE. ``lineage`` is owned
-by :mod:`.state_db_nodes` (``record_lineage`` / ``derive_group``) and has
-its own migration ahead of it. This function only ever lived beside the
-policy code because ``state_db_nodes`` was over the per-file line cap,
-and carrying its storage along as a side effect of the policy move would
-have been a second migration smuggled inside the first.
-
-So it keeps ``db_path``, and keeps reading SQLite, until ``lineage``
-itself moves. Its own file is what makes that visible: a reader looking
-for "what is left on SQLite here" finds a module, not a stray function at
-the bottom of a PostgreSQL one.
+The file stays, and it earns its keep for the reason it was split out in
+the first place: the classification is a distinct question from the policy
+that consumes it. :mod:`.state_db_acl_policy` answers "what is this agent
+allowed to do"; this answers "what IS this agent to that one".
 
 Re-exported from :mod:`.state_db_acl_policy` (and thence from
 :mod:`.state_db_nodes`) so every existing import path keeps working.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 __all__ = ["sender_target_relationship"]
 
@@ -30,37 +26,40 @@ def sender_target_relationship(
     *,
     sender: str,
     target: str,
-    db_path: Path | None = None,
 ) -> str:
     """Classify the ``sender → target`` lineage relationship.
 
     Returns one of:
 
     * ``"self"``    — same node (trivial self-send).
-    * ``"parent"``  — target is sender's parent in the lineage table.
+    * ``"parent"``  — target is sender's parent in the lineage store.
     * ``"child"``   — target is one of sender's direct children.
     * ``"sibling"`` — sender and target share the same parent.
     * ``"other"``   — no lineage path (cross-group or unrelated).
 
     Used by :func:`scitex_agent_container._listen._acl.check_send_acl`
     to apply the per-spec outbound/inbound policy on the right edge.
-    Pure read of the ``lineage`` table — no policy state consulted.
+    Pure read of the lineage store — no policy state consulted.
+
+    TWO POINT READS, NOT A SCAN. Every one of the five answers is decided
+    by the two parents alone: ``target`` being ``sender``'s parent, or
+    ``sender`` being ``target``'s, or the two agreeing. ``child_name`` is
+    the store's identity, so each is an indexed ``get`` — the same two
+    round-trips the SQLite version made, against a table that no longer has
+    to exist on this host to be readable.
+
+    ``"self"`` is answered BEFORE either read, so the commonest trivial
+    case never touches the store at all.
     """
     if not sender or not target:
         return "other"
     if sender == target:
         return "self"
-    from .state_db import open_db
 
-    with open_db(db_path) as conn:
-        sender_parent_row = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name = ?", (sender,)
-        ).fetchone()
-        target_parent_row = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name = ?", (target,)
-        ).fetchone()
-    sender_parent = str(sender_parent_row["parent_name"]) if sender_parent_row else None
-    target_parent = str(target_parent_row["parent_name"]) if target_parent_row else None
+    from .state_db_lineage_store import parent_name_of
+
+    sender_parent = parent_name_of(sender)
+    target_parent = parent_name_of(target)
     if sender_parent == target:
         return "parent"
     if target_parent == sender:
@@ -72,3 +71,5 @@ def sender_target_relationship(
     ):
         return "sibling"
     return "other"
+
+# EOF

--- a/src/scitex_agent_container/_state/state_db_lineage_rename.py
+++ b/src/scitex_agent_container/_state/state_db_lineage_rename.py
@@ -1,0 +1,137 @@
+"""Move an agent's lineage edge onto a new name — and refuse when it cannot.
+
+The lineage half of the agent-rename flow. It replaces two entries that
+:data:`.._lifecycle._rename_db.NAME_COLUMNS` carried until 2026-08-28,
+``("lineage", "child_name")`` and ``("lineage", "parent_name")``, which had
+been renamed by a SQLite ``UPDATE`` over a table that no longer exists.
+
+Leaving those pairs behind was not an option, and the reason is the one
+:mod:`.._lifecycle._rename_db` already states for ``comms_nodes`` and
+``node_comms_policy``: ``rename_rows`` SKIPS a table absent from
+``sqlite_master``, so a stale pair does not crash — it reports SUCCESS
+while the edge stays under the old name. For lineage that silence is a
+PRIVILEGE CHANGE in both directions:
+
+  * the renamed agent's own edge left behind makes the new name a ROOT,
+    and a root MAY SPAWN (:func:`.state_db_nodes.spawn_allowed`);
+  * its children's edges left behind make each of THEM a root too, on the
+    same reasoning, while ``check_lineage_acl`` stops recognising the
+    parent's authority over agents it actually spawned.
+
+THE HALF THAT MOVES, AND THE HALF THE SCHEMA WILL NOT LET MOVE
+==============================================================
+``child_name`` is the store's IDENTITY, so renaming it is not an update: it
+is one record ending and another beginning. :func:`rename_lineage` copies
+the stored values onto the new identity and RETIRES the old one — the
+:func:`.state_db_acl_policy.rename_comms_policy` precedent exactly.
+
+``parent_name`` is IMMUTABLE, and IMMUTABLE means the first value is kept
+FOREVER. Not "until a privileged writer overrides it": there is no
+override. ``hide`` and ``unhide`` append ops carrying no values, so a
+retired-and-restored record comes back with its field stamps intact, and
+the next ``put`` merges against them and loses. So an edge that names
+``old`` as the parent CANNOT be re-pointed at ``new``. This module does not
+pretend otherwise and does not paper over it:
+
+  * It REFUSES the rename, before touching anything, naming every child
+    whose edge it cannot move — :exc:`LineageRenameError`, which
+    :mod:`.._lifecycle._rename` lets propagate so the whole rename unwinds.
+  * It does NOT hide those edges instead. That "works" in the sense that
+    nothing is left pointing at a dead name, and it is the worst available
+    option: an agent with no edge is a ROOT, so hiding N children's edges
+    would hand N agents spawn authority as a side effect of renaming their
+    parent. Silent escalation is the failure this whole file exists to
+    prevent; doing it deliberately would be worse than doing it by
+    accident.
+
+The practical shape of the refusal: an agent that has never spawned
+anything renames exactly as before, and an agent that HAS spawned children
+cannot be renamed until those edges are dealt with by a human who knows
+what the DAG should say. That is a real restriction this migration
+introduces, stated here rather than discovered later.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["LineageRenameError", "rename_lineage"]
+
+
+class LineageRenameError(RuntimeError):
+    """A lineage edge could not follow the rename. NOTHING was changed.
+
+    Raised before any write, so the store is exactly as it was and the
+    caller's unwind has nothing to undo for this step.
+    """
+
+
+def rename_lineage(*, old: str, new: str) -> bool:
+    """Move ``old``'s own lineage edge onto ``new``. ``True`` iff one moved.
+
+    Two things happen, in this order, and the order is the safety property:
+
+    1. REFUSE FIRST. If any edge names ``old`` as a PARENT, raise
+       :exc:`LineageRenameError` naming those children. ``parent_name`` is
+       IMMUTABLE and cannot be re-pointed (see the module docstring), and
+       the alternatives — leaving them, or hiding them — both grant spawn
+       authority to agents that should not have it. Nothing is written.
+    2. MOVE THE CHILD-SIDE EDGE. If ``old`` is itself a child, copy its
+       ``parent_name`` and ``created_at`` verbatim onto the ``new``
+       identity and hide the ``old`` record. ``created_at`` is carried, NOT
+       re-stamped: the spawn happened when it happened, and the field is
+       IMMUTABLE, so a re-stamp would be both a lie and a conflict.
+
+    Idempotent in the useful sense: with nothing live under ``old`` it
+    returns ``False`` and writes nothing, so a re-run after a partial
+    rename does not clobber the record already sitting under ``new``.
+
+    The inverse is ``rename_lineage(old=new, new=old)``, which is what
+    :mod:`.._lifecycle._rename` pushes onto its undo stack.
+    """
+    if not old or not new or old == new:
+        return False
+
+    from scitex_dev.store import ANY_REVISION
+
+    from .state_db_lineage_store import ACTOR, run_with_reconnect
+
+    def _move(store: Any) -> bool:
+        orphaned = sorted(
+            str(row.values["child_name"])
+            for row in store.rows()
+            if str(row.values["parent_name"]) == old
+        )
+        if orphaned:
+            raise LineageRenameError(
+                f"cannot rename {old!r} to {new!r}: "
+                f"{len(orphaned)} lineage edge(s) name it as the PARENT "
+                f"({', '.join(orphaned)}), and ``parent_name`` is IMMUTABLE "
+                f"in the lineage store — the first value is kept forever, so "
+                f"those edges cannot be re-pointed. Leaving them would make "
+                f"each of those agents a ROOT (a root may spawn); hiding "
+                f"them would do the same. Nothing was changed. Resolve the "
+                f"DAG for those children first, or rename a leaf."
+            )
+
+        row = store.get({"child_name": old})
+        if row is None:
+            return False
+        moved = {
+            "child_name": new,
+            "parent_name": str(row.values["parent_name"]),
+            # Verbatim. The edge is a historical fact and the field is
+            # IMMUTABLE; re-stamping would rewrite when the spawn happened.
+            "created_at": float(row.values["created_at"]),
+        }
+        if store.is_hidden({"child_name": new}):
+            store.unhide(
+                {"child_name": new}, expected_revision=ANY_REVISION, actor=ACTOR
+            )
+        store.put(moved, expected_revision=ANY_REVISION, actor=ACTOR)
+        store.hide({"child_name": old}, expected_revision=ANY_REVISION, actor=ACTOR)
+        return True
+
+    return bool(run_with_reconnect(_move))
+
+# EOF

--- a/src/scitex_agent_container/_state/state_db_lineage_store.py
+++ b/src/scitex_agent_container/_state/state_db_lineage_store.py
@@ -1,0 +1,463 @@
+"""The ``lineage`` store — schema, connection, and the edge index.
+
+The spawn DAG: one record per CHILD, naming the parent that spawned it.
+ON POSTGRESQL SINCE 2026-08-28, opened field for field from the
+``sac_lineage`` schema :mod:`.._store_plugin` had declared for it since the
+classification was written.
+
+WHY THIS TABLE IS DIFFERENT FROM THE THREE THAT WENT BEFORE IT
+==============================================================
+``comms_grants`` was authorisation, ``node_comms_policy`` was policy, and
+``comms_nodes`` was routing. Each of those is READ by the ACL. ``lineage``
+is what the ACL is DERIVED FROM: :func:`..state_db_nodes.derive_group`
+turns these edges into the default-ACL group,
+:func:`.state_db_lineage_rel.sender_target_relationship` turns them into
+the self/parent/child/sibling classification every send is judged against,
+and :func:`._lineage.descendants_of` turns them into the manage-scope
+``check_lineage_acl`` gates agent CRUD with. An edge that cannot be read is
+not a degraded answer; it is a DIFFERENT ACL.
+
+That is also why the readers here are not best-effort. A store that
+answered "no edges" on an outage would make every agent a ROOT, and a root
+may spawn (:func:`..state_db_nodes.spawn_allowed`) — the outage would hand
+out spawn authority. ``host_store`` resolves ``SCITEX_STORE_DSN`` or the
+per-host PostgreSQL with NO SQLite fallback, so an unreachable primary
+raises ``StoreTargetError`` naming the DSN instead of resolving an empty
+local file and quietly promoting the whole fleet.
+
+``db_path`` IS GONE from every signature that took it. It named a SQLite
+file; there is no file. Test isolation comes from pointing
+``SCITEX_STORE_DSN`` at a throwaway schema (the ``pg_schema`` fixture),
+which is stronger than a temp path was because it exercises the real
+resolver.
+
+``parent_name`` IS IMMUTABLE, AND THAT IS THE CONFLICT POLICY ITSELF
+====================================================================
+:mod:`.._store_plugin` declares it so, and the declaration is implemented
+rather than revisited. A child has exactly one parent, ever. If two hosts
+claim different parents for one child, that is a real contradiction about
+the spawn DAG, and LAST_WRITER_WINS would silently rewrite the family tree
+— which, because the ACL derives group membership from it, is a silent
+PRIVILEGE CHANGE.
+
+MEASURED BEFORE THE CUTOVER, and it is not hypothetical: on 2026-08-28 the
+fleet's four state.db files held 23 edges between them and ONE child
+disagreed — ``scitex-cards`` recorded ``proj-scitex-hub`` as its parent on
+scitex-compute-03 and ``scitex-agent-container`` on scitex-compute-04.
+Exactly the contradiction this rule exists to surface.
+
+IMMUTABLE KEEPS THE FIRST VALUE AND DOES NOT RAISE. A later, differing
+write is reported in ``PutResult.conflicts`` as a ``MergeConflict``
+carrying ``kept`` / ``rejected`` / ``reason``, and both values stay in the
+oplog. That maps onto :func:`..state_db_nodes.record_lineage`'s
+keeps-first-and-logs contract exactly — but it maps onto it only if the
+caller READS the conflicts, which is why the writer there inspects the
+result rather than relying on an exception that never comes.
+
+MULTI_WRITER, NOT SINGLE_WRITER
+===============================
+A cross-host spawn is BROKERED, so the edge can legitimately be written by
+either end: the child's host through
+:func:`.._lifecycle._spawn_gate.check_spawn`, or the broker host through
+:mod:`.._listen._agent_exec`. A second writer must get the loud
+``MergeConflict`` that says WHAT the two disagree about, not an ownership
+rejection that says only that somebody else got there first.
+
+ONE HANDLE PER PROCESS
+======================
+Same judgement, and the same measurement, as
+:mod:`.state_db_comms_nodes_store`: ``psycopg.connect`` costs 10.707 ms
+against ``sqlite3.connect``'s 0.067 ms (159x, live primary, card
+``sqlite-out-per-call-connect-cost-20260828``), and these readers sit on
+the ACL path of EVERY message send and every agent-CRUD request. A per-call
+``Store`` would pay that connect on each one. See
+:func:`open_lineage_store` for the target-keyed invalidation and
+:func:`run_with_reconnect` for what happens when the connection dies under
+the cached handle.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Row, Store, StoreTarget
+
+__all__ = [
+    "ACTOR",
+    "CONNECT_TIMEOUT_ENV",
+    "LINEAGE_STORE",
+    "LineageEdges",
+    "lineage_edge_as_dict",
+    "lineage_schema",
+    "new_lineage_store",
+    "open_lineage_store",
+    "parent_name_of",
+    "read_edges",
+    "reset_lineage_store",
+    "run_with_reconnect",
+]
+
+#: Logical store name. Renders as four physical tables
+#: (``lineage_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+LINEAGE_STORE = "lineage"
+
+ACTOR = "scitex-agent-container"
+
+#: Operator override for the libpq connect timeout, in seconds.
+CONNECT_TIMEOUT_ENV = "SAC_LINEAGE_CONNECT_TIMEOUT_S"
+
+#: Seconds libpq may spend establishing a connection before giving up.
+#:
+#: NOT a tuning knob, for the same reason it is not one in
+#: :mod:`.state_db_comms_nodes_store`. These edges are read from
+#: ``check_send_acl`` and ``check_lineage_acl``, which the listen daemon
+#: calls while serving a request, so a connect with libpq's default (wait
+#: forever) turns a BLACKHOLED primary into a stalled handler: not a slow
+#: 403, no answer at all, for every request the daemon is serving. A
+#: dead-but-reachable host RSTs immediately and was never the danger; a host
+#: that swallows SYN is, and that is the ordinary shape of a machine losing
+#: power or a firewall rule landing.
+DEFAULT_CONNECT_TIMEOUT_S = 5
+
+
+def _connect_timeout_s() -> int:
+    """The configured connect timeout. Bad values fall back, loudly-ish."""
+    raw = os.environ.get(CONNECT_TIMEOUT_ENV, "")
+    if not raw.strip():
+        return DEFAULT_CONNECT_TIMEOUT_S
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return DEFAULT_CONNECT_TIMEOUT_S
+    # 0 means "wait forever" to libpq, which is the behaviour this constant
+    # exists to prevent; treat it as unset rather than honouring it.
+    return parsed if parsed > 0 else DEFAULT_CONNECT_TIMEOUT_S
+
+
+def _with_connect_timeout(target: Any) -> Any:
+    """Return ``target`` with a bounded ``connect_timeout`` in its DSN.
+
+    ``scitex_dev``'s Postgres dialect calls ``psycopg.connect(target.dsn)``
+    with no timeout argument, so the bound has to travel IN the DSN. libpq
+    reads ``connect_timeout`` from the URI query string, which is the form
+    both resolutions produce (the ``SCITEX_STORE_DSN`` override and the
+    per-host socket DSN).
+
+    An explicit ``connect_timeout`` already in the DSN is left ALONE: the
+    operator who wrote it outranks this default.
+
+    Non-Postgres targets pass through untouched.
+    """
+    from scitex_dev.store import Backend, StoreTarget
+
+    if target.backend is not Backend.POSTGRES:
+        return target
+    dsn = str(target.dsn)
+    if "connect_timeout" in dsn:
+        return target
+    separator = "&" if "?" in dsn else "?"
+    return StoreTarget.postgres(
+        f"{dsn}{separator}connect_timeout={_connect_timeout_s()}",
+        pkg=target.pkg,
+        name=target.name,
+    )
+
+
+def _is_connection_lost(exc: BaseException) -> bool:
+    """Is ``exc`` a DEAD CONNECTION rather than a rejected operation?
+
+    The distinction decides whether retrying can possibly help. A
+    ``RevisionMismatchError`` is a verdict about the DATA and means the same
+    thing on a fresh connection, so retrying it would only hide it.
+    ``psycopg.OperationalError`` / ``InterfaceError`` mean the socket is
+    gone, and every future call on that handle raises the same thing forever
+    — psycopg3 never reconnects, and neither does ``Store``.
+    """
+    try:
+        import psycopg
+    except ImportError:  # pragma: no cover - the Postgres path needs psycopg
+        return False
+    return isinstance(exc, (psycopg.OperationalError, psycopg.InterfaceError))
+
+
+def run_with_reconnect(operation: "Callable[[Store], Any]") -> Any:
+    """Run ``operation`` against the shared handle; reopen ONCE if it died.
+
+    The cache is keyed on the resolved target, which self-heals a changed
+    DSN and a failed CONNECT — neither of those leaves a handle behind. It
+    does NOT heal the case that actually happens: the connection dying UNDER
+    a cached handle. Verified against the live primary for the sibling
+    directory store by killing the backend with ``pg_terminate_backend``:
+    the cached handle then raised ``OperationalError: the connection is
+    closed`` on every subsequent call, forever, while a fresh connection
+    proved the server healthy. In the long-lived listen daemon that is one
+    PostgreSQL restart permanently breaking the ACL until every daemon is
+    restarted by hand.
+
+    RETRY ONCE, NOT IN A LOOP. A second failure is a real outage and must
+    reach the caller.
+
+    THE HONEST CAVEAT: a retry re-runs the operation. Every reader here is a
+    pure read, so re-running one is free. The one WRITER,
+    :func:`..state_db_nodes.record_lineage`, is a get-then-put that is
+    idempotent by construction — a re-run reads the row the first attempt
+    may have committed and returns without writing again.
+    """
+    try:
+        return operation(open_lineage_store())
+    except Exception as exc:
+        if not _is_connection_lost(exc):
+            raise
+        reset_lineage_store()
+        return operation(open_lineage_store())
+
+
+def lineage_schema() -> Any:
+    """The declared ``sac_lineage`` schema, as this module opens it.
+
+    Three fields, matching :data:`.._store_plugin.LINEAGE` field for field.
+    The store name is the bare table name — ``sac_`` is the plugin
+    namespace, not the store's, exactly as ``comms_nodes`` is opened under
+    its bare name while the plugin declares ``sac_comms_nodes``.
+    """
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
+
+    return Schema(
+        name=LINEAGE_STORE,
+        fields={
+            # The CHILD is the identity, exactly as the SQLite PRIMARY KEY
+            # treated it: a child has one parent, ever, so one record per
+            # child makes distinct edges distinct records and a union can
+            # drop none of them.
+            "child_name": FieldPolicy(
+                kind=FieldKind.TEXT,
+                role=FieldRole.IDENTITY,
+                required=True,
+                merge=MergeRule.IMMUTABLE,
+                indexed=True,
+            ),
+            # IMMUTABLE — see the module docstring. This is the conflict
+            # policy, not a timestamp preference: a differing second claim
+            # is a contradiction about the spawn DAG and the ACL derives
+            # group membership from it.
+            "parent_name": FieldPolicy(
+                kind=FieldKind.TEXT,
+                role=FieldRole.DATA,
+                required=True,
+                merge=MergeRule.IMMUTABLE,
+                indexed=True,
+            ),
+            # When the edge was FIRST recorded. IMMUTABLE for the ordinary
+            # reason a historical stamp is: the spawn happened once.
+            "created_at": FieldPolicy(
+                kind=FieldKind.REAL,
+                role=FieldRole.DATA,
+                required=True,
+                merge=MergeRule.IMMUTABLE,
+                indexed=False,
+            ),
+        },
+    )
+
+
+#: The process-wide handle and the target it was opened for. Guarded by
+#: ``_HANDLE_LOCK``; see :func:`open_lineage_store` for why it exists.
+_HANDLE_LOCK = threading.Lock()
+_HANDLE: "Store | None" = None
+_HANDLE_TARGET: "StoreTarget | None" = None
+
+
+def new_lineage_store() -> "Store":
+    """Construct a FRESH, caller-owned handle. RAISES if PostgreSQL is down.
+
+    For code that legitimately wants its own connection and will close it —
+    the one-shot data migration, chiefly. Ordinary readers and writers want
+    :func:`open_lineage_store` instead, which hands back the shared one.
+
+    Raising is the whole point, and here it is sharper than for the
+    directory: every reader of these edges treats "no parent" as ROOT, and a
+    root may spawn. A store that answered empty instead of raising would
+    turn a database outage into a fleet-wide grant of spawn authority.
+    """
+    from scitex_dev.store import Store, WriterPolicy, host_store
+
+    schema = lineage_schema()
+    return Store(
+        _with_connect_timeout(
+            host_store(pkg="scitex_agent_container", name=schema.name)
+        ),
+        schema,
+        node=socket.gethostname(),
+        # MULTI_WRITER as declared — a brokered spawn is legitimately
+        # written by either end; see the module docstring.
+        writer_policy=WriterPolicy.MULTI_WRITER,
+        actor=ACTOR,
+    )
+
+
+def open_lineage_store() -> "Store":
+    """The process's shared lineage store. DO NOT ``close()`` the result.
+
+    ONE HANDLE PER PROCESS, BECAUSE THIS IS THE ACL PATH
+    ====================================================
+    ``derive_group`` and ``sender_target_relationship`` run per MESSAGE
+    (``check_send_acl``), and ``descendants_of`` runs per agent-CRUD request
+    (``check_lineage_acl``). Paying a 10.7 ms connect on each is not a cost
+    the ACL can carry — see the module docstring for the measurement.
+
+    ``Store`` carries its own internal ``RLock`` and is built to be shared,
+    so one handle per process is the intended shape rather than a shortcut.
+
+    THE CACHE IS KEYED ON THE RESOLVED TARGET, NOT ON "have we opened one"
+    ---------------------------------------------------------------------
+    ``host_store`` re-resolves ``SCITEX_STORE_DSN`` on every call and is
+    cheap (an env read and a frozen dataclass — it does not connect), so the
+    key costs nothing and buys correctness: a changed DSN yields a different
+    ``StoreTarget``, which swaps the handle instead of silently serving the
+    previous database. That is not a hypothetical — the test suite's
+    ``pg_schema`` fixture points the variable at a fresh throwaway schema per
+    test, and a cache that ignored it would hand every test the first test's
+    store. :func:`reset_lineage_store` is the explicit hook for anything
+    that needs to drop the handle without changing the target.
+    """
+    global _HANDLE, _HANDLE_TARGET
+
+    from scitex_dev.store import host_store
+
+    target = _with_connect_timeout(
+        host_store(pkg="scitex_agent_container", name=LINEAGE_STORE)
+    )
+    with _HANDLE_LOCK:
+        if _HANDLE is not None and _HANDLE_TARGET == target:
+            return _HANDLE
+        _close_handle_locked()
+        handle = new_lineage_store()
+        _HANDLE, _HANDLE_TARGET = handle, target
+        return handle
+
+
+def reset_lineage_store() -> None:
+    """Drop the shared handle, closing it. Idempotent.
+
+    The reset hook for anything that changes where the store resolves to
+    WITHOUT changing ``SCITEX_STORE_DSN`` (a changed DSN invalidates the
+    cache on its own — see :func:`open_lineage_store`). Tests use it in a
+    real fixture teardown; the ecosystem bans ``monkeypatch``, so the hook
+    is a plain function rather than an attribute anyone reaches in and
+    rewrites.
+    """
+    with _HANDLE_LOCK:
+        _close_handle_locked()
+
+
+def _close_handle_locked() -> None:
+    """Drop the cached handle. Caller MUST hold ``_HANDLE_LOCK``.
+
+    The reference is cleared BEFORE the close, so a connection that raises on
+    close cannot leave a dead handle cached — which would make every later
+    call fail on a store nothing can replace.
+    """
+    global _HANDLE, _HANDLE_TARGET
+
+    handle, _HANDLE, _HANDLE_TARGET = _HANDLE, None, None
+    if handle is None:
+        return
+    try:
+        handle.close()
+    except Exception:  # stx-allow: fallback (reason: the handle is already dropped; a server that vanished makes close() raise, and failing here would turn a successful re-open into an error)
+        pass
+
+
+def lineage_edge_as_dict(row: "Row") -> dict[str, Any]:
+    """One stored edge in the shape the SQLite row had.
+
+    The three columns the table declared, and nothing derived: unlike the
+    directory, this table never carried a hand-rolled ``updated_at`` or
+    ``source_host`` for the primitive to replace.
+    """
+    values = row.values
+    return {
+        "child_name": str(values["child_name"]),
+        "parent_name": str(values["parent_name"]),
+        "created_at": float(values["created_at"]),
+    }
+
+
+@dataclass(frozen=True)
+class LineageEdges:
+    """The whole spawn DAG, indexed both ways, from ONE store read.
+
+    WHY AN INDEX RATHER THAN A QUERY PER QUESTION. ``Store`` exposes
+    ``get`` (by identity) and ``rows`` (everything) and no query-by-field
+    verb, so "who are X's children" cannot be pushed to the server the way
+    ``WHERE parent_name = ?`` was. Reading the table once and indexing it in
+    Python is not a workaround for that: it is FEWER round-trips than the
+    SQLite version made. ``derive_group`` issued up to three statements,
+    ``sender_target_relationship`` two, and ``descendants_of`` one PER BFS
+    LEVEL; each is now one read.
+
+    The table is small by construction — one row per agent that has ever
+    been spawned by another agent, 23 across the whole fleet when it was
+    measured on 2026-08-28 — and it is bounded by the number of agents, not
+    by traffic. If that ever stops being true the fix is a query verb on the
+    primitive, not a cache here.
+    """
+
+    #: child → parent. The edge, exactly as stored.
+    parent_of: dict[str, str]
+    #: parent → its direct children. Derived from :attr:`parent_of`.
+    children_of: dict[str, set[str]]
+
+    def children(self, name: str) -> set[str]:
+        """``name``'s direct children; empty for a leaf or an unknown name."""
+        return set(self.children_of.get(name, ()))
+
+    def parent(self, name: str) -> "str | None":
+        """``name``'s parent, or ``None`` for a root or an unknown name."""
+        return self.parent_of.get(name)
+
+
+def read_edges() -> LineageEdges:
+    """Every live edge, indexed both ways. One round-trip.
+
+    Hidden records are EXCLUDED. Nothing hides a lineage edge in normal
+    operation — the spawn DAG is append-only — but the rename flow retires a
+    child's old identity by hiding it, and a hidden edge must not keep
+    conferring group membership on a name that no longer exists.
+    """
+    rows = run_with_reconnect(lambda store: store.rows())
+    parent_of: dict[str, str] = {}
+    children_of: dict[str, set[str]] = {}
+    for row in rows:
+        values = row.values
+        child = str(values["child_name"])
+        parent = str(values["parent_name"])
+        parent_of[child] = parent
+        children_of.setdefault(parent, set()).add(child)
+    return LineageEdges(parent_of=parent_of, children_of=children_of)
+
+
+def parent_name_of(name: str) -> "str | None":
+    """``name``'s parent, by IDENTITY lookup. ``None`` for a root.
+
+    The single-question form of :meth:`LineageEdges.parent`, and the one to
+    use when the parent is the ONLY thing wanted: ``child_name`` is the
+    identity, so this is an indexed point read rather than a table scan.
+    ``spawn_allowed`` and ``sender_target_relationship`` ask exactly this
+    and nothing else.
+
+    A HIDDEN edge reads as ``None`` — deliberately, and it is the reason
+    this does not pass ``include_hidden``. A retired edge must not keep
+    conferring the child status that a live one does.
+    """
+    if not name:
+        return None
+    row = run_with_reconnect(lambda store: store.get({"child_name": name}))
+    return None if row is None else str(row.values["parent_name"])
+
+# EOF

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -52,8 +52,6 @@ All times stored as ``REAL`` unix-seconds (float).
 
 from __future__ import annotations
 
-import logging
-import time
 from pathlib import Path
 from typing import Any
 
@@ -65,7 +63,6 @@ from .state_db_acl_policy import (
     record_comms_policy,
     sender_target_relationship,
 )
-_logger = logging.getLogger(__name__)
 
 __all__ = [
     "CommsNodeConflictError",
@@ -104,107 +101,19 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-def record_lineage(
-    *,
-    child: str,
-    parent: str,
-    db_path: Path | None = None,
-) -> None:
-    """Record ``parent`` as ``child``'s parent (keep-first-parent).
-
-    Idempotent; a child's parent is set once and immutable. A DIFFERENT
-    parent KEEPS the existing one (logged, not raised) so a restart by a
-    non-original-parent caller works in-place without re-parenting;
-    identity drift stays impossible. Permission is gated upstream by
-    ``check_spawn``.
-    """
-    if not child or not parent:
-        raise ValueError("record_lineage: child and parent must be non-empty")
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        existing = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name = ?", (child,)
-        ).fetchone()
-        if existing is not None:
-            if existing["parent_name"] == parent:
-                return  # idempotent no-op
-            _logger.warning(
-                "record_lineage: child %r keeps parent %r (ignored re-parent to %r)",
-                child,
-                existing["parent_name"],
-                parent,
-            )
-            return
-        conn.execute(
-            "INSERT INTO lineage (child_name, parent_name, created_at) "
-            "VALUES (?, ?, ?)",
-            (child, parent, time.time()),
-        )
-
-
-def derive_group(
-    *,
-    name: str,
-    db_path: Path | None = None,
-) -> set[str]:
-    """Return the set of nodes inside ``name``'s default-ACL group.
-
-    A *group* is a parent together with its direct children
-    (handoff §2). Concretely:
-
-    * If ``name`` is a parent (any rows in ``lineage`` with
-      ``parent_name = name``): group = {name} ∪ {its direct children}.
-    * If ``name`` is a child (row in ``lineage`` with
-      ``child_name = name``): group = {its parent} ∪ {parent's other
-      children}.
-    * If ``name`` has no edges at all: group = {name} (singleton —
-      a fresh registration starts unattached).
-
-    The derivation is intentionally local — it never walks the full
-    lineage tree. That keeps the default-ACL semantics simple and
-    matches handoff §2: "the group is the unit of default ACL" (one
-    parent + its direct children, not the entire ancestry).
-
-    Phase-3 (ADR-0010 Step 2): if ``name``'s ``node_comms_policy`` row
-    sets ``lineage_group = 'solitary'``, the group is forced to
-    ``{name}`` and the lineage-table walk is skipped. That isolates a
-    capsule from its siblings AND its parent without depending on the
-    lineage table being empty — clew capsule children adopt this so a
-    sibling capsule can never address them through the group-default
-    ACL even though they share a parent edge.
-    """
-    if not name:
-        raise ValueError("derive_group: name must be non-empty")
-    # Phase-3 solitary override — short-circuits to the singleton group
-    # without touching the lineage table.
-    policy = read_comms_policy(name=name)
-    if policy["lineage_group"] == "solitary":
-        return {name}
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        children_rows = conn.execute(
-            "SELECT child_name FROM lineage WHERE parent_name = ?", (name,)
-        ).fetchall()
-        if children_rows:
-            group: set[str] = {name}
-            for r in children_rows:
-                group.add(str(r["child_name"]))
-            return group
-        parent_row = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name = ?", (name,)
-        ).fetchone()
-        if parent_row is None:
-            return {name}
-        parent = str(parent_row["parent_name"])
-        sibling_rows = conn.execute(
-            "SELECT child_name FROM lineage WHERE parent_name = ?", (parent,)
-        ).fetchall()
-        group = {parent}
-        for r in sibling_rows:
-            group.add(str(r["child_name"]))
-        return group
+# ``record_lineage`` (the WRITER) and ``derive_group`` (the reader that
+# turns edges into the default-ACL unit) moved into
+# :mod:`.state_db_lineage_group` on 2026-08-28, when ``lineage`` left
+# SQLite. The store-shaped writer — a get, a conditional unhide, a put
+# whose ``PutResult.conflicts`` must be inspected because IMMUTABLE keeps
+# the first value WITHOUT raising — does not fit under this module's line
+# cap beside everything else it carries. Same split, same reason, as
+# :mod:`.state_db_lineage_rel`. Re-exported here so every existing
+# ``from ..._state.state_db_nodes import record_lineage`` keeps resolving.
+from .state_db_lineage_group import (  # noqa: E402
+    derive_group,
+    record_lineage,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -249,9 +158,11 @@ from .state_db_groups import (  # noqa: E402
 def spawn_allowed(
     *,
     caller: str | None,
-    db_path: Path | None = None,
 ) -> tuple[bool, str | None]:
     """Decide whether ``caller`` is allowed to call ``sac agents start``.
+
+    ``db_path`` is GONE (2026-08-28): the parent lookup this makes is a
+    read of the shared PostgreSQL lineage store, not of a SQLite file.
 
     Current policy (handoff §4 / WI-2, relaxed per operator ruling
     2026-07-05): a *root* node (no parent) is allowed to spawn.
@@ -301,15 +212,14 @@ def spawn_allowed(
         or is_privileged(name=caller)
     ):
         return apply_may_spawn_gate(caller=caller, base=(True, None))
-    from .state_db import open_db
+    # One indexed point read: ``child_name`` is the store's identity, so
+    # "who is my parent" is a ``get``, not a scan.
+    from .state_db_lineage_store import parent_name_of
 
-    with open_db(db_path) as conn:
-        parent_row = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name = ?", (caller,)
-        ).fetchone()
-    if parent_row is None:
+    parent = parent_name_of(caller)
+    if parent is None:
         return apply_may_spawn_gate(caller=caller, base=(True, None))
-    return (False, _spawn_denied_reason(caller, parent_row["parent_name"]))
+    return (False, _spawn_denied_reason(caller, parent))
 
 
 def _spawn_denied_reason(caller: str, parent: str) -> str:

--- a/src/scitex_agent_container/_state/state_db_schema.py
+++ b/src/scitex_agent_container/_state/state_db_schema.py
@@ -19,9 +19,11 @@ anywhere; it simply never had a writer. Same day again, and for the same
 kind of reason rather than a move: ``definitions``, ``instance_heartbeats``
 and ``events`` — see the three departure notes inside the registry block.
 
-WHAT IS STILL HERE, after all of that: ``instances`` and the WI-1 / WI-2
-pair ``channel_events`` + ``lineage``. Three tables, and every one of them
-has a live writer AND a live reader.
+WHAT IS STILL HERE, after all of that: ``instances`` and the WI-1
+durability table ``channel_events``. The WI-2 spawn DAG ``lineage`` was
+the third until 2026-08-28, when it left for the shared PostgreSQL store
+— see its departure note below. Two tables, and each of them has a live
+writer AND a live reader.
 """
 
 from __future__ import annotations
@@ -246,12 +248,25 @@ CREATE INDEX IF NOT EXISTS idx_channel_events_target_id
 -- included, and the MCP ``db_export`` tool exposes no ``tables``
 -- parameter with which to hold it back.
 
-CREATE TABLE IF NOT EXISTS lineage (
-    child_name   TEXT PRIMARY KEY,
-    parent_name  TEXT NOT NULL,
-    created_at   REAL NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_lineage_parent ON lineage(parent_name);
+-- ``lineage`` (and ``idx_lineage_parent``) was defined here until
+-- 2026-08-28. The spawn DAG moved to PostgreSQL via scitex_dev.store; its
+-- schema is created on first open by
+-- ``state_db_lineage_store.open_lineage_store``, so there is nothing to
+-- create here.
+--
+-- REMOVED rather than left behind, and of the five tables that have left
+-- this file this is the one where an empty leftover would have been
+-- ACTIVELY DANGEROUS rather than merely wrong. Every reader of these edges
+-- treats "no row for this child" as ROOT — and a root MAY SPAWN
+-- (``spawn_allowed``). A CREATE TABLE with no writer therefore would not
+-- have degraded the ACL, it would have INVERTED it: an empty table hands
+-- every agent in the fleet the spawn authority the gate exists to
+-- withhold, silently, with nothing logged and nothing 403ing. The same
+-- emptiness also collapses ``derive_group`` to a singleton (isolating
+-- agents that should mesh) and ``descendants_of`` to nothing (so
+-- ``check_lineage_acl`` denies a parent authority over its own child).
+-- No table at all is the honest answer: the reader raises rather than
+-- answering "no parent" from the wrong database.
 
 -- The ADR-0014 comms graph ``comms_nodes`` (and its ``host`` index) was
 -- defined here until 2026-08-28. It moved to PostgreSQL via

--- a/src/scitex_agent_container/_store_plugin.py
+++ b/src/scitex_agent_container/_store_plugin.py
@@ -186,6 +186,10 @@ COMMS_NODES = Schema.build(
 # ---------------------------------------------------------------------------
 # HISTORY — append-only; merging must never lose a branch.
 # ---------------------------------------------------------------------------
+# The spawn DAG. LIVE ON POSTGRESQL SINCE 2026-08-28, opened field for
+# field by ``_state.state_db_lineage_store``; what follows describes a
+# schema the fleet is running, not one it is planning.
+#
 # One record per CHILD (a child has exactly one parent, ever), so distinct
 # edges are distinct records and a union can drop none of them. The
 # load-bearing choice is IMMUTABLE on ``parent_name``: if two hosts claim
@@ -195,10 +199,24 @@ COMMS_NODES = Schema.build(
 # ACL derives group membership from it (check_lineage_acl), so a silent
 # rewrite is a silent privilege change.
 #
+# THE CONTRADICTION WAS MEASURED BEFORE THE CUTOVER, and it was real: the
+# fleet's four state.db files held 23 edges between them and one child
+# disagreed — ``scitex-cards`` recorded ``proj-scitex-hub`` as its parent
+# on scitex-compute-03 and ``scitex-agent-container`` on scitex-compute-04.
+# The migration refuses to pick a winner (it reports and exits non-zero);
+# this rule is what keeps a later write from picking one silently.
+#
 # MULTI_WRITER, not SINGLE_WRITER: a cross-host spawn is brokered, so the
 # edge can legitimately be written by either end, and a second writer must
 # get the loud MergeConflict rather than an ownership rejection that says
 # nothing about WHY the two disagree.
+#
+# IMMUTABLE KEEPS THE FIRST VALUE AND DOES NOT RAISE. The rejected value
+# comes back in ``PutResult.conflicts``, so ``record_lineage`` INSPECTS the
+# result rather than waiting for an exception that never arrives. The same
+# property is why an edge can never be re-pointed once written, which is
+# what makes ``rename_lineage`` refuse to rename an agent that has
+# children instead of pretending it moved their edges.
 LINEAGE = Schema.build(
     "sac_lineage",
     {
@@ -371,6 +389,9 @@ CLASSIFIED: dict[str, tuple[Schema, Truth, WriterPolicy]] = {
         Truth.FLEET,
         WriterPolicy.MULTI_WRITER,
     ),
+    # LIVE since 2026-08-28. HISTORY + MULTI_WRITER both survived the
+    # move unchanged: the edges are append-only, and a brokered spawn is
+    # legitimately written by either end.
     "sac_lineage": (LINEAGE, Truth.HISTORY, WriterPolicy.MULTI_WRITER),
     "sac_instances": (INSTANCES, Truth.PER_HOST, WriterPolicy.SINGLE_WRITER),
     "sac_incarnations": (INCARNATIONS, Truth.PER_HOST, WriterPolicy.SINGLE_WRITER),

--- a/tests/scitex_agent_container/_lifecycle/test__ci_deliver.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_deliver.py
@@ -34,7 +34,7 @@ def _seams(
     seams = dict(
         post=lambda name, text: posts.append(name),
         owner_resolver=lambda repo, **kw: owner,
-        ancestors=lambda *, name, db_path=None: list(ancestors),
+        ancestors=lambda *, name: list(ancestors),
         already_delivered=lambda **kw: already,
         failure_streak=lambda **kw: streak,
         failing_checks=lambda repo, pr: list(checks),
@@ -102,7 +102,7 @@ def test_one_post_failure_does_not_abort_remaining_targets():
     seams = dict(
         post=flaky_post,
         owner_resolver=lambda repo, **kw: "proj-x",
-        ancestors=lambda *, name, db_path=None: ["lead"],
+        ancestors=lambda *, name: ["lead"],
         already_delivered=lambda **kw: False,
         record=lambda **kw: None,
     )
@@ -118,7 +118,7 @@ def test_delivered_message_names_repo_pr_and_conclusion():
     seams = dict(
         post=lambda name, text: captured.append(text),
         owner_resolver=lambda repo, **kw: "proj-x",
-        ancestors=lambda *, name, db_path=None: [],
+        ancestors=lambda *, name: [],
         already_delivered=lambda **kw: False,
         failure_streak=lambda **kw: 0,
         record=lambda **kw: None,

--- a/tests/scitex_agent_container/_lifecycle/test__rename_db.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_db.py
@@ -44,11 +44,10 @@ _SEED = [
     # An ``INSERT INTO comms_nodes`` row was here until 2026-08-28. The
     # ADR-0014 directory moved to PostgreSQL, so SQLite has no such table and
     # the seed would raise on every test in this file.
-    (
-        "INSERT INTO lineage (child_name, parent_name, created_at) "
-        "VALUES (?, ?, ?)",
-        ("child-a", OLD, 1.0),
-    ),
+    # An ``INSERT INTO lineage`` row was here until 2026-08-28. The spawn
+    # DAG moved to PostgreSQL, so SQLite has no such table and the seed
+    # would raise on every test in this file — the same reason the
+    # ``comms_nodes`` seed above went.
     # The history half. It was ``INSERT INTO turns`` until 2026-08-28, when
     # the diary trio left SQLite for per-host PostgreSQL; then ``INSERT INTO
     # attempts`` for the rest of that day, until ``attempts`` was deleted for
@@ -168,13 +167,21 @@ def test_count_rows_is_empty_when_the_db_does_not_exist(tmp_path: Path):
 # as its own ``acl-policy`` step, with its inverse on the undo stack.
 
 
-def test_rename_moves_the_lineage_parent_edge(seeded: Path):
-    # Arrange
-    sql = "SELECT parent_name FROM lineage WHERE child_name = 'child-a'"
-    # Act
-    rename_rows(seeded, OLD, NEW)
-    # Assert
-    assert _one(seeded, sql) == NEW
+# ``test_rename_moves_the_lineage_parent_edge`` was here until 2026-08-28.
+# ``rename_rows`` no longer touches lineage at all: the spawn DAG moved to
+# the shared PostgreSQL store, and the two ``NAME_COLUMNS`` pairs that drove
+# this assertion were removed with it.
+#
+# The behaviour did NOT simply move to another file unchanged, and that is
+# worth stating here rather than leaving a reader to discover it. The
+# replacement, ``state_db_lineage_rename.rename_lineage`` (covered by
+# ``_state/test_state_db_lineage_rename.py``, and run by ``_rename.apply_plan``
+# as its own ``lineage`` step with an inverse on the undo stack), can move an
+# agent's OWN edge but REFUSES to rename an agent that has children:
+# ``parent_name`` is IMMUTABLE in the store, so the edges asserted on here —
+# ``child-a``'s pointer at the renamed agent — are precisely the ones that
+# cannot be re-pointed. This test asserted a capability the new storage does
+# not have, so porting it would have meant asserting something false.
 
 
 def test_rename_moves_the_history_rows(seeded: Path):

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
@@ -166,7 +166,7 @@ def test_gate_lineage_record_is_idempotent_on_same_parent(pg_schema: str, db_pat
 
 def test_gate_denies_child_caller_under_root_only_policy(pg_schema: str, db_path, sac_name) -> None:
     # Arrange — "worker-a" is a child of "root" → not a root → may not spawn.
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     sac_name("worker-a")
     # Act
     ctx = pytest.raises(SpawnDeniedError)
@@ -180,7 +180,7 @@ def test_gate_allows_restart_keeps_existing_parent(pg_schema: str, db_path, sac_
     # different-lineage caller must SUCCEED in-place (no re-parent, no
     # SpawnDeniedError) — the 409 the ACL previously raised is now gone,
     # so a developer/research peer can restart a down agent.
-    record_lineage(child="child-f", parent="root-1", db_path=db_path)
+    record_lineage(child="child-f", parent="root-1")
     sac_name("root-2")
     # Act — must not raise; record_lineage keeps the existing parent
     result = enforce_spawn_gate("child-f")

--- a/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
@@ -209,11 +209,12 @@ def test_admin_start_records_no_lineage_edge(
 
 
 def test_mcp_tool_spawn_is_denied_for_child_caller(
+    pg_schema: str,
     isolated_state, sac_name, tmp_path
 ) -> None:
     # Arrange — the MCP tool runs through the real CLI; a child caller
     # ("worker-a", parented to "root") must be rejected by check_spawn.
-    record_lineage(child="worker-a", parent="root", db_path=isolated_state)
+    record_lineage(child="worker-a", parent="root")
     sac_name("worker-a")
     yaml_root = tmp_path / "yaml"
     _write_spec(yaml_root, "denied-child")
@@ -242,11 +243,12 @@ def test_mcp_tool_spawn_is_denied_for_child_caller(
 
 
 def test_mcp_tool_spawn_deny_does_not_launch_child(
+    pg_schema: str,
     isolated_state, sac_name, tmp_path
 ) -> None:
     # Arrange — same denied child; assert no live instance row was created
     # (the gate fired BEFORE any runtime/instance bookkeeping).
-    record_lineage(child="worker-b", parent="root", db_path=isolated_state)
+    record_lineage(child="worker-b", parent="root")
     sac_name("worker-b")
     yaml_root = tmp_path / "yaml"
     _write_spec(yaml_root, "never-launched")

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -77,7 +77,6 @@ def test_acl_allows_self_send(db_path: Path) -> None:
     decision, _reason = check_send_acl(
         claimed_from_agent=sender,
         target="alice",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -85,12 +84,11 @@ def test_acl_allows_self_send(db_path: Path) -> None:
 
 def test_acl_allows_intra_group_parent_to_child(db_path: Path, pg_schema: str) -> None:
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     # Act
     decision, _reason = check_send_acl(
         claimed_from_agent="root",
         target="worker-a",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -99,13 +97,12 @@ def test_acl_allows_intra_group_parent_to_child(db_path: Path, pg_schema: str) -
 def test_acl_allows_intra_group_sibling_to_sibling(db_path: Path, pg_schema: str) -> None:
     """Handoff §4: 'parent↔child *and* sibling↔sibling, bidirectional'."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
+    record_lineage(child="worker-b", parent="root")
     # Act
     decision, _reason = check_send_acl(
         claimed_from_agent="worker-a",
         target="worker-b",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -115,13 +112,12 @@ def test_acl_allows_cross_group_by_default(db_path: Path, pg_schema: str) -> Non
     """Messaging default-allow (operator 2026-07-03): two unrelated
     lineage families, no grant → ALLOW."""
     # Arrange — two unrelated families
-    record_lineage(child="child-1", parent="root-1", db_path=db_path)
-    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    record_lineage(child="child-1", parent="root-1")
+    record_lineage(child="child-2", parent="root-2")
     # Act
     decision, _reason = check_send_acl(
         claimed_from_agent="child-1",
         target="child-2",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -131,14 +127,13 @@ def test_acl_blocked_sender_is_blocked(db_path: Path, pg_schema: str) -> None:
     """Override preserved: an explicit block still yields a "block"
     decision even under the cross-group default-allow."""
     # Arrange — two unrelated families + an explicit block
-    record_lineage(child="child-1", parent="root-1", db_path=db_path)
-    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    record_lineage(child="child-1", parent="root-1")
+    record_lineage(child="child-2", parent="root-2")
     block_send(sender="child-1", target="child-2")
     # Act
     decision, _reason = check_send_acl(
         claimed_from_agent="child-1",
         target="child-2",
-        db_path=db_path,
     )
     # Assert
     assert decision == "block"
@@ -147,14 +142,13 @@ def test_acl_blocked_sender_is_blocked(db_path: Path, pg_schema: str) -> None:
 def test_acl_allows_cross_group_with_explicit_grant(db_path: Path, pg_schema: str) -> None:
     """Explicit cross-group grant flips a deny to allow."""
     # Arrange — two unrelated families + grant child-1 → child-2
-    record_lineage(child="child-1", parent="root-1", db_path=db_path)
-    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    record_lineage(child="child-1", parent="root-1")
+    record_lineage(child="child-2", parent="root-2")
     grant_send(sender="child-1", target="child-2")
     # Act
     decision, _reason = check_send_acl(
         claimed_from_agent="child-1",
         target="child-2",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -180,12 +174,11 @@ def test_acl_admin_caller_honors_claimed_from_agent(db_path: Path, pg_schema: st
     (cross-host forwarder). The metadata claim is honoured verbatim.
     """
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     # Act — the admin caller (host-wide bearer) speaks for root
     decision, _reason = check_send_acl(
         claimed_from_agent="root",
         target="worker-a",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -200,7 +193,6 @@ def test_acl_denies_when_no_identity_at_all(db_path: Path) -> None:
     decision, _reason = check_send_acl(
         claimed_from_agent=None,
         target="anyone",
-        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -213,7 +205,6 @@ def test_acl_denies_when_target_missing(db_path: Path) -> None:
     decision, _reason = check_send_acl(
         claimed_from_agent=sender,
         target="",
-        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -229,7 +220,7 @@ def test_spawn_allows_root_caller(pg_schema: str, db_path: Path) -> None:
     # Arrange
     caller = "root"
     # Act
-    decision, _reason = check_spawn(caller=caller, db_path=db_path)
+    decision, _reason = check_spawn(caller=caller)
     # Assert
     assert decision == "allow"
 
@@ -239,7 +230,7 @@ def test_spawn_allows_admin_caller_when_caller_is_none(db_path: Path) -> None:
     # Arrange
     caller = None
     # Act
-    decision, _reason = check_spawn(caller=caller, db_path=db_path)
+    decision, _reason = check_spawn(caller=caller)
     # Assert
     assert decision == "allow"
 
@@ -247,9 +238,9 @@ def test_spawn_allows_admin_caller_when_caller_is_none(db_path: Path) -> None:
 def test_spawn_denies_child_caller(pg_schema: str, db_path: Path) -> None:
     """A node with a parent (child) is NOT allowed to spawn."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     # Act
-    decision, _reason = check_spawn(caller="worker-a", db_path=db_path)
+    decision, _reason = check_spawn(caller="worker-a")
     # Assert
     assert decision == "deny"
 
@@ -262,9 +253,9 @@ def test_spawn_deny_reason_explains_root_only_policy(pg_schema: str, db_path: Pa
     the same server's own a2a_peers output (2026-08-10).
     """
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     # Act
-    _decision, reason = check_spawn(caller="worker-a", db_path=db_path)
+    _decision, reason = check_spawn(caller="worker-a")
     # Assert
     assert reason is not None and "developer, researcher, privileged" in reason
 
@@ -320,8 +311,8 @@ def test_http_node_message_send_allows_cross_group_by_default(
     """End-to-end: messaging default-allow — a cross-group sender (two
     unrelated lineage families) now lands (< 400)."""
     # Arrange
-    record_lineage(child="child-1", parent="root-1", db_path=db_path)
-    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    record_lineage(child="child-1", parent="root-1")
+    record_lineage(child="child-2", parent="root-2")
     app = create_app(token=TOKEN)
     # Act
     with TestClient(app) as client:
@@ -340,8 +331,8 @@ def test_http_node_message_send_403_body_carries_per_spec_reason(
     """A per-spec ``inbound.siblings=deny`` override still 403s and the
     body explains the denial (the deny path survives default-allow)."""
     # Arrange — siblings so the per-spec inbound-sibling deny applies.
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
+    record_lineage(child="worker-b", parent="root")
     record_comms_policy(name="worker-b", inbound_siblings="deny")
     app = create_app(token=TOKEN)
     # Act
@@ -361,8 +352,8 @@ def test_http_node_message_send_allows_intra_group(
 ) -> None:
     """Intra-group send (sibling-to-sibling) lands."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
+    record_lineage(child="worker-b", parent="root")
     app = create_app(token=TOKEN)
     # Act
     with TestClient(app) as client:
@@ -380,8 +371,8 @@ def test_http_node_message_send_allows_after_explicit_grant(
 ) -> None:
     """A cross-group grant flips the deny to an allow."""
     # Arrange
-    record_lineage(child="child-1", parent="root-1", db_path=db_path)
-    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    record_lineage(child="child-1", parent="root-1")
+    record_lineage(child="child-2", parent="root-2")
     grant_send(sender="child-1", target="child-2")
     app = create_app(token=TOKEN)
     # Act
@@ -415,8 +406,8 @@ def test_http_host_bearer_with_from_agent_lands(
     """The host-wide bearer + ``metadata.from_agent=worker-a`` is the
     only authenticated shape there is, and it lands."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
+    record_lineage(child="worker-b", parent="root")
     app = create_app(token=TOKEN)
     # Act
     with TestClient(app) as client:
@@ -436,8 +427,8 @@ def test_http_unknown_bearer_is_rejected_with_403(
     verdict a minted per-node token USED to escape; with the table gone
     there is no second bearer that can be admitted."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
+    record_lineage(child="worker-b", parent="root")
     app = create_app(token=TOKEN)
     # Act
     with TestClient(app) as client:
@@ -496,7 +487,7 @@ def test_http_agents_start_denies_child_caller_with_403(
 ) -> None:
     """Root-only spawn (current policy): a child caller → 403."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     app = create_app(token=TOKEN)
     body = {"name": "new-agent", "caller": "worker-a"}
     # Act
@@ -515,7 +506,7 @@ def test_http_agents_start_403_carries_role_policy_text(
     isolated_listen_env, db_path: Path
 ) -> None:
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     app = create_app(token=TOKEN)
     body = {"name": "new-agent", "caller": "worker-a"}
     # Act
@@ -569,8 +560,8 @@ def cross_group_deny_scenario(isolated_listen_env, db_path: Path, pg_schema: str
     via the surviving deny path: a per-spec ``inbound.siblings=deny`` on
     the target. child-1 and child-2 are siblings under a shared root so
     the sibling relationship applies."""
-    record_lineage(child="child-1", parent="root", db_path=db_path)
-    record_lineage(child="child-2", parent="root", db_path=db_path)
+    record_lineage(child="child-1", parent="root")
+    record_lineage(child="child-2", parent="root")
     record_comms_policy(name="child-2", inbound_siblings="deny")
     app = create_app(token=TOKEN)
     with TestClient(app) as client:
@@ -658,8 +649,8 @@ def body_leak_scenario(isolated_listen_env, db_path: Path, pg_schema: str) -> di
     """Denied send carrying a secret in its body — must not leak. Denial
     is triggered by a per-spec ``inbound.siblings=deny`` (the surviving
     deny path under messaging default-allow)."""
-    record_lineage(child="child-1", parent="root", db_path=db_path)
-    record_lineage(child="child-2", parent="root", db_path=db_path)
+    record_lineage(child="child-1", parent="root")
+    record_lineage(child="child-2", parent="root")
     record_comms_policy(name="child-2", inbound_siblings="deny")
     app = create_app(token=TOKEN)
     with TestClient(app) as client:
@@ -719,10 +710,10 @@ def fanout_scope_scenario(isolated_listen_env, db_path: Path, pg_schema: str) ->
     untouched. Denial via ``inbound.siblings=deny`` on child-2 (siblings
     child-1/child-2 under a shared root); bystander is unrelated.
     """
-    record_lineage(child="child-1", parent="root", db_path=db_path)
-    record_lineage(child="child-2", parent="root", db_path=db_path)
+    record_lineage(child="child-1", parent="root")
+    record_lineage(child="child-2", parent="root")
     record_comms_policy(name="child-2", inbound_siblings="deny")
-    record_lineage(child="bystander", parent="root-3", db_path=db_path)
+    record_lineage(child="bystander", parent="root-3")
     app = create_app(token=TOKEN)
     with TestClient(app) as client:
         resp = client.post(
@@ -808,8 +799,8 @@ def live_broker_event(isolated_listen_env, db_path: Path, pg_schema: str) -> dic
 
     import httpx
 
-    record_lineage(child="child-1", parent="root", db_path=db_path)
-    record_lineage(child="child-2", parent="root", db_path=db_path)
+    record_lineage(child="child-1", parent="root")
+    record_lineage(child="child-2", parent="root")
     record_comms_policy(name="child-2", inbound_siblings="deny")
     app = create_app(token=TOKEN)
 

--- a/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
+++ b/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
@@ -46,7 +46,7 @@ _TOKEN = "test-token-approve-flow"
 
 
 @pytest.fixture
-def isolated_state(tmp_path: Path) -> Iterator[Path]:
+def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
     saved_default = state_db.DEFAULT_DB_PATH
@@ -67,7 +67,7 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
         # still-meaningful behaviour this file covers is the BLOCK /
         # UNBLOCK decision primitives + CLI, plus the pending-prompt clear
         # (pending seeded directly via ``record_pending_prompt``).
-        record_lineage(child="worker-a", parent="root", db_path=db)
+        record_lineage(child="worker-a", parent="root")
         yield db
     finally:
         state_db.DEFAULT_DB_PATH = saved_default

--- a/tests/scitex_agent_container/_listen/test__acl_check_lineage.py
+++ b/tests/scitex_agent_container/_listen/test__acl_check_lineage.py
@@ -36,7 +36,7 @@ def test_admin_caller_is_allowed(db_path: Path) -> None:
     # Arrange — caller None is the host-wide bearer / operator
     # path; always allowed.
     # Act
-    decision, _ = check_lineage_acl(caller=None, target="any-target", db_path=db_path)
+    decision, _ = check_lineage_acl(caller=None, target="any-target")
     # Assert
     assert decision == "allow"
 
@@ -45,7 +45,7 @@ def test_empty_caller_is_treated_as_admin(db_path: Path) -> None:
     # Arrange — defensive: empty string normalises to admin
     # (matches spawn_allowed's treatment).
     # Act
-    decision, _ = check_lineage_acl(caller="", target="x", db_path=db_path)
+    decision, _ = check_lineage_acl(caller="", target="x")
     # Assert
     assert decision == "allow"
 
@@ -58,7 +58,7 @@ def test_empty_caller_is_treated_as_admin(db_path: Path) -> None:
 def test_self_management_is_allowed(db_path: Path) -> None:
     # Arrange — caller managing its own runtime (e.g. status of self).
     # Act
-    decision, _ = check_lineage_acl(caller="alice", target="alice", db_path=db_path)
+    decision, _ = check_lineage_acl(caller="alice", target="alice")
     # Assert
     assert decision == "allow"
 
@@ -70,19 +70,19 @@ def test_self_management_is_allowed(db_path: Path) -> None:
 
 def test_direct_child_is_allowed(pg_schema: str, db_path: Path) -> None:
     # Arrange — root → child edge.
-    record_lineage(child="kid", parent="root", db_path=db_path)
+    record_lineage(child="kid", parent="root")
     # Act
-    decision, _ = check_lineage_acl(caller="root", target="kid", db_path=db_path)
+    decision, _ = check_lineage_acl(caller="root", target="kid")
     # Assert
     assert decision == "allow"
 
 
 def test_transitive_descendant_is_allowed(pg_schema: str, db_path: Path) -> None:
     # Arrange — root → alice → ada (grandchild).
-    record_lineage(child="alice", parent="root", db_path=db_path)
-    record_lineage(child="ada", parent="alice", db_path=db_path)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="ada", parent="alice")
     # Act
-    decision, _ = check_lineage_acl(caller="root", target="ada", db_path=db_path)
+    decision, _ = check_lineage_acl(caller="root", target="ada")
     # Assert
     assert decision == "allow"
 
@@ -96,7 +96,7 @@ def test_deny_when_caller_has_no_lineage_to_target(pg_schema: str, db_path: Path
     # Arrange — alice and bob are unrelated roots.
     # (no lineage records: both are independent root nodes)
     # Act
-    decision, _ = check_lineage_acl(caller="alice", target="bob", db_path=db_path)
+    decision, _ = check_lineage_acl(caller="alice", target="bob")
     # Assert
     assert decision == "deny"
 
@@ -104,10 +104,10 @@ def test_deny_when_caller_has_no_lineage_to_target(pg_schema: str, db_path: Path
 def test_deny_for_sibling_target(pg_schema: str, db_path: Path) -> None:
     # Arrange — alice + bob share a parent but are siblings.
     # Lineage gate denies sibling control (only descendants).
-    record_lineage(child="alice", parent="root", db_path=db_path)
-    record_lineage(child="bob", parent="root", db_path=db_path)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="bob", parent="root")
     # Act
-    decision, _ = check_lineage_acl(caller="alice", target="bob", db_path=db_path)
+    decision, _ = check_lineage_acl(caller="alice", target="bob")
     # Assert
     assert decision == "deny"
 
@@ -115,9 +115,9 @@ def test_deny_for_sibling_target(pg_schema: str, db_path: Path) -> None:
 def test_deny_for_ancestor_target(pg_schema: str, db_path: Path) -> None:
     # Arrange — child cannot operate on its parent (the gate is
     # downward only).
-    record_lineage(child="kid", parent="root", db_path=db_path)
+    record_lineage(child="kid", parent="root")
     # Act
-    decision, _ = check_lineage_acl(caller="kid", target="root", db_path=db_path)
+    decision, _ = check_lineage_acl(caller="kid", target="root")
     # Assert
     assert decision == "deny"
 
@@ -125,9 +125,9 @@ def test_deny_for_ancestor_target(pg_schema: str, db_path: Path) -> None:
 def test_deny_reason_names_caller_and_target(pg_schema: str, db_path: Path) -> None:
     # Arrange — the deny reason must identify both names so the
     # 403 body lets the operator diagnose without guessing.
-    record_lineage(child="alice", parent="root", db_path=db_path)
+    record_lineage(child="alice", parent="root")
     # Act
-    _, reason = check_lineage_acl(caller="alice", target="unrelated", db_path=db_path)
+    _, reason = check_lineage_acl(caller="alice", target="unrelated")
     # Assert
     assert "alice" in (reason or "") and "unrelated" in (reason or "")
 
@@ -140,7 +140,7 @@ def test_deny_reason_names_caller_and_target(pg_schema: str, db_path: Path) -> N
 def test_returns_allow_tuple_with_none_reason(db_path: Path) -> None:
     # Arrange
     # Act
-    decision, reason = check_lineage_acl(caller=None, target="x", db_path=db_path)
+    decision, reason = check_lineage_acl(caller=None, target="x")
     # Assert
     assert (decision, reason) == ("allow", None)
 
@@ -148,6 +148,6 @@ def test_returns_allow_tuple_with_none_reason(db_path: Path) -> None:
 def test_returns_deny_tuple_with_string_reason(pg_schema: str, db_path: Path) -> None:
     # Arrange
     # Act
-    decision, reason = check_lineage_acl(caller="alice", target="bob", db_path=db_path)
+    decision, reason = check_lineage_acl(caller="alice", target="bob")
     # Assert — deny carries a non-empty reason string for the body.
     assert decision == "deny" and isinstance(reason, str) and reason

--- a/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
+++ b/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
@@ -79,8 +79,8 @@ def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
         # deny path: ``worker-a`` and ``lead`` are siblings under a shared
         # root and ``lead`` carries a per-spec ``inbound.siblings=deny``,
         # so ``worker-a → lead`` is denied.
-        record_lineage(child="worker-a", parent="root", db_path=db)
-        record_lineage(child="lead", parent="root", db_path=db)
+        record_lineage(child="worker-a", parent="root")
+        record_lineage(child="lead", parent="root")
         record_comms_policy(name="lead", inbound_siblings="deny")
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -70,7 +70,7 @@ def _seed_child_from_labels(
     2026-08-10 defect — a helper that no longer mirrors production stops
     being able to catch a production bug.
     """
-    record_lineage(child=name, parent="root-parent", db_path=db_path)
+    record_lineage(child=name, parent="root-parent")
     record_comms_policy(
         name=name,
         group_name=group_from_labels(labels),
@@ -112,7 +112,6 @@ def test_send_allowed_within_same_named_group(db_path: Path, pg_schema: str) -> 
     decision, _reason = check_send_acl(
         claimed_from_agent="alice",
         target="bob",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -129,7 +128,6 @@ def test_send_allowed_cross_group_by_default(db_path: Path, pg_schema: str) -> N
     decision, _reason = check_send_acl(
         claimed_from_agent="alice",
         target="carol",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -146,7 +144,6 @@ def test_send_blocked_sender_still_denied_cross_group(db_path: Path, pg_schema: 
     decision, _reason = check_send_acl(
         claimed_from_agent="alice",
         target="carol",
-        db_path=db_path,
     )
     # Assert
     assert decision == "block"
@@ -162,7 +159,6 @@ def test_send_allowed_cross_group_with_explicit_grant(db_path: Path, pg_schema: 
     decision, _reason = check_send_acl(
         claimed_from_agent="alice",
         target="carol",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -172,13 +168,12 @@ def test_ungrouped_pair_allowed_by_default(db_path: Path, pg_schema: str) -> Non
     """Messaging default-allow: two ungrouped agents in unrelated lineage
     families may now message each other with no grant."""
     # Arrange — no group_name on either; unrelated lineage families.
-    record_lineage(child="x", parent="root-x", db_path=db_path)
-    record_lineage(child="y", parent="root-y", db_path=db_path)
+    record_lineage(child="x", parent="root-x")
+    record_lineage(child="y", parent="root-y")
     # Act
     decision, _reason = check_send_acl(
         claimed_from_agent="x",
         target="y",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -199,7 +194,6 @@ def test_send_allowed_developer_to_researcher(db_path: Path, pg_schema: str) -> 
     decision, _reason = check_send_acl(
         claimed_from_agent="dev-1",
         target="res-1",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -214,7 +208,6 @@ def test_send_allowed_researcher_to_generalist(db_path: Path, pg_schema: str) ->
     decision, _reason = check_send_acl(
         claimed_from_agent="res-1",
         target="gen-1",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -229,7 +222,6 @@ def test_send_allowed_generalist_to_developer_all_directions(db_path: Path, pg_s
     decision, _reason = check_send_acl(
         claimed_from_agent="gen-1",
         target="dev-1",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -247,7 +239,6 @@ def test_send_allowed_mesh_group_to_non_mesh_group(db_path: Path, pg_schema: str
     decision, _reason = check_send_acl(
         claimed_from_agent="dev-1",
         target="solver-1",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -264,7 +255,6 @@ def test_send_allowed_non_mesh_group_to_mesh_group(db_path: Path, pg_schema: str
     decision, _reason = check_send_acl(
         claimed_from_agent="solver-1",
         target="res-1",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -278,10 +268,10 @@ def test_send_allowed_non_mesh_group_to_mesh_group(db_path: Path, pg_schema: str
 def test_developer_child_may_spawn(pg_schema: str, db_path: Path) -> None:
     """A developer-group caller may spawn even as a (non-root) child."""
     # Arrange
-    record_lineage(child="dev-1", parent="root", db_path=db_path)
+    record_lineage(child="dev-1", parent="root")
     record_comms_policy(name="dev-1", group_name="developer")
     # Act
-    decision, _reason = check_spawn(caller="dev-1", db_path=db_path)
+    decision, _reason = check_spawn(caller="dev-1")
     # Assert
     assert decision == "allow"
 
@@ -289,10 +279,10 @@ def test_developer_child_may_spawn(pg_schema: str, db_path: Path) -> None:
 def test_non_developer_child_still_denied_spawn(pg_schema: str, db_path: Path) -> None:
     """Backward-compatible: a non-developer child is still root-only denied."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     record_comms_policy(name="worker-a", group_name="analysts")
     # Act
-    decision, _reason = check_spawn(caller="worker-a", db_path=db_path)
+    decision, _reason = check_spawn(caller="worker-a")
     # Assert
     assert decision == "deny"
 
@@ -320,7 +310,7 @@ def test_child_with_developer_late_in_its_groups_may_spawn(pg_schema: str, db_pa
     # Arrange
     _seed_child_from_labels("grant", GRANT_LABELS, db_path=db_path)
     # Act
-    decision, _reason = check_spawn(caller="grant", db_path=db_path)
+    decision, _reason = check_spawn(caller="grant")
     # Assert
     assert decision == "allow"
 
@@ -335,7 +325,7 @@ def test_child_with_developer_late_in_its_groups_may_manage_peers(
     _seed_child_from_labels("grant", GRANT_LABELS, db_path=db_path)
     # Act
     decision, _reason = check_lineage_acl(
-        caller="grant", target="unrelated-peer", db_path=db_path
+        caller="grant", target="unrelated-peer"
     )
     # Assert
     assert decision == "allow"
@@ -346,7 +336,7 @@ def test_child_with_researcher_late_in_its_groups_may_spawn(pg_schema: str, db_p
     labels = {"role": "worker", "groups": ["generalist", "researcher"]}
     _seed_child_from_labels("nv", labels, db_path=db_path)
     # Act
-    decision, _reason = check_spawn(caller="nv", db_path=db_path)
+    decision, _reason = check_spawn(caller="nv")
     # Assert
     assert decision == "allow"
 
@@ -356,7 +346,7 @@ def test_child_with_privileged_late_in_its_groups_may_spawn(pg_schema: str, db_p
     labels = {"role": "worker", "groups": ["generalist", "privileged"]}
     _seed_child_from_labels("dotfiles", labels, db_path=db_path)
     # Act
-    decision, _reason = check_spawn(caller="dotfiles", db_path=db_path)
+    decision, _reason = check_spawn(caller="dotfiles")
     # Assert
     assert decision == "allow"
 
@@ -371,7 +361,7 @@ def test_multi_group_child_with_no_authorising_group_is_still_denied(
     labels = {"role": "worker", "groups": ["generalist", "active", "analysts"]}
     _seed_child_from_labels("worker-b", labels, db_path=db_path)
     # Act
-    decision, _reason = check_spawn(caller="worker-b", db_path=db_path)
+    decision, _reason = check_spawn(caller="worker-b")
     # Assert
     assert decision == "deny"
 
@@ -394,7 +384,7 @@ def test_labelled_researcher_child_may_spawn(pg_schema: str, db_path: Path) -> N
         "neurovista", {"groups": ["researcher", "active"]}, db_path=db_path
     )
     # Act
-    decision, _reason = check_spawn(caller="neurovista", db_path=db_path)
+    decision, _reason = check_spawn(caller="neurovista")
     # Assert
     assert decision == "allow"
 
@@ -409,7 +399,7 @@ def test_role_derived_researcher_child_may_spawn(pg_schema: str, db_path: Path) 
     # Arrange
     _seed_child_from_labels("res-by-role", {"role": "researcher"}, db_path=db_path)
     # Act
-    decision, _reason = check_spawn(caller="res-by-role", db_path=db_path)
+    decision, _reason = check_spawn(caller="res-by-role")
     # Assert
     assert decision == "allow"
 
@@ -421,7 +411,7 @@ def test_role_derived_researcher_child_may_manage_peer(pg_schema: str, db_path: 
     record_comms_policy(name="scitex-clew", group_name="developer")
     # Act
     decision, _reason = check_lineage_acl(
-        caller="res-by-role", target="scitex-clew", db_path=db_path
+        caller="res-by-role", target="scitex-clew"
     )
     # Assert
     assert decision == "allow"
@@ -434,7 +424,7 @@ def test_role_derived_developer_child_may_spawn(pg_schema: str, db_path: Path) -
         "dev-by-role", {"role": "project-maintainer"}, db_path=db_path
     )
     # Act
-    decision, _reason = check_spawn(caller="dev-by-role", db_path=db_path)
+    decision, _reason = check_spawn(caller="dev-by-role")
     # Assert
     assert decision == "allow"
 
@@ -449,7 +439,7 @@ def test_worker_role_child_still_denied_spawn(pg_schema: str, db_path: Path) -> 
     # Arrange
     _seed_child_from_labels("worker-1", {"role": "worker"}, db_path=db_path)
     # Act
-    decision, _reason = check_spawn(caller="worker-1", db_path=db_path)
+    decision, _reason = check_spawn(caller="worker-1")
     # Assert
     assert decision == "deny"
 
@@ -465,7 +455,7 @@ def test_isolated_solver_child_still_denied_spawn(pg_schema: str, db_path: Path)
         "solver-1", {"role": "researcher", "groups": ["solver"]}, db_path=db_path
     )
     # Act
-    decision, _reason = check_spawn(caller="solver-1", db_path=db_path)
+    decision, _reason = check_spawn(caller="solver-1")
     # Assert
     assert decision == "deny"
 
@@ -481,7 +471,7 @@ def test_researcher_child_with_may_spawn_false_is_denied(pg_schema: str, db_path
         "res-nospawn", {"role": "researcher"}, db_path=db_path, may_spawn=False
     )
     # Act
-    decision, _reason = check_spawn(caller="res-nospawn", db_path=db_path)
+    decision, _reason = check_spawn(caller="res-nospawn")
     # Assert
     assert decision == "deny"
 
@@ -495,10 +485,10 @@ def test_developer_may_manage_unrelated_agent(pg_schema: str, db_path: Path) -> 
     """Developer-group caller manages a target with NO lineage edge."""
     # Arrange
     record_comms_policy(name="dev-1", group_name="developer")
-    record_lineage(child="victim", parent="someone-else", db_path=db_path)
+    record_lineage(child="victim", parent="someone-else")
     # Act
     decision, _reason = check_lineage_acl(
-        caller="dev-1", target="victim", db_path=db_path
+        caller="dev-1", target="victim"
     )
     # Assert
     assert decision == "allow"
@@ -508,10 +498,10 @@ def test_non_developer_cannot_manage_unrelated_agent(pg_schema: str, db_path: Pa
     """Backward-compatible: non-developer with no lineage edge → deny."""
     # Arrange
     record_comms_policy(name="worker-a", group_name="analysts")
-    record_lineage(child="victim", parent="someone-else", db_path=db_path)
+    record_lineage(child="victim", parent="someone-else")
     # Act
     decision, _reason = check_lineage_acl(
-        caller="worker-a", target="victim", db_path=db_path
+        caller="worker-a", target="victim"
     )
     # Assert
     assert decision == "deny"
@@ -533,7 +523,7 @@ def test_researcher_may_manage_developer_target_via_mesh(pg_schema: str, db_path
     record_comms_policy(name="scitex-todo", group_name="developer")
     # Act
     decision, _reason = check_lineage_acl(
-        caller="neurovista", target="scitex-todo", db_path=db_path
+        caller="neurovista", target="scitex-todo"
     )
     # Assert
     assert decision == "allow"
@@ -549,10 +539,10 @@ def test_mesh_caller_cannot_manage_isolated_solver_target(pg_schema: str, db_pat
     # Arrange — researcher caller, solver target (outside the mesh).
     record_comms_policy(name="res-1", group_name="researcher")
     record_comms_policy(name="solver-1", group_name="solver")
-    record_lineage(child="solver-1", parent="someone-else", db_path=db_path)
+    record_lineage(child="solver-1", parent="someone-else")
     # Act
     decision, _reason = check_lineage_acl(
-        caller="res-1", target="solver-1", db_path=db_path
+        caller="res-1", target="solver-1"
     )
     # Assert
     assert decision == "deny"

--- a/tests/scitex_agent_container/_listen/test__acl_phase3.py
+++ b/tests/scitex_agent_container/_listen/test__acl_phase3.py
@@ -51,14 +51,13 @@ def test_outbound_siblings_deny_blocks_sibling_send(db_path: Path, pg_schema: st
     """Gap-1: sender with outbound.siblings=deny cannot address a sibling
     even though they share the same parent (group ACL would allow)."""
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
+    record_lineage(child="cap-b", parent="root")
     record_comms_policy(name="cap-a", outbound_siblings="deny")
     # Act
     decision, _ = check_send_acl(
         claimed_from_agent="cap-a",
         target="cap-b",
-        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -67,13 +66,12 @@ def test_outbound_siblings_deny_blocks_sibling_send(db_path: Path, pg_schema: st
 def test_outbound_parent_deny_blocks_send_to_parent(db_path: Path, pg_schema: str) -> None:
     """Gap-1: child with outbound.parent=deny cannot send to its parent."""
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
     record_comms_policy(name="cap-a", outbound_parent="deny")
     # Act
     decision, _ = check_send_acl(
         claimed_from_agent="cap-a",
         target="root",
-        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -83,13 +81,12 @@ def test_outbound_default_allows_sibling_send(db_path: Path, pg_schema: str) -> 
     """Default-preservation: with no comms policy row, the legacy
     intra-group sibling allow continues to fire (Phase-3 is opt-in)."""
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
+    record_lineage(child="cap-b", parent="root")
     # Act
     decision, _ = check_send_acl(
         claimed_from_agent="cap-a",
         target="cap-b",
-        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -104,14 +101,13 @@ def test_inbound_siblings_deny_rejects_sibling_inbound(db_path: Path, pg_schema:
     """Gap-2: target with inbound.siblings=deny rejects a sibling sender
     even when the sender's outbound policy permits."""
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
+    record_lineage(child="cap-b", parent="root")
     record_comms_policy(name="cap-b", inbound_siblings="deny")
     # Act
     decision, _ = check_send_acl(
         claimed_from_agent="cap-a",
         target="cap-b",
-        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -121,13 +117,12 @@ def test_inbound_parent_deny_rejects_send_from_parent(db_path: Path, pg_schema: 
     """Gap-2: target with inbound.parent=deny rejects its own parent's
     send (the parent appears as ``rel='child'`` from sender's POV)."""
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
     record_comms_policy(name="cap-a", inbound_parent="deny")
     # Act
     decision, _ = check_send_acl(
         claimed_from_agent="root",
         target="cap-a",
-        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -144,7 +139,7 @@ def test_may_spawn_false_denies_root_spawn(pg_schema: str, db_path: Path) -> Non
     # Arrange
     record_comms_policy(name="root", may_spawn=False)
     # Act
-    decision, _ = check_spawn(caller="root", db_path=db_path)
+    decision, _ = check_spawn(caller="root")
     # Assert
     assert decision == "deny"
 
@@ -154,6 +149,6 @@ def test_may_spawn_default_preserves_root_allow(pg_schema: str, db_path: Path) -
     legacy root-only allow."""
     # Arrange — no lineage row (caller is a root) and no policy row.
     # Act
-    decision, _ = check_spawn(caller="root", db_path=db_path)
+    decision, _ = check_spawn(caller="root")
     # Assert
     assert decision == "allow"

--- a/tests/scitex_agent_container/_listen/test__node_channel.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel.py
@@ -29,7 +29,7 @@ TOKEN = "test-kind-pin-token"
 
 
 @pytest.fixture
-def kind_env(tmp_path: Path):
+def kind_env(pg_schema: str, tmp_path: Path):
     """Isolated state.db so ``channel_events`` reads back our send."""
     saved_home = os.environ.get("HOME")
     saved_db_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
@@ -50,8 +50,8 @@ def kind_env(tmp_path: Path):
     state_db.init_schema(db)
 
     # Same-group ACL — alice (sender) and lead (target) both rooted.
-    record_lineage(child="alice", parent="root", db_path=db)
-    record_lineage(child="lead", parent="root", db_path=db)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="lead", parent="root")
 
     try:
         yield {"db": db, "tmp_path": tmp_path}

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -62,7 +62,7 @@ TOKEN = "test-token-wi3"
 
 
 @pytest.fixture
-def isolated_env(tmp_path: Path):
+def isolated_env(pg_schema: str, tmp_path: Path):
     saved_home = os.environ.get("HOME")
     saved_reg_env = os.environ.get("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
     saved_run_env = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
@@ -87,8 +87,8 @@ def isolated_env(tmp_path: Path):
     # common root so they share a group. Without this the new
     # ACL gate would deny ``permitted-peer → external-bob`` as
     # cross-group (each unattached node is its own singleton).
-    record_lineage(child="permitted-peer", parent="root", db_path=db_path)
-    record_lineage(child="external-bob", parent="root", db_path=db_path)
+    record_lineage(child="permitted-peer", parent="root")
+    record_lineage(child="external-bob", parent="root")
 
     try:
         yield tmp_path

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -889,8 +889,8 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env, pg_schema: str)
     state_db.record_instance_start(name="alice", host="host-a", a2a_port=0, db_path=db)
     # Permitted-peer is registered as a child of root, so is alice;
     # they share a group and ACL allows the send.
-    record_lineage(child="permitted-peer", parent="root", db_path=db)
-    record_lineage(child="alice", parent="root", db_path=db)
+    record_lineage(child="permitted-peer", parent="root")
+    record_lineage(child="alice", parent="root")
 
     host_a_port = _free_port()
     host_b_port = _free_port()
@@ -969,8 +969,8 @@ def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env, pg_sch
     # Arrange
     db = cross_host_env["db"]
     state_db.record_instance_start(name="alice", host="host-a", a2a_port=0, db_path=db)
-    record_lineage(child="permitted-peer", parent="root", db_path=db)
-    record_lineage(child="alice", parent="root", db_path=db)
+    record_lineage(child="permitted-peer", parent="root")
+    record_lineage(child="alice", parent="root")
     host_a_port = _free_port()
     host_b_port = _free_port()
     with state_db.open_db(db) as conn:
@@ -1033,7 +1033,7 @@ def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env, pg_sch
 
 
 @pytest.fixture
-def missing_peer_token_response(tmp_path: Path):
+def missing_peer_token_response(pg_schema: str, tmp_path: Path):
     """Drive a forwarder POST with NO peer-token written for the
     destination host, so the forwarder must fall through to the loud
     502 path. Yielded value is the live ``httpx.Response`` so each
@@ -1052,8 +1052,8 @@ def missing_peer_token_response(tmp_path: Path):
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     state_db.init_schema(db)
-    record_lineage(child="permitted-peer", parent="root", db_path=db)
-    record_lineage(child="alice", parent="root", db_path=db)
+    record_lineage(child="permitted-peer", parent="root")
+    record_lineage(child="alice", parent="root")
     state_db.record_instance_start(
         name="alice", host="host-z", a2a_port=9999, db_path=db
     )
@@ -1279,8 +1279,8 @@ def test_cross_host_send_via_ssh_shim_delivers_to_remote_inbox(
     """
     # Arrange
     db = cross_host_ssh_env["db"]
-    record_lineage(child="permitted-peer", parent="root", db_path=db)
-    record_lineage(child="alice", parent="root", db_path=db)
+    record_lineage(child="permitted-peer", parent="root")
+    record_lineage(child="alice", parent="root")
     # Act
     event = _drive_ssh_cross_host_send(
         cross_host_ssh_env, sender="permitted-peer", text="hi via ssh"
@@ -1298,8 +1298,8 @@ def test_cross_host_send_via_ssh_shim_preserves_from_agent_metadata(
     """
     # Arrange
     db = cross_host_ssh_env["db"]
-    record_lineage(child="permitted-peer", parent="root", db_path=db)
-    record_lineage(child="alice", parent="root", db_path=db)
+    record_lineage(child="permitted-peer", parent="root")
+    record_lineage(child="alice", parent="root")
     # Act
     event = _drive_ssh_cross_host_send(
         cross_host_ssh_env, sender="permitted-peer", text="probe"
@@ -1323,8 +1323,8 @@ def test_cross_host_send_with_explicit_grant_unblocks_cross_group_push(
     # the fixture's tmp HOME pins them to a file: comms_grants is PostgreSQL
     # now. record_lineage below still takes db_path — lineage is still SQLite.
     db = cross_host_ssh_env["db"]
-    record_lineage(child="alice", parent="root-a", db_path=db)
-    record_lineage(child="outsider", parent="root-b", db_path=db)
+    record_lineage(child="alice", parent="root-a")
+    record_lineage(child="outsider", parent="root-b")
     # db_path is gone from the grants primitives — that store is on
     # PostgreSQL and isolates via SCITEX_STORE_DSN (the pg_schema fixture).
     # record_lineage above KEEPS its db_path: that module is still on SQLite.
@@ -1354,8 +1354,8 @@ def test_cross_host_send_without_grant_returns_403_from_target_listen(
     db = cross_host_ssh_env["db"]
     host_a_port = cross_host_ssh_env["host_a_port"]
     host_b_port = cross_host_ssh_env["host_b_port"]
-    record_lineage(child="alice", parent="root", db_path=db)
-    record_lineage(child="outsider", parent="root", db_path=db)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="outsider", parent="root")
     state_db_nodes_grant.record_comms_policy(
         name="alice", inbound_siblings="deny"
     )
@@ -1393,8 +1393,8 @@ def test_cross_host_send_via_ssh_shim_uses_peer_token_bearer_header(
     """
     # Arrange
     db = cross_host_ssh_env["db"]
-    record_lineage(child="permitted-peer", parent="root", db_path=db)
-    record_lineage(child="alice", parent="root", db_path=db)
+    record_lineage(child="permitted-peer", parent="root")
+    record_lineage(child="alice", parent="root")
     _drive_ssh_cross_host_send(
         cross_host_ssh_env, sender="permitted-peer", text="bearer probe"
     )
@@ -1437,8 +1437,8 @@ def _roundtrip_local_send(cross_host_env, *, metadata: dict) -> dict:
     intra-group ACL allows the send.
     """
     db = cross_host_env["db"]
-    record_lineage(child="bob", parent="root", db_path=db)
-    record_lineage(child="alice", parent="root", db_path=db)
+    record_lineage(child="bob", parent="root")
+    record_lineage(child="alice", parent="root")
     port = _free_port()
     app = create_app(token=SHARED_TOKEN, local_host="host-a")
 

--- a/tests/scitex_agent_container/_listen/test_server_lineage_acl.py
+++ b/tests/scitex_agent_container/_listen/test_server_lineage_acl.py
@@ -169,7 +169,7 @@ def test_gate_denies_caller_with_no_lineage_edge(pg_schema: str, db_path: Path):
     caller = "alice"
     # Act
     decision, _reason = check_lineage_acl(
-        caller=caller, target="unrelated-target", db_path=db_path
+        caller=caller, target="unrelated-target"
     )
     # Assert
     assert decision == "deny"
@@ -180,7 +180,7 @@ def test_gate_deny_reason_names_the_target(pg_schema: str, db_path: Path):
     caller = "alice"
     # Act
     _decision, reason = check_lineage_acl(
-        caller=caller, target="unrelated-target-4", db_path=db_path
+        caller=caller, target="unrelated-target-4"
     )
     # Assert
     assert reason is not None and "unrelated-target-4" in reason
@@ -191,7 +191,7 @@ def test_gate_allows_caller_targeting_self(pg_schema: str, db_path: Path):
     caller = "alice"
     # Act
     decision, _reason = check_lineage_acl(
-        caller=caller, target="alice", db_path=db_path
+        caller=caller, target="alice"
     )
     # Assert
     assert decision == "allow"
@@ -199,9 +199,9 @@ def test_gate_allows_caller_targeting_self(pg_schema: str, db_path: Path):
 
 def test_gate_allows_caller_targeting_direct_child(pg_schema: str, db_path: Path):
     # Arrange — alice has child ``kid`` via the lineage table.
-    record_lineage(child="kid", parent="alice", db_path=db_path)
+    record_lineage(child="kid", parent="alice")
     # Act
-    decision, _reason = check_lineage_acl(caller="alice", target="kid", db_path=db_path)
+    decision, _reason = check_lineage_acl(caller="alice", target="kid")
     # Assert
     assert decision == "allow"
 
@@ -210,10 +210,10 @@ def test_gate_allows_caller_targeting_transitive_descendant(
     pg_schema: str, db_path: Path
 ):
     # Arrange — root → alice → ada (grandchild).
-    record_lineage(child="alice", parent="root", db_path=db_path)
-    record_lineage(child="ada", parent="alice", db_path=db_path)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="ada", parent="alice")
     # Act
-    decision, _reason = check_lineage_acl(caller="root", target="ada", db_path=db_path)
+    decision, _reason = check_lineage_acl(caller="root", target="ada")
     # Assert
     assert decision == "allow"
 
@@ -225,7 +225,7 @@ def test_gate_allows_the_administrative_caller(pg_schema: str, db_path: Path):
     caller = None
     # Act
     decision, _reason = check_lineage_acl(
-        caller=caller, target="unrelated-target", db_path=db_path
+        caller=caller, target="unrelated-target"
     )
     # Assert
     assert decision == "allow"

--- a/tests/scitex_agent_container/_state/test__lineage.py
+++ b/tests/scitex_agent_container/_state/test__lineage.py
@@ -1,15 +1,19 @@
 """Tests for :mod:`scitex_agent_container._state._lineage`.
 
 PR-3 Checkpoint 3 — pins the BFS transitive descendants walk used
-by the lineage-scoped ACL gate. Real sqlite via the test-isolated
-state.db (no mocks, PA-306). AAA + one-assert (PA-307).
+by the lineage-scoped ACL gate. AAA + one-assert (PA-307).
+
+REAL POSTGRESQL SINCE 2026-08-28, not a temp SQLite file. The walk reads
+the shared lineage store, so isolation comes from ``pg_schema`` pointing
+``SCITEX_STORE_DSN`` at a throwaway schema — which is stronger than the
+``tmp_path`` these tests used to take, because it exercises the real
+resolver instead of a path threaded past it. Still no mocks (PA-306).
+
+These SKIP on a host with no writable database, which includes every agent
+container (loopback there is a read-only replica of the fleet cluster).
 """
 
 from __future__ import annotations
-
-from pathlib import Path
-
-import pytest
 
 from scitex_agent_container._state._lineage import (
     ancestors_to_root,
@@ -17,38 +21,26 @@ from scitex_agent_container._state._lineage import (
 )
 from scitex_agent_container._state.state_db_nodes import record_lineage
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def db_path(tmp_path: Path) -> Path:
-    """Per-test sqlite — the lineage walk is exercised against a
-    fresh, isolated state.db so tests don't leak edges between
-    cases."""
-    return tmp_path / "state.db"
-
 
 # ---------------------------------------------------------------------------
 # Empty / leaf cases
 # ---------------------------------------------------------------------------
 
 
-def test_descendants_empty_when_node_unknown(db_path: Path) -> None:
+def test_descendants_empty_when_node_unknown(pg_schema: str) -> None:
     # Arrange — no lineage rows for "ghost".
     # Act
-    result = descendants_of(name="ghost", db_path=db_path)
+    result = descendants_of(name="ghost")
     # Assert
     assert result == set()
 
 
-def test_descendants_empty_when_node_is_leaf(db_path: Path) -> None:
+def test_descendants_empty_when_node_is_leaf(pg_schema: str) -> None:
     # Arrange — register a parent → child edge; "child" itself
     # has no further descendants.
-    record_lineage(child="child", parent="root", db_path=db_path)
+    record_lineage(child="child", parent="root")
     # Act
-    result = descendants_of(name="child", db_path=db_path)
+    result = descendants_of(name="child")
     # Assert
     assert result == set()
 
@@ -66,21 +58,21 @@ def test_descendants_empty_for_empty_name() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_descendants_returns_direct_children(db_path: Path) -> None:
+def test_descendants_returns_direct_children(pg_schema: str) -> None:
     # Arrange — root has two direct children.
-    record_lineage(child="alice", parent="root", db_path=db_path)
-    record_lineage(child="bob", parent="root", db_path=db_path)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="bob", parent="root")
     # Act
-    result = descendants_of(name="root", db_path=db_path)
+    result = descendants_of(name="root")
     # Assert
     assert result == {"alice", "bob"}
 
 
-def test_descendants_excludes_the_node_itself(db_path: Path) -> None:
+def test_descendants_excludes_the_node_itself(pg_schema: str) -> None:
     # Arrange — the returned set must NOT include ``name``.
-    record_lineage(child="alice", parent="root", db_path=db_path)
+    record_lineage(child="alice", parent="root")
     # Act
-    result = descendants_of(name="root", db_path=db_path)
+    result = descendants_of(name="root")
     # Assert
     assert "root" not in result
 
@@ -90,38 +82,38 @@ def test_descendants_excludes_the_node_itself(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_descendants_walks_grandchildren(db_path: Path) -> None:
+def test_descendants_walks_grandchildren(pg_schema: str) -> None:
     # Arrange — root → alice → ada; "ada" is a grandchild.
-    record_lineage(child="alice", parent="root", db_path=db_path)
-    record_lineage(child="ada", parent="alice", db_path=db_path)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="ada", parent="alice")
     # Act
-    result = descendants_of(name="root", db_path=db_path)
+    result = descendants_of(name="root")
     # Assert
     assert "ada" in result
 
 
-def test_descendants_walks_four_levels_deep(db_path: Path) -> None:
+def test_descendants_walks_four_levels_deep(pg_schema: str) -> None:
     # Arrange — a 4-deep chain.
-    record_lineage(child="b", parent="a", db_path=db_path)
-    record_lineage(child="c", parent="b", db_path=db_path)
-    record_lineage(child="d", parent="c", db_path=db_path)
-    record_lineage(child="e", parent="d", db_path=db_path)
+    record_lineage(child="b", parent="a")
+    record_lineage(child="c", parent="b")
+    record_lineage(child="d", parent="c")
+    record_lineage(child="e", parent="d")
     # Act
-    result = descendants_of(name="a", db_path=db_path)
+    result = descendants_of(name="a")
     # Assert
     assert result == {"b", "c", "d", "e"}
 
 
-def test_descendants_walks_branching_tree(db_path: Path) -> None:
+def test_descendants_walks_branching_tree(pg_schema: str) -> None:
     # Arrange — root has two children, each with two grandchildren.
-    record_lineage(child="alice", parent="root", db_path=db_path)
-    record_lineage(child="bob", parent="root", db_path=db_path)
-    record_lineage(child="ada", parent="alice", db_path=db_path)
-    record_lineage(child="alex", parent="alice", db_path=db_path)
-    record_lineage(child="ben", parent="bob", db_path=db_path)
-    record_lineage(child="bea", parent="bob", db_path=db_path)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="bob", parent="root")
+    record_lineage(child="ada", parent="alice")
+    record_lineage(child="alex", parent="alice")
+    record_lineage(child="ben", parent="bob")
+    record_lineage(child="bea", parent="bob")
     # Act
-    result = descendants_of(name="root", db_path=db_path)
+    result = descendants_of(name="root")
     # Assert
     assert result == {"alice", "bob", "ada", "alex", "ben", "bea"}
 
@@ -131,24 +123,24 @@ def test_descendants_walks_branching_tree(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_descendants_does_not_include_siblings(db_path: Path) -> None:
+def test_descendants_does_not_include_siblings(pg_schema: str) -> None:
     # Arrange — alice and bob are siblings under root. From
     # alice's perspective, bob is NOT a descendant.
-    record_lineage(child="alice", parent="root", db_path=db_path)
-    record_lineage(child="bob", parent="root", db_path=db_path)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="bob", parent="root")
     # Act
-    result = descendants_of(name="alice", db_path=db_path)
+    result = descendants_of(name="alice")
     # Assert
     assert "bob" not in result
 
 
-def test_descendants_does_not_include_ancestors(db_path: Path) -> None:
+def test_descendants_does_not_include_ancestors(pg_schema: str) -> None:
     # Arrange — root → alice → ada. From alice's perspective,
     # root is NOT a descendant (it's an ancestor).
-    record_lineage(child="alice", parent="root", db_path=db_path)
-    record_lineage(child="ada", parent="alice", db_path=db_path)
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="ada", parent="alice")
     # Act
-    result = descendants_of(name="alice", db_path=db_path)
+    result = descendants_of(name="alice")
     # Assert
     assert "root" not in result
 
@@ -158,17 +150,17 @@ def test_descendants_does_not_include_ancestors(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_descendants_respects_max_depth_bound(db_path: Path) -> None:
+def test_descendants_respects_max_depth_bound(pg_schema: str) -> None:
     # Arrange — 6-deep chain; ask for max_depth=3 → only first
     # 3 levels of descendants visible.
-    record_lineage(child="b", parent="a", db_path=db_path)
-    record_lineage(child="c", parent="b", db_path=db_path)
-    record_lineage(child="d", parent="c", db_path=db_path)
-    record_lineage(child="e", parent="d", db_path=db_path)
-    record_lineage(child="f", parent="e", db_path=db_path)
-    record_lineage(child="g", parent="f", db_path=db_path)
+    record_lineage(child="b", parent="a")
+    record_lineage(child="c", parent="b")
+    record_lineage(child="d", parent="c")
+    record_lineage(child="e", parent="d")
+    record_lineage(child="f", parent="e")
+    record_lineage(child="g", parent="f")
     # Act
-    result = descendants_of(name="a", db_path=db_path, max_depth=3)
+    result = descendants_of(name="a", max_depth=3)
     # Assert
     assert result == {"b", "c", "d"}
 
@@ -178,57 +170,65 @@ def test_descendants_respects_max_depth_bound(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_ancestors_empty_when_node_has_no_parent(db_path: Path) -> None:
+def test_ancestors_empty_when_node_has_no_parent(pg_schema: str) -> None:
     # Arrange — no lineage rows for "lonely".
     # Act
-    chain = ancestors_to_root(name="lonely", db_path=db_path)
+    chain = ancestors_to_root(name="lonely")
     # Assert
     assert chain == []
 
 
-def test_ancestors_single_parent_returns_one_element_chain(db_path: Path) -> None:
+def test_ancestors_single_parent_returns_one_element_chain(pg_schema: str) -> None:
     # Arrange
-    record_lineage(child="kid", parent="mom", db_path=db_path)
+    record_lineage(child="kid", parent="mom")
     # Act
-    chain = ancestors_to_root(name="kid", db_path=db_path)
+    chain = ancestors_to_root(name="kid")
     # Assert
     assert chain == ["mom"]
 
 
-def test_ancestors_chain_is_ordered_parent_first_root_last(db_path: Path) -> None:
+def test_ancestors_chain_is_ordered_parent_first_root_last(pg_schema: str) -> None:
     # Arrange — pusher → parent → grandparent → lead.
-    record_lineage(child="pusher", parent="parent", db_path=db_path)
-    record_lineage(child="parent", parent="grandparent", db_path=db_path)
-    record_lineage(child="grandparent", parent="lead", db_path=db_path)
+    record_lineage(child="pusher", parent="parent")
+    record_lineage(child="parent", parent="grandparent")
+    record_lineage(child="grandparent", parent="lead")
     # Act
-    chain = ancestors_to_root(name="pusher", db_path=db_path)
+    chain = ancestors_to_root(name="pusher")
     # Assert
     assert chain == ["parent", "grandparent", "lead"]
 
 
-def test_ancestors_chain_excludes_the_queried_agent(db_path: Path) -> None:
+def test_ancestors_chain_excludes_the_queried_agent(pg_schema: str) -> None:
     # Arrange
-    record_lineage(child="a", parent="b", db_path=db_path)
+    record_lineage(child="a", parent="b")
     # Act
-    chain = ancestors_to_root(name="a", db_path=db_path)
+    chain = ancestors_to_root(name="a")
     # Assert
     assert "a" not in chain
 
 
-def test_ancestors_cycle_in_hand_edited_db_is_bounded(db_path: Path) -> None:
-    # Arrange — record_lineage prevents cycles, so inject one directly to
-    # prove the depth guard (same "cannot trust the DB blindly" rationale
-    # as descendants_of). record_lineage first creates the table.
-    import sqlite3
-
-    record_lineage(child="x", parent="y", db_path=db_path)
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            "INSERT OR REPLACE INTO lineage (child_name, parent_name, created_at) "
-            "VALUES ('y', 'x', 0.0)"
-        )
-        conn.commit()
+def test_ancestors_cycle_is_bounded(pg_schema: str) -> None:
+    # Arrange — two edges that point at each other. This used to be an
+    # ``INSERT OR REPLACE`` that bent an existing row into a loop; against
+    # the store that is impossible, because ``parent_name`` is IMMUTABLE
+    # and the first value is kept forever. A cycle can therefore only
+    # arrive as two SEPARATE edges, which is what this builds — a more
+    # faithful reproduction of the only shape the guard can ever meet.
+    record_lineage(child="x", parent="y")
+    record_lineage(child="y", parent="x")
     # Act
-    chain = ancestors_to_root(name="x", db_path=db_path, max_depth=5)
+    chain = ancestors_to_root(name="x", max_depth=5)
     # Assert
     assert len(chain) <= 5
+
+
+def test_descendants_cycle_is_bounded(pg_schema: str) -> None:
+    # Arrange — the DOWN walk over the same mutually-pointing pair. It had
+    # no cycle test at all before, because the SQLite version could only be
+    # given a cycle by hand-editing the file.
+    record_lineage(child="x", parent="y")
+    record_lineage(child="y", parent="x")
+    # Act
+    found = descendants_of(name="x", max_depth=5)
+    # Assert
+    assert found == {"y"}

--- a/tests/scitex_agent_container/_state/test_lead_inbox.py
+++ b/tests/scitex_agent_container/_state/test_lead_inbox.py
@@ -316,8 +316,8 @@ def _push_kind(lead_env, *, kind: str, summary: str, from_agent: str) -> dict:
     port = _free_port()
     _setup_lead_at_port(lead_env, port)
     # Lead must be reachable for ACL — same-group send.
-    record_lineage(child=from_agent, parent="root", db_path=lead_env["db"])
-    record_lineage(child="lead", parent="root", db_path=lead_env["db"])
+    record_lineage(child=from_agent, parent="root")
+    record_lineage(child="lead", parent="root")
 
     app = create_app(token=TOKEN, local_host="127.0.0.1")
     with _run_listen(app, port):
@@ -431,8 +431,8 @@ def test_regression_agent_completion_event_lands_in_lead_inbox(lead_env, pg_sche
     # config.yaml).
     port = _free_port()
     _setup_lead_at_port(lead_env, port)
-    record_lineage(child="alice", parent="root", db_path=lead_env["db"])
-    record_lineage(child="lead", parent="root", db_path=lead_env["db"])
+    record_lineage(child="alice", parent="root")
+    record_lineage(child="lead", parent="root")
     app = create_app(token=TOKEN, local_host="127.0.0.1")
 
     # Act — agent pushes a completion event over the real HTTP stack.

--- a/tests/scitex_agent_container/_state/test_state_db_export_tables.py
+++ b/tests/scitex_agent_container/_state/test_state_db_export_tables.py
@@ -4,12 +4,21 @@ The filter was added for ``sac registry sync``, which shipped only the
 ``comms_nodes`` delta. Both are gone as of 2026-08-28 — the directory moved
 to the shared PostgreSQL store, so there is no slice to ship and no verb to
 ship it. The filter itself stays useful for any subset of the tables that
-remain, and these tests now exercise it with ``lineage`` / ``instances``.
+remain, and these tests now exercise it with ``channel_events`` /
+``instances`` — the two that are left.
 
-``comms_nodes`` is asserted here in ONE direction only: that asking for it
-now FAILS. A filter that still accepted the name would emit an empty array
-and read as "sac exports the directory, and it is empty" — the
-success-shaped answer this whole migration exists to remove.
+They exercised it with ``lineage`` until 2026-08-28, when the spawn DAG
+moved to the shared PostgreSQL store and left ``KNOWN_TABLES``. The subject
+of these tests is the FILTER, not that particular table, so they were
+repointed rather than deleted.
+
+``comms_nodes`` and now ``lineage`` are each asserted here in ONE direction
+only: that asking for them FAILS. A filter that still accepted the name
+would emit an empty array and read as "sac exports this, and it is empty" —
+the success-shaped answer this whole migration exists to remove. For
+``lineage`` that reading would be the worst of the three, because an empty
+edge set does not mean "no data", it means "every agent is a root", and a
+root may spawn.
 """
 
 from __future__ import annotations
@@ -79,14 +88,16 @@ def test_export_state_tables_filter_emits_the_named_tables_rows(
         export_state,
         record_instance_start,
     )
-    from scitex_agent_container._state.state_db_nodes import record_lineage
+    from scitex_agent_container._state.state_db_channel import persist_event
 
-    record_lineage(child="child-a", parent="parent-a", db_path=db_path)
+    persist_event(
+        target="agent-a", event={"from_agent": "peer", "kind": "message", "ts": 1.0}
+    )
     record_instance_start("agent-a", host="h1")
     # Act
-    payload = export_state(tables=["lineage"])
+    payload = export_state(tables=["channel_events"])
     # Assert
-    assert len(payload["tables"]["lineage"]) == 1
+    assert len(payload["tables"]["channel_events"]) == 1
 
 
 def test_export_state_tables_filter_excludes_unlisted_tables(
@@ -97,12 +108,14 @@ def test_export_state_tables_filter_excludes_unlisted_tables(
         export_state,
         record_instance_start,
     )
-    from scitex_agent_container._state.state_db_nodes import record_lineage
+    from scitex_agent_container._state.state_db_channel import persist_event
 
-    record_lineage(child="child-a", parent="parent-a", db_path=db_path)
+    persist_event(
+        target="agent-a", event={"from_agent": "peer", "kind": "message", "ts": 1.0}
+    )
     record_instance_start("agent-a", host="h1")
     # Act
-    payload = export_state(tables=["lineage"])
+    payload = export_state(tables=["channel_events"])
     # Assert
     assert payload["tables"]["instances"] == []
 
@@ -138,29 +151,33 @@ def test_export_state_tables_filter_unknown_table_raises(
 
 def test_db_export_tables_flag_exits_zero(db_path: Path) -> None:
     # Arrange
-    from scitex_agent_container._state.state_db_nodes import record_lineage
+    from scitex_agent_container._state.state_db_channel import persist_event
     from scitex_agent_container.cli_pkg.db_group import db_export
 
-    record_lineage(child="child-a", parent="parent-a", db_path=db_path)
+    persist_event(
+        target="agent-a", event={"from_agent": "peer", "kind": "message", "ts": 1.0}
+    )
     runner = CliRunner()
     # Act
-    result = runner.invoke(db_export, ["--tables", "lineage"])
+    result = runner.invoke(db_export, ["--tables", "channel_events"])
     # Assert
     assert result.exit_code == 0, result.output
 
 
 def test_db_export_tables_flag_emits_only_named_table(db_path: Path) -> None:
     # Arrange
-    from scitex_agent_container._state.state_db_nodes import record_lineage
+    from scitex_agent_container._state.state_db_channel import persist_event
     from scitex_agent_container.cli_pkg.db_group import db_export
 
-    record_lineage(child="child-a", parent="parent-a", db_path=db_path)
+    persist_event(
+        target="agent-a", event={"from_agent": "peer", "kind": "message", "ts": 1.0}
+    )
     runner = CliRunner()
     # Act
-    result = runner.invoke(db_export, ["--tables", "lineage"])
+    result = runner.invoke(db_export, ["--tables", "channel_events"])
     payload = json.loads(result.stdout)
     # Assert
-    assert len(payload["tables"]["lineage"]) == 1
+    assert len(payload["tables"]["channel_events"]) == 1
 
 
 def test_db_export_tables_flag_unknown_name_exits_two(
@@ -189,7 +206,7 @@ def test_db_export_tables_flag_unknown_name_names_offender_in_output(
     assert "not_a_real_table" in result.output
 
 
-def test_db_export_tables_flag_csv_includes_lineage(
+def test_db_export_tables_flag_csv_includes_channel_events(
     db_path: Path,
 ) -> None:
     # Arrange
@@ -197,10 +214,41 @@ def test_db_export_tables_flag_csv_includes_lineage(
 
     runner = CliRunner()
     # Act
-    result = runner.invoke(db_export, ["--tables", "lineage,instances"])
+    result = runner.invoke(db_export, ["--tables", "channel_events,instances"])
     payload = json.loads(result.stdout)
     # Assert
-    assert "lineage" in payload["tables"]
+    assert "channel_events" in payload["tables"]
+
+
+def test_db_export_tables_flag_rejects_lineage(
+    db_path: Path,
+) -> None:
+    """The spawn DAG left KNOWN_TABLES on 2026-08-28.
+
+    It must fail at PARSE time rather than emit an empty array. An empty
+    ``lineage`` does not read as "no data" to anything downstream — it
+    reads as "every agent is a root", and a root may spawn.
+    """
+    # Arrange
+    from scitex_agent_container.cli_pkg.db_group import db_export
+
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(db_export, ["--tables", "lineage"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_export_state_rejects_lineage_now_that_it_moved(
+    db_path: Path,
+) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db import export_state
+
+    # Act
+    # Assert — see the CLI twin above for why an empty array is worse.
+    with pytest.raises(ValueError, match="unknown table"):
+        export_state(tables=["lineage"])
 
 
 def test_db_export_tables_flag_csv_includes_instances(
@@ -211,7 +259,7 @@ def test_db_export_tables_flag_csv_includes_instances(
 
     runner = CliRunner()
     # Act
-    result = runner.invoke(db_export, ["--tables", "lineage,instances"])
+    result = runner.invoke(db_export, ["--tables", "channel_events,instances"])
     payload = json.loads(result.stdout)
     # Assert
     assert "instances" in payload["tables"]

--- a/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
+++ b/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
@@ -120,9 +120,9 @@ def test_grant_child_with_developer_in_its_groups_passes_check_spawn(
     spawn while its registry row listed developer."""
     # Arrange
     _record_grant_like("grant", GRANT_GROUPS, db_path)
-    record_lineage(child="grant", parent="scitex-agent-container", db_path=db_path)
+    record_lineage(child="grant", parent="scitex-agent-container")
     # Act
-    decision, _reason = check_spawn(caller="grant", db_path=db_path)
+    decision, _reason = check_spawn(caller="grant")
     # Assert
     assert decision == "allow"
 
@@ -134,9 +134,9 @@ def test_child_with_only_researcher_in_its_groups_passes_check_spawn(
     """The researcher half of the operator's ruling, on the same footing."""
     # Arrange
     _record_grant_like("nv", ["generalist", "researcher"], db_path)
-    record_lineage(child="nv", parent="lead", db_path=db_path)
+    record_lineage(child="nv", parent="lead")
     # Act
-    decision, _reason = check_spawn(caller="nv", db_path=db_path)
+    decision, _reason = check_spawn(caller="nv")
     # Assert
     assert decision == "allow"
 
@@ -147,9 +147,9 @@ def test_child_with_only_privileged_in_its_groups_passes_check_spawn(
 ) -> None:
     # Arrange
     _record_grant_like("dotfiles", ["generalist", "privileged"], db_path)
-    record_lineage(child="dotfiles", parent="lead", db_path=db_path)
+    record_lineage(child="dotfiles", parent="lead")
     # Act
-    decision, _reason = check_spawn(caller="dotfiles", db_path=db_path)
+    decision, _reason = check_spawn(caller="dotfiles")
     # Assert
     assert decision == "allow"
 
@@ -163,9 +163,9 @@ def test_child_with_only_privileged_in_its_groups_passes_check_spawn(
 def test_child_in_no_authorising_group_is_still_denied(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("worker", ["generalist", "active"], db_path)
-    record_lineage(child="worker", parent="lead", db_path=db_path)
+    record_lineage(child="worker", parent="lead")
     # Act
-    decision, _reason = check_spawn(caller="worker", db_path=db_path)
+    decision, _reason = check_spawn(caller="worker")
     # Assert
     assert decision == "deny"
 
@@ -173,9 +173,9 @@ def test_child_in_no_authorising_group_is_still_denied(pg_schema: str, db_path: 
 def test_ungrouped_child_is_still_denied(pg_schema: str, db_path: Path) -> None:
     # Arrange
     record_comms_policy(name="worker")
-    record_lineage(child="worker", parent="lead", db_path=db_path)
+    record_lineage(child="worker", parent="lead")
     # Act
-    decision, _reason = check_spawn(caller="worker", db_path=db_path)
+    decision, _reason = check_spawn(caller="worker")
     # Assert
     assert decision == "deny"
 
@@ -185,9 +185,9 @@ def test_isolated_solver_group_gets_no_spawn_authority(pg_schema: str, db_path: 
     set-valued read."""
     # Arrange
     _record_grant_like("solver", ["solver", "capsule"], db_path)
-    record_lineage(child="solver", parent="clew", db_path=db_path)
+    record_lineage(child="solver", parent="clew")
     # Act
-    decision, _reason = check_spawn(caller="solver", db_path=db_path)
+    decision, _reason = check_spawn(caller="solver")
     # Assert
     assert decision == "deny"
 
@@ -237,9 +237,9 @@ def test_legacy_row_without_a_set_still_resolves_to_its_primary(
 def test_legacy_developer_row_still_passes_check_spawn(pg_schema: str, db_path: Path) -> None:
     # Arrange
     record_comms_policy(name="legacy", group_name="developer")
-    record_lineage(child="legacy", parent="lead", db_path=db_path)
+    record_lineage(child="legacy", parent="lead")
     # Act
-    decision, _reason = check_spawn(caller="legacy", db_path=db_path)
+    decision, _reason = check_spawn(caller="legacy")
     # Assert
     assert decision == "allow"
 
@@ -310,9 +310,9 @@ def test_a_bare_string_group_names_is_rejected(db_path: Path) -> None:
 def test_denial_names_the_groups_the_gate_actually_resolved(pg_schema: str, db_path: Path) -> None:
     # Arrange
     _record_grant_like("worker", ["generalist", "active"], db_path)
-    record_lineage(child="worker", parent="lead", db_path=db_path)
+    record_lineage(child="worker", parent="lead")
     # Act
-    _decision, reason = spawn_allowed(caller="worker", db_path=db_path)
+    _decision, reason = spawn_allowed(caller="worker")
     # Assert
     assert "'active', 'generalist'" in reason
 
@@ -325,9 +325,9 @@ def test_denial_no_longer_claims_the_caller_holds_none_of_the_groups(
     a2a_peers output; it must not come back."""
     # Arrange
     _record_grant_like("worker", ["generalist"], db_path)
-    record_lineage(child="worker", parent="lead", db_path=db_path)
+    record_lineage(child="worker", parent="lead")
     # Act
-    _decision, reason = spawn_allowed(caller="worker", db_path=db_path)
+    _decision, reason = spawn_allowed(caller="worker")
     # Assert
     assert "is in none of the" not in reason
 
@@ -337,9 +337,9 @@ def test_denial_spells_researcher_in_full(pg_schema: str, db_path: Path) -> None
     hypothesis about a string mismatch. Name the real group."""
     # Arrange
     _record_grant_like("worker", ["generalist"], db_path)
-    record_lineage(child="worker", parent="lead", db_path=db_path)
+    record_lineage(child="worker", parent="lead")
     # Act
-    _decision, reason = spawn_allowed(caller="worker", db_path=db_path)
+    _decision, reason = spawn_allowed(caller="worker")
     # Assert
     assert "researcher" in reason
 
@@ -350,9 +350,9 @@ def test_denial_points_at_refresh_acl_when_the_row_may_be_stale(
 ) -> None:
     # Arrange
     _record_grant_like("worker", ["generalist"], db_path)
-    record_lineage(child="worker", parent="lead", db_path=db_path)
+    record_lineage(child="worker", parent="lead")
     # Act
-    _decision, reason = spawn_allowed(caller="worker", db_path=db_path)
+    _decision, reason = spawn_allowed(caller="worker")
     # Assert
     assert "refresh-acl" in reason
 
@@ -364,8 +364,8 @@ def test_denial_distinguishes_an_absent_row_from_an_ungrouped_agent(
     """The 2026-08-09 host_exec lesson, applied to the spawn gate: both
     produce an empty group set and they are different facts."""
     # Arrange — a lineage edge but NO policy row for the caller.
-    record_lineage(child="stranger", parent="lead", db_path=db_path)
+    record_lineage(child="stranger", parent="lead")
     # Act
-    _decision, reason = spawn_allowed(caller="stranger", db_path=db_path)
+    _decision, reason = spawn_allowed(caller="stranger")
     # Assert
     assert "NO node_comms_policy row" in reason

--- a/tests/scitex_agent_container/_state/test_state_db_lineage_rel.py
+++ b/tests/scitex_agent_container/_state/test_state_db_lineage_rel.py
@@ -1,100 +1,77 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""``sender_target_relationship`` — the SQLite half that did NOT move.
+"""``sender_target_relationship`` — the classifier, now over the store.
 
 These tests lived in ``test_state_db_acl_policy.py`` until 2026-08-28, when
-``node_comms_policy`` moved to PostgreSQL and this function did not. They are
-here, not there, for the reason the function itself moved modules: it reads
-``lineage``, a different table with a different owner, still on SQLite and
-still taking ``db_path``.
+``node_comms_policy`` moved to PostgreSQL and this function did not. They
+moved here because it read ``lineage``, a different table with a different
+owner, still on SQLite at the time.
 
-MEASURED WHERE THE PROPERTY STILL LIVES, which is the point. Leaving them in
-a file whose subject is now a PostgreSQL store would have made them read as
-coverage of the migrated code; they are not. They cover the table that stayed
-behind, and they will move again when it moves.
+THAT SENTENCE IS NOW DISCHARGED. ``lineage`` moved the same day, so the
+function no longer takes ``db_path`` and no longer reads a file. The tests
+stay in this file — the classification is still a distinct question from
+the policy that consumes it — but they take ``pg_schema`` now, and the
+"measured where the property still lives" note they carried was about a
+SQLite table that no longer exists.
 
-Real SQLite, no mocks — the same isolation these tests always had.
+Real PostgreSQL, no mocks. These SKIP on a host with no writable database.
 """
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
-import pytest
-
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
     record_lineage,
     sender_target_relationship,
 )
 
 
-@pytest.fixture
-def db_path(tmp_path: Path):
-    db = tmp_path / "state.db"
-    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
-    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
-    try:
-        yield db
-    finally:
-        state_db.DEFAULT_DB_PATH = saved_default
-        if saved_env is None:
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
-        else:
-            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
-
-
-def test_two_children_of_one_parent_are_siblings(db_path: Path) -> None:
+def test_two_children_of_one_parent_are_siblings(pg_schema: str) -> None:
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
+    record_lineage(child="cap-b", parent="root")
     # Act
-    rel = sender_target_relationship(sender="cap-a", target="cap-b", db_path=db_path)
+    rel = sender_target_relationship(sender="cap-a", target="cap-b")
     # Assert
     assert rel == "sibling"
 
 
-def test_a_child_addressing_its_parent_is_parent(db_path: Path) -> None:
+def test_a_child_addressing_its_parent_is_parent(pg_schema: str) -> None:
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
     # Act
-    rel = sender_target_relationship(sender="cap-a", target="root", db_path=db_path)
+    rel = sender_target_relationship(sender="cap-a", target="root")
     # Assert
     assert rel == "parent"
 
 
-def test_a_parent_addressing_its_child_is_child(db_path: Path) -> None:
+def test_a_parent_addressing_its_child_is_child(pg_schema: str) -> None:
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
     # Act
-    rel = sender_target_relationship(sender="root", target="cap-a", db_path=db_path)
+    rel = sender_target_relationship(sender="root", target="cap-a")
     # Assert
     assert rel == "child"
 
 
-def test_unrelated_nodes_are_other(db_path: Path) -> None:
+def test_unrelated_nodes_are_other(pg_schema: str) -> None:
     # Arrange — no lineage edges.
     # Act
-    rel = sender_target_relationship(sender="cap-a", target="cap-z", db_path=db_path)
+    rel = sender_target_relationship(sender="cap-a", target="cap-z")
     # Assert
     assert rel == "other"
 
 
-def test_a_node_addressing_itself_is_self(db_path: Path) -> None:
+def test_a_node_addressing_itself_is_self(pg_schema: str) -> None:
     # Arrange
     # Act
-    rel = sender_target_relationship(sender="cap-a", target="cap-a", db_path=db_path)
+    rel = sender_target_relationship(sender="cap-a", target="cap-a")
     # Assert
     assert rel == "self"
 
 
-def test_an_empty_sender_is_other(db_path: Path) -> None:
+def test_an_empty_sender_is_other(pg_schema: str) -> None:
     # Arrange
     # Act
-    rel = sender_target_relationship(sender="", target="cap-a", db_path=db_path)
+    rel = sender_target_relationship(sender="", target="cap-a")
     # Assert
     assert rel == "other"

--- a/tests/scitex_agent_container/_state/test_state_db_lineage_rename.py
+++ b/tests/scitex_agent_container/_state/test_state_db_lineage_rename.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``rename_lineage`` — what moves, and what the schema will not let move.
+
+The lineage half of the agent-rename flow, replacing the two
+``NAME_COLUMNS`` pairs that renamed the SQLite table until 2026-08-28.
+
+The asymmetry is the whole subject of this file. ``child_name`` is the
+store IDENTITY, so an agent's OWN edge can be moved (copy onto the new
+identity, retire the old). ``parent_name`` is IMMUTABLE, so the edges that
+name the agent as a PARENT cannot be re-pointed at all — the first value is
+kept forever, and ``hide``/``unhide`` append ops carrying no values, so
+even a retire-and-restore comes back with its field stamps intact.
+
+That leaves three possible behaviours for renaming an agent that has
+children, and two of them are silent privilege escalations:
+
+  * leave the children's edges pointing at a name nothing answers to →
+    each child resolves to NO parent → each child is a ROOT → each child
+    may spawn;
+  * hide those edges instead → identical outcome, reached deliberately;
+  * REFUSE. Which is what it does, and what these tests pin.
+
+Real PostgreSQL via ``pg_schema``, no mocks. SKIPs on a host with no
+writable database, which includes every agent container.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._state.state_db_lineage_group import record_lineage
+from scitex_agent_container._state.state_db_lineage_rename import (
+    LineageRenameError,
+    rename_lineage,
+)
+from scitex_agent_container._state.state_db_lineage_store import (
+    new_lineage_store,
+    read_edges,
+    reset_lineage_store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _drop_cached_handle():
+    """Start and end with an empty process-wide handle cache."""
+    reset_lineage_store()
+    yield
+    reset_lineage_store()
+
+
+# ---------------------------------------------------------------------------
+# The half that moves: an agent's own edge.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def renamed_leaf(pg_schema: str):
+    """A childless agent renamed. Yields ``(moved, created_at_before)``."""
+    record_lineage(child="old-name", parent="root")
+    store = new_lineage_store()
+    try:
+        before = float(store.get({"child_name": "old-name"}).values["created_at"])
+    finally:
+        store.close()
+    moved = rename_lineage(old="old-name", new="new-name")
+    yield moved, before
+
+
+def test_renaming_a_leaf_reports_that_an_edge_moved(renamed_leaf) -> None:
+    # Arrange
+    moved, _before = renamed_leaf
+    # Act
+    result = moved
+    # Assert
+    assert result is True
+
+
+def test_the_new_name_inherits_the_parent(renamed_leaf) -> None:
+    # Arrange
+    _moved, _before = renamed_leaf
+    # Act
+    parent = read_edges().parent("new-name")
+    # Assert
+    assert parent == "root"
+
+
+def test_the_old_name_no_longer_resolves_to_a_parent(renamed_leaf) -> None:
+    """The escalation this step exists to prevent, checked directly.
+
+    An edge left behind under the old name is not the danger; an edge
+    MISSING under the live name is, because no parent means ROOT and a root
+    may spawn. This asserts the old identity stopped answering.
+    """
+    # Arrange
+    _moved, _before = renamed_leaf
+    # Act
+    parent = read_edges().parent("old-name")
+    # Assert
+    assert parent is None
+
+
+def test_created_at_travels_verbatim(renamed_leaf) -> None:
+    """The spawn happened when it happened; a rename is not a re-spawn."""
+    # Arrange
+    _moved, before = renamed_leaf
+    store = new_lineage_store()
+    # Act
+    try:
+        after = float(store.get({"child_name": "new-name"}).values["created_at"])
+    finally:
+        store.close()
+    # Assert
+    assert after == before
+
+
+def test_the_old_identity_is_hidden_not_hard_deleted(renamed_leaf) -> None:
+    """Nothing is ever hard-deleted, so the history stays auditable."""
+    # Arrange
+    _moved, _before = renamed_leaf
+    store = new_lineage_store()
+    # Act
+    try:
+        hidden = store.is_hidden({"child_name": "old-name"})
+    finally:
+        store.close()
+    # Assert
+    assert hidden is True
+
+
+def test_renaming_an_unknown_name_is_a_no_op(pg_schema: str) -> None:
+    # Arrange
+    old, new = "never-existed", "whatever"
+    # Act
+    moved = rename_lineage(old=old, new=new)
+    # Assert
+    assert moved is False
+
+
+def test_the_rename_round_trips_through_its_inverse(pg_schema: str) -> None:
+    """The undo the rename flow pushes is the same verb, arguments swapped."""
+    # Arrange
+    record_lineage(child="alpha", parent="root")
+    # Act
+    rename_lineage(old="alpha", new="beta")
+    rename_lineage(old="beta", new="alpha")
+    # Assert
+    assert read_edges().parent("alpha") == "root"
+
+
+# ---------------------------------------------------------------------------
+# The half that cannot move: edges naming this agent as the PARENT.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def refused_rename(pg_schema: str):
+    """Try to rename an agent that HAS children. Yields the refusal."""
+    record_lineage(child="kid-a", parent="the-parent")
+    record_lineage(child="kid-b", parent="the-parent")
+    record_lineage(child="the-parent", parent="grandparent")
+    try:
+        rename_lineage(old="the-parent", new="renamed-parent")
+    except LineageRenameError as exc:
+        yield exc
+        return
+    pytest.fail("rename_lineage accepted a rename it cannot carry out")
+
+
+def test_renaming_a_parent_is_refused(pg_schema: str) -> None:
+    # Arrange
+    record_lineage(child="kid-a", parent="the-parent")
+    # Act
+    # (the rename is the act; it must refuse rather than half-succeed)
+    # Assert
+    with pytest.raises(LineageRenameError):
+        rename_lineage(old="the-parent", new="renamed-parent")
+
+
+def test_the_refusal_names_the_blocking_children(refused_rename) -> None:
+    """A refusal must say WHAT it saw, not merely that it refused."""
+    # Arrange
+    message = str(refused_rename)
+    # Act
+    named = "kid-a" in message and "kid-b" in message
+    # Assert
+    assert named is True
+
+
+def test_the_refusal_explains_that_parent_name_is_immutable(
+    refused_rename,
+) -> None:
+    # Arrange
+    message = str(refused_rename)
+    # Act
+    explained = "IMMUTABLE" in message
+    # Assert
+    assert explained is True
+
+
+def test_a_refused_rename_leaves_the_children_pointing_at_the_old_name(
+    refused_rename,
+) -> None:
+    """Refused BEFORE any write, so there is nothing for the unwind to undo."""
+    # Arrange
+    _exc = refused_rename
+    # Act
+    edges = read_edges()
+    # Assert
+    assert edges.parent("kid-a") == "the-parent"
+
+
+def test_a_refused_rename_leaves_the_parents_own_edge_alone(
+    refused_rename,
+) -> None:
+    # Arrange
+    _exc = refused_rename
+    # Act
+    edges = read_edges()
+    # Assert
+    assert edges.parent("the-parent") == "grandparent"
+
+
+def test_a_refused_rename_creates_nothing_under_the_new_name(
+    refused_rename,
+) -> None:
+    # Arrange
+    _exc = refused_rename
+    # Act
+    edges = read_edges()
+    # Assert
+    assert edges.parent("renamed-parent") is None
+
+# EOF

--- a/tests/scitex_agent_container/_state/test_state_db_lineage_store.py
+++ b/tests/scitex_agent_container/_state/test_state_db_lineage_store.py
@@ -139,16 +139,31 @@ def test_the_first_parent_is_what_the_store_still_holds(contradicted_edge) -> No
 
 @pytest.fixture
 def reparent_attempt(pg_schema: str, caplog: pytest.LogCaptureFixture):
-    """A re-parent attempt through the production writer. Yields the log."""
+    """A re-parent attempt through the production writer.
+
+    Yields the WARNING messages it emitted, SNAPSHOT HERE rather than the
+    ``caplog`` object itself, and that detail is the whole fixture.
+    ``caplog.records`` is PHASE-SCOPED: the plugin resets its capture
+    handler between setup / call / teardown, so a record emitted inside a
+    FIXTURE is filed under "setup" and ``caplog.records`` reads EMPTY from
+    the test body.
+
+    Measured, because the first version of this file got it wrong and CI
+    caught it: yielding ``caplog`` made the assertion below fail on an
+    empty list while pytest's own report printed the record under
+    "Captured log setup" three lines further down. The reparent had been
+    refused correctly the whole time — the test was reading the wrong
+    phase, not observing a missing log.
+    """
     record_lineage(child="kid", parent="original")
     with caplog.at_level(logging.WARNING):
         record_lineage(child="kid", parent="usurper")
-    yield caplog
+    yield [record.getMessage() for record in caplog.records]
 
 
 def test_a_reparent_attempt_keeps_the_original_parent(reparent_attempt) -> None:
     # Arrange
-    _caplog = reparent_attempt
+    _messages = reparent_attempt
     # Act
     parent = parent_name_of("kid")
     # Assert
@@ -158,11 +173,11 @@ def test_a_reparent_attempt_keeps_the_original_parent(reparent_attempt) -> None:
 def test_a_reparent_attempt_is_logged_rather_than_raised(reparent_attempt) -> None:
     """Logged, not raised — the restart-in-place contract from WI-2."""
     # Arrange
-    caplog = reparent_attempt
+    messages = reparent_attempt
     # Act
-    messages = [record.getMessage() for record in caplog.records]
+    logged = [message for message in messages if "keeps parent" in message]
     # Assert
-    assert any("keeps parent" in message for message in messages)
+    assert logged != []
 
 
 def test_recording_the_same_parent_twice_is_a_no_op(pg_schema: str) -> None:

--- a/tests/scitex_agent_container/_state/test_state_db_lineage_store.py
+++ b/tests/scitex_agent_container/_state/test_state_db_lineage_store.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The ``lineage`` store — the properties the SQLite version could not have.
+
+Companion to the 2026-08-28 move. Behaviour that merely SURVIVED the
+migration (the three group relations, the walks, the ACL decisions) stays
+covered by the suites that already owned it. What is here is the set of
+claims the STORE introduces, each of which the ACL now rests on:
+
+* IMMUTABLE ``parent_name`` KEEPS THE FIRST VALUE AND DOES NOT RAISE.
+  ``record_lineage`` is built on that sentence, so it is measured against
+  the real primitive rather than taken from the documentation. If ``put``
+  ever started raising instead of reporting, the writer would go from
+  "logs a contradiction" to "crashes a spawn", and only this file would
+  say so.
+* The solitary short-circuit never opens the store. Cheap against SQLite,
+  load-bearing against PostgreSQL: an isolated capsule must resolve its
+  own group without a network round-trip.
+* The handle is cached per process and EVICTED when the DSN changes.
+
+Real PostgreSQL via the ``pg_schema`` fixture, no mocks. These SKIP on a
+host with no writable database — which includes every agent container,
+where loopback is a read-only replica of the fleet cluster. See
+``tests/_store_isolation.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from scitex_agent_container._state import state_db_lineage_store as store_mod
+from scitex_agent_container._state.state_db_lineage_group import (
+    derive_group,
+    record_lineage,
+)
+from scitex_agent_container._state.state_db_lineage_store import (
+    new_lineage_store,
+    open_lineage_store,
+    parent_name_of,
+    read_edges,
+    reset_lineage_store,
+)
+
+UNREACHABLE_DSN = "postgresql://sac_tests@127.0.0.1:1/there_is_no_server_here"
+
+
+@pytest.fixture(autouse=True)
+def _drop_cached_handle():
+    """Drop the process-wide handle around every test in this file.
+
+    The cache is keyed on the resolved target, so ``pg_schema`` already
+    swaps it — but these tests assert ON the handle, so they must start
+    from a known-empty cache rather than from whatever a neighbour left
+    behind. A real function call, not ``monkeypatch``: the reset hook
+    exists precisely so nobody has to reach into the module.
+    """
+    reset_lineage_store()
+    yield
+    reset_lineage_store()
+
+
+# ---------------------------------------------------------------------------
+# The premise the writer is built on: IMMUTABLE keeps first, never raises.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def contradicted_edge(pg_schema: str):
+    """Two DIFFERENT parents written for one child, through the primitive.
+
+    Yields ``(second_put_result, store)``. The store stays open so a test
+    can read back what survived.
+    """
+    from scitex_dev.store import ANY_REVISION
+
+    store = new_lineage_store()
+    try:
+        store.put(
+            {"child_name": "kid", "parent_name": "first", "created_at": 1.0},
+            expected_revision=ANY_REVISION,
+        )
+        result = store.put(
+            {"child_name": "kid", "parent_name": "second", "created_at": 2.0},
+            expected_revision=ANY_REVISION,
+        )
+        yield result, store
+    finally:
+        store.close()
+
+
+def test_a_second_differing_parent_does_not_raise(contradicted_edge) -> None:
+    """The whole keep-first contract depends on ``put`` returning normally."""
+    # Arrange
+    result, _store = contradicted_edge
+    # Act
+    conflicted_fields = [conflict.field for conflict in result.conflicts]
+    # Assert
+    assert "parent_name" in conflicted_fields
+
+
+def test_the_conflict_names_the_kept_parent(contradicted_edge) -> None:
+    # Arrange
+    result, _store = contradicted_edge
+    # Act
+    parent_conflict = next(
+        conflict for conflict in result.conflicts if conflict.field == "parent_name"
+    )
+    # Assert
+    assert parent_conflict.kept == "first"
+
+
+def test_the_conflict_names_the_rejected_parent(contradicted_edge) -> None:
+    # Arrange
+    result, _store = contradicted_edge
+    # Act
+    parent_conflict = next(
+        conflict for conflict in result.conflicts if conflict.field == "parent_name"
+    )
+    # Assert
+    assert parent_conflict.rejected == "second"
+
+
+def test_the_first_parent_is_what_the_store_still_holds(contradicted_edge) -> None:
+    # Arrange
+    _result, store = contradicted_edge
+    # Act
+    stored = str(store.get({"child_name": "kid"}).values["parent_name"])
+    # Assert
+    assert stored == "first"
+
+
+# ---------------------------------------------------------------------------
+# record_lineage over the store.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def reparent_attempt(pg_schema: str, caplog: pytest.LogCaptureFixture):
+    """A re-parent attempt through the production writer. Yields the log."""
+    record_lineage(child="kid", parent="original")
+    with caplog.at_level(logging.WARNING):
+        record_lineage(child="kid", parent="usurper")
+    yield caplog
+
+
+def test_a_reparent_attempt_keeps_the_original_parent(reparent_attempt) -> None:
+    # Arrange
+    _caplog = reparent_attempt
+    # Act
+    parent = parent_name_of("kid")
+    # Assert
+    assert parent == "original"
+
+
+def test_a_reparent_attempt_is_logged_rather_than_raised(reparent_attempt) -> None:
+    """Logged, not raised — the restart-in-place contract from WI-2."""
+    # Arrange
+    caplog = reparent_attempt
+    # Act
+    messages = [record.getMessage() for record in caplog.records]
+    # Assert
+    assert any("keeps parent" in message for message in messages)
+
+
+def test_recording_the_same_parent_twice_is_a_no_op(pg_schema: str) -> None:
+    # Arrange
+    record_lineage(child="kid", parent="mum")
+    # Act
+    record_lineage(child="kid", parent="mum")
+    # Assert
+    assert read_edges().parent_of["kid"] == "mum"
+
+
+def test_an_empty_child_name_is_a_programming_error(pg_schema: str) -> None:
+    # Arrange
+    child = ""
+    # Act
+    # (the call itself is the act; it must refuse rather than write)
+    # Assert
+    with pytest.raises(ValueError):
+        record_lineage(child=child, parent="mum")
+
+
+def test_read_edges_indexes_children_by_parent(pg_schema: str) -> None:
+    # Arrange
+    record_lineage(child="kid-a", parent="root")
+    record_lineage(child="kid-b", parent="root")
+    # Act
+    children = read_edges().children("root")
+    # Assert
+    assert children == {"kid-a", "kid-b"}
+
+
+def test_parent_name_of_an_unknown_name_is_none(pg_schema: str) -> None:
+    # Arrange
+    name = "never-spawned"
+    # Act
+    parent = parent_name_of(name)
+    # Assert
+    assert parent is None
+
+
+# ---------------------------------------------------------------------------
+# The solitary short-circuit must not touch PostgreSQL at all.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def solitary_capsule(pg_schema: str):
+    """A capsule with ``lineage_group='solitary'`` AND a real parent edge.
+
+    The edge matters: without one, a singleton answer would prove nothing,
+    because an agent with no edges is a singleton anyway.
+    """
+    from scitex_agent_container._state.state_db_acl_policy import (
+        record_comms_policy,
+    )
+
+    record_comms_policy(
+        name="capsule",
+        outbound_siblings="allow",
+        outbound_parent="allow",
+        inbound_siblings="allow",
+        inbound_parent="allow",
+        lineage_group="solitary",
+        may_spawn=True,
+    )
+    record_lineage(child="capsule", parent="root")
+    record_lineage(child="sibling", parent="root")
+    reset_lineage_store()
+    yield "capsule"
+
+
+def test_a_solitary_capsule_resolves_to_itself(solitary_capsule: str) -> None:
+    # Arrange
+    name = solitary_capsule
+    # Act
+    group = derive_group(name=name)
+    # Assert
+    assert group == {name}
+
+
+def test_the_solitary_path_never_opens_the_lineage_store(
+    solitary_capsule: str,
+) -> None:
+    """Proven by OBSERVING THE REAL MODULE rather than by patching it.
+
+    The process-wide handle starts as ``None`` (the fixture resets it), and
+    opening the store is the only thing that fills it. A handle still
+    ``None`` after the call is direct evidence that no round-trip happened
+    — which is the property that keeps an isolated capsule resolvable when
+    the primary is unreachable.
+    """
+    # Arrange
+    derive_group(name=solitary_capsule)
+    # Act
+    handle_after = store_mod._HANDLE
+    # Assert
+    assert handle_after is None
+
+
+# ---------------------------------------------------------------------------
+# The cached handle.
+# ---------------------------------------------------------------------------
+
+
+def test_the_handle_is_shared_across_calls(pg_schema: str) -> None:
+    # Arrange
+    first = open_lineage_store()
+    # Act
+    second = open_lineage_store()
+    # Assert
+    assert first is second
+
+
+@pytest.fixture
+def repointed_dsn(pg_schema: str):
+    """Open the store, then repoint ``SCITEX_STORE_DSN`` at nothing.
+
+    Real ``os.environ`` save/restore, not ``monkeypatch``: the point is
+    that the REAL resolver reads the REAL variable.
+    """
+    open_lineage_store()
+    saved = os.environ.get("SCITEX_STORE_DSN")
+    os.environ["SCITEX_STORE_DSN"] = UNREACHABLE_DSN
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SCITEX_STORE_DSN", None)
+        else:
+            os.environ["SCITEX_STORE_DSN"] = saved
+
+
+def test_a_changed_dsn_evicts_the_cached_handle(repointed_dsn) -> None:
+    """The cache is keyed on the RESOLVED TARGET, not on "have we opened one".
+
+    Proven without needing a second database: repointing at an address
+    nothing answers must FAIL rather than hand back the previous handle. A
+    cache keyed on mere existence would serve the old connection and
+    silently read the wrong store — which is the bug this key prevents, and
+    the one the ``pg_schema`` fixture would otherwise hit on every test
+    after the first.
+    """
+    # Arrange
+    _ = repointed_dsn
+    # Act
+    # (opening again is the act; it must re-resolve rather than reuse)
+    # Assert
+    with pytest.raises(Exception):
+        open_lineage_store()
+
+# EOF

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -31,6 +31,7 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_lineage_store import read_edges
 from scitex_agent_container._state.state_db_nodes import (
     derive_group,
     record_comms_policy,
@@ -52,7 +53,18 @@ def db_path(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def test_lineage_table_exists(db_path: Path) -> None:
+def test_lineage_table_is_absent_from_a_fresh_state_db(db_path: Path) -> None:
+    """INVERTED on 2026-08-28, and kept rather than deleted.
+
+    This asserted the SQLite ``lineage`` table EXISTS. The spawn DAG moved
+    to the shared PostgreSQL store and its DDL is gone, so the honest
+    version of the same question is the opposite one — and it is worth
+    asking, because an empty leftover would be worse here than a crash:
+    every reader treats "no row for this child" as ROOT, and a root MAY
+    SPAWN. A stray ``CREATE TABLE lineage`` sneaking back into the schema
+    would hand the whole fleet spawn authority, silently. This test is what
+    would notice.
+    """
     # Arrange
     conn_ctx = state_db.open_db(db_path)
     # Act
@@ -61,7 +73,7 @@ def test_lineage_table_exists(db_path: Path) -> None:
             "SELECT name FROM sqlite_master WHERE type='table' AND name='lineage'"
         ).fetchall()
     # Assert
-    assert len(rows) == 1
+    assert rows == []
 
 
 # ``test_comms_grants_table_exists`` and ``test_comms_grants_has_column``
@@ -82,35 +94,33 @@ def test_lineage_table_exists(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_record_lineage_persists_parent_pointer(db_path: Path) -> None:
+def test_record_lineage_persists_parent_pointer(pg_schema: str) -> None:
     # Arrange
-    record_lineage(child="bob", parent="alice", db_path=db_path)
-    # Act
-    conn_ctx = state_db.open_db(db_path)
-    with conn_ctx as conn:
-        row = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name='bob'"
-        ).fetchone()
+    record_lineage(child="bob", parent="alice")
+    # Act — read back through the production index, not raw SQL.
+    parent = read_edges().parent("bob")
     # Assert
-    assert row["parent_name"] == "alice"
+    assert parent == "alice"
 
 
-def test_record_lineage_idempotent_no_duplicate_rows(db_path: Path) -> None:
-    """Re-recording the same edge does not duplicate the row."""
+def test_record_lineage_idempotent_no_duplicate_rows(pg_schema: str) -> None:
+    """Re-recording the same edge does not duplicate the record.
+
+    ``child_name`` is the store IDENTITY, so a duplicate is not merely
+    unlikely — it is unrepresentable. Kept anyway: the test now pins that
+    the SECOND call still leaves exactly one live edge for ``bob``, which
+    is the property the caller depends on however it is enforced.
+    """
     # Arrange
-    record_lineage(child="bob", parent="alice", db_path=db_path)
-    record_lineage(child="bob", parent="alice", db_path=db_path)
+    record_lineage(child="bob", parent="alice")
+    record_lineage(child="bob", parent="alice")
     # Act
-    conn_ctx = state_db.open_db(db_path)
-    with conn_ctx as conn:
-        rows = conn.execute(
-            "SELECT child_name FROM lineage WHERE child_name='bob'"
-        ).fetchall()
+    bobs = [child for child in read_edges().parent_of if child == "bob"]
     # Assert
-    assert len(rows) == 1
+    assert len(bobs) == 1
 
 
-def test_record_lineage_re_parent_keeps_existing_parent(db_path: Path) -> None:
+def test_record_lineage_re_parent_keeps_existing_parent(pg_schema: str) -> None:
     """A re-parent attempt keeps the original parent (no raise, no switch).
 
     A restart of an existing agent by a different-lineage caller must not
@@ -119,16 +129,11 @@ def test_record_lineage_re_parent_keeps_existing_parent(db_path: Path) -> None:
     implicit: a raising record_lineage would error this test.)
     """
     # Arrange
-    record_lineage(child="bob", parent="alice", db_path=db_path)
+    record_lineage(child="bob", parent="alice")
     # Act — a different parent must NOT raise; it keeps "alice"
-    record_lineage(child="bob", parent="other-root", db_path=db_path)
+    record_lineage(child="bob", parent="other-root")
     # Assert — original parent kept, not switched to the new caller
-    conn_ctx = state_db.open_db(db_path)
-    with conn_ctx as conn:
-        row = conn.execute(
-            "SELECT parent_name FROM lineage WHERE child_name='bob'"
-        ).fetchone()
-    assert row["parent_name"] == "alice"
+    assert read_edges().parent("bob") == "alice"
 
 
 # ---------------------------------------------------------------------------
@@ -140,17 +145,17 @@ def test_derive_group_of_root_with_no_children_is_self_only(pg_schema: str, db_p
     # Arrange
     name = "root"
     # Act
-    group = derive_group(name=name, db_path=db_path)
+    group = derive_group(name=name)
     # Assert
     assert group == {"root"}
 
 
 def test_derive_group_of_parent_includes_direct_children(pg_schema: str, db_path: Path) -> None:
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
+    record_lineage(child="worker-b", parent="root")
     # Act
-    group = derive_group(name="root", db_path=db_path)
+    group = derive_group(name="root")
     # Assert
     assert group == {"root", "worker-a", "worker-b"}
 
@@ -158,10 +163,10 @@ def test_derive_group_of_parent_includes_direct_children(pg_schema: str, db_path
 def test_derive_group_of_child_includes_parent_and_siblings(pg_schema: str, db_path: Path) -> None:
     """Sibling sees the same group as the parent does — bidirectional."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
-    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
+    record_lineage(child="worker-b", parent="root")
     # Act
-    group = derive_group(name="worker-a", db_path=db_path)
+    group = derive_group(name="worker-a")
     # Assert
     assert group == {"root", "worker-a", "worker-b"}
 
@@ -169,10 +174,10 @@ def test_derive_group_of_child_includes_parent_and_siblings(pg_schema: str, db_p
 def test_derive_group_excludes_cross_group_nodes(pg_schema: str, db_path: Path) -> None:
     """A different root's children are not in this group."""
     # Arrange — two unrelated families
-    record_lineage(child="child-1", parent="root-1", db_path=db_path)
-    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    record_lineage(child="child-1", parent="root-1")
+    record_lineage(child="child-2", parent="root-2")
     # Act
-    group = derive_group(name="child-1", db_path=db_path)
+    group = derive_group(name="child-1")
     # Assert
     assert group == {"root-1", "child-1"}
 
@@ -182,7 +187,7 @@ def test_derive_group_of_unknown_node_is_singleton(pg_schema: str, db_path: Path
     # Arrange
     name = "fresh"
     # Act
-    group = derive_group(name=name, db_path=db_path)
+    group = derive_group(name=name)
     # Assert
     assert group == {"fresh"}
 
@@ -206,11 +211,11 @@ def test_derive_group_solitary_returns_a_singleton_despite_siblings(
     empty — so a sibling capsule can never address it via the group-default
     ACL even though they share a parent edge."""
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
+    record_lineage(child="cap-b", parent="root")
     record_comms_policy(name="cap-a", lineage_group="solitary")
     # Act
-    group = derive_group(name="cap-a", db_path=db_path)
+    group = derive_group(name="cap-a")
     # Assert
     assert group == {"cap-a"}
 
@@ -221,10 +226,10 @@ def test_derive_group_without_a_policy_keeps_the_legacy_siblings(
     """Default-preservation: with no policy record, derive_group keeps the
     legacy parent + direct-children semantics."""
     # Arrange
-    record_lineage(child="cap-a", parent="root", db_path=db_path)
-    record_lineage(child="cap-b", parent="root", db_path=db_path)
+    record_lineage(child="cap-a", parent="root")
+    record_lineage(child="cap-b", parent="root")
     # Act
-    group = derive_group(name="cap-a", db_path=db_path)
+    group = derive_group(name="cap-a")
     # Assert
     assert "cap-b" in group
 
@@ -239,7 +244,7 @@ def test_spawn_allowed_returns_true_for_admin_caller(db_path: Path) -> None:
     # Arrange
     caller = None
     # Act
-    allowed, _reason = spawn_allowed(caller=caller, db_path=db_path)
+    allowed, _reason = spawn_allowed(caller=caller)
     # Assert
     assert allowed is True
 
@@ -249,7 +254,7 @@ def test_spawn_allowed_returns_true_for_root_node(pg_schema: str, db_path: Path)
     # Arrange
     caller = "root"
     # Act
-    allowed, _reason = spawn_allowed(caller=caller, db_path=db_path)
+    allowed, _reason = spawn_allowed(caller=caller)
     # Assert
     assert allowed is True
 
@@ -257,9 +262,9 @@ def test_spawn_allowed_returns_true_for_root_node(pg_schema: str, db_path: Path)
 def test_spawn_allowed_returns_false_for_child_node(pg_schema: str, db_path: Path) -> None:
     """A node with a parent → child → denied under current policy."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     # Act
-    allowed, _reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="worker-a")
     # Assert
     assert allowed is False
 
@@ -276,9 +281,9 @@ def test_spawn_allowed_deny_reason_explains_role_policy(
     the same server's own a2a_peers output (2026-08-10).
     """
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     # Act
-    _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    _allowed, reason = spawn_allowed(caller="worker-a")
     # Assert
     assert reason is not None and "developer, researcher, privileged" in reason
 
@@ -290,9 +295,9 @@ def test_spawn_deny_reason_for_unregistered_caller_says_it_has_no_row(
     """No policy row and "registered but ungrouped" both resolve to an
     empty group set, and they are DIFFERENT facts (2026-08-09)."""
     # Arrange — a lineage edge but no node_comms_policy row.
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     # Act
-    _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    _allowed, reason = spawn_allowed(caller="worker-a")
     # Assert
     assert "NO node_comms_policy row" in reason
 
@@ -303,10 +308,10 @@ def test_spawn_allowed_returns_true_for_developer_group_child(
 ) -> None:
     """A developer-group child may spawn even though it has a parent."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     record_comms_policy(name="worker-a", group_name="developer")
     # Act
-    allowed, _reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="worker-a")
     # Assert
     assert allowed is True
 
@@ -317,10 +322,10 @@ def test_spawn_allowed_returns_true_for_researcher_group_child(
 ) -> None:
     """A researcher-group child may spawn even though it has a parent."""
     # Arrange
-    record_lineage(child="neurovista", parent="scitex-cv", db_path=db_path)
+    record_lineage(child="neurovista", parent="scitex-cv")
     record_comms_policy(name="neurovista", group_name="researcher")
     # Act
-    allowed, _reason = spawn_allowed(caller="neurovista", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="neurovista")
     # Assert
     assert allowed is True
 
@@ -336,10 +341,10 @@ def test_spawn_allowed_returns_true_for_privileged_group_child(
     strongest group was absent from the spawn allowlist.
     """
     # Arrange
-    record_lineage(child="dotfiles", parent="root", db_path=db_path)
+    record_lineage(child="dotfiles", parent="root")
     record_comms_policy(name="dotfiles", group_name="privileged")
     # Act
-    allowed, _reason = spawn_allowed(caller="dotfiles", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="dotfiles")
     # Assert
     assert allowed is True
 
@@ -350,10 +355,10 @@ def test_spawn_allowed_returns_false_for_non_dev_research_group_child(
 ) -> None:
     """A child in an unrelated named group is still denied."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     record_comms_policy(name="worker-a", group_name="analysts")
     # Act
-    allowed, _reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="worker-a")
     # Assert
     assert allowed is False
 
@@ -369,10 +374,10 @@ def test_spawn_allowed_deny_reason_for_non_dev_research_group_child(
     without guessing (2026-08-10).
     """
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     record_comms_policy(name="worker-a", group_name="analysts")
     # Act
-    _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    _allowed, reason = spawn_allowed(caller="worker-a")
     # Assert
     assert reason is not None and "['analysts']" in reason
 
@@ -383,14 +388,14 @@ def test_spawn_allowed_may_spawn_false_still_denies_developer_child(
 ) -> None:
     """Per-spec may_spawn=false overrides the developer-group allow."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     record_comms_policy(
         name="worker-a",
         group_name="developer",
         may_spawn=False,
     )
     # Act
-    allowed, _reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="worker-a")
     # Assert
     assert allowed is False
 
@@ -401,14 +406,14 @@ def test_spawn_allowed_may_spawn_false_reason_for_developer_child(
 ) -> None:
     """The deny reason names the per-spec may_spawn=false override."""
     # Arrange
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-a", parent="root")
     record_comms_policy(
         name="worker-a",
         group_name="developer",
         may_spawn=False,
     )
     # Act
-    _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    _allowed, reason = spawn_allowed(caller="worker-a")
     # Assert
     assert reason is not None and "may_spawn=false" in reason
 
@@ -419,14 +424,14 @@ def test_spawn_allowed_may_spawn_false_still_denies_researcher_child(
 ) -> None:
     """Per-spec may_spawn=false overrides the researcher-group allow."""
     # Arrange
-    record_lineage(child="neurovista", parent="scitex-cv", db_path=db_path)
+    record_lineage(child="neurovista", parent="scitex-cv")
     record_comms_policy(
         name="neurovista",
         group_name="researcher",
         may_spawn=False,
     )
     # Act
-    allowed, _reason = spawn_allowed(caller="neurovista", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="neurovista")
     # Assert
     assert allowed is False
 
@@ -437,14 +442,14 @@ def test_spawn_allowed_may_spawn_false_reason_for_researcher_child(
 ) -> None:
     """The deny reason names the per-spec may_spawn=false override."""
     # Arrange
-    record_lineage(child="neurovista", parent="scitex-cv", db_path=db_path)
+    record_lineage(child="neurovista", parent="scitex-cv")
     record_comms_policy(
         name="neurovista",
         group_name="researcher",
         may_spawn=False,
     )
     # Act
-    _allowed, reason = spawn_allowed(caller="neurovista", db_path=db_path)
+    _allowed, reason = spawn_allowed(caller="neurovista")
     # Assert
     assert reason is not None and "may_spawn=false" in reason
 
@@ -459,10 +464,10 @@ def test_spawn_allowed_may_spawn_false_reason_for_researcher_child(
 def test_spawn_allowed_allows_developer_group_child(pg_schema: str, db_path: Path) -> None:
     """A child in the developer group may spawn (group short-circuit)."""
     # Arrange
-    record_lineage(child="worker-dev", parent="root", db_path=db_path)
+    record_lineage(child="worker-dev", parent="root")
     record_comms_policy(name="worker-dev", group_name="developer")
     # Act
-    allowed, _reason = spawn_allowed(caller="worker-dev", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="worker-dev")
     # Assert
     assert allowed is True
 
@@ -470,10 +475,10 @@ def test_spawn_allowed_allows_developer_group_child(pg_schema: str, db_path: Pat
 def test_spawn_allowed_allows_research_group_child(pg_schema: str, db_path: Path) -> None:
     """A child in the researcher group may spawn (the incident's case)."""
     # Arrange
-    record_lineage(child="neurovista", parent="scitex-cv", db_path=db_path)
+    record_lineage(child="neurovista", parent="scitex-cv")
     record_comms_policy(name="neurovista", group_name="researcher")
     # Act
-    allowed, _reason = spawn_allowed(caller="neurovista", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="neurovista")
     # Assert
     assert allowed is True
 
@@ -481,10 +486,10 @@ def test_spawn_allowed_allows_research_group_child(pg_schema: str, db_path: Path
 def test_spawn_allowed_denies_child_in_neither_group(pg_schema: str, db_path: Path) -> None:
     """A child in NEITHER the developer nor research group stays denied."""
     # Arrange
-    record_lineage(child="worker-gen", parent="root", db_path=db_path)
+    record_lineage(child="worker-gen", parent="root")
     record_comms_policy(name="worker-gen", group_name="generalist")
     # Act
-    allowed, _reason = spawn_allowed(caller="worker-gen", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="worker-gen")
     # Assert
     assert allowed is False
 
@@ -498,10 +503,10 @@ def test_spawn_allowed_deny_reason_names_group_policy(pg_schema: str, db_path: P
     time (2026-08-10).
     """
     # Arrange
-    record_lineage(child="worker-gen", parent="root", db_path=db_path)
+    record_lineage(child="worker-gen", parent="root")
     record_comms_policy(name="worker-gen", group_name="generalist")
     # Act
-    _allowed, reason = spawn_allowed(caller="worker-gen", db_path=db_path)
+    _allowed, reason = spawn_allowed(caller="worker-gen")
     # Assert
     assert reason is not None and "developer, researcher, privileged" in reason
 
@@ -513,10 +518,10 @@ def test_spawn_deny_reason_points_at_refresh_acl_for_a_stale_row(
     """A denial whose group list disagrees with the spec means a STALE
     row; the message must name the command that re-publishes it."""
     # Arrange
-    record_lineage(child="worker-gen", parent="root", db_path=db_path)
+    record_lineage(child="worker-gen", parent="root")
     record_comms_policy(name="worker-gen", group_name="generalist")
     # Act
-    _allowed, reason = spawn_allowed(caller="worker-gen", db_path=db_path)
+    _allowed, reason = spawn_allowed(caller="worker-gen")
     # Assert
     assert "refresh-acl" in reason
 
@@ -527,14 +532,14 @@ def test_spawn_allowed_developer_group_child_still_respects_may_spawn(
 ) -> None:
     """The per-spec may_spawn=false deny survives the group short-circuit."""
     # Arrange
-    record_lineage(child="worker-dev", parent="root", db_path=db_path)
+    record_lineage(child="worker-dev", parent="root")
     record_comms_policy(
         name="worker-dev",
         group_name="developer",
         may_spawn=False,
     )
     # Act
-    allowed, _reason = spawn_allowed(caller="worker-dev", db_path=db_path)
+    allowed, _reason = spawn_allowed(caller="worker-dev")
     # Assert
     assert allowed is False
 

--- a/tests/smoke/_node_comms.py
+++ b/tests/smoke/_node_comms.py
@@ -153,9 +153,9 @@ def _set_up_two_groups(db: Path) -> dict[str, str]:
 
     Returns ``{name: bearer}`` — see :func:`_host_bearers`.
     """
-    record_lineage(child="alpha", parent="parent_a", db_path=db)
-    record_lineage(child="beta", parent="parent_a", db_path=db)
-    record_lineage(child="gamma", parent="parent_b", db_path=db)
+    record_lineage(child="alpha", parent="parent_a")
+    record_lineage(child="beta", parent="parent_a")
+    record_lineage(child="gamma", parent="parent_b")
     return _host_bearers("parent_a", "alpha", "beta", "parent_b", "gamma")
 
 
@@ -183,8 +183,8 @@ def _set_up_denied_send(db: Path) -> dict[str, str]:
 
     Returns ``{name: bearer}`` — see :func:`_host_bearers`.
     """
-    record_lineage(child="alpha", parent="parent_a", db_path=db)
-    record_lineage(child="gamma", parent="parent_a", db_path=db)
+    record_lineage(child="alpha", parent="parent_a")
+    record_lineage(child="gamma", parent="parent_a")
     record_comms_policy(name="gamma", inbound_siblings="deny")
     return _host_bearers("parent_a", "alpha", "gamma")
 
@@ -196,7 +196,7 @@ def _set_up_four_siblings(db: Path) -> dict[str, str]:
     not conflict with gamma's group-B placement there.
     """
     for child in ("alpha", "beta", "gamma", "zeta"):
-        record_lineage(child=child, parent="parent_a", db_path=db)
+        record_lineage(child=child, parent="parent_a")
     return _host_bearers("parent_a", "alpha", "beta", "gamma", "zeta")
 
 


### PR DESCRIPTION
The spawn DAG leaves SQLite for the shared PostgreSQL store, implementing the `sac_lineage` schema `_store_plugin` had already declared: `child_name` identity, `parent_name` IMMUTABLE, `Truth.HISTORY`, `WriterPolicy.MULTI_WRITER`. `KNOWN_TABLES` goes from three names to two.

## Why this one is the dangerous table

Of the tables that have left `state.db`, this is the one where an **empty leftover would have been worse than a crash**. Every reader treats "no row for this child" as ROOT, and a root MAY SPAWN (`spawn_allowed`). A `CREATE TABLE` with no writer would not have degraded the ACL — it would have **inverted** it, handing the fleet the spawn authority the gate exists to withhold, with nothing logged and nothing 403ing. So the DDL is removed rather than left behind, and the departure note in `state_db_schema.py` says exactly that.

## Pre-cutover measurement — and it found a real contradiction

Read read-only from all four hosts' `state.db` before writing a line of the migration:

| host | edges |
|---|---|
| scitex-compute-01 | 0 |
| scitex-compute-03 | 7 |
| scitex-compute-04 | 16 |
| scitex-nas-03 | 0 |
| **total** | **23** |

One child disagrees across hosts:

```
scitex-cards -> proj-scitex-hub          (scitex-compute-03)
scitex-cards -> scitex-agent-container   (scitex-compute-04)
```

These put `scitex-cards` in **different ACL groups**, so there is no safe default. `scripts/migrate_lineage_to_postgres.py` reports the pair and **exits non-zero** rather than letting run order pick a winner — the house rule from the `comms_nodes` rollout. Its `verify` counts *this host's* rows through the production reader rather than a global store count, which is vacuously true on a shared store once a second host migrates.

## Shape

- New `_state/state_db_lineage_store.py` — schema, per-process handle with error-path eviction and retry-once reconnect, and a two-way edge index. The handle matters: `derive_group` and `sender_target_relationship` sit on the ACL path of every message send.
- New `_state/state_db_lineage_group.py` — `record_lineage` + `derive_group`, split out under the per-file cap.
- Every reader rewritten over the store, keeping its public name. The walks keep their cycle guards and now make **one** round-trip each, where `descendants_of` previously issued a query per BFS level.
- `db_path` is gone from those six **and** from the four `_listen/_acl.py` gates — after this move no lookup behind them reads a SQLite file, so a parameter promising SQLite isolation promised something none of them could deliver.

## The rename can now refuse — a real behaviour change

`parent_name` is IMMUTABLE, and `hide`/`unhide` append ops carrying no values, so an edge naming an agent as **parent** can never be re-pointed. Measured against the real primitive, not assumed.

`rename_lineage` therefore moves an agent's *own* edge (identity move — the `rename_comms_policy` precedent) and **refuses** to rename an agent that has children, naming them. The two alternatives — leaving those edges, or hiding them — both make each orphaned child a root, i.e. the silent privilege escalation the step exists to prevent. Wired into `_rename` as its own step with an inverse on the undo stack; the two stale `lineage` pairs leave `_rename_db.NAME_COLUMNS`.

**Renaming an agent that has spawned children is now refused outright.** That is a genuine restriction this PR introduces, stated rather than discovered later.

## Verification

| suite | result |
|---|---|
| `_state` | 968 passed, 431 skipped, 0 failed |
| `_listen` | 795 passed, 201 skipped, 0 failed |
| `_lifecycle` | 2120 passed, 163 skipped, 0 failed |
| `tests/develop/test_sqlite_footprint_frozen.py` | 6 passed |

Control on `origin/develop` for `_listen`: 800 passed / 196 skipped. Same 996 total; 5 tests move to skipped because they now need a writable store.

**Honest caveat:** the 27 new store-backed tests in `test_state_db_lineage_store.py` / `test_state_db_lineage_rename.py` **all SKIP in an agent container** — loopback there is a read-only replica of the fleet cluster, so `pg_schema` cannot create a schema. They collect cleanly (imports and signatures are right) but were **not executed locally**; CI provisions its own database and is where they actually run.

What *was* executed locally, against the real `scitex_dev.store` primitive on a SQLite target (`merge_field` is backend-independent):

- a differing `parent_name` **does not raise**, keeps the first value, and reports `kept`/`rejected` in `PutResult.conflicts` — which is why `record_lineage` inspects the result instead of waiting for an exception that never comes;
- a hide/unhide round trip **does not reset** IMMUTABLE — this is what makes the rename refusal necessary rather than a preference;
- the identity move carries `parent_name` and `created_at` verbatim and hides rather than deletes the old identity.

Fresh-DB proof via `init_schema`: neither `lineage` nor `idx_lineage_parent` is created.

## Pre-existing problem found, not fixed here

`_rename_db.NAME_COLUMNS` still names `("comms_grants", "sender_name")` and `("comms_grants", "target_name")`, but that table's SQLite DDL was deleted in #1247. By this module's own documented hazard, `rename_rows` silently skips tables absent from `sqlite_master`, so a rename reports success while grants stay under the old name — an authorization bug of exactly the class this file warns about. Left alone deliberately: this PR's scope is `lineage`, and two sibling PRs are in flight on the same shared files. Worth its own change.

## Scope

Touches `lineage` only. `feat/state-instances-to-postgres` and `feat/state-channel-events-to-postgres` are in flight; after all three land `KNOWN_TABLES` should be empty. `git merge origin/develop` before pushing was **"Already up to date"** — neither sibling had landed, so there was nothing to reconcile and no name of theirs could be restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCMkub2ZBiL4huQUxMDDb
