### PR TITLE
fix(migrate): a waiver for an already-imported target is moot, not an error

### DIFF
--- a/scripts/_channel_import_guard.py
+++ b/scripts/_channel_import_guard.py
@@ -159,6 +159,19 @@ def refusals(
     cannot survive. So each is refused when its own precondition does not
     hold, rather than being quietly ignored.
 
+    MOOT IS NOT THE SAME AS UNNECESSARY, and merging them broke the script's
+    own contract. A waiver named for a target this run has ALREADY IMPORTED is
+    MOOT: nothing is blocking it because the work is done, and refusing there
+    made re-running the exact command that succeeded exit 1 on an
+    already-correct state — indistinguishable from real failure to any retry
+    wrapper or runbook, and a direct contradiction of RE-RUNNING IS SAFE in the
+    script's module docstring. That case is now a NOTE and a no-op.
+
+    A waiver named for a target that was never blocked at all is UNNECESSARY
+    and is still REFUSED. That is the habit-forming case the two-flag design
+    exists to prevent: an override passed where no override was ever needed is
+    how "pass the flag anyway" becomes reflex.
+
     WHY THIS STAYS CONSERVATIVE, deliberately. The guard cannot tell whether
     a shift would actually strand anything, because that depends on where live
     CONSUMERS sit and there is no server-side record of consumer position:
@@ -169,11 +182,18 @@ def refusals(
     """
     refused: list[str] = []
     waived: list[str] = []
-    unnecessary = set(accepted_replay) | set(accepted)
+    named = set(accepted_replay) | set(accepted)
+    # Named-but-not-needed splits in two, and collapsing them cost the
+    # documented command its idempotence. See the MOOT/UNNECESSARY note below.
+    moot: set[str] = set()
+    unnecessary = set(named)
     for target in sorted(grouped):
         entries = grouped[target]
         _, already = offset_for(conn, target=target, entries=entries)
         if already:
+            if target in named:
+                unnecessary.discard(target)
+                moot.add(target)
             continue
         unclaimed, claimed = newer_rows_than_source(
             conn, target=target, entries=entries
@@ -235,13 +255,18 @@ def refusals(
             f"they are an import whose state.db is GONE, assert that instead "
             f"with --accept-imported-history {target}."
         )
+    for target in sorted(moot):
+        waived.append(
+            f"{target}: ALREADY IMPORTED, so the waiver flag was not needed "
+            f"and did nothing. This run is a no-op for it. Re-running is safe "
+            f"— the flag can stay in the command or be dropped, either way."
+        )
     for target in sorted(unnecessary):
         refused.append(
             f"{target}: named to a waiver flag, but nothing is blocking it — "
-            f"either it has no rows newer than this state.db, or the newer "
-            f"rows it does have are already accounted for by a recorded "
-            f"import. That case has its own mechanism and needs no override. "
-            f"Drop the flag for {target!r} and re-run."
+            f"it has no rows newer than this state.db, so there is nothing to "
+            f"waive. That is not a case an override exists for. Drop the flag "
+            f"for {target!r} and re-run."
         )
     return refused, waived
 

--- a/tests/develop/test_migrate_channel_events_replay.py
+++ b/tests/develop/test_migrate_channel_events_replay.py
@@ -42,7 +42,13 @@ import pytest
 from scitex_agent_container._state.state_db_channel_store import (
     reset_channel_connection,
 )
-from tests.develop._channel_migration_kit import event_row, legacy_db, query, run
+from tests.develop._channel_migration_kit import (
+    event_row,
+    execute,
+    legacy_db,
+    query,
+    run,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -185,7 +191,7 @@ def test_that_refusal_says_the_case_has_its_own_mechanism(
     # Act
     run(earlier, "--commit", "--accept-post-cutover-replay", "lead")
     # Assert
-    assert "needs no override" in capsys.readouterr().out
+    assert "nothing to waive" in capsys.readouterr().out
 
 
 def test_the_waiver_is_per_target_and_does_not_leak(
@@ -247,3 +253,116 @@ def test_the_remedy_text_no_longer_promises_that_stopping_clears_it(
     run(later, "--commit")
     # Assert
     assert "STOPPING THE DAEMON WILL NOT CLEAR THIS" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# MOOT IS NOT UNNECESSARY.
+#
+# Measured 2026-08-29, re-running the exact command that had just completed
+# compute-03's import against merged develop:
+#
+#   --commit --db-path <compute-03> --accept-post-cutover-replay scitex-agent-container
+#     REFUSED ... named to a waiver flag, but nothing is blocking it   exit 1
+#   --commit --db-path <compute-03>
+#     exit 0, 19/19 targets MATCHES SQLite, nothing moved
+#
+# The refusal was literally true -- after a successful import nothing IS
+# blocking the target -- and it still broke the script's own RE-RUNNING IS
+# SAFE contract. exit 1 on an already-correct state is indistinguishable from
+# real failure to a retry wrapper, a cron, or an operator following a runbook.
+#
+# The cause was one line's position: `unnecessary.discard(target)` sat below
+# both early-continues, so an already-imported target never left the set.
+# ---------------------------------------------------------------------------
+
+
+def test_re_running_a_successful_import_with_its_flag_is_a_no_op(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """THE REGRESSION. The documented command must stay re-runnable."""
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Act
+    rc = run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert
+    assert rc == 0
+
+
+def test_that_re_run_moves_nothing(tmp_path: Path, pg_schema: str) -> None:
+    """Idempotent in the rows too, not merely in the exit code."""
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Act
+    run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert
+    assert query(
+        "SELECT id FROM sac_channel_events WHERE target = %s ORDER BY id",
+        ("lead",),
+    ) == [(1,), (2,), (3,), (4,)]
+
+
+def test_that_re_run_says_the_flag_was_moot(
+    tmp_path: Path, pg_schema: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Silently accepting it would teach the operator the flag is always fine.
+
+    Saying "already imported, the flag did nothing" is what keeps the next
+    person from concluding the waiver is a harmless thing to leave on.
+    """
+    # Arrange
+    _earlier, later = _blocked(tmp_path)
+    run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    capsys.readouterr()
+    # Act
+    run(later, "--commit", "--accept-post-cutover-replay", "lead")
+    # Assert
+    assert "ALREADY IMPORTED" in capsys.readouterr().out
+
+
+def _overlapping_unattributed(tmp_path: Path) -> tuple[Path, Path]:
+    """An earlier host that OVERLAPS the later one, with its ledger removed.
+
+    The earlier host's 9.0 row postdates the later host's newest (3.0), so it
+    blocks; deleting the ledger entry makes it unattributed, which is the
+    state a store imported before provenance existed is in. Without the
+    overlap there is nothing to waive and the FIRST run refuses too — which
+    is what my initial version of this test got wrong.
+    """
+    earlier = legacy_db(
+        tmp_path / "host-a",
+        [event_row("lead", "a-1", 1.0), event_row("lead", "a-late", 9.0)],
+    )
+    later = _later_host(tmp_path)
+    run(earlier, "--commit")
+    execute("DELETE FROM sac_channel_import WHERE target = %s", ("lead",))
+    return earlier, later
+
+
+def test_the_imported_history_waiver_is_needed_first(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """CONTROL for the test below: without the flag this really is blocked.
+
+    A re-run test proves nothing if the first run never needed the flag.
+    """
+    # Arrange
+    _earlier, later = _overlapping_unattributed(tmp_path)
+    # Act
+    rc = run(later, "--commit")
+    # Assert
+    assert rc == 1
+
+
+def test_the_same_holds_for_the_imported_history_waiver(
+    tmp_path: Path, pg_schema: str
+) -> None:
+    """Both flags share the code path, so both share the contract."""
+    # Arrange
+    _earlier, later = _overlapping_unattributed(tmp_path)
+    run(later, "--commit", "--accept-imported-history", "lead")
+    # Act
+    rc = run(later, "--commit", "--accept-imported-history", "lead")
+    # Assert
+    assert rc == 0


### PR DESCRIPTION
The last thread from the `channel_events` migration, and it is one I introduced in #1265.

## The defect

Re-running the exact command that had just completed compute-03's import — against merged `ef3151a3`, same file, same store, seconds apart:

```
--commit --db-path <compute-03> --accept-post-cutover-replay scitex-agent-container
    REFUSED ... named to a waiver flag, but nothing is blocking it        exit 1

--commit --db-path <compute-03>
    exit 0, 19/19 targets MATCHES SQLite, nothing moved
```

The refusal is **literally true** — after a successful import nothing *is* blocking that target — and it was what the operator's condition asked for: a waiver that cannot quietly become a second "proceed anyway" habit. It still contradicts the script's own module docstring, which says **RE-RUNNING IS SAFE**, and on which the provenance backfill depends.

`exit 1` on an already-correct state is indistinguishable from real failure to a retry wrapper, a cron, or an operator following a runbook. It cost nothing this time only because I predicted it from the code before running and read the message rather than the exit code.

## Moot is not unnecessary

| case | meaning | now |
|---|---|---|
| **moot** | the target is ALREADY IMPORTED; the waiver did nothing because the work is done | a NOTE, no-op, **exit 0** |
| **unnecessary** | the target was never blocked at all — no rows newer than this `state.db`, nothing to waive | **still REFUSED** |

The second is the habit-forming case the two-flag design exists to prevent, and it keeps its teeth. Only the first changes.

Cause was one line's position: `unnecessary.discard(target)` sat below both early-`continue`s, so an already-imported target never left the set. Applies to **both** waivers — they share the code path, so they share the contract.

## Evidence

**Red first:** 16 collected, **4 failed / 12 passed** against merged `ef3151a3` — the two new re-run assertions, the reworded never-blocked message, and the imported-history re-run.

**Green:** whole `tests/develop` slice — **224 passed, 1 skipped** (pre-existing, no `_skills/`). Ruff clean. Both files well under the 512-line cap.

## Two corrections to my own work, found while writing this

**I reworded a message my own test pinned.** Splitting the refusal into moot/unnecessary changed the never-blocked wording, and `test_that_refusal_says_the_case_has_its_own_mechanism` failed on the old phrase. I re-pointed it at the *reason* (`nothing to waive`) rather than restoring the old words, since the message legitimately changed — but flagging it, because "update the assertion to match new output" is exactly the move that hides a regression when it is done carelessly.

**My first version of the imported-history re-run test was never blocked in the first place.** The earlier host's rows were all *older* than the later host's, so there was nothing to waive and the FIRST run refused too — a re-run test stacked on top of that proves nothing. Rebuilt on an overlapping fixture (earlier host's `9.0` row postdates the later host's newest) and added `test_the_imported_history_waiver_is_needed_first` as an explicit control asserting the setup really is blocked without the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCMkub2ZBiL4huQUxMDDb
