### PR TITLE
feat(liveness): agents come back on their own after a rate wall lifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`sac agents resume-rate-limited` — the third agent-liveness enforcer, and
+  the shape the other two divide the fleet around without covering.** A
+  provider rate wall leaves the tmux session ALIVE, so `fleet-reconcile` hands
+  off (correctly — there is no corpse), and the banner is not an auth banner,
+  so the auth healer's matcher excludes it (also correctly, and it says why:
+  *a restart does not fix a rate wall*). Two right answers, and the agent
+  stays stopped. On 2026-08-28 a session limit stopped a set of agents at
+  ~17:25 UTC, the limit lifted at 19:10 UTC, and nothing resumed until the
+  operator asked at 20:56 UTC — 1h46m a human had to catch. The new verb reads
+  the reset time out of the provider's OWN banner, HOLDS while the wall stands
+  (so it structurally cannot spend a token against a live limit), and then
+  CONTINUES the agent through the verified delivery path rather than
+  restarting it, because the session and its whole context survived the wall.
+  A wall whose reset it cannot parse is held and REPORTED, never guessed at.
+  Scheduled as the `sac.resume-rate-limited-agents` JobSpec.
+
+### Fixed
+- **Two liveness enforcers had silently stopped firing, and `enabled` +
+  `active` were both still true.** On scitex-compute-04
+  `fleet-reconcile.timer` last triggered 2026-08-19 17:51 UTC and
+  `restart-login-expired-agents.timer` 2026-08-20 03:36 UTC, both sitting in
+  systemd's `elapsed` sub-state with `NextElapseUSecMonotonic=infinity`. A
+  timer rendered from `OnBootSec` + `OnUnitActiveSec` alone never re-arms if
+  the unit is started later than `OnBootSec` after boot, and `Persistent=true`
+  does not help because systemd applies it only to `OnCalendar=` timers. Both
+  are re-armed on that host and the defect, its control, and the repair (which
+  belongs in `scitex_dev.jobs._systemd.build_timer_unit`, not here — an
+  `on_calendar` breaks sac's lossless cron lowering) are documented in
+  `_jobs/_specs_liveness`.
+
 ## [0.27.0] - 2026-08-26
 
 **A job that has nothing to do is not a job that failed.** The theme of this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,18 @@ versioning follows [SemVer](https://semver.org/).
   Scheduled as the `sac.resume-rate-limited-agents` JobSpec.
 
 ### Fixed
-- **Two liveness enforcers had silently stopped firing, and `enabled` +
-  `active` were both still true.** On scitex-compute-04
-  `fleet-reconcile.timer` last triggered 2026-08-19 17:51 UTC and
-  `restart-login-expired-agents.timer` 2026-08-20 03:36 UTC, both sitting in
-  systemd's `elapsed` sub-state with `NextElapseUSecMonotonic=infinity`. A
-  timer rendered from `OnBootSec` + `OnUnitActiveSec` alone never re-arms if
-  the unit is started later than `OnBootSec` after boot, and `Persistent=true`
-  does not help because systemd applies it only to `OnCalendar=` timers. Both
-  are re-armed on that host and the defect, its control, and the repair (which
-  belongs in `scitex_dev.jobs._systemd.build_timer_unit`, not here — an
-  `on_calendar` breaks sac's lossless cron lowering) are documented in
-  `_jobs/_specs_liveness`.
+- **`sac.fleet-reconcile`'s liveness was being read from the wrong
+  instrument.** Hosts still carry ORPHAN per-leaf `<job>.timer` /
+  `<job>.service` units from the retired lowering model, and on
+  scitex-compute-04 `fleet-reconcile.timer` reported `active` + `enabled`
+  with `SubState=elapsed` and a last trigger of 2026-08-19 — nine days
+  silent — WHILE the ecosystem supervisor's `PeriodicRunner` was running the
+  same job every five minutes and had logged 3,764 executions of it. Reading
+  `systemctl --user list-timers` therefore yields a confidently wrong answer,
+  and re-arming an orphan puts a SECOND scheduler on a job that already has
+  one. `_jobs/_specs_liveness` now says where these jobs actually run
+  (`~/.scitex/dev/runtime/periodic-executions.jsonl`), why the orphans are
+  dead, and that they want removing rather than reviving.
 
 ## [0.27.0] - 2026-08-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.27.0"
+version = "0.28.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs(*, executable: str | None = None) -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Nine jobs today:
+    Ten jobs today:
 
     * ``sac.accounts-keepalive`` (``kind="timer"``) — the DISTRIBUTION half
       of the single-refresher model, and the sibling of
@@ -71,6 +71,29 @@ def provide_jobs(*, executable: str | None = None) -> "list[JobSpec]":
       duplication described below, one costume over. The crontab is host state a
       PR cannot edit, so the cron retirement is an operator/dotfiles step that
       must land WITH the enable.
+
+    * ``sac.resume-rate-limited-agents`` (``kind="timer"``) — the THIRD member
+      of that family, and the shape the first two divide the fleet around
+      without covering. A provider rate wall leaves the tmux session ALIVE, so
+      fleet-reconcile hands off (correctly — there is no corpse), and the
+      banner is not an auth banner, so the auth matcher excludes it (also
+      correctly, and it says why at the exclusion: *a restart does not fix a
+      rate wall*). Two right answers, and the agent stays stopped.
+
+      INCIDENT 2026-08-28: a session limit stopped a set of agents at ~17:25
+      UTC and lifted at 19:10 UTC; nothing resumed until the operator asked at
+      20:56 UTC. This job reads the reset time out of the provider's OWN
+      banner, HOLDS while the wall stands — so it structurally cannot spend a
+      token against a live limit — and then CONTINUES the agent through the
+      verified delivery path rather than restarting it, because the session
+      and its whole context survived the wall. A wall whose reset it cannot
+      parse is held and REPORTED, never guessed at.
+
+      It keeps its OWN debounce ledger, like the other two keep theirs: the
+      history file is a flat ``{agent: [epoch, ...]}`` with no subsystem key,
+      so three enforcers sharing one file would consume each other's budget
+      and race on one atomic write. Not gated: unlike its login-expired
+      sibling there is no incumbent doing this job, because nothing was.
 
     * ``sac.heal-agent-auth`` — RETIRED 2026-08-20, and the succession is the
       reason. This spec declared the INCUMBENT healer

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -141,6 +141,13 @@ BORN_CANONICAL: frozenset[str] = frozenset(
         # is VERIFIED firing on all seven hosts; retiring the hand-written
         # unit is a separate, deliberate step on the migration card.
         "scitex-agent-container-accounts-snapshot-live",
+        # Added 2026-08-28, after the incident that showed nothing owned the
+        # rate-wall shape. Born canonical in the strongest sense available:
+        # no host carries a legacy unit for it because no host has ever
+        # carried ANY unit for it — there was no predecessor doing this job,
+        # which is precisely why a rate-limited fleet stayed stopped for
+        # 1h46m. Nothing for a migration to displace.
+        "scitex-agent-container-resume-rate-limited-agents",
     }
 )
 

--- a/src/scitex_agent_container/_jobs/_specs_liveness.py
+++ b/src/scitex_agent_container/_jobs/_specs_liveness.py
@@ -19,60 +19,42 @@ one is also the proof that the division was previously INCOMPLETE — two
 enforcers that hand off to each other look exhaustive right up until an agent
 lands between them.
 
-A KNOWN DEFECT IN HOW THESE ARE SCHEDULED, which is NOT fixed here
-------------------------------------------------------------------
-A systemd timer rendered from ``OnBootSec`` + ``OnUnitActiveSec`` alone —
-which is what :func:`scitex_dev.jobs._systemd.build_timer_unit` emits for
-every one of these — dies PERMANENTLY if the timer unit is started later
-than ``OnBootSec`` after boot. Both monotonic elapse points are then already
-in the past, systemd marks the unit ``elapsed``, and it never re-arms.
-``Persistent=true`` cannot save it: systemd documents that setting as
-applying ONLY to ``OnCalendar=`` timers.
+WHERE THESE ACTUALLY RUN, because the obvious instrument gives a WRONG answer
+----------------------------------------------------------------------------
+``kind="timer"`` no longer means a per-leaf ``systemd --user`` timer, and it
+no longer means a crontab line either. Both lowerings are RETIRED. Every
+periodic JobSpec is executed in-process by the ecosystem supervisor's
+``PeriodicRunner`` (:mod:`scitex_dev._supervisor._periodic`), which owns the
+clock and writes one record per start, finish and skip to
+``~/.scitex/dev/runtime/periodic-executions.jsonl``.
 
-MEASURED on scitex-compute-04, 2026-08-28, on ``fleet-reconcile.timer``::
+THAT LOG IS THE INSTRUMENT. ``systemctl --user list-timers`` is NOT, and
+reading it produces a confidently wrong answer: hosts still carry ORPHAN
+``<job>.timer`` / ``<job>.service`` units from the retired model, and those
+orphans report their own long-dead state. Measured 2026-08-28 on
+scitex-compute-04, ``fleet-reconcile.timer`` read ``ActiveState=active``,
+``UnitFileState=enabled``, ``SubState=elapsed``, ``LastTriggerUSec=Wed
+2026-08-19 17:51:10 UTC`` — nine days silent — WHILE the supervisor was
+running the same job every five minutes and had logged 3,764 executions of
+it. An investigation that stopped at ``list-timers`` would have concluded the
+fleet's liveness enforcement had been dead for over a week. It was not.
 
-    TimersMonotonic={ OnUnitActiveUSec=5min ; next_elapse=0 }
-    TimersMonotonic={ OnBootUSec=5min ; next_elapse=0 }
-    NextElapseUSecMonotonic=infinity
-    LastTriggerUSec=Wed 2026-08-19 17:51:10 UTC
-    ActiveState=active   SubState=elapsed   UnitFileState=enabled
+(The orphans are dead for a real reason, and it is worth knowing so nobody
+"fixes" one by re-arming it: a timer rendered from ``OnBootSec`` +
+``OnUnitActiveSec`` alone never re-arms if the unit is started later than
+``OnBootSec`` after boot, and ``Persistent=true`` does not help because
+systemd applies it only to ``OnCalendar=`` timers. Re-arming an orphan does
+not repair anything — it puts a SECOND scheduler on a job the supervisor
+already runs, with independent debounce state. That is the double-supervisor
+hazard, and it was created and reverted while writing this file. The orphans
+want removing, not reviving: ``dev-timer-monotonic-dead-end-20260828``.)
 
-Boot was 2026-08-27 08:15:24 UTC and the timer unit became active
-2026-08-28 03:17:08 — nineteen hours later. It had not fired in NINE DAYS
-while reporting ``active`` and ``enabled``.
-``restart-login-expired-agents.timer`` was in the same state, last triggered
-2026-08-20 03:36:01 UTC.
-
-The control that isolates the cause is ``accounts-keepalive.timer`` on the
-SAME host with the SAME monotonic-only shape, still firing every minute —
-because it happened to have been active continuously since boot. The
-discriminating variable is WHEN the unit started relative to boot.
-
-WHY THE OBVIOUS FIX IS NOT APPLIED HERE. Adding ``on_calendar`` would give
-these timers a schedule that always has a next elapse, and it was tried. It
-BREAKS sac's strict cron lowering: ``_up_timer_losses`` treats ANY
-``on_calendar`` as a lossy field, unconditionally, on the grounds that a
-crontab line carries no timezone. That reasoning is right for a
-zone-bearing calendar and wrong for a zone-free interval like
-``*-*-* *:0/5:00``, which lowers to ``*/5 * * * *`` exactly — but the guard
-does not distinguish them, and sac's own ``test_no_job_degrades_when_lowered
-_onto_cron`` correctly fails. Cron lowering is the real deployment path for
-a host without ``systemd --user`` (scitex-nas-03 is one), so it is not
-something to weaken from this side.
-
-The fix belongs in ``scitex_dev.jobs._systemd.build_timer_unit``: emit
-``OnActiveSec=`` beside ``OnUnitActiveSec=``. ``OnActiveSec`` is relative to
-the TIMER's own activation, so a unit started at any point after boot always
-has a base for its first fire, and the ``OnUnitActiveSec`` chain sustains
-itself from there. It names no timezone and adds no cron loss. Tracked as
-``dev-timer-monotonic-dead-end-20260828``.
-
-UNTIL THAT LANDS, arming is an operational step with a REQUIRED check: after
-enabling a timer, trigger its service ONCE (``systemctl --user start
-<name>.service``) so ``OnUnitActiveSec`` has a base for this boot, then
-confirm the timer reads ``SubState=waiting`` with a real ``NextElapse``.
-``enabled`` and ``active`` are BOTH true of a timer that will never fire
-again, so neither is the check.
+WHICH CADENCE FIELD IS LIVE. ``PeriodicRunner`` reads
+``on_unit_active_sec`` first and falls back to ``schedule`` (the cron
+expression); it never reads ``on_calendar``. So both fields below are
+load-bearing and ``on_calendar`` would be silently ignored — quite apart
+from breaking sac's strict cron-lowering guard, which is where an attempt to
+add one was caught.
 """
 
 from __future__ import annotations

--- a/src/scitex_agent_container/_jobs/_specs_liveness.py
+++ b/src/scitex_agent_container/_jobs/_specs_liveness.py
@@ -1,16 +1,78 @@
-"""The two AGENT-LIVENESS enforcers, which only make sense side by side.
+"""The three AGENT-LIVENESS enforcers, which only make sense side by side.
 
 Split out of :mod:`._jobs_plugin` (at the per-file cap). They are one concern
-divided in two, and each one's scope is defined by what the other handles:
+divided three ways, and each one's scope is defined by what the others handle:
 
 * ``fleet-reconcile`` restarts CORPSES — no tmux session, so no context to lose.
 * ``restart-login-expired-agents`` restarts the LIVE-BUT-WEDGED half — tmux is
   up and the pane is frozen behind an auth banner — which fleet-reconcile
   deliberately will not touch.
+* ``resume-rate-limited-agents`` RESUMES the LIVE-BUT-PAUSED half — tmux is up
+  and the pane is frozen behind a provider rate wall — which the other two
+  BOTH decline, each for a good reason, which is how the gap stayed invisible
+  until it cost 1h46m of fleet downtime on 2026-08-28.
 
-Keeping them in one file is what makes either readable: they share a rate-limit
-vocabulary, run on the same beat by design, and a reader checking "who covers a
-wedged agent?" must see both answers at once.
+Keeping them in one file is what makes any of them readable: they share a
+rate-limit vocabulary, run on the same beat by design, and a reader checking
+"who covers a stopped agent?" must see all three answers at once. The third
+one is also the proof that the division was previously INCOMPLETE — two
+enforcers that hand off to each other look exhaustive right up until an agent
+lands between them.
+
+A KNOWN DEFECT IN HOW THESE ARE SCHEDULED, which is NOT fixed here
+------------------------------------------------------------------
+A systemd timer rendered from ``OnBootSec`` + ``OnUnitActiveSec`` alone —
+which is what :func:`scitex_dev.jobs._systemd.build_timer_unit` emits for
+every one of these — dies PERMANENTLY if the timer unit is started later
+than ``OnBootSec`` after boot. Both monotonic elapse points are then already
+in the past, systemd marks the unit ``elapsed``, and it never re-arms.
+``Persistent=true`` cannot save it: systemd documents that setting as
+applying ONLY to ``OnCalendar=`` timers.
+
+MEASURED on scitex-compute-04, 2026-08-28, on ``fleet-reconcile.timer``::
+
+    TimersMonotonic={ OnUnitActiveUSec=5min ; next_elapse=0 }
+    TimersMonotonic={ OnBootUSec=5min ; next_elapse=0 }
+    NextElapseUSecMonotonic=infinity
+    LastTriggerUSec=Wed 2026-08-19 17:51:10 UTC
+    ActiveState=active   SubState=elapsed   UnitFileState=enabled
+
+Boot was 2026-08-27 08:15:24 UTC and the timer unit became active
+2026-08-28 03:17:08 — nineteen hours later. It had not fired in NINE DAYS
+while reporting ``active`` and ``enabled``.
+``restart-login-expired-agents.timer`` was in the same state, last triggered
+2026-08-20 03:36:01 UTC.
+
+The control that isolates the cause is ``accounts-keepalive.timer`` on the
+SAME host with the SAME monotonic-only shape, still firing every minute —
+because it happened to have been active continuously since boot. The
+discriminating variable is WHEN the unit started relative to boot.
+
+WHY THE OBVIOUS FIX IS NOT APPLIED HERE. Adding ``on_calendar`` would give
+these timers a schedule that always has a next elapse, and it was tried. It
+BREAKS sac's strict cron lowering: ``_up_timer_losses`` treats ANY
+``on_calendar`` as a lossy field, unconditionally, on the grounds that a
+crontab line carries no timezone. That reasoning is right for a
+zone-bearing calendar and wrong for a zone-free interval like
+``*-*-* *:0/5:00``, which lowers to ``*/5 * * * *`` exactly — but the guard
+does not distinguish them, and sac's own ``test_no_job_degrades_when_lowered
+_onto_cron`` correctly fails. Cron lowering is the real deployment path for
+a host without ``systemd --user`` (scitex-nas-03 is one), so it is not
+something to weaken from this side.
+
+The fix belongs in ``scitex_dev.jobs._systemd.build_timer_unit``: emit
+``OnActiveSec=`` beside ``OnUnitActiveSec=``. ``OnActiveSec`` is relative to
+the TIMER's own activation, so a unit started at any point after boot always
+has a base for its first fire, and the ``OnUnitActiveSec`` chain sustains
+itself from there. It names no timezone and adds no cron loss. Tracked as
+``dev-timer-monotonic-dead-end-20260828``.
+
+UNTIL THAT LANDS, arming is an operational step with a REQUIRED check: after
+enabling a timer, trigger its service ONCE (``systemctl --user start
+<name>.service``) so ``OnUnitActiveSec`` has a base for this boot, then
+confirm the timer reads ``SubState=waiting`` with a real ``NextElapse``.
+``enabled`` and ``active`` are BOTH true of a timer that will never fire
+again, so neither is the check.
 """
 
 from __future__ import annotations
@@ -126,6 +188,47 @@ def liveness_jobs(*, executable: str | None = None) -> "list[JobSpec]":
             # same beat rather than harmonising into one; it is the window a
             # wedged agent stays wedged. A no-op pass is one `tmux list-sessions`
             # plus two pane captures ~4s apart.
+            on_boot_sec="5min",
+            on_unit_active_sec="5min",
+        ),
+        JobSpec(
+            name="scitex-agent-container-resume-rate-limited-agents",
+            schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
+            # SELF-BOUNDING (600s), and DELIBERATELY larger than its siblings'
+            # 300s. Their remedy is a restart; this one's is a VERIFIED
+            # delivery, which waits for the agent to be idle, submits, and then
+            # proves the payload left the compose box — tens of seconds per
+            # agent by design, because an unverified nudge is the failure this
+            # remedy exists to avoid. A pass killed at this timeout is SAFE:
+            # the resume history is persisted per resume, not at the end, so
+            # the next tick still honours the debounce for anything already
+            # woken.
+            command=(
+                f"/usr/bin/timeout 600 {sac} agents resume-rate-limited --apply"
+            ),
+            description=(
+                "Resumes LIVE agents parked behind a provider rate wall whose "
+                "published reset has PASSED — the shape the other two liveness "
+                "enforcers divide the fleet around without covering. "
+                "fleet-reconcile sees a live tmux session and correctly hands "
+                "off; the auth healer's matcher excludes 429 by design ('a "
+                "restart does not fix a rate wall'). INCIDENT 2026-08-28: a "
+                "session limit stopped agents at ~17:25 UTC, lifted at 19:10 "
+                "UTC, and NOTHING resumed until the operator asked at 20:56 "
+                "UTC. It CONTINUES the agent (verified delivery, proven to "
+                "leave the compose box) and never restarts one — the session, "
+                "context and conversation all survived the wall, and a restart "
+                "would destroy what makes resuming worth doing. It reads the "
+                "reset time from the provider's own banner and HOLDS until it "
+                "passes, so it cannot spend a token against a limit that is "
+                "still standing; a wall whose reset it cannot READ is held and "
+                "reported, never guessed at. Rate-limited per agent (30min "
+                "debounce, <=2/agent/hour) and per pass, on its OWN ledger so "
+                "the three enforcers' debounces cannot consume each other's. "
+                "An agent it cannot wake is RECORDED as degraded, not nudged "
+                "forever."
+            ),
+            kind="timer",
             on_boot_sec="5min",
             on_unit_active_sec="5min",
         ),

--- a/src/scitex_agent_container/_ratelimit/__init__.py
+++ b/src/scitex_agent_container/_ratelimit/__init__.py
@@ -1,0 +1,73 @@
+"""The rate-wall reviver: the THIRD agent-liveness shape, and the one nothing owned.
+
+sac's two existing enforcers are defined by each other, and a rate wall falls
+between them:
+
+    no tmux session               a CORPSE     ``sac.fleet-reconcile``
+    session + frozen auth banner  a WEDGE      ``sac.restart-login-expired-agents``
+    session + frozen rate banner  a PAUSE      here
+
+INCIDENT 2026-08-28. A session limit stopped a set of agents at ~17:25 UTC;
+the limit lifted at 19:10 UTC; nothing resumed until the operator asked at
+20:56 UTC. One hour forty-six minutes of dead time a human had to catch.
+
+Neither existing enforcer was at fault, which is what made the hole invisible.
+``fleet-reconcile`` saw live tmux sessions and correctly handed off — measured
+on scitex-compute-04, sessions created 05:33 UTC were still listed at 21:15
+UTC, so its rule returned ``OK``/``session-alive``. The auth healer's matcher
+excludes 429 by design and says why at the exclusion: *a restart does not fix
+a rate wall*. It is right, and the corollary nobody had written is that a
+rate wall does not need fixing — it needs WAITING OUT and then CONTINUING.
+
+Layout — the rule is separated from the doing, as in the siblings:
+
+* :mod:`._banner` — the PURE pane parser: is there a wall, and when does it
+  lift? Fitted to real captured banners, and it never guesses a reset.
+* :mod:`._rule`   — the PURE decision table (no IO, no clock of its own).
+* :mod:`._resume` — the one mutation: a VERIFIED nudge, never a restart.
+* :mod:`._alarm`  — the rails, and an honest note about who reads them.
+* :mod:`._pass`   — the IO: read panes, hold what is walled, wake what is free.
+
+Driven by ``sac agents resume-rate-limited`` (read-only by default) and
+scheduled as the ``sac.resume-rate-limited-agents`` JobSpec.
+
+WHY THIS CANNOT HOT-LOOP AGAINST A LIVE LIMIT
+    Structurally, not by tuning. The resume branch of :func:`._rule.decide`
+    is unreachable until ``now >= reset_at``, where ``reset_at`` is read from
+    the provider's own banner. A wall we cannot time yields ``RESET_UNKNOWN``
+    and is HELD, not guessed at. So the pass cannot spend a token against a
+    limit that is still standing, which is the failure mode that would make
+    an outage longer instead of shorter.
+"""
+
+from __future__ import annotations
+
+from ._alarm import SUBSYSTEM
+from ._banner import LimitObservation, observe_pane
+from ._pass import (
+    DEFAULT_INTERVAL,
+    DEFAULT_PASS_CAP,
+    AgentReport,
+    PassOutcome,
+    history_path,
+    resume_pass,
+)
+from ._resume import RESUME_MESSAGE
+from ._rule import MANAGED_POLICIES, Decision, Verdict, decide
+
+__all__ = [
+    "AgentReport",
+    "DEFAULT_INTERVAL",
+    "DEFAULT_PASS_CAP",
+    "Decision",
+    "LimitObservation",
+    "MANAGED_POLICIES",
+    "PassOutcome",
+    "RESUME_MESSAGE",
+    "SUBSYSTEM",
+    "Verdict",
+    "decide",
+    "history_path",
+    "observe_pane",
+    "resume_pass",
+]

--- a/src/scitex_agent_container/_ratelimit/_alarm.py
+++ b/src/scitex_agent_container/_ratelimit/_alarm.py
@@ -7,22 +7,31 @@ recording what happened is secondary and must not be able to take it down.
 
 WHO ACTUALLY READS THIS, stated because the constitution requires it
 --------------------------------------------------------------------
-Honestly: **the event log has no production reader today.** Measured
-2026-08-28 — ``_events.read_events`` has zero non-test callers in this
-repository. So the log is a durable record, not a signal, and this enforcer
-does NOT rely on it to reach a human.
+Two sinks, and the honest ranking between them matters.
 
-The signal that does reach one is the EXIT CODE, and it is why
-:meth:`.._ratelimit._pass.PassOutcome.exit_code` is written the way it is. A
-non-zero exit fails the ``systemd --user`` unit, and a failed unit is visible
-in ``systemctl --user list-units --failed``, in the journal, and to the
-ecosystem supervisor that owns the host. That is the reader of record.
+**The reader of record is the EXIT CODE**, because this job runs under the
+ecosystem supervisor's ``PeriodicRunner``, which writes one record per start
+AND per finish — carrying ``exit_code`` and ``ok`` — to
+``~/.scitex/dev/runtime/periodic-executions.jsonl``. That log is the
+supervisor's product rather than a side effect (its own module says so), and
+it is the file an operator greps to answer "did this run, and what happened".
+It is also the only place that records a run which never STARTED, which is
+the failure with no other witness. So the exit code is not shouted into a
+void: it is persisted per run, per host, by the scheduler itself.
 
-It is also why ``WAITING`` exits ZERO. A wall that has not lifted is the
-normal state during a rate limit and can persist for hours; failing the unit
-for it would leave the only real signal permanently on, and a permanently
-failing unit is one nobody looks at — which would put this job back in the
-same class as the log it cannot rely on.
+**The event log written here is the weaker sink, and it must be said
+plainly: it has no production reader today.** Measured 2026-08-28 —
+``_events.read_events`` has zero non-test callers in this repository. The
+per-agent records below are a durable, structured history for whoever
+eventually reads them; they are NOT how a failure reaches a human today. An
+enforcer that relied on them alone would be a check whose failure nothing
+reads.
+
+That ranking is why ``WAITING`` exits ZERO. A wall that has not lifted is the
+normal state during a rate limit and can persist for hours; a non-zero exit
+there would stamp ``ok: false`` on the execution log every five minutes for
+the whole window, and a signal that is always on is one its reader learns to
+skip — which would demote the strong sink to the weak one.
 
 WHICH VERDICTS GET A PER-AGENT RECORD
 -------------------------------------

--- a/src/scitex_agent_container/_ratelimit/_alarm.py
+++ b/src/scitex_agent_container/_ratelimit/_alarm.py
@@ -27,6 +27,31 @@ eventually reads them; they are NOT how a failure reaches a human today. An
 enforcer that relied on them alone would be a check whose failure nothing
 reads.
 
+RECORD OR CHECK? Say it plainly: at sac's layer this is a **record**, and at
+the supervisor's layer it is a **check** — but one whose alarm has no last
+mile.
+
+The supervisor half is genuinely a check and not a print: ``PeriodicRunner``
+folds each exit into a per-job rollup and, after ``UNHEALTHY_AFTER``
+consecutive failures — or for a job that has never once succeeded — writes a
+distinct ``job_unhealthy`` record, de-duplicated so it announces once and
+re-armed on recovery so a flapping job is announced again, plus an
+``unhealthy`` flag per job in the supervisor's ``state.json``. That is a
+state machine with hysteresis.
+
+What does NOT exist, measured 2026-08-28 and not dressed up: nothing polls
+either file and tells a human. ``job_unhealthy`` and ``unhealthy`` have zero
+matches anywhere under ``scitex_dev/_cli``, so no verb even reports them; and
+no sac enforcer writes a board card (zero ``scitex_cards`` imports across
+``_reconcile``, ``_authheal`` and this package). So the human-facing consumer
+today is a person running ``sac agents resume-rate-limited`` or grepping
+``periodic-executions.jsonl`` during an incident — which is precisely the
+posture that let the outage this job exists to end run 1h46m unnoticed.
+
+That gap is the same for all three enforcers, it is not created here, and it
+is tracked rather than left implied:
+``liveness-enforcer-failures-reach-no-human-20260828``.
+
 That ranking is why ``WAITING`` exits ZERO. A wall that has not lifted is the
 normal state during a rate limit and can persist for hours; a non-zero exit
 there would stamp ``ok: false`` on the execution log every five minutes for

--- a/src/scitex_agent_container/_ratelimit/_alarm.py
+++ b/src/scitex_agent_container/_ratelimit/_alarm.py
@@ -1,0 +1,134 @@
+"""Record rate-wall verdicts in sac's event log — and prove the pass ran.
+
+Side rails, exactly as :mod:`.._reconcile._alarm` and :mod:`.._authheal._alarm`
+are: a write that fails is printed by the log rail itself and can never crash
+or skip the pass that feeds it. Waking a parked agent is the primary job;
+recording what happened is secondary and must not be able to take it down.
+
+WHO ACTUALLY READS THIS, stated because the constitution requires it
+--------------------------------------------------------------------
+Honestly: **the event log has no production reader today.** Measured
+2026-08-28 — ``_events.read_events`` has zero non-test callers in this
+repository. So the log is a durable record, not a signal, and this enforcer
+does NOT rely on it to reach a human.
+
+The signal that does reach one is the EXIT CODE, and it is why
+:meth:`.._ratelimit._pass.PassOutcome.exit_code` is written the way it is. A
+non-zero exit fails the ``systemd --user`` unit, and a failed unit is visible
+in ``systemctl --user list-units --failed``, in the journal, and to the
+ecosystem supervisor that owns the host. That is the reader of record.
+
+It is also why ``WAITING`` exits ZERO. A wall that has not lifted is the
+normal state during a rate limit and can persist for hours; failing the unit
+for it would leave the only real signal permanently on, and a permanently
+failing unit is one nobody looks at — which would put this job back in the
+same class as the log it cannot rely on.
+
+WHICH VERDICTS GET A PER-AGENT RECORD
+-------------------------------------
+Narrow, and the narrowness is the point: a DEGRADED record means sac tried
+and cannot fix this itself.
+
+* ``FAILED`` — we nudged and could not prove the agent took it.
+* ``OVER-BUDGET`` — it keeps falling back behind a wall faster than the
+  hourly cap allows us to wake it, which is a pattern a human should see.
+* ``RESET-UNKNOWN`` — a wall we can see and cannot time. Nothing here can
+  resolve it; only a new pattern in :data:`.._ratelimit._banner.LIMIT_RE`'s
+  reset clause can.
+
+``COOLING-DOWN`` and ``CAPPED`` get no per-agent record and are carried in
+the pass record's counts instead: both resolve themselves on the next tick
+without anyone intervening, and an alarm that fires on a working rate limit
+teaches its reader to ignore it.
+
+``WAITING`` likewise gets none, for the strongest version of that reason: it
+is not a problem at all. It is this job doing exactly what it was built to
+do.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from .._events import (
+    EmitOutcome,
+    SubjectState,
+    SubjectVerdict,
+    emit_subject_verdicts,
+    log_pass_completed,
+)
+from ._rule import Verdict
+
+__all__ = ["SUBSYSTEM", "record_pass_completed", "record_reports"]
+
+SUBSYSTEM = "rate-limit-resume"
+_SUBJECT_KIND = "agent"
+_DEGRADED = (Verdict.FAILED, Verdict.OVER_BUDGET, Verdict.RESET_UNKNOWN)
+_HEALTHY = (Verdict.RESUMED,)
+
+
+def _verdict_for(report: Any) -> SubjectVerdict | None:
+    """Map one agent's report onto sac's states, or ``None`` for no record."""
+    if report.verdict in _DEGRADED:
+        return SubjectVerdict(
+            subject=report.name,
+            state=SubjectState.DEGRADED,
+            verdict=report.verdict.value,
+            detail=(
+                f"{report.name} is still parked behind a rate wall and sac "
+                f"could not get it working again — {report.detail}"
+            ),
+            subject_kind=_SUBJECT_KIND,
+        )
+    if report.verdict in _HEALTHY:
+        return SubjectVerdict(
+            subject=report.name,
+            state=SubjectState.HEALTHY,
+            verdict=report.verdict.value,
+            detail=f"{report.name} is working again — {report.detail}",
+            subject_kind=_SUBJECT_KIND,
+        )
+    return None
+
+
+def record_reports(
+    reports: Iterable[Any],
+    *,
+    path: Any = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> EmitOutcome:
+    """Record one event per agent from this pass's ``reports``. Never raises."""
+    verdicts = [v for v in (_verdict_for(report) for report in reports) if v]
+    return emit_subject_verdicts(
+        SUBSYSTEM, verdicts, path=path, now=now, err_stream=err_stream
+    )
+
+
+def record_pass_completed(
+    stats: Mapping[str, int],
+    *,
+    mode: str,
+    host: str = "",
+    path: Any = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> bool:
+    """Record that a resume pass RAN. Returns did-write; never raises.
+
+    Written on EVERY pass, above all one that found nothing to do. A rail
+    that writes only when there is trouble cannot tell HEALTHY from DEAD —
+    and "this enforcer stopped running" is precisely the failure this fleet
+    has already had: ``fleet-reconcile``'s timer sat in systemd's ``elapsed``
+    state for nine days, reporting ``active``, firing never, and nothing
+    noticed because a silent enforcer and a satisfied one look identical.
+    """
+    return log_pass_completed(
+        subsystem=SUBSYSTEM,
+        mode=mode,
+        counts=dict(stats),
+        detail=f"rate-limit resume {mode} pass completed on {host or 'this host'}",
+        path=path,
+        now=now,
+        err_stream=err_stream,
+    )

--- a/src/scitex_agent_container/_ratelimit/_banner.py
+++ b/src/scitex_agent_container/_ratelimit/_banner.py
@@ -1,0 +1,294 @@
+"""Is this pane PAUSED behind a provider rate wall, and until WHEN?
+
+PURE — no tmux, no clock of its own, no I/O. Every input is passed in, so
+the whole table below is exercised against real captured panes.
+
+WHY A SEPARATE MATCHER FROM ``auth_status.banner_kind``
+------------------------------------------------------
+That matcher deliberately EXCLUDES this case, and says so at the line where
+it excludes it: ``429 (rate limit) is deliberately excluded — a restart does
+not fix a rate wall``. It is right. A rate wall is not a wedge and not a
+death: it is a PAUSE WITH A PUBLISHED END TIME, and the only correct
+response is to wait for that time and then carry on. Restarting during the
+wall burns the agent's context and hits the same wall on the next turn.
+
+So this module answers a different question from the auth matcher, and the
+two populations are disjoint by construction: an auth banner names a
+credential problem, this one names a quota window.
+
+THE SPECIMENS THIS IS BUILT ON — real captures, not invented
+------------------------------------------------------------
+Recovered from agent transcripts on 2026-08-28 (the ``⎿`` result marker and
+the NBSP after it are exactly the rendering ``auth_status._MARKERS`` already
+strips, which is why this module reuses that stripper rather than growing a
+second one)::
+
+    ⎿ You've hit your weekly limit · resets 8am (UTC)
+       /usage-credits to finish what you're working on.
+
+    You've hit your weekly limit · resets 11pm (UTC)
+    You've hit your weekly limit · resets 8am (Asia/Tokyo)
+    You've hit your weekly limit · resets 5pm (Asia/Tokyo)
+
+and the phrasing the operator quoted from the 2026-08-28 17:25 UTC incident::
+
+    You've hit your session limit · resets 7:10pm
+
+The window word varies (``weekly`` / ``session`` / ``usage``); the shape does
+not. The apostrophe arrives as ASCII ``'`` in some captures and U+2019 in
+others, so both are matched — a detector that silently stopped matching on a
+typographic quote would report a healthy fleet during an outage.
+
+WHAT THIS MODULE REFUSES TO DO
+------------------------------
+It never GUESSES a reset time. A banner whose reset clause it cannot parse
+yields ``reset_at=None`` — a distinct, reportable state — and the rule above
+it holds rather than resuming. Inventing a reset is precisely how a reviver
+starts hammering a wall that is still up, which costs quota and extends the
+outage it was built to end.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+__all__ = [
+    "LIMIT_RE",
+    "LimitObservation",
+    "SPECIMEN_PANES",
+    "observe_pane",
+    "parse_reset_at",
+    "resolve_clock_near",
+]
+
+#: The banner itself. Anchored on "you<'>ve hit your <word> limit" so agent
+#: PROSE about a rate limit ("figrecipe died behind a weekly limit") does not
+#: match: the anchor is the provider's own first-person sentence, which an
+#: agent writing about the incident does not reproduce verbatim at the start
+#: of a line. Both apostrophes; case-insensitive.
+LIMIT_RE = re.compile(
+    r"you['’]ve\s+hit\s+your\s+(?P<window>[a-z0-9-]+)\s+limit",
+    re.IGNORECASE,
+)
+
+#: The reset clause. ``resets 8am (UTC)`` / ``resets 7:10pm`` /
+#: ``resets 23:00 (Asia/Tokyo)`` / ``resets at 2026-06-18T05:00Z``. The
+#: timezone is OPTIONAL in the rendering and therefore optional here; when it
+#: is absent the caller supplies the frame it is reading the pane in, which is
+#: the only defensible substitute for a label the provider did not print.
+_RESET_RE = re.compile(
+    r"resets?\s+(?:at\s+)?(?P<clock>"
+    r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?Z?"  # ISO instant
+    r"|\d{1,2}(?::\d{2})?\s*(?:am|pm)"  # 8am / 7:10pm
+    r"|\d{1,2}:\d{2}"  # 23:00
+    r")\s*(?:\((?P<tz>[^)]{1,40})\))?",
+    re.IGNORECASE,
+)
+
+_ISO_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?(Z?)$")
+_CLOCK_RE = re.compile(r"^(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$", re.IGNORECASE)
+
+#: Verbatim captures, kept in the module they justify so a future reader can
+#: see WHAT the patterns above were fitted to without hunting a transcript.
+#: The tests assert against these, so a rendering change that breaks the
+#: matcher breaks a test rather than silently returning "not limited".
+SPECIMEN_PANES: tuple[str, ...] = (
+    "⎿ You've hit your weekly limit · resets 8am (UTC)",
+    "You've hit your weekly limit · resets 11pm (UTC)",
+    "You've hit your weekly limit · resets 8am (Asia/Tokyo)",
+    "You’ve hit your session limit · resets 7:10pm",
+)
+
+
+@dataclass(frozen=True)
+class LimitObservation:
+    """One pane, read once. THREE states, never two.
+
+    ``readable=False`` is not ``limited=False``. A pane we could not capture
+    told us nothing about that agent, and reporting "not limited" there would
+    be an instrument announcing good news about something it never saw — the
+    same distinction :class:`.._authheal._detect.Roster` draws for the roster
+    and :class:`.._reconcile._budget.HistoryRead` for the ledger.
+
+    ``line_index`` is the pane line the banner was found on, counted from the
+    TOP of the capture. It exists for the freeze comparison in the rule: a
+    banner that MOVED between two captures means the pane is still producing
+    output, which is an agent working (or quoting the incident), never one
+    parked behind a wall.
+    """
+
+    readable: bool
+    limited: bool = False
+    window: str = ""
+    reset_at: datetime | None = None
+    reset_text: str = ""
+    line_index: int | None = None
+    detail: str = ""
+
+
+def resolve_clock_near(
+    *, hour: int, minute: int, now: datetime, tz: timezone
+) -> datetime:
+    """The occurrence of ``hour:minute`` NEAREST to ``now`` — past or future.
+
+    The provider prints a bare wall-clock time ("resets 8am") with no date,
+    and the naive readings are both wrong. "The next 8am" turns a wall that
+    lifted an hour ago into a 23-hour wait; "today's 8am" is simply wrong
+    either side of midnight.
+
+    Nearest-occurrence is right because a reset is always near: a session
+    window is hours and a weekly window still names a time inside the coming
+    week. Half a day is the furthest an unlabelled clock time can honestly be
+    from the moment you read it, so the candidate within ±12h is unique and
+    is the one the provider meant.
+
+    Worked, with the 2026-08-28 incident's own numbers: the banner said
+    ``resets 7:10pm`` and was read at 21:00 UTC. Today's 19:10 is 1h50m
+    behind; tomorrow's is 22h ahead. Nearest is today's — the wall is DOWN,
+    which is the answer that gets the agent working again.
+    """
+    anchor = now.astimezone(tz)
+    same_day = anchor.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    candidates = [same_day - timedelta(days=1), same_day, same_day + timedelta(days=1)]
+    return min(candidates, key=lambda c: abs(c - anchor))
+
+
+def _zone(name: str) -> timezone | None:
+    """The tzinfo for a printed zone label, or ``None`` if we cannot name it.
+
+    ``None`` is a real answer and the caller must not paper over it: a label
+    we cannot resolve makes the printed clock time unanchored, and an
+    unanchored reset is exactly the thing this module refuses to guess.
+    """
+    label = name.strip()
+    if label.upper() in ("UTC", "GMT", "Z"):
+        return timezone.utc
+    # stx-allow: fallback (reason: zoneinfo is stdlib but its tz DATABASE is an
+    # OS package that can be absent in a minimal container; an unresolvable
+    # label must degrade to "we cannot anchor this", never to a wrong instant)
+    try:
+        from zoneinfo import ZoneInfo
+
+        return ZoneInfo(label)  # type: ignore[return-value]
+    except Exception:
+        return None
+
+
+def parse_reset_at(
+    text: str, *, now: datetime, default_tz: timezone
+) -> tuple[datetime | None, str]:
+    """Extract the reset instant from a banner line. ``(instant, raw)``.
+
+    ``instant is None`` means the clause was absent or unparseable, and the
+    ``raw`` half still carries whatever was matched so the operator sees WHAT
+    could not be read rather than a bare failure.
+
+    ``default_tz`` is used ONLY when the provider printed no zone label. That
+    is a substitution, so it is the caller's frame — the zone the sweep is
+    running in — and not a constant hidden in here.
+    """
+    match = _RESET_RE.search(text)
+    if match is None:
+        return None, ""
+    raw = match.group(0).strip()
+    clock = match.group("clock").strip()
+    label = match.group("tz")
+    tz = _zone(label) if label else default_tz
+    if tz is None:
+        return None, raw
+
+    iso = _ISO_RE.match(clock)
+    if iso is not None:
+        year, month, day, hour, minute, second, zulu = iso.groups()
+        return (
+            datetime(
+                int(year),
+                int(month),
+                int(day),
+                int(hour),
+                int(minute),
+                int(second or 0),
+                tzinfo=timezone.utc if zulu else tz,
+            ),
+            raw,
+        )
+
+    bare = _CLOCK_RE.match(clock)
+    if bare is None:
+        return None, raw
+    hour_s, minute_s, meridiem = bare.groups()
+    hour = int(hour_s)
+    minute = int(minute_s or 0)
+    if meridiem:
+        meridiem = meridiem.lower()
+        if meridiem == "pm" and hour != 12:
+            hour += 12
+        elif meridiem == "am" and hour == 12:
+            hour = 0
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        return None, raw
+    return resolve_clock_near(hour=hour, minute=minute, now=now, tz=tz), raw
+
+
+def observe_pane(
+    pane: str | None, *, now: datetime, default_tz: timezone
+) -> LimitObservation:
+    """Read ONE captured pane for a rate wall. Pure.
+
+    Scans from the BOTTOM up and reports the LAST banner, because a pane is a
+    scrolling log: an older wall that has already lifted sits above a newer
+    one, and the newest line is the only one describing the agent's current
+    state.
+
+    Left TUI decoration is stripped with the SAME stripper the auth matcher
+    uses (:func:`.._runners._tmux.auth_status._strip_markers`), so the NBSP
+    that Claude's Ink TUI renders after ``⎿`` is handled in one place. That
+    NBSP is not a detail: leaving it out of the strip set once already made a
+    real banner undetectable.
+    """
+    if pane is None:
+        return LimitObservation(
+            readable=False,
+            detail="pane could not be captured — NO evidence, which is not "
+            "evidence of a working agent",
+        )
+
+    from .._runners._tmux.auth_status import _strip_markers
+
+    lines = pane.splitlines()
+    for index in range(len(lines) - 1, -1, -1):
+        stripped = _strip_markers(lines[index])
+        found = LIMIT_RE.search(stripped)
+        if found is None:
+            continue
+        reset_at, raw = parse_reset_at(stripped, now=now, default_tz=default_tz)
+        window = found.group("window").lower()
+        if reset_at is None:
+            unread = raw or "no reset clause at all"
+            detail = (
+                f"a {window} rate wall is rendered at pane line {index}, but its "
+                f"reset clause could not be read ({unread!r}). Refusing to GUESS "
+                f"when it lifts — a guessed reset is how a reviver starts "
+                f"hammering a wall that is still up"
+            )
+        else:
+            detail = (
+                f"a {window} rate wall is rendered at pane line {index}, lifting "
+                f"at {reset_at.isoformat()} (read from {raw!r})"
+            )
+        return LimitObservation(
+            readable=True,
+            limited=True,
+            window=window,
+            reset_at=reset_at,
+            reset_text=raw,
+            line_index=index,
+            detail=detail,
+        )
+    return LimitObservation(
+        readable=True,
+        limited=False,
+        detail="no rate-wall banner anywhere in the captured pane",
+    )

--- a/src/scitex_agent_container/_ratelimit/_pass.py
+++ b/src/scitex_agent_container/_ratelimit/_pass.py
@@ -126,6 +126,13 @@ class PassOutcome:
         wall and cannot say when it lifts, or we could not look at all, or we
         cannot read our own memory of what we already did. Each needs a human,
         and none may be logged as a healthy tick.
+
+        The code is not shouted into a void: the ecosystem supervisor's
+        ``PeriodicRunner`` persists it per run as ``exit_code`` / ``ok`` in
+        ``~/.scitex/dev/runtime/periodic-executions.jsonl``, alongside a
+        record for a run it could not START at all. See :mod:`._alarm` for
+        why that log, and not this package's own event log, is the reader of
+        record.
         """
         if self.of(Verdict.UNREADABLE, Verdict.RESET_UNKNOWN, Verdict.BUDGET_UNKNOWN):
             return 2
@@ -264,7 +271,7 @@ def resume_pass(
     # sibling ``fleet-reconcile`` cannot afford the same assumption, which is
     # why it carries a blackout breaker and this does not.
     sessions_readable = True
-    # stx-allow: fallback (reason: a raising pane capture must become the rule's UNREADABLE verdict for every agent, never an empty fleet that reads as "nobody is walled". The refusal is NOT swallowed: each agent gets an UNREADABLE AgentReport in this pass's `reports`, which reaches the `sac agents resume-rate-limited` stdout line from cli_pkg/_agents_resume_rate_limited.py:_print_report (the systemd journal for a timer-driven run), the pass-record `counts` in runtime_root()/sac-events.jsonl via ._alarm.record_pass_completed, and exit code 2 from PassOutcome.exit_code, which fails the systemd unit)
+    # stx-allow: fallback (reason: a raising pane capture must become the rule's UNREADABLE verdict for every agent, never an empty fleet that reads as "nobody is walled". The refusal is NOT swallowed: each agent gets an UNREADABLE AgentReport in this pass's `reports`, which reaches the `sac agents resume-rate-limited` stdout line from cli_pkg/_agents_resume_rate_limited.py:_print_report (the systemd journal for a timer-driven run), the pass-record `counts` in runtime_root()/sac-events.jsonl via ._alarm.record_pass_completed, and exit code 2 from PassOutcome.exit_code, which the ecosystem supervisor's PeriodicRunner persists as `exit_code`/`ok` in ~/.scitex/dev/runtime/periodic-executions.jsonl)
     try:
         captures = (capture_fn or (lambda: _real_captures(interval)))()
     except Exception as exc:
@@ -277,7 +284,7 @@ def resume_pass(
 
     reports: list[AgentReport] = []
     for spec in fleet_spec_paths(specs_dir):
-        # stx-allow: fallback (reason: one malformed or foreign spec.yaml must not abort the fleet sweep, mirroring `sac agents reconcile`. The failure is NOT swallowed: it becomes an UNREADABLE AgentReport in this pass's `reports`, which reaches three named sinks — the `sac agents resume-rate-limited` stdout line rendered by cli_pkg/_agents_resume_rate_limited.py:_print_report (the systemd journal, for the timer-driven run), the pass-record `counts` written to runtime_root()/sac-events.jsonl by ._alarm.record_pass_completed, and exit code 2 via PassOutcome.exit_code, which fails the systemd unit)
+        # stx-allow: fallback (reason: one malformed or foreign spec.yaml must not abort the fleet sweep, mirroring `sac agents reconcile`. The failure is NOT swallowed: it becomes an UNREADABLE AgentReport in this pass's `reports`, which reaches three named sinks — the `sac agents resume-rate-limited` stdout line rendered by cli_pkg/_agents_resume_rate_limited.py:_print_report (the systemd journal, for the timer-driven run), the pass-record `counts` written to runtime_root()/sac-events.jsonl by ._alarm.record_pass_completed, and exit code 2 via PassOutcome.exit_code, which the ecosystem supervisor's PeriodicRunner persists as `exit_code`/`ok` in ~/.scitex/dev/runtime/periodic-executions.jsonl)
         try:
             config = load_config(spec)
         except Exception as exc:

--- a/src/scitex_agent_container/_ratelimit/_pass.py
+++ b/src/scitex_agent_container/_ratelimit/_pass.py
@@ -1,0 +1,346 @@
+"""One resume pass: read every live pane, hold what is walled, wake what is free.
+
+The IO half. The decision is pure and lives in :mod:`._rule`; the banner
+parse in :mod:`._banner`; the one mutation in :mod:`._resume`. This module
+only wires facts into the rule and carries out what the rule authorises.
+
+Every collaborator is an injectable seam with a REAL default, so tests drive
+the whole pass against real temp files, real captured panes and a recorder in
+place of the single irreversible act. No mocks.
+
+BLINDNESS HERE CAN ONLY CAUSE INACTION
+--------------------------------------
+This pass acts only on an agent it can SEE a frozen banner on, so every way
+of failing to look — no tmux server, an unreadable pane, an empty session
+list — removes agents from the candidate set rather than adding them. That is
+the opposite of ``sac.fleet-reconcile``, where a blind read once meant "the
+whole fleet is dead" and could have restarted all of it; that job needs a
+blackout breaker, and this one structurally cannot want one. Blindness is
+still REPORTED (``UNREADABLE``, exit 2) — inaction we did not choose is not
+the same as a clean pass.
+
+THE BUDGET IS THIS ENFORCER'S OWN
+---------------------------------
+It keeps its own history file (``SAC_RATE_LIMIT_HISTORY``), exactly as
+``restart-login-expired`` keeps one separate from ``fleet-reconcile``'s: the
+ledger is a flat ``{agent: [epoch, ...]}`` with no subsystem key, so sharing
+a file would make three enforcers' debounces silently consume each other's
+budget and race on one atomic write.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from .._reconcile._budget import Budget, DEFAULT_PASS_CAP, read_history, save_history
+from ._banner import observe_pane
+from ._resume import real_resume
+from ._rule import Verdict, decide
+
+__all__ = [
+    "DEFAULT_INTERVAL",
+    "DEFAULT_PASS_CAP",
+    "AgentReport",
+    "PassOutcome",
+    "SUBSYSTEM",
+    "history_path",
+    "resume_pass",
+]
+
+SUBSYSTEM = "rate-limit-resume"
+
+#: Seconds between the two pane captures whose agreement defines "frozen".
+#: Matched to the auth healer's default so the two sweeps judge "frozen" by
+#: the same standard and cannot disagree about whether a pane is advancing.
+DEFAULT_INTERVAL = 4.0
+
+#: Explicit override for WHERE this enforcer's memory lives — SEPARATE from
+#: both siblings'. See the module docstring.
+_HISTORY_ENV = "SAC_RATE_LIMIT_HISTORY"
+
+_BUDGET_VERDICTS = {
+    "debounce": Verdict.COOLING_DOWN,
+    "over-budget": Verdict.OVER_BUDGET,
+    "pass-cap": Verdict.CAPPED,
+}
+
+#: Verdicts that SPEND budget: we touched the agent, whether or not it woke.
+#: A failed nudge must cost the same as a successful one, or an agent that
+#: cannot be woken is retried without limit.
+_SPENT = (Verdict.RESUMED, Verdict.FAILED)
+
+
+@dataclass(frozen=True)
+class AgentReport:
+    """One agent, one verdict, and WHY — in machine and human form."""
+
+    name: str
+    verdict: Verdict
+    reason: str
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "verdict": self.verdict.value,
+            "reason": self.reason,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class PassOutcome:
+    """Everything one pass concluded and did."""
+
+    reports: tuple[AgentReport, ...] = ()
+    alarm: Any = None
+    heartbeat_ok: bool = False
+    applied: bool = False
+
+    def of(self, *verdicts: Verdict) -> tuple[AgentReport, ...]:
+        return tuple(r for r in self.reports if r.verdict in verdicts)
+
+    def counts(self) -> dict[str, int]:
+        out = {v.value: 0 for v in Verdict}
+        for report in self.reports:
+            out[report.verdict.value] += 1
+        return {k: v for k, v in out.items() if v}
+
+    def exit_code(self) -> int:
+        """0 clean · 1 we owed a resume and did not deliver it · 2 we were blind.
+
+        WAITING IS ZERO, and that is the load-bearing line. A wall that has
+        not lifted yet is the NORMAL state during a rate limit, not a fault:
+        exiting non-zero there would put this unit into a permanent failed
+        state for hours at a time, and an alarm that is always on is an alarm
+        nobody reads. The pass is doing exactly its job when it holds.
+
+        RESET_UNKNOWN is TWO, with UNREADABLE and BUDGET_UNKNOWN, because all
+        three are unresolved readings rather than known-bad outcomes: we saw a
+        wall and cannot say when it lifts, or we could not look at all, or we
+        cannot read our own memory of what we already did. Each needs a human,
+        and none may be logged as a healthy tick.
+        """
+        if self.of(Verdict.UNREADABLE, Verdict.RESET_UNKNOWN, Verdict.BUDGET_UNKNOWN):
+            return 2
+        if self.of(
+            Verdict.FAILED,
+            Verdict.OVER_BUDGET,
+            Verdict.COOLING_DOWN,
+            Verdict.CAPPED,
+            Verdict.WOULD_RESUME,
+        ):
+            return 1
+        return 0
+
+
+def history_path() -> Path:
+    """Where this enforcer remembers what it already woke."""
+    override = os.environ.get(_HISTORY_ENV)
+    if override:
+        return Path(override).expanduser()
+    from .._state.state_paths import runtime_root
+
+    return runtime_root() / "rate-limit-resume-history.json"
+
+
+def _real_captures(interval: float) -> dict[str, tuple[str | None, str | None]]:
+    from .._authheal._detect import capture_live_panes
+
+    return capture_live_panes(interval)
+
+
+def _perform(
+    name: str,
+    decision: Any,
+    *,
+    budget: Budget | None,
+    apply: bool,
+    now: float,
+    resume_fn: Callable[[str], bool],
+) -> AgentReport:
+    """Turn one authorised RESUME into what actually happened to it."""
+    if budget is None:
+        return AgentReport(
+            name,
+            Verdict.BUDGET_UNKNOWN,
+            "budget-unreadable",
+            f"{name}'s wall has lifted, but this pass cannot read its own "
+            f"restart ledger, so it cannot honour the debounce. Refusing to "
+            f"wake anything on a budget it cannot enforce",
+        )
+    check = budget.check(name, now)
+    if not check.allowed:
+        return AgentReport(
+            name,
+            _BUDGET_VERDICTS[check.reason],
+            check.reason,
+            f"{decision.detail} — but {check.detail}",
+        )
+    if not apply:
+        return AgentReport(
+            name, Verdict.WOULD_RESUME, decision.reason, decision.detail
+        )
+    woke = resume_fn(name)
+    verdict = Verdict.RESUMED if woke else Verdict.FAILED
+    detail = (
+        f"{decision.detail} — resumed, and the payload was PROVEN to leave the "
+        f"compose box"
+        if woke
+        else f"{decision.detail} — the nudge was NOT provably submitted, so "
+        f"this agent is still parked. Recorded as degraded rather than "
+        f"bounced again"
+    )
+    return AgentReport(name, verdict, decision.reason, detail)
+
+
+def resume_pass(
+    *,
+    apply: bool = False,
+    limit: int = DEFAULT_PASS_CAP,
+    specs_dir: Path | None = None,
+    history_file: Path | None = None,
+    events_path: Path | None = None,
+    alarm: bool = True,
+    now: float | None = None,
+    interval: float = DEFAULT_INTERVAL,
+    capture_fn: Callable[[], dict[str, tuple[str | None, str | None]]] | None = None,
+    resume_fn: Callable[[str], bool] | None = None,
+    default_tz: timezone = timezone.utc,
+    err_stream: Any = None,
+) -> PassOutcome:
+    """Sweep the fleet for lifted rate walls and wake what is behind them.
+
+    Parameters
+    ----------
+    apply
+        Actually wake agents. Default ``False`` — detection is read-only, and
+        the nudge is the only mutation in the whole flow.
+    limit
+        Cap on resumes in ONE pass: the blast radius of one bad tick.
+    default_tz
+        The frame a bare printed clock ("resets 8am") is read in when the
+        provider printed no zone label. It is a SUBSTITUTION for a missing
+        label, so it belongs to the caller and is never hidden in the parser.
+    capture_fn, resume_fn
+        The two live seams. Defaults are the real two-capture tmux read and
+        the real verified delivery.
+    """
+    from ..config import load_config
+    from .._reconcile._pass import fleet_spec_paths
+
+    now = now if now is not None else time.time()
+    moment = datetime.fromtimestamp(now, tz=timezone.utc)
+    resume_fn = resume_fn if resume_fn is not None else real_resume
+    history_file = history_file if history_file is not None else history_path()
+    stream = err_stream if err_stream is not None else sys.stderr
+
+    # PROVE we can read our own memory before acting on it. A budget we
+    # cannot read is not a budget, and treating an unreadable ledger as an
+    # empty one would silently disarm every rate limit on a permission error.
+    read = read_history(history_file)
+    budget = Budget(read.history, pass_cap=limit) if read.enforceable else None
+    if budget is None:
+        print(f"[{SUBSYSTEM}] REFUSING to wake anything: {read.detail}", file=stream)
+
+    # A capture that RAISED is not an empty fleet. Carrying that distinction is
+    # what makes the rule's ``sessions-unreadable`` leg reachable from
+    # production rather than from tests alone — a branch only a test can reach
+    # is a branch nobody has evidence about.
+    #
+    # Note the ASYMMETRY with the empty-but-successful case, which is
+    # deliberate and not an oversight: ``_list_tui_sessions`` returns ``[]``
+    # both for a quiet host and for a tmux it could not read, and those are
+    # indistinguishable from here. That ambiguity is TOLERABLE for this pass
+    # and only for this pass, because it acts solely on agents it can SEE a
+    # frozen banner on — so every way of failing to look removes candidates
+    # rather than adding them, and blindness can only cost inaction. The
+    # sibling ``fleet-reconcile`` cannot afford the same assumption, which is
+    # why it carries a blackout breaker and this does not.
+    sessions_readable = True
+    # stx-allow: fallback (reason: a raising pane capture must become the rule's UNREADABLE verdict for every agent, never an empty fleet that reads as "nobody is walled". The refusal is NOT swallowed: each agent gets an UNREADABLE AgentReport in this pass's `reports`, which reaches the `sac agents resume-rate-limited` stdout line from cli_pkg/_agents_resume_rate_limited.py:_print_report (the systemd journal for a timer-driven run), the pass-record `counts` in runtime_root()/sac-events.jsonl via ._alarm.record_pass_completed, and exit code 2 from PassOutcome.exit_code, which fails the systemd unit)
+    try:
+        captures = (capture_fn or (lambda: _real_captures(interval)))()
+    except Exception as exc:
+        sessions_readable = False
+        captures = {}
+        print(
+            f"[{SUBSYSTEM}] could not read the fleet's panes: {exc}",
+            file=stream,
+        )
+
+    reports: list[AgentReport] = []
+    for spec in fleet_spec_paths(specs_dir):
+        # stx-allow: fallback (reason: one malformed or foreign spec.yaml must not abort the fleet sweep, mirroring `sac agents reconcile`. The failure is NOT swallowed: it becomes an UNREADABLE AgentReport in this pass's `reports`, which reaches three named sinks — the `sac agents resume-rate-limited` stdout line rendered by cli_pkg/_agents_resume_rate_limited.py:_print_report (the systemd journal, for the timer-driven run), the pass-record `counts` written to runtime_root()/sac-events.jsonl by ._alarm.record_pass_completed, and exit code 2 via PassOutcome.exit_code, which fails the systemd unit)
+        try:
+            config = load_config(spec)
+        except Exception as exc:
+            reports.append(
+                AgentReport(
+                    spec.parent.name,
+                    Verdict.UNREADABLE,
+                    "spec-unreadable",
+                    f"could not read {spec}: {exc}",
+                )
+            )
+            continue
+
+        name = config.name
+        policy = config.restart.policy
+        pane1, pane2 = captures.get(name, (None, None))
+        decision = decide(
+            name=name,
+            policy=policy,
+            session_present=(name in captures) if sessions_readable else None,
+            first=observe_pane(pane1, now=moment, default_tz=default_tz),
+            second=observe_pane(pane2, now=moment, default_tz=default_tz),
+            now=moment,
+        )
+        if decision.verdict is not Verdict.RESUME:
+            reports.append(
+                AgentReport(name, decision.verdict, decision.reason, decision.detail)
+            )
+            continue
+        report = _perform(
+            name,
+            decision,
+            budget=budget,
+            apply=apply,
+            now=now,
+            resume_fn=resume_fn,
+        )
+        if budget is not None and report.verdict in _SPENT:
+            budget.record(name, now)
+            # stx-allow: fallback (reason: a ledger write that fails must stop this pass from waking anything else — the alternative is an unbounded loop with no memory — but must not lose the reports already earned)
+            try:
+                save_history(history_file, budget.history, now=now)
+            except OSError as exc:
+                budget.spent = budget.pass_cap
+                print(
+                    f"[{SUBSYSTEM}] CANNOT RECORD resumes to {history_file}: {exc} "
+                    f"— capping this pass so nothing is woken without memory",
+                    file=stream,
+                )
+        reports.append(report)
+
+    outcome = PassOutcome(reports=tuple(reports), applied=apply)
+    if not alarm:
+        return outcome
+    from ._alarm import record_pass_completed, record_reports
+
+    emitted = record_reports(outcome.reports, path=events_path, now=now)
+    beat = record_pass_completed(
+        outcome.counts(),
+        mode="apply" if apply else "check",
+        path=events_path,
+        now=now,
+    )
+    return PassOutcome(
+        reports=outcome.reports, alarm=emitted, heartbeat_ok=beat, applied=apply
+    )

--- a/src/scitex_agent_container/_ratelimit/_resume.py
+++ b/src/scitex_agent_container/_ratelimit/_resume.py
@@ -1,0 +1,67 @@
+"""The ONE mutation: wake an agent whose rate wall has lifted.
+
+Separated from the pass so the pass stays a decision loop and this stays the
+single irreversible act — the same split :mod:`.._reconcile._perform` makes,
+for the same reason.
+
+WHY A NUDGE AND NOT A RESTART
+-----------------------------
+The agent is ALIVE. Its tmux session, its Claude session and its whole
+conversation survived the wall — the only thing that ended was the turn the
+wall interrupted. Restarting it would destroy exactly the context that makes
+resuming worth doing, and sac's auth matcher already reached this conclusion
+from the other direction when it excluded 429 from the restart path: ``a
+restart does not fix a rate wall``. Nor does it need fixing. It needs
+continuing.
+
+WHY ``_delivery.deliver`` AND NOT ``tmux send-keys``
+---------------------------------------------------
+Because a nudge that is not VERIFIED is the failure this fleet has already
+had. :mod:`.._delivery` exists because "the operator saw a message land in a
+peer's composer while the agent stayed idle" — text arrives in the compose
+box and is never submitted, so the sender believes it delivered and the
+agent never moved. That is indistinguishable, from the outside, from the
+outage we are trying to end, and it is the exact state the 2026-08-28 agents
+were found in: a prompt sitting unsent at ``❯`` for hours.
+
+``deliver`` sends a tokenised payload, waits for idle, submits, and then
+PROVES the payload left the compose box, returning a three-valued assessment
+(``True`` / ``False`` / ``None`` for "could not tell"). We take only ``True``
+as success. A resume we cannot prove is reported as a failure, never as a
+win — a reviver that reports success it did not achieve leaves the operator
+believing the fleet recovered.
+"""
+
+from __future__ import annotations
+
+__all__ = ["RESUME_MESSAGE", "real_resume"]
+
+#: What the woken agent is told. Deliberately short, deliberately about the
+#: agent's OWN state rather than a new instruction: this pass knows that a
+#: wall lifted, and knows nothing whatever about what the agent was doing.
+#: Handing it a task would be this enforcer inventing work; pointing it back
+#: at its own board is the only direction it is entitled to give.
+RESUME_MESSAGE = (
+    "Your provider rate limit has reset and this turn was resumed "
+    "automatically by sac.resume-rate-limited-agents (you were paused, not "
+    "restarted — your context is intact). Re-read your own scitex-cards board "
+    "and continue the work that was interrupted; if nothing is outstanding, "
+    "say so and stop."
+)
+
+
+def real_resume(name: str) -> bool:
+    """Wake ONE local agent. ``True`` only on a PROVEN submission.
+
+    ``_delivery.assess_delivery`` answers three-valued on purpose, and the
+    two non-``True`` answers are both failures HERE even though they differ
+    in kind: ``False`` is "the payload is still sitting unsent" and ``None``
+    is "we could not tell". Neither is a resumed agent, and this enforcer's
+    whole value is that an agent it could not recover becomes visible instead
+    of being counted clean.
+    """
+    from .._delivery._assess import assess_delivery
+    from .._delivery._deliver import deliver
+
+    state = deliver(name, RESUME_MESSAGE)
+    return assess_delivery(state).verdict is True

--- a/src/scitex_agent_container/_ratelimit/_rule.py
+++ b/src/scitex_agent_container/_ratelimit/_rule.py
@@ -1,0 +1,214 @@
+"""The PURE rule: may sac wake THIS agent from a rate wall, and is it time yet?
+
+No IO, no clock of its own — ``now`` is passed in — so every leg below is
+driven directly by tests instead of inferred from a live fleet.
+
+THE THIRD SHAPE, and why it needed its own rule
+-----------------------------------------------
+sac already owns two agent-liveness shapes, and they are defined by each
+other:
+
+    no tmux session               a CORPSE            ``sac.fleet-reconcile``
+    session + frozen auth banner  a WEDGE             ``sac.restart-login-expired-agents``
+
+A rate wall is neither, which is exactly why nothing recovered from one. On
+2026-08-28 a session limit stopped a set of agents at ~17:25 UTC and the
+limit lifted at 19:10 UTC; nothing resumed until the operator asked at
+20:56 UTC — one hour and forty-six minutes a human had to notice.
+
+* ``fleet-reconcile`` did not act, and was RIGHT not to: the tmux sessions
+  were still alive (measured on scitex-compute-04 — sessions created
+  05:33 UTC were still listed at 21:15 UTC), so its rule returns
+  ``OK``/``session-alive`` and hands off. It restarts corpses; there was no
+  corpse.
+* ``restart-login-expired-agents`` did not act, and was also right: its
+  matcher deliberately excludes 429, saying so at the exclusion —
+  ``a restart does not fix a rate wall``.
+
+Both correct, and the agent stayed stopped. This rule is the missing third
+answer.
+
+THE PRINCIPLES THIS TABLE ENCODES
+---------------------------------
+1. **A wall is a PAUSE WITH A PUBLISHED END, not a fault.** While the wall
+   is up the only correct action is NOTHING. :attr:`Verdict.WAITING` is a
+   first-class success, not a deferred failure, and it is what makes hot-
+   looping against a live limit structurally impossible: the resume branch
+   is unreachable until ``now >= reset_at``. A reviver that retries into a
+   standing limit burns the quota that ends the outage.
+2. **Never guess when a wall lifts.** An unparseable reset clause is
+   :attr:`Verdict.RESET_UNKNOWN` — hold, and REPORT. Guessing is how a
+   reviver starts hammering.
+3. **A moving pane is a working agent.** A banner at a different pane
+   position across two captures means output is still being produced, so
+   the agent is working, or quoting the incident in prose. Never touch it.
+   Same freeze discipline as the auth healer, for the same reason: a false
+   positive here interrupts an agent that was fine.
+4. **"I could not look" is not "nothing is there"** — the rule sac's other
+   two enforcers already live by, kept here so all three agree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from ._banner import LimitObservation
+
+__all__ = ["Decision", "MANAGED_POLICIES", "Verdict", "decide"]
+
+#: ``restart.policy`` values that put an agent under this enforcer's care —
+#: the SAME set ``sac.fleet-reconcile`` uses, so a spec is either managed by
+#: all of sac's liveness enforcers or by none of them. Two enforcers with
+#: different ideas of who they are responsible for is a gap nobody can see.
+MANAGED_POLICIES = ("always", "on-failure")
+
+
+class Verdict(str, Enum):
+    """What we concluded about ONE agent. Every leg is printed, never silent."""
+
+    # --- reachable by the pure rule ---------------------------------------
+    NOT_MANAGED = "NOT-MANAGED"  # restart.policy never/absent → not ours
+    NO_SESSION = "NO-SESSION"  # a corpse → fleet-reconcile's, not ours
+    UNREADABLE = "UNREADABLE"  # we could not read the pane. NOT "it is fine".
+    NOT_LIMITED = "NOT-LIMITED"  # no rate wall on this pane
+    MOVING = "MOVING"  # a wall is quoted but the pane advances → working
+    WAITING = "WAITING"  # walled, and the wall has NOT lifted yet → hold
+    RESET_UNKNOWN = "RESET-UNKNOWN"  # walled, reset unreadable → hold + report
+    RESUME = "RESUME"  # walled, the wall HAS lifted → wake it
+
+    # --- reachable only by the pass (what it did with a RESUME) -----------
+    WOULD_RESUME = "WOULD-RESUME"  # --check: reported, not performed
+    RESUMED = "RESUMED"
+    FAILED = "FAILED"  # we nudged and it did not come back
+    OVER_BUDGET = "OVER-BUDGET"  # out of hourly budget → reported, not nudged
+    COOLING_DOWN = "COOLING-DOWN"  # inside the debounce → wait, do not report
+    CAPPED = "CAPPED"  # this pass's cap spent; next pass retries
+    BUDGET_UNKNOWN = "BUDGET-UNKNOWN"  # cannot read our OWN memory → refuse
+
+
+@dataclass(frozen=True)
+class Decision:
+    """A verdict plus WHY, in both machine and human form.
+
+    ``reason`` is a short stable code (tests and JSON key off it); ``detail``
+    is the sentence an operator reads. Both mandatory — a verdict whose cause
+    is not stated is the silent skip this whole command exists to abolish.
+    """
+
+    verdict: Verdict
+    reason: str
+    detail: str
+
+
+def decide(
+    *,
+    name: str,
+    policy: str,
+    session_present: bool | None,
+    first: LimitObservation,
+    second: LimitObservation,
+    now: datetime,
+) -> Decision:
+    """Decide ONE agent's fate from facts alone. Pure — no IO, no clock.
+
+    Parameters
+    ----------
+    policy
+        ``spec.restart.policy``. Same opt-in as ``sac.fleet-reconcile``.
+    session_present
+        Whether a live tmux session for ``name`` was found. ``None`` means
+        the enumeration itself failed, which is not the same as "no session".
+    first, second
+        Two readings of the SAME pane, taken an interval apart. The pair is
+        what separates a parked agent from a working one: a banner that
+        stayed at the same pane line across both is frozen; one that moved
+        means the pane is still advancing.
+    now
+        The instant the SECOND capture was taken, timezone-aware. Compared
+        against the reset the banner published — this comparison is the
+        whole mechanism, so it is an argument and never a call to a clock.
+    """
+    if policy not in MANAGED_POLICIES:
+        return Decision(
+            Verdict.NOT_MANAGED,
+            "policy-never",
+            f"restart.policy={policy!r} — sac never promised to keep {name} "
+            f"running, so there is nothing here to resume",
+        )
+
+    if session_present is None:
+        return Decision(
+            Verdict.UNREADABLE,
+            "sessions-unreadable",
+            f"could not enumerate tmux sessions, so we do not know whether "
+            f"{name} has one. Refusing to infer anything from a reading we "
+            f"failed to take",
+        )
+    if not session_present:
+        return Decision(
+            Verdict.NO_SESSION,
+            "no-session",
+            f"{name} has no live tmux session — a corpse is "
+            f"`sac agents reconcile`'s to resurrect, not this pass's. A rate "
+            f"wall is a pause in a LIVE session; there is no pane here to read",
+        )
+
+    if not (first.readable and second.readable):
+        return Decision(
+            Verdict.UNREADABLE,
+            "pane-unreadable",
+            f"{name}'s pane could not be captured on both reads "
+            f"({second.detail or first.detail}) — no evidence, which is not "
+            f"evidence that it is working",
+        )
+
+    if not second.limited:
+        return Decision(
+            Verdict.NOT_LIMITED,
+            "no-wall",
+            f"no rate wall on {name}'s pane — nothing for this pass to do",
+        )
+
+    if not first.limited or first.line_index != second.line_index:
+        return Decision(
+            Verdict.MOVING,
+            "pane-advancing",
+            f"{name}'s pane shows a rate-wall banner but it MOVED between the "
+            f"two reads (line {first.line_index} → {second.line_index}), so "
+            f"the pane is still producing output. That is an agent working, or "
+            f"one quoting the incident — never one parked behind a wall",
+        )
+
+    if second.reset_at is None:
+        return Decision(
+            Verdict.RESET_UNKNOWN,
+            "reset-unreadable",
+            f"{name} is parked behind a frozen {second.window or 'rate'} wall "
+            f"whose reset time could not be read ({second.detail}). Holding: "
+            f"waking it on a guessed reset would hammer a wall that may still "
+            f"be up, which costs the very quota that ends the outage. This is "
+            f"reported, not swallowed",
+        )
+
+    if now < second.reset_at:
+        remaining = second.reset_at - now
+        return Decision(
+            Verdict.WAITING,
+            "wall-still-up",
+            f"{name} is parked behind a {second.window or 'rate'} wall that "
+            f"lifts at {second.reset_at.isoformat()} — {remaining} from now. "
+            f"Holding, ON PURPOSE: this is the normal state during a limit, "
+            f"not a fault, and touching it now would spend quota against a "
+            f"wall that is still standing",
+        )
+
+    return Decision(
+        Verdict.RESUME,
+        "wall-lifted",
+        f"{name} is parked behind a frozen {second.window or 'rate'} wall "
+        f"whose published reset ({second.reset_at.isoformat()}) has PASSED — "
+        f"the pause is over and nothing inside the agent will notice, because "
+        f"the thing that would have noticed is the turn the wall stopped",
+    )

--- a/src/scitex_agent_container/cli_pkg/_agents_resume_rate_limited.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_resume_rate_limited.py
@@ -1,0 +1,204 @@
+"""``sac agents resume-rate-limited`` — wake agents whose rate wall has lifted.
+
+The operator's window onto :mod:`.._ratelimit`, and the THIRD sibling of
+``sac agents reconcile`` (corpses) and ``sac agents restart-login-expired``
+(auth wedges). Those two divide agent liveness between them and a provider
+rate wall falls in the gap: the tmux session is alive, so ``reconcile`` hands
+off, and the banner is not an auth banner, so the auth healer's matcher
+excludes it — deliberately, saying *a restart does not fix a rate wall*.
+
+Which is true, and points at what this verb does instead. A rate wall is a
+PAUSE WITH A PUBLISHED END TIME. Nothing is broken; the agent simply stopped
+mid-turn and nothing inside it will ever notice the wall came down, because
+the thing that would have noticed IS the turn that stopped. So this verb
+waits for the reset the provider itself printed, and then continues the agent
+— it never restarts one, because restarting would destroy the context that
+made resuming worth doing.
+
+Rendering rule (inherited from the siblings): there is no quiet path. Every
+agent this pass touched gets a line saying what we concluded and WHY.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .._ratelimit import DEFAULT_INTERVAL, DEFAULT_PASS_CAP, Verdict, resume_pass
+from ._helpers import _json_flag, console
+
+#: Colour per verdict. Anything that leaves an agent parked is loud on purpose;
+#: magenta is reserved for "we could not determine this", which must never read
+#: as a clean line.
+_STYLE = {
+    Verdict.RESUMED: ("green", "RESUMED"),
+    Verdict.WAITING: ("cyan", "WAITING"),
+    Verdict.WOULD_RESUME: ("yellow", "WOULD-RESUME"),
+    Verdict.COOLING_DOWN: ("yellow", "COOLING-DOWN"),
+    Verdict.CAPPED: ("yellow", "CAPPED"),
+    Verdict.OVER_BUDGET: ("red", "OVER-BUDGET"),
+    Verdict.FAILED: ("red", "FAILED"),
+    Verdict.RESET_UNKNOWN: ("magenta", "RESET-UNKNOWN"),
+    Verdict.UNREADABLE: ("magenta", "UNREADABLE"),
+    Verdict.BUDGET_UNKNOWN: ("magenta", "BUDGET-UNKNOWN"),
+}
+
+#: Verdicts printed per agent. The three omitted ones — NOT-MANAGED,
+#: NO-SESSION and NOT-LIMITED — are the overwhelming majority of a healthy
+#: fleet and say nothing an operator needs per agent; they are carried by the
+#: count line instead. That is not tidiness: an earlier sibling printed its
+#: equivalent population every pass and produced 93,778 identical lines in a
+#: 32 MB timer log, which buries the handful of lines that matter.
+_ALWAYS_SHOWN = tuple(_STYLE)
+
+
+def _print_report(report) -> None:
+    colour, label = _STYLE.get(report.verdict, ("white", report.verdict.value))
+    # soft_wrap: a wrapped agent name is one you cannot grep out of a timer log.
+    console.print(f"[{colour}]{label:<15}[/{colour}] {report.name}", soft_wrap=True)
+    console.print(f"    [dim]{report.detail}[/dim]", soft_wrap=True)
+
+
+@click.command(name="resume-rate-limited")
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="ACTUALLY wake the agents whose wall has lifted. Without this, nothing "
+    "is touched.",
+)
+@click.option(
+    "--check",
+    "check",
+    is_flag=True,
+    default=False,
+    help="Report only, mutate nothing (dry-run). This is already the DEFAULT.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=DEFAULT_PASS_CAP,
+    show_default=True,
+    help="Global cap on resumes in ONE pass — the blast radius of a bad tick.",
+)
+@click.option(
+    "--interval",
+    type=float,
+    default=DEFAULT_INTERVAL,
+    show_default=True,
+    help="Seconds between the two pane captures used for the frozen check.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON (for timers).")
+@click.pass_context
+def resume_rate_limited(
+    ctx: click.Context,
+    apply: bool,
+    check: bool,
+    limit: int,
+    interval: float,
+    as_json: bool,
+) -> None:
+    """Resume LIVE agents parked behind a provider rate wall that has RESET.
+
+    \b
+    Detect (read-only — the DEFAULT):
+      $ sac agents resume-rate-limited
+      $ sac agents resume-rate-limited --check --json
+    \b
+    Remedy:
+      $ sac agents resume-rate-limited --apply
+
+    THE RULE — the wall's own clock decides, and only a frozen pane qualifies:
+
+    \b
+      no session          a CORPSE. `sac agents reconcile`'s, not this verb's.
+      pane ADVANCING      the agent is working (or quoting the incident in
+                          prose). Never touched.
+      wall STILL UP       HELD, on purpose, and this exits 0. Waiting is the
+                          normal state during a limit, not a fault — and it is
+                          what makes hammering a live limit impossible here.
+      reset UNREADABLE    HELD and REPORTED (exit 2). A guessed reset is how a
+                          reviver starts burning the quota that ends the outage.
+      wall LIFTED         resumed, through the VERIFIED delivery path, which
+                          proves the nudge left the compose box. A nudge that
+                          merely lands in the composer and is never submitted
+                          is indistinguishable from the outage itself.
+
+    The agent is CONTINUED, never restarted: its session, context and
+    conversation all survived the wall. Rate-limited exactly like its siblings
+    (30-min/agent debounce, <=2/agent/hour, --limit per pass); an agent that
+    cannot be woken is RECORDED as degraded rather than nudged forever.
+
+    Exits 0 when nothing is parked or everything parked is legitimately
+    waiting, 1 when a resume was owed and not delivered, and 2 when something
+    could not be determined — an unreadable pane, an unreadable reset clause,
+    or an unreadable resume history.
+    """
+    if apply and check:
+        raise click.UsageError(
+            "--apply and --check are contradictory. Dry-run is the DEFAULT: "
+            "drop both flags to preview, pass --apply to resume."
+        )
+
+    outcome = resume_pass(apply=apply, limit=limit, interval=interval)
+    code = outcome.exit_code()
+
+    if _json_flag(ctx, as_json):
+        click.echo(
+            json.dumps(
+                {
+                    "mode": "apply" if apply else "check",
+                    "exit_code": code,
+                    "counts": outcome.counts(),
+                    "pass_recorded": outcome.heartbeat_ok,
+                    "agents": [r.to_dict() for r in outcome.reports],
+                },
+                indent=2,
+            )
+        )
+        raise SystemExit(code)
+
+    mode = "apply" if apply else "check (read-only)"
+    shown = outcome.of(*_ALWAYS_SHOWN)
+    console.print(
+        f"[bold]sac agents resume-rate-limited[/bold]  {mode} — "
+        f"{len(shown)} agent(s) behind a rate wall, "
+        f"{len(outcome.reports) - len(shown)} with nothing to report\n"
+    )
+    for report in shown:
+        _print_report(report)
+
+    counts = outcome.counts()
+    if counts:
+        console.print(
+            "\n" + "  ".join(f"{k.lower()}={v}" for k, v in sorted(counts.items()))
+        )
+
+    stuck = outcome.of(Verdict.FAILED, Verdict.OVER_BUDGET)
+    if stuck:
+        console.print(
+            f"\n[red]{len(stuck)} agent(s) are STILL parked and sac could not "
+            f"get them working again.[/red] Each is recorded as degraded.",
+            soft_wrap=True,
+        )
+    blind = outcome.of(Verdict.RESET_UNKNOWN, Verdict.UNREADABLE)
+    if blind:
+        console.print(
+            f"\n[magenta]{len(blind)} agent(s) could not be DETERMINED.[/magenta] "
+            f"A wall whose reset clause does not parse needs a new pattern in "
+            f"_ratelimit._banner; nothing here can resolve it by guessing.",
+            soft_wrap=True,
+        )
+    if not outcome.heartbeat_ok:
+        console.print(
+            "\n[yellow]note:[/yellow] this pass could not record that it RAN. "
+            "A silent enforcer and a satisfied one look identical.",
+            soft_wrap=True,
+        )
+    raise SystemExit(code)
+
+
+def register(agent_group) -> None:
+    agent_group.add_command(resume_rate_limited)

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -137,6 +137,23 @@ from ._agents_restart_login_expired import (  # noqa: E402
 )
 
 _register_restart_login_expired(agent_group)
+# `resume-rate-limited` — the THIRD enforcer, and the shape the other two
+# divide the fleet around without covering. `reconcile` owns corpses;
+# `restart-login-expired` owns auth wedges; a provider rate wall is neither.
+# The tmux session is alive (so reconcile hands off) and the banner is not an
+# auth banner (so the auth matcher excludes it, saying "a restart does not fix
+# a rate wall" — correct, and the corollary is that it does not need fixing,
+# it needs waiting out). INCIDENT 2026-08-28: a session limit stopped agents
+# at ~17:25 UTC, the limit lifted at 19:10 UTC, and nothing resumed until the
+# operator asked at 20:56 UTC. This verb reads the reset the provider itself
+# printed, HOLDS until it passes — so it structurally cannot hammer a live
+# limit — and then CONTINUES the agent through the verified delivery path
+# rather than restarting it, because the context survived the wall.
+from ._agents_resume_rate_limited import (  # noqa: E402
+    register as _register_resume_rate_limited,
+)
+
+_register_resume_rate_limited(agent_group)
 # `auth-audit` — READ-ONLY comparison of the shipped auth verdict against the
 # pane's LAYOUT. It exists because `auth-status` flags WORKING agents: a banner
 # is the last thing an agent RENDERED, not proof it is broken now, so an agent

--- a/tests/scitex_agent_container/_jobs/test__specs_liveness.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_liveness.py
@@ -124,3 +124,113 @@ def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
     job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
     assert isinstance(job, jobs_mod.JobSpec)
+
+
+# --- the SCHEDULE these three share, and the defect around it ----------------------
+#
+# A timer rendered from OnBootSec + OnUnitActiveSec ALONE dies permanently the
+# first time the unit is started later than OnBootSec after boot — both
+# monotonic elapse points are then in the past, systemd marks it `elapsed`, and
+# it never re-arms. `Persistent=true` cannot save it; systemd documents that
+# setting as applying only to OnCalendar= timers. The repair belongs in
+# scitex-dev's build_timer_unit (an OnActiveSec= base); see the module
+# docstring of _jobs/_specs_liveness for why it is not an on_calendar here.
+# What IS pinned below is the cron schedule those jobs must keep, because the
+# cron lowering is the real deployment path on a host with no systemd --user.
+#
+# MEASURED on scitex-compute-04, 2026-08-28, on fleet-reconcile.timer itself:
+#     NextElapseUSecMonotonic=infinity
+#     LastTriggerUSec=Wed 2026-08-19 17:51:10 UTC
+#     ActiveState=active  SubState=elapsed  UnitFileState=enabled
+# Boot was 2026-08-27 08:15:24 UTC; the unit became active 2026-08-28 03:17:08,
+# 19 hours later. Nine days without firing while reporting healthy. The control
+# that isolates the cause is `accounts-keepalive.timer` on the SAME host with
+# the SAME monotonic-only shape, still firing every minute — because it had
+# been active continuously since boot. The discriminating variable is WHEN the
+# unit started relative to boot, nothing else.
+#
+# These are the guards that keep the wall-clock anchor from being dropped again.
+
+_LIVENESS_JOBS = (
+    "scitex-agent-container-fleet-reconcile",
+    "scitex-agent-container-restart-login-expired-agents",
+    "scitex-agent-container-resume-rate-limited-agents",
+)
+
+
+@pytest.mark.parametrize("name", _LIVENESS_JOBS)
+def test_every_liveness_timer_keeps_its_cron_schedule(name: str) -> None:
+    # Arrange — the cron LOWERING reads `schedule`, not `on_calendar`. Dropping
+    # it while adding the wall-clock anchor would silently unschedule these
+    # jobs on any host that lowers to crontab instead of systemd.
+    # Act
+    job = _job(name)
+    # Assert
+    assert job.schedule == "*/5 * * * *"
+
+
+def test_the_three_enforcers_sweep_on_one_beat() -> None:
+    # Arrange — one cadence across all three, so a reader reasoning about "how
+    # long can an agent stay stopped" gets ONE answer rather than three. They
+    # are one concern divided three ways, not three schedules.
+    # Act
+    cadences = {_job(name).on_unit_active_sec for name in _LIVENESS_JOBS}
+    # Assert
+    assert cadences == {"5min"}
+
+
+# --- the THIRD enforcer: the rate-wall reviver -------------------------------
+
+
+def test_resume_rate_limited_job_name_is_package_prefixed() -> None:
+    # Arrange — the shape the other two divide the fleet around without
+    # covering: a live session parked behind a provider rate wall. Both
+    # correctly declined it, and the agent stayed stopped for 1h46m.
+    # Act
+    job = _job("scitex-agent-container-resume-rate-limited-agents")
+    # Assert
+    assert job.name == "scitex-agent-container-resume-rate-limited-agents"
+
+
+def test_resume_rate_limited_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer. A wrong kind raises at
+    # construction and `ecosystem up` then silently DROPS sac's whole provider,
+    # taking the other two liveness enforcers down with it.
+    # Act
+    job = _job("scitex-agent-container-resume-rate-limited-agents")
+    # Assert
+    assert job.kind == "timer"
+
+
+def test_resume_rate_limited_command_is_the_applying_form() -> None:
+    # Arrange — a scheduled DRY-RUN would detect parked agents and wake none.
+    # The whole point is `--apply`; detection stays read-only and the verified
+    # nudge is the only mutation in the flow.
+    # Act
+    job = _job("scitex-agent-container-resume-rate-limited-agents")
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == (
+        "/usr/bin/timeout 600",
+        "agents resume-rate-limited --apply",
+    )
+
+
+def test_resume_rate_limited_outlives_a_verified_delivery() -> None:
+    # Arrange — DELIBERATELY larger than the siblings' 300s. Their remedy is a
+    # restart; this one's is a verified delivery that waits for idle, submits,
+    # and proves the payload left the compose box — tens of seconds per agent
+    # by design, because an unverified nudge is the failure it exists to avoid.
+    # Act
+    job = _job("scitex-agent-container-resume-rate-limited-agents")
+    # Assert
+    assert job.command.startswith("/usr/bin/timeout 600 ")
+
+
+def test_resume_rate_limited_constructs_as_a_real_jobspec() -> None:
+    # Arrange — construction must not raise (a bad field drops the whole
+    # provider). Assert it is the canonical contract type, not a look-alike.
+    # Act
+    job = _job("scitex-agent-container-resume-rate-limited-agents")
+    # Assert
+    assert isinstance(job, jobs_mod.JobSpec)

--- a/tests/scitex_agent_container/_ratelimit/test__banner.py
+++ b/tests/scitex_agent_container/_ratelimit/test__banner.py
@@ -1,0 +1,214 @@
+"""Tests for ``_ratelimit._banner`` — is there a wall, and when does it lift?
+
+Pure, so every leg is driven by passing a pane and a clock in. No mocks and
+nothing to mock.
+
+The behaviours that matter, in the order they matter:
+
+* every REAL captured banner parses. These are verbatim specimens, not
+  invented strings, and a rendering change that breaks the matcher must break
+  a test rather than silently return "no wall" — which reads as a healthy
+  fleet during an outage.
+* an unparseable reset is ``None``, never a guess. Guessing is how a reviver
+  starts hammering a wall that is still up.
+* the NEAREST occurrence of a bare clock time is the right reading, and the
+  leg that proves it uses the 2026-08-28 incident's own numbers.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scitex_agent_container._ratelimit._banner import (
+    SPECIMEN_PANES,
+    observe_pane,
+    parse_reset_at,
+    resolve_clock_near,
+)
+
+# 2026-08-28 21:00 UTC — after the incident's 19:10 UTC reset, which is the
+# vantage that makes the nearest-occurrence rule answer "the wall is down".
+NOW = datetime(2026, 8, 28, 21, 0, tzinfo=timezone.utc)
+
+
+def _observe(pane: str | None, *, now: datetime = NOW):
+    return observe_pane(pane, now=now, default_tz=timezone.utc)
+
+
+# --- the real specimens: every captured rendering must parse ----------------
+
+
+@pytest.mark.parametrize("pane", SPECIMEN_PANES)
+def test_every_captured_specimen_is_detected(pane: str) -> None:
+    # Arrange — verbatim panes recovered from agent transcripts. A matcher
+    # that stops recognising one of these reports a healthy fleet during an
+    # outage, which is the whole failure this module exists to prevent.
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.limited is True
+
+
+@pytest.mark.parametrize("pane", SPECIMEN_PANES)
+def test_every_captured_specimen_yields_a_reset(pane: str) -> None:
+    # Arrange — a detected wall with no reset time cannot be waited out, so
+    # detection alone is not enough for any of the shipped renderings.
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.reset_at is not None
+
+
+def test_the_incident_banner_resolves_to_its_real_reset() -> None:
+    # Arrange — the 2026-08-28 banner the operator quoted, read at 21:00 UTC.
+    # The provider printed a bare "7:10pm" with no date and no zone; the
+    # limit really did lift at 19:10 UTC. This is the positive control for
+    # resolve_clock_near: "the NEXT 7:10pm" would answer tomorrow and leave
+    # the agent parked for another 22 hours.
+    pane = "You’ve hit your session limit · resets 7:10pm"
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.reset_at == datetime(2026, 8, 28, 19, 10, tzinfo=timezone.utc)
+
+
+def test_a_labelled_zone_beats_the_default() -> None:
+    # Arrange — "8am (Asia/Tokyo)" is 23:00 UTC the previous day, NOT 08:00
+    # UTC. Reading a labelled banner in the sweep's own frame would move the
+    # reset by nine hours and wake the agent into a standing wall.
+    pane = "You've hit your weekly limit · resets 8am (Asia/Tokyo)"
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.reset_at.utcoffset() == timedelta(hours=9)
+
+
+def test_the_window_word_is_carried_through() -> None:
+    # Arrange — session / weekly / usage are different windows and the
+    # operator must see which one stopped the agent; a detector that
+    # normalised them away would answer "a limit" to "which limit".
+    pane = "You've hit your session limit · resets 11pm (UTC)"
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.window == "session"
+
+
+# --- refusals: what must NOT be read as a wall ------------------------------
+
+
+def test_an_unreadable_pane_is_not_a_clean_pane() -> None:
+    # Arrange — a pane we could not capture told us nothing. Reporting
+    # "not limited" here is an instrument announcing good news about
+    # something it never saw.
+    # Act
+    observation = _observe(None)
+    # Assert
+    assert observation.readable is False
+
+
+def test_agent_prose_about_a_limit_is_not_a_wall() -> None:
+    # Arrange — an agent writing ABOUT the incident must never be treated as
+    # one parked behind it. The anchor is the provider's own first-person
+    # sentence, which prose does not reproduce at the start of a line.
+    pane = "figrecipe died behind a weekly limit and resets are not the issue"
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.limited is False
+
+
+def test_a_wall_with_no_reset_clause_yields_no_instant() -> None:
+    # Arrange — the wall is real but untimed. The rule above must HOLD on
+    # this, so the parser has to hand it up as None rather than inventing a
+    # time; a guessed reset is how a reviver burns the quota that would have
+    # ended the outage.
+    pane = "You've hit your session limit"
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.reset_at is None
+
+
+def test_an_untimed_wall_is_still_detected() -> None:
+    # Arrange — the same pane. Failing to PARSE the reset must not also lose
+    # the fact that a wall is there; those are two different findings and the
+    # second one is what gets reported to a human.
+    pane = "You've hit your session limit"
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.limited is True
+
+
+def test_the_newest_banner_wins_over_an_older_one() -> None:
+    # Arrange — a pane is a scrolling log, so a lifted wall sits ABOVE a
+    # current one. Reading the first match would answer with a reset that
+    # already expired and wake the agent into the newer wall.
+    pane = "\n".join(
+        [
+            "You've hit your weekly limit · resets 1am (UTC)",
+            "...work...",
+            "You've hit your session limit · resets 11pm (UTC)",
+        ]
+    )
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.reset_at == datetime(2026, 8, 28, 23, 0, tzinfo=timezone.utc)
+
+
+# --- the nearest-occurrence rule, on its own -------------------------------
+
+
+def test_a_recent_past_clock_resolves_backwards() -> None:
+    # Arrange — 19:10 read at 21:00. Nearest is 1h50m behind, not 22h ahead.
+    # Act
+    resolved = resolve_clock_near(hour=19, minute=10, now=NOW, tz=timezone.utc)
+    # Assert
+    assert resolved == datetime(2026, 8, 28, 19, 10, tzinfo=timezone.utc)
+
+
+def test_a_near_future_clock_resolves_forwards() -> None:
+    # Arrange — 23:00 read at 21:00. Nearest is 2h ahead, not 22h behind.
+    # Act
+    resolved = resolve_clock_near(hour=23, minute=0, now=NOW, tz=timezone.utc)
+    # Assert
+    assert resolved == datetime(2026, 8, 28, 23, 0, tzinfo=timezone.utc)
+
+
+def test_a_clock_across_midnight_resolves_to_the_next_day() -> None:
+    # Arrange — 01:00 read at 23:30. The nearest 01:00 is 90 minutes ahead on
+    # the FOLLOWING date; "today's 01:00" is 22.5 hours behind and wrong.
+    late = datetime(2026, 8, 28, 23, 30, tzinfo=timezone.utc)
+    # Act
+    resolved = resolve_clock_near(hour=1, minute=0, now=late, tz=timezone.utc)
+    # Assert
+    assert resolved == datetime(2026, 8, 29, 1, 0, tzinfo=timezone.utc)
+
+
+def test_an_iso_reset_is_taken_literally() -> None:
+    # Arrange — a fully-qualified instant needs no nearest-occurrence guess
+    # and must not get one.
+    # Act
+    instant, _raw = parse_reset_at(
+        "resets at 2026-06-18T05:00Z", now=NOW, default_tz=timezone.utc
+    )
+    # Assert
+    assert instant == datetime(2026, 6, 18, 5, 0, tzinfo=timezone.utc)
+
+
+def test_midnight_meridiem_is_not_read_as_noon() -> None:
+    # Arrange — "12am" is 00:00, "12pm" is 12:00. Getting this backwards
+    # moves a reset by twelve hours in the direction that wakes an agent into
+    # a standing wall.
+    # Act
+    instant, _raw = parse_reset_at(
+        "resets 12am (UTC)", now=NOW, default_tz=timezone.utc
+    )
+    # Assert
+    assert instant.hour == 0

--- a/tests/scitex_agent_container/_ratelimit/test__pass.py
+++ b/tests/scitex_agent_container/_ratelimit/test__pass.py
@@ -1,0 +1,418 @@
+"""Tests for ``_ratelimit._pass`` — the whole enforcer, end to end, no mocks.
+
+Real on-disk v3 specs, a real temp resume ledger, a real temp sac event log,
+real captured banner text, and a real recorder standing in for the ONE
+irreversible act. Nothing is patched and nothing is monkeypatched: every
+collaborator is a production keyword argument with a real default, and the
+tests pass real values into them.
+
+THE POSITIVE CONTROL THIS FILE IS BUILT AROUND
+    :func:`test_the_incident_fleet_is_held_before_the_reset` and
+    :func:`test_the_incident_fleet_is_resumed_after_the_reset` are ONE
+    experiment run twice. Same fleet, same specs, same captured panes, same
+    ledger — the ONLY variable is the clock, moved across the reset the
+    provider published. Before it the pass holds and touches nothing; after
+    it the pass wakes the agent. A green result in the second without a red
+    one in the first would prove nothing at all, which is why both legs are
+    asserted against the SAME recorder.
+
+    The clock values are the 2026-08-28 incident's own: the wall lifted at
+    19:10 UTC and the operator noticed at 20:56 UTC. The "before" leg is set
+    at 18:00 UTC, inside the outage.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from scitex_agent_container._events import read_events
+from scitex_agent_container._ratelimit._pass import resume_pass
+from scitex_agent_container._ratelimit._rule import Verdict
+
+from tests.scitex_agent_container._reconcile._fleet import Recorder, write_spec
+
+#: The captured 2026-08-28 banner, in the pane position it really occupied:
+#: last conversation line, directly above the prompt box.
+WALLED_PANE = "\n".join(
+    [
+        "● Working on the migration...",
+        "  ⎿ You’ve hit your session limit · resets 7:10pm (UTC)",
+        "     /usage-credits to finish what you’re working on.",
+        "────────────────────────────────────────────",
+        "❯ ",
+    ]
+)
+CLEAN_PANE = "\n".join(
+    [
+        "● Done.",
+        "────────────────────────────────────────────",
+        "❯ ",
+    ]
+)
+
+DURING_OUTAGE = datetime(2026, 8, 28, 18, 0, tzinfo=timezone.utc).timestamp()
+AFTER_RESET = datetime(2026, 8, 28, 20, 56, tzinfo=timezone.utc).timestamp()
+
+
+def _frozen(pane: str) -> tuple[str, str]:
+    """Two identical captures — a pane that did not advance."""
+    return (pane, pane)
+
+
+@pytest.fixture()
+def fleet(tmp_path):
+    """One managed agent whose live pane shows the incident's rate wall."""
+    registry = tmp_path / "agents"
+    write_spec(registry, "alpha")
+    return {
+        "specs_dir": registry,
+        "history_file": tmp_path / "resume-history.json",
+        "events_path": tmp_path / "sac-events.jsonl",
+    }
+
+
+def _run(fleet, *, now, recorder, panes=None, apply=True, **overrides):
+    kwargs = dict(fleet)
+    kwargs.update(
+        {
+            "apply": apply,
+            "now": now,
+            "resume_fn": recorder,
+            "capture_fn": lambda: (
+                panes if panes is not None else {"alpha": _frozen(WALLED_PANE)}
+            ),
+        }
+    )
+    kwargs.update(overrides)
+    return resume_pass(**kwargs)
+
+
+def _verdict_of(outcome, name: str) -> Verdict:
+    return next(r.verdict for r in outcome.reports if r.name == name)
+
+
+# --- THE POSITIVE CONTROL: one experiment, the clock as the only variable ---
+
+
+def test_the_incident_fleet_is_held_before_the_reset(fleet) -> None:
+    # Arrange — 18:00 UTC on 2026-08-28: the session wall is up and lifts at
+    # 19:10. This is the RED half of the control. If the pass acted here it
+    # would spend a token against a standing limit and lengthen the outage
+    # it exists to end.
+    recorder = Recorder()
+    # Act
+    _run(fleet, now=DURING_OUTAGE, recorder=recorder)
+    # Assert
+    assert recorder.names == []
+
+
+def test_the_held_agent_is_reported_as_waiting(fleet) -> None:
+    # Arrange — the same 18:00 UTC pass. Holding must be a STATED verdict,
+    # not an absence: an agent nobody reports on is an agent nobody watches.
+    recorder = Recorder()
+    # Act
+    outcome = _run(fleet, now=DURING_OUTAGE, recorder=recorder)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.WAITING
+
+
+def test_waiting_exits_zero_because_it_is_not_a_fault(fleet) -> None:
+    # Arrange — a wall can stand for hours. Exiting non-zero would leave the
+    # systemd unit permanently failed, and a permanently failing unit is one
+    # nobody looks at — which would destroy the only signal this job has.
+    recorder = Recorder()
+    # Act
+    outcome = _run(fleet, now=DURING_OUTAGE, recorder=recorder)
+    # Assert
+    assert outcome.exit_code() == 0
+
+
+def test_the_incident_fleet_is_resumed_after_the_reset(fleet) -> None:
+    # Arrange — 20:56 UTC, the minute the operator had to ask. Same fleet,
+    # same specs, same captured panes, same ledger as the two legs above;
+    # ONLY the clock moved, past the 19:10 reset the provider printed. This
+    # is the GREEN half, and it is the claim that this enforcer would have
+    # recovered the fleet 1h46m before a human did.
+    recorder = Recorder()
+    # Act
+    _run(fleet, now=AFTER_RESET, recorder=recorder)
+    # Assert
+    assert recorder.names == ["alpha"]
+
+
+def test_the_resumed_agent_is_reported_as_resumed(fleet) -> None:
+    # Arrange — the same 20:56 UTC pass, with a resume that succeeded.
+    recorder = Recorder()
+    # Act
+    outcome = _run(fleet, now=AFTER_RESET, recorder=recorder)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.RESUMED
+
+
+# --- the read-only default -------------------------------------------------
+
+
+def test_the_default_pass_wakes_nothing(fleet) -> None:
+    # Arrange — detection is read-only by default and the nudge is the only
+    # mutation in the whole flow, so a pass without --apply must be provably
+    # inert even when the wall has lifted.
+    recorder = Recorder()
+    # Act
+    _run(fleet, now=AFTER_RESET, recorder=recorder, apply=False)
+    # Assert
+    assert recorder.names == []
+
+
+def test_a_check_pass_still_names_the_owed_resume(fleet) -> None:
+    # Arrange — inert is not the same as silent. A dry run must say what it
+    # WOULD have done, or it cannot be used to preview anything.
+    recorder = Recorder()
+    # Act
+    outcome = _run(fleet, now=AFTER_RESET, recorder=recorder, apply=False)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.WOULD_RESUME
+
+
+# --- the debounce, on this enforcer's OWN ledger ----------------------------
+
+
+def test_a_second_pass_inside_the_debounce_holds(fleet) -> None:
+    # Arrange — the timer ticks every 5 minutes and the per-agent debounce is
+    # 30, so a woken agent is cooling down for its next five ticks. Waking it
+    # again each tick is the restart loop that is worse than the outage.
+    recorder = Recorder()
+    _run(fleet, now=AFTER_RESET, recorder=recorder)
+    # Act
+    _run(fleet, now=AFTER_RESET + 60, recorder=recorder)
+    # Assert
+    assert recorder.names == ["alpha"]
+
+
+def test_the_resume_is_persisted_to_the_ledger(fleet) -> None:
+    # Arrange — the debounce above is only real if it survives the process.
+    # Each pass is a separate short-lived CLI invocation, so an in-memory
+    # budget would reset every five minutes and enforce nothing.
+    recorder = Recorder()
+    # Act
+    _run(fleet, now=AFTER_RESET, recorder=recorder)
+    # Assert
+    assert "alpha" in json.loads(fleet["history_file"].read_text())
+
+
+def test_an_unreadable_ledger_refuses_to_wake_anything(fleet, tmp_path) -> None:
+    # Arrange — a budget we cannot read is not a budget. Treating an
+    # unreadable ledger as an empty one would silently disarm every rate
+    # limit on a permission error, which is the loudest possible way to be
+    # quiet.
+    recorder = Recorder()
+    blocked = tmp_path / "nope"
+    blocked.mkdir()
+    # Act
+    _run(fleet, now=AFTER_RESET, recorder=recorder, history_file=blocked)
+    # Assert
+    assert recorder.names == []
+
+
+# --- the failure path: an agent we could not wake must be VISIBLE -----------
+
+
+def test_an_unprovable_nudge_is_a_failure_not_a_win(fleet) -> None:
+    # Arrange — the delivery layer could not prove the payload left the
+    # compose box. A reviver that reports success it did not achieve leaves
+    # the operator believing the fleet recovered; that is the outage with an
+    # extra step.
+    recorder = Recorder(ok=False)
+    # Act
+    outcome = _run(fleet, now=AFTER_RESET, recorder=recorder)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.FAILED
+
+
+def test_a_failed_resume_reaches_the_exit_code(fleet) -> None:
+    # Arrange — the exit code is this job's REAL reader: a non-zero exit
+    # fails the systemd unit, which is visible in `list-units --failed`, in
+    # the journal, and to the ecosystem supervisor. The event log has no
+    # production reader, so the exit code has to carry it.
+    recorder = Recorder(ok=False)
+    # Act
+    outcome = _run(fleet, now=AFTER_RESET, recorder=recorder)
+    # Assert
+    assert outcome.exit_code() == 1
+
+
+def test_a_failed_resume_is_recorded_as_degraded(fleet) -> None:
+    # Arrange — an enforcer that gives up SILENTLY is the original bug with
+    # extra steps. The record is written to a real temp event log and read
+    # back with the production reader.
+    recorder = Recorder(ok=False)
+    # Act
+    _run(fleet, now=AFTER_RESET, recorder=recorder)
+    # Assert
+    assert any(
+        e.subject == "alpha" and e.event == "subject-degraded"
+        for e in read_events(fleet["events_path"])
+    )
+
+
+def test_a_wall_we_cannot_time_is_reported_not_guessed(fleet) -> None:
+    # Arrange — a real banner whose reset clause does not parse. Nothing here
+    # can resolve it, so it must reach a human rather than be waited out on
+    # an invented deadline.
+    recorder = Recorder()
+    untimed = "\n".join(["  ⎿ You've hit your session limit", "❯ "])
+    # Act
+    outcome = _run(
+        fleet,
+        now=AFTER_RESET,
+        recorder=recorder,
+        panes={"alpha": _frozen(untimed)},
+    )
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.RESET_UNKNOWN
+
+
+def test_an_untimed_wall_exits_two_as_indeterminate(fleet) -> None:
+    # Arrange — the same pass. "We saw a wall and cannot say when it lifts"
+    # is an unresolved reading, not a known-bad outcome, so it groups with
+    # the blind cases rather than the failed ones.
+    recorder = Recorder()
+    untimed = "\n".join(["  ⎿ You've hit your session limit", "❯ "])
+    # Act
+    outcome = _run(
+        fleet,
+        now=AFTER_RESET,
+        recorder=recorder,
+        panes={"alpha": _frozen(untimed)},
+    )
+    # Assert
+    assert outcome.exit_code() == 2
+
+
+# --- who this pass is NOT for, at pass level --------------------------------
+
+
+def test_an_agent_with_no_session_is_left_to_reconcile(fleet) -> None:
+    # Arrange — the agent is registered but has no live pane, so it never
+    # appears in the capture. That is fleet-reconcile's half of the fleet.
+    recorder = Recorder()
+    # Act
+    outcome = _run(fleet, now=AFTER_RESET, recorder=recorder, panes={})
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.NO_SESSION
+
+
+def test_a_healthy_pane_is_never_nudged(fleet) -> None:
+    # Arrange — a live agent with no wall at all. This is the majority of
+    # every pass, and touching one of these would interrupt working agents
+    # every five minutes forever.
+    recorder = Recorder()
+    # Act
+    _run(fleet, now=AFTER_RESET, recorder=recorder, panes={"alpha": _frozen(CLEAN_PANE)})
+    # Assert
+    assert recorder.names == []
+
+
+def test_an_unmanaged_agent_is_never_nudged(fleet, tmp_path) -> None:
+    # Arrange — restart.policy "never" means sac never promised to keep this
+    # agent running, so it is not this enforcer's to wake even behind a
+    # lifted wall. Same opt-in as fleet-reconcile.
+    recorder = Recorder()
+    write_spec(fleet["specs_dir"], "beta", policy="never")
+    # Act
+    outcome = _run(
+        fleet,
+        now=AFTER_RESET,
+        recorder=recorder,
+        panes={"beta": _frozen(WALLED_PANE)},
+    )
+    # Assert
+    assert _verdict_of(outcome, "beta") is Verdict.NOT_MANAGED
+
+
+# --- who watches the watcher ------------------------------------------------
+
+
+def test_every_pass_records_that_it_ran(fleet) -> None:
+    # Arrange — a pass that found nothing to do writes the most important
+    # record there is. fleet-reconcile's timer sat in systemd's `elapsed`
+    # state for NINE DAYS reporting `active` and firing never, and nothing
+    # noticed, because a silent enforcer and a satisfied one look identical.
+    recorder = Recorder()
+    # Act
+    _run(fleet, now=AFTER_RESET, recorder=recorder, panes={"alpha": _frozen(CLEAN_PANE)})
+    # Assert
+    assert any(
+        e.event == "pass-completed" and e.subsystem == "rate-limit-resume"
+        for e in read_events(fleet["events_path"])
+    )
+
+
+# --- blindness: it may cost inaction, it may NOT look like a clean pass ------
+
+
+class _Blind:
+    """A capture seam that FAILS, the way a broken tmux read really does.
+
+    Not a mock — a plain callable with the production signature, which is the
+    only thing the pass ever asks of it.
+    """
+
+    def __call__(self):
+        raise OSError("tmux: connection refused")
+
+
+def test_a_failed_capture_is_not_an_empty_fleet(fleet) -> None:
+    # Arrange — the pane read itself blew up. Treating that as "no agent is
+    # walled" would report a healthy fleet on the strength of having seen
+    # nothing, which is the instrument failure every enforcer in this package
+    # is built to refuse.
+    recorder = Recorder()
+    # Act
+    outcome = resume_pass(
+        **fleet,
+        apply=True,
+        now=AFTER_RESET,
+        resume_fn=recorder,
+        capture_fn=_Blind(),
+    )
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.UNREADABLE
+
+
+def test_a_blind_pass_cannot_exit_clean(fleet) -> None:
+    # Arrange — the same failed read. The exit code is this job's real reader,
+    # so a pass that learned nothing must not let the systemd unit log a
+    # healthy tick.
+    recorder = Recorder()
+    # Act
+    outcome = resume_pass(
+        **fleet,
+        apply=True,
+        now=AFTER_RESET,
+        resume_fn=recorder,
+        capture_fn=_Blind(),
+    )
+    # Assert
+    assert outcome.exit_code() == 2
+
+
+def test_a_blind_pass_wakes_nothing(fleet) -> None:
+    # Arrange — the same failed read. Blindness here may cost INACTION; it must
+    # never authorise action, because a nudge sent on evidence we do not have
+    # would interrupt an agent that was working.
+    recorder = Recorder()
+    # Act
+    resume_pass(
+        **fleet,
+        apply=True,
+        now=AFTER_RESET,
+        resume_fn=recorder,
+        capture_fn=_Blind(),
+    )
+    # Assert
+    assert recorder.names == []

--- a/tests/scitex_agent_container/_ratelimit/test__rule.py
+++ b/tests/scitex_agent_container/_ratelimit/test__rule.py
@@ -1,0 +1,196 @@
+"""Tests for ``_ratelimit._rule`` — may sac wake THIS agent, and is it time?
+
+The rule is pure, so every leg is driven by passing facts in. No mocks and
+nothing to mock: no tmux, no clock, no database.
+
+The behaviours that matter, in the order they matter:
+
+* a LIFTED wall on a frozen pane is the resume case, and it is the leg that
+  proves this enforcer would have recovered the 2026-08-28 fleet.
+* a STANDING wall is HELD and that is a SUCCESS. This is the leg that makes
+  hammering a live limit structurally impossible rather than merely unlikely
+  — the resume branch is unreachable while ``now < reset_at``.
+* an UNREADABLE reset is never guessed at.
+* a MOVING pane is a working agent and is never touched. A false positive
+  here interrupts something that was fine.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from scitex_agent_container._ratelimit._banner import LimitObservation
+from scitex_agent_container._ratelimit._rule import Verdict, decide
+
+NOW = datetime(2026, 8, 28, 21, 0, tzinfo=timezone.utc)
+LIFTED = datetime(2026, 8, 28, 19, 10, tzinfo=timezone.utc)
+STANDING = datetime(2026, 8, 28, 23, 0, tzinfo=timezone.utc)
+
+
+def _walled(reset_at: datetime | None = LIFTED, *, line: int = 12):
+    """A readable pane showing a rate wall at a fixed line."""
+    return LimitObservation(
+        readable=True,
+        limited=True,
+        window="session",
+        reset_at=reset_at,
+        reset_text="resets 7:10pm",
+        line_index=line,
+        detail="a session rate wall",
+    )
+
+
+def _decide(**overrides):
+    """Decide for a managed, live agent frozen behind a LIFTED wall.
+
+    That is the interesting case — every leg below differs from it in
+    exactly one fact.
+    """
+    facts = {
+        "name": "alpha",
+        "policy": "on-failure",
+        "session_present": True,
+        "first": _walled(),
+        "second": _walled(),
+        "now": NOW,
+    }
+    facts.update(overrides)
+    return decide(**facts)
+
+
+# --- the resume case: the leg that recovers the fleet -----------------------
+
+
+def test_a_lifted_wall_authorises_a_resume() -> None:
+    # Arrange — the exact 2026-08-28 shape: a live session, a frozen banner,
+    # and a published reset that has already passed. Nothing inside the agent
+    # will notice the wall came down, because the thing that would have
+    # noticed IS the turn the wall stopped.
+    # Act
+    decision = _decide()
+    # Assert
+    assert decision.verdict is Verdict.RESUME
+
+
+def test_the_resume_names_the_lifted_wall() -> None:
+    # Arrange — a verdict whose cause is not stated is the silent skip this
+    # whole enforcer exists to abolish.
+    # Act
+    decision = _decide()
+    # Assert
+    assert decision.reason == "wall-lifted"
+
+
+# --- the hold cases: waiting is a SUCCESS, not a deferred failure -----------
+
+
+def test_a_standing_wall_is_held_not_resumed() -> None:
+    # Arrange — the wall lifts at 23:00 and it is 21:00. This is THE leg that
+    # makes hot-looping impossible: the resume branch cannot be reached while
+    # the wall stands, so the pass cannot spend a token against a live limit
+    # and make the outage longer.
+    # Act
+    decision = _decide(first=_walled(STANDING), second=_walled(STANDING))
+    # Assert
+    assert decision.verdict is Verdict.WAITING
+
+
+def test_an_unreadable_reset_is_held_not_guessed() -> None:
+    # Arrange — a real wall we cannot time. Inventing a reset is exactly how
+    # a reviver starts hammering a limit that is still in force.
+    # Act
+    decision = _decide(first=_walled(None), second=_walled(None))
+    # Assert
+    assert decision.verdict is Verdict.RESET_UNKNOWN
+
+
+# --- the refusals: who this enforcer is NOT for -----------------------------
+
+
+def test_an_unmanaged_agent_is_never_touched() -> None:
+    # Arrange — restart.policy defaults to "never", so a spec that omits a
+    # restart block is not ours. Same opt-in as fleet-reconcile, deliberately:
+    # two enforcers with different ideas of who they cover is a gap nobody
+    # can see.
+    # Act
+    decision = _decide(policy="never")
+    # Assert
+    assert decision.verdict is Verdict.NOT_MANAGED
+
+
+def test_a_corpse_is_handed_to_fleet_reconcile() -> None:
+    # Arrange — no live session means no pane to be walled. A rate wall is a
+    # pause in a LIVE session; resurrecting corpses is a different job with a
+    # different remedy, and a pass cannot both delegate a case and act on it.
+    # Act
+    decision = _decide(session_present=False)
+    # Assert
+    assert decision.verdict is Verdict.NO_SESSION
+
+
+def test_an_unreadable_session_list_is_not_an_absent_session() -> None:
+    # Arrange — "I could not enumerate" and "there is nothing there" lead to
+    # opposite conclusions, and sac's other two enforcers already refuse to
+    # collapse them. All three must agree or the fleet gets two answers.
+    # Act
+    decision = _decide(session_present=None)
+    # Assert
+    assert decision.verdict is Verdict.UNREADABLE
+
+
+def test_an_uncapturable_pane_is_not_a_working_agent() -> None:
+    # Arrange — the decisive read failed. Reporting NOT-LIMITED here would be
+    # an instrument announcing good news about a thing it never observed.
+    # Act
+    decision = _decide(second=LimitObservation(readable=False, detail="no capture"))
+    # Assert
+    assert decision.verdict is Verdict.UNREADABLE
+
+
+def test_a_clean_pane_is_nothing_to_do() -> None:
+    # Arrange — the overwhelming majority of a healthy fleet.
+    # Act
+    decision = _decide(second=LimitObservation(readable=True, limited=False))
+    # Assert
+    assert decision.verdict is Verdict.NOT_LIMITED
+
+
+def test_a_moving_banner_means_the_agent_is_working() -> None:
+    # Arrange — the banner is at a different pane line across the two reads,
+    # so output is still being produced. That is an agent working, or one
+    # QUOTING the incident in prose; nudging it would interrupt something
+    # that was fine. Same freeze discipline as the auth healer.
+    # Act
+    decision = _decide(first=_walled(line=8), second=_walled(line=12))
+    # Assert
+    assert decision.verdict is Verdict.MOVING
+
+
+def test_a_wall_that_only_just_appeared_is_moving() -> None:
+    # Arrange — no wall on the first read, one on the second. The pane
+    # advanced between the captures, so the agent was producing output during
+    # the observation window and has not settled behind the wall yet.
+    # Act
+    decision = _decide(first=LimitObservation(readable=True, limited=False))
+    # Assert
+    assert decision.verdict is Verdict.MOVING
+
+
+# --- ordering: ownership is asked before liveness ---------------------------
+
+
+def test_policy_is_checked_before_the_pane() -> None:
+    # Arrange — an unmanaged agent behind a lifted wall on an unreadable
+    # pane. "Is it ours?" precedes every other question, so this must answer
+    # NOT-MANAGED rather than UNREADABLE; reading pane evidence for an agent
+    # we would never act on can only produce noise.
+    # Act
+    decision = _decide(
+        policy="never",
+        first=LimitObservation(readable=False),
+        second=LimitObservation(readable=False),
+    )
+    # Assert
+    assert decision.verdict is Verdict.NOT_MANAGED


### PR DESCRIPTION
## The incident

2026-08-28: a session rate limit (HTTP 429, "You've hit your session limit ·
resets 7:10pm") stopped a set of agents at ~17:25 UTC. The limit lifted at
19:10 UTC. **Nothing resumed until the operator asked at 20:56 UTC** — 1h46m
of dead time a human had to catch.

A session-scoped cron cannot fix this: it dies with the session it would
revive. Per constitution §6 the job belongs to the supervisor, declared by sac
as a JobSpec.

---

## 0. The three questions a reviewer should ask first

### Can this hot-loop against a limit that is still in force?

**No, and not by tuning — by reachability.** The 429 banner carries its own
reset, we parse it, and the resume branch sits *after* two guards in
`_ratelimit/_rule.decide`:

```python
if second.reset_at is None:
    return Decision(Verdict.RESET_UNKNOWN, "reset-unreadable", ...)   # HOLD
if now < second.reset_at:
    return Decision(Verdict.WAITING, "wall-still-up", ...)            # HOLD
return Decision(Verdict.RESUME, "wall-lifted", ...)                   # only here
```

Note what the waiting is *made of*: this package defines **no retry or backoff
delay at all** — its only time constant is `DEFAULT_INTERVAL = 4.0`, the
spacing between the two pane captures used for the frozen check. The wait is
not a guessed interval; it is the wall's own published end time. (The 30-min
per-agent debounce it inherits from the shared `Budget` is a separate
mechanism: a cap on how often it may *act* once a wall has lifted, not a
substitute for knowing *when* it lifts.) `resolve_clock_near`
turns the bare `resets 7:10pm` into an instant by taking the occurrence
nearest the reading (the ±12h window is the furthest an unlabelled clock can
honestly be), and a labelled zone wins over the sweep's own frame. Verified
against the incident's real numbers: `resets 7:10pm` read at 21:00 UTC →
`2026-08-28 19:10+00:00`, the actual reset.

Proof it is asserted rather than merely written — the guards were broken on
purpose:

| mutation | result |
|---|---|
| `if now < second.reset_at:` → `if False:` | **3 failed**, 49 passed |
| `if second.reset_at is None:` → `if False:` | **3 failed**, 49 passed |
| restored | **52 passed** |

And the behavioural control: the same fleet, specs, panes and ledger run twice
with **only the clock moved** across 19:10 UTC. At 18:00 the recorder is
empty; at 20:56 it holds `["alpha"]`.

### When it cannot revive something, who reads that?

**At sac's layer this is a RECORD. At the supervisor's layer it is a CHECK
whose alarm has no last mile.** Stated in the code, not just here.

The check half is real: a non-zero exit is consumed by the supervisor's
`PeriodicRunner`, which writes `ok:false` plus a captured `stderr_tail`, folds
exits into a per-job rollup, and after `UNHEALTHY_AFTER` consecutive failures
— or for a job that has never once succeeded — writes a distinct
`job_unhealthy` record, de-duplicated so it announces once and **re-armed on
recovery** so a flapper is announced again, plus an `unhealthy` flag per job
in the supervisor's `state.json`. Hysteresis, not a print.

What does not exist, measured and not dressed up: **nothing polls those files
and tells a human.** `job_unhealthy` and `unhealthy` have zero matches under
`scitex_dev/_cli`; `_events.read_events` has zero non-test callers; and no sac
enforcer writes a board card (zero `scitex_cards` imports across `_reconcile`,
`_authheal`, `_ratelimit`). So today's human-facing consumer is a person
running the verb or grepping `periodic-executions.jsonl` during an incident.

That gap is identical for all three enforcers and is not introduced here, so
it is tracked rather than absorbed:
`liveness-enforcer-failures-reach-no-human-20260828`. That card also records a
claim that is **currently false** — `restart-login-expired`'s docstring
promises a "BOARD CARD" that is never written.

### Does the new job repeat the dead-timer shape?

**It cannot, because it has no timer at all** — and the premise needs
correcting: per-leaf systemd timers are *retired*. Verified three ways.

1. **Declaration** — the new job's cadence fields are byte-identical to its
   two siblings: `kind=timer`, `schedule="*/5 * * * *"`,
   `on_unit_active_sec="5min"`, `on_boot_sec="5min"`, `on_calendar=None`.
   `PeriodicRunner` reads `on_unit_active_sec`, then `schedule`; it never
   reads `on_calendar`.
2. **Installation** — `scitex-dev ecosystem up` writes *only*
   `scitex-dev-ecosystem.service` and reports *"cron: no managed block present
   (correct — cron is retired)"*. No per-leaf unit is planned for any job, and
   `systemctl --user list-unit-files | grep -c resume-rate-limited` is **0**.
3. **The removal control, which is the decisive one.** I disabled both sibling
   timers on compute-04 at 21:55 UTC. They now read `inactive dead disabled`
   — and the jobs kept running anyway:

```
fleet-reconcile.timer                inactive dead disabled
restart-login-expired-agents.timer   inactive dead disabled
0 units named resume-rate-limited

...yet, from the supervisor's execution log, last 30 min:
  fleet-reconcile               started=6 finished=6
      22:00:07Z started   22:00:08Z finished exit=0
      22:05:08Z started   22:05:12Z finished exit=0
  restart-login-expired-agents  started=6 finished=6
      22:00:07Z started   22:00:13Z finished exit=0
      22:05:08Z started   22:05:13Z finished exit=0
```

Deleting the timer did not stop the job, which proves the timer was never what
scheduled it.

And the **natural** control, on a host I never touched — compute-01 has never
had these units at all:

```
compute-01: systemd unit-files matching reconcile|login-expired  ->  0
compute-01: supervisor executions in the last 30 min:
    fleet-reconcile                6 finished
    restart-login-expired-agents   6 finished
```

Zero timers, twelve runs. The dead-timer shape cannot recur in something that
owns no timer.

---

## 1. What is DECLARED vs SCHEDULED vs LAST-ACTUALLY-RAN

**Read the instrument note first — I got this wrong once and it changes the
whole answer.**

`kind="timer"` no longer means a per-leaf `systemd --user` timer, and it no
longer means a crontab line either. **Both lowerings are retired.** Every
periodic JobSpec is executed in-process by the ecosystem supervisor's
`PeriodicRunner` (`scitex_dev/_supervisor/_periodic.py`), which owns the clock
and writes one record per start, finish and skip to
`~/.scitex/dev/runtime/periodic-executions.jsonl`. `scitex-dev ecosystem up`
confirms it: *"cron: no managed block present (correct — cron is retired)"*.

So **`systemctl --user list-timers` is the wrong instrument**, and it gives a
confidently wrong answer, because hosts still carry ORPHAN `<job>.timer` /
`<job>.service` units from the retired model. On scitex-compute-04:

```
fleet-reconcile.timer   ActiveState=active  UnitFileState=enabled
                        SubState=elapsed    LastTrigger=Wed 2026-08-19 17:51:10 UTC
```

Nine days silent — **while the supervisor was running the same job every five
minutes and had logged 3,764 executions of it.** My first pass through this
investigation stopped at `list-timers` and concluded the fleet's liveness
enforcement had been dead for over a week. It had not.

### The corrected table

Declared = in sac's JobSpec provider. Scheduled/last-ran = read from each
host's `periodic-executions.jsonl`, not from systemd.

| Host | Supervisor | fleet-reconcile | restart-login-expired | resume-rate-limited (this PR) |
|---|---|---|---|---|
| compute-01 | **running** | **SCHEDULED**, every 5 min, 3,130 logged runs | **SCHEDULED**, every 5 min | not yet declared |
| compute-03 | **running** | **SCHEDULED**, every 5 min (most recent run exit 2 — a blind pass) | **SCHEDULED**, every 5 min, exit 0 | not yet declared |
| compute-04 | **running** | **SCHEDULED**, every 5 min, 3,764 logged runs, last exit 0 | **SCHEDULED**, every 5 min | not yet declared |
| compute-02 | **ABSENT** | **not scheduled** — no supervisor, no sac jobs at all | not scheduled | not scheduled |
| nas-03 | **ABSENT** | **not scheduled** — no supervisor | not scheduled | not scheduled |

Orphan per-leaf units, for completeness: compute-04 carries eleven
`<job>.timer`/`.service` pairs from the retired model, two of which
(`fleet-reconcile`, `restart-login-expired-agents`) read `enabled` + `elapsed`
with last triggers of 2026-08-19 and 2026-08-20. compute-03 carries a couple.
They are inert relics, not the live schedule.

*(The brief said the supervisor is absent on nas-03; it is also absent on
compute-02. `systemctl --user` works there — `Linger=yes`,
`XDG_RUNTIME_DIR=/run/user/1000`, and it lists a non-sac timer — so the empty
result is a real absence, not a blind probe.)*

---

## 2. Verdict — would `fleet-reconcile` have revived them? **NO.**

And this is now the *only* defect in play, which strengthens the case rather
than weakening it: the enforcers were **armed and running every five minutes
throughout the incident**, and the agents still stayed stopped.

**a) Its rule refuses, by design.** `_reconcile/_rule.py`:

```python
if session_present:
    return Decision(Verdict.OK, "session-alive",
        f"tmux session for {name} exists — alive; hands off (a wedged "
        f"session is auth-heal's job, never ours)")
```

**b) The sessions survived the wall.** On compute-04 the migration agents'
tmux sessions were created 05:33 UTC on 2026-08-28 and were still listed at
21:15 UTC — they lived straight through the 17:25 event. A rate wall stops the
*turn*, not the process. So `session_present=True` and the rule returns
`OK`/`session-alive` for every one of them.

The sibling doesn't cover it either, and says so at the exclusion —
`_runners/_tmux/auth_status.py`:

```python
# Standalone HTTP auth-rejection line (401 Unauthorized / 403 Forbidden). 429
# (rate limit) is deliberately excluded — a restart does not fix a rate wall.
```

Both enforcers were **right**, both were **running**, and the agent still
stayed stopped. That is what made the gap invisible: two handoffs that look
exhaustive until an agent lands between them. The corollary nobody had written
down is that a rate wall does not need *fixing* — it needs **waiting out and
then continuing**.

---

## 3. What changed

### New: `sac agents resume-rate-limited` + the `sac.resume-rate-limited-agents` JobSpec

The third liveness shape, disjoint from the other two by construction:

| shape | owner |
|---|---|
| no tmux session → a CORPSE | `sac.fleet-reconcile` |
| session + frozen **auth** banner → a WEDGE | `sac.restart-login-expired-agents` |
| session + frozen **rate** banner → a PAUSE | **`sac.resume-rate-limited-agents`** |

* **Runs outside every agent session** — a periodic JobSpec on the ecosystem
  supervisor's clock, in a different failure domain from the thing it revives.
  That is the whole point of not using a session cron.
* **It cannot hot-loop against a live limit, structurally.** The resume branch
  of `_ratelimit/_rule.decide` is unreachable while `now < reset_at`, where
  `reset_at` is parsed from the provider's own banner. `WAITING` is a
  first-class success verdict, not a deferred failure.
* **It never guesses a reset.** An unparseable reset clause is
  `RESET_UNKNOWN`: held and reported, exit 2. A guessed reset is exactly how a
  reviver starts burning the quota that would have ended the outage.
* **It CONTINUES, never restarts.** The session, context and conversation all
  survived the wall; restarting would destroy what makes resuming worth doing.
  The nudge goes through `_delivery.deliver`, which waits for idle, submits,
  and **proves the payload left the compose box**. A nudge that merely lands
  in the composer and is never submitted is indistinguishable from the outage
  itself — and that is literally the state the 2026-08-28 agents were found
  in, a prompt sitting unsent at `❯` for hours. Only
  `assess_delivery(...).verdict is True` counts as success.
* **Same rate-limiting discipline as its siblings** — 30 min/agent debounce,
  ≤2/agent/hour, `--limit` per pass, on its **own** ledger
  (`SAC_RATE_LIMIT_HISTORY`). The ledger is a flat `{agent: [epoch, ...]}`
  with no subsystem key, so three enforcers sharing one file would consume
  each other's budget and race on one atomic write.
* **An agent it cannot wake is RECORDED as degraded**, not nudged forever.

The banner parser is fitted to **real captured specimens**, not invented
strings, recovered from agent transcripts:

```
⎿ You've hit your weekly limit · resets 8am (UTC)
You've hit your weekly limit · resets 11pm (UTC)
You've hit your weekly limit · resets 8am (Asia/Tokyo)
You've hit your session limit · resets 7:10pm          ← the incident
```

They are checked in as `SPECIMEN_PANES` and asserted against, so a rendering
change breaks a test instead of silently reporting a healthy fleet.

### Who reads the signal

Two sinks, ranked honestly.

**The reader of record is the exit code**, because the `PeriodicRunner`
persists `exit_code` and `ok` per run to
`~/.scitex/dev/runtime/periodic-executions.jsonl` — and also records a run it
could not *start*, the failure with no other witness. That log is the
supervisor's product, not a side effect.

**sac's own event log is the weaker sink and has no production reader today:**
`_events.read_events` has zero non-test callers. The per-agent
`subject-degraded` records are a durable history, not how a failure reaches a
human. Saying so is the point — a check whose failure nothing reads is not a
check.

That ranking is why `WAITING` exits **0**: a wall can stand for hours, and
stamping `ok: false` on the execution log every five minutes for the whole
window teaches its reader to skip it.

### Also corrected in this PR: the instrument, in code

`_jobs/_specs_liveness` now documents where these jobs actually run, why the
orphan units are dead, and that they want **removing, not reviving** — because
re-arming one puts a second scheduler on a job the supervisor already runs.
See §5.

### Not changed: the schedule fields

Adding `on_calendar` was tried and backed out for three independent reasons:
sac's `test_no_job_degrades_when_lowered_onto_cron` correctly fails on it
(`_up_timer_losses` treats any `on_calendar` as lossy); the guard's premise —
a crontab line carries no timezone — is right in general even though it is
over-broad for a zone-free interval; and decisively, **`PeriodicRunner` never
reads `on_calendar` at all** (it reads `on_unit_active_sec`, then `schedule`),
so the field would have been inert. Both existing fields are load-bearing and
are kept.

---

## 4. Verification

**Tests EXECUTED vs COLLECTED** (absolute-path pytest, worktree source — the
run loads `.worktrees/agent-a6bd3421d034a2bbf/src/scitex_agent_container/`,
verified by `__file__`, not the installed package):

* `_ratelimit/` — **55 collected, 55 executed, 55 passed**, 0 skipped.
* `_ratelimit/` + `_jobs/` + `_reconcile/` + `_authheal/` — **552 collected,
  552 executed, 552 passed**, 0 skipped.
* `tests/develop/` (the repo's own guards) — **132 passed, 15 skipped** in
  101s. The 15 skips are pre-existing PostgreSQL-dependent tests, none mine.
* The whole suite is 18,078 selected tests and takes far longer than a local
  bound allows; **CI's `pytest-matrix` jobs are the authority** and are on this
  PR.

**Mutation control — proving the green could have gone red.** A test that
cannot fail proves nothing, so the two load-bearing guards were broken on
purpose:

| mutation | result |
|---|---|
| replace `if now < second.reset_at:` with `if False:` (remove the wall-still-up hold) | **3 failed**, 49 passed |
| replace `if second.reset_at is None:` with `if False:` (guess instead of hold) | **3 failed**, 49 passed |
| restored | **52 passed** |

**Positive control in the suite itself.** `test_the_incident_fleet_is_held_before_the_reset`
and `test_the_incident_fleet_is_resumed_after_the_reset` are one experiment run
twice — same fleet, same specs, same captured panes, same ledger, and the
**clock as the only variable**, moved across the incident's real 19:10 UTC
reset. At 18:00 UTC the recorder is empty; at 20:56 UTC (the minute the
operator had to ask) it holds `["alpha"]`. Both legs assert against the same
recorder.

**End-to-end smoke:** `sac agents resume-rate-limited --json` against the
worktree source returns exit 0 with valid JSON and `"pass_recorded": true`,
i.e. the who-watches-the-watcher rail wrote to a real event log.

**Deploy gate honoured.** `restart-login-expired`'s gate says do not enable
until the host's `auth-heal.py` `scan_tui` cron is retired. Verified on all
four hosts: `auth-heal.py` is absent everywhere, and no host has a `scan_tui`
crontab entry (compute-03's only crontab line is an ssh tunnel; compute-02 and
compute-04 have no crontab at all).

---

## 5. A mistake I made on the live fleet, and reverted

Reported because it is the most useful thing in this PR for the next person.

Acting on the wrong instrument (§1), I concluded the two enforcer timers on
compute-04 were dead and **re-armed them** at ~21:41 UTC by triggering each
service once. That worked exactly as I predicted — `elapsed` → `waiting`, and
they then fired on their own at 21:46 and 21:51 — which felt like
confirmation, and was in fact **a second scheduler on a job the supervisor was
already running every five minutes**, with independent debounce state. That is
precisely the double-supervisor hazard the codebase warns about in three
separate places.

I found it by asking where `kind=timer` jobs actually execute, and reverted at
~21:55 UTC: both timers stopped and disabled, verified `inactive dead
disabled`, with the supervisor confirmed still running both jobs (a
fleet-reconcile finished exit 0 at 21:55:09).

**Blast radius: none.** The overlap lasted ~14 minutes and the legacy timer
fired twice. Both passes exited 0 having restarted nothing — I had measured
that first: `sac agents reconcile --json` returned `{NOT-MANAGED: 18, OK: 3,
SKIPPED: 97}` with zero `WOULD-RESTART`, and `restart-login-expired --json`
returned `{UNOBSERVED: 114}`. No agent was touched.

Net effect on the host: better than before. The two orphans were `enabled` +
`elapsed` — a trap that reads as armed — and are now explicitly `disabled`.

---

## 6. What remains unarmed, and what that implies

* **compute-01, compute-03, compute-04** — supervisor running, both existing
  enforcers scheduled and executing. The new job joins them when this merges
  and each host's supervisor picks up the new provider output.
* **compute-02 — no ecosystem supervisor and no sac jobs at all.** Every
  liveness enforcer is absent. An agent that stops there stops until a human
  notices. This is a gap the brief did not mention and it is not smaller than
  nas-03's.
* **nas-03 — no supervisor, so nothing here reaches it.** With cron retired,
  the supervisor is now the *only* execution path for a periodic JobSpec, so
  "no supervisor" means "no periodic jobs at all", full stop. nas-03 is not
  silently excluded from this PR; it is unprotected, and installing a
  supervisor there is its own decision — it is also the host where sac agents
  have historically had the most trouble running at all.
* **The orphan units are still on disk** on compute-04 and compute-03 (nine
  more on compute-04 beyond the two I disabled). Every one is a trap for the
  next investigation. Filed as
  `dev-timer-monotonic-dead-end-20260828`, re-scoped to *remove the orphans*.

## Notes

* Two lint warnings on the new files (`STX-IO006` on the `--json` output,
  `STX-NL001` on year literals in a test) are the same warnings the sibling
  enforcers already carry — `_agents_reconcile.py`,
  `_agents_restart_login_expired.py` and `_reconcile/_fleet.py` each produce
  them today. No new warning class is introduced, and years are an explicit
  carve-out in the STX-NL001 rule text.
* No mocks, no monkeypatch: every collaborator is a production keyword
  argument with a real default, and the tests pass real temp files, real spec
  YAML, real captured panes and a plain recorder object into them.

Card: `ratelimit-revival-through-supervisor-20260828`
