### PR TITLE
refactor(vocabulary): the retired engine's name leaves every tracked file outside docs/adr/ (160 -> 97; 88 detector, 9 shipped-release record)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,18 +47,65 @@ versioning follows [SemVer](https://semver.org/).
   any host — not because it finished.
 
 ### Changed
-- **`tests/develop/test_sqlite_footprint_frozen.py` keeps its scans and loses
-  its allowlists.** Four frozen inventories (`FROZEN_SQLITE`, `_SCRIPTS`,
-  `_TESTS`, `_DDL`) are empty, and their staleness tests were vacuous with
-  them — a test that cannot fail is worse than no test, because the file still
-  lists it. The predicate "every module importing sqlite3 appears in
-  FROZEN_SQLITE" collapses to "nothing imports sqlite3", which is the rule the
-  operator asked for with no list between the reader and it. The import scan,
-  the `CREATE TABLE` scan (with `POSTGRES_DDL` for legitimate PostgreSQL
-  definers) and the VENDOR scan all stay, as do the planted-file positive
-  controls. The vendor scan is the one that must outlive the others:
-  `SQLiteSession` is the shape SQLite returns in once nobody writes
-  `import sqlite3`, and no import check can see it.
+- **The retired engine's NAME is gone from every tracked file outside
+  `docs/adr/`, and a gate keeps it that way.** #1274 removed the engine; this
+  removes the vocabulary, which is the half that carried the last reversal —
+  a previous removal was undone in effect rather than in commit, because the
+  code stayed clean while the documentation went on naming the engine as the
+  default. 78 lines across 30 files: release notes, module and test
+  docstrings, four copies of one container banner, two quoted operator rulings
+  and eleven citations of a task-board id. Every line keeps its facts, dates
+  and measurements; only the name goes, replaced by what it was in that
+  sentence — a driver, a catalogue table, a local file, a retired engine.
+  Measured on the tree with NO exclusions: the only tracked files that still
+  name it are the three ADRs, which are the one allowed place because an ADR
+  records a decision that was taken, and the two detectors.
+- **Three of those lines were stale, and two of them were wrong.**
+  `_fleet_env.py` quoted scitex-dev's `resolve_target` on a sentence that
+  module no longer contains — it now reads "deliberately no third" — so the
+  quote is restored to what the cited source actually says.
+  `test_state_db_acl_policy.py` said `lineage` was "still" on the old engine;
+  it moved to PostgreSQL on 2026-08-28, which the neighbouring test file's own
+  docstring already said. `openai_session_store.py` pointed at a frozen
+  constant that was deleted along with the allowlists.
+- **The footprint ratchet's FILENAME no longer carries the engine's name**, and
+  is now `tests/develop/test_retired_engine_footprint_frozen.py`. The scans
+  read file CONTENT, so a path was never an offence — but the old name was the
+  last thing in the repository forcing a cross-reference to spell the word, and
+  two files had to.
+- **The task-board card cited for the 159x per-call connect measurement is
+  re-identified as `store-connect-cost-per-call-20260828`.** Its previous id
+  embedded the engine's name, eleven docstrings cite it as provenance, and an
+  identifier is not exempt. Mangling it in those citations would have made them
+  unresolvable, so the card was superseded and cross-linked instead: the
+  original keeps its history and is closed as re-identified, NOT as completed.
+
+### Added
+- **`tests/develop/test_the_engine_name_stays_gone.py` — the name gate.** The
+  footprint ratchet next door asserts that nothing USES the retired engine;
+  this asserts that nothing NAMES it. The two are deliberately independent:
+  prose can name the engine without importing it, and — as the vendor scan
+  exists to prove — code can open it without naming it. `docs/adr/` is exempt,
+  both detectors are exempt, and a staleness gate deletes an exemption that
+  stops matching, so it cannot decay into a blessed filename. Ignore-rule
+  PATTERN lines are exempt — a `.gitignore` line excluding the engine's files
+  is a refusal, not a mention — while comments inside those same files are
+  prose and are not. Verified by planting the word in a tracked source file:
+  the gate goes red, and green again once it is removed.
+
+### Changed
+- **The footprint ratchet keeps its scans and loses its allowlists.** Four
+  frozen inventories (the module, script, test and DDL lists) are empty, and
+  their staleness tests were vacuous with them — a test that cannot fail is
+  worse than no test, because the file still lists it. The predicate "every
+  module importing the retired driver appears in the frozen list" collapses
+  to "nothing imports it", which is the rule the operator asked for with no
+  list between the reader and it. The import scan, the `CREATE TABLE` scan
+  (with `POSTGRES_DDL` for legitimate PostgreSQL definers) and the VENDOR
+  scan all stay, as do the planted-file positive controls. The vendor scan is
+  the one that must outlive the others: a vendored session object is the
+  shape the engine returns in once nobody writes the import, and no import
+  check can see it.
 
 ### Added
 - **`sac agents resume-rate-limited` — the third agent-liveness enforcer, and
@@ -78,7 +125,8 @@ versioning follows [SemVer](https://semver.org/).
   Scheduled as the `sac.resume-rate-limited-agents` JobSpec.
 
 ### Removed
-- **The SQLite read surface: `sac db show` / `db query` / `db export` /
+- **The retired engine's read surface: `sac db show` / `db query` /
+  `db export` /
   `db import`, their MCP and `sac.db.*` twins, and `state_db_health`.** These
   were the last reachable callers of `state_db.open_db` / `init_schema` /
   `table_counts` in `src/`; after this change the three functions have
@@ -103,7 +151,8 @@ versioning follows [SemVer](https://semver.org/).
 ### Changed
 - **`GET /agents` and the `host_exec` ACL denial now name the PostgreSQL
   target they actually consulted.** Both printed `state_db.DEFAULT_DB_PATH` —
-  a SQLite path neither one opens. The field is there because on 2026-08-09 an
+  a local-file path neither one opens. The field is there because on
+  2026-08-09 an
   empty `agents` list was read as fleet-wide data loss when the honest reading
   was "you asked the wrong database", so dropping it would have restored the
   ambiguity it exists to prevent; it now resolves the real locator instead
@@ -145,8 +194,9 @@ versioning follows [SemVer](https://semver.org/).
 - **`sac agents rename` now carries an agent's ACL grants, and REFUSES rather
   than guessing when it cannot.** `comms_grants` was the last pair of
   `(table, column)` entries inside `_lifecycle/_rename_db`, and that module
-  renamed rows with a SQLite `UPDATE` over a table that has not existed since
-  2026-08-28 — it SKIPS a table absent from `sqlite_master`, so the rename
+  renamed rows with a single-engine `UPDATE` over a table that has not
+  existed since 2026-08-28 — it SKIPS a table absent from that engine's own
+  catalogue, so the rename
   reported success having moved nothing. For an ACL table that silence cut
   both ways: the renamed agent silently LOST every cross-group permission an
   operator had granted it (`check_send_acl` asks `has_grant` about the LIVE
@@ -195,8 +245,9 @@ versioning follows [SemVer](https://semver.org/).
   `[store]`.
 
 ### Removed
-- **`_lifecycle/_rename_db.py`, and with it the last SQLite-ENGINE module in
-  `src/`.** It walked `sqlite_master` to rewrite an agent's rows across every
+- **`_lifecycle/_rename_db.py`, and with it the last module in `src/` bound
+  to the retired ENGINE.** It walked that engine's own catalogue table to
+  rewrite an agent's rows across every
   table; every one of those tables now lives in PostgreSQL and is renamed by
   its own step with its own inverse. The `state-db` step, `Layout.state_db`,
   `_rename_db`'s frozen-footprint entry and its test file all go in the same
@@ -249,14 +300,16 @@ grounds that had nothing to do with the thing they measured.
 
 ## [0.26.3] - 2026-08-24
 
-**Off SQLite.** Every remaining piece of runtime state that a container wrote
-to a private SQLite file now lives in the per-host PostgreSQL on `:55432`,
+**Off the local-file engine.** Every remaining piece of runtime state that a
+container wrote to a private database file now lives in the per-host
+PostgreSQL on `:55432`,
 where a second agent on the same host can see it. This is the release that
 carries the migration the operator directed on 2026-08-24, plus the day's
 repairs to the things the migration exposed.
 
 ### Changed
-- **State moved off SQLite onto per-host PostgreSQL**: both remaining ACL
+- **State moved off the local-file engine onto per-host PostgreSQL**: both
+  remaining ACL
   tables (#1161) and the ACL pending-prompt flag (#1158); the inbound dispatch
   ledger (#1169); the agent auth cache (#1203); relocation residency, leases
   and journal (#1207); and the two raw `instances` readers now go through the
@@ -912,7 +965,8 @@ change that needs one.
          read from postgresql://scitex_cards@127.0.0.1:55432/scitex_cards (uuid 1d55dd6e)
 
   This fleet currently has four stores — two Postgres clones, an abandoned
-  SQLite inbox sidecar (365 rows, 149 unseen, zero-byte WAL, no write since the
+  local-file inbox sidecar (365 rows, 149 unseen, zero-byte WAL, no write
+  since the
   previous morning while readers kept attaching), and a YAML file that
   `scitex-cards done` resolved to while `$SCITEX_CARDS_DB` named Postgres. A
   count with no named source is unfalsifiable: it looks identical whether it
@@ -2234,7 +2288,7 @@ change that needs one.
   overrides at INFO instead. The defaults are DATA — no sac logic names a
   consumer, and per-agent opt-out needs no new mechanism (set the key in
   `spec.env`, or `""` to neutralise). Seeded with `SCITEX_CARDS_DUAL_WRITE=1`
-  and `SCITEX_CARDS_READ_BACKEND=sqlite`.
+  and a `SCITEX_CARDS_READ_BACKEND` pin naming the engine of the day.
 
 - **`auth-heal` is declared as a `kind="timer"` JobSpec (`sac.heal-agent-auth`)
   instead of a hand-written crontab line** (PR #753). The cron line was
@@ -2688,14 +2742,16 @@ what had to be true for it to actually arrive.
   workflow — not an equivalent setup, the same bytes. Green PR ⇒ green release,
   by construction.
 
-- **`claim_port()` lost a race and raised a raw sqlite traceback — the bug that
+- **`claim_port()` lost a race and raised a raw driver traceback — the bug that
   ghosted v0.21.18/19.** The pinned-port branch was a TOCTOU: it `SELECT`ed for a
   clash, then `INSERT`ed, with nothing in between. A concurrent claimant landing
-  in that window tripped `UNIQUE(port)` and `sqlite3.IntegrityError` escaped to
+  in that window tripped `UNIQUE(port)` and the driver's `IntegrityError`
+  escaped to
   the caller. *Which* error you got — the intended diagnosis or a driver
   traceback — was decided purely by thread timing, which is why the failure moved
-  between releases and read as a flake. Reproduced deterministically (16 threads,
-  real sqlite, no mocks): 6 raw escapes, 9 clean errors. The claim is now a single
+  between releases and read as a flake. Reproduced deterministically (16
+  threads, a real database, no mocks): 6 raw escapes, 9 clean errors. The
+  claim is now a single
   atomic statement (`INSERT ... ON CONFLICT DO NOTHING` + read-back).
 
 - **A lost port race is now resolved by ORIGIN, so a concurrent fleet relaunch
@@ -3082,7 +3138,8 @@ cannot be stopped. It was held back rather than published.
 
 - **Tests raced real servers against arbitrary 5-second deadlines (#661).** The
   loopback server wasn't dead — it was **slow** (`server.started` measured at
-  7.49s, because the listen lifespan does a filesystem walk plus SQLite upserts
+  7.49s, because the listen lifespan does a filesystem walk plus database
+  upserts
   before reporting ready). The old wait also **swallowed the server's startup
   exception**, burned its ceiling, and then blamed a timeout — so a *crashed*
   server and a *slow* one produced the identical error. The idiom was copy-pasted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,14 +52,22 @@ versioning follows [SemVer](https://semver.org/).
   removes the vocabulary, which is the half that carried the last reversal —
   a previous removal was undone in effect rather than in commit, because the
   code stayed clean while the documentation went on naming the engine as the
-  default. 78 lines across 30 files: release notes, module and test
-  docstrings, four copies of one container banner, two quoted operator rulings
-  and eleven citations of a task-board id. Every line keeps its facts, dates
-  and measurements; only the name goes, replaced by what it was in that
-  sentence — a driver, a catalogue table, a local file, a retired engine.
-  Measured on the tree with NO exclusions: the only tracked files that still
-  name it are the three ADRs, which are the one allowed place because an ADR
-  records a decision that was taken, and the two detectors.
+  default. 69 lines across 30 files: module and test docstrings, four copies
+  of one container banner, two quoted operator rulings, eleven citations of a
+  task-board id, and the notes under `[Unreleased]`. Every line keeps its
+  facts, dates and measurements; only the name goes, replaced by what it was
+  in that sentence — a driver, a catalogue table, a local file, a retired
+  engine.
+- **The nine changelog lines under SHIPPED version headings are left alone,
+  deliberately.** `[0.26.3]`, `[0.25.0]`, `[0.21.25]`, `[0.21.20]` and the
+  never-published `[0.21.16]` each describe what that release actually
+  contained. Rewriting one does not remove the dependency — it makes the
+  published changelog disagree with the published tag, which is the same
+  failure as an incident record losing the cause it names. So sac does not
+  reach zero, and that is the correct answer rather than one to engineer
+  around: the honest instrument for a frozen record is an exemption, not an
+  edit. `[Unreleased]` is still enforced, because nothing has shipped
+  claiming it yet.
 - **Three of those lines were stale, and two of them were wrong.**
   `_fleet_env.py` quoted scitex-dev's `resolve_target` on a sentence that
   module no longer contains — it now reads "deliberately no third" — so the
@@ -300,16 +308,14 @@ grounds that had nothing to do with the thing they measured.
 
 ## [0.26.3] - 2026-08-24
 
-**Off the local-file engine.** Every remaining piece of runtime state that a
-container wrote to a private database file now lives in the per-host
-PostgreSQL on `:55432`,
+**Off SQLite.** Every remaining piece of runtime state that a container wrote
+to a private SQLite file now lives in the per-host PostgreSQL on `:55432`,
 where a second agent on the same host can see it. This is the release that
 carries the migration the operator directed on 2026-08-24, plus the day's
 repairs to the things the migration exposed.
 
 ### Changed
-- **State moved off the local-file engine onto per-host PostgreSQL**: both
-  remaining ACL
+- **State moved off SQLite onto per-host PostgreSQL**: both remaining ACL
   tables (#1161) and the ACL pending-prompt flag (#1158); the inbound dispatch
   ledger (#1169); the agent auth cache (#1203); relocation residency, leases
   and journal (#1207); and the two raw `instances` readers now go through the
@@ -965,8 +971,7 @@ change that needs one.
          read from postgresql://scitex_cards@127.0.0.1:55432/scitex_cards (uuid 1d55dd6e)
 
   This fleet currently has four stores — two Postgres clones, an abandoned
-  local-file inbox sidecar (365 rows, 149 unseen, zero-byte WAL, no write
-  since the
+  SQLite inbox sidecar (365 rows, 149 unseen, zero-byte WAL, no write since the
   previous morning while readers kept attaching), and a YAML file that
   `scitex-cards done` resolved to while `$SCITEX_CARDS_DB` named Postgres. A
   count with no named source is unfalsifiable: it looks identical whether it
@@ -2288,7 +2293,7 @@ change that needs one.
   overrides at INFO instead. The defaults are DATA — no sac logic names a
   consumer, and per-agent opt-out needs no new mechanism (set the key in
   `spec.env`, or `""` to neutralise). Seeded with `SCITEX_CARDS_DUAL_WRITE=1`
-  and a `SCITEX_CARDS_READ_BACKEND` pin naming the engine of the day.
+  and `SCITEX_CARDS_READ_BACKEND=sqlite`.
 
 - **`auth-heal` is declared as a `kind="timer"` JobSpec (`sac.heal-agent-auth`)
   instead of a hand-written crontab line** (PR #753). The cron line was
@@ -2742,16 +2747,14 @@ what had to be true for it to actually arrive.
   workflow — not an equivalent setup, the same bytes. Green PR ⇒ green release,
   by construction.
 
-- **`claim_port()` lost a race and raised a raw driver traceback — the bug that
+- **`claim_port()` lost a race and raised a raw sqlite traceback — the bug that
   ghosted v0.21.18/19.** The pinned-port branch was a TOCTOU: it `SELECT`ed for a
   clash, then `INSERT`ed, with nothing in between. A concurrent claimant landing
-  in that window tripped `UNIQUE(port)` and the driver's `IntegrityError`
-  escaped to
+  in that window tripped `UNIQUE(port)` and `sqlite3.IntegrityError` escaped to
   the caller. *Which* error you got — the intended diagnosis or a driver
   traceback — was decided purely by thread timing, which is why the failure moved
-  between releases and read as a flake. Reproduced deterministically (16
-  threads, a real database, no mocks): 6 raw escapes, 9 clean errors. The
-  claim is now a single
+  between releases and read as a flake. Reproduced deterministically (16 threads,
+  real sqlite, no mocks): 6 raw escapes, 9 clean errors. The claim is now a single
   atomic statement (`INSERT ... ON CONFLICT DO NOTHING` + read-back).
 
 - **A lost port race is now resolved by ORIGIN, so a concurrent fleet relaunch
@@ -3138,8 +3141,7 @@ cannot be stopped. It was held back rather than published.
 
 - **Tests raced real servers against arbitrary 5-second deadlines (#661).** The
   loopback server wasn't dead — it was **slow** (`server.started` measured at
-  7.49s, because the listen lifespan does a filesystem walk plus database
-  upserts
+  7.49s, because the listen lifespan does a filesystem walk plus SQLite upserts
   before reporting ready). The old wait also **swallowed the server's startup
   exception**, burned its ceiling, and then blamed a timeout — so a *crashed*
   server and a *slow* one produced the identical error. The idiom was copy-pasted

--- a/docs/adr/0022-state-in-postgres-configuration-in-git.md
+++ b/docs/adr/0022-state-in-postgres-configuration-in-git.md
@@ -2,6 +2,13 @@
 
 * **Status**: Proposed (first slice implemented)
 * **Date**: 2026-08-12
+* **Later ruling, 2026-08-19** (the storage-consolidation order that made
+  `SCITEX_STORE_DSN` a fleet default):
+  「sqlite 根絶をしてください」/「fail fast, fail loud, no fallbacks」.
+  Recorded here rather than in the module it governs
+  (`runtimes/_fleet_env.py`), because an ADR is the one place the
+  eradication rule permits the name to stand — so the operator's words
+  survive verbatim instead of being reworded out of the tree.
 * **Operator rulings**: 「state.db というものは使ってはいけません」/
   「sqlite 使った瞬間負けだと思った方が良いです」/
   「今 5432 を scitex のために使ってるものはすべて間違い」/

--- a/docs/design/telegram-fold.md
+++ b/docs/design/telegram-fold.md
@@ -157,18 +157,19 @@ The 5 persistence tools (`get_history`, `get_unread`, `mark_read`,
 `search_messages`, `get_context`) are **not** ported into sac. From the audit
 (`05_sac-mcp-telegram.md`):
 
-> The split is clean: transport tools (reply/react/edit/download/send_document)
-> belong wherever the bot token lives; persistence tools
-> (history/unread/mark_read/search/get_context) are telegrammer's distinct
-> value-add and only make sense if you keep the SQLite store.
+The audit's finding, paraphrased: the split is clean, because transport tools
+(reply/react/edit/download/send_document) belong wherever the bot token
+lives, while persistence tools (history/unread/mark_read/search/get_context)
+are telegrammer's distinct value-add and only make sense if you keep its
+local message database.
 
 Sac's bus is intentionally non-persistent (`_inbox_bus.py` comments: "No
 persistence: replay belongs on disk (`session.jsonl`), not in the bus.").
-Re-introducing a SQLite store into sac MCP would contradict that.
+Re-introducing a local message store into sac MCP would contradict that.
 
 If history/search must survive, ship a separate `tg-archiver` sidecar that
-subscribes to the bus and writes telegrammer-compatible SQLite. Out of scope
-for this fold.
+subscribes to the bus and writes a telegrammer-compatible store. Out of
+scope for this fold.
 
 ## Allowed-users model
 
@@ -242,7 +243,7 @@ config files.
   per-agent; default target should probably be `master`. Configurable?
   Multi-subscriber fanout?
 - Persistence: do you want a `tg-archiver` sidecar that re-creates
-  telegrammer's SQLite store from the bus, or is `session.jsonl` enough?
+  telegrammer's message store from the bus, or is `session.jsonl` enough?
 - Cross-host: today the bus is per-`sac listen`. Should Telegram-driven
   messages reach agents on other hosts in this round, or wait for the
   generic cross-host A2A story?

--- a/src/scitex_agent_container/_state/openai_session_store.py
+++ b/src/scitex_agent_container/_state/openai_session_store.py
@@ -11,11 +11,11 @@ WHY THIS EXISTS AT ALL
 The ``openai-agents`` SDK persists multi-turn memory through a ``Session``
 object, and sac used the SDK's own file-backed one — a real per-agent
 database under ``~/.scitex/agent-container/runtime/openai-sessions/``. It was
-the LAST local database sac opened, and the only one no import scan
-scan could ever see, because the import happens inside the vendor package.
-That is the whole hole ``tests/develop/test_sqlite_footprint_frozen.py``'s
-vendor gate was written to measure, and closing it is what empties
-``FROZEN_VENDOR_SQLITE``.
+the LAST local database sac opened, and the only one no import scan could
+ever see, because the import happens inside the vendor package. That is the
+whole hole the vendor gate in
+``tests/develop/test_retired_engine_footprint_frozen.py`` was written to
+measure, and closing it is what took that gate's live population to zero.
 
 THE RUNNER IS LIVE, so this is not a paper migration: handyman-05's spec sets
 ``handler: openai_session``, eleven specs name ``openai-agents``, and the

--- a/src/scitex_agent_container/_state/port_allocator.py
+++ b/src/scitex_agent_container/_state/port_allocator.py
@@ -127,7 +127,7 @@ def get_port(agent_name: str) -> int | None:
     A scan by design — the store identity is the port, so the agent is data.
     See :mod:`.port_allocator_store` for the cost, which is stated there
     rather than hidden. The handle is the per-process cached one (card
-    sqlite-out-per-call-connect-cost-20260828): never closed here.
+    store-connect-cost-per-call-20260828): never closed here.
     """
     store = port_store()
     for port, holder in live_claims(store).items():

--- a/src/scitex_agent_container/_state/port_allocator_store.py
+++ b/src/scitex_agent_container/_state/port_allocator_store.py
@@ -76,7 +76,7 @@ is the live one, and the loudness IMMUTABLE was meant to buy comes from the
 mandatory read-back instead, which works under any merge rule.
 
 THE STORE HANDLE IS CACHED PER PROCESS (card
-sqlite-out-per-call-connect-cost-20260828)
+store-connect-cost-per-call-20260828)
 ============================================
 ``Store.__init__`` pays a psycopg connect (measured 10.7 ms — 159x the old
 local open) plus a schema advisory lock and two catalogue probes on EVERY
@@ -224,7 +224,7 @@ def port_store() -> "Store":
 
     Keyed by the RESOLVED target and the pid (module docstring says why:
     per-call construction costs a 10.7 ms psycopg connect on the agent-start
-    path — card sqlite-out-per-call-connect-cost-20260828 — while the
+    path — card store-connect-cost-per-call-20260828 — while the
     ``pg_schema`` fixture and forked test processes both invalidate a naive
     singleton). ``Store`` serialises its own operations internally, so one
     shared handle per process is safe for concurrent threads.

--- a/src/scitex_agent_container/_state/state_db_comms_nodes_store.py
+++ b/src/scitex_agent_container/_state/state_db_comms_nodes_store.py
@@ -110,7 +110,7 @@ Every other migrated module opens and closes a ``Store`` per call. This one
 caches: ``comms_nodes`` is the a2a ROUTING path, read once per message, and
 ``psycopg.connect`` costs 10.707 ms against the 0.067 ms the previous
 local-file backend paid (159x, measured on the live primary — card
-``sqlite-out-per-call-connect-cost-20260828``). See
+``store-connect-cost-per-call-20260828``). See
 :func:`open_comms_nodes_store` for the end-to-end number, the target-keyed
 invalidation, and what happens when the connection dies.
 """
@@ -367,7 +367,7 @@ def open_comms_nodes_store() -> "Store":
     ``resolve_forward_target`` and ``_agents_list``, which run PER MESSAGE.
 
     Measured on the live primary (card
-    ``sqlite-out-per-call-connect-cost-20260828``): the previous local-file
+    ``store-connect-cost-per-call-20260828``): the previous local-file
     connect cost 0.067 ms and ``psycopg.connect`` 10.707 ms — 159x — and
     ``Store.__init__``
     pays that connect plus the dialect ``schema_lock`` and two probes even

--- a/src/scitex_agent_container/_state/state_db_grants_store.py
+++ b/src/scitex_agent_container/_state/state_db_grants_store.py
@@ -21,7 +21,7 @@ order the ports landed in, and it costs twice:
 
 * ``psycopg.connect`` is 10.707 ms against the previous 0.067 ms
   (159x, measured on the live primary, card
-  ``sqlite-out-per-call-connect-cost-20260828``). :func:`.has_grant` is
+  ``store-connect-cost-per-call-20260828``). :func:`.has_grant` is
   called by ``_listen._acl.check_send_acl`` for every cross-group message,
   so the per-call open was paying that connect on the ACL path.
 * a connection dying UNDER a cached handle is the failure the target-keyed

--- a/src/scitex_agent_container/_state/state_db_groups.py
+++ b/src/scitex_agent_container/_state/state_db_groups.py
@@ -55,8 +55,8 @@ about what the spec said.
 from __future__ import annotations
 
 # ``db_path`` IS GONE from every reader below (2026-08-28). It named a
-# SQLite file, and the only thing any of them did with it was hand it to
-# ``read_comms_policy`` — which now reads ``node_comms_policy`` from
+# local database file, and the only thing any of them did with it was hand
+# it to ``read_comms_policy`` — which now reads ``node_comms_policy`` from
 # PostgreSQL. Leaving the parameter would have been worse than removing
 # it: a caller passing a ``tmp_path`` would believe it had isolated the
 # read, and it would silently have been reading the live fleet store.

--- a/src/scitex_agent_container/_state/state_db_instances_store.py
+++ b/src/scitex_agent_container/_state/state_db_instances_store.py
@@ -86,7 +86,7 @@ ONE HANDLE PER PROCESS — MANDATORY HERE, NOT AN OPTIMISATION
 ``instances`` sits under ``_send_resolve``, ``resolve_node_host``,
 ``resolve_forward_target`` and ``_agents_list`` — the a2a routing path, run
 PER MESSAGE. Measured on the live primary (card
-``sqlite-out-per-call-connect-cost-20260828``): the previous local-file
+``store-connect-cost-per-call-20260828``): the previous local-file
 connect cost 0.067 ms and ``psycopg.connect`` 10.707 ms — 159x — and
 ``Store.__init__``
 pays that connect plus the dialect ``schema_lock`` and two probes even when

--- a/src/scitex_agent_container/_state/state_db_lineage_store.py
+++ b/src/scitex_agent_container/_state/state_db_lineage_store.py
@@ -68,7 +68,7 @@ ONE HANDLE PER PROCESS
 Same judgement, and the same measurement, as
 :mod:`.state_db_comms_nodes_store`: ``psycopg.connect`` costs 10.707 ms
 against the previous 0.067 ms (159x, live primary, card
-``sqlite-out-per-call-connect-cost-20260828``), and these readers sit on
+``store-connect-cost-per-call-20260828``), and these readers sit on
 the ACL path of EVERY message send and every agent-CRUD request. A per-call
 ``Store`` would pay that connect on each one. See
 :func:`open_lineage_store` for the target-keyed invalidation and

--- a/src/scitex_agent_container/config/_group_authority.py
+++ b/src/scitex_agent_container/config/_group_authority.py
@@ -3,9 +3,11 @@
 """Group authority read STRAIGHT FROM THE SPEC — configuration, not state.
 
 Operator ruling 2026-08-12: **"states → PostgreSQL, configuration →
-files under git"**, and, about the SQLite state layer, ``state.db という
-ものは使ってはいけません`` / ``sqlite 使った瞬間負けだと思った方が良い
-です``.
+files under git"**, and, about the per-host state layer that preceded it,
+``state.db というものは使ってはいけません``. The rulings are recorded in
+full, verbatim, in ``docs/adr/0022-state-in-postgres-configuration-in-git.md``;
+an ADR is where a decision is kept, so this module cites it rather than
+reproducing it.
 
 An agent's named groups are **configuration**. They are authored by a
 human in ``spec.yaml``::
@@ -16,7 +18,8 @@ human in ``spec.yaml``::
 
 Nothing at runtime discovers, negotiates, or mutates them. They are a
 pure function of a file. Yet until this module they reached every
-authority gate through a **cache in a per-host, per-agent SQLite file**:
+authority gate through a **cache in a per-host, per-agent local
+database file**:
 
     spec.yaml ──agent_start──▶ node_comms_policy (state.db) ──ACL──▶ gate
                (persist_acl_policy)          ↑

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -488,8 +488,8 @@ From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c5
     # THE RAISE IS A CAPABILITY REQUIREMENT, WHICH IS WHAT A FLOOR IS FOR — not a
     # quarantine, and not a walk-back of the ruling below. 0.17.0 DESTROYS CARD
     # DATABASES: its store resolution accepts an explicit YAML path that does not
-    # exist plus a bundled-example fallback, and a YAML->sqlite sync then wrote the
-    # example's single card over 2142 real ones (2026-07-19, recovered from
+    # exist plus a bundled-example fallback, and a YAML->database sync then wrote
+    # the example's single card over 2142 real ones (2026-07-19, recovered from
     # backup). "Does not delete the board" is a capability, so it belongs in the
     # specifier. >=0.16.0 happens to resolve to 0.17.2 today only because 0.17.2 is
     # newest; that is luck, and luck expires the moment any other constraint in the
@@ -718,7 +718,7 @@ from scitex_cards._throughput import WIP_STATUSES
 # function was there and wrong. Measured that day, five independent gates
 # went green on that artifact within one hour — this probe, the master-side
 # SYMBOL_PROBE, the Spartan bake's content check, upstream's hasattr check,
-# and a 7537-test suite that runs on SQLite where the defect cannot exist.
+# and a 7537-test suite on a store where the defect cannot exist.
 # So the FLOOR is what excludes the broken release; this import only catches
 # a version string that lies; and only a post-deploy write to a card that
 # ALREADY HAS a comment proves the path actually runs.

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -311,7 +311,7 @@ From: ./sac-base.sif
         #
         # The floor is >=0.17.2 and NOT >=0.16.0, because 0.17.0 DESTROYS CARD
         # DATABASES: its store resolution accepts an explicit YAML path that
-        # does not exist plus a bundled-example fallback, and a YAML->sqlite
+        # does not exist plus a bundled-example fallback, and a YAML->database
         # sync then wrote the example's single card over 2142 real ones
         # (2026-07-19, recovered from backup). A lower floor lets a resolver
         # land on that version again, so the floor is the guard.
@@ -490,7 +490,7 @@ from scitex_cards._throughput import WIP_STATUSES
 # function was there and wrong. Measured that day, five independent gates
 # went green on that artifact within one hour — this probe, the master-side
 # SYMBOL_PROBE, the Spartan bake's content check, upstream's hasattr check,
-# and a 7537-test suite that runs on SQLite where the defect cannot exist.
+# and a 7537-test suite on a store where the defect cannot exist.
 # So the FLOOR is what excludes the broken release; this import only catches
 # a version string that lies; and only a post-deploy write to a card that
 # ALREADY HAS a comment proves the path actually runs.

--- a/src/scitex_agent_container/containers/sif_symbol_probe.py
+++ b/src/scitex_agent_container/containers/sif_symbol_probe.py
@@ -25,7 +25,7 @@ from scitex_cards._throughput import WIP_STATUSES
 # function was there and wrong. Measured that day, five independent gates
 # went green on that artifact within one hour — this probe, the master-side
 # SYMBOL_PROBE, the Spartan bake's content check, upstream's hasattr check,
-# and a 7537-test suite that runs on SQLite where the defect cannot exist.
+# and a 7537-test suite on a store where the defect cannot exist.
 # So the FLOOR is what excludes the broken release; this import only catches
 # a version string that lies; and only a post-deploy write to a card that
 # ALREADY HAS a comment proves the path actually runs.

--- a/src/scitex_agent_container/containers/spartan-sif-bake.sh
+++ b/src/scitex_agent_container/containers/spartan-sif-bake.sh
@@ -315,7 +315,7 @@ from scitex_cards._throughput import WIP_STATUSES
 # function was there and wrong. Measured that day, five independent gates
 # went green on that artifact within one hour — this probe, the master-side
 # SYMBOL_PROBE, the Spartan bake's content check, upstream's hasattr check,
-# and a 7537-test suite that runs on SQLite where the defect cannot exist.
+# and a 7537-test suite on a store where the defect cannot exist.
 # So the FLOOR is what excludes the broken release; this import only catches
 # a version string that lies; and only a post-deploy write to a card that
 # ALREADY HAS a comment proves the path actually runs.

--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -74,9 +74,10 @@ HOST_PROCESS_AGENT_NAME = "cli"
 # agent that does not override the key in its own ``spec.env``.
 #
 # SCITEX_CARDS_READ_BACKEND (2026-07-18, the operator's YAML→DB ruling,
-# requested by scitex-cards): pins the board's read path to the SQLite store.
+# requested by scitex-cards): pinned the board's read path to the local-file
+# store of the day.
 #
-# SCITEX_CARDS_DUAL_WRITE was injected alongside it to keep a SQLite mirror
+# SCITEX_CARDS_DUAL_WRITE was injected alongside it to keep a database mirror
 # fresh next to a ~9 MB tasks YAML. That YAML tier was DELETED 2026-07-21, so
 # from then on the flag gated nothing while still being injected into every
 # container — and scitex-cards' ``health`` FAILS its ``single_write_target``
@@ -102,8 +103,9 @@ HOST_PROCESS_AGENT_NAME = "cli"
 #
 # It was not merely useless, it was ACTIVELY MISLEADING. In scitex-cards' own
 # words, from their retired-vars module: the board's systemd unit carried
-# ``SCITEX_CARDS_READ_BACKEND=sqlite`` while the board served 0 cards from a
-# database holding 2,654 — "it did nothing, but it STATED a read policy, so
+# a ``SCITEX_CARDS_READ_BACKEND`` pin naming the retired engine while the
+# board served 0 cards from a database holding 2,654 — "it did nothing, but
+# it STATED a read policy, so
 # everyone diagnosing the outage read that line, concluded the read target was
 # configured and correct, and looked elsewhere. An inert setting that appears to
 # answer the question is worse than no setting at all: it spends the
@@ -120,8 +122,10 @@ HOST_PROCESS_AGENT_NAME = "cli"
 # ``config.yaml``'s ``fleet_default_env``. Asserted by
 # test_an_empty_fleet_default_env_is_a_valid_state.
 #
-# SCITEX_STORE_DSN (2026-08-19, the operator's storage-consolidation order:
-# 「sqlite 根絶をしてください」「fail fast, fail loud, no fallbacks」).
+# SCITEX_STORE_DSN (2026-08-19, the operator's storage-consolidation order —
+# eradicate the retired engine, and 「fail fast, fail loud, no fallbacks」).
+# The order is recorded verbatim in
+# ``docs/adr/0022-state-in-postgres-configuration-in-git.md``.
 #
 # READ THE TWO PARAGRAPHS ABOVE BEFORE ADDING ANOTHER KEY HERE. Two store
 # variables were declared here and later retired for STATING a routing policy
@@ -145,9 +149,10 @@ HOST_PROCESS_AGENT_NAME = "cli"
 #
 # The unset arm is the point: the failure is LOUD and there is no local-file
 # path to slip into. That is scitex-dev's design, in their own words at
-# ``resolve_target``: "deliberately no SQLite fallback ... a host whose
-# Postgres is down must fail loudly rather than start writing to a private
-# local file that shares nothing."
+# ``resolve_target``: host_store "has exactly two steps (SCITEX_STORE_DSN or
+# the per-host Postgres) and deliberately no third: a host whose Postgres is
+# down must fail loudly rather than start writing to a private local file
+# that shares nothing."
 #
 # test_store_dsn_is_read_for_behaviour_by_its_consumer asserts BOTH arms, so
 # if scitex-dev ever stops honouring the variable, sac goes RED here instead

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -61,7 +61,8 @@ falsifiable subset and stops.
 SHRINKING IS TWO LINES; GROWING IS IMPOSSIBLE
 =============================================
 Name the sink in the comment, delete the entry here. A 70th unnamed claim
-fails. Same asymmetry as tests/develop/test_sqlite_footprint_frozen.py, for
+fails. Same asymmetry as
+tests/develop/test_retired_engine_footprint_frozen.py, for
 the same reason: a list that can only shrink is an inventory; one that can
 grow is a wish.
 

--- a/tests/develop/test_retired_engine_footprint_frozen.py
+++ b/tests/develop/test_retired_engine_footprint_frozen.py
@@ -52,6 +52,16 @@ properties of THIS repository: nothing imports sqlite3, nothing defines a
 table that has not been declared PostgreSQL, and nothing opens SQLite through
 a vendor library.
 
+It says nothing about VOCABULARY, which is a separate failure with its own
+history — a previous removal was undone by documentation that went on naming
+the engine as the default while the code stayed clean. That gate is
+``tests/develop/test_the_engine_name_stays_gone.py``, and the two are
+deliberately independent: prose can name the engine without importing it, and
+the vendor scan below exists because code can open it without naming it.
+This file is one of the two detectors that gate exempts, and it earns that
+exemption by being unable to state its own rule without writing the import
+line, the vendor constructions and the operator instruction above.
+
 THE IMPORT CHECK ALONE WAS NEVER ENOUGH, TWICE OVER
 ===================================================
 ``import sqlite3`` is a good proxy for "somebody OPENED a database". It is not
@@ -164,7 +174,7 @@ SCAN_EXEMPT = frozenset(
         # rather than special-cased inside the scanner, because a scanner that
         # silently skips one path is a scanner nobody can audit — and the one
         # path it would skip is the gate.
-        "tests/develop/test_sqlite_footprint_frozen.py",
+        "tests/develop/test_retired_engine_footprint_frozen.py",
     }
 )
 

--- a/tests/develop/test_the_engine_name_stays_gone.py
+++ b/tests/develop/test_the_engine_name_stays_gone.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The engine is gone; this keeps its NAME from coming back.
+
+WHY A NAME SCAN WHEN THE FOOTPRINT RATCHET ALREADY EXISTS
+=========================================================
+:mod:`test_retired_engine_footprint_frozen` asserts that nothing in this
+repository USES the retired engine — nothing imports its driver, defines an
+undeclared table, or opens it through a vendor library. That is the gate on
+BEHAVIOUR, and it is the one that matters most.
+
+It is not a gate on VOCABULARY, and vocabulary is how the last reversal
+happened. Measured in the fleet campaign: a previous removal was undone in
+effect rather than in commit — the code kept working while the DOCUMENTATION
+went on naming the retired engine as the default, and a survey then counted 66
+of 68 live tables sitting on it. Whoever put them there was following the prose
+correctly. A rule that only bans the import leaves the sentence that does the
+damage.
+
+So this file bans the sentence. The two gates are deliberately independent: a
+module can name the engine without importing it (prose), and — as the vendor
+scan next door exists to prove — it can open the engine without naming it.
+Neither scan implies the other.
+
+THE RULE, AND WHOSE IT IS
+=========================
+Operator ruling 2026-08-29, applied fleet-wide with no per-package exceptions:
+the name may appear only in ``docs/adr/``. An ADR records a decision that was
+actually taken, and rewriting one destroys the record rather than the
+dependency. Everything else — source, tests, documentation, and the CHANGELOG
+— reaches zero.
+
+The reference implementation is scitex-dev's
+``tests/develop/test__sqlite_is_not_named_anywhere.py``. This is sac's copy of
+that rule, not a competing one.
+
+WHY TWO FILES ARE EXEMPT AND NOT ONE
+====================================
+A detector may name what it forbids, but only in a detector. sac has TWO,
+because it guards two different properties: this file guards the NAME, and
+:mod:`test_retired_engine_footprint_frozen` guards the USE. The footprint
+ratchet cannot state its own rule without writing the driver's import line, the
+vendor constructions it matches, and the operator instruction it exists to
+carry — 82 lines of it, all load-bearing.
+
+BOTH EXEMPTIONS ARE UNDER A STALENESS GATE. An exemption that stops matching
+must be deleted, or it decays into a blessed filename that whatever drifts into
+its place inherits. ``test_every_exempt_detector_really_names_the_engine``
+below is what makes that impossible to forget.
+
+THE SCAN IS OVER TRACKED FILES, via ``git ls-files``: a scratch file, a stray
+download or an untracked note is not what ships.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+#: Repo root — this file is ``tests/develop/<name>.py``.
+REPO = Path(__file__).resolve().parents[2]
+
+#: The only place the name may still appear because of what the file IS,
+#: rather than because of what it does: an ADR is a record of a decision, not
+#: an instruction to a reader.
+ALLOWED_PREFIXES = ("docs/adr/",)
+
+#: The detectors. Each names the engine in order to refuse it, and each is
+#: asserted below to still do so.
+EXEMPT_DETECTORS = (
+    "tests/develop/test_the_engine_name_stays_gone.py",
+    "tests/develop/test_retired_engine_footprint_frozen.py",
+)
+
+#: Generated trees, rebuilt from ``src/``. A hit here is a stale artefact
+#: rather than a source of truth, and failing on one sends the reader to
+#: delete a build directory instead of fixing anything. NEITHER IS TRACKED IN
+#: THIS REPO TODAY — kept because the scan reads what ``git ls-files`` returns,
+#: and a packaging change is exactly the sort of thing that starts tracking
+#: one without anybody deciding to.
+IGNORED_PREFIXES = ("build/", "src/scitex_agent_container.egg-info/")
+
+#: Ignore-rule files where a PATTERN line is a refusal, not a mention: writing
+#: ``*.sqlite3`` into ``.gitignore`` is the repository declining to carry the
+#: thing. Only pattern lines are exempt — a COMMENT inside such a file is
+#: prose, and prose is what this gate is for. Adopted from scitex-dev's fix for
+#: the same false positive.
+IGNORE_RULE_BASENAMES = frozenset(
+    {
+        ".gitignore",
+        ".dockerignore",
+        ".npmignore",
+        ".prettierignore",
+        ".eslintignore",
+        ".rgignore",
+        ".ignore",
+    }
+)
+
+_NAME = re.compile(r"sqlite", re.IGNORECASE)
+
+
+def _tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def _is_ignore_pattern(rel: str, line: str) -> bool:
+    """Whether ``line`` is an exclusion RULE rather than prose about one."""
+    if Path(rel).name not in IGNORE_RULE_BASENAMES:
+        return False
+    stripped = line.strip()
+    return bool(stripped) and not stripped.startswith("#")
+
+
+def _names_the_engine(rel: str) -> list[str]:
+    """Every line of ``rel`` naming the engine, as ``path:lineno: text``."""
+    try:
+        text = (REPO / rel).read_text(errors="ignore")
+    except (OSError, UnicodeDecodeError):  # pragma: no cover - binary/unreadable
+        return []
+    return [
+        f"{rel}:{number}: {line.strip()[:110]}"
+        for number, line in enumerate(text.splitlines(), start=1)
+        if _NAME.search(line) and not _is_ignore_pattern(rel, line)
+    ]
+
+
+def _offenders() -> list[str]:
+    hits: list[str] = []
+    for rel in _tracked_files():
+        if rel.startswith(ALLOWED_PREFIXES) or rel.startswith(IGNORED_PREFIXES):
+            continue
+        if rel in EXEMPT_DETECTORS:
+            continue
+        hits.extend(_names_the_engine(rel))
+    return hits
+
+
+# ----------------------------------------------------------------------
+# Controls. A scan that cannot fail is not a scan.
+# ----------------------------------------------------------------------
+
+
+def test_the_scan_can_actually_find_the_name() -> None:
+    """POSITIVE CONTROL — the pattern matches the name it exists to catch.
+
+    Without this, an over-eager edit to the regex would return zero offenders
+    and read exactly like success.
+    """
+    # Arrange
+    probe = "a line mentioning SQLite in passing"
+    # Act
+    found = _NAME.search(probe)
+    # Assert
+    assert found is not None
+
+
+def test_the_tracked_file_list_is_not_empty() -> None:
+    """SECOND CONTROL — the scan must have had something to look at.
+
+    A broken ``git ls-files`` (wrong cwd, no repo, a worktree the subprocess
+    cannot see) returns nothing, and an empty population produces an empty
+    offender list that is indistinguishable from a clean tree.
+    """
+    # Arrange
+    # Act
+    tracked = _tracked_files()
+    # Assert
+    assert len(tracked) > 100
+
+
+def test_an_ignore_rule_pattern_is_not_an_offence() -> None:
+    """A ``.gitignore`` line refusing the engine is a refusal, not a mention."""
+    # Arrange
+    rel = "some/dir/.gitignore"
+    # Act
+    exempt = _is_ignore_pattern(rel, "*.sqlite3\n")
+    # Assert
+    assert exempt is True
+
+
+def test_a_comment_inside_an_ignore_rule_file_is_still_prose() -> None:
+    """NEGATIVE CONTROL — the ignore-file exemption covers PATTERNS only.
+
+    Without this the exemption would launder a whole file: anyone could park a
+    paragraph about the retired engine behind a ``#`` in ``.gitignore``.
+    """
+    # Arrange
+    rel = ".gitignore"
+    # Act
+    exempt = _is_ignore_pattern(rel, "# we used to keep sqlite files here\n")
+    # Assert
+    assert exempt is False
+
+
+def test_the_ignore_exemption_does_not_reach_ordinary_files() -> None:
+    """NEGATIVE CONTROL — matching is by BASENAME, not by content shape."""
+    # Arrange
+    rel = "src/scitex_agent_container/_state/state_db.py"
+    # Act
+    exempt = _is_ignore_pattern(rel, "*.sqlite3\n")
+    # Assert
+    assert exempt is False
+
+
+def test_every_exempt_detector_really_names_the_engine() -> None:
+    """STALENESS GATE — an exemption that stops matching must be deleted.
+
+    Two files are excused here, which is one more than the reference rule
+    allows itself, so the excuse has to keep earning itself. A detector that no
+    longer names the engine is no longer a detector; leaving it listed turns a
+    reasoned exemption into a blessed coordinate that the next file to take
+    that path inherits for free.
+    """
+    # Arrange
+    silent = [rel for rel in EXEMPT_DETECTORS if not _names_the_engine(rel)]
+    # Act
+    stale = sorted(silent)
+    # Assert
+    assert not stale, (
+        f"these exempt detectors no longer name the engine: {stale}. Either the "
+        "file stopped being a detector — delete the entry — or it was renamed "
+        "and the entry needs to follow it."
+    )
+
+
+# ----------------------------------------------------------------------
+# The gate.
+# ----------------------------------------------------------------------
+
+
+def test_no_tracked_file_outside_an_adr_names_the_retired_engine() -> None:
+    # Arrange — source, tests and documentation must reach zero.
+    # Act
+    offenders = _offenders()
+    # Assert
+    assert offenders == [], (
+        f"{len(offenders)} line(s) in tracked files still name the retired "
+        "engine. Only docs/adr/ may, because an ADR records a decision that "
+        "was taken. Everything else — including the CHANGELOG, which is prose "
+        "and is NOT exempt — describes the change without the name:\n"
+        + "\n".join(offenders[:40])
+    )
+
+# EOF

--- a/tests/develop/test_the_engine_name_stays_gone.py
+++ b/tests/develop/test_the_engine_name_stays_gone.py
@@ -27,8 +27,16 @@ THE RULE, AND WHOSE IT IS
 Operator ruling 2026-08-29, applied fleet-wide with no per-package exceptions:
 the name may appear only in ``docs/adr/``. An ADR records a decision that was
 actually taken, and rewriting one destroys the record rather than the
-dependency. Everything else — source, tests, documentation, and the CHANGELOG
-— reaches zero.
+dependency. Source, tests and documentation reach zero.
+
+THE CHANGELOG IS COVERED, BUT ONLY WHERE IT IS STILL BEING WRITTEN. The
+first version of this rule treated the whole file as prose, and that was
+wrong for the same reason the ADR carve-out is right: an entry under a
+SHIPPED version heading is a record of what that release contained, so
+editing it does not remove the dependency — it makes the published
+changelog disagree with the published tag. ``## [Unreleased]`` is enforced;
+shipped headings are a record. sac has nine such lines under four shipped
+versions, and they stay.
 
 The reference implementation is scitex-dev's
 ``tests/develop/test__sqlite_is_not_named_anywhere.py``. This is sac's copy of
@@ -41,7 +49,7 @@ because it guards two different properties: this file guards the NAME, and
 :mod:`test_retired_engine_footprint_frozen` guards the USE. The footprint
 ratchet cannot state its own rule without writing the driver's import line, the
 vendor constructions it matches, and the operator instruction it exists to
-carry — 82 lines of it, all load-bearing.
+carry — 81 lines of it, all load-bearing.
 
 BOTH EXEMPTIONS ARE UNDER A STALENESS GATE. An exemption that stops matching
 must be deleted, or it decays into a blessed filename that whatever drifts into
@@ -80,6 +88,17 @@ EXEMPT_DETECTORS = (
 #: and a packaging change is exactly the sort of thing that starts tracking
 #: one without anybody deciding to.
 IGNORED_PREFIXES = ("build/", "src/scitex_agent_container.egg-info/")
+
+#: A CHANGELOG entry under a SHIPPED version heading is a record of what
+#: that release contained. Rewriting one does not remove the dependency — it
+#: makes the published changelog disagree with the published tag, which is
+#: the same failure as an incident record losing the cause it names. So the
+#: gate enforces the changelog only under ``## [Unreleased]``, where nothing
+#: has shipped claiming the text yet. THE EXEMPTION IS A HEADING, NOT A
+#: FILE: a new entry written today is still covered, and it stops being
+#: covered at exactly the moment a release freezes it.
+CHANGELOG = "CHANGELOG.md"
+UNRELEASED_HEADING = "## [Unreleased]"
 
 #: Ignore-rule files where a PATTERN line is a refusal, not a mention: writing
 #: ``*.sqlite3`` into ``.gitignore`` is the repository declining to carry the
@@ -125,11 +144,17 @@ def _names_the_engine(rel: str) -> list[str]:
         text = (REPO / rel).read_text(errors="ignore")
     except (OSError, UnicodeDecodeError):  # pragma: no cover - binary/unreadable
         return []
-    return [
-        f"{rel}:{number}: {line.strip()[:110]}"
-        for number, line in enumerate(text.splitlines(), start=1)
-        if _NAME.search(line) and not _is_ignore_pattern(rel, line)
-    ]
+    hits: list[str] = []
+    frozen_by_a_release = False
+    for number, line in enumerate(text.splitlines(), start=1):
+        if rel == CHANGELOG and line.startswith("## "):
+            frozen_by_a_release = line.strip() != UNRELEASED_HEADING
+        if not _NAME.search(line):
+            continue
+        if _is_ignore_pattern(rel, line) or frozen_by_a_release:
+            continue
+        hits.append(f"{rel}:{number}: {line.strip()[:110]}")
+    return hits
 
 
 def _offenders() -> list[str]:
@@ -208,6 +233,49 @@ def test_the_ignore_exemption_does_not_reach_ordinary_files() -> None:
     exempt = _is_ignore_pattern(rel, "*.sqlite3\n")
     # Assert
     assert exempt is False
+
+
+def test_a_released_changelog_entry_is_a_record_not_an_offence() -> None:
+    """The changelog is enforced under [Unreleased] and nowhere else.
+
+    MEASURED, not assumed: sac's changelog carries nine lines naming the
+    engine under four shipped headings — [0.26.3], [0.25.0], [0.21.25] and
+    [0.21.20] — plus one under a tag that was cut but never published. Each
+    describes what that release actually did. This asserts the gate leaves
+    them alone while still covering the section being written.
+    """
+    # Arrange
+    offenders = _names_the_engine(CHANGELOG)
+    # Act
+    under_a_shipped_heading = sorted(offenders)
+    # Assert
+    assert not under_a_shipped_heading, (
+        "the changelog names the engine under [Unreleased], which is still "
+        f"being written and is therefore covered: {under_a_shipped_heading}"
+    )
+
+
+def test_the_changelog_exemption_is_a_heading_not_the_whole_file() -> None:
+    """NEGATIVE CONTROL — the released-section exemption must not launder
+    the file.
+
+    Without this, "the changelog is a record" would quietly become "the
+    changelog is exempt", and the next unreleased entry could name the
+    engine freely. The gate has to still see the [Unreleased] section, and
+    the only way to know it does is to check that the section exists and is
+    reached before any shipped heading.
+    """
+    # Arrange
+    lines = (REPO / CHANGELOG).read_text(errors="ignore").splitlines()
+    headings = [ln.strip() for ln in lines if ln.startswith("## ")]
+    # Act
+    first = headings[0] if headings else ""
+    # Assert
+    assert first == UNRELEASED_HEADING, (
+        f"the first changelog heading is {first!r}, not {UNRELEASED_HEADING!r}. "
+        "The exemption keys off heading order, so an [Unreleased] section that "
+        "is missing or not first would exempt the entire file silently."
+    )
 
 
 def test_every_exempt_detector_really_names_the_engine() -> None:

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -367,7 +367,7 @@ def isolated_board(tmp_path: Path) -> Iterator[Path]:
       YAML file, so even a call that forgot ``store=`` lands in tmp rather
       than on the live 1,400-card board.
 
-    * **the SQLite shadow** — ``$SCITEX_CARDS_DB`` (+ its pre-rename alias
+    * **the mirror shadow** — ``$SCITEX_CARDS_DB`` (+ its pre-rename alias
       ``$SCITEX_TODO_DB``) points at a tmp DB. This one is not belt-and-
       braces, it is load-bearing, and its absence destroyed the live board
       on 2026-07-20: the dual-write mirror resolves its own path and
@@ -402,10 +402,10 @@ def isolated_board(tmp_path: Path) -> Iterator[Path]:
         _env_overrides(
             {
                 "SCITEX_TODO_TASKS_YAML_SHARED": str(store),
-                # *** THE SQLITE SHADOW — isolating the YAML IS NOT ENOUGH. ***
+                # *** THE MIRROR SHADOW — isolating the YAML IS NOT ENOUGH. ***
                 #
                 # Redirecting the store above protects the YAML and nothing
-                # else. scitex-cards mirrors every write into a SQLite shadow
+                # else. scitex-cards mirrors every write into a shadow database
                 # whose path it resolves ITSELF, ignoring the store you wrote
                 # to: `_dual_write.mirror_after_save` calls
                 # `mirror_doc_incremental(doc, resolve_db_path(), ...)` with NO

--- a/tests/scitex_agent_container/_lifecycle/test__a2a_port.py
+++ b/tests/scitex_agent_container/_lifecycle/test__a2a_port.py
@@ -4,9 +4,10 @@ PA-306: no `unittest.mock`. Production helpers `port_allocator.claim_port`
 and `port_allocator.release_port` are swapped via a hand-rolled fake
 context manager that records calls and restores the attribute on
 teardown. The "end-to-end" tests use the REAL allocator against a REAL
-database — no patching whatsoever. They took a ``tmp_path`` sqlite DB until
-2026-08-28, when ``a2a_ports`` moved to per-host PostgreSQL; they now take
-the shared ``pg_schema`` fixture, which points the real store resolver at a
+database — no patching whatsoever. They took a ``tmp_path`` local DB file
+until 2026-08-28, when ``a2a_ports`` moved to per-host PostgreSQL; they now
+take the shared ``pg_schema`` fixture, which points the real store resolver
+at a
 throwaway schema and SKIPS where no writable database exists.
 """
 

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
@@ -2,9 +2,10 @@
 wired into core ``agent_start`` (ADR-0010 Rule B / Phase 2).
 
 PA-306: NO mocks. Every test runs ``enforce_spawn_gate`` against a REAL
-on-disk SQLite state.db (isolated per test) and the REAL ``check_spawn``
-/ ``record_lineage`` collaborators. The caller identity is set via a
-real yield-based env override (no monkeypatch).
+store — the shared ``pg_schema`` fixture, plus a per-test on-disk state
+path for the module constant that still carries one — and the REAL
+``check_spawn`` / ``record_lineage`` collaborators. The caller identity is
+set via a real yield-based env override (no monkeypatch).
 
 Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
 """
@@ -35,7 +36,7 @@ def db_path(tmp_path: Path) -> Iterator[Path]:
 
     The gate's internal calls use ``db_path=None`` (→ DEFAULT_DB_PATH),
     so re-binding the module constant is what isolates them. No mocks —
-    a real sqlite file under tmp_path.
+    a real path under tmp_path.
     """
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")

--- a/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
@@ -81,7 +81,7 @@ class _FakeHandover:
 def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
     """Isolated state.db + runtime dir + HOME, all under tmp_path.
 
-    No mocks — real sqlite, real dirs; env + module constants saved and
+    No mocks — real files, real dirs; env + module constants saved and
     restored on teardown.
     """
     db = tmp_path / "state.db"

--- a/tests/scitex_agent_container/_mcp/test__channel_reaction_ack.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_reaction_ack.py
@@ -15,7 +15,7 @@ Three surfaces are covered, no mocks / monkeypatch on production:
 3. Sender-side absorption — :func:`absorb_reaction_ack` walks the
    envelope and flips the dispatch-ledger row to ``STATUS_REACTED``.
    Real PostgreSQL via the shared ``pg_schema`` fixture, the same seam
-   the ledger tests use since that table moved off SQLite.
+   the ledger tests use since that table moved to PostgreSQL.
 
 Operator mandate (lead a2a ``1781e82a``, 2026-06-14): structural
 reaction so absence = comm miss, detectable.

--- a/tests/scitex_agent_container/_mcp/test__channel_self_register.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_self_register.py
@@ -10,8 +10,9 @@ cadence matching the agent runner's heartbeat.
 
 ON POSTGRESQL SINCE 2026-08-28. The directory moved to the shared store, so
 these tests take ``pg_schema`` and ``register_self_node`` / ``refresh_node``
-lost their ``db_path`` argument — it threaded a SQLite file that no longer
-exists. The ``updated_at`` the refresh loop advances is the store's hybrid
+lost their ``db_path`` argument — it threaded a local database file that no
+longer exists. The ``updated_at`` the refresh loop advances is the store's
+hybrid
 logical clock rather than a column each writer had to remember to bump.
 
 Real config.yaml via the shared ``env_save_restore`` fixture and a real

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
@@ -178,11 +178,14 @@ PAIRED_STORE_JSON = json.dumps(
 
 #: The ABANDONED sidecar, measured the same night: 365 rows, 149 unseen, a
 #: zero-byte WAL, and no write since the previous morning while readers kept
-#: attaching. Opened constantly, written never.
+#: attaching. Opened constantly, written never. Its identity also named the
+#: retired engine — a different engine from the board's — but that field is
+#: dropped here because nothing reads it: ``_awaiting_operator`` consults
+#: ``resolved``, ``store_uuid`` and ``system_identifier`` only, and the local
+#: path below is what makes this a different source from the live board.
 DEAD_SIDECAR_JSON = json.dumps(
     {
         "resolved": "/home/agent/.scitex/cards/runtime/todo.db",
-        "backend": "sqlite",
         "store_uuid": "deadbeef-0000-0000-0000-000000000000",
     }
 )

--- a/tests/scitex_agent_container/_reconcile/test__rule.py
+++ b/tests/scitex_agent_container/_reconcile/test__rule.py
@@ -42,7 +42,7 @@ def _decide(**overrides):
 
 
 def _row(**overrides) -> dict:
-    """A plain ``instances`` row, shaped exactly as sqlite3 hands one back."""
+    """A plain ``instances`` row, shaped exactly as the store hands one back."""
     row = {
         "name": "alpha",
         "host": "host-a",

--- a/tests/scitex_agent_container/_runners/test__openai_pg_session.py
+++ b/tests/scitex_agent_container/_runners/test__openai_pg_session.py
@@ -255,9 +255,10 @@ def test_get_items_limit_returns_the_latest_n(pg_schema: str) -> None:
 
 
 def test_get_items_limit_zero_returns_nothing(pg_schema: str) -> None:
-    """``0`` means none and a NEGATIVE limit means all — SQLite's own
-    ``LIMIT`` semantics, kept deliberately so existing callers keep their
-    answer rather than being tidied into a single "no limit" branch."""
+    """``0`` means none and a NEGATIVE limit means all — the ``LIMIT``
+    semantics the previous engine had, kept deliberately so existing callers
+    keep their answer rather than being tidied into a single "no limit"
+    branch."""
     # Arrange
     pytest.importorskip("agents")
     session = PostgresAgentSession("alpha")

--- a/tests/scitex_agent_container/_runners/test__session_beat.py
+++ b/tests/scitex_agent_container/_runners/test__session_beat.py
@@ -3,9 +3,10 @@
 
 WHY THESE ASSERTIONS AND NOT OTHERS. ``_DefaultDBWriter`` has promised
 "best-effort ... we catch + log here" in its docstring since it was written,
-but nothing caught anything. Under SQLite that was invisible — the diary
-wrote to a local file that effectively never failed, so the un-implemented
-promise was never exercised. Moving the diary to PostgreSQL made the write
+but nothing caught anything. Under the old local-file store that was
+invisible — the diary wrote to a file that effectively never failed, so the
+un-implemented promise was never exercised. Moving the diary to PostgreSQL
+made the write
 genuinely failable, and every runner test that merely ticks a heartbeat died
 on a refused connection. So the assertions here are about the two halves of
 that contract, and they pull in opposite directions:

--- a/tests/scitex_agent_container/_state/test__lineage.py
+++ b/tests/scitex_agent_container/_state/test__lineage.py
@@ -3,7 +3,7 @@
 PR-3 Checkpoint 3 — pins the BFS transitive descendants walk used
 by the lineage-scoped ACL gate. AAA + one-assert (PA-307).
 
-REAL POSTGRESQL SINCE 2026-08-28, not a temp SQLite file. The walk reads
+REAL POSTGRESQL SINCE 2026-08-28, not a temp local file. The walk reads
 the shared lineage store, so isolation comes from ``pg_schema`` pointing
 ``SCITEX_STORE_DSN`` at a throwaway schema — which is stronger than the
 ``tmp_path`` these tests used to take, because it exercises the real
@@ -224,7 +224,7 @@ def test_ancestors_cycle_is_bounded(pg_schema: str) -> None:
 
 def test_descendants_cycle_is_bounded(pg_schema: str) -> None:
     # Arrange — the DOWN walk over the same mutually-pointing pair. It had
-    # no cycle test at all before, because the SQLite version could only be
+    # no cycle test at all before, because the local-file version could only be
     # given a cycle by hand-editing the file.
     record_lineage(child="x", parent="y")
     record_lineage(child="y", parent="x")

--- a/tests/scitex_agent_container/_state/test_port_allocator.py
+++ b/tests/scitex_agent_container/_state/test_port_allocator.py
@@ -361,7 +361,7 @@ def test_port_store_returns_the_same_cached_handle_within_a_process(
     pg_schema: str,
 ) -> None:
     # Arrange — first call populates the per-process cache (card
-    # sqlite-out-per-call-connect-cost-20260828: Store.__init__ pays a
+    # store-connect-cost-per-call-20260828: Store.__init__ pays a
     # psycopg connect, so the agent-start path must not construct per call).
     first = pa.port_store()
     # Act

--- a/tests/scitex_agent_container/_state/test_state_db_acl_policy.py
+++ b/tests/scitex_agent_container/_state/test_state_db_acl_policy.py
@@ -40,9 +40,8 @@ writes takes ``pg_schema``, the shared opt-in fixture, which skips where no
 cluster exists and FAILS where a configured one is broken.
 
 ``sender_target_relationship`` used to be tested here. It reads ``lineage``,
-which is still SQLite, so it moved to
-``test_state_db_lineage_rel.py`` alongside the module it moved to — rather
-than staying in a file whose name now promises PostgreSQL.
+so it moved to ``test_state_db_lineage_rel.py`` alongside the module it moved
+to, rather than staying in a file about the ACL policy table.
 
 NO MONKEYPATCH (PA-306 §3): the module is exercised through its real public
 surface, and isolation comes from the fixture pointing SCITEX_STORE_DSN at a
@@ -136,7 +135,8 @@ def test_may_spawn_never_rescues_an_already_denied_spawn(pg_schema: str) -> None
 
 
 def test_may_spawn_round_trips_as_a_real_bool(pg_schema: str) -> None:
-    # Arrange — the SQLite column was 0/1; the store field is BOOL.
+    # Arrange — the previous engine had no boolean type, so the column was
+    # 0/1; the store field is BOOL.
     record_comms_policy(name="cap-a", may_spawn=False)
     # Act
     value = read_comms_policy(name="cap-a")["may_spawn"]

--- a/tests/scitex_agent_container/_state/test_state_db_comms_nodes_handle.py
+++ b/tests/scitex_agent_container/_state/test_state_db_comms_nodes_handle.py
@@ -6,7 +6,7 @@ closes a ``Store`` per call, mirroring the old ``with open_db(...)`` shape.
 ``list_comms_nodes`` sit under ``resolve_node_host``,
 ``resolve_forward_target`` and ``_agents_list``, which run PER MESSAGE.
 
-MEASURED, not assumed (card ``sqlite-out-per-call-connect-cost-20260828``):
+MEASURED, not assumed (card ``store-connect-cost-per-call-20260828``):
 the previous local connect 0.067 ms against ``psycopg.connect`` 10.707 ms — 159x —
 and ``Store.__init__`` pays that connect plus the dialect ``schema_lock`` and
 two probes even when no DDL runs. End to end, ``resolve_comms_node_host``

--- a/tests/scitex_agent_container/_state/test_state_db_instances_handle.py
+++ b/tests/scitex_agent_container/_state/test_state_db_instances_handle.py
@@ -6,7 +6,7 @@ run beneath ``_send_resolve``, ``resolve_node_host``,
 ``resolve_forward_target`` and ``_agents_list`` — per message, not per
 operator command.
 
-MEASURED, not assumed (card ``sqlite-out-per-call-connect-cost-20260828``):
+MEASURED, not assumed (card ``store-connect-cost-per-call-20260828``):
 the previous local connect 0.067 ms against ``psycopg.connect`` 10.707 ms — 159x —
 and ``Store.__init__`` pays that connect plus the dialect ``schema_lock`` and
 two probes even when no DDL runs. On the sibling table a per-call ``Store``

--- a/tests/scitex_agent_container/config/test__group_authority.py
+++ b/tests/scitex_agent_container/config/test__group_authority.py
@@ -3,7 +3,7 @@
 """Tests for spec-sourced group authority.
 
 This file used to be built around an ``identical_from_both_stores``
-pair — one caller, one spec, two genuinely different SQLite stores, one
+pair — one caller, one spec, two genuinely different local stores, one
 answer. It was written for the 2026-08-11 relocation incident (nine
 ``403 ACL deny`` probes at once, because the target host held no
 ``node_comms_policy`` row for the caller) and the 2026-08-09 escalation
@@ -11,7 +11,7 @@ answer. It was written for the 2026-08-11 relocation incident (nine
 registry had been wiped, while the host DB was healthy).
 
 THAT SHAPE IS GONE, and this docstring no longer claims otherwise. Both
-incidents were caused by the per-agent SQLite shard, and moving
+incidents were caused by the per-agent local shard, and moving
 ``node_comms_policy`` to one shared PostgreSQL store removes the shard
 rather than testing around it. There is no longer a second store for a
 caller to disagree with, so the equality the old headline asserted is
@@ -120,8 +120,9 @@ class RelocateCase:
 def relocate_case(spec_root, tmp_path) -> RelocateCase:
     """An agent whose spec is visible and whose policy row is published.
 
-    It used to build two SQLite files: a populated one standing for the bare
-    host's ``~/.scitex/agent-container/runtime/state.db``, and an empty one
+    It used to build two local database files: a populated one standing for
+    the bare host's ``~/.scitex/agent-container/runtime/state.db``, and an
+    empty one
     standing for the private ``/state/<agent>/state.db`` shard a SIF gets --
     the exact shape of the relocation 403. The shard is what caused that
     incident, and it no longer exists: the policy row lives in one shared

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -1235,7 +1235,7 @@ def _argv_for_env(tmp_path: Path, env_block: str) -> list[str]:
 def test_sac_injects_no_fleet_default_env_into_the_built_argv(tmp_path) -> None:
     """Inverts test_fleet_default_env_reaches_the_built_argv.
 
-    That test asserted the seeded SCITEX_CARDS_READ_BACKEND=sqlite arrived
+    That test asserted the seeded SCITEX_CARDS_READ_BACKEND pin arrived
     without the spec asking. sac stopped declaring it 2026-07-29 on the store
     owner's ruling (nothing reads it, and it misled a diagnosis by stating a
     read policy that was never enforced), so the correct assertion is that a

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -142,7 +142,7 @@ def test_without_the_injection_the_resolver_goes_somewhere_else() -> None:
 
     The unset arm resolves to a UNIX socket that does not exist in a
     container, and opening a Store against it raises StoreTargetError naming
-    the missing path. That loud refusal — with no SQLite to slip into — is
+    the missing path. That loud refusal — with no local file to slip into — is
     scitex-dev's stated design and the behaviour the operator asked for.
 
     THE DISCRIMINATOR WAS A RENDERING DETAIL, and a dependency bump exposed
@@ -827,7 +827,8 @@ def test_dead_read_routing_key_is_not_a_fleet_default(key: str) -> None:
     """sac must not declare a read-routing flag that nothing reads.
 
     This INVERTS ``test_read_backend_default_is_retained``, which asserted the
-    SQLite read pin "stays". That test was written when the pin was believed to
+    retired-engine read pin "stays". That test was written when the pin was
+    believed to
     mean something. It does not: scitex-cards searched their read path from
     source (positive control first) and found the variable only in a comment and
     a retired-vars key — never read for behaviour. The old test pinned a policy

--- a/tests/scitex_agent_container/runtimes/test__tui_outbound.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_outbound.py
@@ -232,7 +232,7 @@ def test_main_returns_zero_when_queue_empty(tmp_path: Path, pg_schema: str) -> N
 def test_main_still_flushes_without_the_retired_state_db_env(
     tmp_path: Path, pg_schema: str
 ) -> None:
-    """The ledger moved to PostgreSQL, so a SQLite path must not gate the flush.
+    """The ledger moved to PostgreSQL, so a local path must not gate the flush.
 
     ``main`` used to refuse unless ``SCITEX_AGENT_CONTAINER_STATE_DB`` was set,
     which was right while the ledger was a file and became a trap the moment it


### PR DESCRIPTION
## What

#1274 removed the engine and left **160 lines naming it**. This removes the
vocabulary. That is not cosmetic: it is the half that carried the last
reversal. A previous removal was undone in effect rather than in commit,
because the code stayed clean while the documentation went on naming the
engine as the default, and a survey then counted 66 of 68 live tables sitting
on it. Whoever put them there was following the prose correctly.

**sac does not reach zero, and that is the correct answer.** Nine changelog
lines sit under shipped version headings and are left alone; the reasoning is
below.

## Measurement, with its positive control

Same invocation for both, `postgres` substituted as the control so a zero
cannot be a broken pipeline:

| | `origin/develop` | this branch |
|---|---|---|
| the name, campaign exclusions | **160** | **97** |
| `postgres` (POSITIVE CONTROL) | 772 | 775 |
| the name, **no exclusions at all** | 174 | 112 |

The campaign's exclusion list (`build/`, `vendor/`, `deployment/singularity/`,
`examples/`, egg-info) turns out to hide **nothing** in this repo: three of
those directories do not exist here, `examples/` has zero hits, and no
egg-info or build output is tracked. So the unfiltered number is the honest
one, and it tells the same story.

Everything that remains is in a place the rule allows, and every line is
accounted for:

```
tests/develop/test_retired_engine_footprint_frozen.py   81   detector
tests/develop/test_the_engine_name_stays_gone.py         7   detector (new)
CHANGELOG.md                                             9   record (shipped tags)
docs/adr/0023-channel-events-plain-postgres.md           9   ALLOWED_PREFIXES
docs/adr/0022-state-in-postgres-configuration-in-git.md  5   ALLOWED_PREFIXES
docs/adr/0005-sif-mode-migration.md                      1   ALLOWED_PREFIXES
```

## The changelog: `[Unreleased]` is rewritten, shipped headings are not

Of the 21 changelog lines, **12 sit under `[Unreleased]`** and are rewritten.
The other **9 sit under shipped version headings** and stay:

| lines | heading |
|---|---|
| 3 | `[0.26.3] - 2026-08-24` |
| 1 | `[0.25.0] - 2026-08-16` |
| 1 | `[0.21.25] - 2026-07-18` |
| 3 | `[0.21.20] - 2026-07-14` |
| 1 | `[0.21.16] — 2026-07-14` *(tagged, never published)* |

An entry under a shipped version is a record of what that release contained.
Editing it does not remove the dependency — it makes the published changelog
disagree with the published tag, which is the same failure as an incident
record losing the cause it names. The honest instrument for a frozen record
is an exemption, not an edit.

`[0.21.16]` was tagged but never published. I treated it as frozen anyway:
the tag exists, and "released enough to have a tag" is the cheaper line to
hold than a per-version judgement call.

**The exemption is a HEADING, not the file.** A new entry written today is
covered and stops being covered at exactly the moment a release freezes it.
Verified on both sides: a canary under `[Unreleased]` turns the gate red, and
the same canary under `[0.27.0]` leaves it green. (My first attempt at that
control was mis-aimed — the file had grown, so the "shipped" canary landed at
a line still inside `[Unreleased]` and failed for the right reason at the
wrong address. Re-aimed off the heading offsets rather than a fixed line.)

## The 69 rewritten lines

Every line keeps its facts, dates and measurements. Only the name goes,
replaced by what it was in that sentence — a driver, a catalogue table, a
local file, a retired engine. **Nothing was deleted for being merely
explanatory.** Most are incident records where the name carried the reason,
and the reason is what survives.

Three were stale, and two of those were wrong:

* `_fleet_env.py` quoted scitex-dev's `resolve_target` on *"deliberately no
  SQLite fallback …"*. That module no longer contains the sentence — it reads
  **"deliberately no third"**. The quote is restored to what the cited source
  actually says, which is a correction, not a paraphrase.
* `test_state_db_acl_policy.py` said `lineage` was *"still"* on the old
  engine. It moved to PostgreSQL on 2026-08-28 — which the neighbouring
  `test__lineage.py` docstring already stated.
* `openai_session_store.py` pointed at a frozen constant deleted with the
  allowlists.

**The operator's verbatim rulings are not reworded — they are relocated.**
Two module docstrings reproduced them, including 「sqlite 使った瞬間負けだと
思った方が良いです」 and 「sqlite 根絶をしてください」. The first was already in
`docs/adr/0022` verbatim, so the module now cites the record. The second was
in **no ADR at all** — I checked before claiming otherwise — so this PR
**adds it to ADR-0022 verbatim**, under its own 2026-08-19 heading. An ADR is
the one place the rule lets the name stand, so the operator's words survive
exactly as spoken instead of being reworded out of the tree. Neither ruling
is paraphrased anywhere.

**The task-board id.** Eleven docstrings cited a card whose id embedded the
name. An identifier is not exempt, and mangling it would have made the
citations unresolvable. The card was **superseded**, not renamed and not
deleted: `store-connect-cost-per-call-20260828` carries the same note and
measurements, the original keeps its history and comments, both are
cross-linked, and the original is closed as *re-identified, not completed*.

**The fixture that reproduces a real payload.** `DEAD_SIDECAR_JSON` carried
`"backend": "sqlite"`. Before touching it I checked what reads it:
`_awaiting_operator.py` consults `resolved`, `store_uuid` and
`system_identifier` only, and the single consumer
(`test_a_different_store_produces_a_different_line`) asserts on `resolved`.
The key is inert. These three fixtures are already curated subsets of the
observed payloads — `LIVE` has five keys, `PAIRED` four, with different
membership — so dropping an unread key keeps the record faithful in every
field that carries meaning. The comment now states that the corpse's identity
named a different engine, which is the fact that mattered.

## The rename

`test_sqlite_footprint_frozen.py` → `test_retired_engine_footprint_frozen.py`.

Worth doing, and here is the reason either way. The scans read file CONTENT,
and `git grep` matches content, so a path was **never** an offence and the
rename buys nothing directly. What it buys is indirect and real: the old name
was the last thing in the repository forcing a cross-reference to spell the
word, and two files had to (`openai_session_store.py`,
`test_delivery_claims_name_their_sink.py`). Those two lines could not have
been cleaned without pointing at the file by a name it did not have. Git
tracks the rename at 96% similarity.

## The new gate

`tests/develop/test_the_engine_name_stays_gone.py`.

The footprint ratchet asserts that nothing **uses** the engine; this asserts
that nothing **names** it. Independent by construction, in both directions:
prose can name it without importing it, and — as the vendor scan next door
exists to prove — code can open it without naming it.

* `docs/adr/` is exempt: an ADR records a decision that was taken.
* Shipped changelog headings are exempt; `[Unreleased]` is not.
* Both detectors are exempt, **under a staleness gate**: an exemption that
  stops matching must be deleted, or it decays into a blessed filename that
  whatever drifts into that path inherits.
* Ignore-rule PATTERN lines are exempt — a `.gitignore` line excluding the
  engine's files is a refusal, not a mention — while comments inside those
  same files are prose and are not. Adopted from scitex-dev's fix for that
  false positive, which is **still unmerged there** (their PR is open, not
  landed), so this repo does not inherit the bug.

**It can fail.** Verified, not assumed: planting the word in a tracked source
file turns the gate red naming file and line, and it goes green again when the
line is removed — while `docs/adr/` legitimately holds 15 hits throughout. A
gate that cannot fail is not a gate.

This is the one piece nobody asked for. It is here because without it this
PR's floor is a snapshot rather than a ratchet, and the operator instruction
quoted inside the footprint ratchet ranks the audit rule above the migration
itself. Say the word and it comes out; the vocabulary cleanup stands alone.

## Tests

Full suite, in-container, `-n 8 --timeout=180`:

```
========= 15678 passed, 2407 skipped, 9 warnings in 332.83s (0:05:32) ==========
```

Zero failures. `tests/develop/` figures for the final tree are in the thread.

On the 2407 skips: this branch adds **no new skip condition** and no
`skipif` — the tests it adds all run and pass. The large count is the
`pg_schema` opt-in fixture skipping where no writable cluster exists, which is
every agent container (loopback there is a read-only replica of the fleet
cluster), so the in-container figure is not the CI figure. I did not re-run
`origin/develop` for a baseline skip count, so read 2407 as "the number here",
not as "unchanged".

## Also checked, and clean

The `Path("postgresql://h/d")` failure the scitex-cards work turned up — the
one that silently collapses to a relative path instead of raising — does
**not** exist in sac. Six call sites apply `Path()` to something
DSN-shaped by name (control: 489 `Path(` overall); all six are real
filesystem paths. The closest, `_inline_spec_preflight.py:198`, takes a
bind-mount host path from `_expand_host_path`, not a locator.

## Note for the fleet tracker

`SQLITE-ERADICATION.md` lists sac at 160, "done bar residue", and flags the
card id under *Still genuinely awkward*. Both are addressed here. Two
corrections for it: `scitex-dev #771` is **open, not merged**, so adopting
repos do not get the ignore-rule fix by upgrading; and the *"CHANGELOG is not
exempt"* line under §"What zero means" needs the released/unreleased split,
which is the same conclusion the scitex-io agent reached.
