### PR TITLE
refactor(migrate): decouple the four carriers from state_db.DEFAULT_DB_PATH

### DIFF
--- a/scripts/migrate_auth_state_to_postgres.py
+++ b/scripts/migrate_auth_state_to_postgres.py
@@ -32,6 +32,7 @@ Nothing is deleted from SQLite — the old table stays untouched as a fallback.
 from __future__ import annotations
 
 import argparse
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -56,7 +57,7 @@ def _sqlite_rows(db_path: Path) -> list[dict]:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--db", type=Path, default=None,
-                    help="SQLite state.db to read (default: sac's resolved DEFAULT_DB_PATH)")
+                    help="SQLite state.db to read (default: $SCITEX_AGENT_CONTAINER_STATE_DB, else <runtime>/state.db)")
     ap.add_argument("--commit", action="store_true",
                     help="actually write; without it this is a dry run that writes nothing")
     args = ap.parse_args()
@@ -66,9 +67,14 @@ def main() -> int:
         get_auth_state,
         record_auth_checks,
     )
-    from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+    from scitex_agent_container._runtime_paths import runtime_base_dir
 
-    db_path = args.db or DEFAULT_DB_PATH
+    db_path = args.db or Path(
+            os.environ.get(
+                "SCITEX_AGENT_CONTAINER_STATE_DB",
+                str(runtime_base_dir() / "state.db"),
+            )
+        )
     print(f"source (sqlite)  : {db_path}")
     print(f"target (postgres): {auth_state_store_target().locator}")
 

--- a/scripts/migrate_incarnations_to_postgres.py
+++ b/scripts/migrate_incarnations_to_postgres.py
@@ -42,6 +42,7 @@ as a fallback for a human, untouched.
 from __future__ import annotations
 
 import argparse
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -80,7 +81,7 @@ def main() -> int:
         "--db",
         type=Path,
         default=None,
-        help="SQLite state.db to read (default: sac's resolved DEFAULT_DB_PATH)",
+        help="SQLite state.db to read (default: $SCITEX_AGENT_CONTAINER_STATE_DB, else <runtime>/state.db)",
     )
     # WRITING IS OPT-IN. This script used to write by DEFAULT, with --dry-run
     # as the opt-in — so the bare, obvious invocation was the destructive one.
@@ -106,14 +107,19 @@ def main() -> int:
 
     from scitex_dev.store import ANY_REVISION
 
-    from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+    from scitex_agent_container._runtime_paths import runtime_base_dir
     from scitex_agent_container._state.state_db_incarnations import (
         get_incarnation,
         incarnation_store_target,
         open_incarnation_store,
     )
 
-    db_path = args.db or DEFAULT_DB_PATH
+    db_path = args.db or Path(
+            os.environ.get(
+                "SCITEX_AGENT_CONTAINER_STATE_DB",
+                str(runtime_base_dir() / "state.db"),
+            )
+        )
     print(f"source (sqlite) : {db_path}")
     print(f"target (postgres): {incarnation_store_target().locator}")
 

--- a/scripts/migrate_relocation_to_postgres.py
+++ b/scripts/migrate_relocation_to_postgres.py
@@ -43,6 +43,7 @@ Nothing is deleted from SQLite — the old tables stay untouched as a fallback.
 from __future__ import annotations
 
 import argparse
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -248,13 +249,18 @@ def main() -> int:
         "--db-path",
         type=Path,
         default=None,
-        help="override the SQLite source (defaults to state_db.DEFAULT_DB_PATH)",
+        help="override the SQLite source (default: $SCITEX_AGENT_CONTAINER_STATE_DB, else <runtime>/state.db)",
     )
     args = parser.parse_args()
 
-    from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+    from scitex_agent_container._runtime_paths import runtime_base_dir
 
-    db_path = args.db_path or DEFAULT_DB_PATH
+    db_path = args.db_path or Path(
+            os.environ.get(
+                "SCITEX_AGENT_CONTAINER_STATE_DB",
+                str(runtime_base_dir() / "state.db"),
+            )
+        )
     print(f"source: {db_path}")
     if not Path(db_path).exists():
         print("source does not exist — nothing to migrate")

--- a/scripts/migrate_verdict_delivered_to_postgres.py
+++ b/scripts/migrate_verdict_delivered_to_postgres.py
@@ -115,6 +115,7 @@ success path: a row that cannot be written raises.
 from __future__ import annotations
 
 import argparse
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -152,7 +153,7 @@ def main(argv: list[str] | None = None) -> int:
         "--state-db",
         type=Path,
         default=None,
-        help="SQLite state.db (default: the package's DEFAULT_DB_PATH)",
+        help="SQLite state.db (default: $SCITEX_AGENT_CONTAINER_STATE_DB, else <runtime>/state.db)",
     )
     parser.add_argument(
         "--commit",
@@ -162,9 +163,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.state_db is None:
-        from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+        from scitex_agent_container._runtime_paths import runtime_base_dir
 
-        args.state_db = Path(DEFAULT_DB_PATH)
+        args.state_db = Path(
+            os.environ.get(
+                "SCITEX_AGENT_CONTAINER_STATE_DB",
+                str(runtime_base_dir() / "state.db"),
+            )
+        )
 
     from scitex_agent_container._state.state_db_verdict_dedup import (
         record_verdict_delivered,


### PR DESCRIPTION
**Stage A of the SQLite eradication.** Nothing is deleted; this only removes the four migration scripts' dependency on a symbol a later stage must delete.

## Why this has to be first

`scripts/migrate_*_to_postgres.py` are the tools that still have to carry roughly **16,700 ledger and state rows that exist only in SQLite** — per-agent overlay shards on compute-04/03, plus the whole of laptop-01, which was never migrated at all. Four of them import `DEFAULT_DB_PATH` from `_state.state_db`. Deleting that symbol before the fleet sweep completes would break the very scripts the sweep needs, so the carriers get decoupled first.

## What changed

In each of incarnations / relocation / auth_state / verdict_delivered:

```diff
- from scitex_agent_container._state.state_db import DEFAULT_DB_PATH
+ from scitex_agent_container._runtime_paths import runtime_base_dir

  db_path = args.db or Path(
      os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB",
                     str(runtime_base_dir() / "state.db")))
```

`_runtime_paths` imports only `os` and `pathlib`, so no cycle. Deliberately **not** imported from `_migrate_lib` — these four lack that module's `sys.path` bootstrap and are loaded via `spec_from_file_location`.

## Equivalence proved on both branches

Same script, old vs new, dry run:

| | old | new |
|---|---|---|
| env **set** | `/state/scitex-agent-container/state.db` | `/state/scitex-agent-container/state.db` |
| env **unset** | `~/.scitex/agent-container/runtime/state.db` | `~/.scitex/agent-container/runtime/state.db` |

The unset case is the one that matters: it is the fallback the inlining had to reproduce. Testing only the set case would have exercised `os.environ.get` and never `runtime_base_dir()`.

## Also

Four argparse `help=` strings named `DEFAULT_DB_PATH` as the default; they now name the actual precedence, so no help text survives describing a symbol the file no longer uses.

Module docstrings still discuss `DEFAULT_DB_PATH` by name — left deliberately. The hazard they describe (the path resolves differently in a container than on the host, so run these on the host) is still true and still load-bearing; rewriting them belongs with the stage that deletes the symbol.

## Gate

- `rg` finds **zero** executable `DEFAULT_DB_PATH` references under `scripts/`
- all four compile
- `tests/develop/test_migrate_scripts_do_not_write_by_default.py` — **16 passed**