### PR TITLE
feat(migrate): --accept-post-cutover-replay, and a remedy that can be followed

### DIFF
--- a/scripts/_channel_import_guard.py
+++ b/scripts/_channel_import_guard.py
@@ -110,6 +110,7 @@ def refusals(
     grouped: dict[str, list[dict]],
     *,
     accepted: frozenset[str] = frozenset(),
+    accepted_replay: frozenset[str] = frozenset(),
 ) -> tuple[list[str], list[str]]:
     """``(refused, waived)`` — targets this migration MUST NOT touch.
 
@@ -143,13 +144,32 @@ def refusals(
 
     ``accepted`` is the operator asserting, PER NAMED TARGET, that the
     unattributed rows above them are an import whose ``state.db`` is gone.
-    There is deliberately no blanket ``--force``: a bypass covering every
-    target at once restores exactly the corruption this guard exists to
-    prevent, and this guard has already proved its worth by refusing rather
-    than corrupting.
+    ``accepted_replay`` is a DIFFERENT assertion for a different fact: those
+    rows really are live daemon traffic, and the operator accepts the named,
+    bounded consequence of importing anyway. There is deliberately no blanket
+    ``--force``: a bypass covering every target at once restores exactly the
+    corruption this guard exists to prevent, and this guard has already proved
+    its worth by refusing rather than corrupting.
+
+    THE TWO WAIVERS ARE NOT INTERCHANGEABLE, and keeping them apart is the
+    point of having two. They assert opposite things about the same rows —
+    "this is another host's history" versus "this is live traffic and I accept
+    a replay" — and only one of them can be true. Two flags that both mean
+    "proceed anyway" collapse into one habit, and the habit is what a guard
+    cannot survive. So each is refused when its own precondition does not
+    hold, rather than being quietly ignored.
+
+    WHY THIS STAYS CONSERVATIVE, deliberately. The guard cannot tell whether
+    a shift would actually strand anything, because that depends on where live
+    CONSUMERS sit and there is no server-side record of consumer position:
+    ``list_since_id`` takes the id from the request and ``Last-Event-ID`` is a
+    client-side variable. Do not "fix" the imprecision — the only way to make
+    this predicate exact is information the system does not have, and every
+    attempt to sharpen it ends in a guard that cannot refuse.
     """
     refused: list[str] = []
     waived: list[str] = []
+    unnecessary = set(accepted_replay) | set(accepted)
     for target in sorted(grouped):
         entries = grouped[target]
         _, already = offset_for(conn, target=target, entries=entries)
@@ -160,10 +180,35 @@ def refusals(
         )
         if not unclaimed:
             continue
+        unnecessary.discard(target)
+        if target in accepted and target in accepted_replay:
+            refused.append(
+                f"{target}: named to BOTH --accept-imported-history and "
+                f"--accept-post-cutover-replay. Those assert opposite things "
+                f"about the same {unclaimed} row(s) — another host's history, "
+                f"or live daemon traffic — and at most one can be true. "
+                f"Decide which, and pass only that one."
+            )
+            continue
         if target in accepted:
             waived.append(
                 f"{target}: {unclaimed} unattributed row(s) ACCEPTED as "
                 f"imported history on the operator's explicit assertion"
+            )
+            continue
+        if target in accepted_replay:
+            count, lo, hi, undelivered = prov.unattributed_span(
+                conn,
+                target=target,
+                newest_ts=max(float(r["ts"]) for r in entries),
+            )
+            waived.append(
+                f"{target}: ACCEPTING A REPLAY. {count} post-cutover row(s) at "
+                f"ids {lo}..{hi} ({undelivered} undelivered) stay exactly where "
+                f"they are — this host's {len(entries)} row(s) are offset ABOVE "
+                f"them, so nothing becomes unreachable. THE COST YOU ARE "
+                f"ACCEPTING: a consumer sitting at Last-Event-ID {hi} will "
+                f"receive this host's {len(entries)} row(s) as if new."
             )
             continue
         seen = (
@@ -181,16 +226,31 @@ def refusals(
             f"daemon traffic. Do ONE of: (1) if those rows came from ANOTHER "
             f"HOST's state.db, re-run this with --commit --db-path pointing at "
             f"THAT file — it moves no rows and records the window it "
-            f"recognises, after which this refusal clears; (2) if `sac listen` "
-            f"really has served {target!r} since the cutover, stop it on every "
-            f"host serving {target!r} and re-run; (3) if that state.db is gone, "
-            f"assert it per target with --accept-imported-history {target}."
+            f"recognises, after which this refusal CLEARS BY ITSELF; (2) if "
+            f"`sac listen` really has served {target!r} since the cutover, "
+            f"those rows are live traffic and STOPPING THE DAEMON WILL NOT "
+            f"CLEAR THIS — they are already written and nothing removes them; "
+            f"stopping it only prevents MORE, and you then accept the named "
+            f"consequence with --accept-post-cutover-replay {target}; (3) if "
+            f"they are an import whose state.db is GONE, assert that instead "
+            f"with --accept-imported-history {target}."
+        )
+    for target in sorted(unnecessary):
+        refused.append(
+            f"{target}: named to a waiver flag, but nothing is blocking it — "
+            f"either it has no rows newer than this state.db, or the newer "
+            f"rows it does have are already accounted for by a recorded "
+            f"import. That case has its own mechanism and needs no override. "
+            f"Drop the flag for {target!r} and re-run."
         )
     return refused, waived
 
 
 def dry_run_refusals(
-    grouped: dict[str, list[dict]], *, accepted: frozenset[str]
+    grouped: dict[str, list[dict]],
+    *,
+    accepted: frozenset[str],
+    accepted_replay: frozenset[str] = frozenset(),
 ) -> tuple[list[str], list[str]]:
     """:func:`refusals` for the dry run — READ-ONLY, and never fatal.
 
@@ -222,6 +282,8 @@ def dry_run_refusals(
         ).fetchone()[0]
         if not exists:
             return [], []
-        return refusals(conn, grouped, accepted=accepted)
+        return refusals(
+            conn, grouped, accepted=accepted, accepted_replay=accepted_replay
+        )
     finally:
         conn.close()

--- a/scripts/_channel_import_provenance.py
+++ b/scripts/_channel_import_provenance.py
@@ -191,3 +191,40 @@ def newer_rows(conn: Any, *, target: str, newest_ts: float) -> tuple[int, int]:
         ).fetchone()[0]
     )
     return unattributed, total - unattributed
+
+
+def unattributed_span(
+    conn: Any, *, target: str, newest_ts: float
+) -> tuple[int, int, int, int]:
+    """``(count, lo_id, hi_id, undelivered)`` for the rows nothing accounts for.
+
+    The numbers ``--accept-post-cutover-replay`` has to PRINT before it waives
+    anything. A flag whose name is honest and whose output is silent still
+    lets the next operator use it without knowing what they bought, so the
+    caller states the target, the count, the id range and the replay risk on
+    one line at the point of use.
+
+    ``undelivered`` is the sharper half of that risk. These rows keep their
+    ids and stay reachable — the import is offset ABOVE them — so an
+    already-delivered row costs nothing but a possible duplicate on one
+    consumer's reconnect. An UNDELIVERED one is traffic still waiting to be
+    read, and an operator should see that number before deciding.
+    """
+    if not ledger_exists(conn):
+        row = conn.execute(
+            "SELECT COUNT(*), COALESCE(MIN(id), 0), COALESCE(MAX(id), 0), "
+            "COUNT(*) FILTER (WHERE delivered_at IS NULL) "
+            "FROM sac_channel_events WHERE target = %s AND ts > %s",
+            (target, newest_ts),
+        ).fetchone()
+        return int(row[0]), int(row[1]), int(row[2]), int(row[3])
+    row = conn.execute(
+        "SELECT COUNT(*), COALESCE(MIN(e.id), 0), COALESCE(MAX(e.id), 0), "
+        "COUNT(*) FILTER (WHERE e.delivered_at IS NULL) "
+        "FROM sac_channel_events e "
+        "WHERE e.target = %s AND e.ts > %s AND NOT EXISTS ("
+        "  SELECT 1 FROM sac_channel_import i "
+        "  WHERE i.target = e.target AND e.id BETWEEN i.lo_id AND i.hi_id)",
+        (target, newest_ts),
+    ).fetchone()
+    return int(row[0]), int(row[1]), int(row[2]), int(row[3])

--- a/scripts/migrate_channel_events_to_postgres.py
+++ b/scripts/migrate_channel_events_to_postgres.py
@@ -312,6 +312,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--accept-post-cutover-replay",
+        action="append",
+        default=[],
+        metavar="TARGET",
+        help=(
+            "assert that the unattributed rows above TARGET really are live "
+            "daemon traffic, and accept the consequence: they keep their ids "
+            "and stay reachable, but a consumer at their top id receives this "
+            "host's rows as if new. NAMED PER TARGET and repeatable. This is "
+            "NOT interchangeable with --accept-imported-history: the two "
+            "assert opposite things about the same rows"
+        ),
+    )
+    parser.add_argument(
         "--table-owner",
         metavar="ROLE",
         help=(
@@ -332,13 +346,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     # A waiver aimed at a target this state.db does not contain waives
     # NOTHING, and would read exactly like one that worked. Refuse the typo.
     accepted = frozenset(args.accept_imported_history)
-    unknown = sorted(accepted - set(grouped))
-    if unknown:
-        parser.error(
-            f"--accept-imported-history names {unknown} , which "
-            f"{'is' if len(unknown) == 1 else 'are'} not in {db_path}. "
-            f"Targets in this file: {sorted(grouped)}"
-        )
+    accepted_replay = frozenset(args.accept_post_cutover_replay)
+    for flag, named in (
+        ("--accept-imported-history", accepted),
+        ("--accept-post-cutover-replay", accepted_replay),
+    ):
+        unknown = sorted(named - set(grouped))
+        if unknown:
+            parser.error(
+                f"{flag} names {unknown} , which "
+                f"{'is' if len(unknown) == 1 else 'are'} not in {db_path}. "
+                f"Targets in this file: {sorted(grouped)}"
+            )
 
     if not args.commit:
         for target in sorted(grouped):
@@ -354,7 +373,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         # cannot be opened is reported as unchecked rather than as clean —
         # the same shape ``_migrate_lib._preview_collisions`` uses, and for
         # the same reason.
-        blocked, waived = guard.dry_run_refusals(grouped, accepted=accepted)
+        blocked, waived = guard.dry_run_refusals(
+            grouped, accepted=accepted, accepted_replay=accepted_replay
+        )
         for line in waived:
             print(f"  ACCEPTED {line}")
         if blocked:
@@ -395,7 +416,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("REFUSED — no rows were written. SQLite left untouched.")
             return 1
 
-        blocked, waived = guard.refusals(conn, grouped, accepted=accepted)
+        blocked, waived = guard.refusals(
+            conn, grouped, accepted=accepted, accepted_replay=accepted_replay
+        )
         for line in waived:
             print(f"  ACCEPTED {line}")
         if blocked:

--- a/tests/develop/test_migrate_channel_events_replay.py
+++ b/tests/develop/test_migrate_channel_events_replay.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""``--accept-post-cutover-replay``: naming the consequence, not hiding it.
+
+WHY A SECOND WAIVER RATHER THAN REUSING THE FIRST
+=================================================
+Measured on the primary 2026-08-29, importing compute-03's last host: the
+guard refused ``scitex-agent-container`` over 13 rows at ids 7981..7993,
+written between 21:53 and 00:10 that night by ``ci`` and
+``figrecipe-sqlite-out``, every one ``delivered=True``. They are live daemon
+traffic, and the refusal was CORRECT — a true positive, not another false
+shape. 233 further newer rows were excused automatically because a recorded
+import accounted for them, which is the provenance mechanism working.
+
+But no remedy the message offered could clear it:
+
+* re-importing the other host's ``state.db`` does not apply — these rows came
+  from no import;
+* ``--accept-imported-history`` would have been a FALSE assertion;
+* and "stop ``sac listen`` and re-run", which the message did say, CANNOT
+  work: the rows are already written and stopping a daemon does not remove
+  rows. That was the same structural flaw as the guard this effort was
+  dispatched to fix, reproduced in its own remedy text.
+
+So the honest move is a flag that states what is true — these ARE
+post-cutover writes — and makes the operator accept a named, bounded cost.
+
+WHY THE COST IS BOUNDED, measured rather than asserted: ``offset_for``
+returns ``pg_max``, so this host's rows land ABOVE the daemon's. The
+post-cutover rows keep their ids and stay reachable; nothing is stranded.
+The whole harm is that a consumer sitting exactly at the top id receives this
+host's rows as if new. That is the OPPOSITE of the catastrophic shape, which
+needs the daemon rows to hold LOW ids relative to the imported range.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._state.state_db_channel_store import (
+    reset_channel_connection,
+)
+from tests.develop._channel_migration_kit import event_row, legacy_db, query, run
+
+
+@pytest.fixture(autouse=True)
+def _drop_cached_connection() -> Iterator[None]:
+    reset_channel_connection()
+    yield
+    reset_channel_connection()
+
+
+def _earlier_host(tmp_path: Path) -> Path:
+    return legacy_db(
+        tmp_path / "host-a",
+        [event_row("lead", "a-1", 1.0), event_row("lead", "a-2", 2.0)],
+    )
+
+
+def _later_host(tmp_path: Path) -> Path:
+    return legacy_db(tmp_path / "host-b", [event_row("lead", "b-1", 3.0)])
+
+
+def _daemon_served(target: str, *, ts: float) -> int:
+    """The REAL writer mints an id, exactly as ``sac listen`` would."""
+    from scitex_agent_container._state.state_db_channel import persist_event
+
+    return persist_event(target=target, event={"msg_id": f"post-{ts}", "ts": ts})
+
+
+def _blocked(tmp_path: Path) -> tuple[Path, Path]:
+    """The measured shape: an accounted-for import PLUS live daemon rows."""
+    earlier, later = _earlier_host(tmp_path), _later_host(tmp_path)
+    run(earlier, "--commit")
+    _daemon_served("lead", ts=99.0)
+    return earlier, later
+
+
+def test_the_replay_waiver_lets_the_import_through(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The blocked target imports once the operator accepts the named cost."""
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    # Act
+    rc = run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert
+    assert rc == 0
+
+
+def test_the_daemon_rows_keep_their_ids(tmp_path: Path, pg_schema: str) -> None:
+    """THE CLAIM THE FLAG MAKES. Nothing post-cutover moves or disappears.
+
+    If the waiver shifted the daemon's rows it would be selling the
+    catastrophic outcome under a reassuring name.
+    """
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    # Act
+    run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert — 1,2 the earlier import; 3 the daemon's; 4 this host's, ABOVE it.
+    assert query(
+        "SELECT id FROM sac_channel_events WHERE target = %s ORDER BY id",
+        ("lead",),
+    ) == [(1,), (2,), (3,), (4,)]
+
+
+def test_the_waiver_prints_the_consequence_it_accepts(
+    tmp_path: Path, pg_schema: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A flag whose name is honest and whose output is silent is still a trap.
+
+    The operator has to see the target, the count, the id range and the replay
+    risk at the point of use — not go and measure them afterwards, which is
+    what this incident actually cost.
+    """
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    # Act
+    run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert
+    assert "Last-Event-ID" in capsys.readouterr().out
+
+
+def test_the_printed_consequence_names_the_id_range(
+    tmp_path: Path, pg_schema: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """"1 row(s) at ids 3..3" is checkable; "some rows" is not."""
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    # Act
+    run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert
+    assert "ids 3..3" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# THE TWO WAIVERS MUST NOT COLLAPSE INTO ONE HABIT.
+# ---------------------------------------------------------------------------
+
+
+def test_naming_both_waivers_for_one_target_is_refused(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """They assert opposite things; at most one can be true."""
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    # Act
+    rc = run(
+        later,
+        "--commit",
+        "--accept-post-cutover-replay",
+        "lead",
+        "--accept-imported-history",
+        "lead",
+    )
+    # Assert
+    assert rc == 1
+
+
+def test_a_waiver_for_a_target_that_is_not_blocked_is_refused(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """An override for a case that already has a mechanism is refused.
+
+    Silently ignoring it is how "pass the flag anyway" becomes the habit that
+    a guard cannot survive.
+    """
+    # Arrange — the earlier host alone; nothing is blocking anything.
+    earlier = _earlier_host(tmp_path)
+    # Act
+    rc = run(earlier, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert
+    assert rc == 1
+
+
+def test_that_refusal_says_the_case_has_its_own_mechanism(
+    tmp_path: Path, pg_schema: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Refusing without saying why just moves the confusion."""
+    # Arrange
+    earlier = _earlier_host(tmp_path)
+    # Act
+    run(earlier, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert
+    assert "needs no override" in capsys.readouterr().out
+
+
+def test_the_waiver_is_per_target_and_does_not_leak(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """``ci`` is named; ``lead`` is the blocked one. A disguised --force
+    would return 0."""
+    # Arrange
+    earlier = _earlier_host(tmp_path)
+    later = legacy_db(
+        tmp_path / "host-b",
+        [event_row("lead", "b-1", 3.0), event_row("ci", "c-1", 3.5)],
+    )
+    run(earlier, "--commit")
+    _daemon_served("lead", ts=99.0)
+    # Act
+    rc = run(later, "--commit", "--accept-post-cutover-replay", "ci")
+    # Assert
+    assert rc == 1
+
+
+def test_a_typoed_target_is_still_refused(tmp_path: Path, pg_schema: str) -> None:
+    """A waiver aimed at a target this state.db lacks waives NOTHING, and
+    would read exactly like one that worked."""
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    # Act
+    refused = pytest.raises(SystemExit)
+    # Assert
+    with refused:
+        run(later, "--commit", "--accept-post-cutover-replay", "leadd")
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE CONTROLS — the guard must still refuse without the flag.
+# ---------------------------------------------------------------------------
+
+
+def test_without_the_flag_the_target_is_still_refused(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """The whole point is that this is opt-in per target, every run."""
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    # Act
+    rc = run(later, "--commit")
+    # Assert
+    assert rc == 1
+
+
+def test_the_remedy_text_no_longer_promises_that_stopping_clears_it(
+    tmp_path: Path, pg_schema: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CONDITION 3. The old text sent an operator to stop the daemon and
+    re-run, which cannot work — the rows are already written."""
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    # Act
+    run(later, "--commit")
+    # Assert
+    assert "STOPPING THE DAEMON WILL NOT CLEAR THIS" in capsys.readouterr().out


### PR DESCRIPTION
**`channel_events` is complete: 9,060 rows across all four hosts.** This PR is the flag that made the last one possible.

## What refused, and why it was right

Importing compute-03's last host, the guard refused `scitex-agent-container` over **13 rows at ids 7981–7993**, written between 21:53 and 00:10 that night by `ci` and `figrecipe-sqlite-out`, every one `delivered=True`. Live daemon traffic — **a true positive.** 233 further newer rows were excused automatically because a recorded import accounted for them, which is #1260's provenance mechanism working exactly as designed.

But **no remedy the message offered could clear it**:

- re-importing the other host's `state.db` does not apply — these rows came from no import;
- `--accept-imported-history` would have been a **false assertion**;
- and *"stop `sac listen` and re-run"*, which the message did say, **cannot work** — the rows are already written and stopping a daemon does not remove rows.

That last one was the same structural flaw as the guard this whole effort was dispatched to fix, reproduced in its own remedy text.

## Why a second flag rather than the alternatives

- **Leave it** permanently parks one target of nineteen with no path to completion, and parks it *because of a remedy that cannot be followed*. It looks like a decision and is an abandonment.
- **`--skip-target`** lands 18 now and defers this exact decision to whoever picks it up next, minus the measurements that would let them make it. Deferring a decision is fine; deferring it while discarding the evidence is not.
- **`--accept-post-cutover-replay`** is the only one that states what is true.

## It prints what it is buying

```
ACCEPTED scitex-agent-container: ACCEPTING A REPLAY. 13 post-cutover row(s) at ids 7981..7993
(0 undelivered) stay exactly where they are — this host's 2 row(s) are offset ABOVE them, so
nothing becomes unreachable. THE COST YOU ARE ACCEPTING: a consumer sitting at Last-Event-ID
7993 will receive this host's 2 row(s) as if new.
```

Target, count, id range, undelivered count, and the replay risk — on one line, at the point of use. A flag whose name is honest and whose output is silent still lets the next person use it without knowing what they bought.

**Why the cost is bounded**, measured rather than asserted: `offset_for` returns `pg_max`, so the import lands *above* the daemon's rows. They keep their ids and stay reachable. That is the opposite of the catastrophic shape, which needs the daemon rows to hold **low** ids relative to the imported range.

## The two waivers cannot stand in for each other

They assert opposite things about the same rows — "another host's history" vs "live traffic I accept a replay on" — and at most one can be true. Naming **both** for one target is refused. So is naming **either** for a target that is not blocked: that case already has a mechanism and needs no override, and silently ignoring the flag is how "pass it anyway" becomes the habit a guard cannot survive.

## Deliberately conservative — please do not "fix" this

The guard cannot tell whether a shift would actually strand anything, because that depends on where live **consumers** sit, and there is no server-side record of consumer position: `list_since_id` takes the id from the request, and `Last-Event-ID` is a client-side variable. The imprecision is not a bug to sharpen — every attempt to make this predicate exact needs information the system does not have, and ends in a guard that cannot refuse. Said in the module docstring too, so the next reader meets it there.

## Evidence

**Red first:** 11 collected, **9 failed / 2 passed** against merged `e9e7895b` — the 2 passing being the negative controls (still refuses without the flag; typo'd target still rejected).

**Green:** whole `tests/develop` slice — **194 passed, 1 skipped** (pre-existing, no `_skills/`). Ruff clean. All files under the 512-line cap.

**The live run**, as `ywatanabe__leaves-sqlite-triage` against the primary:

```
3/3 compute-03: 1055 row(s) across 19 target(s)   exit 0
  lead: 3 row(s), cursor -> 996  OFFSET +7 (relocated target)
  ... all 19 targets: MATCHES SQLite
```

`lead` taking `OFFSET +7` is the nas-03/compute-03 case working correctly: nas-03's ids 1–7 stay put, compute-03's 987–989 land at 994–996.

**Verified as the consumer** (`ywatanabe__sac-listen`, not the migrating role): `init_channel_schema` OK, 9,060 rows visible, all three tables owned by `scitex_store_owner`, `can_act_as_owner=True`.

## Two things this run exposed, carded rather than left here

- **`sac_channel_import.source_host` records the machine that RAN the import, not the source machine.** All 53 windows say `scitex-compute-04`, including nas-03's and compute-03's, because I imported their copied `state.db` files from compute-04 — the documented use of `--db-path`. `source_path` only disambiguates because I happened to name the copies after their hosts. A confidently wrong hostname is worse than none. (`sac-channel-ledger-source-host-is-the-runner`)
- **sac has no SET-capable migration role**, so `imported_by` on all 53 windows reads `ywatanabe__leaves-sqlite-triage` — another project's identity. Needs CREATEROLE, which no agent has. (`sac-migration-role-for-sac`, blocked on the operator)

Stacked on nothing; independent of #1262, which fixes the `INHERIT` vs `SET` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCMkub2ZBiL4huQUxMDDb
