### PR TITLE
fix(migrate): the ownership gate counted readers as consumers

### DIFF
--- a/scripts/_pg_table_owner.py
+++ b/scripts/_pg_table_owner.py
@@ -202,38 +202,92 @@ def ensure_owner(
 
 def _reference_population(
     conn: Any, *, managed: Sequence[str]
-) -> tuple[str | None, list[str]]:
-    """``(reference_table, roles)`` — who can already use the REST of the store.
+) -> tuple[str | None, list[str], dict[str, str]]:
+    """``(reference_table, roles, why)`` — who WRITES the rest of the store.
 
     The population is derived from a table this migration did NOT create, so
     it is an INDEPENDENT question from "did we set the owner we intended".
-    Deriving it from our own tables would make the check below tautological:
-    it would confirm that the roles which can use these tables can use these
+    Deriving it from our own tables would make the checks below tautological:
+    they would confirm that the roles which can use these tables can use these
     tables.
+
+    THE PREDICATE IS ``INSERT``, NOT ``SELECT``, AND THAT IS A CORRECTION
+    ====================================================================
+    The first version asked who could SELECT the reference table, which swept
+    in every member of PostgreSQL's built-in ``pg_read_all_data`` — read-only
+    auditors, monitoring roles, and the fleet's nightly-dump role
+    ``svc_backup``. Measured on the primary 2026-08-28, hours after the gate
+    shipped: ``svc_backup`` is a member of ``pg_read_all_data`` and nothing
+    else, holds SELECT and NOT INSERT/UPDATE/DELETE, has no explicit grant on
+    any store table, and cannot act as ``scitex_store_owner``. It therefore
+    failed the gate and BLOCKED compute-04's migration — on 96 of 96 candidate
+    reference tables, so it was not a fluke of which table got chosen. It was
+    a false positive on every possible run.
+
+    The refusal's own reasoning names the fix: the hazard is that a consumer
+    reaches ``init_channel_schema``, whose ``CREATE INDEX IF NOT EXISTS``
+    needs owner rights. A role that cannot WRITE the store never opens a
+    channel connection and never runs that statement, so it is not a consumer
+    in the sense this gate is about. ``INSERT`` is the crisp signal for
+    "participates in this store as a writer".
+
+    Measured with the corrected predicate on the same 96 tables: ZERO roles
+    trigger a refusal anywhere, while all 127 agent roles stay in the
+    population. The gate keeps its teeth and loses the false positive.
+
+    THIS WAS THE SAME ERROR CLASS AS THE MIGRATION GUARD IT SHIPPED WITH — a
+    predicate right about the thing it measured and wrong about which rows it
+    applied to. Worth saying out loud, because the next widening of this
+    population will be tempting for exactly the reason the last one was.
 
     Superusers are excluded. They pass every privilege test by fiat, so
     including them would let one superuser row hide every real consumer's
     failure.
+
+    ``why`` records HOW each role reaches the table — membership in its owner,
+    or an explicit grant — so a future false positive is visible IN THE
+    REFUSAL rather than only to somebody who goes and measures it.
     """
     rows = conn.execute(
-        "SELECT c.relname, r.rolname FROM pg_class c "
+        "SELECT c.relname, r.rolname, "
+        "       pg_has_role(r.oid, c.relowner, 'USAGE'), "
+        "       pg_get_userbyid(c.relowner) "
+        "FROM pg_class c "
         "JOIN pg_namespace n ON n.oid = c.relnamespace "
         "CROSS JOIN pg_roles r "
         "WHERE n.nspname = current_schema() AND c.relkind = 'r' "
         "AND c.relname <> ALL(%s) "
         "AND r.rolcanlogin AND NOT r.rolsuper "
-        "AND has_table_privilege(r.oid, c.oid, 'SELECT')",
+        "AND has_table_privilege(r.oid, c.oid, 'INSERT')",
         (list(managed),),
     ).fetchall()
     by_table: dict[str, list[str]] = {}
-    for table, role in rows:
+    reasons: dict[str, dict[str, str]] = {}
+    for table, role, by_membership, owner_name in rows:
         by_table.setdefault(str(table), []).append(str(role))
+        reasons.setdefault(str(table), {})[str(role)] = (
+            f"writes {table} as a member of {owner_name}"
+            if by_membership
+            else f"writes {table} through an explicit grant"
+        )
     if not by_table:
-        return None, []
+        return None, [], {}
     # The widest population, so the check speaks for as much of the fleet as
     # the database can attest to. Ties break by name, so two runs agree.
     reference = max(sorted(by_table), key=lambda t: len(by_table[t]))
-    return reference, sorted(by_table[reference])
+    return reference, sorted(by_table[reference]), reasons[reference]
+
+
+def _named_with_reasons(roles: Sequence[str], why: dict[str, str]) -> str:
+    """``role (why it counts as a consumer)``, comma-joined.
+
+    The reason travels WITH the name because this gate's first false positive
+    cost a blocked migration and a manual investigation the message could have
+    short-circuited: ``svc_backup`` alone says nothing, while ``svc_backup
+    (reads everything via pg_read_all_data)`` would have been self-evidently
+    wrong to the operator reading it.
+    """
+    return ", ".join(f"{r} ({why.get(r, 'no reason recorded')})" for r in roles)
 
 
 def owner_inheritance_problems(
@@ -252,27 +306,47 @@ def owner_inheritance_problems(
     naming a role this session happens to be a member of — its own leaf role,
     say — passes :func:`owner_is_reachable` and still reproduces 2026-08-28
     exactly.
+
+    WHAT THIS CAN AND CANNOT CATCH, stated rather than implied. Where the
+    store's access is by MEMBERSHIP and no ``--table-owner`` is given, the
+    intended owner is derived as the reference table's own owner, so the
+    population and the assertion collapse onto the same role and this check
+    cannot fail. That is not a defect to paper over — it is the correct answer
+    for that configuration, and pretending otherwise would make it the kind of
+    check that reassures without measuring. It has real work to do in exactly
+    three cases: an operator-supplied ``--table-owner``; a store whose access
+    is by explicit GRANT rather than membership; and a schema whose tables do
+    not all share one owner. :func:`consumer_access_problems` is the one that
+    stays sharp in the ordinary case, because it asks about the REAL tables
+    after the DDL, whose owner can differ from the reference table's.
     """
-    reference, roles = _reference_population(conn, managed=managed)
+    reference, roles, why = _reference_population(conn, managed=managed)
     if reference is None:
         return [], (
             "no other table in this schema to derive a consumer population "
             "from — consumer access UNCHECKED, not verified clean"
         )
-    short = conn.execute(
-        "SELECT r.rolname FROM pg_roles r WHERE r.rolname = ANY(%s) "
-        "AND NOT pg_has_role(r.oid, %s::regrole, 'USAGE') ORDER BY 1",
-        (roles, owner),
-    ).fetchall()
+    short = [
+        str(r[0])
+        for r in conn.execute(
+            "SELECT r.rolname FROM pg_roles r WHERE r.rolname = ANY(%s) "
+            "AND NOT pg_has_role(r.oid, %s::regrole, 'USAGE') ORDER BY 1",
+            (roles, owner),
+        ).fetchall()
+    ]
     if not short:
-        return [], f"{len(roles)} consumer role(s) inherit {owner!r}"
-    names = ", ".join(str(r[0]) for r in short)
+        return [], (
+            f"{len(roles)} writer role(s) of {reference!r} inherit {owner!r}"
+        )
     return [
-        f"{len(short)} of the {len(roles)} role(s) that can use {reference!r} "
-        f"cannot act as {owner!r}: {names}. Tables owned by it would be "
-        f"unusable to them through init_channel_schema's CREATE INDEX IF NOT "
-        f"EXISTS, which needs OWNER rights and which no GRANT supplies."
-    ], f"consumer population drawn from {reference!r}"
+        f"{len(short)} of the {len(roles)} role(s) that WRITE {reference!r} "
+        f"cannot act as {owner!r}: {_named_with_reasons(short, why)}. Tables "
+        f"owned by it would be unusable to them through init_channel_schema's "
+        f"CREATE INDEX IF NOT EXISTS, which needs OWNER rights and which no "
+        f"GRANT supplies. If a role named here does not in fact write this "
+        f"store, the POPULATION is wrong rather than the owner — see "
+        f"_reference_population."
+    ], f"consumer population drawn from writers of {reference!r}"
 
 
 def consumer_access_problems(
@@ -296,7 +370,7 @@ def consumer_access_problems(
     nothing but these tables cannot answer the question, and "nobody
     complained" from a database with nobody in it is not a pass.
     """
-    reference, roles = _reference_population(conn, managed=managed)
+    reference, roles, why = _reference_population(conn, managed=managed)
     if reference is None:
         return [], (
             "no other table in this schema to derive a consumer population "
@@ -320,15 +394,15 @@ def consumer_access_problems(
             (roles, *([table] * len(_NEEDED)), table),
         ).fetchall()
         if short:
-            names = ", ".join(str(r[0]) for r in short)
+            names = _named_with_reasons([str(r[0]) for r in short], why)
             problems.append(
                 f"{table} (owner {table_owner(conn, table)!r}) is NOT usable by "
-                f"{len(short)} of the {len(roles)} role(s) that can use "
+                f"{len(short)} of the {len(roles)} role(s) that WRITE "
                 f"{reference!r}: {names}. Those roles connect to this table "
                 f"through init_channel_schema, whose CREATE INDEX IF NOT "
                 f"EXISTS needs OWNER rights — a GRANT will not fix it."
             )
     return problems, (
-        f"consumer access checked for {len(roles)} role(s) drawn from "
+        f"consumer access checked for {len(roles)} writer role(s) of "
         f"{reference!r}"
     )

--- a/tests/develop/test_migrate_channel_events_ownership.py
+++ b/tests/develop/test_migrate_channel_events_ownership.py
@@ -368,3 +368,113 @@ def test_an_empty_schema_reports_the_check_as_unrun(pg_schema: str) -> None:
         _problems, note = owners.consumer_access_problems(conn, managed=MANAGED)
     # Assert
     assert "UNCHECKED" in note
+
+
+# ---------------------------------------------------------------------------
+# THE POPULATION MUST BE WRITERS, NOT READERS.
+#
+# Measured on the primary 2026-08-28, hours after the gate shipped: the
+# nightly-dump role `svc_backup` is a member of PostgreSQL's built-in
+# `pg_read_all_data` and nothing else -- SELECT on everything, INSERT on
+# nothing, no explicit grant anywhere, and it cannot act as
+# scitex_store_owner. A population derived from SELECT swept it in, so the
+# gate REFUSED compute-04's migration on 96 of 96 candidate reference tables.
+# It was a false positive on every possible run, and it blocked the last host
+# of the channel_events migration.
+#
+# A role that cannot WRITE the store never opens a channel connection and
+# never reaches init_channel_schema's CREATE INDEX IF NOT EXISTS, which is
+# the whole hazard the refusal is about.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def read_only_role(store_owner: str, store_reference: str) -> str:
+    """A login role that can READ the reference table and not write it.
+
+    Derived from the catalog rather than named: on the fleet this finds
+    `svc_backup` through `pg_read_all_data`, and any cluster with an auditor
+    or monitoring role will offer its own. Skipped, loudly, where the shape
+    does not exist -- a skip that reads as a pass is how a suite reports green
+    while measuring nothing.
+    """
+    rows = raw_query(
+        "SELECT r.rolname FROM pg_roles r "
+        "WHERE r.rolcanlogin AND NOT r.rolsuper AND r.rolname <> current_user "
+        "AND has_table_privilege(r.oid, %s::regclass, 'SELECT') "
+        "AND NOT has_table_privilege(r.oid, %s::regclass, 'INSERT') "
+        "AND NOT pg_has_role(r.oid, %s::regrole, 'USAGE') ORDER BY 1",
+        (store_reference, store_reference, store_owner),
+    )
+    if not rows:
+        pytest.skip(
+            "this cluster has no read-only login role that can SELECT but not "
+            "INSERT the reference table, so the svc_backup false positive "
+            "cannot be reproduced here"
+        )
+    return str(rows[0][0])
+
+
+def test_a_read_only_role_does_not_block_the_migration(
+    tmp_path: Path,
+    pg_schema: str,
+    store_owner: str,
+    store_reference: str,
+    read_only_role: str,
+) -> None:
+    """THE FALSE POSITIVE. A backup role must not refuse the whole import."""
+    # Arrange
+    db = legacy_db(tmp_path, _seed_rows())
+    # Act
+    rc = run(db, "--commit")
+    # Assert
+    assert rc == 0
+
+
+def test_a_read_only_role_is_not_in_the_consumer_population(
+    pg_schema: str, store_owner: str, store_reference: str, read_only_role: str
+) -> None:
+    """The predicate itself, asked directly: readers are not consumers here."""
+    # Arrange
+    owners = script_module("_pg_table_owner")
+    # Act
+    with raw_conn() as conn:
+        _ref, roles, _why = owners._reference_population(conn, managed=MANAGED)
+    # Assert
+    assert read_only_role not in roles
+
+
+def test_a_writer_role_is_still_in_the_consumer_population(
+    pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """NEGATIVE CONTROL for the narrowing — it must not empty the population.
+
+    A predicate that excluded everybody would pass the test above and make the
+    gate incapable of ever refusing, which is the failure this narrowing is
+    most at risk of.
+    """
+    # Arrange
+    owners = script_module("_pg_table_owner")
+    # Act
+    with raw_conn() as conn:
+        _ref, roles, _why = owners._reference_population(conn, managed=MANAGED)
+    # Assert
+    assert roles
+
+
+def test_the_population_records_why_each_role_is_a_consumer(
+    pg_schema: str, store_owner: str, store_reference: str
+) -> None:
+    """The reason travels with the name, so the NEXT false positive is visible.
+
+    `svc_backup` on its own said nothing and cost a measurement session;
+    `svc_backup (writes ... as a member of ...)` would have been obviously
+    wrong in the refusal text itself.
+    """
+    # Arrange
+    owners = script_module("_pg_table_owner")
+    # Act
+    with raw_conn() as conn:
+        _ref, roles, why = owners._reference_population(conn, managed=MANAGED)
+    # Assert
+    assert all(why.get(role) for role in roles)


### PR DESCRIPTION
Follow-up to #1260, which refused compute-04 on its first real run:

```
REFUSED 1 of the 128 role(s) that can use 'a2a_ports_cursor' cannot act as
'scitex_store_owner': svc_backup
REFUSED — no rows were written. SQLite left untouched.
```

## Your reading of svc_backup is right — measured independently

On the live primary, before changing anything:

| | |
|---|---|
| `rolsuper` / `rolcanlogin` | `False` / `True` |
| member of | `['pg_read_all_data']` — and nothing else |
| SELECT / INSERT / UPDATE / DELETE on `a2a_ports_cursor` | `True` / `False` / `False` / `False` |
| `relacl` on that table | `NULL` — so it reaches SELECT purely via the built-in role |
| `pg_has_role(svc_backup, scitex_store_owner, 'USAGE')` | `False` |

It never opens a channel connection, never reaches `init_channel_schema`, and never runs the `CREATE INDEX IF NOT EXISTS` the refusal is about. It is not a consumer in the sense the gate is about.

## The defect was the population, and it was not a near miss

I enumerated rather than assuming the chosen reference table was unlucky. Across **all 96 candidate reference tables** in `public`:

| predicate | roles that would trigger a refusal |
|---|---|
| `SELECT` (shipped) | `svc_backup`, on **96 of 96** tables |
| `INSERT` (this PR) | **none** |

So it was a false positive on *every possible run*, not a fluke of table choice. The INSERT predicate keeps all 127 agent roles in the population.

This is the same error class as the migration guard it shipped alongside — a predicate right about the thing it measured and wrong about which rows it applied to. That is now said out loud in `_reference_population`, because the next widening will be tempting for the reason the last one was.

## I did not take your suggestion wholesale

You offered two options. **"Membership in the owner chain" is the wrong one** and I did not use it: the intended owner is *derived* as the reference table's owner, so a population defined as "members of that owner" would make the pre-DDL gate assert something true by construction — a check that cannot fail. Deriving from an actual **privilege on a real table** also keeps working on a store whose access is by explicit `GRANT` rather than membership.

## The gate keeps its teeth

Not softened to a warning; still refuses before the DDL. A role that **writes** the store and cannot act as the intended owner still stops the run. Unchanged and still passing: `test_naming_an_owner_the_fleet_cannot_inherit_refuses`, `test_the_consumer_check_catches_a_leaf_owned_table`, `test_an_unreachable_owner_refuses_before_creating_anything`. New control `test_a_writer_role_is_still_in_the_consumer_population` pins that the narrowing did not empty the population — the failure mode a narrowing is most at risk of.

## Refusals now say why a role counts as a consumer

Per your suggestion: each named role carries `writes <table> as a member of <owner>` or `writes <table> through an explicit grant`, and the message ends with "if a role named here does not in fact write this store, the POPULATION is wrong rather than the owner". Had that shipped, `svc_backup (reads everything via pg_read_all_data)` would have been self-evidently wrong in the message you read.

## One thing I found while fixing this, and am stating rather than hiding

`owner_inheritance_problems` (the pre-DDL gate) **cannot fail** in the fleet's ordinary configuration: where access is by membership and no `--table-owner` is given, the intended owner *is* the reference table's owner, so the population and the assertion collapse onto the same role. That is the correct answer for that configuration, but a check that reassures without measuring is exactly what you have been catching me on, so the docstring now states it. It has real work in three cases — an explicit `--table-owner`, a grant-based store, a mixed-owner schema. `consumer_access_problems` is the one that stays sharp in the ordinary case, because it asks about the **real** tables after the DDL, whose owner can differ from the reference table's.

## Evidence

**Red first.** With an `svc_backup`-shaped role in the cluster and #1260's merged code, the ownership module was **10 failed / 7 passed** of 17 — the false positive refuses the very migration run that every other ownership test depends on, so it poisons the whole gate rather than tripping one assertion.

**Green.** 46 collected, **46 EXECUTED, 0 skipped** (the read-only-role fixture did not skip — the cluster has the role). `tests/develop`: 178 passed, 1 skipped (pre-existing, no `_skills/`). Ruff clean.

**End to end**, run as `ywatanabe__cli` with `svc_backup` present — the operator's compute-04 step:

```
owner:  scitex_store_owner (owner of 1 other table(s) in this schema)
  4 writer role(s) of 'sac_comms_nodes_rows' inherit 'scitex_store_owner'
  REOWNED sac_channel_events: owner 'ywatanabe__cli' -> 'scitex_store_owner'
  REOWNED sac_channel_cursor: owner 'ywatanabe__cli' -> 'scitex_store_owner'
  REOWNED sac_channel_import: owner 'ywatanabe__cli' -> 'scitex_store_owner'
  consumer access checked for 4 writer role(s) of 'sac_comms_nodes_rows'
exit: 0
```

The test cluster is a fresh `initdb` PostgreSQL 18 given the fleet's role tree — `scitex_store_owner` ← `ywatanabe` ← `ywatanabe__*`, migrating identity a non-superuser leaf — plus `svc_backup` built from `pg_read_all_data`, so the false positive is reproduced from the real shape rather than described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCMkub2ZBiL4huQUxMDDb
