### PR TITLE
feat(migrate): the inbound_dispatches migration that was never written, and a scope for shard sweeps

### DIFF
--- a/scripts/migrate_dispatches_to_postgres.py
+++ b/scripts/migrate_dispatches_to_postgres.py
@@ -12,15 +12,50 @@ cutover that silently starts from empty gives up both.
 ====================================================
 The store identifies a row by ``(agent, dispatch_id)``. SQLite had no
 ``agent`` column: the FILE was the scope, so which agent a row belonged to
-was never recorded. There is no way to recover it, and the plausible guess --
-``from_agent`` -- is wrong often enough to matter, because ``from_agent`` is
-who SENT the dispatch, not whose ledger it was written into. Inventing a
-scope would fabricate exactly the fact the migration cannot know.
+was never recorded. There is no way to recover it FROM THE MAIN DATABASE,
+and the plausible guess -- ``from_agent`` -- is wrong often enough to
+matter, because ``from_agent`` is who SENT the dispatch, not whose ledger it
+was written into. Inventing a scope would fabricate exactly the fact the
+migration cannot know.
 
 The empty string is not a workaround, it is the value the code already uses:
 ``record_dispatch`` writes ``"agent": agent or ""``, and ``find_dispatch``
 falls back to scanning every row when it has no agent to key on. So carried
 rows are found by dispatch_id, which is what the old SQLite lookup did.
+
+...BUT A SHARD KNOWS ITS AGENT, AND ``--agent`` IS HOW YOU SAY SO
+=================================================================
+The paragraph above was written about ``~/.scitex/agent-container/runtime/
+state.db`` and is still true of it. It is NOT true of the per-agent overlay
+shards, which sac keeps one directory down as
+``~/.scitex/agent-container/runtime/<agent>/state.db``. Those were never
+swept by any of these migrations, and for a shard the fact the main
+database lost is right there in the path: the FILE was the scope, and the
+file is named after the agent.
+
+So ``--agent`` supplies it. The default is ``""`` -- byte-identical to the
+behaviour above -- so every invocation written before this flag existed
+means exactly what it meant then::
+
+    # the main database, unchanged
+    python3 scripts/migrate_dispatches_to_postgres.py --db-path ~/.scitex/agent-container/runtime/state.db
+
+    # the shards, each carrying its own scope
+    for db in ~/.scitex/agent-container/runtime/*/state.db; do
+        python3 scripts/migrate_dispatches_to_postgres.py \
+            --db-path "$db" --agent "$(basename "$(dirname "$db")")"
+    done
+
+THE SCOPE IS PRINTED ON EVERY RUN, dry or not, because ``agent`` is an
+IMMUTABLE IDENTITY field: a row written under the wrong scope is a
+different record forever, and cannot be re-scoped in place. Reading one
+line of the dry run is the cheap way to catch a forgotten flag; there is no
+cheap way to catch it afterwards.
+
+There is deliberately no path-sniffing that infers the agent from
+``--db-path``. A guess that is usually right is the worst kind here: the
+one time the layout differs it would stamp a plausible wrong scope, and the
+operator would have no reason to look.
 
 RUN IT ON THE HOST, NOT IN A CONTAINER
 ======================================
@@ -46,6 +81,7 @@ import argparse
 import sqlite3
 import sys
 from pathlib import Path
+from typing import Any, Mapping
 
 TABLE = "dispatches"
 COLUMNS = (
@@ -86,8 +122,37 @@ def read_rows(db_path: Path) -> list[dict]:
         conn.close()
 
 
-def migrate(rows: list[dict], commit: bool) -> int:
-    """Write through the production store. Returns rows written, or -1."""
+def _record(row: Mapping[str, Any], agent: str) -> dict:
+    """One SQLite row as the store's record, scoped to ``agent``.
+
+    Extracted from :func:`migrate` when ``--agent`` arrived, so the one
+    decision this script makes that a caller can get wrong -- WHICH SCOPE
+    the rows are stamped with -- is a pure function that can be asserted on
+    without a PostgreSQL server.
+
+    ``agent`` is passed in rather than defaulted here: the empty string is a
+    real choice about the main database (see the module docstring), not an
+    absence, and a default would let a caller forget to make it.
+    """
+    return {
+        "agent": agent,
+        "dispatch_id": row["dispatch_id"],
+        "from_agent": row["from_agent"] or "",
+        "to_agent": row["to_agent"] or "",
+        "conversation_id": row["conversation_id"] or "",
+        "text_summary": row["text_summary"] or "",
+        "status": row["status"] or "",
+        "ts": float(row["ts"]),
+    }
+
+
+def migrate(rows: list[dict], commit: bool, agent: str = "") -> int:
+    """Write through the production store. Returns rows written, or -1.
+
+    ``agent`` defaults to ``""`` -- the scope this script has always
+    written, and the only honest one for the main database. A shard sweep
+    passes the directory name instead; see the module docstring.
+    """
     print(f"{TABLE}: {len(rows)} row(s)")
     if not rows or not commit:
         # scitex-dev is imported only on the WRITE path, so "what would move?"
@@ -107,18 +172,7 @@ def migrate(rows: list[dict], commit: bool) -> int:
     already = 0
     try:
         for row in rows:
-            values = {
-                # See the module docstring: the scope was never recorded, and
-                # `record_dispatch` writes this same empty string.
-                "agent": "",
-                "dispatch_id": row["dispatch_id"],
-                "from_agent": row["from_agent"] or "",
-                "to_agent": row["to_agent"] or "",
-                "conversation_id": row["conversation_id"] or "",
-                "text_summary": row["text_summary"] or "",
-                "status": row["status"] or "",
-                "ts": float(row["ts"]),
-            }
+            values = _record(row, agent)
             key = {k: values[k] for k in IDENTITY_FIELDS}
             if store.get(key, include_hidden=True) is not None:
                 already += 1
@@ -168,14 +222,39 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="actually write; without it this is a dry run that touches nothing",
     )
+    parser.add_argument(
+        "--agent",
+        default="",
+        help=(
+            "scope to stamp on every carried row (default: '', the "
+            "unscoped value the main state.db has always been migrated "
+            "with). Pass the agent name when reading a per-agent shard at "
+            "runtime/<agent>/state.db, where the file name IS the scope the "
+            "table never recorded. It is an IMMUTABLE identity field: a row "
+            "written under the wrong scope cannot be re-scoped."
+        ),
+    )
     args = parser.parse_args(argv)
 
     db_path = args.db_path or default_db_path()
     print(f"source: {db_path}{'' if db_path.is_file() else '  (ABSENT)'}")
     print(f"mode:   {'COMMIT' if args.commit else 'DRY RUN'}")
+    # Printed on EVERY run, dry included, and before anything is read.
+    # ``agent`` is an immutable identity field, so this is the last cheap
+    # moment to notice a forgotten (or a mistaken) --agent.
+    if args.agent:
+        print(
+            f"scope:  agent={args.agent!r} — every carried row is stamped "
+            f"with it (immutable; cannot be re-scoped afterwards)"
+        )
+    else:
+        print(
+            "scope:  agent='' — UNSCOPED, the main state.db's only honest "
+            "value. For a runtime/<agent>/state.db shard, pass --agent."
+        )
 
     rows = read_rows(db_path)
-    if migrate(rows, args.commit) < 0:
+    if migrate(rows, args.commit, agent=args.agent) < 0:
         print("FAILED — the table did not verify. SQLite left untouched.")
         return 1
     if not args.commit:

--- a/scripts/migrate_inbound_dispatches_to_postgres.py
+++ b/scripts/migrate_inbound_dispatches_to_postgres.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""One-shot: copy the SQLite ``inbound_dispatches`` ledger into PostgreSQL.
+
+THE MIGRATION THAT WAS NEVER WRITTEN
+====================================
+:mod:`_state.inbound_ledger` was cut over to PostgreSQL by #1169 on
+2026-08-20. Every other table that moved got a
+``scripts/migrate_*_to_postgres.py`` companion — thirteen of them by
+2026-08-29 — and this one did not. The code stopped reading SQLite and
+nothing carried the rows across, so they have been sitting in a file
+nothing opens since the cutover. Measured fleet-wide 2026-08-29: 5,200+
+rows, of which 133 are still ``pending`` or ``reporting``.
+
+Those 133 are the reason this is not merely a history-preservation
+exercise. A ``pending`` row is an inbound dispatch whose requester is still
+owed a completion report; :func:`claim_oldest_pending` is the only thing
+that can discharge it, and it reads PostgreSQL now. Until the row is here,
+that debt is invisible to the code that exists to pay it.
+
+IT SWEEPS ONE FILE. THE SHARDS ARE FILES TOO.
+=============================================
+The sibling migrations were all run against the MAIN host database,
+``~/.scitex/agent-container/runtime/state.db``. sac also gives each agent
+its own overlay shard, and a shard is a whole separate SQLite file with the
+same tables in it. Those were never swept: measured on scitex-compute-04
+2026-08-29, 1,908 dispatch rows sit in shards and are absent from
+PostgreSQL. (That count was taken across the dispatch ledgers rather than
+per table, so read it as the size of the shard blind spot, not as this
+table's share of it — which is a number this script's own dry run is the
+right instrument for.)
+
+There is no ``--all-shards`` flag here on purpose. ``--db-path`` already
+names one file, the run is idempotent, and a shell loop is a thing an
+operator can read, interrupt and re-run::
+
+    for db in ~/.scitex/agent-container/runtime/*/state.db; do
+        python3 scripts/migrate_inbound_dispatches_to_postgres.py --db-path "$db"
+    done
+
+(dry run first — drop nothing, add ``--commit`` only once the listing above
+looks right). A flag that walked the tree itself would decide the glob for
+the operator and hide which file each row came from, which is the one fact
+they need when a row fails.
+
+NO ``--agent`` FLAG, AND THAT IS THE DIFFERENCE FROM THE SIBLING
+================================================================
+``migrate_dispatches_to_postgres.py`` — the OUTBOUND ledger — has to stamp
+``agent=""`` on every row and says so at length: its SQLite table had no
+``agent`` column, the FILE was the scope, and the fact is unrecoverable
+from the main database. It grew an ``--agent`` option so a shard sweep can
+supply the scope the file name knows and the row does not.
+
+This table is the other case. ``inbound_dispatches.agent`` is ``TEXT NOT
+NULL`` and always was; :func:`record_inbound` refuses an empty one. So the
+scope is IN THE ROW, on the main database and in every shard alike, and it
+is carried verbatim. An ``--agent`` flag here could only mean "overwrite
+the recorded owner", which would fabricate exactly the fact this table did
+not lose.
+
+A STATUS DISAGREEMENT IS NOT A COLLISION
+========================================
+Several of these migrations pass ``collides_with`` and refuse when the
+store already holds a record with different values. This one does NOT, and
+the difference is real rather than an omission.
+
+``status`` is the field whose entire purpose is to move: pending ->
+reporting -> reported/failed, written by a live Stop hook. A row that reads
+``pending`` in SQLite and ``reported`` in the store is not two hosts
+disagreeing about a fact — it is one row, correctly ahead of the file. So
+the already-present record is LEFT ALONE (``NEW_RECORD``, never
+``ANY_REVISION``, which the library owns), exactly as the outbound sibling
+argues: "re-running with ANY_REVISION would push a delivered dispatch back
+to whatever SQLite last saw."
+
+``reporting`` IS CARRIED AS ``reporting``, NOT REWOUND TO ``pending``
+====================================================================
+Tempting, because a ``reporting`` row is stuck: :func:`claim_oldest_pending`
+only ever claims ``pending``, so a row abandoned mid-report will never be
+claimed again and its requester never hears back. Rewinding it would look
+like a repair.
+
+It is not one. ``reporting`` means a Stop hook CLAIMED the row and then
+died — before pushing the completion, or after pushing it and before
+settling. The two are indistinguishable from here, and rewinding gambles a
+DOUBLE report against a missing one. A migration is the wrong place to take
+that bet: it is a copy, and the operator who decides to re-arm those rows
+should do it deliberately, against a store where they can see them. So they
+move verbatim, and the dry run COUNTS them so the decision is at least
+visible.
+
+``reported_ts`` IS OMITTED WHEN THE ROW NEVER SETTLED
+=====================================================
+``NULL`` in SQLite, absent in the record. The schema makes it
+``required=False`` for the reason its own docstring gives: "a row that has
+not settled has no settle time, and inventing one would make 'never
+reported' indistinguishable from 'reported at epoch'."
+
+DUPLICATE IDENTITIES COLLAPSE, AND ARE COUNTED
+==============================================
+The store's identity is ``(agent, from_agent, dispatch_id, ts)``. SQLite's
+was an ``AUTOINCREMENT`` id, so two wakes for the same agent from the same
+peer, with no dispatch id, in the same float instant were FREE there and
+are ONE record here — which is why :func:`record_inbound` now advances
+``ts`` by a microsecond on collision. Rows already in the file predate that
+retry, so the collapse is reported rather than discovered as an
+unexplained shortfall in the verify line.
+
+VERIFICATION COUNTS THIS RUN'S ROWS, NOT THE STORE'S
+====================================================
+``_migrate_lib`` compares ``verify()`` against the number of rows read, so
+a verifier returning "how many records does the store hold" is vacuously
+true the moment anything else has migrated — and this script is designed to
+be run once per shard into ONE host store, so from the second file onward
+a global count would be green no matter what happened. The bug was found
+during the ``comms_nodes`` rollout and re-stated by ``lineage`` and
+``instances``; it applies here with more force, not less.
+
+RUN IT ON THE HOST, NOT IN A CONTAINER
+======================================
+``_migrate_lib.default_db_path`` reads ``SCITEX_AGENT_CONTAINER_STATE_DB``
+first, which inside a container names THAT CONTAINER'S OWN SHARD. A
+container run would therefore migrate one small file, faithfully, and
+report success — the shape that made the diary migration look finished for
+three days.
+
+A DRY RUN IS THE DEFAULT. ``--commit`` is the whole opt-in. Nothing is
+deleted from SQLite; the old table stays as a fallback.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+# ...and this script's OWN directory, which a direct ``python scripts/x.py``
+# supplies for free and an ``importlib.util.spec_from_file_location`` load
+# does not. The develop-tier test that pins "a bare invocation writes
+# nothing" loads these scripts the second way.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _migrate_lib import SqliteSource, run_migration  # noqa: E402
+
+from scitex_agent_container._state.inbound_ledger import (  # noqa: E402
+    IDENTITY_FIELDS,
+    STATUS_PENDING,
+    STATUS_REPORTING,
+    STORE_NAME,
+    VALID_STATUSES,
+    open_inbound_store,
+)
+
+#: The legacy SQLite table. Its DDL, before #1169 deleted it::
+#:
+#:     id           INTEGER PRIMARY KEY AUTOINCREMENT
+#:     agent        TEXT NOT NULL
+#:     from_agent   TEXT NOT NULL
+#:     dispatch_id  TEXT
+#:     status       TEXT NOT NULL DEFAULT 'pending'
+#:     ts           REAL NOT NULL
+#:     reported_ts  REAL
+TABLE = "inbound_dispatches"
+
+#: The two statuses that mean the dispatch is still owed a report. Named
+#: rather than spelled inline: the dry-run listing, the summary and the
+#: reader all have to agree on what "unfinished" means.
+UNFINISHED = (STATUS_PENDING, STATUS_REPORTING)
+
+SOURCE = SqliteSource(
+    table=TABLE,
+    # ``id`` is SELECTed but never carried: the PostgreSQL row is these
+    # columns minus the surrogate. It is here so a failure line can name
+    # WHICH SQLite row failed, which is the one thing an operator needs to
+    # go back to the file with.
+    columns=("id", "agent", "from_agent", "dispatch_id", "status", "ts", "reported_ts"),
+    # ``ts`` rather than rowid: FIFO by ``ts`` is the order
+    # ``claim_oldest_pending`` reads this ledger in, so it is the order the
+    # dry-run listing should be read in too. ``rowid`` rather than ``id``
+    # for the tiebreak — identical here, and it survives a host whose table
+    # is narrower than this column list.
+    order_by="ts ASC, rowid ASC",
+)
+
+
+def _as_float(value: Any) -> "float | None":
+    """``float(value)``, or ``None`` when it is not a number.
+
+    NEVER RAISES, and that is a requirement rather than defensiveness:
+    ``_migrate_lib.migrate_rows`` calls ``to_record`` OUTSIDE its per-row
+    ``try``, so an exception raised in the mapping does not fail one row —
+    it aborts the pass and strands every row after it. The library's own
+    docstring makes that promise ("one row's failure never aborts the
+    pass"), and keeping it is the consumer's job.
+
+    ``bool`` is excluded because ``float(True)`` is ``1.0``, which would
+    turn a nonsense value into a plausible timestamp.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_text(value: Any) -> "str | None":
+    """``str(value)``, or ``None`` when the column was NULL/absent.
+
+    ``None`` is propagated rather than stringified: ``str(None)`` is
+    ``"None"``, which the store would accept as a perfectly good agent name.
+    A dropped key fails loudly at the ``put`` instead, naming the row.
+    """
+    return None if value is None else str(value)
+
+
+def _record(row: Mapping[str, Any]) -> dict[str, Any]:
+    """One SQLite row as the store's record.
+
+    ``None`` values are DROPPED. For the required fields (``agent``,
+    ``from_agent``, ``ts``, ``status``) that turns a NULL or an absent
+    column into a loud per-row ``put`` failure that names the row, rather
+    than a silently plausible value. For ``reported_ts`` it is the correct
+    representation of "never settled" — see the module docstring.
+
+    ``dispatch_id`` is the exception: NULL becomes ``""``, because the
+    store's identity fields must be present and ``inbound_ledger`` already
+    rules that ``""`` is how "this wake carried no dispatch id" is spelled.
+    """
+    values: dict[str, Any] = {
+        "agent": _as_text(row.get("agent")),
+        "from_agent": _as_text(row.get("from_agent")),
+        "dispatch_id": _as_text(row.get("dispatch_id")) or "",
+        "ts": _as_float(row.get("ts")),
+        "status": _as_text(row.get("status")),
+        "reported_ts": _as_float(row.get("reported_ts")),
+    }
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def _key(record: Mapping[str, Any]) -> dict[str, Any]:
+    """The identity mapping. ``.get`` so a defective record cannot raise here.
+
+    Same reason as :func:`_as_float`: ``key_of`` is called outside the
+    library's per-row ``try``.
+    """
+    return {field: record.get(field) for field in IDENTITY_FIELDS}
+
+
+def _identity(record: Mapping[str, Any]) -> tuple:
+    """The identity as a HASHABLE tuple, for set membership in the verify."""
+    return tuple(record.get(field) for field in IDENTITY_FIELDS)
+
+
+def _describe(row: Mapping[str, Any]) -> str:
+    """One dry-run line. Leads with whether the dispatch still owes a report.
+
+    An ``UNKNOWN!`` marker is not decoration: ``status`` is free text in the
+    store, so a value outside :data:`VALID_STATUSES` would migrate happily
+    and then match no reader's filter. Better seen in the dry run.
+    """
+    status = str(row.get("status"))
+    if status in UNFINISHED:
+        mark = "UNFINISHED"
+    elif status in VALID_STATUSES:
+        mark = "settled   "
+    else:
+        mark = "UNKNOWN!  "
+    return (
+        f"{mark} {status:<9} ts={row.get('ts')}  {row.get('agent')} "
+        f"<- {row.get('from_agent')}  "
+        f"dispatch_id={row.get('dispatch_id') or '-'}  sqlite_id={row.get('id')}"
+    )
+
+
+def _summarise(rows: Iterable[Mapping[str, Any]], log) -> None:
+    """Report the facts about the rows AS A SET, which no per-row line shows.
+
+    Emitted from the source read because that is where ``_migrate_lib``
+    already reports source-shaped facts ("no such file", "columns absent",
+    "0 rows"). Each line carries its own count so it reads correctly
+    wherever the library places its own row-count line relative to these.
+    """
+    rows = list(rows)
+    if not rows:
+        return
+    counts: dict[str, int] = {}
+    for row in rows:
+        status = str(row.get("status"))
+        counts[status] = counts.get(status, 0) + 1
+    breakdown = "  ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    log(f"  status breakdown of the {len(rows)} row(s) read: {breakdown}")
+
+    unfinished = sum(count for status, count in counts.items() if status in UNFINISHED)
+    if unfinished:
+        log(
+            f"  UNFINISHED: {unfinished} of them are {'/'.join(UNFINISHED)} — "
+            f"each is an inbound dispatch whose requester is still owed a "
+            f"completion report, and only PostgreSQL is read for those now. "
+            f"They move VERBATIM: a 'reporting' row is NOT rewound to "
+            f"'pending' (see the module docstring — that would gamble a "
+            f"double report against a missing one)."
+        )
+
+    identities = [_identity(_record(row)) for row in rows]
+    collapsed = len(identities) - len(set(identities))
+    if collapsed:
+        log(
+            f"  {collapsed} row(s) share an identity with another row in this "
+            f"file: SQLite kept them apart with its AUTOINCREMENT id, and the "
+            f"store's identity is {IDENTITY_FIELDS}. They collapse into one "
+            f"record each. Counted here so the verify line is not read as a "
+            f"shortfall."
+        )
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    """Read one SQLite file, (maybe) write, verify THIS RUN's rows.
+
+    No ``collides_with``: a status disagreement is the store being correctly
+    ahead of the file, not two writers disagreeing (module docstring).
+
+    No ``should_hide``: this table has no tombstone column. A ``reported``
+    row is settled history, not a withdrawal, and hiding it would make it
+    read as absent to ``list_inbound``.
+
+    No ``actor``: the library passes it only to ``Store.hide``, which is
+    never reached here, and ``open_inbound_store`` already stamps the
+    store's declared single writer on every put it makes.
+    """
+    # Captured by the source below and read by the verify. A local rather
+    # than a module global so a second call to ``main`` in one process — a
+    # test, a wrapper, an operator's REPL — cannot verify against the
+    # previous run's rows.
+    captured: list[Mapping[str, Any]] = []
+
+    class _CapturingSource(SqliteSource):
+        """The library's reader, plus "remember what was read" and a summary.
+
+        ``run_migration`` owns the read and hands ``verify`` nothing, so
+        this is the seam through which the verifier learns which rows the
+        run is responsible for. Same shape as the ``lineage`` migration.
+        """
+
+        def read(self, db_path: Path, *, log: Any = print) -> list[dict]:
+            rows = super().read(db_path, log=log)
+            captured.clear()
+            captured.extend(rows)
+            _summarise(rows, log)
+            return rows
+
+    source = _CapturingSource(
+        table=SOURCE.table, columns=SOURCE.columns, order_by=SOURCE.order_by
+    )
+
+    def _verify() -> int:
+        """How many of THIS run's rows the production reader can see.
+
+        ``store.rows()`` is the same scan ``claim_oldest_pending`` and
+        ``list_inbound`` perform, so a record the store accepted but cannot
+        serve counts as absent — which is the whole reason verification
+        reads back rather than trusting the write count.
+
+        Counted per SOURCE ROW, not per distinct identity: two rows that
+        collapsed into one record are both genuinely represented, and
+        counting identities would report that correct outcome as a
+        shortfall. The collapse itself is reported by :func:`_summarise`.
+        """
+        store = open_inbound_store()
+        try:
+            present = {
+                tuple(row.values.get(field) for field in IDENTITY_FIELDS)
+                for row in store.rows()
+            }
+        finally:
+            store.close()
+        return sum(1 for row in captured if _identity(_record(row)) in present)
+
+    return run_migration(
+        argv=argv,
+        description=__doc__,
+        source=source,
+        store_name=STORE_NAME,
+        open_store=open_inbound_store,
+        to_record=_record,
+        key_of=_key,
+        verify=_verify,
+        describe_row=_describe,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/develop/test_migrate_inbound_dispatches.py
+++ b/tests/develop/test_migrate_inbound_dispatches.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""What the two dispatch migrations STAMP on a row, asserted without a server.
+
+WHY A SEPARATE FILE FROM THE DIRECTIONAL TESTS.
+``test_migrate_scripts_do_not_write_by_default.py`` answers one question for
+every migration script — "does a bare invocation reach the store?" — with an
+unreachable DSN as the instrument. It answers it for
+``migrate_inbound_dispatches_to_postgres.py`` too. It cannot answer THIS
+question, because a script that never reaches the store also never reveals
+what it would have written.
+
+The mapping is where both of these scripts can be silently wrong, and the
+two are wrong in OPPOSITE directions, which is the whole reason the pair is
+tested together here:
+
+* ``migrate_dispatches_to_postgres.py`` (OUTBOUND) has no ``agent`` column
+  to read, so it stamps one. Before ``--agent`` existed it could only ever
+  stamp ``""``, which is right for the main ``state.db`` and wrong for a
+  per-agent shard — where the file's own directory name IS the scope.
+* ``migrate_inbound_dispatches_to_postgres.py`` (INBOUND) has an ``agent``
+  column that was ``TEXT NOT NULL`` from the first day, so it must carry
+  what the row says and must NOT grow a flag that overrides it.
+
+Both stamp an IMMUTABLE identity field. A row written under the wrong scope
+is a different record forever and cannot be re-scoped in place, so "wrong
+here" is not a re-runnable mistake.
+
+NO MOCKS, NO MONKEYPATCH (PA-306 §3). The mapping functions are pure, so
+they are called directly; the tests that need a whole ``main()`` build a real
+SQLite file and read real stdout through ``capsys``, with ``sys.argv`` saved
+and restored by hand. Nothing here reaches PostgreSQL — every one of these
+paths is a dry run, which is precisely the property its sibling file pins.
+
+LIVES IN tests/develop/, NOT the mirror tree — these scripts sit at the repo
+root under ``scripts/`` with no ``src/`` counterpart, so a ``test_*.py``
+under ``tests/<pkg>/`` is an orphan and PS-204 §2 fails the build.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import inspect
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "scripts"
+
+
+def _load(name: str):
+    """Import a repo-root script by path, the way its siblings' tests do."""
+    path = SCRIPTS / name
+    if not path.exists():
+        pytest.skip(f"{name} not present in this checkout")
+    spec = importlib.util.spec_from_file_location(name.replace(".py", ""), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@contextlib.contextmanager
+def _argv(argv: list[str]):
+    """Set ``sys.argv``, then put back exactly what was there. PA-306."""
+    saved = list(sys.argv)
+    sys.argv = argv
+    try:
+        yield
+    finally:
+        sys.argv = saved
+
+
+INBOUND = "migrate_inbound_dispatches_to_postgres.py"
+OUTBOUND = "migrate_dispatches_to_postgres.py"
+
+
+def _inbound_sqlite(tmp_path: Path, rows: list[tuple]) -> Path:
+    """A real ``inbound_dispatches`` table, with the DDL #1169 deleted."""
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """CREATE TABLE inbound_dispatches (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               agent TEXT NOT NULL, from_agent TEXT NOT NULL,
+               dispatch_id TEXT, status TEXT NOT NULL DEFAULT 'pending',
+               ts REAL NOT NULL, reported_ts REAL)"""
+    )
+    conn.executemany(
+        "INSERT INTO inbound_dispatches "
+        "(agent, from_agent, dispatch_id, status, ts, reported_ts) "
+        "VALUES (?,?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _outbound_sqlite(tmp_path: Path) -> Path:
+    """One outbound dispatch, with the columns that script SELECTs."""
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """CREATE TABLE dispatches (
+               dispatch_id TEXT PRIMARY KEY, from_agent TEXT, to_agent TEXT,
+               conversation_id TEXT, text_summary TEXT, status TEXT,
+               ts REAL NOT NULL)"""
+    )
+    conn.execute(
+        "INSERT INTO dispatches VALUES (?,?,?,?,?,?,?)",
+        ("d-9", "alpha", "beta", "c1", "hi", "sent", 900.0),
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# INBOUND — the agent is IN THE ROW, and every field maps or is dropped
+# ---------------------------------------------------------------------------
+
+
+def test_inbound_record_carries_the_agent_recorded_in_the_row():
+    """THE POINT OF THE WHOLE SCRIPT.
+
+    Its outbound sibling writes ``agent=""`` because its table never had the
+    column. This one's did, so a row that says ``beta`` must arrive as
+    ``beta`` — not as ``""``, and not as ``from_agent`` (which is who SENT
+    the wake, not whose ledger it landed in).
+    """
+    # Arrange
+    module = _load(INBOUND)
+    row = {"agent": "beta", "from_agent": "alpha", "dispatch_id": "d-1",
+           "status": "pending", "ts": 1000.5, "reported_ts": None}
+    # Act
+    record = module._record(row)
+    # Assert
+    assert record["agent"] == "beta"
+
+
+def test_inbound_record_maps_a_null_dispatch_id_to_the_empty_string():
+    """``dispatch_id`` is optional at the call site and an IDENTITY field.
+
+    ``inbound_ledger`` already rules that ``""`` is how "this wake carried
+    no dispatch id" is spelled, which is what the SQLite ``NULL`` meant.
+    """
+    # Arrange
+    module = _load(INBOUND)
+    row = {"agent": "beta", "from_agent": "alpha", "dispatch_id": None,
+           "status": "pending", "ts": 1000.5, "reported_ts": None}
+    # Act
+    record = module._record(row)
+    # Assert
+    assert record["dispatch_id"] == ""
+
+
+def test_inbound_record_omits_reported_ts_when_the_row_never_settled():
+    """An unsettled row has no settle time, and inventing one would make
+    "never reported" indistinguishable from "reported at epoch"."""
+    # Arrange
+    module = _load(INBOUND)
+    row = {"agent": "beta", "from_agent": "alpha", "dispatch_id": "d-1",
+           "status": "pending", "ts": 1000.5, "reported_ts": None}
+    # Act
+    record = module._record(row)
+    # Assert
+    assert "reported_ts" not in record
+
+
+def test_inbound_record_carries_reported_ts_when_the_row_did_settle():
+    """NEGATIVE CONTROL for the test above — a mapping that dropped
+    ``reported_ts`` unconditionally would pass it and lose every settle
+    time in the table."""
+    # Arrange
+    module = _load(INBOUND)
+    row = {"agent": "beta", "from_agent": "alpha", "dispatch_id": "d-1",
+           "status": "reported", "ts": 1000.5, "reported_ts": 1001.25}
+    # Act
+    record = module._record(row)
+    # Assert
+    assert record["reported_ts"] == 1001.25
+
+
+def test_inbound_record_carries_a_reporting_status_verbatim():
+    """``reporting`` is NOT rewound to ``pending``.
+
+    Rewinding looks like a repair — ``claim_oldest_pending`` only ever
+    claims ``pending``, so a row abandoned mid-report is stuck — but a
+    ``reporting`` row may already have pushed its completion, so the rewind
+    gambles a DOUBLE report against a missing one. A copy is the wrong place
+    to take that bet.
+    """
+    # Arrange
+    module = _load(INBOUND)
+    row = {"agent": "beta", "from_agent": "alpha", "dispatch_id": "d-1",
+           "status": "reporting", "ts": 1000.5, "reported_ts": None}
+    # Act
+    record = module._record(row)
+    # Assert
+    assert record["status"] == "reporting"
+
+
+def test_inbound_record_never_raises_on_a_row_with_no_columns_at_all():
+    """TOTALITY IS A REQUIREMENT, NOT DEFENSIVENESS.
+
+    ``_migrate_lib.migrate_rows`` calls ``to_record`` OUTSIDE its per-row
+    ``try``, so an exception in the mapping does not fail one row — it
+    aborts the pass and strands every row after it, against the library's
+    own promise that "one row's failure never aborts the pass". A host whose
+    table is narrower than the column list produces exactly this shape,
+    because ``SqliteSource`` intersects the columns with ``PRAGMA
+    table_info`` rather than assuming them present.
+    """
+    # Arrange
+    module = _load(INBOUND)
+    # Act
+    record = module._record({})
+    # Assert
+    assert record == {"dispatch_id": ""}
+
+
+def test_inbound_key_never_raises_on_a_defective_record():
+    """``key_of`` is called outside the same ``try``, so it is total too.
+
+    The defective row then fails LOUDLY at the ``put``, inside the try,
+    named in ``MigrationReport.failed`` — one row, not the pass.
+    """
+    # Arrange
+    module = _load(INBOUND)
+    # Act
+    key = module._key({})
+    # Assert
+    assert key == {"agent": None, "from_agent": None,
+                   "dispatch_id": None, "ts": None}
+
+
+def test_inbound_key_is_exactly_the_stores_identity_fields():
+    """Read from ``inbound_ledger.IDENTITY_FIELDS`` rather than re-typed, so
+    the two cannot drift apart."""
+    # Arrange
+    from scitex_agent_container._state.inbound_ledger import IDENTITY_FIELDS
+    module = _load(INBOUND)
+    record = {"agent": "b", "from_agent": "a", "dispatch_id": "d",
+              "ts": 1.0, "status": "pending"}
+    # Act
+    key = module._key(record)
+    # Assert
+    assert tuple(key) == IDENTITY_FIELDS
+
+
+def test_inbound_source_reads_fifo_by_ts():
+    """``claim_oldest_pending`` reads this ledger FIFO by ``ts``, so the
+    dry-run listing must be readable in the same order."""
+    # Arrange
+    module = _load(INBOUND)
+    # Act
+    order_by = module.SOURCE.order_by
+    # Assert
+    assert order_by.startswith("ts ASC")
+
+
+def test_inbound_source_selects_every_column_the_sqlite_table_had():
+    """A column missing here is a column silently not migrated."""
+    # Arrange
+    module = _load(INBOUND)
+    # Act
+    columns = set(module.SOURCE.columns)
+    # Assert
+    assert columns == {"id", "agent", "from_agent", "dispatch_id",
+                       "status", "ts", "reported_ts"}
+
+
+def test_inbound_describe_marks_an_unfinished_row():
+    """The 133 unfinished dispatches measured fleet-wide are the reason this
+    migration is not merely history preservation — they must stand out in
+    the listing an operator reads before committing."""
+    # Arrange
+    module = _load(INBOUND)
+    row = {"agent": "beta", "from_agent": "alpha", "dispatch_id": "d-1",
+           "status": "pending", "ts": 1000.5, "id": 7}
+    # Act
+    line = module._describe(row)
+    # Assert
+    assert line.startswith("UNFINISHED")
+
+
+def test_inbound_describe_flags_a_status_no_reader_would_match():
+    """``status`` is free TEXT in the store, so a value outside
+    ``VALID_STATUSES`` migrates happily and then matches no reader's
+    filter. Better seen in the dry run than never."""
+    # Arrange
+    module = _load(INBOUND)
+    row = {"agent": "beta", "from_agent": "alpha", "dispatch_id": "d-1",
+           "status": "half-done", "ts": 1000.5, "id": 7}
+    # Act
+    line = module._describe(row)
+    # Assert
+    assert line.startswith("UNKNOWN!")
+
+
+def test_inbound_has_no_agent_flag():
+    """THE DELIBERATE ASYMMETRY WITH THE SIBLING, pinned.
+
+    An ``--agent`` here could only mean "overwrite the owner the row
+    recorded", which fabricates the one fact this table did not lose. The
+    script builds its parser through ``_migrate_lib.add_common_arguments``,
+    so this asserts the shared CLI did not grow the flag either.
+    """
+    # Arrange
+    module = _load(INBOUND)
+    # Act — argparse rejects an unknown option with SystemExit(2)
+    with _argv(["migrate"]):
+        try:
+            module.main(["--agent", "beta"])
+            rejected = False
+        except SystemExit:
+            rejected = True
+    # Assert
+    assert rejected
+
+
+def test_inbound_dry_run_counts_rows_that_collapse_to_one_record(tmp_path, capsys):
+    """SQLite's AUTOINCREMENT kept same-instant wakes apart; the store's
+    identity does not. The collapse is REPORTED so the verify line is not
+    read as an unexplained shortfall."""
+    # Arrange
+    db = _inbound_sqlite(tmp_path, [
+        ("alpha", "lead", None, "pending", 1002.5, None),
+        ("alpha", "lead", None, "pending", 1002.5, None),
+    ])
+    module = _load(INBOUND)
+    # Act
+    with _argv(["migrate"]):
+        module.main(["--db-path", str(db)])
+    # Assert
+    assert "1 row(s) share an identity" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# OUTBOUND — the agent is NOT in the row, so --agent supplies it
+# ---------------------------------------------------------------------------
+
+
+_OUTBOUND_ROW = {
+    "dispatch_id": "d-9", "from_agent": "alpha", "to_agent": "beta",
+    "conversation_id": "c1", "text_summary": "hi", "status": "sent",
+    "ts": 900.0,
+}
+
+
+def test_outbound_record_defaults_to_the_unscoped_empty_string():
+    """BACK-COMPAT, pinned. Every invocation written before ``--agent``
+    existed must keep meaning what it meant: the main ``state.db`` never
+    recorded a scope, and ``record_dispatch`` writes this same ``""``."""
+    # Arrange
+    module = _load(OUTBOUND)
+    # Act
+    default = inspect.signature(module.migrate).parameters["agent"].default
+    # Assert
+    assert default == ""
+
+
+def test_outbound_record_stamps_the_agent_it_is_given():
+    """A shard DOES know its agent — it is the directory the file sits in —
+    so a shard sweep can carry the real scope instead of ``""``."""
+    # Arrange
+    module = _load(OUTBOUND)
+    # Act
+    record = module._record(_OUTBOUND_ROW, "beta")
+    # Assert
+    assert record["agent"] == "beta"
+
+
+def test_outbound_record_leaves_every_other_field_alone():
+    """NEGATIVE CONTROL — ``--agent`` must change the scope and nothing
+    else, so a shard row and a main-db row differ in exactly one field."""
+    # Arrange
+    module = _load(OUTBOUND)
+    # Act
+    scoped = module._record(_OUTBOUND_ROW, "beta")
+    unscoped = module._record(_OUTBOUND_ROW, "")
+    # Assert
+    assert {k: v for k, v in scoped.items() if k != "agent"} == {
+        k: v for k, v in unscoped.items() if k != "agent"
+    }
+
+
+def test_outbound_dry_run_announces_the_unscoped_default(tmp_path, capsys):
+    """``agent`` is IMMUTABLE, so the dry run is the last cheap moment to
+    notice a forgotten ``--agent``. It must SAY which scope it will use."""
+    # Arrange
+    db = _outbound_sqlite(tmp_path)
+    module = _load(OUTBOUND)
+    # Act
+    with _argv(["migrate"]):
+        module.main(["--db-path", str(db)])
+    # Assert
+    assert "agent='' — UNSCOPED" in capsys.readouterr().out
+
+
+def test_outbound_dry_run_announces_the_agent_it_was_given(tmp_path, capsys):
+    """NEGATIVE CONTROL for the line above — a script that printed the
+    unscoped notice unconditionally would pass that test and mislead every
+    shard sweep."""
+    # Arrange
+    db = _outbound_sqlite(tmp_path)
+    module = _load(OUTBOUND)
+    # Act
+    with _argv(["migrate"]):
+        module.main(["--db-path", str(db), "--agent", "beta"])
+    # Assert
+    assert "agent='beta'" in capsys.readouterr().out

--- a/tests/develop/test_migrate_scripts_do_not_write_by_default.py
+++ b/tests/develop/test_migrate_scripts_do_not_write_by_default.py
@@ -487,3 +487,127 @@ def test_instances_dry_run_ignores_a_missing_verify_role(tmp_path, capsys):
     run = _run_instances_no_verify_role(target, capsys, [])
     # Assert
     assert run.rc == 0
+
+
+# ---------------------------------------------------------------------------
+# inbound_dispatches — THE MIGRATION THAT DID NOT EXIST
+#
+# THIS FILE ENUMERATES SCRIPTS BY HAND. There is no discovery loop over
+# ``scripts/migrate_*.py``, so a new migration is covered by this guard only
+# when somebody adds a section like this one. That is the same shape as the
+# gap being closed here: the cutover (#1169, 2026-08-20) landed with no
+# migration script at all, and nothing in the repo enumerated the thirteen
+# tables that had one against the fourteen that had moved.
+#
+# The table matters more than most. Measured fleet-wide 2026-08-29: 5,200+
+# rows stranded in SQLite, 133 of them still ``pending``/``reporting`` — each
+# an inbound dispatch whose requester is still owed a completion report from
+# a ``claim_oldest_pending`` that reads PostgreSQL and nothing else. So a
+# bare invocation that quietly wrote, or a ``--commit`` that quietly could
+# not, are both worse here than a lost observation.
+# ---------------------------------------------------------------------------
+
+
+def _sqlite_with_inbound_dispatches(tmp_path) -> Path:
+    """One settled row and one unfinished one, with the DDL #1169 deleted.
+
+    The ``pending`` row is deliberate: a source query that filtered
+    unfinished dispatches out would still print a plausible dry run, and
+    those are the rows the migration exists for.
+    """
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """CREATE TABLE inbound_dispatches (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               agent TEXT NOT NULL, from_agent TEXT NOT NULL,
+               dispatch_id TEXT, status TEXT NOT NULL DEFAULT 'pending',
+               ts REAL NOT NULL, reported_ts REAL)"""
+    )
+    conn.executemany(
+        "INSERT INTO inbound_dispatches "
+        "(agent, from_agent, dispatch_id, status, ts, reported_ts) "
+        "VALUES (?,?,?,?,?,?)",
+        [
+            ("agent-x", "lead", "d-1", "reported", 1000.5, 1001.0),
+            ("agent-x", "lead", None, "pending", 1002.5, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _run_inbound_dispatches(tmp_path, capsys, extra: list[str]) -> Run:
+    db = _sqlite_with_inbound_dispatches(tmp_path)
+    module = _load("migrate_inbound_dispatches_to_postgres.py")
+    argv = ["migrate", "--db-path", str(db), *extra]
+    rc: int | None = None
+    err: BaseException | None = None
+    with _dead_store_and_argv(argv):
+        try:
+            rc = module.main()
+        except BaseException as exc:
+            err = exc
+    return Run(rc=rc, out=capsys.readouterr().out, error=err)
+
+
+def test_inbound_dispatches_bare_invocation_succeeds(tmp_path, capsys):
+    """A dry run is a success, not an error."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_inbound_dispatches(target, capsys, [])
+    # Assert
+    assert run.rc == 0
+
+
+def test_inbound_dispatches_bare_invocation_announces_a_dry_run(tmp_path, capsys):
+    """It must SAY it wrote nothing, so a reader is not left guessing."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_inbound_dispatches(target, capsys, [])
+    # Assert
+    assert "DRY RUN" in run.out
+
+
+def test_inbound_dispatches_bare_invocation_lists_the_unfinished_row(
+    tmp_path, capsys
+):
+    """UNFINISHED rows MOVE, and are marked.
+
+    A ``pending`` row is a completion report still owed; a source query that
+    carried only settled history would still print a plausible dry run, and
+    the debt would stay invisible to the only code that can discharge it.
+    """
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_inbound_dispatches(target, capsys, [])
+    # Assert
+    assert "UNFINISHED" in run.out
+
+
+def test_inbound_dispatches_bare_invocation_never_reaches_the_store(
+    tmp_path, capsys
+):
+    """The dead DSN is the detector: a writer could not have stayed silent."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_inbound_dispatches(target, capsys, [])
+    # Assert
+    assert run.error is None
+
+
+def test_inbound_dispatches_commit_does_reach_for_the_store(tmp_path, capsys):
+    """NEGATIVE CONTROL — without it the three tests above still pass on a
+    script that can never write anything, which is exactly how the diary
+    migration shipped unable to carry a single row."""
+    # Arrange
+    target = tmp_path
+    # Act
+    run = _run_inbound_dispatches(target, capsys, ["--commit"])
+    # Assert
+    assert run.error is not None


### PR DESCRIPTION
## The gap

`_state/inbound_ledger.py` was cut over to PostgreSQL by #1169 (2026-08-20)
**with no data migration**. Every other table that moved got a
`scripts/migrate_*_to_postgres.py` companion — thirteen of them — and this one
did not, so the rows have been sitting in a file nothing opens. Measured
fleet-wide 2026-08-29: **5,200+ rows, 133 of them still `pending`/`reporting`**.

Those 133 are why this is not history preservation. A `pending` row is an
inbound dispatch whose requester is still owed a completion report, and
`claim_oldest_pending` — the only thing that can discharge it — reads
PostgreSQL and nothing else. Until the row is there, the debt is invisible to
the code that exists to pay it.

## `scripts/migrate_inbound_dispatches_to_postgres.py`

Built on `_migrate_lib`, so dry-run-by-default, `--commit`, `--db-path`, the
read-only source open, `NEW_RECORD` idempotent writes, the `MigrationReport`
and the run-it-on-the-host caveat all come from the library. Four decisions are
its own:

- **A status disagreement is NOT a collision.** `status` is the field whose
  whole purpose is to move, so a row reading `pending` in SQLite and `reported`
  in the store is one row correctly *ahead* of the file, not two writers
  disagreeing. `NEW_RECORD` leaves it alone; no `collides_with` is passed.
- **`reporting` is carried as `reporting`, not rewound to `pending`.** Rewinding
  looks like a repair — `claim_oldest_pending` only claims `pending`, so an
  abandoned row is stuck — but it gambles a *double* report against a missing
  one. The dry run counts them so the choice is at least visible.
- **`reported_ts` is omitted when the row never settled**, per the schema's own
  reasoning: inventing one makes "never reported" indistinguishable from
  "reported at epoch".
- **`verify()` counts THIS RUN's rows** through the production reader, not the
  store's total. It is meant to be run once per shard into ONE host store, so a
  global count would be vacuously green from the second file onward — the bug
  found during the `comms_nodes` rollout.

The mapping is **total by requirement**, not by caution: `_migrate_lib` calls
`to_record` and `key_of` *outside* its per-row `try`, so a raise there does not
fail one row, it aborts the pass. A NULL or absent column drops its key and
fails loudly at the `put`, naming the row.

Dry run against a fixture:

```
source: .../state.db
target: inbound_dispatches
mode:   DRY RUN
  status breakdown of the 5 row(s) read: pending=2  reported=1  reporting=1  weird=1
  UNFINISHED: 3 of them are pending/reporting — ...
  1 row(s) share an identity with another row in this file: ...
inbound_dispatches: 5 row(s)
  settled    reported  ts=1000.5  alpha <- lead  dispatch_id=d-1  sqlite_id=1
  UNFINISHED pending   ts=1002.5  alpha <- lead  dispatch_id=-    sqlite_id=2
  UNKNOWN!   weird     ts=1004.5  beta <- alpha  dispatch_id=d-3  sqlite_id=5

DRY RUN — 5 row(s) would move. Re-run with --commit.
```

## `--agent`, and why it is per-script

All thirteen existing migrators only ever read the main `runtime/state.db`; the
per-agent overlay shards at `runtime/<agent>/state.db` were never swept (1,908
dispatch rows on scitex-compute-04 alone).

This table needs no help there — `inbound_dispatches.agent` is `TEXT NOT NULL`,
so the scope is *in the row*. The **outbound** sibling does: its docstring says
the scope is unrecoverable, which is true of the main database and **false of a
shard**, where the file's directory name IS the scope. So
`migrate_dispatches_to_postgres.py` grows `--agent`, defaulting to `""` so every
invocation written before it means exactly what it meant then, and printing the
scope on **every** run — `agent` is an IMMUTABLE identity field, so a row written
under the wrong scope is a different record forever and cannot be re-scoped in
place. There is deliberately no path-sniffing that infers the agent from
`--db-path`: a guess that is usually right would stamp a plausible wrong scope
the one time the layout differs, and nobody would have a reason to look.

It is **not** in `_migrate_lib`'s shared CLI, whose stated contract is "one
meaning each, spelled the same in every migration". `--agent` cannot honour
that: `dispatches` is the only table whose SQLite side never recorded the scope,
so a shared flag would do nothing on twelve of thirteen scripts — and on a table
that DOES record the agent its only possible meanings are "override the recorded
owner" or "filter", two incompatible readings behind one spelling.

## Tests

`test_migrate_scripts_do_not_write_by_default.py` **enumerates scripts by
hand** — there is no discovery loop — so the new script is added there
explicitly: bare run succeeds, announces a dry run, lists the unfinished row,
never reaches the store; `--commit` **does** reach it (the negative control,
verified raising against `127.0.0.1:59999`).

`test_migrate_inbound_dispatches.py` covers the mapping both scripts can be
silently wrong about, in opposite directions. No mocks, no monkeypatch: real
SQLite files, real stdout, `argv`/env saved and restored by hand.

```
40 passed                                   (the two files)
170 passed, 114 skipped                     (tests/develop + test_dispatch_ledger.py)
```

The 114 skips are the tests that need a live PostgreSQL, which this container
does not have — so the `--commit` path is exercised here only against an
unreachable DSN, never against a real store.

## Not done, on purpose

**Nothing was run with `--commit`.** Building the tool was the task; the fleet
sweep is separate. SQLite is left untouched either way — the old tables remain
as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011i8WxnYcwJTX5eJLoPNQZK
