### PR TITLE
test(sqlite): stop the suite creating state.db as a fixture side effect

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -518,6 +518,34 @@ def _assert_state_floor_intact(request: pytest.FixtureRequest) -> Iterator[None]
         if resolved != floor and floor not in resolved.parents:
             breaches.append(f"  {module_path}.{attr}\n      -> {resolved}")
 
+    # THE ENV VAR IS PART OF THE FLOOR, AND ITS ABSENCE IS A BREACH.
+    #
+    # `$SCITEX_AGENT_CONTAINER_STATE_DB` is force-set at the top of this file
+    # so `state_db.DEFAULT_DB_PATH` is BORN inside the sandbox and every
+    # subprocess inherits the same sandbox. The loop above reads the constant,
+    # which is only half the pair: a test that DROPS the env var without
+    # restoring it leaves the constant looking perfectly correct right up until
+    # the next `importlib.reload(state_db)`, at which point the fallback
+    # (`runtime_base_dir() / "state.db"`) re-pins it at the operator's REAL
+    # runtime directory for the rest of this worker's session. That is the
+    # exact Errno-122 escape the constants check was written for, arriving one
+    # reload later through the half nothing was watching.
+    #
+    # So UNSET is NOT "nothing to assert about". It is the floor already
+    # dismantled, and reporting it as a breach is the only reading that does
+    # not depend on whether some later test happens to reload the module.
+    state_db_env = os.environ.get(_STATE_DB_KEY)
+    if state_db_env is None:
+        breaches.append(
+            f"  ${_STATE_DB_KEY}\n"
+            "      -> UNSET (dropped without restore; the next reload of\n"
+            "         state_db re-pins DEFAULT_DB_PATH outside the floor)"
+        )
+    else:
+        resolved_env = Path(state_db_env).resolve()
+        if resolved_env != floor and floor not in resolved_env.parents:
+            breaches.append(f"  ${_STATE_DB_KEY}\n      -> {resolved_env}")
+
     # The card board is checked by ASKING THE RESOLVER, not by reading a
     # constant: `scitex_cards._db.resolve_db_path()` is a function evaluated at
     # every write, so the only honest question is the one the dual-write mirror

--- a/tests/integration/test_listen_notify_delivery.py
+++ b/tests/integration/test_listen_notify_delivery.py
@@ -117,7 +117,6 @@ def listen_state_db(tmp_path: Path, pg_schema: str):
     state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
-    state_db.init_schema(db)
     try:
         yield {"db": db}
     finally:

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -565,7 +565,6 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
     os.environ.update(keys)
     state_db.DEFAULT_DB_PATH = db
     _session_state.DEFAULT_STATE_ROOT = runtime_dir
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker_force_propagation.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker_force_propagation.py
@@ -59,7 +59,6 @@ def isolated_listen_env(tmp_path: Path):
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -307,7 +307,6 @@ def _fire_monitor_restart_against_foreign_db(
     before = {r["id"] for r in list_active_instances()}
 
     foreign = tmp_path / "foreign" / "state.db"
-    state_db.init_schema(foreign)
     saved = state_db.DEFAULT_DB_PATH
     state_db.DEFAULT_DB_PATH = foreign
     try:

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
@@ -42,7 +42,6 @@ def db_path(tmp_path: Path) -> Iterator[Path]:
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
@@ -98,7 +98,6 @@ def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ.update(keys)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -53,7 +53,6 @@ def db_path(tmp_path: Path):
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
+++ b/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
@@ -55,7 +55,6 @@ def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"

--- a/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
+++ b/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
@@ -63,7 +63,6 @@ def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
     saved_cooldown_env = os.environ.get("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S")
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -87,7 +87,6 @@ def db_path(tmp_path: Path):
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test__acl_phase3.py
+++ b/tests/scitex_agent_container/_listen/test__acl_phase3.py
@@ -31,7 +31,6 @@ def db_path(tmp_path: Path):
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test__acl_routes.py
+++ b/tests/scitex_agent_container/_listen/test__acl_routes.py
@@ -35,7 +35,6 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
@@ -67,7 +67,6 @@ def isolated_listen_env(tmp_path: Path):
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"

--- a/tests/scitex_agent_container/_listen/test__agent_exec_declined.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_declined.py
@@ -38,7 +38,6 @@ def isolated_listen_env(tmp_path: Path):
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"

--- a/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
@@ -48,7 +48,6 @@ def isolated_listen_env(tmp_path: Path):
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"

--- a/tests/scitex_agent_container/_listen/test__agents_list.py
+++ b/tests/scitex_agent_container/_listen/test__agents_list.py
@@ -81,7 +81,6 @@ def empty_store(tmp_path: Path):
     importlib.reload(state_db_mod)
     importlib.reload(registry_mod)
     importlib.reload(agents_list_mod)
-    state_db_mod.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test__node_channel.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel.py
@@ -47,7 +47,6 @@ def kind_env(pg_schema: str, tmp_path: Path):
     state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
-    state_db.init_schema(db)
 
     # Same-group ACL — alice (sender) and lead (target) both rooted.
     record_lineage(child="alice", parent="root")

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -81,7 +81,6 @@ def isolated_env(pg_schema: str, tmp_path: Path):
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     _state_db.DEFAULT_DB_PATH = db_path
-    _state_db.init_schema(db_path)
 
     # WI-2 ACL: register the WI-3 demo nodes as siblings under a
     # common root so they share a group. Without this the new

--- a/tests/scitex_agent_container/_listen/test__notify.py
+++ b/tests/scitex_agent_container/_listen/test__notify.py
@@ -74,7 +74,6 @@ def notify_env(tmp_path: Path, pg_schema: str):
     state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
-    state_db.init_schema(db)
 
     try:
         yield {"db": db, "tmp_path": tmp_path}

--- a/tests/scitex_agent_container/_listen/test__registry_endpoints.py
+++ b/tests/scitex_agent_container/_listen/test__registry_endpoints.py
@@ -76,7 +76,6 @@ def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
     prev_env = _swap_env(_STATE_DB_ENV, str(db))
     prev_attr = _state_db.DEFAULT_DB_PATH
     _state_db.DEFAULT_DB_PATH = db
-    _state_db.init_schema(db)
     try:
         yield db
     finally:
@@ -92,7 +91,6 @@ def isolated_host_env(tmp_path: Path) -> Iterator[Path]:
     prev_host_env = _swap_env(_SAC_HOST_ENV, "test-host")
     prev_attr = _state_db.DEFAULT_DB_PATH
     _state_db.DEFAULT_DB_PATH = db
-    _state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test__self_peer_persistence.py
+++ b/tests/scitex_agent_container/_listen/test__self_peer_persistence.py
@@ -69,7 +69,6 @@ def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
     prev_env = _swap_env(_STATE_DB_ENV, str(db))
     prev_attr = _state_db.DEFAULT_DB_PATH
     _state_db.DEFAULT_DB_PATH = db
-    _state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -299,24 +299,14 @@ class TestListAgents:
     ):
         # Arrange — Q1: when port_allocator has a claim, the row carries it.
         from scitex_agent_container._state import port_allocator as _pa
-        from scitex_agent_container._state import state_db as _state_db
 
-        db = isolated_env / "state.db"
-        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-        saved_db_path = _state_db.DEFAULT_DB_PATH
-        _state_db.DEFAULT_DB_PATH = db
-        try:
-            _state_db.init_schema(db)
-            _pa.claim_port("alpha", range_=(22000, 22001))
-            r = _reg.Registry()
-            r.add("alpha", "/path/to/spec.yaml", "sc-alpha", pid=12345)
-            # Act
-            body = client.get("/agents", headers=auth_headers).json()
-            # Assert
-            assert body["agents"][0]["a2a_port"] == 22000
-        finally:
-            _state_db.DEFAULT_DB_PATH = saved_db_path
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        _pa.claim_port("alpha", range_=(22000, 22001))
+        r = _reg.Registry()
+        r.add("alpha", "/path/to/spec.yaml", "sc-alpha", pid=12345)
+        # Act
+        body = client.get("/agents", headers=auth_headers).json()
+        # Assert
+        assert body["agents"][0]["a2a_port"] == 22000
 
     def test_registered_agent_row_carries_turn_url_when_allocator_claimed(
         self, client, auth_headers, isolated_env, pg_schema
@@ -324,24 +314,14 @@ class TestListAgents:
         # Arrange — Q1: turn_url ships alongside a2a_port for the
         # nudge→turn dispatcher.
         from scitex_agent_container._state import port_allocator as _pa
-        from scitex_agent_container._state import state_db as _state_db
 
-        db = isolated_env / "state.db"
-        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-        saved_db_path = _state_db.DEFAULT_DB_PATH
-        _state_db.DEFAULT_DB_PATH = db
-        try:
-            _state_db.init_schema(db)
-            _pa.claim_port("alpha", range_=(22100, 22101))
-            r = _reg.Registry()
-            r.add("alpha", "/path/to/spec.yaml", "sc-alpha", pid=12345)
-            # Act
-            body = client.get("/agents", headers=auth_headers).json()
-            # Assert
-            assert body["agents"][0]["turn_url"].endswith(":22100/v1/turn")
-        finally:
-            _state_db.DEFAULT_DB_PATH = saved_db_path
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        _pa.claim_port("alpha", range_=(22100, 22101))
+        r = _reg.Registry()
+        r.add("alpha", "/path/to/spec.yaml", "sc-alpha", pid=12345)
+        # Act
+        body = client.get("/agents", headers=auth_headers).json()
+        # Assert
+        assert body["agents"][0]["turn_url"].endswith(":22100/v1/turn")
 
     def test_registered_agent_row_carries_null_a2a_port_when_no_claim(
         self, client, auth_headers, isolated_env
@@ -349,46 +329,24 @@ class TestListAgents:
         # Arrange — Q1: when port_allocator has NO claim for the name,
         # the row still ships the key (= null) so consumers can branch
         # on field presence rather than key presence.
-        from scitex_agent_container._state import state_db as _state_db
-
-        db = isolated_env / "state.db"
-        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-        saved_db_path = _state_db.DEFAULT_DB_PATH
-        _state_db.DEFAULT_DB_PATH = db
-        try:
-            _state_db.init_schema(db)
-            r = _reg.Registry()
-            r.add("portless", "/path/to/spec.yaml", "sc-portless", pid=98765)
-            # Act
-            body = client.get("/agents", headers=auth_headers).json()
-            # Assert
-            assert body["agents"][0]["a2a_port"] is None
-        finally:
-            _state_db.DEFAULT_DB_PATH = saved_db_path
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        r = _reg.Registry()
+        r.add("portless", "/path/to/spec.yaml", "sc-portless", pid=98765)
+        # Act
+        body = client.get("/agents", headers=auth_headers).json()
+        # Assert
+        assert body["agents"][0]["a2a_port"] is None
 
     def test_registered_agent_row_carries_null_turn_url_when_no_claim(
         self, client, auth_headers, isolated_env
     ):
         # Arrange — Q1: turn_url is null when a2a_port resolves to null
         # (derive_turn_url's bothness rule).
-        from scitex_agent_container._state import state_db as _state_db
-
-        db = isolated_env / "state.db"
-        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-        saved_db_path = _state_db.DEFAULT_DB_PATH
-        _state_db.DEFAULT_DB_PATH = db
-        try:
-            _state_db.init_schema(db)
-            r = _reg.Registry()
-            r.add("portless", "/path/to/spec.yaml", "sc-portless", pid=98765)
-            # Act
-            body = client.get("/agents", headers=auth_headers).json()
-            # Assert
-            assert body["agents"][0]["turn_url"] is None
-        finally:
-            _state_db.DEFAULT_DB_PATH = saved_db_path
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        r = _reg.Registry()
+        r.add("portless", "/path/to/spec.yaml", "sc-portless", pid=98765)
+        # Act
+        body = client.get("/agents", headers=auth_headers).json()
+        # Assert
+        assert body["agents"][0]["turn_url"] is None
 
 
 # --- GET /agents/<name>/status -------------------------------------------
@@ -454,23 +412,13 @@ class TestAgentStatus:
         # Arrange — Q1: when port_allocator has a claim, status surfaces
         # the derived turn_url so scitex-todo's resolver can dispatch.
         from scitex_agent_container._state import port_allocator as _pa
-        from scitex_agent_container._state import state_db as _state_db
 
-        db = isolated_env / "state.db"
-        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-        saved_db_path = _state_db.DEFAULT_DB_PATH
-        _state_db.DEFAULT_DB_PATH = db
-        try:
-            _state_db.init_schema(db)
-            _write_spec(isolated_env, "beta")
-            _pa.claim_port("beta", range_=(23000, 23001))
-            # Act
-            body = client.get("/agents/beta/status", headers=auth_headers).json()
-            # Assert
-            assert body["turn_url"].endswith(":23000/v1/turn")
-        finally:
-            _state_db.DEFAULT_DB_PATH = saved_db_path
-            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        _write_spec(isolated_env, "beta")
+        _pa.claim_port("beta", range_=(23000, 23001))
+        # Act
+        body = client.get("/agents/beta/status", headers=auth_headers).json()
+        # Assert
+        assert body["turn_url"].endswith(":23000/v1/turn")
 
 
 # --- POST /agents/<name>/send --------------------------------------------
@@ -849,7 +797,6 @@ def cross_host_env(tmp_path: Path):
     state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
-    state_db.init_schema(db)
     # WI-4 Q4(b): seed the per-host bearer registry. The forwarder
     # pulls ``peer-tokens/host-a.token`` to authenticate when
     # forwarding to host A. ``$HOME`` is already tmp_path so the
@@ -1086,7 +1033,6 @@ def missing_peer_token_response(pg_schema: str, tmp_path: Path):
     state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
-    state_db.init_schema(db)
     record_lineage(child="permitted-peer", parent="root")
     record_lineage(child="alice", parent="root")
     state_db.record_instance_start(

--- a/tests/scitex_agent_container/_listen/test_server_lineage_acl.py
+++ b/tests/scitex_agent_container/_listen/test_server_lineage_acl.py
@@ -45,7 +45,6 @@ from starlette.testclient import TestClient
 
 from scitex_agent_container._listen._acl import check_lineage_acl, deny_response
 from scitex_agent_container._listen.server import create_app
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import record_lineage
 
 HOST_TOKEN = "host-token-lineage-acl"
@@ -78,9 +77,8 @@ def isolated_env(tmp_path: Path, env_save_restore):
 
 @pytest.fixture
 def db_path(isolated_env) -> Path:
-    """The state.db ``isolated_env`` pointed the env at, schema applied."""
+    """The state.db path ``isolated_env`` pointed the env at."""
     db = isolated_env / "state.db"
-    state_db.init_schema(db)
     return db
 
 

--- a/tests/scitex_agent_container/_network/test_peer.py
+++ b/tests/scitex_agent_container/_network/test_peer.py
@@ -306,9 +306,6 @@ class TestResolvePeerUrlCrossHostFallback:
         # the honest "is the agent running?" error must still fire.
         env_save_restore.set("SAC_HOST", "lead-host")
         resolve_yaml_to(_write_auto_port_yaml(tmp_path))
-        from scitex_agent_container._state.state_db import init_schema
-
-        init_schema()
         # Act
         action = lambda: resolve_peer_url("clew")
         # Assert

--- a/tests/scitex_agent_container/_reconcile/conftest.py
+++ b/tests/scitex_agent_container/_reconcile/conftest.py
@@ -29,7 +29,6 @@ def db_path(tmp_path: Path):
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_state/test_lead_inbox.py
+++ b/tests/scitex_agent_container/_state/test_lead_inbox.py
@@ -262,7 +262,6 @@ def lead_env(tmp_path: Path, env_save_restore):
     state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
-    state_db.init_schema(db)
 
     # Lead config — production reads this via the env-routed config.yaml.
     # Each test that actually pushes rewrites ``a2a_port`` with the

--- a/tests/scitex_agent_container/_state/test_state_db_acl_deny_notify.py
+++ b/tests/scitex_agent_container/_state/test_state_db_acl_deny_notify.py
@@ -41,7 +41,6 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
     saved_cooldown_env = os.environ.get("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S")
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_state/test_state_db_comms_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_comms_nodes.py
@@ -74,14 +74,16 @@ FOREIGN_HOST = f"not-{THIS_NODE}"
 
 @pytest.fixture
 def db_path(tmp_path: Path) -> Path:
-    """A real state.db — still needed for the ``instances`` half of the resolver.
+    """A per-test state.db PATH — the file is left for the code to make.
 
-    ``resolve_node_host`` reads ``instances`` from SQLite and falls through to
-    the PostgreSQL directory, so the resolver tests below need both stores.
+    This called ``init_schema`` here until the suite stopped creating SQLite
+    files as a side effect. Nothing was lost: the only test that reads this
+    database opens it through ``state_db.open_db``, which initialises on first
+    use, so the file is still made by the production path rather than by a
+    fixture reaching for it first.
     """
     # Arrange
     p = tmp_path / "state.db"
-    state_db.init_schema(p)
     return p
 
 

--- a/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
+++ b/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
@@ -57,7 +57,6 @@ def db_path(tmp_path: Path):
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -44,7 +44,6 @@ from scitex_agent_container._state.state_db_nodes import (
 def db_path(tmp_path: Path) -> Path:
     # Arrange
     p = tmp_path / "state.db"
-    state_db.init_schema(p)
     return p
 
 

--- a/tests/scitex_agent_container/_state/test_state_db_nodes_group.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes_group.py
@@ -37,7 +37,6 @@ def db_path(tmp_path: Path):
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/a2a/test__server.py
+++ b/tests/scitex_agent_container/a2a/test__server.py
@@ -691,7 +691,6 @@ def _isolated_db(tmp_path: Path, pg_schema: str):
     saved_default = _state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     _state_db.DEFAULT_DB_PATH = db
-    _state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
@@ -726,9 +726,6 @@ class TestDispatchStrictHostKeyChecking:
 class TestLookupRemotePeer:
     def test_no_active_row_returns_none(self, fake_home, state_db, env_save_restore):
         # Arrange — fresh state.db with no instances row for "alpha".
-        from scitex_agent_container._state.state_db import init_schema
-
-        init_schema()
         # Act
         result = lookup_remote_peer("alpha")
         # Assert
@@ -768,9 +765,6 @@ class TestTryDispatchRemote:
 
     def test_no_active_row_returns_false(self, fake_home, state_db, env_save_restore):
         # Arrange — no row; caller proceeds local.
-        from scitex_agent_container._state.state_db import init_schema
-
-        init_schema()
         calls: list = []
         # Act
         dispatched = try_dispatch_remote(

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
@@ -67,7 +67,6 @@ def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
@@ -99,7 +99,6 @@ def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ.update(keys)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_verify_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_verify_wiring.py
@@ -86,7 +86,6 @@ def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ.update(keys)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
+++ b/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
@@ -38,7 +38,6 @@ def db_path(tmp_path: Path):
     saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     state_db.DEFAULT_DB_PATH = db
-    state_db.init_schema(db)
     try:
         yield db
     finally:

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -118,7 +118,6 @@ def comms_env(pg_schema: str, disk_tmp: Path) -> Iterator[dict[str, Any]]:
     state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = disk_tmp / "registry"
     _ss.DEFAULT_STATE_ROOT = disk_tmp / "runtime"
-    state_db.init_schema(db)
     try:
         yield {"db": db, "tmp": disk_tmp}
     finally:


### PR DESCRIPTION
## What

`init_schema` has issued **zero** `CREATE TABLE` since 2026-08-28: `KNOWN_TABLES`
is `()` and both `_SCHEMA_*` constants are comment-only (verified by parsing them:
0 effective SQL lines out of ~10.5 KB). So every remaining call under `tests/` did
exactly one thing — `_connect(path)`, which creates an empty SQLite file on disk.
No call site anywhere in `tests/` binds the return value.

Three changes, all side effects, no assertion touched.

### 1. `_listen/test_server.py` — five inline blocks

Each called `init_schema` and then, in a `finally:`, did

```python
os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
```

with **no saved value and no restore**. Those five were the repository's only
unpaired pops of that variable — every other pop in `tests/` is guarded by
`if saved is None:`. The `try/finally` existed solely to undo the redirect the
`init_schema` call needed, so it goes with the call. The `pg_schema`-backed
assertions are byte-for-byte unchanged.

### 2. `tests/conftest.py` — the floor alarm reads the env var too

`_assert_state_floor_intact` checked the three import-time **constants** but never
the env var they are derived from. A teardown that drops
`$SCITEX_AGENT_CONTAINER_STATE_DB` without restoring it leaves those constants
looking perfectly correct — right up until the next `importlib.reload(state_db)`,
which re-derives `DEFAULT_DB_PATH` from the fallback and re-pins it at the
operator's real runtime dir for the rest of that worker's session. That is the
Errno-122 escape the alarm was written for, arriving one reload later through the
half nothing was watching. **UNSET is now reported as a breach**, as is a value
resolving outside the floor.

### 3. The sweep — 38 further files

The same call deleted wherever it was pure scaffolding, plus the function-local
`from ... import init_schema` that existed only to serve it, plus one module-level
import that this made unused.

## Five files deliberately keep the call

Where `init_schema` is the **subject** rather than a side effect, removing it does
not fail loudly — in three of the five the assertion would keep **passing**
against an empty file `sqlite3.connect` had just created, which is worse than a
failure:

| file | why |
|---|---|
| `_state/test_state_db.py` | `assert (not pre_existed) and db_path.exists()` *is* the assertion |
| `_state/test_state_db_health.py` | `real_store` must classify as `populated`; `test_the_core_tables_are_all_created_by_init_schema` is about what the call makes |
| `_state/test_state_db_instances.py` | "a fresh state.db has no `instances` table" — vacuous without a real database |
| `_state/test_state_db_turns_errors_heartbeats.py` | the fixture's file-existence dependency (owned by a later stage) |
| `_helpers/fleet_root.py` | `make_state_db`; `test__rename_db` asserts on the database it builds |

Independent corroboration: four of these five are already inventoried in
`FROZEN_SQLITE_TESTS` as "tests of production code that still speaks SQLite", and
the fifth is the helper one of them builds its database with. They retire when
that code does, not here.

## Measurement

Same `--basetemp` both sides, whole suite, files counted on disk afterwards:

| | SQLite files created |
|---|---|
| unmodified `develop` (control) | **213** |
| this branch | **71** |

The control matters: an "after" count means nothing unless the files provably
appear before. They do.

What is left is not `init_schema(` in a test. It is migration-carrier fixtures
building a source database to be drained, the SQLite-layer tests above, Claude
session `*.sqlite3` files, the cards mirror, and production paths that open a
database themselves — `open_db` still calls `init_schema` unconditionally, which
is why e.g. `test_comms_nodes_is_gone_from_a_fresh_state_db` still produces a file
after its fixture stopped making one.

## Test runs

| run | result |
|---|---|
| `develop` baseline, `-n auto` | 1 failed, 15798 passed, 2465 skipped |
| this branch, single worker | 1 failed, 15798 passed, 2465 skipped (18m28s) |
| this branch, `-n auto` | 1 failed, 15798 passed, 2465 skipped (2m52s) |
| this branch, `-n auto -p randomly` | 1 failed, 15798 passed, 2465 skipped (3m08s) |

All three produced the same 71 SQLite files. The single-worker run matters here
because the scaffolding removed was built around an order-dependent bug: one
process, one env, no xdist sharding to hide a leak.

The single failure is identical on `develop` and pre-existing:
`_maintenance/test__layers_migration_plan.py::test_the_unreadable_reason_survives_a_multiline_error`,
which is sensitive to the length of the `--basetemp` path in a truncated error
string.

## Caveats

- The loopback PostgreSQL in this container is a **read-only replica**, so all 68
  tests in `_listen/test_server.py` — including the five blocks edited here —
  **skip locally**. Their runtime correctness is verified by CI, not by me.
- `tests/develop/test_sqlite_footprint_frozen.py` is untouched (owned by another
  stage). Nothing here removes an `import sqlite3`, so neither the frozen lists
  nor their staleness tests move.
