### PR TITLE
fix(a2a): the turn bridge must read the A2A envelope its peers actually send

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -80,6 +80,56 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Routing helper
 # ---------------------------------------------------------------------------
+def extract_turn_text(body: object) -> tuple[str | None, dict]:
+    """Pull the turn text (and sac metadata) out of either accepted body shape.
+
+    Returns ``(text, metadata)`` — ``metadata`` is the envelope's
+    ``params.metadata`` when there is one, else ``{}``, so the caller can fall
+    back to it for ``from_agent`` / ``dispatch_id``.
+
+    TWO SHAPES REACH THIS BRIDGE, and accepting only one is what broke
+    cross-host messaging on 2026-09-02 even after the route alias landed:
+
+        flat      {"text": "...", "from_agent": "...", "dispatch_id": "..."}
+        A2A v1    {"jsonrpc": "2.0", "method": "SendMessage", "params":
+                   {"message": {"parts": [{"text": "..."}]},
+                    "metadata": {"from_agent": ..., "dispatch_id": ...}}}
+
+    The flat form is what ``sac listen`` synthesises for a local wake. The
+    envelope is what every a2a caller in this package actually sends
+    (``_channel_tools._wrap_message_send``) — sac extension fields live under
+    ``params.metadata`` because A2A v1's strict validator rejects unknown
+    fields at the params root. A bridge that reads only ``body["text"]``
+    answers ``missing or empty 'text' field`` to a perfectly well-formed peer
+    message, which is what it did.
+
+    Multi-part messages are joined with newlines rather than silently taking
+    part[0]: dropping the tail of a message is worse than a long inject.
+    """
+    if not isinstance(body, dict):
+        return None, {}
+    flat = body.get("text")
+    if isinstance(flat, str) and flat.strip():
+        return flat, {}
+    params = body.get("params")
+    if not isinstance(params, dict):
+        return None, {}
+    meta = params.get("metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    message = params.get("message")
+    if not isinstance(message, dict):
+        return None, meta
+    parts = message.get("parts")
+    if not isinstance(parts, list):
+        return None, meta
+    texts = [
+        p["text"]
+        for p in parts
+        if isinstance(p, dict) and isinstance(p.get("text"), str) and p["text"].strip()
+    ]
+    return ("\n".join(texts) if texts else None), meta
+
+
 def is_turn_route(path: str, agent_name: str) -> bool:
     """True iff ``path`` is a turn-delivery route for ``agent_name``.
 
@@ -187,7 +237,7 @@ class _TurnBridgeHandler(BaseHTTPRequestHandler):
         except ValueError as exc:
             self._respond(400, {"error": f"bad JSON: {exc}"})
             return
-        text = body.get("text") if isinstance(body, dict) else None
+        text, envelope_meta = extract_turn_text(body)
         if not isinstance(text, str) or not text.strip():
             self._respond(400, {"error": "missing or empty 'text' field"})
             return
@@ -197,6 +247,10 @@ class _TurnBridgeHandler(BaseHTTPRequestHandler):
         # for an operator send / boot turn → no report is owed.
         raw_from = body.get("from_agent") if isinstance(body, dict) else None
         raw_did = body.get("dispatch_id") if isinstance(body, dict) else None
+        # An A2A envelope carries these under ``params.metadata`` instead of at
+        # the root; the flat form still wins when both are present.
+        raw_from = raw_from or envelope_meta.get("from_agent")
+        raw_did = raw_did or envelope_meta.get("dispatch_id")
         from_agent = raw_from if isinstance(raw_from, str) and raw_from else None
         dispatch_id = raw_did if isinstance(raw_did, str) and raw_did else None
         try:

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -1149,3 +1149,77 @@ def test_write_bridge_event_names_the_agent(tmp_path: Path) -> None:
         )
     # Assert
     assert "agent=figrecipe" in log_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# extract_turn_text — the two body shapes that actually reach this bridge
+# ---------------------------------------------------------------------------
+def test_extract_turn_text_reads_the_flat_body() -> None:
+    """The shape `sac listen` synthesises for a local wake."""
+    # Arrange
+    body = {"text": "hello", "from_agent": "peer"}
+    # Act
+    text, _meta = bridge.extract_turn_text(body)
+    # Assert
+    assert text == "hello"
+
+
+def test_extract_turn_text_reads_the_a2a_envelope() -> None:
+    """The shape every a2a caller in this package sends.
+
+    Regression for 2026-09-02: after the message:send route alias landed, a
+    real peer message still bounced with `missing or empty text field`,
+    because the bridge read only body["text"] while _wrap_message_send nests
+    the content at params.message.parts[].text.
+    """
+    # Arrange
+    body = {
+        "jsonrpc": "2.0",
+        "method": "SendMessage",
+        "params": {"message": {"parts": [{"text": "from a peer"}]}, "metadata": {}},
+    }
+    # Act
+    text, _meta = bridge.extract_turn_text(body)
+    # Assert
+    assert text == "from a peer"
+
+
+def test_extract_turn_text_returns_envelope_metadata_for_from_agent() -> None:
+    """sac extension fields live under params.metadata, not at the root.
+
+    A2A v1 rejects unknown fields at the params root, so the sender cannot put
+    them where the flat reader looked; without this the inbound would be
+    recorded with no requester and the completion report would be owed to
+    nobody.
+    """
+    # Arrange
+    body = {
+        "params": {
+            "message": {"parts": [{"text": "x"}]},
+            "metadata": {"from_agent": "business", "dispatch_id": "d1"},
+        }
+    }
+    # Act
+    _text, meta = bridge.extract_turn_text(body)
+    # Assert
+    assert meta["from_agent"] == "business"
+
+
+def test_extract_turn_text_joins_multipart_instead_of_dropping_the_tail() -> None:
+    """Taking parts[0] would silently truncate a multi-part message."""
+    # Arrange
+    body = {"params": {"message": {"parts": [{"text": "a"}, {"text": "b"}]}}}
+    # Act
+    text, _meta = bridge.extract_turn_text(body)
+    # Assert
+    assert text == "a\nb"
+
+
+def test_extract_turn_text_rejects_an_empty_envelope() -> None:
+    """An envelope with no usable text must still be refused, not injected."""
+    # Arrange
+    body = {"params": {"message": {"parts": [{"text": "   "}]}}}
+    # Act
+    text, _meta = bridge.extract_turn_text(body)
+    # Assert
+    assert text is None


### PR DESCRIPTION
Completes #1282. That PR let peer messages reach the bridge; they then died on `missing or empty 'text' field` — a well-formed peer message refused as malformed.

Two body shapes reach this bridge: the flat `{text, from_agent, dispatch_id}` that `sac listen` synthesises for a local wake, and the A2A v1 envelope every a2a caller in this package sends (`_channel_tools._wrap_message_send`), which nests content at `params.message.parts[].text` and puts sac extension fields under `params.metadata` — A2A v1 rejects unknown fields at the params root, so the sender cannot put them where the flat reader looked.

`extract_turn_text` accepts both, prefers the flat form, joins multi-part messages rather than dropping the tail, and returns the envelope metadata so `from_agent`/`dispatch_id` still reach the ledger.

5 new tests (flat body, envelope, metadata fallback, multi-part join, empty-envelope refusal); 56 passed locally.

Measured end to end today, one error at a time: 404 no-turn-route → 400 missing-text → delivered. Sibling host-side faults fixed in the same investigation: peer tokens, 192 specs naming a dropped database, no host resolving any peer name, and every listen bound loopback-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChyXC2ud4SQYRWPJ8sjeQa