### PR TITLE
test(freshness): supply the upstream axis scitex-dev #785 requires

### DIFF
--- a/tests/scitex_agent_container/_freshness/test___init__.py
+++ b/tests/scitex_agent_container/_freshness/test___init__.py
@@ -26,11 +26,21 @@ from __future__ import annotations
 import importlib
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+#: "a git command that pulls" — the shape an editable remedy must have. Not
+#: the literal string `git pull`: the primitive composes
+#: `git -C <repo> pull --ff-only` so the command works from any CWD and can
+#: never rewrite unpushed commits, and an older primitive emits a bare
+#: `git pull`. Both are the same promise; a `pip install -U` is not.
+#: Unanchored on purpose: `.match()` pins it to the start of a REMEDY
+#: string, while `.search()` finds the `fix:` line inside rendered output.
+_GIT_PULL = re.compile(r"git\b(?:\s+\S+)*?\s+pull\b")
 
 from scitex_agent_container._freshness import (
     DIST_NAME,
@@ -90,9 +100,40 @@ def _report(**evidence):
     )
 
 
+def _upstream_evidence(behind: int) -> dict:
+    """The second editable axis, when the installed primitive has it.
+
+    scitex-dev grew a distinction this fixture predates. Distance from the
+    latest release tag says only that the tag is not in HEAD's history, and
+    release tags are cut on `main` — so a perfectly healthy `develop` is
+    permanently "behind" one, and reporting STALE on that alone prints a
+    `git pull` that can never close the gap. Distance from the TRACKING
+    REMOTE is the one gap a pull does close, so it is now the only fact that
+    may be judged STALE; tag distance on its own reads as UNKNOWN.
+
+    Supplied CONDITIONALLY because sac's `[dev]` floor still permits a
+    primitive that predates these keys, and ``StaticSources`` rejects an
+    unknown kwarg. FOLLOW-UP: inline them once the floor moves past the
+    release that ships them — the same floor bump the module docstring
+    already asks for.
+    """
+    if versioning is None:
+        return {}
+    import inspect
+
+    params = inspect.signature(versioning.StaticSources).parameters
+    if "editable_behind_upstream" not in params:
+        return {}
+    return {
+        "editable_behind_upstream": behind,
+        "editable_repo": "/home/ywatanabe/proj/scitex-agent-container",
+    }
+
+
 # An editable checkout behind its own release tag — the operator's actual
 # situation: his `.venv` advertised 0.21.21 from a frozen .dist-info while
-# executing current develop.
+# executing current develop. The remote genuinely carries those 7 commits,
+# which is what makes this both STALE and fixable by a pull.
 EDITABLE_BEHIND = dict(
     install_kind="editable",
     effective_version="0.21.24",
@@ -101,6 +142,7 @@ EDITABLE_BEHIND = dict(
     executable="/home/ywatanabe/proj/scitex-agent-container/.venv/bin/python",
     editable_ahead_behind=(0, 7),
     pypi_latest="0.21.24",
+    **_upstream_evidence(7),
 )
 
 # A wheel genuinely behind what shipped — the one case where a version
@@ -201,8 +243,12 @@ class TestActsOnTheVerdict:
         report = stale_editable
         # Act
         text, _code = _render(report, as_json=False)
-        # Assert — an alarm that does not say what to DO gets ignored.
-        assert "git pull" in text
+        # Assert — an alarm that does not say what to DO gets ignored. Matched
+        # as "a git command that pulls" rather than the literal `git pull`,
+        # because the primitive now composes `git -C <repo> pull --ff-only`:
+        # CWD-independent so it cannot hit the wrong repo, and never
+        # `--rebase`, which would rewrite the operator's unpushed work.
+        assert _GIT_PULL.search(text), text
 
     def test_a_fresh_verdict_exits_zero(self, fresh_report):
         # Arrange
@@ -305,8 +351,19 @@ class TestNeverClobbersAnEditableCheckout:
         report = stale_editable
         # Act
         remedies = [f.remedy for f in report.stale if f.remedy]
-        # Assert — stated positively, not merely as the absence of pip.
-        assert all(r.startswith("git pull") for r in remedies), remedies
+        # Assert — stated positively, not merely as the absence of pip. The
+        # shape is "a git command that pulls", which admits the primitive's
+        # `git -C <repo> pull --ff-only` without admitting a wheel clobber.
+        assert all(_GIT_PULL.match(r) for r in remedies), remedies
+
+    def test_no_editable_remedy_rewrites_unpushed_work(self, stale_editable):
+        # Arrange — `--rebase` rewrites commits the developer has not pushed.
+        # A WARNING's remedy must not be able to cost anybody their work.
+        report = stale_editable
+        # Act
+        remedies = " ".join(f.remedy for f in report.stale)
+        # Assert
+        assert "--rebase" not in remedies
 
     def test_an_editable_stale_report_has_a_remedy_at_all(self, stale_editable):
         # Arrange

--- a/tests/scitex_agent_container/_freshness/test___init__.py
+++ b/tests/scitex_agent_container/_freshness/test___init__.py
@@ -33,15 +33,6 @@ from pathlib import Path
 
 import pytest
 
-#: "a git command that pulls" — the shape an editable remedy must have. Not
-#: the literal string `git pull`: the primitive composes
-#: `git -C <repo> pull --ff-only` so the command works from any CWD and can
-#: never rewrite unpushed commits, and an older primitive emits a bare
-#: `git pull`. Both are the same promise; a `pip install -U` is not.
-#: Unanchored on purpose: `.match()` pins it to the start of a REMEDY
-#: string, while `.search()` finds the `fix:` line inside rendered output.
-_GIT_PULL = re.compile(r"git\b(?:\s+\S+)*?\s+pull\b")
-
 from scitex_agent_container._freshness import (
     DIST_NAME,
     LISTEN_UNIT,
@@ -91,6 +82,15 @@ requires_primitive = pytest.mark.skipif(
         "The degradation tests in TestDegradesToUnknown still run."
     ),
 )
+
+#: "a git command that pulls" — the shape an editable remedy must have. Not
+#: the literal string `git pull`: the primitive composes
+#: `git -C <repo> pull --ff-only` so the command works from any CWD and can
+#: never rewrite unpushed commits, while an older primitive emits a bare
+#: `git pull`. Both are the same promise; a `pip install -U` is not.
+#: Unanchored on purpose: `.match()` pins it to the start of a REMEDY
+#: string, while `.search()` finds the `fix:` line inside rendered output.
+_GIT_PULL = re.compile(r"git\b(?:\s+\S+)*?\s+pull\b")
 
 
 def _report(**evidence):


### PR DESCRIPTION
Companion to **scitex-dev PR #785** — land this first, or sac's freshness
suite breaks the moment that fix is installed.

## What #785 changes

`sac --version` on a healthy `develop` checkout printed:

```
  * editable checkout DIVERGED from its latest tag (+46/-3)
      fix: git pull --rebase
```

The operator ran it. `git` said **"Already up to date"**. The identical
warning came back. Measured on this repo: `v0.27.0` is an ancestor of
`origin/main` and *not* of `origin/develop`; `develop` is `+46/-3` against
that tag and `0/0` against `origin/develop`. Release tags are cut on `main`,
so "behind the latest tag" is the permanent, healthy state of every
development branch — and a pull moves HEAD toward `origin/<branch>` and
nowhere else, so it could never close that gap.

After #785, STALE is decided on distance from the **tracking remote** — the
one gap a pull closes. Tag distance alone is UNKNOWN, and the remedy becomes
`git -C <repo> pull --ff-only` (CWD-independent, and never `--rebase`, which
rewrites unpushed work).

## Why this repo needs a change

`EDITABLE_BEHIND` records `editable_ahead_behind=(0, 7)` and says nothing
about a remote, and `stale_editable` **hard-fails** if the primitive does not
judge that STALE:

```python
if report.state is not versioning.Currency.STALE:
    pytest.fail("precondition: the primitive must judge this evidence STALE, ...")
```

Under the new contract that evidence is UNKNOWN, so every test built on that
fixture would break. The fixture's intent was always "genuinely behind, and a
pull fixes it" — it now says so, by recording that the remote carries those
7 commits.

## Version-tolerant on purpose

The evidence goes in through `_upstream_evidence()`, which supplies the new
keys only when the installed `StaticSources` accepts them. sac's `[dev]` floor
still permits a primitive that predates them, and `StaticSources` rejects an
unknown kwarg — so an unconditional edit would break CI *now* instead of
later. Measured both ways in the container:

| primitive | result |
|---|---|
| installed scitex-dev 0.57.0 (pre-#785) | 52 passed — helper returns `{}`, old behaviour intact |
| #785's tree on `PYTHONPATH` | 52 passed — helper supplies the upstream axis |

A `FOLLOW-UP` on the helper says to inline it once the floor moves — the same
floor bump the module docstring already asks for.

## Assertions

Two widen from the literal string `git pull` to "a git command that pulls", so
they admit `git -C <repo> pull --ff-only` without admitting a wheel clobber.
One test is added: no editable remedy may contain `--rebase`. That reason was
the whole argument for dropping the old string and nothing asserted it.
