### PR TITLE
refactor(state): delete DEFAULT_DB_PATH, the last of the retired engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ versioning follows [SemVer](https://semver.org/).
 ## [Unreleased]
 
 ### Removed
+- **`state_db.DEFAULT_DB_PATH`, and the ~4900-times-per-run test ceremony that
+  rebound it.** The engine deletion below left the PATH behind — a `Path`
+  naming a `state.db` that nothing created and nothing could open — explicitly
+  deferring its removal as "a separate change with a separate argument",
+  roughly fifty test modules having saved and restored it as isolation. This
+  is that change: the constant is gone, with 102 save/set/restore lines across
+  32 test modules, 31 imports they orphaned, one sentinel entry in the test
+  suite's state-floor alarm, and two tests that asserted properties of the
+  constant itself. Neither could fail any more — the constant selected no
+  storage, so a wrong value moved nothing.
+  **`$SCITEX_AGENT_CONTAINER_STATE_DB` is NOT removed** and is still
+  sandboxed per-test: sac injects it into every container, `agents rename`
+  rewrites it inside the spec, and `sac whoami` reports it. It no longer
+  selects storage, so a leak can no longer misdirect a write — it is kept
+  sandboxed because subprocesses inherit it.
+  Several fixtures still `importlib.reload(state_db)` to re-derive a constant
+  that no longer exists. Those reloads are inert and their docstrings now say
+  so; rewriting them is deliberately left out of an engine deletion.
 - **The storage engine itself. sac opens no local database, and the audit rule
   that says so now has no allowlist to read around it.** `state_db.py` kept a
   connection factory, `init_schema`, `open_db`, `table_counts` and the

--- a/src/scitex_agent_container/_lifecycle/_rename_plan.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_plan.py
@@ -38,11 +38,16 @@ class Layout:
     Every path derives from ``root``, so a caller — a test, or an operator
     with a non-standard install — can point the whole rename somewhere
     else. Deliberately NOT read from the module-level constants elsewhere
-    in sac (``Registry.REGISTRY_DIR``, ``_session_state.DEFAULT_STATE_ROOT``,
-    ``state_db.DEFAULT_DB_PATH``): those are computed from ``$HOME`` at
-    IMPORT time, so a fixture that sets ``$HOME`` afterwards CANNOT redirect
-    them. A test that trusted that would look isolated while reading — and
-    writing — the live fleet.
+    in sac (``Registry.REGISTRY_DIR``, ``_session_state.DEFAULT_STATE_ROOT``):
+    those are computed from ``$HOME`` at IMPORT time, so a fixture that sets
+    ``$HOME`` afterwards CANNOT redirect them. A test that trusted that would
+    look isolated while reading — and writing — the live fleet.
+
+    ``state_db.DEFAULT_DB_PATH`` was the third name in that list until
+    2026-08-30, when it was deleted along with the ``state.db`` it addressed.
+    It is dropped rather than left as an example, because an import-time
+    hazard illustrated with a constant that no longer exists teaches the
+    reader to look for a trap the code can no longer set.
     """
 
     root: Path

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -18,6 +18,17 @@ disk and a set of verbs that answered every question with a plausible zero —
 the exact success-shaped wrong answer each departing table was removed to
 avoid, one level up, in the accessor that was supposed to be the safe one.
 
+``DEFAULT_DB_PATH`` WENT LAST, AND IT IS WHY THIS PARAGRAPH EXISTS. The engine
+deletion left the PATH behind — a ``Path`` naming a ``state.db`` that nothing
+created and nothing could open — on the stated ground that retiring it was "a
+separate change with a separate argument", roughly fifty test modules having
+saved and restored it as isolation ceremony. This is that change. The argument
+is the one the constant's own comment made against itself: it selected no
+storage, so the ~4900 per-test rebindings isolated nothing, and the test
+sandbox's state-floor check spent a third of its sentinels proving a constant
+nobody reads still pointed somewhere harmless. A guard that cannot fail costs
+exactly what it appears to buy.
+
 WHAT STAYED, AND WHY EACH IS HERE
 =================================
 :func:`now_iso` and :func:`new_uuid7` are pure value helpers with callers all
@@ -36,36 +47,13 @@ next reader should not have to open it to find that out.
 
 from __future__ import annotations
 
-import os
 import uuid
 from datetime import datetime, timezone
-from pathlib import Path
 
 # Re-exported for the 7 modules that ``from ...state_db import
 # _resolve_host`` (claude_session, _node_channel, state_db_export,
 # state_db_gc, _send, send_cmds, _dispatch).
-from .._runtime_paths import runtime_base_dir
 from .state_db_hostname import resolve_host as _resolve_host  # noqa: F401
-
-#: THE PATH IS ALL THAT IS LEFT OF ``state.db``, AND NOTHING CREATES IT.
-#:
-#: Kept for one reason only: the test sandbox's state-floor check
-#: (``tests/conftest.py::_assert_state_floor_intact``) reads it, alongside
-#: ``registry.REGISTRY_DIR`` and ``_session_state.DEFAULT_STATE_ROOT``, to
-#: prove a suite has not pointed an import-time constant at the operator's
-#: real runtime directory. It selects no storage: no code path in ``src/``
-#: opens it, and with the engine deleted no code path can.
-#:
-#: Retiring the constant is a separate change with a separate argument —
-#: roughly fifty test modules save/restore it as isolation ceremony that has
-#: already stopped isolating anything — and doing it here would have hidden a
-#: fifty-file fixture rewrite inside an engine deletion.
-DEFAULT_DB_PATH = Path(
-    os.environ.get(
-        "SCITEX_AGENT_CONTAINER_STATE_DB",
-        str(runtime_base_dir() / "state.db"),
-    )
-)
 
 
 def now_iso() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,12 +113,20 @@ os.environ["SAC_LISTEN_NOTIFY"] = "0"
 # --- NEVER let a test touch the REAL sac state root -----------------------
 # Same class as the watchdog ledger above, same reason it belongs HERE.
 #
-# sac resolves its state root under $HOME. Three of those paths are
+# sac resolves its state root under $HOME. Two of those paths are
 # module-level constants computed at IMPORT time from an env var:
 #
-#   SCITEX_AGENT_CONTAINER_STATE_DB      -> _state.state_db.DEFAULT_DB_PATH
 #   SCITEX_AGENT_CONTAINER_REGISTRY_DIR  -> _state.registry.REGISTRY_DIR
 #   SCITEX_AGENT_CONTAINER_RUNTIME_DIR   -> _runners._session_state.DEFAULT_STATE_ROOT
+#
+# `SCITEX_AGENT_CONTAINER_STATE_DB` was a third until 2026-08-30, feeding
+# `_state.state_db.DEFAULT_DB_PATH`. That constant is deleted; the variable is
+# still force-set below because it remains load-bearing on THREE other paths —
+# sac injects it into every container (`runtimes/_apptainer_build_argv`), a
+# rename rewrites it inside the spec (`_lifecycle/_rename_spec.ENV_RULES`), and
+# `sac whoami` reports it. It no longer selects any storage, so a test that
+# leaks it can no longer make a WRITE land off the floor; it is sandboxed here
+# so subprocesses inherit the sandbox and report it truthfully.
 #
 # Because they are computed at import, a *fixture* that only sets the env var
 # is too late — the value is already baked. Setting the env HERE, in the
@@ -427,24 +435,29 @@ def pytest_sessionstart(session: pytest.Session) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Per-test state.db isolation, layered ON TOP of the floor above.
+# Per-test `$SCITEX_AGENT_CONTAINER_STATE_DB` isolation, layered ON TOP of the
+# floor above.
 #
-# The floor keeps every write off the operator's real state.db. This fixture
-# additionally gives each test its OWN database, and that second layer is not
-# cosmetic — it is what stops the port ratchet from re-forming INSIDE a single
-# run. `claim_port` never releases, so ~4900 tests sharing one floor database
-# would march through [19000, 19999] and exhaust it from the inside, failing
-# late tests for the same reason the release was failing. A fresh DB per test
-# means the allocator always starts from an empty `a2a_ports` table and always
-# finds 19000 free, so isolation alone cures the exhaustion and no test has to
-# learn to call `release_port`.
+# WHAT THIS FIXTURE IS FOR NOW, STATED PLAINLY, BECAUSE IT IS NOT WHAT IT WAS
+# FOR. It was per-test DATABASE isolation, and the second layer earned its keep
+# by stopping the port ratchet re-forming inside a single run: `claim_port`
+# never releases, so ~4900 tests sharing one floor database marched through
+# [19000, 19999] and exhausted it from the inside — the mechanism that killed
+# ghost tag v0.21.18. That argument is SPENT. `a2a_ports` moved to PostgreSQL
+# on 2026-08-28 and the storage engine itself was deleted on 2026-08-29, so
+# there is no database here to give a test its own copy of, and the exhaustion
+# it prevented is prevented by the `pg_schema` fixture instead.
 #
-# BOTH handles are redirected. The env var alone is not enough once
-# `state_db` has been imported (DEFAULT_DB_PATH is already baked), and the
-# constant alone is not enough for a subprocess (which reads the env). Tests
-# that additionally `importlib.reload(state_db)` re-derive the constant from
-# the env we set here, so they keep working; tests with their own isolation
-# fixture just override both again — this only moves the DEFAULT.
+# What survives is narrower and worth keeping on its own terms: this variable
+# is still injected into every container, rewritten by a rename, and reported
+# by `sac whoami`, and a subprocess inherits whatever the parent leaves in the
+# env. Giving each test a distinct value keeps that inheritance sandboxed and
+# keeps the floor alarm below able to name the test that dropped it.
+#
+# It redirects ONE handle. It used to redirect two — the env var and
+# `state_db.DEFAULT_DB_PATH` — because the constant was baked at import while a
+# subprocess read only the env. The constant went with the engine on
+# 2026-08-30; the env var was always the half that reached anything.
 # ---------------------------------------------------------------------------
 
 _STATE_DB_KEY = "SCITEX_AGENT_CONTAINER_STATE_DB"
@@ -485,14 +498,22 @@ _state_db_seq = itertools.count()
 # is not a check.
 #
 # ORDERING IS LOAD-BEARING: ``_isolate_state_db`` below legitimately points
-# ``DEFAULT_DB_PATH`` at a per-test tmp db and restores it on teardown, so this
-# assertion has to run AFTER that restore. Fixture finalization is LIFO, so
-# this fixture must be SET UP FIRST — which is why ``_isolate_state_db``
-# requests it by name rather than relying on declaration order.
+# ``$SCITEX_AGENT_CONTAINER_STATE_DB`` at a per-test tmp path and restores it on
+# teardown, so this assertion has to run AFTER that restore. Fixture
+# finalization is LIFO, so this fixture must be SET UP FIRST — which is why
+# ``_isolate_state_db`` requests it by name rather than relying on declaration
+# order.
 # ---------------------------------------------------------------------------
 
+# `("..._state.state_db", "DEFAULT_DB_PATH")` was the first entry until
+# 2026-08-30. It is NOT replaced, and the loss is smaller than the missing line
+# looks: the two constants left are the two that still SELECT STORAGE, and the
+# env-var checks below cover the exact escape the deleted entry watched for. A
+# mis-pinned `DEFAULT_DB_PATH` could not have moved a byte since the engine was
+# deleted — `getattr(..., None)` would simply have skipped it forever once the
+# attribute was gone, which is a sentinel that reports "intact" because it can
+# no longer look. Deleting it is the honest form of that.
 _STATE_FLOOR_CONSTANTS = (
-    ("scitex_agent_container._state.state_db", "DEFAULT_DB_PATH"),
     ("scitex_agent_container._state.registry", "REGISTRY_DIR"),
     ("scitex_agent_container._runners._session_state", "DEFAULT_STATE_ROOT"),
 )
@@ -520,26 +541,30 @@ def _assert_state_floor_intact(request: pytest.FixtureRequest) -> Iterator[None]
 
     # THE ENV VAR IS PART OF THE FLOOR, AND ITS ABSENCE IS A BREACH.
     #
-    # `$SCITEX_AGENT_CONTAINER_STATE_DB` is force-set at the top of this file
-    # so `state_db.DEFAULT_DB_PATH` is BORN inside the sandbox and every
-    # subprocess inherits the same sandbox. The loop above reads the constant,
-    # which is only half the pair: a test that DROPS the env var without
-    # restoring it leaves the constant looking perfectly correct right up until
-    # the next `importlib.reload(state_db)`, at which point the fallback
-    # (`runtime_base_dir() / "state.db"`) re-pins it at the operator's REAL
-    # runtime directory for the rest of this worker's session. That is the
-    # exact Errno-122 escape the constants check was written for, arriving one
+    # `$SCITEX_AGENT_CONTAINER_STATE_DB` is force-set at the top of this file so
+    # every subprocess inherits the same sandbox. It used to be half of a pair —
+    # the other half being `state_db.DEFAULT_DB_PATH`, which the loop above read
+    # — and the pairing is why this clause exists: a test that DROPPED the env
+    # var without restoring it left the constant looking perfectly correct right
+    # up until the next `importlib.reload(state_db)`, at which point the
+    # fallback re-pinned it at the operator's REAL runtime directory for the
+    # rest of the worker's session. That was the Errno-122 escape, arriving one
     # reload later through the half nothing was watching.
+    #
+    # THE CONSTANT IS GONE (2026-08-30) AND THIS CLAUSE IS NOT, because what it
+    # now guards is different and still real: the variable is inherited by every
+    # subprocess a test spawns, and sac injects, rewrites and REPORTS it. A test
+    # that drops it hands the next subprocess the operator's value.
     #
     # So UNSET is NOT "nothing to assert about". It is the floor already
     # dismantled, and reporting it as a breach is the only reading that does
-    # not depend on whether some later test happens to reload the module.
+    # not depend on what some later test happens to spawn.
     state_db_env = os.environ.get(_STATE_DB_KEY)
     if state_db_env is None:
         breaches.append(
             f"  ${_STATE_DB_KEY}\n"
-            "      -> UNSET (dropped without restore; the next reload of\n"
-            "         state_db re-pins DEFAULT_DB_PATH outside the floor)"
+            "      -> UNSET (dropped without restore; the next subprocess\n"
+            "         inherits the operator's value, not the sandbox)"
         )
     else:
         resolved_env = Path(state_db_env).resolve()
@@ -593,28 +618,32 @@ def _assert_state_floor_intact(request: pytest.FixtureRequest) -> Iterator[None]
         )
 
 
-# scope="function" is SPELLED OUT (it is also pytest's default) because the
-# whole fix depends on it, and a future "let's not rebuild the DB 4900 times"
-# optimisation to scope="session"/"module" would silently REINTRODUCE the bug:
-# `claim_port` never releases, so any db shared across tests re-accumulates
-# rows until [19000, 19999] is exhausted mid-run. Per-TEST or it does not work.
+# scope="function" is SPELLED OUT (it is also pytest's default) because a
+# future "let's not do this 4900 times" widening to scope="session"/"module"
+# would stop the value being per-test, and per-test is the entire remaining
+# point: a shared value cannot tell you WHICH test leaked it, which is what the
+# floor alarm above is built to say. The original reason was sharper — a shared
+# DATABASE re-accumulated `a2a_ports` rows until [19000, 19999] was exhausted
+# mid-run, the ghost-tag mechanism — and that reason expired with the engine.
+# The scope is kept on the weaker argument, and the weaker argument is stated
+# rather than left to look like the strong one.
 @pytest.fixture(autouse=True, scope="function")
 def _isolate_state_db(
     tmp_path_factory: pytest.TempPathFactory,
     _assert_state_floor_intact: None,
 ) -> Iterator[Path]:
-    """Point this test's state.db at a private tmp file. Restores on teardown.
+    """Give this test a private ``$SCITEX_AGENT_CONTAINER_STATE_DB``.
 
     Requests ``_assert_state_floor_intact`` purely for ORDERING: that makes the
     floor assertion set up FIRST and therefore (LIFO) finalize LAST, so it
-    observes ``DEFAULT_DB_PATH`` after the restore below rather than while this
-    fixture still has it pointed at a tmp db.
+    observes the env var after the restore below rather than while this fixture
+    still has it pointed at a tmp path.
     """
-    from scitex_agent_container._state import state_db
-
-    # Computed but deliberately NOT created: `state_db._connect` mkdirs the
-    # parent on first real use, so a test that never opens the DB pays no
-    # mkdir and leaves no empty dir behind (this runs ~4900 times).
+    # A PATH, NOT A DATABASE, and never created. Nothing opens it — the engine
+    # that would have was deleted on 2026-08-29 — so this is a distinct value
+    # to hand each test's subprocesses, not a file. It is still per-test rather
+    # than one shared value because a leak between tests is what the floor
+    # alarm above is trying to be able to name.
     db = (
         tmp_path_factory.getbasetemp()
         / "state-db"
@@ -622,13 +651,10 @@ def _isolate_state_db(
         / "state.db"
     )
     saved_env = os.environ.get(_STATE_DB_KEY)
-    saved_const = state_db.DEFAULT_DB_PATH
     os.environ[_STATE_DB_KEY] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_const
         if saved_env is None:
             os.environ.pop(_STATE_DB_KEY, None)
         else:

--- a/tests/integration/test_listen_notify_delivery.py
+++ b/tests/integration/test_listen_notify_delivery.py
@@ -48,7 +48,6 @@ import uvicorn
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 from tests.scitex_agent_container._helpers.loopback_server import (
     serve_in_thread,
     wait_until_serving,
@@ -107,20 +106,17 @@ def listen_state_db(tmp_path: Path, pg_schema: str):
     }
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
-    saved_db_const = state_db.DEFAULT_DB_PATH
 
     db = tmp_path / "state.db"
     os.environ["HOME"] = str(tmp_path)
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
     os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(tmp_path / "runtime")
-    state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     try:
         yield {"db": db}
     finally:
-        state_db.DEFAULT_DB_PATH = saved_db_const
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         for key, val in saved.items():

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -9,10 +9,11 @@ Two escape routes exist and both are closed:
 
 1. **Paths.** ``Layout`` derives every path from an injectable ``root``.
    That is deliberate: sac's own module-level defaults
-   (``Registry.REGISTRY_DIR``, ``_session_state.DEFAULT_STATE_ROOT``,
-   ``state_db.DEFAULT_DB_PATH``) are computed from ``$HOME`` at IMPORT
-   time, so a fixture that only sets ``$HOME`` CANNOT redirect them — it
-   would read and write the live fleet while looking isolated.
+   (``Registry.REGISTRY_DIR``, ``_session_state.DEFAULT_STATE_ROOT``) are
+   computed from ``$HOME`` at IMPORT time, so a fixture that only sets
+   ``$HOME`` CANNOT redirect them — it would read and write the live fleet
+   while looking isolated. (``state_db.DEFAULT_DB_PATH`` was a third until
+   2026-08-30, when it was deleted with the storage engine.)
 
 2. **The board.** Every scitex-cards call takes an explicit ``store=``.
    That explicit argument is the PRIMARY isolation and it is what these

--- a/tests/scitex_agent_container/_lifecycle/test__a2a_port.py
+++ b/tests/scitex_agent_container/_lifecycle/test__a2a_port.py
@@ -170,8 +170,9 @@ def test_resolve_end_to_end_assigns_int_port(pg_schema: str) -> None:
     """No fakes — drive the real port_allocator against a real database.
 
     The claim ledger moved off ``state.db`` on 2026-08-28, so pinning
-    ``state_db.DEFAULT_DB_PATH`` at a tmp file no longer isolates anything
-    the allocator reads. ``pg_schema`` points the REAL store resolver at a
+    ``state_db.DEFAULT_DB_PATH`` at a tmp file stopped isolating anything the
+    allocator reads — and on 2026-08-30 that constant was deleted outright
+    with the storage engine. ``pg_schema`` points the REAL store resolver at a
     throwaway schema instead. ``DEFAULT_RANGE`` is still saved and restored
     by hand (PA-306 — no monkeypatch).
     """

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -44,7 +44,6 @@ from scitex_agent_container._listen._handler_deadline import (
     client_timeout_for,
 )
 from scitex_agent_container._runners import _session_state
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.registry import Registry
 from scitex_agent_container.config import AgentConfig
 from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
@@ -548,7 +547,6 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
         "SCITEX_DIR": str(home / ".scitex"),
     }
     saved = {k: os.environ.get(k) for k in keys}
-    saved_default = state_db.DEFAULT_DB_PATH
     # ``_session_state.DEFAULT_STATE_ROOT`` is bound ONCE, at import time, from
     # ``runtime_base_dir()`` (_session_state.py:76). Restoring the env var is
     # therefore NOT enough: whichever test first drags that module into the
@@ -559,17 +557,17 @@ def isolated_state(tmp_path: Path) -> Iterator[Path]:
     # after it in the worker ERRORs -- measured 2026-08-24: this file alone,
     # then tests/scitex_agent_container/runtimes/test__cct_token_pool.py, gave
     # 89 passed / 61 errors in one process purely from this leak.
-    # Rebinding it explicitly (same shape as ``state_db.DEFAULT_DB_PATH`` above)
-    # makes the redirect deliberate and, crucially, UNDOES it.
+    # Rebinding it explicitly makes the redirect deliberate and, crucially,
+    # UNDOES it. (This used to say "same shape as ``state_db.DEFAULT_DB_PATH``
+    # above"; that constant was deleted with the storage engine on 2026-08-30,
+    # so ``DEFAULT_STATE_ROOT`` is now the only constant this fixture swaps.)
     saved_state_root = _session_state.DEFAULT_STATE_ROOT
     os.environ.update(keys)
-    state_db.DEFAULT_DB_PATH = db
     _session_state.DEFAULT_STATE_ROOT = runtime_dir
     try:
         yield db
     finally:
         _session_state.DEFAULT_STATE_ROOT = saved_state_root
-        state_db.DEFAULT_DB_PATH = saved_default
         for k, prev in saved.items():
             if prev is None:
                 os.environ.pop(k, None)

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker_force_propagation.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker_force_propagation.py
@@ -43,7 +43,6 @@ from scitex_agent_container._lifecycle._spawn_client import request_spawn
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 
 _TOKEN = "test-token-force-propagation"
 
@@ -53,19 +52,16 @@ def isolated_listen_env(tmp_path: Path):
     """Isolated state.db + registry/runtime dirs (mirrors test__acl.py shape)."""
     db = tmp_path / "state.db"
     saved_env_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default_db = state_db.DEFAULT_DB_PATH
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     try:
         yield tmp_path
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default_db
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         if saved_env_db is None:

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
-import importlib
 import os
 from pathlib import Path
 from typing import Iterator
@@ -46,20 +45,21 @@ def _instances_store(pg_schema: str):
 
 @pytest.fixture
 def db_path(tmp_path: Path) -> Iterator[Path]:
-    """Per-test on-disk state.db, exported via env (save/restore).
+    """Per-test ``$SCITEX_AGENT_CONTAINER_STATE_DB`` value (save/restore).
 
-    ``state_db`` reads ``SCITEX_AGENT_CONTAINER_STATE_DB`` at import into
-    a module-level ``DEFAULT_DB_PATH``; reload after setting the env so
-    every helper (including ``has_grant`` / ``open_db``) lands in the
-    temp DB.
+    IT NO LONGER SELECTS A DATABASE, and the two ``importlib.reload`` calls
+    that used to bracket it are gone with the reason for them. ``state_db``
+    read this variable at import into ``DEFAULT_DB_PATH``, so a fixture that
+    set the env had to reload the module for ``has_grant`` and friends to
+    follow. That constant was deleted on 2026-08-30 and those helpers address
+    the shared PostgreSQL store — the reload re-derived nothing and steered
+    nothing. What is left is an env value a subprocess would inherit, kept
+    per-test so a leak can be attributed.
     """
     p = tmp_path / "state.db"
     key = "SCITEX_AGENT_CONTAINER_STATE_DB"
     saved = os.environ.get(key)
     os.environ[key] = str(p)
-    import scitex_agent_container._state.state_db as mod
-
-    importlib.reload(mod)
     try:
         yield p
     finally:
@@ -67,7 +67,6 @@ def db_path(tmp_path: Path) -> Iterator[Path]:
             os.environ.pop(key, None)
         else:
             os.environ[key] = saved
-        importlib.reload(mod)
 
 
 class _RuntimeStub:
@@ -265,22 +264,21 @@ def _write_health_spec(tmp_path: Path, name: str) -> Path:
     return spec
 
 
-def _fire_monitor_restart_against_foreign_db(
-    db_path: Path, tmp_path: Path, name: str
-) -> tuple[Path, set[str]]:
-    """Arrange + Act: start a health-monitored agent against ``db_path``,
-    then move the process-global default to a FOREIGN db and fire the
-    monitor's restart callback (what the leaked daemon thread does on its
-    next tick).
+def _fire_monitor_restart(db_path: Path, tmp_path: Path, name: str) -> None:
+    """Arrange + Act: start a health-monitored agent, then fire the monitor's
+    restart callback — what the leaked daemon thread does on its next tick.
 
-    Returns ``(foreign_db_path, instance_ids_in_db_path_before_restart)``.
-    The second element exists so a caller can tell "the write went to the
-    right place" apart from "the write was lost entirely" — bare absence
-    from the foreign db is not a positive control, because ``agent_start``
-    has already written a row to ``db_path`` before the callback fires.
+    WAS ``_fire_monitor_restart_against_foreign_db`` UNTIL 2026-08-30, and the
+    dropped half of the name is the point. It used to swap
+    ``state_db.DEFAULT_DB_PATH`` to a "foreign" path around the callback, so a
+    caller could tell a write that went to the right store from one that was
+    lost. That constant is deleted; before it was, it had already stopped
+    selecting where a lifecycle record lands. Swapping it steered nothing, so
+    the swap is removed rather than left as an arrangement that reads like one.
+    It returned ``(foreign_path, ids_before)`` for the same abandoned purpose;
+    its one surviving caller ignored both.
     """
     from scitex_agent_container._lifecycle import lifecycle as lc
-    from scitex_agent_container._state import state_db
     from scitex_agent_container._state.registry import Registry
 
     created: list[_CapturingThread] = []
@@ -301,19 +299,7 @@ def _fire_monitor_restart_against_foreign_db(
     restart_cb = created[0].args[3]
     config = created[0].args[1]
 
-    # An unrelated LATER test isolates itself: the process-global moves.
-    from scitex_agent_container._state.state_db_instances import list_active_instances
-
-    before = {r["id"] for r in list_active_instances()}
-
-    foreign = tmp_path / "foreign" / "state.db"
-    saved = state_db.DEFAULT_DB_PATH
-    state_db.DEFAULT_DB_PATH = foreign
-    try:
-        restart_cb(config)  # the leaked monitor thread fires
-    finally:
-        state_db.DEFAULT_DB_PATH = saved
-    return foreign, before
+    restart_cb(config)  # the leaked monitor thread fires
 
 
 # ``test_monitor_restart_does_not_record_the_instance_into_a_foreign_state_db``
@@ -365,6 +351,6 @@ def test_monitor_restart_callback_still_auto_grants_self_to_lead(
 
     name = "pinned-2"
     # Act
-    _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
+    _fire_monitor_restart(db_path, tmp_path, name)
     # Assert
     assert has_grant(sender=name, target="lead") is True

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
@@ -23,7 +23,6 @@ from scitex_agent_container._lifecycle._spawn_gate import (
     enforce_spawn_gate,
     resolve_spawn_caller,
 )
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
     derive_group,
     record_lineage,
@@ -32,21 +31,20 @@ from scitex_agent_container._state.state_db_nodes import (
 
 @pytest.fixture
 def db_path(tmp_path: Path) -> Iterator[Path]:
-    """Isolated state.db; env + DEFAULT_DB_PATH overridden then restored.
+    """Per-test ``$SCITEX_AGENT_CONTAINER_STATE_DB``, overridden then restored.
 
-    The gate's internal calls use ``db_path=None`` (→ DEFAULT_DB_PATH),
-    so re-binding the module constant is what isolates them. No mocks —
-    a real path under tmp_path.
+    This also re-bound ``state_db.DEFAULT_DB_PATH`` until 2026-08-30, back when
+    the gate's internal calls passed ``db_path=None`` and resolved through that
+    constant. It is deleted with the storage engine and the gate addresses the
+    shared PostgreSQL store, so ``pg_schema`` is what isolates these now. No
+    mocks — a real path under tmp_path.
     """
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
@@ -34,7 +34,6 @@ from typing import Any, Iterator
 import pytest
 
 from scitex_agent_container._lifecycle._start import agent_start
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.registry import Registry
 from scitex_agent_container._state.state_db_nodes import derive_group, record_lineage
 from scitex_agent_container.config import AgentConfig
@@ -95,13 +94,10 @@ def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
         "SCITEX_DIR": str(home / ".scitex"),
     }
     saved = {k: os.environ.get(k) for k in keys}
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ.update(keys)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         for k, prev in saved.items():
             if prev is None:
                 os.environ.pop(k, None)

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -636,12 +636,16 @@ def test_verify_real_liveness_ignores_rows_for_other_agents(
 
 @pytest.fixture
 def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
-    """Per-test on-disk state.db, exported via env (explicit save/restore).
+    """Per-test ``$SCITEX_AGENT_CONTAINER_STATE_DB`` value (explicit
+    save/restore).
 
-    ``state_db`` reads ``SCITEX_AGENT_CONTAINER_STATE_DB`` at import into a
-    module-level ``DEFAULT_DB_PATH``; reload it after setting the env so the
-    ``instances`` / ``a2a_ports`` writes land in the temp DB, not the
-    developer's real ``~/.scitex`` tree. Mirrors the ``_instances`` test.
+    THE RELOAD BELOW NO LONGER RE-DERIVES ANYTHING. ``state_db`` read this
+    variable at import into a module-level ``DEFAULT_DB_PATH`` until
+    2026-08-30, and reloading was how a fixture made that constant follow the
+    env it had just set. The constant is deleted with the storage engine, and
+    the ``instances`` / ``a2a_ports`` writes this fixture was protecting
+    address the shared PostgreSQL store — ``pg_schema`` is what isolates them
+    now. What remains here is an env value subprocesses inherit.
     """
     p = tmp_path / "state.db"
     key = "SCITEX_AGENT_CONTAINER_STATE_DB"

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -34,7 +34,6 @@ from scitex_agent_container._listen._acl import check_send_acl, check_spawn
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_blocks import block_send
 from scitex_agent_container._state.state_db_channel import list_undelivered
 from scitex_agent_container._state.state_db_nodes import (
@@ -50,13 +49,10 @@ def db_path(tmp_path: Path):
     # Arrange
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
+++ b/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
@@ -31,7 +31,6 @@ from starlette.testclient import TestClient
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_blocks import has_block
 from scitex_agent_container._state.state_db_channel import list_undelivered
 from scitex_agent_container._state.state_db_nodes import (
@@ -49,12 +48,10 @@ _TOKEN = "test-token-approve-flow"
 def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
@@ -69,7 +66,6 @@ def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
         record_lineage(child="worker-a", parent="root")
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         if saved_env is None:

--- a/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
+++ b/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
@@ -30,7 +30,6 @@ from starlette.testclient import TestClient
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_acl_deny_notify import (
     last_notified_at,
 )
@@ -56,13 +55,11 @@ def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
     """
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     saved_cooldown_env = os.environ.get("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S")
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
@@ -83,7 +80,6 @@ def isolated_state(pg_schema: str, tmp_path: Path) -> Iterator[Path]:
         record_comms_policy(name="lead", inbound_siblings="deny")
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         if saved_env is None:

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -36,7 +36,6 @@ from scitex_agent_container._listen._acl import (
     check_send_acl,
     check_spawn,
 )
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_blocks import block_send
 from scitex_agent_container._state.state_db_nodes import (
     grant_send,
@@ -84,13 +83,10 @@ def db_path(tmp_path: Path):
     # Arrange
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_listen/test__acl_phase3.py
+++ b/tests/scitex_agent_container/_listen/test__acl_phase3.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container._listen._acl import check_send_acl, check_spawn
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
     record_comms_policy,
     record_lineage,
@@ -28,13 +27,10 @@ def db_path(tmp_path: Path):
     """Isolated state.db (mirrors test__acl.py's fixture)."""
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_listen/test__acl_routes.py
+++ b/tests/scitex_agent_container/_listen/test__acl_routes.py
@@ -21,7 +21,6 @@ import pytest
 from starlette.testclient import TestClient
 
 from scitex_agent_container._listen.server import create_app
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_blocks import has_block
 from scitex_agent_container._state.state_db_nodes import has_grant
 
@@ -32,13 +31,10 @@ _TOKEN = "test-token-acl-routes"
 def isolated_state(tmp_path: Path) -> Iterator[Path]:
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
@@ -33,7 +33,6 @@ from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._runners._session_state import state_dir_for
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 
 _TOKEN = "test-token-agent-exec-deadline"
 
@@ -61,19 +60,16 @@ def isolated_listen_env(tmp_path: Path):
     """Isolated state.db + registry/runtime dirs (mirrors the sibling tests)."""
     db = tmp_path / "state.db"
     saved_env_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default_db = state_db.DEFAULT_DB_PATH
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     try:
         yield tmp_path
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default_db
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         if saved_env_db is None:
@@ -92,8 +88,9 @@ def short_deadline():
 
     ``agents_start`` imports ``AGENT_START_DEADLINE_S`` INSIDE the function
     body, so reassigning the module attribute is picked up on the next call —
-    the same save/restore-seam idiom the sibling tests use for
-    ``state_db.DEFAULT_DB_PATH``.
+    the same save/restore-seam idiom the sibling tests used for
+    ``state_db.DEFAULT_DB_PATH`` until that constant was deleted with the
+    storage engine on 2026-08-30.
     """
     saved = _handler_deadline.AGENT_START_DEADLINE_S
     _handler_deadline.AGENT_START_DEADLINE_S = _TEST_DEADLINE_S

--- a/tests/scitex_agent_container/_listen/test__agent_exec_declined.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_declined.py
@@ -22,7 +22,6 @@ from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._runners._session_state import state_dir_for
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 
 _TOKEN = "test-token-agent-exec-declined"
 
@@ -32,19 +31,16 @@ def isolated_listen_env(tmp_path: Path):
     """Isolated state.db + registry/runtime dirs (mirrors test__agent_exec_subprocess.py)."""
     db = tmp_path / "state.db"
     saved_env_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default_db = state_db.DEFAULT_DB_PATH
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     try:
         yield tmp_path
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default_db
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         if saved_env_db is None:

--- a/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
@@ -32,7 +32,6 @@ from starlette.testclient import TestClient
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 
 _TOKEN = "test-token-agent-exec"
 
@@ -42,19 +41,16 @@ def isolated_listen_env(tmp_path: Path):
     """Isolated state.db + registry/runtime dirs (mirrors test__acl.py shape)."""
     db = tmp_path / "state.db"
     saved_env_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default_db = state_db.DEFAULT_DB_PATH
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     os.environ["HOME"] = str(tmp_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     try:
         yield tmp_path
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default_db
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         if saved_env_db is None:

--- a/tests/scitex_agent_container/_listen/test__forward.py
+++ b/tests/scitex_agent_container/_listen/test__forward.py
@@ -156,11 +156,14 @@ class _SilentHTTP:
 
 @pytest.fixture
 def isolated_state_db(tmp_path: Path, pg_schema: str):
-    """Point ``state_db.DEFAULT_DB_PATH`` (and the env) at ``tmp_path``.
+    """Point ``$SCITEX_AGENT_CONTAINER_STATE_DB`` at ``tmp_path``.
 
     DEPENDS ON ``pg_schema`` since 2026-08-28: the port this module resolves
     comes from the a2a claim ledger, which moved to PostgreSQL, so redirecting
-    ``state.db`` alone no longer isolates what these tests read.
+    ``state.db`` alone no longer isolates what these tests read. It also
+    pinned ``state_db.DEFAULT_DB_PATH`` until 2026-08-30, when that constant
+    was deleted with the storage engine — the env half is all that is left,
+    and ``pg_schema`` is what does the isolating.
     """
     key = "SCITEX_AGENT_CONTAINER_STATE_DB"
     saved = os.environ.get(key)

--- a/tests/scitex_agent_container/_listen/test__node_channel.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel.py
@@ -21,7 +21,6 @@ from starlette.testclient import TestClient
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_channel import list_undelivered
 from scitex_agent_container._state.state_db_nodes import record_lineage
 
@@ -37,14 +36,12 @@ def kind_env(pg_schema: str, tmp_path: Path):
     saved_run_env = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
-    saved_db_const = state_db.DEFAULT_DB_PATH
 
     db = tmp_path / "state.db"
     os.environ["HOME"] = str(tmp_path)
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
     os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(tmp_path / "runtime")
-    state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
 
@@ -55,7 +52,6 @@ def kind_env(pg_schema: str, tmp_path: Path):
     try:
         yield {"db": db, "tmp_path": tmp_path}
     finally:
-        state_db.DEFAULT_DB_PATH = saved_db_const
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         for k, v in (

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -45,7 +45,6 @@ from starlette.testclient import TestClient
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db as _state_db
 from scitex_agent_container._state.state_db_nodes import record_lineage
 from tests.scitex_agent_container._helpers.loopback_server import (
     await_until_serving,
@@ -70,7 +69,6 @@ def isolated_env(pg_schema: str, tmp_path: Path):
     saved_db_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
-    saved_db_const = _state_db.DEFAULT_DB_PATH
 
     os.environ["HOME"] = str(tmp_path)
     os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
@@ -80,7 +78,6 @@ def isolated_env(pg_schema: str, tmp_path: Path):
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
-    _state_db.DEFAULT_DB_PATH = db_path
 
     # WI-2 ACL: register the WI-3 demo nodes as siblings under a
     # common root so they share a group. Without this the new
@@ -94,7 +91,6 @@ def isolated_env(pg_schema: str, tmp_path: Path):
     finally:
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
-        _state_db.DEFAULT_DB_PATH = saved_db_const
         for key, val in (
             ("HOME", saved_home),
             ("SCITEX_AGENT_CONTAINER_REGISTRY_DIR", saved_reg_env),

--- a/tests/scitex_agent_container/_listen/test__notify.py
+++ b/tests/scitex_agent_container/_listen/test__notify.py
@@ -38,7 +38,6 @@ from scitex_agent_container._listen._notify import publish_to_agent
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_channel import list_undelivered
 from scitex_agent_container.a2a._inbox_bus import Broker
 
@@ -64,21 +63,18 @@ def notify_env(tmp_path: Path, pg_schema: str):
     saved_run_env = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
-    saved_db_const = state_db.DEFAULT_DB_PATH
 
     db = tmp_path / "state.db"
     os.environ["HOME"] = str(tmp_path)
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
     os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(tmp_path / "runtime")
-    state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
 
     try:
         yield {"db": db, "tmp_path": tmp_path}
     finally:
-        state_db.DEFAULT_DB_PATH = saved_db_const
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         for k, v in (

--- a/tests/scitex_agent_container/_listen/test__registry_endpoints.py
+++ b/tests/scitex_agent_container/_listen/test__registry_endpoints.py
@@ -23,7 +23,6 @@ import pytest
 
 from scitex_agent_container._listen import _registry_endpoints as _re
 from scitex_agent_container._state import port_allocator as _pa
-from scitex_agent_container._state import state_db as _state_db
 from scitex_agent_container._state import state_db_instances as _instances
 
 
@@ -65,21 +64,19 @@ def _swap_env(name: str, value: str | None) -> str | None:
 
 @pytest.fixture
 def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
-    """Redirect ``state.db`` writes to a per-test tmp file.
+    """Give this test a private ``$SCITEX_AGENT_CONTAINER_STATE_DB``.
 
-    Mirrors the ``cross_host_env`` fixture in ``test_server.py``:
-    ``DEFAULT_DB_PATH`` is captured at import time so just setting the
-    env var is not enough — we swap the module attribute directly and
-    restore it on teardown.
+    Mirrors the ``cross_host_env`` fixture in ``test_server.py``. Both used to
+    swap ``state_db.DEFAULT_DB_PATH`` as well, because that constant was
+    captured at import and setting the env var alone did not move it. The
+    constant was deleted with the storage engine on 2026-08-30; the env var is
+    what a subprocess reads and all that is swapped here now.
     """
     db = tmp_path / "state.db"
     prev_env = _swap_env(_STATE_DB_ENV, str(db))
-    prev_attr = _state_db.DEFAULT_DB_PATH
-    _state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        _state_db.DEFAULT_DB_PATH = prev_attr
         _swap_env(_STATE_DB_ENV, prev_env)
 
 
@@ -89,12 +86,9 @@ def isolated_host_env(tmp_path: Path) -> Iterator[Path]:
     db = tmp_path / "state.db"
     prev_db_env = _swap_env(_STATE_DB_ENV, str(db))
     prev_host_env = _swap_env(_SAC_HOST_ENV, "test-host")
-    prev_attr = _state_db.DEFAULT_DB_PATH
-    _state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        _state_db.DEFAULT_DB_PATH = prev_attr
         _swap_env(_STATE_DB_ENV, prev_db_env)
         _swap_env(_SAC_HOST_ENV, prev_host_env)
 

--- a/tests/scitex_agent_container/_listen/test__self_peer_persistence.py
+++ b/tests/scitex_agent_container/_listen/test__self_peer_persistence.py
@@ -38,7 +38,6 @@ import pytest
 from scitex_agent_container._listen._self_peer_persistence import (
     persist_discovered_self_peers,
 )
-from scitex_agent_container._state import state_db as _state_db
 from scitex_agent_container._state.state_db_nodes import (
     CommsNodeConflictError,
     register_comms_node,
@@ -67,12 +66,9 @@ def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
     """Redirect ``state.db`` writes to a per-test tmp file (no ``monkeypatch``)."""
     db = tmp_path / "state.db"
     prev_env = _swap_env(_STATE_DB_ENV, str(db))
-    prev_attr = _state_db.DEFAULT_DB_PATH
-    _state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        _state_db.DEFAULT_DB_PATH = prev_attr
         _swap_env(_STATE_DB_ENV, prev_env)
 
 

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -787,14 +787,12 @@ def cross_host_env(tmp_path: Path):
     # Arrange
     db = tmp_path / "state.db"
     saved_db_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_db_const = state_db.DEFAULT_DB_PATH
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
 
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     os.environ["HOME"] = str(tmp_path)
-    state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     # WI-4 Q4(b): seed the per-host bearer registry. The forwarder
@@ -805,7 +803,6 @@ def cross_host_env(tmp_path: Path):
     try:
         yield {"db": db, "tmp": tmp_path}
     finally:
-        state_db.DEFAULT_DB_PATH = saved_db_const
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         if saved_db_env is None:
@@ -1023,14 +1020,12 @@ def missing_peer_token_response(pg_schema: str, tmp_path: Path):
     """
     # Arrange — fresh tmp env, NO peer-token for host-z.
     saved_db_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_db_const = state_db.DEFAULT_DB_PATH
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
     db = tmp_path / "state.db"
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     os.environ["HOME"] = str(tmp_path)
-    state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
     record_lineage(child="permitted-peer", parent="root")
@@ -1049,7 +1044,6 @@ def missing_peer_token_response(pg_schema: str, tmp_path: Path):
             )
         yield r
     finally:
-        state_db.DEFAULT_DB_PATH = saved_db_const
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         if saved_db_env is None:

--- a/tests/scitex_agent_container/_network/test__peer_faillloud.py
+++ b/tests/scitex_agent_container/_network/test__peer_faillloud.py
@@ -61,8 +61,12 @@ def resolve_yaml_to():
 
 @pytest.fixture
 def isolated_state_db(tmp_path: Path):
-    """Redirect state.db to a tmp path; reload the module so the
-    module-level DEFAULT_DB_PATH picks it up (explicit save/restore)."""
+    """Per-test ``$SCITEX_AGENT_CONTAINER_STATE_DB`` (explicit save/restore).
+
+    The reload picked up a module-level ``DEFAULT_DB_PATH`` until 2026-08-30.
+    That constant is deleted with the storage engine, so the reload re-derives
+    nothing; the env value survives as something subprocesses inherit.
+    """
     db = tmp_path / "state.db"
     key = "SCITEX_AGENT_CONTAINER_STATE_DB"
     saved = os.environ.get(key)

--- a/tests/scitex_agent_container/_network/test_peer.py
+++ b/tests/scitex_agent_container/_network/test_peer.py
@@ -204,8 +204,12 @@ class TestResolvePeerUrl:
 
 @pytest.fixture
 def isolated_state_db(tmp_path: Path):
-    """Redirect state.db to a tmp path; reload the module so the
-    module-level DEFAULT_DB_PATH picks it up (explicit save/restore)."""
+    """Per-test ``$SCITEX_AGENT_CONTAINER_STATE_DB`` (explicit save/restore).
+
+    The reload picked up a module-level ``DEFAULT_DB_PATH`` until 2026-08-30.
+    That constant is deleted with the storage engine, so the reload re-derives
+    nothing; the env value survives as something subprocesses inherit.
+    """
     import importlib
     import os
 

--- a/tests/scitex_agent_container/_reconcile/conftest.py
+++ b/tests/scitex_agent_container/_reconcile/conftest.py
@@ -4,11 +4,12 @@ Every fixture here hands the pass REAL state it can write to and a test can
 read back: an on-disk ``state.db``, an on-disk fleet registry of v3 specs,
 an on-disk sac event log, an on-disk history file.
 
-The ``db_path`` fixture redirects BOTH handles (the env var AND the
-already-baked ``DEFAULT_DB_PATH`` module constant), because the constant is
-computed at import and an env-only fixture is too late — the trap
+The ``db_path`` fixture redirected BOTH handles — the env var AND the
+already-baked ``DEFAULT_DB_PATH`` module constant — because the constant was
+computed at import and an env-only fixture was too late; that is the trap
 ``tests/conftest.py`` documents at length, and the one that once landed test
-agent names in the live production fleet database.
+agent names in the live production fleet database. The constant was deleted
+with the storage engine on 2026-08-30, so only the env var is redirected now.
 """
 
 from __future__ import annotations
@@ -18,21 +19,17 @@ from pathlib import Path
 
 import pytest
 
-from scitex_agent_container._state import state_db
 
 
 @pytest.fixture
 def db_path(tmp_path: Path):
-    # Arrange — an isolated on-disk state.db, both handles redirected.
+    # Arrange — an isolated per-test value for the env var.
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_state/test_lead_inbox.py
+++ b/tests/scitex_agent_container/_state/test_lead_inbox.py
@@ -31,7 +31,6 @@ from scitex_agent_container._listen.peer_tokens import write_peer_token
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.host_config import LeadConfig
 from scitex_agent_container._state.lead_inbox import (
     LEAD_EVENT_KINDS,
@@ -252,14 +251,12 @@ def lead_env(tmp_path: Path, env_save_restore):
     saved_run_env = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
-    saved_db_const = state_db.DEFAULT_DB_PATH
 
     db = tmp_path / "state.db"
     os.environ["HOME"] = str(tmp_path)
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
     os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
     os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(tmp_path / "runtime")
-    state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
 
@@ -279,7 +276,6 @@ def lead_env(tmp_path: Path, env_save_restore):
     try:
         yield {"db": db, "cfg": cfg, "tmp_path": tmp_path}
     finally:
-        state_db.DEFAULT_DB_PATH = saved_db_const
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
         for k, v in (

--- a/tests/scitex_agent_container/_state/test_state_db_acl_deny_notify.py
+++ b/tests/scitex_agent_container/_state/test_state_db_acl_deny_notify.py
@@ -24,7 +24,6 @@ from typing import Iterator
 
 import pytest
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_acl_deny_notify import (
     DEFAULT_COOLDOWN_S,
     last_notified_at,
@@ -37,14 +36,11 @@ from scitex_agent_container._state.state_db_acl_deny_notify import (
 def isolated_state(tmp_path: Path) -> Iterator[Path]:
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     saved_cooldown_env = os.environ.get("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S")
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
+++ b/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
@@ -31,7 +31,6 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container._listen._acl import check_spawn
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
     is_developer,
     is_privileged,
@@ -54,13 +53,10 @@ def db_path(tmp_path: Path):
     # Arrange
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_state/test_state_db_nodes_group.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes_group.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 import pytest
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
     is_developer,
     read_comms_policy,
@@ -34,13 +33,10 @@ def db_path(tmp_path: Path):
     # Arrange
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/_state/test_state_db_test_isolation.py
+++ b/tests/scitex_agent_container/_state/test_state_db_test_isolation.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_instances import (
     list_active_instances,
     record_instance_start,
@@ -54,16 +53,12 @@ from scitex_agent_container._state.state_db_instances import (
 _REAL_DB = Path("~/.scitex/agent-container/runtime/state.db").expanduser()
 
 
-def test_default_db_path_is_not_the_real_state_db() -> None:
-    """The resolved default must never be the operator's live fleet database."""
-    # Arrange
-    real = _REAL_DB
-    # Act
-    resolved = Path(state_db.DEFAULT_DB_PATH)
-    # Assert
-    assert resolved != real
-
-
+# ``test_default_db_path_is_not_the_real_state_db`` was here until 2026-08-30.
+# It asserted ``state_db.DEFAULT_DB_PATH != ~/.scitex/.../state.db``, and by the
+# end it could not fail for the reason it claimed: the constant selected no
+# storage, so a wrong value moved nothing. It is deleted with the constant
+# rather than repointed. The env-var test below is the half that still guards
+# something — a subprocess inherits it.
 def test_state_db_env_var_is_not_the_real_state_db() -> None:
     """Subprocesses inherit the env, so the env var must be redirected too."""
     # Arrange

--- a/tests/scitex_agent_container/a2a/test__server.py
+++ b/tests/scitex_agent_container/a2a/test__server.py
@@ -666,7 +666,6 @@ import socket as _socket
 
 import httpx as _httpx
 
-from scitex_agent_container._state import state_db as _state_db
 from tests.scitex_agent_container._helpers.loopback_server import (
     run_loopback as _run_loopback_shared,
 )
@@ -688,13 +687,10 @@ def _isolated_db(tmp_path: Path, pg_schema: str):
     """
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = _state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    _state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        _state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
@@ -68,12 +68,15 @@ def _instances_store(pg_schema: str):
 
 @pytest.fixture
 def isolated_state_db(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
-    """Per-test on-disk state.db, exported via env (explicit save/restore).
+    """Per-test ``$SCITEX_AGENT_CONTAINER_STATE_DB`` value (explicit
+    save/restore).
 
-    ``state_db`` reads ``SCITEX_AGENT_CONTAINER_STATE_DB`` at import into a
-    module-level ``DEFAULT_DB_PATH``; reload it after setting the env so the
-    ``instances`` writes land in the temp DB, not the developer's real
-    ``~/.scitex`` tree. Mirrors ``_lifecycle/test__stale_lease.py``.
+    THE RELOAD BELOW NO LONGER RE-DERIVES ANYTHING. ``state_db`` read this
+    variable at import into a module-level ``DEFAULT_DB_PATH`` until
+    2026-08-30; the constant is deleted with the storage engine, and the
+    ``instances`` writes it guarded address the shared PostgreSQL store, which
+    is what ``pg_schema`` isolates. What remains here is an env value
+    subprocesses inherit.
     """
     p = tmp_path / "state.db"
     key = "SCITEX_AGENT_CONTAINER_STATE_DB"

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
@@ -415,13 +415,18 @@ class TestBoundHost:
 
 
 def _reload_state_db_at(path: Path, env_save_restore):
-    """Redirect DEFAULT_DB_PATH at ``path`` and reload the state_db
-    module so the rebound path takes effect.
+    """Point ``$SCITEX_AGENT_CONTAINER_STATE_DB`` at ``path`` and reload the
+    state_db module.
+
+    THE RELOAD NO LONGER REBINDS A PATH. It existed so the import-time
+    ``DEFAULT_DB_PATH`` constant would follow the env var this had just set;
+    that constant was deleted with the storage engine on 2026-08-30, and
+    ``record_instance_start`` and friends address the shared PostgreSQL store.
 
     PA-306 §3 no-mocks: uses the project ``env_save_restore`` fixture
     (NOT pytest's ``monkeypatch``) to manage the env var save/restore.
-    Returns the reloaded module so the caller can call its
-    ``record_instance_start`` etc. against the redirected DB.
+    Returns the module so the caller can call its ``record_instance_start``
+    etc.
     """
     import importlib
 
@@ -434,8 +439,7 @@ def _reload_state_db_at(path: Path, env_save_restore):
 
 class TestRegistryActiveOn:
     def test_missing_state_db_treated_as_not_live(self, tmp_path, env_save_restore):
-        # Arrange — point state.db at a non-existent path; reload module
-        # so DEFAULT_DB_PATH is recomputed.
+        # Arrange — point the env var at a non-existent path.
         import importlib
 
         state_db_mod = _reload_state_db_at(tmp_path / "nope.db", env_save_restore)

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
@@ -169,17 +169,18 @@ def shim_bin(tmp_path: Path, env_save_restore) -> Path:
 
 @pytest.fixture
 def state_db(fake_home: Path) -> Path:
-    """Redirect state.db to a tmp path under fake_home.
+    """Point ``$SCITEX_AGENT_CONTAINER_STATE_DB`` at a tmp path under
+    fake_home.
 
-    DEFAULT_DB_PATH is module-level and reads the env var at import
-    time, so we reload the module after setting the env var. Tests
-    that mutate state.db rely on this to stay isolated; without the
-    reload each test would write to the user's real state.db.
+    ``DEFAULT_DB_PATH`` was module-level and read this env var at import, so
+    this reloaded the module after setting it — without the reload a test
+    would have written to the user's real state.db. That constant was deleted
+    with the storage engine on 2026-08-30 and the writes address the shared
+    PostgreSQL store, so the reload re-derives nothing.
 
-    Both env-var manipulation and module reload are managed locally
-    (no env_save_restore) so the teardown order is unambiguous: we
-    first reset the env, THEN reload, so DEFAULT_DB_PATH lands back
-    on the real path the user expects after the fixture exits.
+    Both the env-var manipulation and the module reload are managed locally
+    (no env_save_restore) so the teardown order stays unambiguous: reset the
+    env first, THEN reload.
     """
     import importlib
     import os as _os

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
@@ -31,7 +31,6 @@ from typing import Iterator
 import pytest
 from click.testing import CliRunner
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_instances import (
     list_active_instances,
     record_instance_start,
@@ -64,13 +63,10 @@ def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
     """Real isolated state.db; env + module constants saved/restored."""
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
@@ -32,7 +32,6 @@ from typing import Any, Iterator
 
 import pytest
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container.cli_pkg.lifecycle._start_single import (
     run_single_targets,
 )
@@ -96,13 +95,10 @@ def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
         "SCITEX_DIR": str(home / ".scitex"),
     }
     saved = {k: os.environ.get(k) for k in keys}
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ.update(keys)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         for k, prev in saved.items():
             if prev is None:
                 os.environ.pop(k, None)

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_verify_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_verify_wiring.py
@@ -27,7 +27,6 @@ from typing import Any, Iterator
 
 import pytest
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container.cli_pkg.lifecycle._start_single import (
     run_single_targets,
 )
@@ -83,13 +82,10 @@ def isolated_state(tmp_path: Path, pg_schema: str) -> Iterator[Path]:
         "SCITEX_DIR": str(home / ".scitex"),
     }
     saved = {k: os.environ.get(k) for k in keys}
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ.update(keys)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         for k, prev in saved.items():
             if prev is None:
                 os.environ.pop(k, None)

--- a/tests/scitex_agent_container/cli_pkg/test__on_start_propagate.py
+++ b/tests/scitex_agent_container/cli_pkg/test__on_start_propagate.py
@@ -49,8 +49,12 @@ def _instances_store(pg_schema: str):
 
 @pytest.fixture
 def isolated_state_db(tmp_path: Path):
-    """Redirect state.db to a tmp path; reload the module so the
-    module-level DEFAULT_DB_PATH picks it up (explicit save/restore)."""
+    """Per-test ``$SCITEX_AGENT_CONTAINER_STATE_DB`` (explicit save/restore).
+
+    The reload picked up a module-level ``DEFAULT_DB_PATH`` until 2026-08-30.
+    That constant is deleted with the storage engine, so the reload re-derives
+    nothing; the env value survives as something subprocesses inherit.
+    """
     db = tmp_path / "state.db"
     key = "SCITEX_AGENT_CONTAINER_STATE_DB"
     saved = os.environ.get(key)

--- a/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
@@ -598,9 +598,11 @@ def test_doctor_against_live_serve_envelope_ok(
 # a2a {grant,revoke,grants} -- cross-group ACL verbs (no mocks).
 #
 # Each test uses ``isolated_state_db`` which pins
-# ``SCITEX_AGENT_CONTAINER_STATE_DB`` at a tmp_path and reloads
-# the state_db module so the import-time DEFAULT_DB_PATH constant
-# picks up the new value. Same seam ``test_db_group.py`` already uses.
+# ``SCITEX_AGENT_CONTAINER_STATE_DB`` at a tmp_path and reloads the state_db
+# module. That reload existed to make the import-time ``DEFAULT_DB_PATH``
+# constant pick up the new value; the constant was deleted with the storage
+# engine on 2026-08-30, so the reload re-derives nothing and the grants these
+# tests read come from the shared PostgreSQL store.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/scitex_agent_container/cli_pkg/test_ports_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_ports_cmds.py
@@ -14,11 +14,12 @@ PA-306 no-mocks: every collaborator is real.
 * Liveness is exercised against REAL sockets: a bound-and-listening
   socket (live) and a bound-then-closed free port (dead / orphan). No
   probe is monkeypatched.
-* A yield-based ``isolated_state`` fixture redirects BOTH state
-  read-paths — ``$HOME`` and the import-time
-  ``state_db.DEFAULT_DB_PATH`` constant — at an isolated ``tmp_path``,
-  so the CLI smoke tests never read or write the live fleet registry
-  (no monkeypatch; these are the codebase's own seams).
+* A yield-based ``isolated_state`` fixture points ``$HOME`` and
+  ``$SCITEX_AGENT_CONTAINER_STATE_DB`` at an isolated ``tmp_path``, so the
+  CLI smoke tests never read or write the live fleet registry (no
+  monkeypatch; these are the codebase's own seams). It also redirected the
+  import-time ``state_db.DEFAULT_DB_PATH`` constant until 2026-08-30, when
+  that constant was deleted with the storage engine.
 """
 
 from __future__ import annotations
@@ -32,7 +33,6 @@ import pytest
 from click.testing import CliRunner
 
 from scitex_agent_container._state import port_allocator as pa
-from scitex_agent_container._state import state_db
 from scitex_agent_container.cli_pkg._main import main
 from scitex_agent_container.cli_pkg.ports_cmds import (
     _reference_map,
@@ -91,34 +91,32 @@ def isolated_state(tmp_path, pg_schema):
     dependency rather than left to autouse ordering, for the same reason
     ``_isolate_state_db`` requests ``_assert_state_floor_intact`` by name.
 
-    ``sac ports`` takes no ``--db``: it resolves state.db from
-    :data:`state_db.DEFAULT_DB_PATH`, a **module-level constant computed
-    at import time**. So overriding ``$HOME`` alone does NOT redirect it
-    — by the time a fixture runs, the constant already points at the
-    developer's real ``~/.scitex/agent-container/runtime/state.db``, and
-    a CLI test would *read* (and ``claim_port`` would *WRITE*) the live
-    fleet registry. In CI that silently invents a registry; on a real
-    host it pollutes one.
+    ``sac ports`` takes no ``--db``. It used to resolve state.db from
+    :data:`state_db.DEFAULT_DB_PATH`, a **module-level constant computed at
+    import time**, so overriding ``$HOME`` alone did NOT redirect it — by the
+    time a fixture ran, the constant already pointed at the developer's real
+    ``~/.scitex/agent-container/runtime/state.db``, and a CLI test would
+    *read* (and ``claim_port`` would *WRITE*) the live fleet registry. In CI
+    that silently invented a registry; on a real host it polluted one.
 
-    So touch both read-paths — the env var AND the constant — exactly as
-    ``tests/smoke/conftest.py::comms_env`` does. These are the seams the
-    codebase itself exposes for this: no monkeypatch, no mock.
+    THAT CONSTANT WAS DELETED WITH THE STORAGE ENGINE on 2026-08-30, and the
+    ledger it addressed had already moved to PostgreSQL. ``pg_schema`` above
+    is what isolates the claim now; ``$HOME`` and the env var are still
+    pinned here because the CLI reads both. These are the seams the codebase
+    itself exposes: no monkeypatch, no mock.
     """
     db = tmp_path / "state.db"
     prior = {
         k: os.environ.get(k)
         for k in ("HOME", "USERPROFILE", "SCITEX_AGENT_CONTAINER_STATE_DB")
     }
-    prior_db_path = state_db.DEFAULT_DB_PATH
 
     os.environ["HOME"] = str(tmp_path)
     os.environ["USERPROFILE"] = str(tmp_path)
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield tmp_path
     finally:
-        state_db.DEFAULT_DB_PATH = prior_db_path
         for k, v in prior.items():
             if v is None:
                 os.environ.pop(k, None)

--- a/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
+++ b/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
@@ -21,7 +21,6 @@ import pytest
 import yaml as _yaml
 from click.testing import CliRunner
 
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
     read_comms_policy,
     record_comms_policy,
@@ -35,13 +34,10 @@ def db_path(tmp_path: Path):
     # Arrange — isolated on-disk state.db via the env override.
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
-    saved_default = state_db.DEFAULT_DB_PATH
     os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
-    state_db.DEFAULT_DB_PATH = db
     try:
         yield db
     finally:
-        state_db.DEFAULT_DB_PATH = saved_default
         if saved_env is None:
             os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
         else:

--- a/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
@@ -101,8 +101,11 @@ def _empty_state_db(tmp_path: Path) -> Iterator[None]:
     by an earlier test in the shared default db (CI runs the whole
     suite) makes ``alpha`` look "running" and the send POSTs to a dead
     loopback port instead of falling through to ``claude --resume``.
-    Redirecting to an empty db (and reloading the import-time
-    ``DEFAULT_DB_PATH``) keeps these resume-path tests deterministic.
+    Redirecting to an empty db kept these resume-path tests deterministic.
+    The reload below was how the import-time ``DEFAULT_DB_PATH`` constant
+    followed that redirect; it was deleted with the storage engine on
+    2026-08-30, so the reload re-derives nothing and the instance rows come
+    from the shared PostgreSQL store.
     """
     import importlib
 

--- a/tests/scitex_agent_container/test__runtime_paths.py
+++ b/tests/scitex_agent_container/test__runtime_paths.py
@@ -63,7 +63,6 @@ def test_empty_env_falls_back_to_default(env_save_restore):
 @pytest.mark.parametrize(
     "module_path, attr, subpath",
     [
-        ("scitex_agent_container._state.state_db", "DEFAULT_DB_PATH", "state.db"),
         ("scitex_agent_container._state.registry", "REGISTRY_DIR", "registry"),
         ("scitex_agent_container._runners._session_state", "DEFAULT_STATE_ROOT", ""),
     ],
@@ -79,7 +78,6 @@ def test_env_relocates_module_constant(
     # restored re-derives the constant from an env var this test has just
     # dropped, which pins it at the operator's real $HOME for every remaining
     # test in this xdist worker. See the fixture's docstring.
-    env_save_restore.delete("SCITEX_AGENT_CONTAINER_STATE_DB")
     env_save_restore.delete("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
     env_save_restore.set(RUNTIME_DIR_ENV, str(tmp_path / "rt"))
     mod = importlib.reload(importlib.import_module(module_path))
@@ -91,17 +89,12 @@ def test_env_relocates_module_constant(
     assert Path(got) == expected
 
 
-def test_per_file_state_db_override_still_wins(env_save_restore, tmp_path):
-    # Arrange — explicit STATE_DB override must beat RUNTIME_DIR.
-    env_save_restore.set(RUNTIME_DIR_ENV, str(tmp_path / "rt"))
-    env_save_restore.set(
-        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "explicit" / "s.db")
-    )
-    mod = importlib.reload(
-        importlib.import_module("scitex_agent_container._state.state_db")
-    )
-    env_save_restore.reload_after_restore(mod)
-    # Act
-    got = mod.DEFAULT_DB_PATH
-    # Assert
-    assert Path(got) == tmp_path / "explicit" / "s.db"
+# ``test_per_file_state_db_override_still_wins`` was here until 2026-08-30. It
+# pinned the precedence ``$SCITEX_AGENT_CONTAINER_STATE_DB`` beat
+# ``$SCITEX_AGENT_CONTAINER_RUNTIME_DIR`` when ``state_db.DEFAULT_DB_PATH``
+# recomputed. Both halves of that sentence are gone: the constant is deleted
+# with the storage engine, and there is no longer any consumer for which the
+# two variables could compete. The variable itself survives — sac injects it
+# into containers, a rename rewrites it, ``sac whoami`` reports it — but none
+# of those resolve it against ``RUNTIME_DIR``, so re-pointing this test at one
+# of them would have been a new assertion wearing a passing test's name.

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -22,7 +22,6 @@ import pytest
 
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container._state import state_db
 
 
 def pytest_configure(config):
@@ -105,7 +104,6 @@ def comms_env(pg_schema: str, disk_tmp: Path) -> Iterator[dict[str, Any]]:
         ),
     }
     saved_consts = {
-        "state_db": state_db.DEFAULT_DB_PATH,
         "registry": _reg.REGISTRY_DIR,
         "session_state": _ss.DEFAULT_STATE_ROOT,
     }
@@ -115,13 +113,11 @@ def comms_env(pg_schema: str, disk_tmp: Path) -> Iterator[dict[str, Any]]:
     os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(disk_tmp / "registry")
     os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(disk_tmp / "runtime")
     os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
-    state_db.DEFAULT_DB_PATH = db
     _reg.REGISTRY_DIR = disk_tmp / "registry"
     _ss.DEFAULT_STATE_ROOT = disk_tmp / "runtime"
     try:
         yield {"db": db, "tmp": disk_tmp}
     finally:
-        state_db.DEFAULT_DB_PATH = saved_consts["state_db"]
         _reg.REGISTRY_DIR = saved_consts["registry"]
         _ss.DEFAULT_STATE_ROOT = saved_consts["session_state"]
         for key, val in saved_env.items():


### PR DESCRIPTION
## What this is, and what it is not

This PR was commissioned as "retire the last SQLite layer: delete the dead
machinery from `state_db.py`, decide `state_db_health.py` and
`_lifecycle/_rename_db.py`, and make `sac db show/query/export/import` honest."

**Almost all of that had already landed.** `develop` advanced four commits
between the brief being written and this branch being cut (#1272, #1273, #1274,
#1275). Measured on this branch's merge base:

| Asked for | Measured state before this PR |
| --- | --- |
| Delete `_default_connector` / `_connect` / `open_db` / `init_schema` / `table_counts` / `_table_filter_clauses` / `import sqlite3` | Already gone (#1274) |
| `import sqlite3` in `src/` | Already **0** — `rg -ni --no-ignore --hidden sqlite src` returns nothing (positive control: 876 files match `def `) |
| Decide `_state/state_db_health.py` | Already deleted |
| Decide `_lifecycle/_rename_db.py` | Already deleted (#1273) |
| Make `sac db show` / `query` / `export` / `import` honest | Already **removed**, with the reasoning recorded in `db_group.py` and `state_db_export.py` |
| Shrink the SQLite freeze allowlist | Already **emptied** — `test_sqlite_footprint_frozen.py` deleted, replaced by `test_retired_engine_footprint_frozen.py`, whose docstring records that all four frozen sets are now empty populations |

So this PR does the one thing that was genuinely left, and it is the thing
`state_db.py` itself nominated:

> Retiring the constant is a separate change with a separate argument —
> roughly fifty test modules save/restore it as isolation ceremony that has
> already stopped isolating anything — and doing it here would have hidden a
> fifty-file fixture rewrite inside an engine deletion.

## The change

`state_db.DEFAULT_DB_PATH` — a `Path` naming a `state.db` that nothing created
and nothing could open — is deleted, along with everything that existed only to
serve it.

The argument is the one the constant's own comment made against itself. It
selected no storage, so the ~4900 per-test rebindings isolated nothing, and the
suite's state-floor alarm spent a third of its sentinels proving that a constant
nobody reads still pointed somewhere harmless. It was read as
`getattr(module, attr, None)` with `if value is None: continue` — so once the
attribute went, that sentinel would have reported "intact" forever **because it
could no longer look**. Per constitution §44, that is worse than deleting it.

Removed:

- the constant, and the `os` / `Path` / `runtime_base_dir` imports it was the
  only user of
- **102** save/set/restore lines across **32** test modules
- the **31** `state_db` imports those lines orphaned
- the `("..._state.state_db", "DEFAULT_DB_PATH")` entry in
  `tests/conftest.py::_STATE_FLOOR_CONSTANTS`
- two tests that asserted properties of the constant itself and could no longer
  fail for the reason they claimed:
  `_state/test_state_db_test_isolation.py::test_default_db_path_is_not_the_real_state_db`
  and `test__runtime_paths.py::test_per_file_state_db_override_still_wins`
- the `DEFAULT_DB_PATH` case from `test__runtime_paths.py`'s three-way
  `test_env_relocates_module_constant` parametrization
- the now-inert `DEFAULT_DB_PATH` swap inside
  `_lifecycle/test__instances_auto_grant.py`, whose helper is renamed
  `_fire_monitor_restart_against_foreign_db` -> `_fire_monitor_restart` because
  the dropped half of the name no longer described anything

## What is deliberately KEPT, and why

**`$SCITEX_AGENT_CONTAINER_STATE_DB` is not removed.** It is independently
load-bearing on three paths that survive the constant:

- `runtimes/_apptainer_build_argv.py:228` — sac emits `--env
  SCITEX_AGENT_CONTAINER_STATE_DB=...` on every container launch
- `_lifecycle/_rename_spec.py:90` — `ENV_RULES` types it `"path"`, so a rename
  rewrites the agent-name component inside the spec
- `cli_pkg/_whoami.py:272` — `sac whoami` reports it

It no longer selects storage, so a leak can no longer misdirect a *write*. It
stays sandboxed per-test because subprocesses inherit it, and the floor alarm's
env-var clause stays — with its rationale rewritten from "protects the constant
from a reload" to what it actually guards now.

`now_iso()` and `new_uuid7()` are untouched. `state_db.py` keeps its name and
gains a docstring paragraph saying what it now is: a namespace of two id helpers
plus the accessor re-exports. Moving them would have churned ~20 importers to no
end.

## Two stale rationales corrected rather than left to read as current

1. `tests/conftest.py` justified per-test isolation by intra-run `a2a_ports`
   exhaustion — the mechanism that killed ghost tag v0.21.18. `a2a_ports` moved
   to PostgreSQL on 2026-08-28; `pg_schema` prevents that now. The `scope="function"`
   is kept on the weaker surviving argument, and the weaker argument is stated
   rather than left looking like the strong one.
2. `tests/conftest.py:636` still explained a `mkdir` performed by
   `state_db._connect` — deleted in #1274.

## Named follow-up, not done here

Roughly eight fixtures still call `importlib.reload(state_db)` whose only stated
purpose was re-deriving the constant. Those reloads are now inert; their
docstrings say so plainly. Rewriting them means editing test bodies and their
`finally:` blocks, which is a fixture change — left out of an engine deletion for
exactly the reason this constant was left out of one.

## Verification

Baseline captured on the merge base **before** any edit: `tests/develop` =
136 passed, 1 skipped.

Run on this branch, `PYTHONPATH` pinned at this worktree's `src/` (the
`enforce_pytest_worktree_source` hook otherwise tests the main checkout's code):

| Suite | Result |
| --- | --- |
| `tests/develop` (audit gate + both engine guards) | **136 passed, 1 skipped** — identical to baseline |
| `tests/develop` + `_state` + `test__runtime_paths.py` + `_reconcile` + `_network` | 1207 passed, 721 skipped |
| `_listen` + `a2a` + `cli_pkg` | 3482 passed, 1149 skipped, 16 deselected |
| `_lifecycle` + `smoke` + `integration` | 3268 passed, 400 skipped, 7 deselected |
| whole-suite `--collect-only` | 18082/18105 collected, no collection errors |

**7957 passed, 0 failed**, every run exit 0. `test_audit.py::test_audit_all_clean`
is green, as are `test_the_engine_name_stays_gone.py` (9) and
`test_retired_engine_footprint_frozen.py` (11). The `tests/develop` run was
repeated *after* the CHANGELOG entry was written, because that guard scans
CHANGELOG's `[Unreleased]` section for the retired engine's name.

### What I could NOT run, and why

**PostgreSQL-backed tests skipped in this container** — that is the bulk of the
2270 skips. The reason is not a missing server:

> PostgreSQL fixture cannot use `postgresql://127.0.0.1:55432/scitex` as
> `ywatanabe__scitex-agent-container`: loopback is a read-only replica of the
> fleet cluster (system_identifier=7672112238472680366); there is no writable
> database on this host

`tests/_store_isolation.py` correctly refuses to create a throwaway schema on a
replica of the production cluster and skips instead. This is environmental and
pre-existing, not caused by this PR — but it means **I have not observed the
PostgreSQL-backed tests pass on this branch**, and CI is what will establish
that.

`--collect-only` was run whole-suite; the remaining directories were not
executed, and no claim is made about them beyond clean collection.
