### PR TITLE
feat(sqlite-out): the OpenAI runner's session memory moves to PostgreSQL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,12 +142,22 @@ slurm = [
 openai = [
     # openai-compat-2: the `openai` harness (spec.harness:
     # openai). Backs `_runners/openai_session.py` (OpenAIAgentsSession — the
-    # concrete HarnessSession over Runner.run_streamed + SQLiteSession)
-    # and the `openai_session` A2A handler/executor. OPTIONAL on purpose:
+    # concrete HarnessSession over Runner.run_streamed) and the
+    # `openai_session` A2A handler/executor. OPTIONAL on purpose:
     # Claude-only deployments must not pull it — every import is lazy and
-    # the handler raises a clear HandlerError when absent. 0.17.4 floor
-    # per the card spec (SQLiteSession + FunctionTool surface stable).
-    "openai-agents>=0.17.4",
+    # the handler raises a clear HandlerError when absent.
+    #
+    # FLOOR RAISED 0.17.4 -> 0.19.0, MEASURED not guessed. Conversation
+    # state moved off the SDK's own SQLite session onto PostgreSQL
+    # (`_runners/_openai_pg_session.py`), and the replacement implements the
+    # SDK's `Session` Protocol through the SDK's OWN settings helpers rather
+    # than a second copy of their precedence rules. Wheels for 0.17.4,
+    # 0.18.0, 0.19.0, 0.20.0, 0.21.0 and 0.22.0 were downloaded and read on
+    # 2026-08-29: `agents/memory/session_settings.py` carries
+    # `resolve_session_limit` in ALL of them and `coerce_session_settings`
+    # only from 0.19.0. Left at 0.17.4 the import would be an ImportError at
+    # the declared minimum — a floor that lies is worse than a high one.
+    "openai-agents>=0.19.0",
 ]
 codex = [
     # Claude Code stays the harness. scitex-genai supplies the local

--- a/src/scitex_agent_container/_runners/_openai_pg_session.py
+++ b/src/scitex_agent_container/_runners/_openai_pg_session.py
@@ -1,0 +1,294 @@
+"""``PostgresAgentSession`` — the ``openai-agents`` ``Session`` on PostgreSQL.
+
+The replacement for the SDK's own file-backed session object, and the last
+piece of sac's SQLite eradication: the runner's conversation memory was the
+only database left that no ``import sqlite3`` scan could see, because the
+import happened inside the vendor package rather than here.
+
+WHAT THE PROTOCOL ACTUALLY IS (read from the installed SDK, not remembered)
+==========================================================================
+``agents.memory.session.Session`` is a ``@runtime_checkable`` Protocol with two
+attributes and four coroutines, measured against openai-agents 0.22.0::
+
+    session_id: str
+    session_settings: SessionSettings | None
+
+    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]
+    async def add_items(self, items: list[TResponseInputItem]) -> None
+    async def pop_item(self) -> TResponseInputItem | None
+    async def clear_session(self) -> None
+
+Three details of the SDK's own call sites are load-bearing and are NOT
+guessable from the signatures:
+
+* ``run_internal/session_persistence.py`` reads settings as
+  ``getattr(session, "session_settings", None) or SessionSettings()`` and then
+  calls ``.resolve(...)`` on the result — so the attribute must be a real
+  ``SessionSettings``, not a dict, or the run raises on an ordinary turn.
+* ``memory/session.py::_session_accepts_wrapper`` INSPECTS the signatures of
+  all four methods and passes a ``wrapper=`` keyword only when EVERY one of
+  them accepts it. Keeping the released signatures keeps us on the legacy
+  shape, which is what the Protocol documents for third-party sessions.
+* ``resolve_session_limit(limit, settings)`` is the SDK's own precedence rule
+  (explicit limit wins, else the settings' limit, else unlimited). Re-deriving
+  it here would be a second copy that drifts, so it is imported.
+
+Everything from ``agents`` is imported INSIDE the methods. The SDK is an
+OPTIONAL extra (``pip install scitex-agent-container[openai]``) and importing
+this module must stay side-effect-free on Claude-only deployments — the same
+contract :mod:`.openai_session` holds.
+
+WHY THE REVISION IS READ BEFORE THE ROW
+=======================================
+Every mutation is a read-modify-write, because ``items`` is one
+LAST_WRITER_WINS JSON list (see :mod:`.._state.openai_session_store` for why
+APPEND cannot express ``pop_item`` / ``clear_session``). The ORDER of the two
+reads decides whether a concurrent turn is caught or silently swallowed:
+
+* ``revision()`` then ``get()`` — a writer landing between them leaves us
+  holding NEWER data with an OLDER revision token, so our ``put`` is REFUSED
+  with ``RevisionMismatchError`` and we retry. Safe.
+* ``get()`` then ``revision()`` — a writer landing between them leaves us
+  holding STALE data with a revision token that already covers the other
+  writer's change, so our ``put`` SUCCEEDS and silently discards their turn.
+
+The second order fails in the direction that loses a conversation without
+raising, which is why the first is written here and stated in prose: it looks
+like an arbitrary swap and is not. This is the same ordering
+``port_allocator_store.try_claim`` depends on for its takeover.
+
+FIVE ATTEMPTS, THEN RAISE
+=========================
+A retry loop bounded at :data:`_MAX_ATTEMPTS`. Losing a race is normal and
+retrying is correct; losing it five times in a row is not a race any more, and
+looping forever would turn a stuck session into a hung turn with no log line.
+The last ``RevisionMismatchError`` is re-raised with its own context, so the
+failure names the record rather than arriving as a timeout somewhere else.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Callable
+
+from .._state.openai_session_store import (
+    items_of,
+    session_key,
+    session_store,
+    session_values,
+)
+
+__all__ = ["PostgresAgentSession", "PostgresSessionConflictError"]
+
+#: Read-modify-write attempts before a concurrent-writer conflict is fatal.
+_MAX_ATTEMPTS = 5
+
+
+class PostgresSessionConflictError(RuntimeError):
+    """A conversation write lost its optimistic lock ``_MAX_ATTEMPTS`` times."""
+
+
+class PostgresAgentSession:
+    """``openai-agents`` conversation memory backed by the fleet's PostgreSQL.
+
+    Structurally satisfies the SDK's ``Session`` Protocol; it deliberately
+    does NOT subclass ``SessionABC``, which the SDK documents as internal and
+    which would make ``agents`` a hard import of this module.
+
+    Args:
+        agent_name: The sac agent that owns the conversation. Half of the
+            store identity — ``session_id`` alone is the CALLER's choice and
+            two agents picking the same one is a naming accident, not a bug
+            anyone would notice.
+        session_id: Logical conversation key. Defaults to ``agent_name``,
+            matching what :class:`~.openai_session.OpenAIAgentsSession` passed
+            to the SDK's own session object.
+        session_settings: ``SessionSettings`` or a plain mapping; coerced
+            LAZILY on first read (see :attr:`session_settings`) so
+            constructing a session never imports the optional SDK.
+    """
+
+    def __init__(
+        self,
+        agent_name: str,
+        *,
+        session_id: str | None = None,
+        session_settings: Any = None,
+    ) -> None:
+        self.agent_name = agent_name
+        self.session_id = session_id or agent_name
+        self._raw_settings = session_settings
+        self._settings: Any = None
+        self._settings_coerced = False
+
+    # -- Session protocol surface ----------------------------------------
+
+    @property
+    def session_settings(self) -> Any:
+        """The SDK's ``SessionSettings``, coerced on FIRST READ and cached.
+
+        A property rather than a plain attribute because the coercion needs
+        ``agents``, and this class must be constructible on a deployment that
+        has never installed it. The SDK reads this attribute during a run
+        (``session_persistence.prepare_input_with_session``), by which point
+        the SDK is necessarily importable.
+
+        ``None`` in, ``None`` out — the SDK's own reader is
+        ``getattr(session, "session_settings", None) or SessionSettings()``,
+        so it supplies the default itself and inventing one here would only
+        add a second place for it to change.
+        """
+        if not self._settings_coerced:
+            if self._raw_settings is None:
+                self._settings = None
+            else:
+                from agents.memory.session_settings import coerce_session_settings
+
+                self._settings = coerce_session_settings(self._raw_settings)
+            self._settings_coerced = True
+        return self._settings
+
+    async def get_items(self, limit: int | None = None) -> list[Any]:
+        """The conversation history, oldest first.
+
+        ``limit`` follows the SDK's own precedence via
+        ``resolve_session_limit``: an explicit value wins, else the session
+        settings' limit, else everything.
+
+        The three limit cases are the file-backed session's, kept
+        deliberately rather than tidied. ``> 0`` returns the LATEST N items in
+        chronological order — the documented contract. ``0`` returns NOTHING
+        and a NEGATIVE value returns EVERYTHING, which reads like a bug and is
+        SQLite's own ``LIMIT`` semantics that the previous implementation
+        explicitly preserved; collapsing them into one "no limit" branch would
+        change what ``get_items(0)`` answers for every existing caller.
+
+        An unknown session answers ``[]``. The Protocol has no
+        "no such session" outcome — see ``items_of``.
+        """
+        from agents.memory.session_settings import resolve_session_limit
+
+        session_limit = resolve_session_limit(limit, self.session_settings)
+        items = await asyncio.to_thread(self._read_items)
+        if session_limit is None or session_limit < 0:
+            return items
+        if session_limit == 0:
+            return []
+        return items[-session_limit:]
+
+    async def add_items(self, items: list[Any]) -> None:
+        """Append ``items`` to the conversation.
+
+        An empty list is a no-op that does NOT touch the store: the SDK calls
+        this after every turn, including turns that produced nothing, and a
+        write per no-op would bump ``updated_at`` and burn a revision for a
+        conversation that did not change.
+        """
+        if not items:
+            return
+        new_items = list(items)
+
+        def _append(current: list[Any]) -> tuple[list[Any], None]:
+            return [*current, *new_items], None
+
+        await asyncio.to_thread(self._mutate, _append)
+
+    async def pop_item(self) -> Any:
+        """Remove and return the newest item, or ``None`` when empty.
+
+        A REMOVAL, and the reason ``items`` cannot be an APPEND-merged
+        collection: the store's merge rules can grow a list and cannot shrink
+        one, so this operation has no representation under APPEND at all.
+        """
+
+        def _pop(current: list[Any]) -> tuple[list[Any], Any]:
+            if not current:
+                return current, None
+            return current[:-1], current[-1]
+
+        return await asyncio.to_thread(self._mutate, _pop)
+
+    async def clear_session(self) -> None:
+        """Drop every item, keeping the record.
+
+        The record survives as an empty conversation rather than being hidden.
+        ``Store.hide`` is the only removal the store offers and a hidden
+        record still OCCUPIES its identity, so hiding here would make the next
+        ``add_items`` re-take a tombstone — the trap
+        ``port_allocator_store`` documents at length. An empty list says the
+        same thing with none of that.
+        """
+
+        def _clear(current: list[Any]) -> tuple[list[Any], None]:
+            return [], None
+
+        await asyncio.to_thread(self._mutate, _clear)
+
+    def close(self) -> None:
+        """Release nothing, on purpose — and say so where a reader will look.
+
+        :meth:`~.openai_session.OpenAIAgentsSession.close` calls ``close()``
+        on whatever session object it holds, because the SDK's file-backed one
+        owned connections that had to be shut. This one holds NO resource of
+        its own: the handle is the per-process cached ``Store``
+        (``_state.openai_session_store.session_store``), shared by every
+        session in the process, and closing it here would break the others and
+        pay a fresh psycopg connect on the next turn.
+        """
+
+    # -- internals -------------------------------------------------------
+
+    def _read_items(self) -> list[Any]:
+        """The stored conversation, as a plain list. Blocking; runs in a thread."""
+        store = session_store()
+        return items_of(store.get(session_key(self.agent_name, self.session_id)))
+
+    def _mutate(self, change: Callable[[list[Any]], "tuple[list[Any], Any]"]) -> Any:
+        """Read-modify-write ``items`` under an optimistic lock.
+
+        ``change`` receives the current list and returns ``(new_list,
+        result)``; ``result`` is handed back to the caller (``pop_item`` needs
+        the removed item, the others need nothing). It must be PURE — it is
+        re-run on every retry.
+
+        The revision is read BEFORE the row; the module docstring carries the
+        measured reason that order is not interchangeable.
+
+        A change that changes NOTHING writes nothing. That is not an
+        optimisation: ``pop_item`` on an unknown session and
+        ``clear_session`` on one would otherwise CREATE an empty record, and
+        the file-backed session they replace ran a ``DELETE`` that matched no
+        rows and left the database untouched. Writing here would invent a
+        conversation out of an operation whose whole meaning is removal.
+        """
+        from scitex_dev.store import NEW_RECORD, RevisionMismatchError
+
+        store = session_store()
+        key = session_key(self.agent_name, self.session_id)
+        last_error: Exception | None = None
+        for _ in range(_MAX_ATTEMPTS):
+            revision = store.revision(key)
+            current = items_of(store.get(key))
+            new_items, result = change(current)
+            if new_items == current:
+                return result
+            expected = NEW_RECORD if revision is None else revision
+            try:
+                store.put(
+                    session_values(
+                        self.agent_name, self.session_id, new_items, time.time()
+                    ),
+                    expected_revision=expected,
+                )
+            except RevisionMismatchError as exc:
+                last_error = exc
+                continue
+            return result
+        raise PostgresSessionConflictError(
+            f"conversation {self.agent_name}/{self.session_id} lost its "
+            f"optimistic lock {_MAX_ATTEMPTS} times running; another writer is "
+            f"holding the session. Last store error: {last_error}"
+        ) from last_error
+
+# EOF

--- a/src/scitex_agent_container/_runners/_openai_session_cli.py
+++ b/src/scitex_agent_container/_runners/_openai_session_cli.py
@@ -18,7 +18,7 @@ the daemon's harness-agnostic drive-until-done loop.
 
 The ONE flag that stays refused is ``--resume-session-id``: the harness
 registry's ``openai-agents`` descriptor declares ``can_resume=False``
-(the ``SQLiteSession`` db persists turns under the agent's own name,
+(the conversation store persists turns under the agent's own name,
 but sac's resume contract — rehydrate a PRIOR conversation from a
 caller-supplied id — is not implemented for this harness). The refusal
 reads the registry rather than hardcoding the answer, so flipping the

--- a/src/scitex_agent_container/_runners/_openai_turn_driver.py
+++ b/src/scitex_agent_container/_runners/_openai_turn_driver.py
@@ -25,7 +25,7 @@ Registry contract (v4 step 4, ``config._harness_registry``): the
 hosts it), ``beat_writer="in-process"`` (the beats below), and
 ``can_resume=False`` — so a ``resume_session_id`` is REFUSED loudly
 here (and earlier, in :mod:`._openai_session_cli`), never silently
-remapped. The ``SQLiteSession`` state db does persist turns across
+remapped. The conversation store DOES persist turns across
 process lifetimes under the agent's own name, but sac's resume
 contract — rehydrate a PRIOR incarnation's conversation from a
 caller-supplied session id — is not implemented for this harness;
@@ -144,7 +144,7 @@ async def run_openai_conversation(
     drains :class:`~._session_inbox.TurnEnvelope` items until a
     :class:`~._session_inbox.ShutdownEnvelope` (or an ``exit_after``
     turn — the one-shot handshake) ends the run. One vendor session is
-    held open for the whole conversation; its ``SQLiteSession`` state db
+    held open for the whole conversation; its PostgreSQL-backed store
     (keyed by the agent's name) carries multi-turn memory.
 
     ``max_restarts`` / ``restart_backoff_s`` are accepted per the

--- a/src/scitex_agent_container/_runners/openai_session.py
+++ b/src/scitex_agent_container/_runners/openai_session.py
@@ -9,9 +9,9 @@ for the shape rationale). Wires:
 * ``Runner.run_streamed()`` → an async generator of
   :class:`~._harness_session.NormalizedEvent`
   (:func:`normalize_stream_event` + :meth:`OpenAIAgentsSession.send`).
-* ``SQLiteSession`` for conversation state (multi-turn memory across
-  :meth:`OpenAIAgentsSession.send` calls; placement via
-  :func:`runtimes._openai_sdk_common.resolve_state_db_path`).
+* :class:`~._openai_pg_session.PostgresAgentSession` for conversation
+  state (multi-turn memory across :meth:`OpenAIAgentsSession.send`
+  calls), held in this host's PostgreSQL rather than a per-agent file.
 * Per-turn spend recording into :mod:`_account.openai_usage`'s ledger
   (best-effort; never fails the turn).
 
@@ -44,10 +44,10 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-from pathlib import Path
 from typing import Any, AsyncIterator, Mapping, Sequence
 
 from ._harness_session import Message, NormalizedEvent, RunResult, ToolSpec
+from ._openai_pg_session import PostgresAgentSession
 # Re-exported so callers have ONE import site for the harness, regardless of
 # which module the transport logic happens to live in.
 from ._openai_mcp import McpConfigError, build_mcp_server
@@ -286,14 +286,14 @@ class OpenAIAgentsSession:
 
     Lifecycle mirrors the Protocol (and the production ``ClaudeSDKClient``
     loop it was modelled on): one :meth:`start` (auth + ``Agent`` +
-    ``SQLiteSession`` construction — no network), N :meth:`send` turns
+    conversation-store construction — no MODEL call), N :meth:`send` turns
     (each one ``Runner.run_streamed`` call, streaming
     :class:`NormalizedEvent`, terminating in ``kind="result"``), then
     :meth:`close`.
 
     Args:
-        agent_name: sac agent identity — names the SDK ``Agent`` and the
-            default state-db file.
+        agent_name: sac agent identity — names the SDK ``Agent`` and one
+            half of the conversation record's store identity.
         model: OpenAI model id. ``None`` → ``SAC_OPENAI_MODEL`` env →
             the SDK's own default.
         instructions: System prompt for the SDK ``Agent`` (``None`` keeps
@@ -317,10 +317,12 @@ class OpenAIAgentsSession:
             the callers that need this (the a2a handler, the runtime) read
             a spec, and handing them a constructor would push SDK imports
             and async connection management into every call site.
-        session_id: Logical conversation key inside the state db.
-            Defaults to ``agent_name``.
-        db_path: SQLite file override (``":memory:"`` for ephemeral
-            state). Default: ``resolve_state_db_path(agent_name)``.
+        session_id: Logical conversation key. Defaults to ``agent_name``;
+            together they identify the row in the ``openai_sessions``
+            store. ``db_path`` IS GONE — it named a per-agent SQLite file
+            and there is no file; state lives in this host's PostgreSQL
+            (:mod:`.._state.openai_session_store`), and tests isolate with
+            the shared ``pg_schema`` fixture rather than an override.
         max_turns: Optional cap forwarded to ``Runner.run_streamed``.
         record_spend: Record per-turn token usage into the
             :mod:`_account.openai_usage` spend ledger (best-effort).
@@ -340,7 +342,6 @@ class OpenAIAgentsSession:
         tools: Sequence[ToolSpec] = (),
         mcp_servers: Mapping[str, Any] | None = None,
         session_id: str | None = None,
-        db_path: str | Path | None = None,
         max_turns: int | None = None,
         record_spend: bool = True,
         tracing: bool = False,
@@ -351,7 +352,6 @@ class OpenAIAgentsSession:
         self.tools = tuple(tools)
         self.mcp_servers = dict(mcp_servers or {})
         self.session_id = session_id or agent_name
-        self.db_path = db_path
         self.max_turns = max_turns
         self.record_spend = record_spend
         self.tracing = tracing
@@ -363,19 +363,20 @@ class OpenAIAgentsSession:
     # -- HarnessSession surface ----------------------------------------
 
     async def start(self) -> None:
-        """Open the session: auth, tool conversion, ``Agent`` + ``SQLiteSession``.
+        """Open the session: auth, tool conversion, ``Agent`` + session store.
 
-        Network-free — the first API call happens on :meth:`send`.
-        Raises :class:`OpenAISessionError` if ``openai-agents`` is not
-        installed, and
-        :class:`~runtimes._openai_sdk_common.OpenAISDKCommonError` if no
-        API key is available.
+        STILL NETWORK-FREE, worth stating because the state moved to
+        PostgreSQL: constructing
+        :class:`~._openai_pg_session.PostgresAgentSession` opens NOTHING, so
+        the first connect of any kind still happens on :meth:`send`. Raises
+        :class:`OpenAISessionError` if ``openai-agents`` is not installed and
+        :class:`~runtimes._openai_sdk_common.OpenAISDKCommonError` if no API
+        key is available.
         """
         agents = _import_agents()
         from ..runtimes._openai_sdk_common import (
             default_openai_model,
             provision_openai_auth,
-            resolve_state_db_path,
         )
 
         provision_openai_auth()
@@ -405,12 +406,9 @@ class OpenAIAgentsSession:
         if model:
             agent_kwargs["model"] = model
         self._agent = agents.Agent(**agent_kwargs)
-        db_path = (
-            self.db_path
-            if self.db_path is not None
-            else resolve_state_db_path(self.agent_name)
+        self._session = PostgresAgentSession(
+            self.agent_name, session_id=self.session_id
         )
-        self._session = agents.SQLiteSession(self.session_id, db_path=str(db_path))
         self._started = True
 
     async def send(self, message: Message) -> AsyncIterator[NormalizedEvent]:
@@ -453,12 +451,13 @@ class OpenAIAgentsSession:
         yield NormalizedEvent(kind="result", result=result, raw=streamed)
 
     async def close(self) -> None:
-        """Tear down the session: MCP connections, then the state db handle.
+        """Tear down the session: MCP connections, then the conversation store.
 
-        Every connected MCP server is cleaned up even if one raises —
-        a stdio server left connected is an orphaned SUBPROCESS, and one
-        failing teardown must not strand the rest. The first error is
-        re-raised after the sweep so the failure is still visible.
+        Every connected MCP server is cleaned up even if one raises — a
+        stdio server left connected is an orphaned SUBPROCESS, and one
+        failing teardown must not strand the rest; the first error is
+        re-raised after the sweep. The duck-typed ``close()`` below is a
+        documented no-op for ``PostgresAgentSession`` (a shared handle).
         """
         servers, self._connected_mcp = self._connected_mcp, []
         first_error: Exception | None = None

--- a/src/scitex_agent_container/_state/openai_session_store.py
+++ b/src/scitex_agent_container/_state/openai_session_store.py
@@ -1,0 +1,299 @@
+"""``openai_sessions`` — the OpenAI runner's conversation state, on PostgreSQL.
+
+The storage adapter behind :mod:`.._runners._openai_pg_session`, split by the
+same RESPONSIBILITY line as :mod:`.port_allocator_store`: this file knows how a
+conversation is STORED, and the runner module knows the ``openai-agents``
+``Session`` protocol it has to satisfy. Nothing here imports ``agents``, so a
+Claude-only deployment can import it without the optional SDK.
+
+WHY THIS EXISTS AT ALL
+======================
+The ``openai-agents`` SDK persists multi-turn memory through a ``Session``
+object, and sac used the SDK's own file-backed one — a real per-agent SQLite
+database under ``~/.scitex/agent-container/runtime/openai-sessions/``. It was
+the LAST SQLite database sac opened, and the only one no ``import sqlite3``
+scan could ever see, because the import happens inside the vendor package.
+That is the whole hole ``tests/develop/test_sqlite_footprint_frozen.py``'s
+vendor gate was written to measure, and closing it is what empties
+``FROZEN_VENDOR_SQLITE``.
+
+THE RUNNER IS LIVE, so this is not a paper migration: handyman-05's spec sets
+``handler: openai_session``, eleven specs name ``openai-agents``, and the
+handymen drive local Qwen models through an OpenAI-compatible gateway. That
+directory held ZERO database files anywhere on the fleet when this was
+written, and that is NOT evidence of disuse — the SDK created the file lazily,
+on the first session write.
+
+``items`` IS LAST_WRITER_WINS, NOT APPEND — AND THAT IS THE LOAD-BEARING CHOICE
+==============================================================================
+A conversation reads like an append-only log, and ``MergeRule.APPEND`` exists,
+so the natural-looking schema is the wrong one. The ``Session`` protocol has
+FOUR operations and two of them are REMOVALS: ``pop_item`` deletes the most
+recent item and returns it (the SDK's own retry/edit path), and
+``clear_session`` deletes every item. ``_merge.merge_field`` under APPEND only
+ever grows a collection — it has no representation for "this element is gone" —
+so a popped item would reappear at the next merge and a cleared session would
+come back in full. Under APPEND the two removal verbs are not merely
+lossy, they are IMPOSSIBLE.
+
+LAST_WRITER_WINS makes the whole item list the unit of change, which is exactly
+the semantics the protocol asks for: every mutation is a read-modify-write of
+the list, and the newest complete list is the conversation. The cost is that
+two concurrent turns on ONE session id race — and that race is caught rather
+than merged, because every write in :mod:`.._runners._openai_pg_session` passes
+the revision it read as ``expected_revision``, so the loser gets a
+``RevisionMismatchError`` and retries against the winner's list.
+
+WriterPolicy.MULTI_WRITER
+=========================
+``Store`` is constructed with ``node=socket.gethostname()`` and sac RELOCATES
+agents between hosts (``_state/relocation_pg.py`` exists for precisely that).
+Under SINGLE_WRITER the first host to write a session would own it forever, and
+the ordinary act of moving an agent to another machine would turn its next turn
+into an illegal write. The same reasoning ``port_allocator_store`` and
+``state_db_grants`` give for their own stores applies here, one level up: the
+record has no single stable owning node.
+
+THE STORE HANDLE IS CACHED PER PROCESS
+======================================
+``Store.__init__`` pays a psycopg connect (measured 10.7 ms) plus a schema
+advisory lock and two catalogue probes on EVERY construction, and this store is
+touched on the hot path — the SDK reads the history before a turn and writes it
+back after, so a per-call handle would pay that twice per turn. So the module
+holds ONE Store per (resolved target, pid) behind a lock, exactly as
+:func:`.port_allocator_store.port_store` does.
+
+The cache key is the ``StoreTarget`` VALUE, not ``str(locator)``: the locator's
+string form is a redacted description that DROPS the DSN query string, so two
+``pg_schema`` DSNs differing only in ``?options=-csearch_path`` stringify
+identically and a string-keyed cache would hand the second test the first
+test's schema. The pid is in the key so a forked child never reuses — or
+closes — the parent's connection through an inherited fd.
+:func:`_reset_store_cache` is the explicit reset for tests; no monkeypatch.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.store import Row, Store
+
+#: The logical store name. ``scitex_dev.store`` renders it as four physical
+#: tables (``<name>_rows``, ``_oplog``, ``_identity``, ``_cursor``).
+STORE_NAME = "openai_sessions"
+
+#: Recorded on every write as the acting component.
+ACTOR = "scitex-agent-container"
+
+__all__ = [
+    "ACTOR",
+    "STORE_NAME",
+    "init_openai_session_schema",
+    "items_of",
+    "open_session_store",
+    "session_key",
+    "session_store",
+    "session_store_target",
+    "session_values",
+]
+
+
+def _schema() -> Any:
+    """The conversation-state schema.
+
+    Built lazily so importing this module does not import scitex-dev; the
+    SQLite-era code was equally lazy about its own imports, for the same
+    reason (import cost off the hot path).
+
+    ``(agent, session_id)`` is the composite IDENTITY, and the store requires
+    IMMUTABLE on identities. Both halves are needed: ``session_id`` alone
+    would collide the moment two agents pick the same logical conversation
+    key, and the SDK's default session id IS the caller's own choice, so a
+    collision is a naming accident rather than a bug anyone would notice.
+
+    ``items`` carries the whole conversation as a JSON array under
+    LAST_WRITER_WINS — the module docstring carries the measured reason APPEND
+    is wrong here (it cannot express ``pop_item`` or ``clear_session``).
+
+    ``updated_at`` is epoch REAL, not ISO text. Every migrated timestamp
+    column across ``_state`` is REAL, and this one exists so an operator can
+    ask which sessions are stale without decoding the item list.
+
+    THIS IS THE FIRST ``FieldKind.JSON`` FIELD IN sac, so the binding was
+    measured rather than assumed. ``_codec.encode`` renders a JSON field with
+    ``json.dumps``, i.e. hands psycopg a ``str``, and the Postgres dialect
+    declares the column ``JSONB`` — for which ``pg_cast`` holds NO cast from
+    ``text``. That looks like a guaranteed
+    ``column "items" is of type jsonb but expression is of type text``. It is
+    not: psycopg3 sends ``str`` parameters as UNKNOWN, not as ``text``, so the
+    server coerces them to the target column's type. Verified against a live
+    PostgreSQL 16 on 2026-08-29 — ``SELECT jsonb_typeof(%s)`` with a Python
+    ``str`` answers ``'object'``, and ``SELECT pg_typeof(%s)`` raises
+    ``IndeterminateDatatype``, which is the untyped parameter saying so
+    itself. (``StrDumper.oid`` reads 25 in the psycopg source; that class
+    attribute is not what goes on the wire for this path, which is why the
+    probe and not the source settled it.)
+    """
+    from scitex_dev.store import FieldKind, FieldPolicy, FieldRole, MergeRule, Schema
+
+    def ident(kind: Any) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.IDENTITY,
+            required=True,
+            merge=MergeRule.IMMUTABLE,
+            indexed=False,
+        )
+
+    def data(kind: Any, *, indexed: bool = False) -> Any:
+        return FieldPolicy(
+            kind=kind,
+            role=FieldRole.DATA,
+            required=True,
+            merge=MergeRule.LAST_WRITER_WINS,
+            indexed=indexed,
+        )
+
+    return Schema(
+        name=STORE_NAME,
+        fields={
+            "agent": ident(FieldKind.TEXT),
+            "session_id": ident(FieldKind.TEXT),
+            "items": data(FieldKind.JSON),
+            "updated_at": data(FieldKind.REAL),
+        },
+    )
+
+
+def session_store_target() -> Any:
+    """Resolve WHERE conversation state lives. Pure — does not connect."""
+    from scitex_dev.store import host_store
+
+    return host_store(pkg="scitex_agent_container", name=STORE_NAME)
+
+
+def open_session_store() -> "Store":
+    """Open a FRESH conversation-state handle. RAISES if PostgreSQL is down.
+
+    The caller owns closing it. This is the constructor for callers that want
+    a handle of their own; the runner goes through the per-process cache in
+    :func:`session_store` instead, so a turn does not pay the connect twice.
+
+    MULTI_WRITER — see the module docstring: an agent relocated to another
+    host must be able to continue its own conversation, and ``node`` is the
+    hostname.
+    """
+    import socket
+
+    from scitex_dev.store import Store, WriterPolicy
+
+    return Store(
+        session_store_target(),
+        _schema(),
+        node=socket.gethostname(),
+        writer_policy=WriterPolicy.MULTI_WRITER,
+        actor=ACTOR,
+    )
+
+
+#: ``(StoreTarget, pid, Store)`` — see the module docstring's cache section.
+#: Guarded by ``_STORE_LOCK``; reset with :func:`_reset_store_cache`.
+_STORE_CACHE: "tuple[Any, int, Store] | None" = None
+_STORE_LOCK = threading.Lock()
+
+
+def session_store() -> "Store":
+    """The per-process cached conversation store. Do NOT close the result.
+
+    Keyed by the RESOLVED target and the pid (the module docstring says why:
+    a psycopg connect per call on the turn path, while the ``pg_schema``
+    fixture and forked test processes both invalidate a naive singleton).
+    ``Store`` serialises its own operations internally, so one shared handle
+    per process is safe for concurrent threads — which matters here because
+    the async session runs every store call through ``asyncio.to_thread``.
+    """
+    global _STORE_CACHE
+    import os
+
+    target = session_store_target()
+    pid = os.getpid()
+    with _STORE_LOCK:
+        if _STORE_CACHE is not None:
+            cached_key, cached_pid, cached = _STORE_CACHE
+            if cached_key == target and cached_pid == pid:
+                return cached
+            # A fork inherited the parent's connection through the same fd:
+            # closing it HERE would send a termination on the parent's socket.
+            # Only the process that opened a handle may close it; a
+            # stale-target handle in the same process is closed so the fd does
+            # not leak per test.
+            if cached_pid == pid:
+                cached.close()
+        fresh = open_session_store()
+        _STORE_CACHE = (target, pid, fresh)
+        return fresh
+
+
+def _reset_store_cache() -> None:
+    """Drop (and close) the cached handle. For tests — plain call, no patching."""
+    global _STORE_CACHE
+    import os
+
+    with _STORE_LOCK:
+        if _STORE_CACHE is not None and _STORE_CACHE[1] == os.getpid():
+            _STORE_CACHE[2].close()
+        _STORE_CACHE = None
+
+
+def init_openai_session_schema() -> str:
+    """Create the conversation tables if missing. Idempotent.
+
+    Returns the resolved store LOCATOR as a string — it names WHERE the
+    conversations actually went, so an operator can check rather than assume.
+    """
+    session_store()  # Store.__init__ creates the tables when absent.
+    return str(session_store_target().locator)
+
+
+def session_key(agent: str, session_id: str) -> dict[str, Any]:
+    """The IDENTITY of one conversation. One place, so the shape cannot drift."""
+    return {"agent": str(agent), "session_id": str(session_id)}
+
+
+def session_values(
+    agent: str, session_id: str, items: list[Any], updated_at: float
+) -> dict[str, Any]:
+    """The full record a conversation write lands. Identity + the whole list.
+
+    The list is passed WHOLE rather than as a delta because ``items`` is
+    LAST_WRITER_WINS: the caller has already done the read-modify-write, and
+    what it hands over is the conversation as it should now stand.
+    """
+    return {
+        **session_key(agent, session_id),
+        "items": list(items),
+        "updated_at": float(updated_at),
+    }
+
+
+def items_of(row: "Row | None") -> list[Any]:
+    """The conversation items on ``row``, or ``[]`` when there is no record.
+
+    An ABSENT record and an EMPTY conversation are deliberately collapsed
+    here, and only here: the ``Session`` protocol has no "no such session"
+    answer — ``get_items`` on an unknown id returns an empty list — so the
+    distinction has to disappear somewhere, and the honest place is the one
+    function whose whole job is decoding a row.
+
+    ``Row.values`` is a mapping (not iterable, and not ``.fields``). The JSON
+    field decodes to whatever was stored; a non-list value is coerced to ``[]``
+    rather than propagated, because the caller's next act is to index it.
+    """
+    if row is None:
+        return []
+    items = row.values.get("items")
+    return list(items) if isinstance(items, list) else []
+
+# EOF

--- a/src/scitex_agent_container/a2a/_handlers.py
+++ b/src/scitex_agent_container/a2a/_handlers.py
@@ -9,7 +9,7 @@ Five built-ins:
 * :func:`handle_openai_session` — drives an OpenAI model via the
   ``openai-agents`` SDK (``spec.harness: openai``; optional
   ``[openai]`` extra). Stateful: turns share the agent's
-  ``SQLiteSession`` conversation state.
+  PostgreSQL-backed conversation state.
 * :func:`handle_claude_cli` — *(legacy)* runs ``claude --print`` with
   the user text and forwards stdout. Kept for back-compat; will be
   removed once ``claude --print`` itself is removed upstream. Migrate
@@ -218,9 +218,10 @@ def handle_openai_session(agent_name: str, user_text: str) -> str:
     :class:`scitex_agent_container._runners.openai_session.OpenAIAgentsSession`
     (the concrete ``HarnessSession`` — see openai-compat-2). Unlike the
     Claude handler this one is STATEFUL: the session persists turns in
-    the agent's ``SQLiteSession`` db (see
-    ``runtimes._openai_sdk_common.resolve_state_db_path``), so repeated
-    A2A sends continue one conversation.
+    the ``openai_sessions`` store keyed by ``(agent, session_id)`` (see
+    ``_state.openai_session_store``), so repeated A2A sends continue one
+    conversation — and a send RAISES rather than forgetting the history
+    when this host's PostgreSQL is unreachable.
 
     Env knobs (mirroring the Claude handler's):
 

--- a/src/scitex_agent_container/a2a/executors/_openai_session.py
+++ b/src/scitex_agent_container/a2a/executors/_openai_session.py
@@ -5,7 +5,8 @@ family (scitex-todo card ``openai-compat-2``). Same wire surface (sync
 ``(name, text) -> str``); the underlying transport is
 ``agents.Runner.run_streamed`` normalized through
 :class:`scitex_agent_container._runners.openai_session.OpenAIAgentsSession`,
-with conversation state persisted in the agent's ``SQLiteSession`` db.
+with conversation state persisted in the agent's ``openai_sessions`` store
+(this host's PostgreSQL — see ``_state.openai_session_store``).
 
 Requires the optional ``[openai]`` extra
 (``pip install scitex-agent-container[openai]``); without it the handler

--- a/src/scitex_agent_container/config/_harness_registry.py
+++ b/src/scitex_agent_container/config/_harness_registry.py
@@ -253,7 +253,7 @@ HARNESS_DESCRIPTORS: dict[str, HarnessDescriptor] = {
             inner_argv=_openai_agents_inner_argv,
             hosted="runner",  # shared session daemon since v4 step 7
             beat_writer="in-process",  # daemon + turn-driver beats, self-stamped
-            # The SQLiteSession db persists turns under the agent's own
+            # The conversation store persists turns under the agent's own
             # name, but sac's resume contract (rehydrate a PRIOR
             # conversation from a caller-supplied session id) is not
             # implemented for this harness — the runner CLI and turn

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -189,7 +189,7 @@ From: ./sac-base.sif
             ipython ipdb \
             "pytest>=7.0.0,<9.0.0" pytest-cov \
             "claude-agent-sdk" \
-            "openai-agents>=0.17.4" \
+            "openai-agents>=0.19.0" \
             "scitex[all]" \
             xarray
         # UV SEMANTICS, NOT PIP (INCIDENT 2026-07-18). ``--no-cache-dir`` and
@@ -346,7 +346,7 @@ From: ./sac-base.sif
             ipython ipdb \
             "pytest>=7.0.0,<9.0.0" pytest-cov \
             "claude-agent-sdk" \
-            "openai-agents>=0.17.4" \
+            "openai-agents>=0.19.0" \
             "scitex[all]" \
             xarray
         /opt/venv-sac/bin/pip install --no-cache-dir \

--- a/src/scitex_agent_container/runtimes/_openai_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_openai_sdk_common.py
@@ -10,8 +10,15 @@ note). Mirrors the concern split established there:
 2. **Workspace resolution** — re-exported verbatim from
    :mod:`runtimes._provider_common` (the openai-compat-1 extraction
    whose whole point was letting THIS module reuse it).
-3. **Session-state placement** — :func:`resolve_state_db_path` picks
-   where the ``openai-agents`` ``SQLiteSession`` database lives.
+
+Session-state placement USED TO BE the third concern here, and it is gone
+rather than moved: the helper picked a filesystem path for a per-agent
+SQLite database, and there is no file to place any more. Conversation
+state lives in this host's PostgreSQL, resolved by
+:mod:`_state.openai_session_store` — a store target, not a path — so the
+question this module answered no longer has a filesystem answer. The
+cross-reference went with the function on purpose: documentation pointing
+at a deleted symbol is how a reader learns to distrust the prose.
 
 The ``openai-agents`` install is OPTIONAL (``pip install
 scitex-agent-container[openai]``): nothing here imports ``agents`` (even
@@ -41,8 +48,6 @@ gain. The contract here is therefore:
 from __future__ import annotations
 
 import os
-import re
-from pathlib import Path
 
 # Workspace + MCP wiring is provider-agnostic — reuse the openai-compat-1
 # extraction verbatim (see runtimes/_provider_common.py). Re-exported so
@@ -53,7 +58,6 @@ from ._provider_common import project_runtime_root, resolve_agent_workspace
 __all__ = [
     "OpenAISDKCommonError",
     "provision_openai_auth",
-    "resolve_state_db_path",
     "default_openai_model",
     "resolve_agent_workspace",
     "project_runtime_root",
@@ -120,62 +124,3 @@ def default_openai_model() -> str | None:
     """
     value = os.environ.get(_SAC_OPENAI_MODEL_ENV, "").strip()
     return value or None
-
-
-# ---------------------------------------------------------------------------
-# Session-state placement (SQLiteSession db)
-# ---------------------------------------------------------------------------
-
-# Filename-safe agent-name filter: keep letters/digits/._- and collapse
-# everything else to "-" so an exotic agent name can't escape the
-# sessions directory or produce an unopenable path.
-_UNSAFE_NAME_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
-
-
-def resolve_state_db_path(
-    agent_name: str,
-    *,
-    home: Path | None = None,
-    override: str | Path | None = None,
-) -> Path:
-    """Resolve where the agent's ``SQLiteSession`` database lives.
-
-    The ``openai-agents`` SDK persists conversation state in a SQLite
-    file (one logical session per ``session_id``). sac places it under
-    the standard per-agent runtime-state root so it survives restarts
-    and never pollutes the workspace repo::
-
-        ~/.scitex/agent-container/runtime/openai-sessions/<agent>.sqlite3
-
-    Args:
-        agent_name: The agent whose state db to resolve. Sanitized to a
-            filename-safe form (non ``[A-Za-z0-9._-]`` runs become ``-``).
-        home: Home-directory override (tests).
-        override: Explicit db path — used verbatim (parent created), for
-            specs that pin state elsewhere. ``:memory:`` is NOT special-
-            cased here; callers wanting ephemeral state pass the SDK's
-            own ``:memory:`` sentinel directly to ``SQLiteSession``.
-
-    Returns:
-        The resolved path. The parent directory is created (best-effort)
-        so ``SQLiteSession`` can open the file immediately.
-    """
-    if override is not None:
-        path = Path(override).expanduser()
-    else:
-        _home = Path(home) if home is not None else Path.home()
-        safe = _UNSAFE_NAME_CHARS.sub("-", agent_name).strip("-") or "agent"
-        path = (
-            _home
-            / ".scitex"
-            / "agent-container"
-            / "runtime"
-            / "openai-sessions"
-            / f"{safe}.sqlite3"
-        )
-    # stx-allow: fallback (reason: state dir may be read-only; SQLiteSession itself fails loudly on open, with a clearer path in hand)
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError:  # stx-allow: fallback (reason: surfaced by SQLiteSession open instead)
-        pass
-    return path

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -236,7 +236,16 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         "scitex_agent_container/runtimes/_apptainer_auth_bind.py:296",
         "scitex_agent_container/runtimes/_cct_rail_alarm.py:198",
         "scitex_agent_container/runtimes/_cct_rail_verdict.py:242",
-        "scitex_agent_container/runtimes/_openai_sdk_common.py:179",
+        # _openai_sdk_common.py:179 LEFT THIS SET 2026-08-29, by DELETION
+        # rather than by naming a sink. The claim was "surfaced by
+        # SQLiteSession open instead" on an `except OSError: pass` guarding
+        # the mkdir of the session-db parent directory — an honest claim while
+        # a session db was a FILE. sac's OpenAI runner now keeps conversation
+        # state in PostgreSQL (`_state/openai_session_store.py`), so there is
+        # no directory to create, no open to surface anything, and the whole
+        # helper went with the file. An entry whose line no longer exists must
+        # leave the list, or it becomes a blessed coordinate for whatever
+        # drifts into position 179.
         "scitex_agent_container/runtimes/_tui_bridge_seam.py:40",
         "scitex_agent_container/runtimes/_tui_inject.py:92",
         "scitex_agent_container/runtimes/_tui_turn_bridge_lifecycle.py:196",

--- a/tests/develop/test_sqlite_footprint_frozen.py
+++ b/tests/develop/test_sqlite_footprint_frozen.py
@@ -118,15 +118,22 @@ docstring to say the schema issues ZERO of them. ``SCAN_EXEMPT`` carries
 those, each with a written reason, and is itself under a staleness gate — an
 exemption that stops matching must leave, or it becomes a blessed filename.
 
-THE IMPORT SCAN CANNOT SEE A VENDORED SQLite, AND THAT IS THE LIVE HOLE
-=======================================================================
-``agents.SQLiteSession(...)`` opens a real SQLite file on disk, per agent, and
-NOTHING in that call chain imports sqlite3 in this repo — the ``openai-agents``
-package does it. An import-based scan is structurally blind to it, and it was
-blind to it for the whole life of this file. ``FROZEN_VENDOR_SQLITE`` freezes
-the constructs instead of the import: ``SQLiteSession(``, ``SqliteDict(``,
-``create_engine("sqlite...``, ``aiosqlite``, ``apsw``, ``libsql``,
-``sqlite:///`` and ``.sqlite``/``.sqlite3`` path literals.
+THE IMPORT SCAN CANNOT SEE A VENDORED SQLite — THE HOLE THAT WAS LIVE HERE
+==========================================================================
+``agents.SQLiteSession(...)`` opened a real SQLite file on disk, per agent, and
+NOTHING in that call chain imported sqlite3 in this repo — the ``openai-agents``
+package did it. An import-based scan is structurally blind to that, and it was
+blind to it for the whole life of this file until the vendor scan landed on
+2026-08-29. ``FROZEN_VENDOR_SQLITE`` freezes the constructs instead of the
+import: ``SQLiteSession(``, ``SqliteDict(``, ``create_engine("sqlite...``,
+``aiosqlite``, ``apsw``, ``libsql``, ``sqlite:///`` and
+``.sqlite``/``.sqlite3`` path literals.
+
+THAT SET IS NOW EMPTY, and the scan stays. The runner's conversation state
+moved to PostgreSQL the day after the scan was written, so the population it
+was built to measure is gone — which is exactly when a ratchet stops being
+evidence and starts being the only thing standing between zero and the next
+one. The set may only shrink; it has, to nothing.
 
 ``sqlite3.connect(`` is deliberately NOT among them. Any module calling it has
 already imported sqlite3 and is therefore covered by ``FROZEN_SQLITE``; adding
@@ -576,22 +583,27 @@ _CONSTRUCTS_VENDOR_SQLITE = re.compile(
 #: Modules under ``src/`` that open SQLite through a VENDOR library rather
 #: than through sqlite3, as SRC-relative paths. THIS LIST MAY ONLY SHRINK.
 #:
-#: Measured 2026-08-29 — and the measurement is the point. Both entries were
-#: invisible to every gate in this file until the scan existed, which is the
-#: concrete evidence that "no module imports sqlite3" was never the same
-#: statement as "no module opens SQLite".
-FROZEN_VENDOR_SQLITE = frozenset(
-    {
-        # ``agents.SQLiteSession(self.session_id, db_path=str(db_path))`` —
-        # conversation state for the OpenAI runner. The database is real and
-        # per-agent; only the sqlite3 import is somebody else's.
-        "_runners/openai_session.py",
-        # Resolves WHERE that database lives: builds ``<agent>.sqlite3`` under
-        # the runtime state dir, and documents the ``:memory:`` sentinel that
-        # opts out of a file entirely.
-        "runtimes/_openai_sdk_common.py",
-    }
-)
+#: EMPTY SINCE 2026-08-29, and it took one day to get here. The scan was
+#: written that morning and found TWO entries that had been invisible to every
+#: other gate in this file — concrete evidence that "no module imports
+#: sqlite3" was never the same statement as "no module opens SQLite". Both are
+#: gone the same day:
+#:
+#:   * ``_runners/openai_session.py`` constructed
+#:     ``agents.SQLiteSession(self.session_id, db_path=str(db_path))`` for the
+#:     OpenAI runner's conversation state. It now constructs
+#:     ``_runners._openai_pg_session.PostgresAgentSession``, which keeps the
+#:     same conversation in this host's PostgreSQL through
+#:     ``_state/openai_session_store.py``.
+#:   * ``runtimes/_openai_sdk_common.py`` resolved WHERE that database lived.
+#:     A store target is not a path, so the helper was deleted rather than
+#:     rewritten — along with the module docstring's cross-reference to it.
+#:
+#: The scan itself STAYS at zero. ``test_the_vendor_list_has_no_stale_entries``
+#: keeps this set honest in the other direction, and the two positive controls
+#: below are planted files precisely so an empty live tree cannot make them
+#: vacuous.
+FROZEN_VENDOR_SQLITE: frozenset[str] = frozenset()
 
 
 def _modules_defining_tables(root: Path) -> set[str]:
@@ -1008,7 +1020,11 @@ def test_the_vendor_regex_matches_the_real_construction() -> None:
     for. A regex can be narrowed by a well-meant edit — an anchor, a word
     boundary — and still walk the whole tree finding nothing.
     """
-    # Arrange — src/scitex_agent_container/_runners/openai_session.py:413
+    # Arrange — the call this scan was written for, as it stood at
+    # src/scitex_agent_container/_runners/openai_session.py:413 before it
+    # moved to PostgreSQL. A LITERAL, not a read of the tree: the tree is
+    # empty by design now, so anchoring this to a live line would delete the
+    # only proof the pattern still matches the shape it exists to catch.
     the_live_call = "agents.SQLiteSession(self.session_id, db_path=str(db_path))"
     # Act
     hit = _CONSTRUCTS_VENDOR_SQLITE.search(the_live_call)
@@ -1022,15 +1038,24 @@ def test_the_vendor_regex_matches_the_real_construction() -> None:
 def test_the_vendor_regex_does_not_match_a_docstring_mention() -> None:
     """NEGATIVE CONTROL — prose ABOUT SQLiteSession must not match.
 
-    Measured 2026-08-29: SEVEN files under src/ name ``SQLiteSession`` and
-    exactly ONE constructs it. If the pattern dropped the ``\\(`` and matched
-    the bare name, the frozen set would have to grow sevenfold to hold every
-    module that merely DOCUMENTS the session db — and a list of documenters
-    is not an inventory of databases. This is the same inversion that once let
-    a ``host_store`` heuristic excuse the real SQLite schema module: a comment
-    describing a thing is that thing, to a regex.
+    Measured 2026-08-29, on the tree this scan was written against: SEVEN
+    files under src/ named ``SQLiteSession`` and exactly ONE constructed it.
+    Had the pattern dropped the ``\\(`` and matched the bare name, the frozen
+    set would have grown sevenfold to hold every module that merely
+    DOCUMENTED the session db — and a list of documenters is not an inventory
+    of databases. This is the same inversion that once let a ``host_store``
+    heuristic excuse the real SQLite schema module: a comment describing a
+    thing is that thing, to a regex.
+
+    All seven are gone now — the construction moved to PostgreSQL and the six
+    prose mentions were reworded with it — so this control is asserted on a
+    literal rather than on the tree. Six documenters could not be told from
+    one database by any live-tree assertion once the tree reaches zero.
     """
-    # Arrange — src/scitex_agent_container/_runners/_openai_session_cli.py:21
+    # Arrange — the prose that stood at
+    # src/scitex_agent_container/_runners/_openai_session_cli.py:21 before the
+    # migration reworded it. Kept as a literal for the same reason as the
+    # positive control above.
     the_prose = "(the ``SQLiteSession`` db persists turns under the agent's own name,"
     # Act
     hit = _CONSTRUCTS_VENDOR_SQLITE.search(the_prose)

--- a/tests/integration/test_apptainer_def_openai_agents.py
+++ b/tests/integration/test_apptainer_def_openai_agents.py
@@ -30,6 +30,7 @@ STX-TQ002 AAA + STX-TQ007 one-assert per test.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -40,6 +41,36 @@ _CONTAINERS = (
     / "scitex_agent_container"
     / "containers"
 )
+
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+#: Matches the ``[openai]`` extra's requirement string in pyproject.toml.
+_OPENAI_FLOOR_RE = re.compile(r'"(openai-agents>=[0-9][^"]*)"')
+
+
+def _openai_floor() -> str:
+    """The ``openai-agents`` floor as pyproject's ``[openai]`` extra declares it.
+
+    DERIVED, NEVER SPELLED OUT. This file's whole job is to assert that two
+    places agree on one version, so a test that hardcodes that version is a
+    THIRD place to forget. It then fails on a LEGITIMATE bump, and its message
+    ("the floor must be identical in both") misdescribes what it actually
+    checked ("both files contain this literal").
+
+    2026-08-30: exactly that happened. The floor moved 0.17.4 -> 0.19.0 in
+    pyproject (the PostgreSQL-backed session needs the SDK's
+    ``coerce_session_settings``, absent before 0.19.0) and this file failed
+    while pointing at the .def — which was indeed stale, but raising it alone
+    would have left the suite red with both files agreeing.
+    """
+    match = _OPENAI_FLOOR_RE.search(_PYPROJECT.read_text())
+    if match is None:
+        raise AssertionError(
+            "pyproject.toml's [openai] extra no longer declares an "
+            "openai-agents floor, so this file's contract has no subject."
+        )
+    return match.group(1)
 
 
 @pytest.fixture(scope="module")
@@ -118,7 +149,7 @@ def test_all_extra_carries_dev_test_tooling(base_def_text: str) -> None:
 
 def test_scitex_def_lists_openai_agents_floor(scitex_def_text: str) -> None:
     # Arrange
-    needle = "openai-agents>=0.17.4"
+    needle = _openai_floor()
     # Act
     present = needle in scitex_def_text
     # Assert
@@ -145,17 +176,15 @@ def test_scitex_def_floors_openai_agents_in_both_branches(
 
 
 def test_scitex_def_floor_matches_pyproject_extra(scitex_def_text: str) -> None:
-    # Arrange — the .def floor mirrors pyproject's [openai] extra; a bump
-    # in one without the other is drift this test refuses.
-    pyproject = (
-        Path(__file__).resolve().parents[2] / "pyproject.toml"
-    ).read_text()
+    # Arrange — pyproject's [openai] extra is the SSoT; the .def must echo
+    # whatever it currently says, so a bump is ONE edit and this test follows.
+    floor = _openai_floor()
     # Act
-    in_both = "openai-agents>=0.17.4" in pyproject and (
-        "openai-agents>=0.17.4" in scitex_def_text
-    )
+    echoed = floor in scitex_def_text
     # Assert
-    assert in_both, (
-        "the openai-agents floor must be identical in pyproject.toml's "
-        "[openai] extra and apptainer-scitex.def (keep in lockstep)."
+    assert echoed, (
+        f"apptainer-scitex.def must carry pyproject's openai-agents floor "
+        f"({floor!r}); a bump in one without the other is drift this test "
+        "refuses. Both resolver branches need it — see the sibling test that "
+        "counts occurrences."
     )

--- a/tests/scitex_agent_container/_runners/test__openai_pg_session.py
+++ b/tests/scitex_agent_container/_runners/test__openai_pg_session.py
@@ -1,0 +1,356 @@
+"""Tests for ``_runners/_openai_pg_session.py`` — the SDK ``Session`` on PostgreSQL.
+
+Two tiers, matching the optional-dependency contract that
+``test_openai_session.py`` states for the runner:
+
+* **No store, no SDK** — construction, the ``session_id`` default, and the
+  lazily-coerced ``session_settings``. These take NO ``pg_schema``, and the
+  autouse unreachable-DSN guard is what makes that an assertion rather than
+  an omission: if constructing a session connected, they would fail on port 1.
+* **Real store** — ``pg_schema`` per test: the round trip, both REMOVAL verbs,
+  the limit semantics, and the composite identity.
+
+THE REMOVAL TESTS ARE THE POINT. ``items`` is ``LAST_WRITER_WINS`` rather than
+``APPEND`` precisely because ``pop_item`` and ``clear_session`` take items
+AWAY, and an append-merged collection has no representation for a gone
+element. That reasoning is only worth what the tests prove, so both verbs are
+exercised against a real store and read back.
+
+PA-306: no mocks, no monkeypatch — isolation comes from the shared
+``pg_schema`` fixture repointing ``SCITEX_STORE_DSN`` at a throwaway schema,
+which exercises the REAL resolver. STX-TQ002 AAA + STX-TQ007
+one-assert-per-test; async via ``asyncio.run(_go())``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._runners._openai_pg_session import PostgresAgentSession
+
+
+def _run(coro_factory: Any) -> Any:
+    """Drive one coroutine factory to completion.
+
+    A helper rather than a fixture: every test below is a single ``asyncio``
+    round trip, and threading an event loop through a fixture would put the
+    store's own ``asyncio.to_thread`` calls on a loop the test does not own.
+    """
+    return asyncio.run(coro_factory())
+
+
+# ---------------------------------------------------------------------------
+# No store, no SDK — construction must not connect
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_defaults_to_the_agent_name() -> None:
+    # Arrange
+    session = PostgresAgentSession("alpha")
+    # Act
+    resolved = session.session_id
+    # Assert
+    assert resolved == "alpha"
+
+
+def test_an_explicit_session_id_wins() -> None:
+    # Arrange
+    session = PostgresAgentSession("alpha", session_id="review-thread")
+    # Act
+    resolved = session.session_id
+    # Assert
+    assert resolved == "review-thread"
+
+
+def test_session_settings_is_none_when_unset() -> None:
+    """``None`` in, ``None`` out — the SDK supplies its own default.
+
+    Reading the property must ALSO not import ``agents``: this test runs on a
+    Claude-only deployment, where it would raise.
+    """
+    # Arrange
+    session = PostgresAgentSession("alpha")
+    # Act
+    settings = session.session_settings
+    # Assert
+    assert settings is None
+
+
+def test_session_settings_coerces_a_mapping_to_the_sdk_dataclass() -> None:
+    # Arrange
+    pytest.importorskip("agents")
+    from agents.memory.session_settings import SessionSettings
+
+    session = PostgresAgentSession("alpha", session_settings={"limit": 3})
+    # Act
+    settings = session.session_settings
+    # Assert
+    assert isinstance(settings, SessionSettings)
+
+
+def test_session_settings_keeps_the_coerced_limit() -> None:
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha", session_settings={"limit": 3})
+    # Act
+    limit = session.session_settings.limit
+    # Assert
+    assert limit == 3
+
+
+def test_it_satisfies_the_sdk_session_protocol() -> None:
+    """Structural conformance, checked against the SDK's own Protocol.
+
+    ``PostgresAgentSession`` deliberately does not subclass ``SessionABC``
+    (which the SDK documents as internal), so nothing but this check stands
+    between a renamed method and a session the ``Runner`` silently ignores.
+    """
+    # Arrange
+    pytest.importorskip("agents")
+    from agents.memory.session import Session
+
+    session = PostgresAgentSession("alpha")
+    # Act
+    conforms = isinstance(session, Session)
+    # Assert
+    assert conforms is True
+
+
+# ---------------------------------------------------------------------------
+# Real store — every test below takes pg_schema because every one does I/O
+# ---------------------------------------------------------------------------
+
+
+def test_get_items_on_an_unknown_session_is_empty(pg_schema: str) -> None:
+    """The Protocol has no "no such session" answer; absent reads as empty."""
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+    # Act
+    items = _run(lambda: session.get_items())
+    # Assert
+    assert items == []
+
+
+def test_added_items_come_back_in_order(pg_schema: str) -> None:
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+    written = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+    ]
+
+    async def _go() -> list[Any]:
+        await session.add_items(list(written))
+        return await session.get_items()
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == written
+
+
+def test_add_items_appends_rather_than_replacing(pg_schema: str) -> None:
+    """Two writes accumulate. LAST_WRITER_WINS is on the FIELD, not the verb."""
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+
+    async def _go() -> list[Any]:
+        await session.add_items([{"role": "user", "content": "one"}])
+        await session.add_items([{"role": "user", "content": "two"}])
+        return await session.get_items()
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert [item["content"] for item in items] == ["one", "two"]
+
+
+def test_pop_item_returns_the_newest_item(pg_schema: str) -> None:
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+
+    async def _go() -> Any:
+        await session.add_items(
+            [{"role": "user", "content": "old"}, {"role": "user", "content": "new"}]
+        )
+        return await session.pop_item()
+
+    # Act
+    popped = _run(_go)
+    # Assert
+    assert popped == {"role": "user", "content": "new"}
+
+
+def test_pop_item_actually_removes_it(pg_schema: str) -> None:
+    """The REMOVAL half, read back from the store.
+
+    This is the assertion an ``APPEND``-merged ``items`` field could not
+    satisfy: a merge rule that only grows a collection would hand the popped
+    item straight back on the next read.
+    """
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+
+    async def _go() -> list[Any]:
+        await session.add_items(
+            [{"role": "user", "content": "old"}, {"role": "user", "content": "new"}]
+        )
+        await session.pop_item()
+        return await session.get_items()
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == [{"role": "user", "content": "old"}]
+
+
+def test_pop_item_on_an_empty_session_is_none(pg_schema: str) -> None:
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+    # Act
+    popped = _run(lambda: session.pop_item())
+    # Assert
+    assert popped is None
+
+
+def test_clear_session_empties_the_conversation(pg_schema: str) -> None:
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+
+    async def _go() -> list[Any]:
+        await session.add_items([{"role": "user", "content": "forget me"}])
+        await session.clear_session()
+        return await session.get_items()
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == []
+
+
+def test_get_items_limit_returns_the_latest_n(pg_schema: str) -> None:
+    """A positive limit returns the LAST n, still oldest-first."""
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+
+    async def _go() -> list[Any]:
+        await session.add_items([{"n": index} for index in range(5)])
+        return await session.get_items(limit=2)
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == [{"n": 3}, {"n": 4}]
+
+
+def test_get_items_limit_zero_returns_nothing(pg_schema: str) -> None:
+    """``0`` means none and a NEGATIVE limit means all — SQLite's own
+    ``LIMIT`` semantics, kept deliberately so existing callers keep their
+    answer rather than being tidied into a single "no limit" branch."""
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+
+    async def _go() -> list[Any]:
+        await session.add_items([{"n": 1}])
+        return await session.get_items(limit=0)
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == []
+
+
+def test_get_items_negative_limit_returns_everything(pg_schema: str) -> None:
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha")
+
+    async def _go() -> list[Any]:
+        await session.add_items([{"n": 1}, {"n": 2}])
+        return await session.get_items(limit=-1)
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == [{"n": 1}, {"n": 2}]
+
+
+def test_session_settings_limit_applies_without_an_explicit_one(
+    pg_schema: str,
+) -> None:
+    """``resolve_session_limit`` precedence, exercised end to end."""
+    # Arrange
+    pytest.importorskip("agents")
+    session = PostgresAgentSession("alpha", session_settings={"limit": 1})
+
+    async def _go() -> list[Any]:
+        await session.add_items([{"n": 1}, {"n": 2}])
+        return await session.get_items()
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == [{"n": 2}]
+
+
+def test_two_agents_sharing_a_session_id_keep_separate_histories(
+    pg_schema: str,
+) -> None:
+    """The identity is COMPOSITE, and this is why.
+
+    ``session_id`` is the caller's own choice, so two agents picking the same
+    one is a naming accident rather than anything a reviewer would spot. Keyed
+    on ``session_id`` alone they would read each other's conversation.
+    """
+    # Arrange
+    pytest.importorskip("agents")
+    alpha = PostgresAgentSession("alpha", session_id="shared")
+    beta = PostgresAgentSession("beta", session_id="shared")
+
+    async def _go() -> list[Any]:
+        await alpha.add_items([{"who": "alpha"}])
+        await beta.add_items([{"who": "beta"}])
+        return await alpha.get_items()
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == [{"who": "alpha"}]
+
+
+def test_close_leaves_the_shared_handle_usable(pg_schema: str) -> None:
+    """``close()`` is a documented NO-OP, and this is the property behind it.
+
+    The runner calls ``close()`` on whatever session object it holds. The
+    handle is the process-wide cached ``Store``, so closing it would break
+    every other session in the process — asserted by reading through a SECOND
+    session object after the first was closed.
+    """
+    # Arrange
+    pytest.importorskip("agents")
+    writer = PostgresAgentSession("alpha")
+    reader = PostgresAgentSession("alpha")
+
+    async def _go() -> list[Any]:
+        await writer.add_items([{"role": "user", "content": "still here"}])
+        writer.close()
+        return await reader.get_items()
+
+    # Act
+    items = _run(_go)
+    # Assert
+    assert items == [{"role": "user", "content": "still here"}]
+
+# EOF

--- a/tests/scitex_agent_container/_runners/test_openai_session.py
+++ b/tests/scitex_agent_container/_runners/test_openai_session.py
@@ -10,8 +10,13 @@ Two tiers, matching the optional-dependency contract:
   succeed with ``agents`` BLOCKED), and terminal-aggregate building.
 * **Real SDK** — ``pytest.importorskip("agents")`` per test: ToolSpec →
   ``FunctionTool`` conversion (including invoking the wrapped handler),
-  normalization of REAL SDK event objects, and the network-free
-  ``start``/``close`` lifecycle against a tmp ``SQLiteSession`` db.
+  normalization of REAL SDK event objects, and the ``start``/``close``
+  lifecycle against a ``PostgresAgentSession``.
+
+``pg_schema`` is taken by EXACTLY the tests that reach the store — the
+round-trip and the failing-turn one — and by no others. It is not autouse
+on purpose: ``__init__``/``start()``/``close()`` open no connection, and a
+test that takes the fixture anyway would stop being able to prove that.
 
 No mocks (PA-306); no live-API turns (a ``send`` happy path needs a
 real OpenAI key — the error-path contract is covered instead, which is
@@ -41,6 +46,7 @@ from scitex_agent_container._runners._harness_session import (
     HarnessSession,
     ToolSpec,
 )
+from scitex_agent_container._runners._openai_pg_session import PostgresAgentSession
 from scitex_agent_container._runners.openai_session import (
     OpenAIAgentsSession,
     OpenAISessionError,
@@ -645,11 +651,18 @@ def test_normalize_real_sdk_agent_updated_event():
     assert normalized.text == "agent_updated:triage"
 
 
-def test_start_builds_sqlite_session_state(openai_env: Path):
+def test_start_builds_postgres_session_state(openai_env: Path):
+    """NO ``pg_schema``: constructing the session must not touch the store.
+
+    That is a property worth asserting rather than a convenience. The store
+    handle is opened on the first READ or WRITE, so ``start()`` stays as
+    network-free as it was when it opened a local file — and the autouse
+    unreachable-DSN guard is what proves it: if construction connected, this
+    test would fail on port 1 instead of passing.
+    """
     # Arrange
-    agents = pytest.importorskip("agents")
-    db_path = openai_env / "state.sqlite3"
-    session = OpenAIAgentsSession("alpha", model="gpt-4o-mini", db_path=db_path)
+    pytest.importorskip("agents")
+    session = OpenAIAgentsSession("alpha", model="gpt-4o-mini")
 
     async def _go() -> Any:
         await session.start()
@@ -660,31 +673,48 @@ def test_start_builds_sqlite_session_state(openai_env: Path):
     # Act
     state = asyncio.run(_go())
     # Assert
-    assert isinstance(state, agents.SQLiteSession)
+    assert isinstance(state, PostgresAgentSession)
 
 
-def test_start_creates_the_state_db_file(openai_env: Path):
+def test_session_state_round_trips_through_postgres(
+    openai_env: Path, pg_schema: str
+):
+    """A turn WRITTEN by one session object is READ by a different one.
+
+    The replacement for ``test_start_creates_the_state_db_file``, which
+    asserted that a file appeared on disk. There is no file; the property
+    that mattered was never the file but that conversation state SURVIVES
+    the session object, so this reads it back through a second
+    ``OpenAIAgentsSession`` — the answer can only come from the store.
+    """
     # Arrange
     pytest.importorskip("agents")
-    db_path = openai_env / "state.sqlite3"
-    session = OpenAIAgentsSession("alpha", model="gpt-4o-mini", db_path=db_path)
+    written = [{"role": "user", "content": "remember this"}]
 
-    async def _go() -> None:
-        await session.start()
-        await session.close()
+    async def _go() -> list[Any]:
+        writer = OpenAIAgentsSession("alpha", model="gpt-4o-mini")
+        await writer.start()
+        try:
+            await writer._session.add_items(list(written))
+        finally:
+            await writer.close()
+        reader = OpenAIAgentsSession("alpha", model="gpt-4o-mini")
+        await reader.start()
+        try:
+            return await reader._session.get_items()
+        finally:
+            await reader.close()
 
     # Act
-    asyncio.run(_go())
+    items = asyncio.run(_go())
     # Assert
-    assert db_path.exists()
+    assert items == written
 
 
 def test_close_resets_started_flag(openai_env: Path):
     # Arrange
     pytest.importorskip("agents")
-    session = OpenAIAgentsSession(
-        "alpha", model="gpt-4o-mini", db_path=openai_env / "s.sqlite3"
-    )
+    session = OpenAIAgentsSession("alpha", model="gpt-4o-mini")
 
     async def _go() -> bool:
         await session.start()
@@ -697,15 +727,23 @@ def test_close_resets_started_flag(openai_env: Path):
     assert started is False
 
 
-def test_send_failure_surfaces_as_turn_ending_error_event(openai_env: Path):
+def test_send_failure_surfaces_as_turn_ending_error_event(
+    openai_env: Path, pg_schema: str
+):
     """Any turn failure (fake key → 401 online, DNS error offline) must
-    yield a terminal ``kind="error"`` event, never leak an exception."""
+    yield a terminal ``kind="error"`` event, never leak an exception.
+
+    ``pg_schema`` because this one DOES touch the store: ``Runner`` reads
+    the conversation history before it calls the model, so the turn reaches
+    PostgreSQL before it reaches the failure being asserted. Without it the
+    autouse guard's unreachable DSN raises there instead, and the test would
+    still go green — on the wrong error.
+    """
     # Arrange
     pytest.importorskip("agents")
     session = OpenAIAgentsSession(
         "alpha",
         model="gpt-4o-mini",
-        db_path=openai_env / "s.sqlite3",
         record_spend=False,
     )
 

--- a/tests/scitex_agent_container/runtimes/test__openai_sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__openai_sdk_common.py
@@ -1,11 +1,19 @@
 """Tests for ``runtimes/_openai_sdk_common.py`` (openai-compat-2).
 
 Covers the auth-provisioning precedence contract (SAC env wins →
-process env fallback → loud failure), model resolution, state-db
-placement, and the ``_provider_common`` re-exports. None of this needs
-the ``openai-agents`` SDK — the module is import-safe on Claude-only
+process env fallback → loud failure), model resolution, and the
+``_provider_common`` re-exports. None of this needs the
+``openai-agents`` SDK — the module is import-safe on Claude-only
 deployments by design, and these tests prove it by never importing
 ``agents``.
+
+STATE-DB PLACEMENT IS NO LONGER ONE OF THE CONCERNS. Seven tests here
+pinned ``resolve_state_db_path`` — the directory, the filename, the
+name sanitiser, the override — and they went with the function when
+the OpenAI runner's conversation state moved to PostgreSQL. Nothing
+replaced them at this level: a store TARGET is not a path, and the
+behaviour that used to be checked here is now checked against a real
+store in ``_runners/test_openai_session.py`` under ``pg_schema``.
 
 PA-306: no ``monkeypatch`` / ``unittest.mock`` — env mutations use an
 explicit save/restore fixture (the ``isolated_env`` pattern from
@@ -16,7 +24,6 @@ one-assert-per-test.
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 import pytest
 
@@ -26,7 +33,6 @@ from scitex_agent_container.runtimes._openai_sdk_common import (
     OpenAISDKCommonError,
     default_openai_model,
     provision_openai_auth,
-    resolve_state_db_path,
 )
 
 _ENV_KEYS = ("SAC_OPENAI_API_KEY", "OPENAI_API_KEY", "SAC_OPENAI_MODEL")
@@ -152,72 +158,6 @@ def test_default_model_whitespace_only_returns_none(clean_env) -> None:
     model = default_openai_model()
     # Assert
     assert model is None
-
-
-# ---------------------------------------------------------------------------
-# resolve_state_db_path
-# ---------------------------------------------------------------------------
-
-
-def test_state_db_lands_under_runtime_openai_sessions(tmp_path: Path) -> None:
-    # Arrange
-    expected_parent = (
-        tmp_path / ".scitex" / "agent-container" / "runtime" / "openai-sessions"
-    )
-    # Act
-    path = resolve_state_db_path("alpha", home=tmp_path)
-    # Assert
-    assert path.parent == expected_parent
-
-
-def test_state_db_filename_is_agent_name_sqlite3(tmp_path: Path) -> None:
-    # Arrange
-    # Act
-    path = resolve_state_db_path("alpha", home=tmp_path)
-    # Assert
-    assert path.name == "alpha.sqlite3"
-
-
-def test_state_db_parent_directory_is_created(tmp_path: Path) -> None:
-    # Arrange
-    # Act
-    path = resolve_state_db_path("alpha", home=tmp_path)
-    # Assert
-    assert path.parent.is_dir()
-
-
-def test_state_db_unsafe_agent_name_is_sanitized(tmp_path: Path) -> None:
-    # Arrange
-    # Act
-    path = resolve_state_db_path("a/b c", home=tmp_path)
-    # Assert
-    assert path.name == "a-b-c.sqlite3"
-
-
-def test_state_db_empty_sanitized_name_falls_back_to_agent(tmp_path: Path) -> None:
-    # Arrange
-    # Act
-    path = resolve_state_db_path("///", home=tmp_path)
-    # Assert
-    assert path.name == "agent.sqlite3"
-
-
-def test_state_db_override_is_used_verbatim(tmp_path: Path) -> None:
-    # Arrange
-    override = tmp_path / "custom" / "state.db"
-    # Act
-    path = resolve_state_db_path("alpha", home=tmp_path, override=override)
-    # Assert
-    assert path == override
-
-
-def test_state_db_override_parent_is_created(tmp_path: Path) -> None:
-    # Arrange
-    override = tmp_path / "custom" / "state.db"
-    # Act
-    resolve_state_db_path("alpha", home=tmp_path, override=override)
-    # Assert
-    assert override.parent.is_dir()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stage C of the SQLite eradication: the OpenAI runner's conversation memory
moves off `agents.SQLiteSession` and onto this host's PostgreSQL. This is the
stage that empties the **vendor** footprint — `FROZEN_VENDOR_SQLITE` shrinks
to `frozenset()` and the scan finds ZERO constructs under `src/`.

The runner is LIVE. handyman-05's spec sets `handler: openai_session`, eleven
specs name `openai-agents`, and the handymen drive local Qwen through an
OpenAI-compatible gateway. The zero session files on the fleet were never
evidence of disuse — the SDK created them lazily, on the first session write.

## What lands

- **`_state/openai_session_store.py`** — the `openai_sessions` store, modelled
  on `port_allocator_store`. Identity `(agent, session_id)`; one row per
  conversation; `MULTI_WRITER` because sac relocates agents between hosts while
  `Store` is constructed with `node=socket.gethostname()`; a per-`(target, pid)`
  handle cache keyed on the **`StoreTarget` value**, not `str(locator)` — the
  string form drops the DSN query, so a string key would hand the second
  `pg_schema` test the first one's schema.
- **`_runners/_openai_pg_session.py`** — `PostgresAgentSession`, structurally
  satisfying the SDK's `Session` Protocol as read from the installed
  openai-agents 0.22.0 rather than from memory. It deliberately does not
  subclass `SessionABC`, which the SDK documents as internal.

## `items` is LAST_WRITER_WINS, not APPEND

`pop_item` and `clear_session` are REMOVALS, and `_merge.merge_field` under
APPEND only ever grows a collection — it has no representation for a gone
element. A popped item would come back at the next merge and a cleared session
would return in full; under APPEND the two removal verbs are not lossy, they
are impossible.

LWW makes the whole list the unit of change. Concurrent turns are then CAUGHT
rather than merged, by a 5-attempt read-modify-write whose `revision()` is read
**before** the row. That order is load-bearing and not interchangeable:
`get()` then `revision()` leaves a stale list holding a token that already
covers the other writer, so the `put` succeeds and silently discards their turn.

## Measured, not assumed

- **openai-agents floor `>=0.17.4` → `>=0.19.0`.** Wheels for 0.17.4, 0.18.0,
  0.19.0, 0.20.0, 0.21.0 and 0.22.0 were downloaded and read:
  `resolve_session_limit` is in `agents/memory/session_settings.py` in all of
  them; `coerce_session_settings` only from **0.19.0**. Left at 0.17.4 the
  import is an `ImportError` at the declared minimum.
- **`items` is sac's first `FieldKind.JSON` field**, so the binding was probed.
  `_codec.encode` hands psycopg a `str` and the Postgres dialect declares the
  column `JSONB`, for which `pg_cast` holds **no** cast from `text` — which
  looks fatal and is not: psycopg3 sends `str` parameters as UNKNOWN. On a live
  PostgreSQL 16, `SELECT jsonb_typeof(%s)` with a Python str answers `'object'`
  and `SELECT pg_typeof(%s)` raises `IndeterminateDatatype`.

## Gates

- `FROZEN_VENDOR_SQLITE` → `frozenset()`. All **seven** files that named
  `SQLiteSession` at 67f66669 are reworded or gone.
- `runtimes/_openai_sdk_common.py:179` leaves `FROZEN_UNNAMED_CLAIMS` by
  DELETION, not by naming a sink: its claim guarded the mkdir of a session-db
  parent directory that no longer exists.
- `_openai_turn_driver.py`'s two docstring edits are line-count neutral, so the
  frozen `:240` coordinate still points at the line it was pinned to.

`resolve_state_db_path` and its seven tests are deleted rather than moved: a
store target is not a path. The module docstring's cross-reference went with
the function.

## Follow-up commit: the floor bump had a second home

CI caught what the local runs did not. `tests/integration/
test_apptainer_def_openai_agents.py::test_scitex_def_floor_matches_pyproject_extra`
went red on BOTH matrix legs (1 failed / 18167 passed each): the floor moved in
pyproject and `apptainer-scitex.def` still said 0.17.4. The guard did exactly
its job.

`926e987d` raises the .def in both resolver branches AND stops the lockstep
tests hardcoding the version — they now derive it from pyproject (the SSoT the
module docstring already names), with a guard that raises when the extraction
finds nothing, so the test cannot go vacuous. A hardcoded version in a
"these two must agree" test is a THIRD place to forget: it fires on a
legitimate bump, and its message then misdescribes what it checked.

## Test results

CI on `926e987d` — **all substantive checks green**:

| check | result |
| --- | --- |
| pytest-matrix-on-ubuntu-py3.11 | **pass** (5m35s) — 18168 passed, 108 skipped |
| pytest-matrix-on-ubuntu-py3.13 | **pass** (8m50s) |
| ruff / rtd-sphinx-build / import-smoke / no-hosted-runners-guard / CLAssistant | pass |

**The PostgreSQL path really ran.** CI's pytest prints every skip reason
(`-rs`), and NONE of them names the `pg_schema` fixture — so all 15
store-backed tests (13 in the new `test__openai_pg_session.py`, 2 in
`test_openai_session.py`) executed against a real PostgreSQL on both legs,
including the round trip, `pop_item`, `clear_session`, the limit semantics and
the composite identity. (The coverage table shows 0% for the new module; many
unrelated modules show 0% there too, so it is an artifact of how coverage is
combined here, not evidence — the skip report is the reliable instrument.)

Local runs in the authoring container:

| run | result |
| --- | --- |
| the 3 affected test files + `tests/develop` | 240 passed, 96 skipped, 0 failed |
| `tests/develop/test_sqlite_footprint_frozen.py` + `test_delivery_claims_name_their_sink.py` | 24 passed |
| `tests/scitex_agent_container/{a2a,config,_runners,runtimes}` + one integration file | 4143 passed, 88 skipped, 0 failed |
| `tests/integration` (whole directory, after the fix) | 1298 passed, 26 skipped, 7 deselected |
| `tests/smoke` | 14 passed, 30 skipped |

All 15 `pg_schema` tests SKIP locally: loopback:55432 here is a read-only
replica of the fleet cluster (`system_identifier=7672112238472680366`), so
there is no writable database on this host. That is why the local table proves
less than the CI one does.
