### PR TITLE
fix(a2a): the turn bridge must answer the message:send verb its listen serves

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -84,9 +84,26 @@ def is_turn_route(path: str, agent_name: str) -> bool:
     """True iff ``path`` is a turn-delivery route for ``agent_name``.
 
     Accepts the bare ``/v1/turn`` (the port already identifies the agent)
-    and the named ``/agents/<agent_name>/{turn,send}`` aliases. A named
-    route for a DIFFERENT agent is rejected (the caller returns 404) so a
-    misrouted POST fails loud rather than landing in the wrong session.
+    and the named ``/agents/<agent_name>/{turn,send,message:send}`` aliases.
+    A named route for a DIFFERENT agent is rejected (the caller returns 404)
+    so a misrouted POST fails loud rather than landing in the wrong session.
+
+    ``message:send`` IS THE FLEET'S A2A VERB, and omitting it here cost a
+    live cross-host outage on 2026-09-02: every peer send to `figrecipe` on
+    compute-03 died with ``no turn route
+    '/agents/figrecipe/message:send'`` while the agent was healthy — running,
+    registered, one live inbox subscriber. Nothing in that 404 says "wrong
+    port": it reads as if the agent is missing, so the hour went to peer
+    tokens, listen restarts and registry collisions before the path itself
+    was read.
+
+    The asymmetry that hid it: a peer resolving the target to the HOST's
+    listen port reaches ``sac listen``, which serves ``message:send``
+    (see ``_channel_tools`` / ``_session_completion`` — the same spelling
+    everywhere); a peer resolving to the AGENT's own a2a port reaches this
+    bridge instead, and only here was the verb unknown. Which of the two a
+    peer resolves is a registry detail no caller controls, so the bridge
+    must answer the same verb its listen does.
     """
     clean = path.split("?", 1)[0].rstrip("/")
     if clean == "/v1/turn":
@@ -94,6 +111,7 @@ def is_turn_route(path: str, agent_name: str) -> bool:
     if agent_name and clean in (
         f"/agents/{agent_name}/turn",
         f"/agents/{agent_name}/send",
+        f"/agents/{agent_name}/message:send",
     ):
         return True
     return False

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -216,6 +216,40 @@ def test_is_turn_route_accepts_named_turn_for_this_agent() -> None:
     assert accepted is True
 
 
+def test_is_turn_route_accepts_the_a2a_message_send_verb() -> None:
+    """The spelling every a2a caller in this package actually posts.
+
+    Regression for a live cross-host outage (2026-09-02): peer sends to
+    `figrecipe` on compute-03 all died with ``no turn route
+    '/agents/figrecipe/message:send'`` while the agent was healthy. A peer
+    that resolves the target to the host's listen port gets ``sac listen``,
+    which serves this verb; one that resolves to the agent's own a2a port
+    gets this bridge, which did not. The caller does not choose which, so
+    both must answer it.
+    """
+    # Arrange
+    path = "/agents/figrecipe/message:send"
+    # Act
+    accepted = bridge.is_turn_route(path, "figrecipe")
+    # Assert
+    assert accepted is True
+
+
+def test_is_turn_route_rejects_message_send_for_another_agent() -> None:
+    """The misroute guard must survive the new alias.
+
+    Widening the accepted set is exactly where a cross-agent leak gets
+    introduced: a POST naming a DIFFERENT agent must still 404 rather than
+    land in this session.
+    """
+    # Arrange
+    path = "/agents/someone-else/message:send"
+    # Act
+    accepted = bridge.is_turn_route(path, "figrecipe")
+    # Assert
+    assert accepted is False
+
+
 def test_is_turn_route_rejects_named_route_for_other_agent() -> None:
     # Arrange
     path = "/agents/someone-else/turn"


### PR DESCRIPTION
Found while restoring cross-host agent messaging for the operator (business on compute-01, figrecipe on compute-03, sac on compute-04).

Every peer send to an agent reached through its OWN a2a port died with `no turn route '/agents/<name>/message:send'` while the agent was healthy — running, registered, one live inbox subscriber. `message:send` is this package's A2A verb everywhere else (_channel_tools, _session_completion, _channel_reaction_ack) and `sac listen` serves it; the bridge accepted only /v1/turn and /agents/<name>/{turn,send}. Which endpoint a peer resolves is a registry detail no caller controls, so both must answer the same verb.

The 404 wording is what made it expensive: it reads as "agent missing", so the investigation went through peer tokens, listen restarts and a registry collision before the path itself was read.

Tests: the verb is accepted for this agent, and still rejected when it names a different one (widening the accepted set is exactly where a cross-agent leak would enter). Verified locally: 51 passed in tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py.

Three sibling faults found in the same investigation are already fixed on the hosts (not code): missing peer tokens for the compute-01/03/04 mesh, 192 agent specs still naming the dropped `scitex_cards` database, and no host resolving any peer hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChyXC2ud4SQYRWPJ8sjeQa