### PR TITLE
fix(migrate): the channel guard could not be satisfied, and the tables came out unusable

### DIFF
--- a/scripts/_channel_import_guard.py
+++ b/scripts/_channel_import_guard.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""WHERE this host's rows land, and WHETHER they may land there.
+
+Split out of ``migrate_channel_events_to_postgres.py`` when the provenance
+correction pushed that file past the per-file line cap. It holds the two
+questions that are about PLACEMENT rather than about copying rows:
+
+* :func:`offset_for` — where do THESE rows already sit, or where must they go?
+* :func:`refusals` — is putting them there safe, or would it strand a live
+  consumer's cursor?
+
+The copying itself, the argv, the verification and the operator output stay in
+the script.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+import _channel_import_provenance as prov
+
+
+def group_by_target(rows: Sequence[Mapping[str, Any]]) -> dict[str, list[dict]]:
+    """The source rows, per target, each list sorted by the source's own id."""
+    grouped: dict[str, list[dict]] = {}
+    for row in rows:
+        grouped.setdefault(str(row["target"]), []).append(dict(row))
+    for entries in grouped.values():
+        entries.sort(key=lambda r: int(r["id"]))
+    return grouped
+
+
+def offset_for(conn: Any, *, target: str, entries: list[dict]) -> tuple[int, bool]:
+    """``(offset, already_imported)`` for this host's rows on this target.
+
+    THE PROBE IS BY CONTENT, NOT BY POSITION, and that is a correction. The
+    first version asked "is the row sitting at the source's own top id
+    mine?" — a question that is only valid when the previous run applied
+    offset 0. For a RELOCATED target the previous run shifted this host's
+    rows above an earlier residency, so the probe landed on the EARLIER
+    host's row, saw a mismatch, and concluded "not mine". It then returned
+    the (now higher) ``pg_max``, so ``ON CONFLICT (target, id) DO NOTHING``
+    had no id to conflict on and the whole history was inserted AGAIN at
+    fresh ids — one extra copy per invocation, with the script's verification
+    unable to see it because it windows on the shifted range it just wrote.
+
+    Asking WHERE THIS ENVELOPE ALREADY SITS answers the same question
+    without assuming the answer. A match yields the offset the previous run
+    used, so the re-import conflicts on every id and moves nothing.
+
+    The candidate is confirmed against the source's FIRST row as well as its
+    last: ``meta_json`` is not unique by construction (the at-least-once
+    retry path can duplicate an envelope), so a lookalike top row alone must
+    not be allowed to imply an offset for the whole run.
+
+    ``already_imported`` distinguishes "we have been here before" from "these
+    ids belong to somebody else", which is what :func:`refusals` needs to tell
+    a relocation apart from a daemon that has moved on. It is ALSO what makes
+    the provenance backfill work: a re-run of an already-imported host records
+    the window this returns without moving a row.
+    """
+    pg_max = int(
+        conn.execute(
+            "SELECT COALESCE(MAX(id), 0) FROM sac_channel_events WHERE target = %s",
+            (target,),
+        ).fetchone()[0]
+    )
+    if pg_max == 0:
+        return 0, False
+
+    first, top = entries[0], entries[-1]
+    landed_at = [
+        int(r[0])
+        for r in conn.execute(
+            "SELECT id FROM sac_channel_events "
+            "WHERE target = %s AND meta_json = %s ORDER BY id",
+            (target, top["meta_json"]),
+        ).fetchall()
+    ]
+    for landed in landed_at:
+        offset = landed - int(top["id"])
+        if offset < 0:
+            continue
+        anchor = conn.execute(
+            "SELECT meta_json FROM sac_channel_events WHERE target = %s AND id = %s",
+            (target, int(first["id"]) + offset),
+        ).fetchone()
+        if anchor is not None and anchor[0] == first["meta_json"]:
+            return offset, True
+    return pg_max, False
+
+
+def newer_rows_than_source(
+    conn: Any, *, target: str, entries: list[dict]
+) -> tuple[int, int]:
+    """``(unattributed, attributed)`` rows this target holds that POSTDATE it.
+
+    The split is the whole fix. ``attributed`` rows sit inside an id window
+    some import CLAIMED, so they are another host's history — which this
+    script has always said it shifts above. ``unattributed`` rows are the ones
+    nothing can account for, and only those can be a daemon that served in the
+    deploy gap.
+    """
+    newest = max(float(row["ts"]) for row in entries)
+    return prov.newer_rows(conn, target=target, newest_ts=newest)
+
+
+def refusals(
+    conn: Any,
+    grouped: dict[str, list[dict]],
+    *,
+    accepted: frozenset[str] = frozenset(),
+) -> tuple[list[str], list[str]]:
+    """``(refused, waived)`` — targets this migration MUST NOT touch.
+
+    THE ORDERING THIS ENFORCES: run the one-shot BEFORE the new code starts
+    serving, per target. ``init_channel_schema`` creates the tables lazily on
+    first connect, so the ordinary deploy sequence — restart ``sac listen``
+    with the new code, then run the one-shot — has the daemon minting ids from
+    1 for any target that receives a message in the gap. Those rows are
+    genuinely new, and shifting the migrated history ABOVE them produces
+    exactly the failure this design exists to prevent: every SQLite-era
+    ``Last-Event-ID`` resolves to a DIFFERENT event, and the post-cutover rows
+    sit BELOW every live cursor, unreachable through ``id > cursor`` forever.
+
+    THE DISCRIMINATOR IS PROVENANCE, NOT TIME, and that is a correction. Time
+    alone answers "could this row belong to an older residency?" — a proxy for
+    the real question, and a proxy that FAILS whenever two hosts served one
+    target over overlapping periods, which is the shape this fleet is in.
+    Measured 2026-08-28: compute-03's import was refused by 152 rows of
+    compute-04's already-imported history, with ZERO post-cutover writes among
+    them, and no operator action could clear it — stopping ``sac listen`` does
+    not remove rows that are already in the table.
+
+    So a row is evidence of a live daemon only if NO RECORDED IMPORT CLAIMS
+    IT. A daemon row minted in the deploy gap belongs to no window, is newer
+    than the source, and is still refused; that is what the negative controls
+    in ``test_migrate_channel_events_overlap.py`` pin, and they are the tests
+    that matter most here.
+
+    A target we have ALREADY imported is exempt: its own rows are trivially
+    not newer than themselves, and a re-run must stay a no-op.
+
+    ``accepted`` is the operator asserting, PER NAMED TARGET, that the
+    unattributed rows above them are an import whose ``state.db`` is gone.
+    There is deliberately no blanket ``--force``: a bypass covering every
+    target at once restores exactly the corruption this guard exists to
+    prevent, and this guard has already proved its worth by refusing rather
+    than corrupting.
+    """
+    refused: list[str] = []
+    waived: list[str] = []
+    for target in sorted(grouped):
+        entries = grouped[target]
+        _, already = offset_for(conn, target=target, entries=entries)
+        if already:
+            continue
+        unclaimed, claimed = newer_rows_than_source(
+            conn, target=target, entries=entries
+        )
+        if not unclaimed:
+            continue
+        if target in accepted:
+            waived.append(
+                f"{target}: {unclaimed} unattributed row(s) ACCEPTED as "
+                f"imported history on the operator's explicit assertion"
+            )
+            continue
+        seen = (
+            ""
+            if not claimed
+            else (
+                f" ({claimed} further newer row(s) ARE accounted for by a "
+                f"recorded import, and were not held against this run)"
+            )
+        )
+        refused.append(
+            f"{target}: {unclaimed} row(s) already in the store are NEWER than "
+            f"anything in this state.db and carry NO import provenance{seen}, "
+            f"so this script cannot tell another host's history from live "
+            f"daemon traffic. Do ONE of: (1) if those rows came from ANOTHER "
+            f"HOST's state.db, re-run this with --commit --db-path pointing at "
+            f"THAT file — it moves no rows and records the window it "
+            f"recognises, after which this refusal clears; (2) if `sac listen` "
+            f"really has served {target!r} since the cutover, stop it on every "
+            f"host serving {target!r} and re-run; (3) if that state.db is gone, "
+            f"assert it per target with --accept-imported-history {target}."
+        )
+    return refused, waived
+
+
+def dry_run_refusals(
+    grouped: dict[str, list[dict]], *, accepted: frozenset[str]
+) -> tuple[list[str], list[str]]:
+    """:func:`refusals` for the dry run — READ-ONLY, and never fatal.
+
+    IT MUST NOT RUN THE DDL. ``new_channel_connection`` applies the schema on
+    open, so reaching for it here would make the dry run CREATE the two
+    tables — a write, in the mode whose entire contract is that it writes
+    nothing. It connects raw instead and treats an absent table as "nothing
+    to refuse", which is exactly true: a store with no rows cannot have moved
+    on past this import.
+
+    A store that cannot be opened is SAID OUT LOUD and skipped rather than
+    reported as "nothing refused" — the reading that would make a clean dry
+    run mean nothing. Same shape as ``_migrate_lib._preview_collisions``.
+    """
+    try:
+        import psycopg
+
+        from scitex_agent_container._state.state_db_channel_store import (
+            _resolve_target,
+        )
+
+        conn = psycopg.connect(str(_resolve_target().dsn), autocommit=True)
+    except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+        print(f"  (ordering check SKIPPED — cannot open the store: {exc!r})")
+        return [], []
+    try:
+        exists = conn.execute(
+            "SELECT to_regclass('sac_channel_events') IS NOT NULL"
+        ).fetchone()[0]
+        if not exists:
+            return [], []
+        return refusals(conn, grouped, accepted=accepted)
+    finally:
+        conn.close()

--- a/scripts/_channel_import_provenance.py
+++ b/scripts/_channel_import_provenance.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Which id windows in ``sac_channel_events`` were IMPORTED, and from where.
+
+THE GUARD THAT COULD NOT BE SATISFIED (measured 2026-08-28)
+===========================================================
+``migrate_channel_events_to_postgres.py`` refuses to import a target when the
+store already holds a row NEWER than everything in the source ``state.db``,
+reasoning that such a row cannot belong to an OLDER residency and is therefore
+the live daemon having moved on. That reasoning assumes SEQUENTIAL relocation:
+host A serves a target until date X, then host B takes over.
+
+This fleet violates the assumption. compute-04 and compute-03 served the SAME
+targets over OVERLAPPING periods — ``scitex-agent-container`` ran 08-09..08-28
+on compute-04 and 08-18..08-22 on compute-03 — so once compute-04's history
+was imported, compute-03's import was refused by rows that were not daemon
+traffic at all. Measured directly against ``sac_channel_events``:
+
+    scitex-agent-container   145 rows newer   0 written after the cutover
+    scitex-cards               2 rows newer   0 written after the cutover
+    figrecipe                  5 rows total   all of it history
+
+The predicate is structurally unsatisfiable in that shape — stopping
+``sac listen`` on both hosts changes nothing, because the offending rows were
+already written and are not going away. Nothing an operator can do clears it.
+
+WHAT ACTUALLY DISCRIMINATES: WAS THE ROW IMPORTED, OR WRITTEN LIVE?
+==================================================================
+Time cannot answer that, and no amount of sharpening the ts comparison will
+make it: an imported row and a daemon row can carry the same timestamp. The
+answer has to be RECORDED at import time, and that is all this module does.
+
+The guard then keeps the ts test — the negative controls that pin the real
+post-cutover hazard still pass for the reason they always did — and applies it
+only to rows NO IMPORT CLAIMS. A daemon row minted in the deploy gap belongs
+to no import window, is newer than the source, and is still refused.
+
+A WINDOW PER IMPORT, NOT A COLUMN PER ROW — AND WHY
+===================================================
+The obvious alternative is a provenance column on ``sac_channel_events``.
+Rejected on three measured grounds:
+
+1. ``meta_json`` IS NOT AVAILABLE as a home. Its stored bytes must stay
+   IDENTICAL or a replayed SSE frame stops matching the live one
+   (``state_db_channel_store`` states this three ways: ``sort_keys``,
+   ``ensure_ascii`` and ``jsonb`` normalisation each break it). Writing
+   provenance into the envelope would corrupt the exact property the
+   migration exists to preserve.
+2. A NEW COLUMN CANNOT BE BACKFILLED from the data. The 7,980 rows already
+   imported carry no provenance and nothing in them says where they came
+   from, so a column would start life NULL — and NULL would have to mean
+   "daemon wrote it", which is precisely the wrong answer for every one of
+   them. The re-run backfill below has the same cost and does not touch the
+   hot table.
+3. The table is written once per message and read on every SSE connect. A
+   migration-only fact does not belong in it.
+
+WHY THE WINDOWS STAY TRUE. Ids for a target only ever move UP: ``_seed_cursor``
+advances the counter with ``GREATEST`` and never winds it back, and a later
+host's import is OFFSET ABOVE the existing maximum. So no row is ever inserted
+INSIDE a recorded window after the fact, and a window recorded once keeps
+meaning what it meant.
+
+BACKFILLING AN IMPORT THAT ALREADY HAPPENED
+===========================================
+Re-run the migration with ``--commit`` against the EARLIER host's ``state.db``.
+That run is already proven to move nothing (``_offset_for`` recognises its own
+rows by content), and it now records the window it recognised. The file can be
+read from anywhere — ``--db-path`` takes a path — so this does not require
+going back to the other machine, only to its ``state.db``.
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+from typing import Any
+
+#: The ledger. Named like the two tables it describes so an operator reading
+#: ``\dt sac_*`` sees the set together.
+LEDGER_TABLE = "sac_channel_import"
+
+#: ``PRIMARY KEY (target, lo_id, hi_id)`` makes re-recording the same window a
+#: no-op, which is what a re-run of an already-imported host must be.
+LEDGER_DDL = """
+CREATE TABLE IF NOT EXISTS sac_channel_import (
+    target          TEXT   NOT NULL,
+    lo_id           BIGINT NOT NULL,
+    hi_id           BIGINT NOT NULL,
+    source_host     TEXT   NOT NULL,
+    source_path     TEXT   NOT NULL,
+    row_count       BIGINT NOT NULL,
+    offset_applied  BIGINT NOT NULL,
+    imported_at     DOUBLE PRECISION NOT NULL,
+    imported_by     TEXT   NOT NULL,
+    PRIMARY KEY (target, lo_id, hi_id)
+);
+"""
+
+
+def source_host() -> str:
+    """The machine whose ``state.db`` is being read.
+
+    ``gethostname`` is honest for the documented usage — the module docstring
+    of the migration says RUN IT ON THE HOST, ONCE PER HOST — and the
+    ``source_path`` recorded alongside it disambiguates the backfill case
+    where a copied file is imported from somewhere else.
+    """
+    return socket.gethostname()
+
+
+def ensure_ledger(conn: Any) -> None:
+    """Create the ledger if missing. Idempotent.
+
+    Deliberately NOT part of ``state_db_channel_store._DDL``: no runtime
+    reader or writer touches this table, and adding it there would make every
+    agent's connect apply DDL for a one-shot's bookkeeping.
+    """
+    conn.execute(LEDGER_DDL)
+
+
+def ledger_exists(conn: Any) -> bool:
+    """Is the ledger present? A dry run must not create it to find out."""
+    return bool(
+        conn.execute(
+            "SELECT to_regclass(%s) IS NOT NULL", (LEDGER_TABLE,)
+        ).fetchone()[0]
+    )
+
+
+def record_import(
+    conn: Any,
+    *,
+    target: str,
+    lo_id: int,
+    hi_id: int,
+    source_path: str,
+    row_count: int,
+    offset_applied: int,
+) -> None:
+    """Claim ``[lo_id, hi_id]`` on ``target`` as an import, not daemon traffic.
+
+    The ids recorded are POST-OFFSET — where the rows actually sit — because
+    that is the space the guard's ``BETWEEN`` is evaluated in.
+    """
+    conn.execute(
+        "INSERT INTO sac_channel_import (target, lo_id, hi_id, source_host, "
+        "source_path, row_count, offset_applied, imported_at, imported_by) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, current_user) "
+        "ON CONFLICT (target, lo_id, hi_id) DO NOTHING",
+        (
+            target,
+            lo_id,
+            hi_id,
+            source_host(),
+            source_path,
+            row_count,
+            offset_applied,
+            time.time(),
+        ),
+    )
+
+
+def newer_rows(conn: Any, *, target: str, newest_ts: float) -> tuple[int, int]:
+    """``(unattributed, attributed)`` rows on ``target`` postdating the import.
+
+    ``unattributed`` — no recorded import claims them — is the number the
+    guard acts on. ``attributed`` is reported so the operator can see that the
+    script looked and found provenance, rather than wondering whether it
+    checked at all.
+
+    A store with NO ledger yet answers ``(all, 0)``, which is exactly the
+    pre-provenance behaviour. That is deliberate: a first run against such a
+    store has no grounds to be more permissive than the old guard was.
+    """
+    total = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM sac_channel_events "
+            "WHERE target = %s AND ts > %s",
+            (target, newest_ts),
+        ).fetchone()[0]
+    )
+    if not total or not ledger_exists(conn):
+        return total, 0
+    unattributed = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM sac_channel_events e "
+            "WHERE e.target = %s AND e.ts > %s AND NOT EXISTS ("
+            "  SELECT 1 FROM sac_channel_import i "
+            "  WHERE i.target = e.target AND e.id BETWEEN i.lo_id AND i.hi_id)",
+            (target, newest_ts),
+        ).fetchone()[0]
+    )
+    return unattributed, total - unattributed

--- a/scripts/_pg_table_owner.py
+++ b/scripts/_pg_table_owner.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Who OWNS the tables a migration creates — and can the fleet still use them?
+
+MEASURED OUTAGE, 2026-08-28
+===========================
+``migrate_channel_events_to_postgres.py`` creates its tables on first connect,
+so they end up owned by WHOEVER RAN IT. The operator ran it as
+``ywatanabe__cli``; ``sac_channel_events`` and ``sac_channel_cursor`` came out
+owned by that leaf role with no grants to anybody. Every agent connects as
+``ywatanabe__<agent>``, and ``init_channel_schema``'s
+``CREATE INDEX IF NOT EXISTS`` requires OWNERSHIP of the table rather than
+merely privileges on it — so the fleet's message channel began failing with
+``InsufficientPrivilege: must be owner of table sac_channel_events`` about
+three minutes later, and stayed broken for six until the tables were reowned
+by break-glass.
+
+THE POST-MIGRATION CHECK PASSED THROUGHOUT, because it ran as the MIGRATING
+role. A verification performed by the writer cannot see a permission the
+writer happens to hold. :func:`consumer_access_problems` therefore asks the
+catalog about OTHER roles BY NAME and never about ``current_user``.
+
+THE ROLE TREE, MEASURED ON THE FLEET PRIMARY (2026-08-28)
+=========================================================
+``ywatanabe__<agent>`` is a member of ``ywatanabe``, which is a member of
+``scitex_store_owner``. Every table in ``public`` is owned by
+``scitex_store_owner`` and carries a NULL ``relacl`` — no explicit grants at
+all. Access works purely by MEMBERSHIP IN THE OWNER. That is why a ``GRANT``
+would not have fixed the outage: ``CREATE INDEX`` needs owner rights, and no
+grant confers those.
+
+Measured on a throwaway table created by a leaf role, for every other agent
+role in the cluster: ``has_table_privilege`` False and
+``pg_has_role(<role>, <owner>, 'USAGE')`` False. Against the reowned
+``sac_channel_events``: both True. Those two catalog questions are the
+instrument this module uses.
+
+NO ROLE NAME IS HARDCODED
+=========================
+``scitex_store_owner`` is a fact about THIS fleet, not about the script, and a
+literal would be wrong on any database provisioned differently — CI's
+throwaway included. The intended owner is DERIVED: whatever role owns the rest
+of the tables in the target schema is, by construction, the role these tables
+must match, because that is the role the fleet's consumers have already been
+measured to inherit. An operator can always override it outright.
+
+A SCHEMA WITH NOTHING ELSE IN IT has no convention to be consistent with, so
+the answer there is ``current_user`` and no ``SET ROLE`` happens. That is the
+virgin-database case, and it is also every ``pg_schema`` test fixture.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Sequence
+
+#: Operator override for the role the created tables must end up owned by.
+#: The ``--table-owner`` flag wins over it; both beat the derivation.
+OWNER_ENV = "SAC_MIGRATION_TABLE_OWNER"
+
+#: The privileges a consumer needs on these tables to do its job. SELECT and
+#: INSERT are the SSE read and the publish path; UPDATE is ``mark_delivered``;
+#: DELETE is retention, which nothing runs yet and which a consumer that
+#: cannot do it would discover only much later.
+_NEEDED = ("SELECT", "INSERT", "UPDATE", "DELETE")
+
+
+def current_role(conn: Any) -> str:
+    """The role statements run as RIGHT NOW — after any ``SET ROLE``."""
+    return str(conn.execute("SELECT current_user").fetchone()[0])
+
+
+def role_exists(conn: Any, role: str) -> bool:
+    """Is ``role`` a role in this cluster?
+
+    Asked separately because ``pg_has_role`` RAISES ``UndefinedObject`` on an
+    unknown name, and a typo'd ``--table-owner`` deserves a sentence rather
+    than a traceback.
+    """
+    return bool(
+        conn.execute("SELECT to_regrole(%s) IS NOT NULL", (role,)).fetchone()[0]
+    )
+
+
+def table_owner(conn: Any, table: str) -> str | None:
+    """The owner of ``table`` in the current schema, or ``None`` if absent."""
+    row = conn.execute(
+        "SELECT pg_get_userbyid(c.relowner) FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = current_schema() AND c.relname = %s",
+        (table,),
+    ).fetchone()
+    return None if row is None else str(row[0])
+
+
+def resolve_intended_owner(
+    conn: Any, *, managed: Sequence[str], override: str | None = None
+) -> tuple[str, str]:
+    """``(role, why)`` — the role ``managed`` must end up owned by.
+
+    Precedence: the explicit override, then the majority owner of the OTHER
+    tables in this schema, then ``current_user``.
+
+    THE MANAGED TABLES ARE EXCLUDED FROM THE DERIVATION ON PURPOSE. Reading
+    their own owner would make a wrong owner self-perpetuating — the exact
+    state the fleet was left in on 2026-08-28, where re-running the migration
+    would have cheerfully confirmed ``ywatanabe__cli`` as correct.
+    """
+    declared = override or os.environ.get(OWNER_ENV, "").strip() or None
+    if declared:
+        return declared, "declared by --table-owner/" + OWNER_ENV
+    row = conn.execute(
+        "SELECT pg_get_userbyid(c.relowner) AS owner, COUNT(*) AS n "
+        "FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = current_schema() AND c.relkind = 'r' "
+        "AND c.relname <> ALL(%s) "
+        "GROUP BY 1 ORDER BY n DESC, owner ASC LIMIT 1",
+        (list(managed),),
+    ).fetchone()
+    if row is not None:
+        return str(row[0]), f"owner of {int(row[1])} other table(s) in this schema"
+    return current_role(conn), "nothing else in this schema to be consistent with"
+
+
+def owner_is_reachable(conn: Any, *, owner: str) -> str | None:
+    """``None`` if this session could hand a table to ``owner``, else why not.
+
+    Asked BEFORE any DDL, because the answer decides whether this migration
+    may run at all: a session that cannot put the tables in the right hands
+    must refuse rather than create them in the wrong ones.
+
+    ``ALTER TABLE ... OWNER TO`` needs two things — the ability to ``SET ROLE``
+    to the new owner, and CREATE on the table's schema for that owner. Only
+    the first is checkable without attempting it; the second surfaces as the
+    error :func:`ensure_owner` reports verbatim.
+    """
+    if owner == current_role(conn):
+        return None
+    if not role_exists(conn, owner):
+        return (
+            f"the intended table owner {owner!r} is not a role in this "
+            f"cluster. Name an existing role with --table-owner, or create it."
+        )
+    allowed = conn.execute(
+        "SELECT pg_has_role(current_user, %s, 'USAGE')", (owner,)
+    ).fetchone()[0]
+    if allowed:
+        return None
+    return (
+        f"this session runs as {current_role(conn)!r}, which is not a member "
+        f"of {owner!r}, so the tables it creates would be owned by a role the "
+        f"other agents cannot use — the 2026-08-28 channel outage exactly. "
+        f"Re-run as a member of {owner!r}, or GRANT {owner} TO "
+        f"{current_role(conn)};"
+    )
+
+
+def ensure_owner(
+    conn: Any, *, managed: Sequence[str], owner: str
+) -> tuple[list[str], list[str]]:
+    """``(repaired, problems)`` — hand every drifted table to ``owner``.
+
+    CALL IT TWICE: once BEFORE the DDL and once after.
+
+    Before, because a table already owned by the wrong role makes the DDL
+    itself fail — ``CREATE INDEX IF NOT EXISTS`` checks ownership before it
+    checks existence, which is the statement that took the fleet's channel
+    down. After, because a table this run has just CREATED is owned by
+    ``current_user`` and has to be handed over.
+
+    REOWNING RATHER THAN ``SET ROLE``-ing FIRST is deliberate. Both need the
+    same two privileges, so neither is cheaper; but only this one can repair a
+    database that is ALREADY wrong, which is the state every host that ran the
+    previous version of this script is in. The cost is a sub-millisecond
+    window, inside one connection, in which a freshly created table is owned
+    by the migrating role.
+    """
+    from psycopg import sql
+
+    repaired: list[str] = []
+    problems: list[str] = []
+    for table in managed:
+        actual = table_owner(conn, table)
+        if actual is None or actual == owner:
+            continue
+        try:
+            conn.execute(
+                sql.SQL("ALTER TABLE {} OWNER TO {}").format(
+                    sql.Identifier(table), sql.Identifier(owner)
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+            problems.append(
+                f"{table} is owned by {actual!r} and cannot be handed to "
+                f"{owner!r} from this session ({exc}). Re-run as {actual!r} "
+                f"— the role that created it — or reown it by break-glass: "
+                f"ALTER TABLE {table} OWNER TO {owner};"
+            )
+        else:
+            repaired.append(f"{table}: owner {actual!r} -> {owner!r}")
+    return repaired, problems
+
+
+def _reference_population(
+    conn: Any, *, managed: Sequence[str]
+) -> tuple[str | None, list[str]]:
+    """``(reference_table, roles)`` — who can already use the REST of the store.
+
+    The population is derived from a table this migration did NOT create, so
+    it is an INDEPENDENT question from "did we set the owner we intended".
+    Deriving it from our own tables would make the check below tautological:
+    it would confirm that the roles which can use these tables can use these
+    tables.
+
+    Superusers are excluded. They pass every privilege test by fiat, so
+    including them would let one superuser row hide every real consumer's
+    failure.
+    """
+    rows = conn.execute(
+        "SELECT c.relname, r.rolname FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "CROSS JOIN pg_roles r "
+        "WHERE n.nspname = current_schema() AND c.relkind = 'r' "
+        "AND c.relname <> ALL(%s) "
+        "AND r.rolcanlogin AND NOT r.rolsuper "
+        "AND has_table_privilege(r.oid, c.oid, 'SELECT')",
+        (list(managed),),
+    ).fetchall()
+    by_table: dict[str, list[str]] = {}
+    for table, role in rows:
+        by_table.setdefault(str(table), []).append(str(role))
+    if not by_table:
+        return None, []
+    # The widest population, so the check speaks for as much of the fleet as
+    # the database can attest to. Ties break by name, so two runs agree.
+    reference = max(sorted(by_table), key=lambda t: len(by_table[t]))
+    return reference, sorted(by_table[reference])
+
+
+def owner_inheritance_problems(
+    conn: Any, *, managed: Sequence[str], owner: str
+) -> tuple[list[str], str]:
+    """``(problems, note)`` — can the fleet's roles ACT AS the intended owner?
+
+    ASKED BEFORE ANY DDL, and that placement is the point. The full check
+    below needs the tables to exist, so running only that one would mean
+    CREATING the tables in order to discover that nobody can use them — the
+    refusal would leave behind the exact hazard it refused. This question
+    needs no table: ownership on these two is inherited, not granted, so
+    ``pg_has_role(<consumer>, <intended owner>, 'USAGE')`` already decides it.
+
+    It is also the question ``--table-owner`` most needs answered. An operator
+    naming a role this session happens to be a member of — its own leaf role,
+    say — passes :func:`owner_is_reachable` and still reproduces 2026-08-28
+    exactly.
+    """
+    reference, roles = _reference_population(conn, managed=managed)
+    if reference is None:
+        return [], (
+            "no other table in this schema to derive a consumer population "
+            "from — consumer access UNCHECKED, not verified clean"
+        )
+    short = conn.execute(
+        "SELECT r.rolname FROM pg_roles r WHERE r.rolname = ANY(%s) "
+        "AND NOT pg_has_role(r.oid, %s::regrole, 'USAGE') ORDER BY 1",
+        (roles, owner),
+    ).fetchall()
+    if not short:
+        return [], f"{len(roles)} consumer role(s) inherit {owner!r}"
+    names = ", ".join(str(r[0]) for r in short)
+    return [
+        f"{len(short)} of the {len(roles)} role(s) that can use {reference!r} "
+        f"cannot act as {owner!r}: {names}. Tables owned by it would be "
+        f"unusable to them through init_channel_schema's CREATE INDEX IF NOT "
+        f"EXISTS, which needs OWNER rights and which no GRANT supplies."
+    ], f"consumer population drawn from {reference!r}"
+
+
+def consumer_access_problems(
+    conn: Any, *, managed: Sequence[str]
+) -> tuple[list[str], str]:
+    """``(problems, note)`` — can the roles that use the store use THESE tables?
+
+    ASKED ABOUT OTHER ROLES, NEVER ABOUT ``current_user``. The writer's own
+    access is exactly what the 2026-08-28 verification measured, and it was
+    true while the fleet was down.
+
+    Two questions per role, because the outage needed both to be answered:
+
+    * ``has_table_privilege`` — can it read and write the rows (the DML half);
+    * ``pg_has_role(role, <table owner>, 'USAGE')`` — can it act as the
+      table's owner, which is what ``CREATE INDEX IF NOT EXISTS`` in
+      ``init_channel_schema`` demands of every agent that opens a connection.
+      This is the half that actually broke, and no GRANT can supply it.
+
+    An empty population is REPORTED, not treated as clean. A schema holding
+    nothing but these tables cannot answer the question, and "nobody
+    complained" from a database with nobody in it is not a pass.
+    """
+    reference, roles = _reference_population(conn, managed=managed)
+    if reference is None:
+        return [], (
+            "no other table in this schema to derive a consumer population "
+            "from — consumer access UNCHECKED, not verified clean"
+        )
+    problems: list[str] = []
+    for table in managed:
+        # A table that does not exist cannot be unusable. Skipping rather than
+        # letting ``regclass`` raise keeps this callable on a half-built
+        # schema, which is where a diagnosis is most likely to be wanted.
+        if table_owner(conn, table) is None:
+            continue
+        privs = " AND ".join(
+            f"has_table_privilege(r.oid, %s::regclass, '{p}')" for p in _NEEDED
+        )
+        short = conn.execute(
+            "SELECT r.rolname FROM pg_roles r WHERE r.rolname = ANY(%s) AND NOT ("
+            f"{privs} AND pg_has_role(r.oid, "
+            "(SELECT c.relowner FROM pg_class c WHERE c.oid = %s::regclass), "
+            "'USAGE')) ORDER BY 1",
+            (roles, *([table] * len(_NEEDED)), table),
+        ).fetchall()
+        if short:
+            names = ", ".join(str(r[0]) for r in short)
+            problems.append(
+                f"{table} (owner {table_owner(conn, table)!r}) is NOT usable by "
+                f"{len(short)} of the {len(roles)} role(s) that can use "
+                f"{reference!r}: {names}. Those roles connect to this table "
+                f"through init_channel_schema, whose CREATE INDEX IF NOT "
+                f"EXISTS needs OWNER rights — a GRANT will not fix it."
+            )
+    return problems, (
+        f"consumer access checked for {len(roles)} role(s) drawn from "
+        f"{reference!r}"
+    )

--- a/scripts/migrate_channel_events_to_postgres.py
+++ b/scripts/migrate_channel_events_to_postgres.py
@@ -52,15 +52,50 @@ unreachable through ``id > cursor`` forever.
 
 So the order is: **stop ``sac listen``, run this, start ``sac listen``** —
 and the script REFUSES rather than trusting anyone to remember. See
-:func:`_refusals` for the discriminator (a stored row whose ``ts`` postdates
-the whole import cannot belong to an older residency) and for the exact
-message it prints. The dry run performs the same check, so the refusal
-surfaces before the cutover window rather than inside it.
+:func:`_channel_import_guard.refusals` for the discriminator and for the
+exact message it prints.
+The dry run performs the same check, so the refusal surfaces before the
+cutover window rather than inside it.
+
+RESIDENCIES CAN OVERLAP, AND THE FIRST DISCRIMINATOR COULD NOT SEE IT
+=====================================================================
+That refusal originally keyed on TIME alone: a stored row postdating the whole
+import "cannot belong to an older residency". True only for SEQUENTIAL
+relocation. compute-04 and compute-03 served the SAME targets over INTERLEAVED
+date ranges, so once compute-04's history was imported, compute-03's import
+was refused by 145 + 2 + 5 rows of which ZERO had been written after the
+cutover — and stopping ``sac listen``, which is what the message told the
+operator to do, could not clear it, because the rows were already in the
+table. The predicate was unsatisfiable.
+
+Time cannot answer "imported, or written live?"; the answer has to be
+RECORDED. Each import now claims the id window it landed in, in
+``sac_channel_import`` (see :mod:`_channel_import_provenance`), and the ts test
+is applied only to rows NO IMPORT CLAIMS. A store whose history predates that
+ledger is backfilled by RE-RUNNING this script against the earlier host's
+``state.db`` — a no-op for the rows, which records the window it recognises.
+
+THE TABLES ARE CREATED BY WHOEVER RUNS THIS, AND THAT CAUSED AN OUTAGE
+======================================================================
+Run as ``ywatanabe__cli`` on 2026-08-28, this script left both tables owned by
+that leaf role. Every agent connects as ``ywatanabe__<agent>`` and reaches
+``init_channel_schema``, whose ``CREATE INDEX IF NOT EXISTS`` needs OWNERSHIP
+of the table; the fleet's channel began failing with ``must be owner of table
+sac_channel_events`` three minutes later and stayed down for six. The
+post-migration verification reported success throughout, because it ran as the
+writer.
+
+Ownership is therefore settled BEFORE any rows move (:mod:`_pg_table_owner`):
+the intended owner is DERIVED from the rest of the schema, drifted tables are
+handed back to it, and the outcome is verified by asking the catalog about
+OTHER roles by name. If that cannot be made true, the migration REFUSES —
+failing here is far better than a channel outage three minutes later.
 
 RE-RUNNING IS SAFE
 ==================
 The insert is ``ON CONFLICT (target, id) DO NOTHING`` inside ONE
-transaction, and the offset decision (see :func:`_offset_for`) probes
+transaction, and the offset decision (see
+:func:`_channel_import_guard.offset_for`) probes
 whether the rows already in PostgreSQL are THIS host's before it shifts
 anything. A second run of the same host therefore moves nothing and shifts
 nothing — INCLUDING a host whose ids were shifted by an earlier residency,
@@ -86,13 +121,25 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Sequence
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from _migrate_lib import SqliteSource, add_common_arguments, default_db_path  # noqa: E402
+import _channel_import_guard as guard  # noqa: E402
+import _channel_import_provenance as prov  # noqa: E402
+import _pg_table_owner as owners  # noqa: E402
+from _migrate_lib import (  # noqa: E402
+    SqliteSource,
+    add_common_arguments,
+    default_db_path,
+)
 
 TABLE = "channel_events"
+
+#: Every table this script may CREATE, and therefore every table whose owner
+#: it is responsible for. The ledger is in here too: a future run by a
+#: different role would hit ``must be owner`` on it just as readily.
+MANAGED = ("sac_channel_events", "sac_channel_cursor", prov.LEDGER_TABLE)
 
 SOURCE = SqliteSource(
     table=TABLE,
@@ -111,85 +158,6 @@ SOURCE = SqliteSource(
     # offset probe below deterministic.
     order_by="target ASC, id ASC",
 )
-
-
-def _group_by_target(rows: Sequence[Mapping[str, Any]]) -> dict[str, list[dict]]:
-    grouped: dict[str, list[dict]] = {}
-    for row in rows:
-        grouped.setdefault(str(row["target"]), []).append(dict(row))
-    for entries in grouped.values():
-        entries.sort(key=lambda r: int(r["id"]))
-    return grouped
-
-
-def _offset_for(conn: Any, *, target: str, entries: list[dict]) -> tuple[int, bool]:
-    """``(offset, already_imported)`` for this host's rows on this target.
-
-    THE PROBE IS BY CONTENT, NOT BY POSITION, and that is a correction. The
-    first version asked "is the row sitting at the source's own top id
-    mine?" — a question that is only valid when the previous run applied
-    offset 0. For a RELOCATED target the previous run shifted this host's
-    rows above an earlier residency, so the probe landed on the EARLIER
-    host's row, saw a mismatch, and concluded "not mine". It then returned
-    the (now higher) ``pg_max``, so ``ON CONFLICT (target, id) DO NOTHING``
-    had no id to conflict on and the whole history was inserted AGAIN at
-    fresh ids — one extra copy per invocation, with the verification below
-    unable to see it because it windows on the shifted range it just wrote.
-
-    Asking WHERE THIS ENVELOPE ALREADY SITS answers the same question
-    without assuming the answer. A match yields the offset the previous run
-    used, so the re-import conflicts on every id and moves nothing.
-
-    The candidate is confirmed against the source's FIRST row as well as its
-    last: ``meta_json`` is not unique by construction (the at-least-once
-    retry path can duplicate an envelope), so a lookalike top row alone must
-    not be allowed to imply an offset for the whole run.
-
-    ``already_imported`` distinguishes "we have been here before" from "these
-    ids belong to somebody else", which is what :func:`_refusals` needs to
-    tell a relocation apart from a daemon that has moved on.
-    """
-    pg_max = int(
-        conn.execute(
-            "SELECT COALESCE(MAX(id), 0) FROM sac_channel_events WHERE target = %s",
-            (target,),
-        ).fetchone()[0]
-    )
-    if pg_max == 0:
-        return 0, False
-
-    first, top = entries[0], entries[-1]
-    landed_at = [
-        int(r[0])
-        for r in conn.execute(
-            "SELECT id FROM sac_channel_events "
-            "WHERE target = %s AND meta_json = %s ORDER BY id",
-            (target, top["meta_json"]),
-        ).fetchall()
-    ]
-    for landed in landed_at:
-        offset = landed - int(top["id"])
-        if offset < 0:
-            continue
-        anchor = conn.execute(
-            "SELECT meta_json FROM sac_channel_events WHERE target = %s AND id = %s",
-            (target, int(first["id"]) + offset),
-        ).fetchone()
-        if anchor is not None and anchor[0] == first["meta_json"]:
-            return offset, True
-    return pg_max, False
-
-
-def _newer_rows_than_source(conn: Any, *, target: str, entries: list[dict]) -> int:
-    """How many rows this target already holds that POSTDATE the import."""
-    newest = max(float(row["ts"]) for row in entries)
-    return int(
-        conn.execute(
-            "SELECT COUNT(*) FROM sac_channel_events "
-            "WHERE target = %s AND ts > %s",
-            (target, newest),
-        ).fetchone()[0]
-    )
 
 
 def _insert(conn: Any, *, entries: list[dict], offset: int) -> None:
@@ -262,83 +230,62 @@ def _pg_facts(conn: Any, *, target: str, lo: int, hi: int) -> tuple[int, int, in
     return int(row[0]), int(row[1]), int(row[2]), int(row[3])
 
 
-def _dry_run_refusals(grouped: dict[str, list[dict]]) -> list[str]:
-    """:func:`_refusals` for the dry run — READ-ONLY, and never fatal.
+def _settle_ownership(conn: Any, *, owner_override: str | None) -> list[str]:
+    """Put the tables in hands the FLEET can use, before a single row moves.
 
-    IT MUST NOT RUN THE DDL. ``new_channel_connection`` applies the schema on
-    open, so reaching for it here would make the dry run CREATE the two
-    tables — a write, in the mode whose entire contract is that it writes
-    nothing. It connects raw instead and treats an absent table as "nothing
-    to refuse", which is exactly true: a store with no rows cannot have moved
-    on past this import.
+    The steps are ordered by what each one needs from the one before, and the
+    two GATES come first so a refusal never leaves anything behind:
 
-    A store that cannot be opened is SAID OUT LOUD and skipped rather than
-    reported as "nothing refused" — the reading that would make a clean dry
-    run mean nothing. Same shape as ``_migrate_lib._preview_collisions``.
+    1. derive the intended owner from the rest of the schema;
+    2. refuse if this session could not hand a table to it — creating tables
+       it cannot give away is how the 2026-08-28 outage started;
+    3. refuse if the roles that use the rest of the store could not act as
+       that owner. NO DDL HAS RUN YET at this point, deliberately: the
+       post-condition check needs the tables to exist, so relying on it alone
+       would mean creating the tables in order to discover that nobody can use
+       them, and the refusal would leave the hazard it refused;
+    4. hand back any table that has ALREADY drifted — the state every host
+       left by the previous version of this script is in. Before the DDL,
+       because ``CREATE INDEX IF NOT EXISTS`` on a table you do not own raises
+       rather than being a no-op;
+    5. apply the DDL, hand over what it created, and re-ask (3)'s question of
+       the real tables.
+
+    Returns problems; an empty list means the tables are usable. Reowning IS a
+    write, so it is reported separately from the all-or-nothing row import and
+    the refusal wording says which of the two it is talking about.
     """
-    try:
-        import psycopg
+    from scitex_agent_container._state.state_db_channel_store import (
+        init_channel_schema,
+    )
 
-        from scitex_agent_container._state.state_db_channel_store import (
-            _resolve_target,
-        )
+    owner, why = owners.resolve_intended_owner(
+        conn, managed=MANAGED, override=owner_override
+    )
+    print(f"owner:  {owner} ({why})")
+    unreachable = owners.owner_is_reachable(conn, owner=owner)
+    if unreachable:
+        return [unreachable]
+    trouble, note = owners.owner_inheritance_problems(
+        conn, managed=MANAGED, owner=owner
+    )
+    print(f"  {note}")
+    if trouble:
+        return trouble
 
-        conn = psycopg.connect(str(_resolve_target().dsn), autocommit=True)
-    except Exception as exc:  # noqa: BLE001 - reported, not swallowed
-        print(f"  (ordering check SKIPPED — cannot open the store: {exc!r})")
-        return []
-    try:
-        exists = conn.execute(
-            "SELECT to_regclass('sac_channel_events') IS NOT NULL"
-        ).fetchone()[0]
-        if not exists:
-            return []
-        return _refusals(conn, grouped)
-    finally:
-        conn.close()
+    for phase in ("before the DDL", "after the DDL"):
+        repaired, trouble = owners.ensure_owner(conn, managed=MANAGED, owner=owner)
+        for line in repaired:
+            print(f"  REOWNED {line} ({phase})")
+        if trouble:
+            return trouble
+        if phase == "before the DDL":
+            init_channel_schema(conn)
+            prov.ensure_ledger(conn)
 
-
-def _refusals(conn: Any, grouped: dict[str, list[dict]]) -> list[str]:
-    """Targets this migration MUST NOT touch, with the remedy named.
-
-    THE ORDERING THIS ENFORCES: run the one-shot BEFORE the new code starts
-    serving, per target. ``init_channel_schema`` creates the tables lazily on
-    first connect, so the ordinary deploy sequence — restart ``sac listen``
-    with the new code, then run this — has the daemon minting ids from 1 for
-    any target that receives a message in the gap. Those rows are genuinely
-    new, but to an id-shifting importer they are indistinguishable from an
-    earlier host's residency, and shifting the migrated history ABOVE them
-    produces exactly the failure this design exists to prevent: every
-    SQLite-era ``Last-Event-ID`` resolves to a DIFFERENT event, and the
-    post-cutover rows sit BELOW every live cursor, unreachable through
-    ``id > cursor`` forever.
-
-    So the script REFUSES rather than guessing. The discriminator is time: a
-    row already in the store whose ``ts`` postdates everything we are about
-    to import cannot be part of an OLDER residency, and is therefore the
-    daemon having moved on. A genuine relocation imported
-    oldest-residency-first never trips this, because the earlier host's rows
-    are older than the later host's by construction.
-
-    A target we have ALREADY imported is exempt: its own rows are trivially
-    not newer than themselves, and a re-run must stay a no-op.
-    """
-    refused: list[str] = []
-    for target in sorted(grouped):
-        entries = grouped[target]
-        _, already = _offset_for(conn, target=target, entries=entries)
-        if already:
-            continue
-        newer = _newer_rows_than_source(conn, target=target, entries=entries)
-        if newer:
-            refused.append(
-                f"{target}: the store already holds {newer} row(s) NEWER than "
-                f"anything in this state.db — the daemon has served this "
-                f"target since the cutover. Importing now would shift this "
-                f"history above them and strand both. STOP `sac listen` on "
-                f"every host serving {target!r}, re-run this, then start it."
-            )
-    return refused
+    trouble, note = owners.consumer_access_problems(conn, managed=MANAGED)
+    print(f"  {note}")
+    return trouble
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -351,6 +298,27 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         )
     )
+    parser.add_argument(
+        "--accept-imported-history",
+        action="append",
+        default=[],
+        metavar="TARGET",
+        help=(
+            "assert that the unattributed rows sitting above TARGET are "
+            "another host's imported history whose state.db is gone. NAMED "
+            "PER TARGET and repeatable; there is deliberately no --force, "
+            "because a blanket bypass restores the corruption the guard "
+            "exists to prevent"
+        ),
+    )
+    parser.add_argument(
+        "--table-owner",
+        metavar="ROLE",
+        help=(
+            "the role the created tables must end up owned by. Derived from "
+            "the rest of the schema when omitted; see _pg_table_owner"
+        ),
+    )
     args = parser.parse_args(argv)
 
     db_path = args.db_path or default_db_path()
@@ -358,8 +326,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"mode:   {'COMMIT' if args.commit else 'DRY RUN'}")
 
     rows = SOURCE.read(db_path)
-    grouped = _group_by_target(rows)
+    grouped = guard.group_by_target(rows)
     print(f"{TABLE}: {len(rows)} row(s) across {len(grouped)} target(s)")
+
+    # A waiver aimed at a target this state.db does not contain waives
+    # NOTHING, and would read exactly like one that worked. Refuse the typo.
+    accepted = frozenset(args.accept_imported_history)
+    unknown = sorted(accepted - set(grouped))
+    if unknown:
+        parser.error(
+            f"--accept-imported-history names {unknown} , which "
+            f"{'is' if len(unknown) == 1 else 'are'} not in {db_path}. "
+            f"Targets in this file: {sorted(grouped)}"
+        )
 
     if not args.commit:
         for target in sorted(grouped):
@@ -375,7 +354,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         # cannot be opened is reported as unchecked rather than as clean —
         # the same shape ``_migrate_lib._preview_collisions`` uses, and for
         # the same reason.
-        blocked = _dry_run_refusals(grouped)
+        blocked, waived = guard.dry_run_refusals(grouped, accepted=accepted)
+        for line in waived:
+            print(f"  ACCEPTED {line}")
         if blocked:
             for line in blocked:
                 print(f"  REFUSED {line}")
@@ -394,16 +375,29 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     # Imported here, not at module scope, so a dry run still answers "what
     # would move?" on a host where the write path's dependencies are absent.
+    import psycopg
+
     from scitex_agent_container._state.state_db_channel_store import (
+        _resolve_target,
         channel_store_locator,
-        new_channel_connection,
     )
 
     print(f"target: {channel_store_locator()}")
-    conn = new_channel_connection()
+    # RAW, not ``new_channel_connection`` — that helper applies the DDL on
+    # open, and the DDL is exactly what must wait until ownership is settled.
+    conn = psycopg.connect(str(_resolve_target().dsn), autocommit=True)
     problems: list[str] = []
     try:
-        blocked = _refusals(conn, grouped)
+        unusable = _settle_ownership(conn, owner_override=args.table_owner)
+        if unusable:
+            for line in unusable:
+                print(f"  REFUSED {line}")
+            print("REFUSED — no rows were written. SQLite left untouched.")
+            return 1
+
+        blocked, waived = guard.refusals(conn, grouped, accepted=accepted)
+        for line in waived:
+            print(f"  ACCEPTED {line}")
         if blocked:
             for line in blocked:
                 print(f"  REFUSED {line}")
@@ -412,14 +406,28 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         offsets: dict[str, int] = {}
         # ONE transaction for the whole import: a partial import would make
-        # the re-run probe in ``_offset_for`` ambiguous, and an ambiguous
-        # probe is how a re-run duplicates a target's whole history.
+        # the re-run probe in ``offset_for`` ambiguous, and an ambiguous probe
+        # is how a re-run duplicates a target's whole history. The provenance
+        # row lands inside it too, so a window is never claimed for rows that
+        # did not land.
         with conn.transaction():
             for target in sorted(grouped):
                 entries = grouped[target]
-                offset, _already = _offset_for(conn, target=target, entries=entries)
+                offset, _already = guard.offset_for(
+                    conn, target=target, entries=entries
+                )
                 offsets[target] = offset
                 _insert(conn, entries=entries, offset=offset)
+                count, lo, hi, _ = _sqlite_facts(entries)
+                prov.record_import(
+                    conn,
+                    target=target,
+                    lo_id=lo + offset,
+                    hi_id=hi + offset,
+                    source_path=str(db_path),
+                    row_count=count,
+                    offset_applied=offset,
+                )
                 top = _seed_cursor(conn, target=target)
                 note = "" if offset == 0 else f"  OFFSET +{offset} (relocated target)"
                 print(f"  {target}: {len(entries)} row(s), cursor -> {top}{note}")

--- a/tests/develop/_channel_migration_kit.py
+++ b/tests/develop/_channel_migration_kit.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Shared fixtures for the ``migrate_channel_events_to_postgres.py`` suites.
+
+Extracted when the overlapping-residency and table-ownership cases arrived:
+both new modules build the same real SQLite file and run the same real script,
+and the alternative to one shared module is two more copies of it.
+
+``test_migrate_channel_events.py`` DELIBERATELY STILL CARRIES ITS OWN COPY.
+Those tests are the negative control for this whole change — they pin the
+post-cutover hazard the guard exists for — and a reviewer has to be able to
+see that not one character of them moved. Rewriting them to import from here
+would put that reassurance behind a diff. The duplication is the price, and it
+is the cheaper half of the trade.
+
+NO MOCKS ANYWHERE IN HERE. A real ``sqlite3`` file under ``tmp_path``, the
+real script loaded from ``scripts/``, and a real PostgreSQL reached through
+the ``pg_schema`` fixture. The whole point of these suites is that the moving
+parts are the ones an operator runs.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "migrate_channel_events_to_postgres.py"
+
+JAPANESE = "作業中断はしてほしくない"
+
+
+@contextlib.contextmanager
+def loaded() -> Iterator[Any]:
+    """Import the script by path — it has no importable package home."""
+    if not SCRIPT.exists():
+        pytest.skip(f"{SCRIPT.name} not present in this checkout")
+    spec = importlib.util.spec_from_file_location(SCRIPT.stem, SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    saved = list(sys.path)
+    # The script reaches its sibling ``_migrate_lib`` the way every migration
+    # in that directory does — by being RUN from there, which puts its own
+    # directory on ``sys.path``. Importing it by path skips that, so the test
+    # supplies what the shell would. Restored afterwards; no monkeypatch.
+    sys.path.insert(0, str(SCRIPT.parent))
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.path[:] = saved
+
+
+def legacy_db(tmp_path: Path, rows: list[tuple]) -> Path:
+    """A SQLite file with the pre-migration ``channel_events`` schema."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE channel_events (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            target        TEXT NOT NULL,
+            source        TEXT,
+            kind          TEXT NOT NULL DEFAULT 'message',
+            content       TEXT,
+            meta_json     TEXT NOT NULL,
+            ts            REAL NOT NULL,
+            delivered_at  REAL
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO channel_events (target, source, kind, content, meta_json, "
+        "ts, delivered_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def event_row(target: str, msg_id: str, ts: float, *, delivered: float | None = None):
+    """One ``channel_events`` row, with a distinct envelope per ``msg_id``.
+
+    The envelope has to differ per row: ``_offset_for`` probes by CONTENT, so
+    two rows sharing a ``meta_json`` would make the re-run probe ambiguous —
+    which is a real property of the production data, not a fixture detail.
+    """
+    return (
+        target,
+        "alice",
+        "message",
+        msg_id,
+        json.dumps({"msg_id": msg_id}, ensure_ascii=False),
+        ts,
+        delivered,
+    )
+
+
+def seed_rows() -> list[tuple]:
+    """Two rows for ``lead`` (one delivered) and one for ``ci`` (never)."""
+    return [
+        (
+            "lead",
+            "alice",
+            "message",
+            "hi",
+            json.dumps({"msg_id": "a", "content": "hi"}, ensure_ascii=False),
+            1.0,
+            2.0,
+        ),
+        (
+            "lead",
+            "alice",
+            "message",
+            JAPANESE,
+            json.dumps({"msg_id": "b", "content": JAPANESE}, ensure_ascii=False),
+            2.0,
+            None,
+        ),
+        (
+            "ci",
+            None,
+            "message",
+            "x",
+            json.dumps({"msg_id": "c"}, ensure_ascii=False),
+            3.0,
+            None,
+        ),
+    ]
+
+
+def run(db: Path, *extra: str) -> int:
+    with loaded() as module:
+        return int(module.main(["--db-path", str(db), *extra]))
+
+
+def query(sql: str, params: tuple = ()) -> list[tuple]:
+    from scitex_agent_container._state.state_db_channel_store import (
+        new_channel_connection,
+    )
+
+    conn = new_channel_connection()
+    try:
+        return list(conn.execute(sql, params).fetchall())
+    finally:
+        conn.close()
+
+
+def execute(sql: str, params: tuple = ()) -> None:
+    """Run a statement that returns no rows. Separate from :func:`query`
+    because psycopg raises rather than handing back an empty list."""
+    from scitex_agent_container._state.state_db_channel_store import (
+        new_channel_connection,
+    )
+
+    conn = new_channel_connection()
+    try:
+        conn.execute(sql, params)
+    finally:
+        conn.close()
+
+
+@contextlib.contextmanager
+def raw_conn() -> Iterator[Any]:
+    """A connection to the store with NO DDL applied.
+
+    ``new_channel_connection`` creates the tables on open, which is right for
+    every other caller and wrong for anything asserting about what exists or
+    who owns it — it would create, and own, the very thing under test.
+    """
+    import psycopg
+
+    from scitex_agent_container._state.state_db_channel_store import (
+        _resolve_target,
+    )
+
+    with psycopg.connect(str(_resolve_target().dsn), autocommit=True) as conn:
+        yield conn
+
+
+def raw_query(sql: str, params: tuple = ()) -> list[tuple]:
+    """Ask the database WITHOUT applying the DDL first."""
+    with raw_conn() as conn:
+        return list(conn.execute(sql, params).fetchall())
+
+
+def script_module(name: str) -> Any:
+    """Import one of the migration's sibling helpers from ``scripts/``.
+
+    They have no package home — the migrations reach each other by being RUN
+    from that directory — so a test that wants to exercise one directly has to
+    supply the ``sys.path`` entry the shell would.
+    """
+    import importlib
+
+    saved = list(sys.path)
+    sys.path.insert(0, str(SCRIPT.parent))
+    try:
+        return importlib.import_module(name)
+    finally:
+        sys.path[:] = saved

--- a/tests/develop/test_migrate_channel_events_overlap.py
+++ b/tests/develop/test_migrate_channel_events_overlap.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Two hosts served the SAME target over OVERLAPPING periods. Import both.
+
+THE FALSE REFUSAL THIS PINS (measured on the fleet, 2026-08-28)
+===============================================================
+The ordering guard refuses a target when the store already holds a row NEWER
+than everything in the source ``state.db``, on the reasoning that such a row
+cannot belong to an OLDER residency and must therefore be the live daemon
+having moved on. That reasoning holds only for SEQUENTIAL relocation.
+
+compute-04 and compute-03 both served ``scitex-agent-container``,
+``scitex-cards`` and ``figrecipe``, over INTERLEAVED date ranges. Once
+compute-04's history was imported, compute-03's import was refused by rows
+that were not daemon traffic at all — 145, 2 and 5 of them, with ZERO written
+after the cutover. The remedy the message printed ("stop ``sac listen`` and
+re-run") could not work, because stopping a daemon does not remove rows that
+are already in the table. The predicate was unsatisfiable.
+
+WHAT MUST STILL FAIL. The tests at the bottom are the NEGATIVE CONTROLS, and
+they matter more than the ones above them: a "fix" that simply stopped
+counting newer rows would make the whole module green while restoring the
+corruption the guard exists to prevent. A row the DAEMON minted in the deploy
+gap has no import provenance, and must still refuse.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._state.state_db_channel_store import (
+    reset_channel_connection,
+)
+from tests.develop._channel_migration_kit import (
+    event_row,
+    execute,
+    legacy_db,
+    query,
+    run,
+)
+
+
+@pytest.fixture(autouse=True)
+def _drop_cached_connection() -> Iterator[None]:
+    """Close the process-wide handle around every test in this module."""
+    reset_channel_connection()
+    yield
+    reset_channel_connection()
+
+
+# ---------------------------------------------------------------------------
+# The two residencies. Their timestamps INTERLEAVE — that is the whole point.
+#
+#   earlier host   1.0        5.0        9.0     (ids 1, 2, 3)
+#   later host           3.0        7.0          (ids 1, 2)
+#
+# Neither range contains the other, and the earlier host's NEWEST row (9.0)
+# postdates the later host's newest (7.0). Under the ts-only discriminator
+# that makes the later host's import permanently refusable.
+# ---------------------------------------------------------------------------
+
+
+def _earlier_host(tmp_path: Path) -> Path:
+    return legacy_db(
+        tmp_path / "compute-04",
+        [
+            event_row("lead", "a-early", 1.0, delivered=1.5),
+            event_row("lead", "a-mid", 5.0),
+            event_row("lead", "a-late", 9.0),
+        ],
+    )
+
+
+def _later_host(tmp_path: Path) -> Path:
+    return legacy_db(
+        tmp_path / "compute-03",
+        [
+            event_row("lead", "b-first", 3.0),
+            event_row("lead", "b-second", 7.0),
+        ],
+    )
+
+
+def test_overlapping_residency_imports_instead_of_refusing(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """THE BUG. A second host whose history INTERLEAVES the first must import.
+
+    Nothing here is post-cutover traffic: every row in the store came from the
+    earlier host's ``state.db``. Refusing this is refusing a migration that
+    can never be performed.
+    """
+    # Arrange
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    # Act
+    rc = run(later, "--commit")
+    # Assert
+    assert rc == 0
+
+
+def test_overlapping_residency_preserves_the_first_hosts_ids(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The earlier host keeps 1..3; the later host is OFFSET above it.
+
+    Id preservation is the property a live ``Last-Event-ID`` rests on, and the
+    fix must not buy the import at its expense.
+    """
+    # Arrange
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    # Act
+    run(later, "--commit")
+    # Assert — 1..3 are the earlier host's, in its own order; 4..5 the later's.
+    assert query(
+        "SELECT id, content FROM sac_channel_events WHERE target = %s ORDER BY id",
+        ("lead",),
+    ) == [
+        (1, "a-early"),
+        (2, "a-mid"),
+        (3, "a-late"),
+        (4, "b-first"),
+        (5, "b-second"),
+    ]
+
+
+def test_overlapping_residency_is_idempotent(tmp_path: Path, pg_schema: str) -> None:
+    """Re-running the later host after the fix must still move nothing."""
+    # Arrange
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    run(later, "--commit")
+    # Act
+    run(later, "--commit")
+    # Assert
+    assert query(
+        "SELECT COUNT(*) FROM sac_channel_events WHERE target = %s", ("lead",)
+    ) == [(5,)]
+
+
+def test_the_dry_run_stops_refusing_the_overlap_too(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The preview and the commit must agree — a dry run that refuses a run
+    which would succeed is as misleading as the reverse."""
+    # Arrange
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    # Act
+    rc = run(later)
+    # Assert
+    assert rc == 0
+
+
+def test_the_import_window_is_recorded_for_each_host(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """PROVENANCE IS THE MECHANISM, so it is asserted rather than assumed.
+
+    Without a recorded window the guard has nothing to distinguish an imported
+    row from a daemon row, and this whole module would be green only because
+    the guard had been weakened.
+    """
+    # Arrange
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    # Act
+    run(later, "--commit")
+    # Assert
+    assert query(
+        "SELECT lo_id, hi_id, row_count, offset_applied FROM sac_channel_import "
+        "WHERE target = %s ORDER BY lo_id",
+        ("lead",),
+    ) == [(1, 3, 3, 0), (4, 5, 2, 3)]
+
+
+def _unattributed_earlier_host(tmp_path: Path) -> tuple[Path, Path]:
+    """The state TONIGHT'S STORE is in: history imported, provenance absent.
+
+    The earlier host lands and its ledger row is then removed, which is
+    exactly what a store imported by the pre-provenance script looks like —
+    7,980 rows nothing can account for.
+    """
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    execute("DELETE FROM sac_channel_import WHERE target = %s", ("lead",))
+    return earlier, later
+
+
+def test_history_with_no_recorded_provenance_still_refuses(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """Un-provenanced rows are treated as the daemon's, not waved through.
+
+    This is the conservative half of the fix and it must stay conservative:
+    the script cannot tell, so it does not guess.
+    """
+    # Arrange
+    _earlier, later = _unattributed_earlier_host(tmp_path)
+    # Act
+    rc = run(later, "--commit")
+    # Assert
+    assert rc == 1
+
+
+def test_re_running_the_earlier_host_backfills_its_provenance(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """THE REMEDY FOR TONIGHT'S STORE — the same command, not a new one.
+
+    Re-running the EARLIER host records the window it already occupies:
+    ``_offset_for`` recognises its own rows by content, so the run moves
+    nothing and only stamps what it recognised. The later host then imports.
+    """
+    # Arrange
+    earlier, later = _unattributed_earlier_host(tmp_path)
+    # Act — the backfill.
+    run(earlier, "--commit")
+    # Assert
+    assert run(later, "--commit") == 0
+
+
+def test_the_operator_can_accept_one_named_target(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The escape hatch when the earlier host's ``state.db`` is GONE.
+
+    Per target, named in full. There is deliberately no ``--force``: a blanket
+    bypass restores exactly the corruption the guard exists to prevent, and
+    naming the target is what keeps the operator's assertion specific enough
+    to be wrong out loud.
+    """
+    # Arrange
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    execute("DELETE FROM sac_channel_import WHERE target = %s", ("lead",))
+    # Act
+    rc = run(later, "--commit", "--accept-imported-history", "lead")
+    # Assert
+    assert rc == 0
+
+
+def test_accepting_a_target_that_is_not_in_the_source_is_an_error(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """A typo'd target must not silently waive nothing and look like it worked."""
+    # Arrange
+    earlier = _earlier_host(tmp_path)
+    # Act
+    refused = pytest.raises(SystemExit)
+    # Assert
+    with refused:
+        run(earlier, "--commit", "--accept-imported-history", "leadd")
+
+
+# ---------------------------------------------------------------------------
+# THE OTHER DIRECTION — a SEQUENTIAL relocation must still take its offset.
+#
+# Measured on the fleet 2026-08-28: nas-03 holds ``lead`` at ids 1..7 and is
+# genuinely the OLDER residency; compute-03 holds ``lead`` at ids 987..989.
+# That one SHOULD be shifted above nas-03's rows — it is the design working,
+# not a false refusal — and it must not be "fixed" along with the overlap.
+# Provenance changes WHEN the guard fires, never WHERE the rows land.
+# ---------------------------------------------------------------------------
+
+
+def _sequential_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """nas-03's residency, then compute-03's — disjoint and in order.
+
+    The later host's ids start high (987) because its own SQLite counter had
+    been running for months. They carry no meaning in the destination, and
+    relocating them is exactly what the offset is for.
+    """
+    import sqlite3
+
+    earlier = legacy_db(
+        tmp_path / "nas-03",
+        [event_row("lead", f"nas-{n}", float(n)) for n in range(1, 8)],
+    )
+    later = legacy_db(
+        tmp_path / "compute-03",
+        [event_row("lead", f"c03-{n}", 100.0 + n) for n in range(1, 4)],
+    )
+    # AUTOINCREMENT hands out 1..3; the measured store has 987..989, and the
+    # gap between the two hosts' id ranges is half the point of the fixture.
+    conn = sqlite3.connect(later)
+    conn.execute("UPDATE channel_events SET id = id + 986")
+    conn.commit()
+    conn.close()
+    return earlier, later
+
+
+def test_a_sequential_relocation_is_still_imported(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The genuine relocation is NOT refused — that half was never broken."""
+    # Arrange
+    earlier, later = _sequential_pair(tmp_path)
+    run(earlier, "--commit")
+    # Act
+    rc = run(later, "--commit")
+    # Assert
+    assert rc == 0
+
+
+def test_a_sequential_relocation_is_still_offset_above_the_earlier_host(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """AND IT STILL MOVES. Provenance must not switch the offset off.
+
+    A change that let the later host keep its own ids would collide with
+    nothing here — 987 is free — and would leave the cursor at 989 with seven
+    rows stranded below it. The rows belong directly above the earlier
+    residency, which is where they have always gone.
+    """
+    # Arrange
+    earlier, later = _sequential_pair(tmp_path)
+    run(earlier, "--commit")
+    # Act
+    run(later, "--commit")
+    # Assert — nas-03 keeps 1..7; compute-03's 987..989 land at 994..996.
+    assert query(
+        "SELECT id FROM sac_channel_events WHERE target = %s ORDER BY id",
+        ("lead",),
+    ) == [(1,), (2,), (3,), (4,), (5,), (6,), (7,), (994,), (995,), (996,)]
+
+
+def test_the_sequential_offset_is_recorded_as_provenance_too(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """So a LATER host is not refused by rows this run legitimately placed.
+
+    Without this the fix would only push the false refusal one host along.
+    """
+    # Arrange
+    earlier, later = _sequential_pair(tmp_path)
+    run(earlier, "--commit")
+    # Act
+    run(later, "--commit")
+    # Assert
+    assert query(
+        "SELECT lo_id, hi_id, offset_applied FROM sac_channel_import "
+        "WHERE target = %s ORDER BY lo_id",
+        ("lead",),
+    ) == [(1, 7, 0), (994, 996, 7)]
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE CONTROLS — the hazard the guard exists for must STILL be caught,
+# and now it has to be caught in the presence of a populated ledger.
+# ---------------------------------------------------------------------------
+
+
+def _daemon_has_served(target: str, *, ts: float) -> None:
+    """The REAL writer mints an id, exactly as ``sac listen`` would."""
+    from scitex_agent_container._state.state_db_channel import persist_event
+
+    persist_event(target=target, event={"msg_id": "post-cutover", "ts": ts})
+
+
+def test_a_daemon_row_above_a_recorded_import_still_refuses(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """THE CONTROL THAT MATTERS MOST.
+
+    The store holds a recorded import AND a row the daemon minted after it.
+    Provenance covers the first and not the second, so the refusal must fire
+    on the second alone. A fix that merely subtracted "rows that are newer"
+    would pass every test above and fail this one.
+    """
+    # Arrange
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    _daemon_has_served("lead", ts=99.0)
+    # Act
+    rc = run(later, "--commit")
+    # Assert
+    assert rc == 1
+
+
+def test_that_refusal_writes_nothing(tmp_path: Path, pg_schema: str) -> None:
+    """All-or-nothing survives the change: no partial import, no shifted ids."""
+    # Arrange
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    _daemon_has_served("lead", ts=99.0)
+    # Act
+    run(later, "--commit")
+    # Assert — the earlier host's 3 rows plus the daemon's 1, and nothing else.
+    assert query(
+        "SELECT COUNT(*) FROM sac_channel_events WHERE target = %s", ("lead",)
+    ) == [(4,)]
+
+
+def test_accepting_a_different_target_does_not_waive_this_one(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The override is PER TARGET, and the test proves it does not leak.
+
+    ``ci`` is named; ``lead`` is the one with the daemon row. If the flag were
+    a disguised ``--force`` this would return 0.
+    """
+    # Arrange
+    earlier = _earlier_host(tmp_path)
+    later = legacy_db(
+        tmp_path / "compute-03",
+        [event_row("lead", "b-first", 3.0), event_row("ci", "c-first", 3.5)],
+    )
+    run(earlier, "--commit")
+    _daemon_has_served("lead", ts=99.0)
+    # Act
+    rc = run(later, "--commit", "--accept-imported-history", "ci")
+    # Assert
+    assert rc == 1

--- a/tests/develop/test_migrate_channel_events_ownership.py
+++ b/tests/develop/test_migrate_channel_events_ownership.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""The migration CREATES its tables, so it decides who can use them.
+
+THE OUTAGE THIS PINS (measured on the fleet, 2026-08-28)
+========================================================
+The one-shot was run as ``ywatanabe__cli``. ``sac_channel_events`` and
+``sac_channel_cursor`` came out owned by that leaf role with a NULL ``relacl``
+— no grants to anybody. Every agent connects as ``ywatanabe__<agent>`` and
+opens the channel through ``init_channel_schema``, whose
+``CREATE INDEX IF NOT EXISTS`` requires OWNERSHIP of the table rather than
+privileges on it. The fleet's message channel began failing with
+``InsufficientPrivilege: must be owner of table sac_channel_events`` three
+minutes later and stayed broken for six, until the tables were reowned to
+``scitex_store_owner`` by break-glass.
+
+The post-migration verification PASSED for the whole outage, because it ran as
+the MIGRATING role. That is the specific trap these tests are built around:
+every assertion below is about a role that is NOT ``current_user``.
+
+WHAT MAKES THESE TESTS REAL. They need two roles in the cluster — one that
+owns the schema's other tables, and one that inherits it — and they DERIVE
+that pair from the catalog rather than naming ``scitex_store_owner``, which is
+a fact about this fleet and not about the code. Where no such pair exists the
+module SKIPS with the reason spelled out, because a skip that looks like a
+pass is how a suite comes to report green while executing nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._state.state_db_channel_store import (
+    reset_channel_connection,
+)
+from tests.develop._channel_migration_kit import (
+    legacy_db,
+    query,
+    raw_conn,
+    raw_query,
+    run,
+    script_module,
+)
+from tests.develop._channel_migration_kit import seed_rows as _seed_rows
+
+MANAGED = ("sac_channel_events", "sac_channel_cursor", "sac_channel_import")
+
+#: A name no cluster has. Used to pin the refusal, and portable because its
+#: absence is the property under test rather than an assumption about roles.
+ABSENT_ROLE = "sac_no_such_owner_role_20260828"
+
+
+@pytest.fixture(autouse=True)
+def _drop_cached_connection() -> Iterator[None]:
+    reset_channel_connection()
+    yield
+    reset_channel_connection()
+
+
+@pytest.fixture()
+def store_owner(pg_schema: str) -> str:
+    """A role this session can hand a table to, that OTHER logins inherit.
+
+    Derived, never named: the pair is whatever the cluster actually has. On
+    the fleet this resolves into the ``ywatanabe__<agent>`` -> ``ywatanabe``
+    -> ``scitex_store_owner`` chain measured on the primary; on a throwaway
+    database it resolves to whatever equivalent that database was given.
+
+    """
+    with raw_conn() as conn:
+        row = conn.execute(
+            "SELECT o.rolname, COUNT(*) FROM pg_roles o CROSS JOIN pg_roles r "
+            "WHERE pg_has_role(current_user, o.oid, 'USAGE') "
+            "AND o.rolname <> current_user "
+            "AND r.rolcanlogin AND NOT r.rolsuper AND r.rolname <> current_user "
+            "AND pg_has_role(r.oid, o.oid, 'USAGE') "
+            "GROUP BY 1 ORDER BY 2 DESC, 1 LIMIT 1"
+        ).fetchone()
+        if row is None:
+            pytest.skip(
+                "this cluster has no role this session can hand a table to "
+                "that another login role inherits, so the 2026-08-28 "
+                "ownership shape cannot be reproduced here"
+            )
+        owner = str(row[0])
+    return owner
+
+
+@pytest.fixture()
+def store_reference(store_owner: str) -> str:
+    """A table in the schema owned by ``store_owner`` — the rest of the store.
+
+    This is what the migration derives its intended owner from, and what the
+    consumer check derives its population from. Both questions are then about
+    a table the migration did NOT create, which is the only way either answer
+    can be independent of the thing being tested.
+    """
+    _add_store_reference(store_owner)
+    return "store_reference"
+
+
+def _add_store_reference(owner: str) -> None:
+    """Put a table owned by ``owner`` into the schema under test.
+
+    USAGE as well as CREATE: without USAGE the role cannot even see the
+    schema, and ``CREATE TABLE`` fails with "no schema has been selected to
+    create in" rather than with a permission error — a message that names the
+    wrong problem. The fleet's ``public`` schema grants both already.
+    """
+    from psycopg import sql
+
+    with raw_conn() as conn:
+        schema = str(conn.execute("SELECT current_schema()").fetchone()[0])
+        conn.execute(
+            sql.SQL("GRANT USAGE, CREATE ON SCHEMA {} TO {}").format(
+                sql.Identifier(schema), sql.Identifier(owner)
+            )
+        )
+        conn.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(owner)))
+        conn.execute(
+            sql.SQL("CREATE TABLE {}.store_reference (id BIGINT PRIMARY KEY)").format(
+                sql.Identifier(schema)
+            )
+        )
+        conn.execute("RESET ROLE")
+
+
+def _owner_of(table: str) -> str | None:
+    rows = raw_query(
+        "SELECT pg_get_userbyid(c.relowner) FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = current_schema() AND c.relname = %s",
+        (table,),
+    )
+    return None if not rows else str(rows[0][0])
+
+
+def test_the_tables_land_owned_by_the_role_the_rest_of_the_schema_uses(
+    tmp_path: Path, pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """The intended owner is DERIVED from the schema, and applied."""
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    # Act
+    run(db, "--commit")
+    # Assert
+    assert _owner_of("sac_channel_events") == store_owner
+
+
+def test_the_cursor_table_lands_owned_by_it_too(
+    tmp_path: Path, pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """``sac_channel_cursor`` is on the same publish path and breaks the same way."""
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    # Act
+    run(db, "--commit")
+    # Assert
+    assert _owner_of("sac_channel_cursor") == store_owner
+
+
+def test_the_provenance_ledger_lands_owned_by_it_too(
+    tmp_path: Path, pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """A table this script creates is a table a later run must be able to use."""
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    # Act
+    run(db, "--commit")
+    # Assert
+    assert _owner_of("sac_channel_import") == store_owner
+
+
+def test_a_consumer_role_can_act_as_the_owner_afterwards(
+    tmp_path: Path, pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """THE QUESTION THAT WAS NEVER ASKED ON 2026-08-28.
+
+    ``pg_has_role(<consumer>, <table owner>, 'USAGE')`` IS PostgreSQL's own
+    ownership test, and it is what ``CREATE INDEX IF NOT EXISTS`` consults
+    every time an agent opens the channel. Asked about a role that is not
+    ``current_user``, so the writer's own access cannot answer it.
+    """
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    run(db, "--commit")
+    consumers = [
+        str(r[0])
+        for r in raw_query(
+            "SELECT rolname FROM pg_roles WHERE rolcanlogin AND NOT rolsuper "
+            "AND rolname <> current_user AND pg_has_role(rolname, %s, 'USAGE') "
+            "ORDER BY 1",
+            (store_owner,),
+        )
+    ]
+    # Act
+    verdicts = raw_query(
+        "SELECT bool_and(pg_has_role(r.rolname, "
+        "(SELECT c.relowner FROM pg_class c WHERE c.oid = "
+        "'sac_channel_events'::regclass), 'USAGE')) FROM pg_roles r "
+        "WHERE r.rolname = ANY(%s)",
+        (consumers,),
+    )
+    # Assert
+    assert verdicts == [(True,)]
+
+
+def test_a_table_created_by_the_wrong_role_is_handed_back(
+    tmp_path: Path, pg_schema: str, store_owner: str
+) -> None:
+    """THE REPAIR PATH — the state every host left by the old script is in.
+
+    The first run has no reference table to learn from, so it creates the
+    tables under the migrating role: precisely what happened as
+    ``ywatanabe__cli``. The reference table then appears, and the second run
+    must hand them over rather than leaving them stranded.
+    """
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    run(db, "--commit")
+    _add_store_reference(store_owner)
+    # Act
+    run(db, "--commit")
+    # Assert
+    assert _owner_of("sac_channel_events") == store_owner
+
+
+def test_the_repair_does_not_disturb_the_rows(
+    tmp_path: Path, pg_schema: str, store_owner: str
+) -> None:
+    """Reowning is a catalog change; the ids a consumer holds must not move."""
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    run(db, "--commit")
+    _add_store_reference(store_owner)
+    # Act
+    run(db, "--commit")
+    # Assert
+    assert query(
+        "SELECT id FROM sac_channel_events WHERE target = %s ORDER BY id",
+        ("lead",),
+    ) == [(1,), (2,)]
+
+
+def test_an_unreachable_owner_refuses_before_creating_anything(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """Failing HERE beats a channel outage three minutes later.
+
+    A named owner that does not exist is the portable form of "this session
+    cannot leave the tables usable": the refusal has to fire before the DDL,
+    not after the rows are in.
+    """
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    # Act
+    rc = run(db, "--commit", "--table-owner", ABSENT_ROLE)
+    # Assert
+    assert rc == 1
+
+
+def test_naming_an_owner_the_fleet_cannot_inherit_refuses(
+    tmp_path: Path, pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """2026-08-28's shape, requested EXPLICITLY, must still be refused.
+
+    ``--table-owner`` naming this session's own role passes the "can I hand a
+    table to it" test trivially — it is already ours — and reproduces the
+    outage exactly. Only a question about OTHER roles catches it.
+    """
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    me = str(raw_query("SELECT current_user")[0][0])
+    # Act
+    rc = run(db, "--commit", "--table-owner", me)
+    # Assert
+    assert rc == 1
+
+
+def test_that_refusal_creates_no_tables_at_all(
+    tmp_path: Path, pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """THE GATE IS BEFORE THE DDL, and this is what proves it.
+
+    A check that ran only after the tables existed would refuse while leaving
+    behind precisely the unusable tables it was refusing — a guard that
+    creates the hazard it reports.
+    """
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    me = str(raw_query("SELECT current_user")[0][0])
+    # Act
+    run(db, "--commit", "--table-owner", me)
+    # Assert
+    assert raw_query("SELECT to_regclass('sac_channel_events') IS NULL") == [(True,)]
+
+
+def test_that_refusal_leaves_the_store_untouched(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """All-or-nothing covers the ownership refusal too — no half-made tables."""
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    # Act
+    run(db, "--commit", "--table-owner", ABSENT_ROLE)
+    # Assert
+    assert raw_query("SELECT to_regclass('sac_channel_events') IS NULL") == [(True,)]
+
+
+def test_the_consumer_check_catches_a_leaf_owned_table(
+    pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """THE INSTRUMENT ITSELF, pointed at 2026-08-28's exact shape.
+
+    A managed table owned by the migrating LEAF role, in a schema whose other
+    table belongs to the store owner. The writer can use it — that is what the
+    night's verification measured — and the roles derived from the reference
+    table cannot. The check must say so.
+    """
+    # Arrange
+    owners = script_module("_pg_table_owner")
+    with raw_conn() as conn:
+        conn.execute("CREATE TABLE sac_channel_events (id BIGINT PRIMARY KEY)")
+        # Act
+        problems, _note = owners.consumer_access_problems(conn, managed=MANAGED)
+    # Assert
+    assert problems
+
+
+def test_the_consumer_check_passes_once_the_table_is_reowned(
+    pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """NEGATIVE CONTROL — the same instrument must go quiet when it should.
+
+    A check that complained either way would pass the test above while telling
+    an operator nothing.
+    """
+    # Arrange
+    from psycopg import sql
+
+    owners = script_module("_pg_table_owner")
+    with raw_conn() as conn:
+        conn.execute("CREATE TABLE sac_channel_events (id BIGINT PRIMARY KEY)")
+        conn.execute(
+            sql.SQL("ALTER TABLE sac_channel_events OWNER TO {}").format(
+                sql.Identifier(store_owner)
+            )
+        )
+        # Act
+        problems, _note = owners.consumer_access_problems(conn, managed=MANAGED)
+    # Assert
+    assert problems == []
+
+
+def test_an_empty_schema_reports_the_check_as_unrun(pg_schema: str) -> None:
+    """A population of nobody is not a pass, and must not read like one.
+
+    ``pg_schema`` gives a schema holding only what the migration creates, so
+    there is no reference table and therefore no consumer population. Saying
+    "unchecked" is the only honest answer available.
+    """
+    # Arrange
+    owners = script_module("_pg_table_owner")
+    # Act
+    with raw_conn() as conn:
+        _problems, note = owners.consumer_access_problems(conn, managed=MANAGED)
+    # Assert
+    assert "UNCHECKED" in note


### PR DESCRIPTION
Unblocks the last host of the `channel_events` migration. compute-04 (7,980 rows), compute-01 (0) and nas-03 (7) are done; compute-03's 1,055 rows were refused by a guard that could not be satisfied.

## 1. The guard asked a question no answer could satisfy

`_refusals` treated *"a stored row newer than everything in this state.db"* as proof the daemon had moved on. That inference holds only for **sequential** relocation — host A serves a target until date X, then host B takes over. This fleet's hosts served the **same targets over overlapping periods** (`scitex-agent-container`: 08-09..08-28 on compute-04, 08-18..08-22 on compute-03), so once compute-04's history was imported, compute-03 was refused by **145 + 2 + 5 rows of which zero were written after the cutover**. The remedy the message printed — stop `sac listen` and re-run — cannot work: stopping a daemon does not remove rows already in the table.

Time cannot answer *"imported, or written live?"*. The answer has to be **recorded**.

Each import now claims the id window it landed in, in a new `sac_channel_import` ledger, and the ts test is applied **only to rows no import claims**. A daemon row minted in the deploy gap belongs to no window, is newer than the source, and is still refused.

**Why a ledger row and not a column on `sac_channel_events`:**

1. `meta_json` is not available as a home — its bytes must stay identical or a replayed SSE frame stops matching the live one.
2. A new column **cannot be backfilled from the data**. The 7,980 existing rows carry no provenance, so the column would start `NULL`, and `NULL` would have to mean "the daemon wrote it" — wrong for every one of them.
3. The table is written once per message and read on every SSE connect. A migration-only fact does not belong in it.

**Backfilling an import that already happened is the same command:** re-run with `--commit --db-path` pointing at the earlier host's `state.db`. `offset_for` recognises its own rows by content, so the run moves nothing and only records the window it recognised.

**There is no `--force`.** `--accept-imported-history` takes a `TARGET`, is repeatable, and `parser.error`s on a name the source does not contain.

**The other direction is preserved.** A genuine sequential relocation still takes its offset: nas-03's `lead` ids 1..7 stay put and compute-03's 987..989 land at 994..996. Provenance changes *when* the guard fires, never *where* rows land. Three tests pin that so it cannot be "fixed" along with the false refusal.

## 2. The tables were owned by whoever ran the script

Run as `ywatanabe__cli` on 2026-08-28, `sac_channel_events` / `sac_channel_cursor` came out owned by that leaf role with a NULL `relacl`. Every agent connects as `ywatanabe__<agent>` and reaches `init_channel_schema`, whose `CREATE INDEX IF NOT EXISTS` needs **ownership** — not privileges, and no `GRANT` supplies it. The channel failed with `must be owner of table sac_channel_events` three minutes later and stayed down ~6 minutes until a break-glass reown. **The post-migration check passed throughout, because it ran as the writer.**

Measured on the primary: every table in `public` is owned by `scitex_store_owner`, `relacl` NULL, and `ywatanabe__<agent>` → `ywatanabe` → `scitex_store_owner`. On a leaf-owned table, every other agent role answers `has_table_privilege` **False** and `pg_has_role(role, owner, 'USAGE')` **False**; on the reowned table both are **True**. Those two catalog questions are the instrument.

Ownership is now settled **before a single row moves**:

1. derive the intended owner from the rest of the schema — no role name is hardcoded; `--table-owner` overrides;
2. refuse if this session could not hand a table to it;
3. refuse if the roles that use the rest of the store could not **act as** that owner — **no DDL has run yet**, so a refusal never leaves behind the unusable tables it was refusing;
4. hand back any table that already drifted (before the DDL — `CREATE INDEX IF NOT EXISTS` on a table you do not own raises rather than being a no-op);
5. apply the DDL, hand over what it created, re-ask (3) of the real tables.

Every assertion is about a role that is **not** `current_user`.

## Evidence

**Red first.** Against the unmodified script, the overlap module was **12 collected / 12 executed / 9 failed / 3 passed** — and the 3 passed for the *wrong* reason (the old guard refused everything, so the negative controls could not fail).

**Green.** 42 collected, **42 executed, 0 skipped**, against a real throwaway PostgreSQL 18 given the fleet's role shape (`scitex_store_owner` ← `ywatanabe` ← `ywatanabe__*`, migrating identity a non-superuser leaf). Wider slice `tests/develop/ tests/scitex_agent_container/_state/`: 1583 passed, 4 skipped (all pre-existing — 3 missing `psutil`, 1 no `_skills/`).

**End to end**, run as `ywatanabe__cli` against the operator's exact overlapping-residency shape:

```
RUN: compute-04 (earlier)
owner:  scitex_store_owner (owner of 1 other table(s) in this schema)
  4 consumer role(s) inherit 'scitex_store_owner'
  REOWNED sac_channel_events: owner 'ywatanabe__cli' -> 'scitex_store_owner' (after the DDL)
  REOWNED sac_channel_cursor: owner 'ywatanabe__cli' -> 'scitex_store_owner' (after the DDL)
  REOWNED sac_channel_import: owner 'ywatanabe__cli' -> 'scitex_store_owner' (after the DDL)
  consumer access checked for 4 role(s) drawn from 'sac_comms_nodes_rows'
exit: 0

RUN: compute-03 (later, OVERLAPPING)
  scitex-agent-container: 3 row(s), cursor -> 11  OFFSET +8 (relocated target)
  verify scitex-agent-container: 3 row(s), ids 1..3, 3 undelivered — MATCHES SQLite
exit: 0

consumers can act as owner: ywatanabe__cli True, ywatanabe__sac-listen True,
                            ywatanabe__scitex-agent-container True,
                            ywatanabe__scitex-cards True
ledger: (scitex-agent-container, 1, 8,  scitex-compute-04, 8, offset 0, by ywatanabe__cli)
        (scitex-agent-container, 9, 11, scitex-compute-04, 3, offset 8, by ywatanabe__cli)
```

Before this change, that second run exited 1.

## Operator note for compute-03

The store holds 7,980 rows imported before the ledger existed, so they are still unattributed and the refusal will still fire. Clear it the honest way, from any host:

```
scripts/migrate_channel_events_to_postgres.py --commit --db-path <compute-04's state.db>   # records the window; moves nothing
scripts/migrate_channel_events_to_postgres.py --commit --db-path <compute-03's state.db>   # now proceeds
```

Repeat the first line for nas-03's `state.db` if its `lead` rows sit above anything compute-03 is importing.

## Residual, stated rather than smuggled

`init_channel_schema` in the **runtime** can still create these tables on a virgin database as whichever agent connects first, with the same outcome. This PR fixes the script the operator runs, per the brief; the daemon-side prevention is a separate change and I did not want it riding along in a PR that already touches the migration under a live cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCMkub2ZBiL4huQUxMDDb
