### PR TITLE
fix(a2a): the cross-host forwarder must resolve peers from the host registry and never fall back to HTTP silently

### DIFF
--- a/src/scitex_agent_container/_listen/_node_channel_forwarders.py
+++ b/src/scitex_agent_container/_listen/_node_channel_forwarders.py
@@ -5,14 +5,35 @@ Holds the WI-4 cross-host forward path that the node-comms routes in
 host. Three callables make up the surface:
 
 * :func:`_forward_to_remote` — entry point + transport selector. Reads
-  the per-host bearer registry and the operator's ``peers:`` block,
-  then dispatches to the HTTP or ssh leg.
-* :func:`_forward_via_http` — legacy HTTP transport (Stage 1). Used
-  when the destination host is NOT in ``host_config.peers``; matches
-  the two-listen test topology's loopback rewrite.
-* :func:`_forward_via_ssh_curl` — ADR-0015 Stage 2 transport. ssh +
-  remote curl into ``127.0.0.1:<port>`` on the destination, reusing
-  the same helper as the ``/v1/turn`` direct-ssh path.
+  the per-host bearer registry, resolves the destination through the
+  SAME peer map the CLI verbs use (config.yaml ``peers:`` UNION the
+  scitex-dev host registry — :func:`~.._state._peer_resolve.peers_with_registry`),
+  and dispatches to the ssh leg. A destination that is not an ssh peer
+  is REFUSED with a 502 that names the fix; it is never guessed at.
+* :func:`_forward_via_ssh_curl` — ADR-0015 Stage 2 transport, the ONLY
+  production transport. ssh + remote curl into ``127.0.0.1:<port>`` on
+  the destination, reusing the same helper as the ``/v1/turn``
+  direct-ssh path.
+* :func:`_forward_via_http` — the in-process TEST transport. Reached
+  only for the ``host-*`` loopback aliases the two-listen suite in
+  ``test_server.py`` stamps on its ``instances`` rows
+  (:func:`_is_test_loopback_alias`); never for a fleet host.
+
+Why there is no HTTP leg for production (measured 2026-09-02)
+--------------------------------------------------------------
+Every agent's bridge and sidecar bind ``127.0.0.1`` by default
+(``runtimes/_tui_turn_bridge_lifecycle.py`` ``DEFAULT_HOST``,
+``runtimes/a2a_sidecar.py`` host default) and no spec on the fleet
+declares ``spec.a2a.host``, so ``http://<host>:<agent-port>/...`` can
+never connect from another machine. This module used to take that leg
+whenever the destination was absent from the RAW ``peers:`` block of
+``~/.scitex/agent-container/config.yaml`` — and ``scitex-compute-01`` /
+``scitex-compute-03`` have no such file at all, so every cross-host send
+from those hosts silently posted plain HTTP and died with ``All
+connection attempts failed``. The CLI verbs (``sac host probe`` and
+friends) had already stopped gating on the raw block and resolve peers
+through the host registry's ``ssh_alias``; the forwarder simply was not
+using the same SSoT. Now it does, and the only fallback is a loud one.
 
 The split keeps the route handlers in :mod:`._node_channel` under the
 per-file LOC cap; ``_node_channel`` re-exports
@@ -24,6 +45,8 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import logging
+from dataclasses import dataclass
 from typing import Any
 
 from starlette.responses import JSONResponse, Response
@@ -32,7 +55,138 @@ __all__ = [
     "_forward_to_remote",
     "_forward_via_http",
     "_forward_via_ssh_curl",
+    "_is_test_loopback_alias",
 ]
+
+log = logging.getLogger(__name__)
+
+#: Hosts this process has already refused with the "not an ssh peer" 502.
+#: The 502 body carries the whole remedy on EVERY call; the WARNING line is
+#: written once per host so the FORWARDING host's listen journal
+#: (``journalctl -u sac-listen`` — the unit's stderr) names the fault
+#: without repeating it for every retry the sender makes.
+_WARNED_UNROUTABLE_HOSTS: set[str] = set()
+
+
+def _is_test_loopback_alias(target_host: str) -> bool:
+    """True only for the in-process two-listen TEST topology's host labels.
+
+    ``host-a`` / ``host-b`` (any ``host-*``) are the labels
+    ``tests/scitex_agent_container/_listen/test_server.py`` stamps on
+    ``instances`` rows so two real ``uvicorn`` listens on ONE machine can
+    play two hosts; :func:`_forward_via_http` rewrites them to
+    ``127.0.0.1``. No fleet host is named this way (fleet names are
+    ``scitex-<kind>-NN``), and this predicate is the ONLY gate under which
+    the forwarder ever posts plain HTTP — it is the test topology, never
+    production. The match is byte-for-byte the rewrite ADR-0015 froze
+    ("do not broaden or tighten the ``host-*`` loopback rewrite").
+    """
+    return target_host.startswith("host-")
+
+
+@dataclass(frozen=True)
+class _PeerRoute:
+    """What :func:`_resolve_ssh_peer` decided about one destination host.
+
+    ``ssh_target`` is the alias to dial (``None`` when the host is not an
+    ssh peer); ``config_path`` names the config.yaml THIS host resolved
+    so the refusal can point at the file to edit; ``reason`` says, in
+    operator terms, why no ssh route exists (empty when one does).
+    """
+
+    ssh_target: str | None
+    config_path: str
+    reason: str = ""
+
+
+def _resolve_ssh_peer(target_host: str) -> _PeerRoute:
+    """Resolve ``target_host`` to an ssh alias through the CLI's SSoT.
+
+    Same map ``sac host probe`` / ``sac host exec`` dispatch on:
+    config.yaml ``peers:`` (glob keys included — ``PeersMap`` resolves
+    them) UNION the scitex-dev host registry rows that carry an
+    ``ssh_alias``. A registry row WITHOUT an alias (inbound ssh not
+    possible) is deliberately not a route, so it lands in the refusal.
+
+    A config.yaml that fails to parse must not disable forwarding: the
+    registry-merged map is still consulted (with an empty config block)
+    and the parse failure is carried into any refusal's ``reason`` so the
+    operator sees BOTH facts in the 502.
+    """
+    from .._state._peer_resolve import peers_with_registry
+    from .._state.host_config import MovingAliasError, _default_config_path
+    from .._state.host_config import load as _load_host_config
+
+    config_note = ""
+    try:
+        _cfg = _load_host_config()
+        raw_peers = _cfg.peers
+        config_path = str(_cfg.source_path or _default_config_path())
+    except Exception as exc:  # noqa: BLE001  # stx-allow: fallback (reason: a malformed config.yaml must not disable cross-host forwarding — the registry-merged map still routes, and the parse failure is carried into the 502 body and this host's listen journal (journalctl -u sac-listen) via the warning below)
+        raw_peers = {}
+        config_path = str(_default_config_path())
+        config_note = f"{config_path} failed to load ({exc}); "
+        log.warning(
+            "cross-host forward: %s failed to load (%s); resolving peers "
+            "from the scitex-dev host registry alone",
+            config_path,
+            exc,
+        )
+
+    peers = peers_with_registry(raw_peers)
+    try:
+        spec = peers[target_host]
+    except MovingAliasError as exc:
+        return _PeerRoute(None, config_path, f"{config_note}{exc}")
+    except KeyError:
+        spec = None
+
+    if spec is not None and spec.ssh:
+        return _PeerRoute(spec.ssh, config_path)
+    if spec is not None:
+        reason = (
+            f"{config_note}{config_path} declares peer {target_host!r} "
+            f"but its ssh: target is empty"
+        )
+    else:
+        from scitex_config._ecosystem import local_state as _local_state
+
+        hosts_yaml = _local_state.user_path("dev", "hosts.yaml")
+        reason = (
+            f"{config_note}it is in neither the peers: block of {config_path} "
+            f"nor the scitex-dev host registry ({hosts_yaml}) with an ssh_alias"
+        )
+    return _PeerRoute(None, config_path, reason)
+
+
+def _refuse_unroutable(
+    *,
+    target_host: str,
+    target_port: int,
+    target_name: str,
+    route: _PeerRoute,
+) -> Response:
+    """The loud 502 for a destination that is not an ssh peer.
+
+    Names the host, states why plain HTTP is not attempted (the fleet's
+    agents bind loopback), and names BOTH fixes. Logged at WARNING once
+    per host per process (see :data:`_WARNED_UNROUTABLE_HOSTS`).
+    """
+    message = (
+        f"cross-host forward to {target_name!r} on host {target_host!r} "
+        f"refused: {target_host!r} is not resolvable to an ssh peer on this "
+        f"host — {route.reason}. The fleet's agents bind 127.0.0.1 (bridge "
+        f"and sidecar default host), so a direct HTTP forward to "
+        f"http://{target_host}:{target_port} cannot work and was not "
+        f"attempted. Fix one of: (1) declare {target_host!r} with an "
+        f"ssh_alias in the scitex-dev host registry hosts.yaml; "
+        f"(2) add `peers: {{{target_host}: {{ssh: <alias>}}}}` to "
+        f"{route.config_path} on this host."
+    )
+    if target_host not in _WARNED_UNROUTABLE_HOSTS:
+        _WARNED_UNROUTABLE_HOSTS.add(target_host)
+        log.warning("%s", message)
+    return JSONResponse({"error": message}, status_code=502)
 
 
 async def _forward_to_remote(
@@ -67,14 +221,15 @@ async def _forward_to_remote(
     the receiving host (handoff §4 acceptance "ACL is enforced at
     the receiving host").
 
-    **Transport selector (ADR-0015 Stage 2)**: when ``target_host``
-    is a member of ``host_config.peers`` (including via glob keys
-    like ``spartan-*``), the forward leg is ssh + remote curl
-    instead of plain HTTP — a WAN hostname like ``ywata-note-win``
-    is rarely routable directly between hosts, but the operator's
-    existing ssh trust to that host is. Hosts NOT in ``peers:`` keep
-    the legacy HTTP path verbatim, including the ``host-*`` loopback
-    alias rewrite the two-listen tests depend on.
+    **Transport selector**: ``target_host`` is resolved through
+    :func:`_resolve_ssh_peer` — config.yaml ``peers:`` (glob keys
+    included) UNION the scitex-dev host registry, the same SSoT the
+    CLI verbs dispatch on. A resolvable host takes the ssh + remote
+    curl leg. A ``host-*`` test-loopback alias
+    (:func:`_is_test_loopback_alias`) takes the in-process HTTP leg.
+    Anything else is refused with a 502 that names the host and both
+    fixes — plain HTTP to a fleet host cannot connect (agents bind
+    loopback) and is never attempted.
     """
     if not target_port:
         return JSONResponse(
@@ -97,34 +252,31 @@ async def _forward_to_remote(
             status_code=502,
         )
 
-    # ADR-0015 transport selector. Resolve ``target_host`` against the
-    # operator's ``peers:`` block (with glob fallback via PeersMap). If
-    # the destination is a known peer, ssh-tunnel the POST; otherwise
-    # fall through to the legacy HTTP path.
-    from .._state.host_config import load as _load_host_config
-
-    try:
-        _cfg = _load_host_config()
-        peer_spec = _cfg.peers.get(target_host)
-    except Exception:  # noqa: BLE001  # stx-allow: fallback (reason: a malformed config.yaml must not silently disable the HTTP fallback)
-        peer_spec = None
-
-    if peer_spec is not None and peer_spec.ssh:
+    route = _resolve_ssh_peer(target_host)
+    if route.ssh_target:
         return await _forward_via_ssh_curl(
             target_host=target_host,
             target_port=target_port,
             target_name=target_name,
             body=body,
             peer_bearer=peer_bearer,
-            ssh_target=peer_spec.ssh,
+            ssh_target=route.ssh_target,
         )
 
-    return await _forward_via_http(
+    if _is_test_loopback_alias(target_host):
+        return await _forward_via_http(
+            target_host=target_host,
+            target_port=target_port,
+            target_name=target_name,
+            body=body,
+            peer_bearer=peer_bearer,
+        )
+
+    return _refuse_unroutable(
         target_host=target_host,
         target_port=target_port,
         target_name=target_name,
-        body=body,
-        peer_bearer=peer_bearer,
+        route=route,
     )
 
 
@@ -136,22 +288,25 @@ async def _forward_via_http(
     body: dict[str, Any],
     peer_bearer: str,
 ) -> Response:
-    """Legacy HTTP-only cross-host forward (Stage 1). Used when
-    ``target_host`` is NOT in ``host_config.peers`` — typically the
-    in-process two-listen test topology, or a deployment where overlay
-    routing makes the canonical host name directly reachable.
+    """In-process TEST transport: plain HTTP to the loopback listen.
+
+    Reached only when :func:`_forward_to_remote` found no ssh peer AND
+    ``target_host`` is a ``host-*`` test-loopback alias
+    (:func:`_is_test_loopback_alias`). Production never lands here:
+    fleet agents bind ``127.0.0.1``, so a direct HTTP forward to
+    another machine cannot connect, and the selector refuses such a
+    host with a 502 instead of calling this.
     """
     import httpx as _httpx
 
     forward_url = (
         f"http://{target_host}:{target_port}/agents/{target_name}/message:send"
     )
-    # In our test loopback both hosts live on 127.0.0.1; the canonical
+    # In the test loopback both hosts live on 127.0.0.1; the canonical
     # host name is a label, not a routable address. Rewrite to
-    # 127.0.0.1 when the resolved host is a known-loopback alias so
-    # the test fixtures can drive both legs on one machine. Real
-    # deployments use ssh-alias / tunnel hostnames and route as-is.
-    if target_host in ("host-a", "host-b") or target_host.startswith("host-"):
+    # 127.0.0.1 for the known-loopback aliases so the test fixtures can
+    # drive both legs on one machine.
+    if _is_test_loopback_alias(target_host):
         forward_url = (
             f"http://127.0.0.1:{target_port}/agents/{target_name}/message:send"
         )
@@ -174,7 +329,7 @@ async def _forward_via_http(
 
     try:
         return JSONResponse(resp.json(), status_code=resp.status_code)
-    except Exception:  # noqa: BLE001  # stx-allow: fallback (reason: non-JSON destination body is tolerated; surfaced as text)
+    except Exception:  # noqa: BLE001  # stx-allow: fallback (reason: a non-JSON destination body is tolerated and returned verbatim as forwarded_body_text in the a2a response the sender receives)
         return JSONResponse(
             {"forwarded_body_text": resp.text}, status_code=resp.status_code
         )

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -178,7 +178,9 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         "scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py:375",
         "scitex_agent_container/_listen/_deploy_freshness.py:227",
         "scitex_agent_container/_listen/_liveness_tick.py:123",
-        "scitex_agent_container/_listen/_node_channel_forwarders.py:177",
+        # _node_channel_forwarders.py LEFT THIS SET 2026-09-02 — the reason
+        # now names where the tolerated non-JSON body goes (the a2a response
+        # the sender receives) instead of claiming it is "surfaced".
         "scitex_agent_container/_maintenance/_install_integrity_pointers.py:193",
         "scitex_agent_container/_maintenance/_install_integrity_pointers.py:226",
         "scitex_agent_container/_maintenance/_venv_dist_assertion.py:120",
@@ -312,7 +314,7 @@ def test_no_new_unnamed_delivery_claim():
         "These `stx-allow` reasons claim the failure is logged/alerted/"
         "reported but name no sink. Name the path or channel in the comment "
         "(e.g. 'logged to runtime/logs/<name>.log') so the claim can be "
-        f"re-checked later:\n  " + "\n  ".join(sorted(new))
+        "re-checked later:\n  " + "\n  ".join(sorted(new))
     )
 
 

--- a/tests/scitex_agent_container/_listen/test__node_channel_forwarders.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel_forwarders.py
@@ -16,17 +16,25 @@ shape as the rest of the package (PA-307).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import logging
 import os
+import textwrap
+import threading
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
 from starlette.responses import JSONResponse
 
+from scitex_agent_container._listen import _node_channel_forwarders as _fwd
 from scitex_agent_container._listen._node_channel_forwarders import (
     _forward_to_remote,
     _forward_via_ssh_curl,
 )
+from scitex_agent_container._listen.peer_tokens import write_peer_token
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
 
@@ -115,7 +123,6 @@ def test_forward_to_remote_502_when_peer_token_file_is_absent(isolated_home):
 # rc!=0 / empty-stdout / non-JSON / ACL-error / non-ACL-error / bearer-
 # validation branches that the loopback ssh_http_shim happy-path tests
 # don't reach, so codecov/patch >= 80% on the diff.
-
 
 
 def test_forward_via_ssh_curl_502s_when_ssh_shim_returns_nonzero_rc(
@@ -289,3 +296,337 @@ def test_forward_via_ssh_curl_502s_when_helper_raises_value_error(
     )
     # Assert
     assert resp.status_code == 502
+
+
+# --- Transport selector: the registry is the SSoT, HTTP is test-only ---------
+#
+# MEASURED 2026-09-02: scitex-compute-01 and scitex-compute-03 have NO
+# ~/.scitex/agent-container/config.yaml, so ``host_config.load().peers`` is
+# ``{}`` there and every cross-host send silently took the plain-HTTP leg —
+# which cannot connect to a fleet host (agents bind 127.0.0.1) — and died with
+# "All connection attempts failed". ``sac host probe`` on the same box already
+# resolved the destination through the scitex-dev host registry's
+# ``ssh_alias``. These tests pin the forwarder to that same SSoT.
+#
+# NO MOCKS: a real ``hosts.yaml`` at the real ``$SCITEX_DIR/dev/`` location
+# (the same seam ``test__peer_resolve.py`` drives), a real absent/malformed
+# ``config.yaml``, real peer-token files, the ``ssh`` shim on ``$PATH`` so the
+# production ``subprocess.run`` records the argv it was handed, and — for the
+# "HTTP is never attempted" claim — a real listener on 127.0.0.1 counting what
+# ARRIVES, because a claim about arrival is settled at the receiving end.
+
+_REGISTRY_ONLY_HOSTS_YAML = textwrap.dedent(
+    """\
+    hosts:
+      scitex-compute-03:
+        kind: workstation
+        ssh_alias: compute-03-via-registry
+        scitex_root: "~/.scitex"
+      scitex-laptop-02:
+        kind: workstation
+        ssh_alias: null
+        scitex_root: "~/.scitex"
+    """
+)
+
+_BODY = {"method": "SendMessage", "params": {}}
+
+
+@pytest.fixture
+def registry_only_peers(isolated_home: Path, env_save_restore):
+    """The measured compute-01 / compute-03 topology: a host registry with
+    ssh aliases and NO config.yaml at all.
+
+    ``SCITEX_AGENT_CONTAINER_CONFIG`` points at a file that does not
+    exist (``host_config.load`` is missing-tolerant → ``peers == {}``);
+    ``SCITEX_DIR`` points at a real ``dev/hosts.yaml`` written here, which
+    is the location both the ``scitex_dev.hosts`` port and sac's degraded
+    YAML reader resolve. Peer tokens are seeded for every host a test
+    below targets so the bearer lookup (which runs FIRST) never masks
+    the transport decision under test.
+    """
+    scitex_dir = isolated_home / "scitex-dir"
+    (scitex_dir / "dev").mkdir(parents=True)
+    (scitex_dir / "dev" / "hosts.yaml").write_text(_REGISTRY_ONLY_HOSTS_YAML)
+    env_save_restore.set("SCITEX_DIR", str(scitex_dir))
+    env_save_restore.delete("SCITEX_DEV_HOSTS_YAML")
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_CONFIG", str(isolated_home / "absent-config.yaml")
+    )
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(isolated_home / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    for host in (
+        "scitex-compute-03",
+        "scitex-laptop-02",
+        "scitex-compute-02",
+        "unrouted-host-z",
+        "127.0.0.1",
+        "host-a",
+    ):
+        write_peer_token(peer_host=host, token=f"bearer-for-{host}")
+    return scitex_dir
+
+
+def _forward(target_host: str, target_port: int = 19008) -> JSONResponse:
+    return asyncio.run(
+        _forward_to_remote(
+            request=None,
+            body=_BODY,
+            target_host=target_host,
+            target_port=target_port,
+            target_name="scitex-hub",
+        )
+    )
+
+
+@contextlib.contextmanager
+def _loopback_json_server(payload: dict):
+    """A real HTTP server on 127.0.0.1 answering every POST with ``payload``.
+
+    Yields ``(port, hits)``; ``hits`` gains one entry per POST that
+    actually arrived, so a test can assert on delivery — or its absence
+    — at the receiving end.
+    """
+    hits: list[str] = []
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 — http.server's fixed method name
+            self.rfile.read(int(self.headers.get("Content-Length") or 0))
+            hits.append(self.path)
+            data = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, *_args):  # keep pytest output clean
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1], hits
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+# (a) absent from raw config, present in the registry → ssh leg, registry alias
+
+
+def test_forward_to_remote_dials_the_registry_alias_when_config_yaml_is_absent(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    _forward("scitex-compute-03")
+    # Assert — the ssh host argument sits right before the remote curl snippet
+    assert subprocess_shim.argv_for("ssh")[-2] == "compute-03-via-registry"
+
+
+def test_forward_to_remote_returns_the_ssh_legs_response_for_a_registry_host(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout='{"ok": true}', stderr="")
+    # Act
+    resp = _forward("scitex-compute-03")
+    # Assert
+    assert (resp.status_code, _read_json_body(resp)) == (200, {"ok": True})
+
+
+# (b) absent from both → loud 502, HTTP never attempted
+
+
+def test_forward_to_remote_502s_for_a_host_in_neither_config_nor_registry(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    resp = _forward("unrouted-host-z")
+    # Assert
+    assert resp.status_code == 502
+
+
+def test_forward_to_remote_refusal_names_the_host_and_the_loopback_bind(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    error = _read_json_body(_forward("unrouted-host-z"))["error"]
+    # Assert
+    assert "'unrouted-host-z'" in error and "bind 127.0.0.1" in error
+
+
+def test_forward_to_remote_refusal_names_both_fixes(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    error = _read_json_body(_forward("unrouted-host-z"))["error"]
+    # Assert — the registry fix AND the config.yaml fix on THIS host
+    assert (
+        "ssh_alias" in error
+        and "hosts.yaml" in error
+        and ("peers: {unrouted-host-z: {ssh: <alias>}}" in error)
+    )
+
+
+def test_forward_to_remote_refusal_names_the_config_path_this_host_resolved(
+    registry_only_peers, subprocess_shim, isolated_home
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    error = _read_json_body(_forward("unrouted-host-z"))["error"]
+    # Assert
+    assert str(isolated_home / "absent-config.yaml") in error
+
+
+def test_forward_to_remote_never_posts_http_to_an_unroutable_host(
+    registry_only_peers, subprocess_shim
+):
+    """Settled at the RECEIVING end. ``127.0.0.1`` as the destination
+    label is neither a peer nor a ``host-*`` alias, so the pre-fix HTTP
+    leg would have posted straight into this listener; the refusal must
+    leave it untouched."""
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    with _loopback_json_server({"reached": True}) as (port, hits):
+        # Act
+        resp = _forward("127.0.0.1", target_port=port)
+    # Assert
+    assert (resp.status_code, hits) == (502, [])
+
+
+def test_forward_to_remote_does_not_dial_ssh_for_an_unroutable_host(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    _forward("unrouted-host-z")
+    # Assert
+    assert subprocess_shim.call_count("ssh") == 0
+
+
+def test_forward_to_remote_502s_for_a_registry_row_without_an_ssh_alias(
+    registry_only_peers, subprocess_shim
+):
+    """A registry row with ``ssh_alias: null`` (inbound ssh impossible) is
+    NOT a route — it must refuse, never pass through to HTTP."""
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    resp = _forward("scitex-laptop-02")
+    # Assert — the REFUSAL, not the HTTP leg's own connection failure
+    assert (
+        resp.status_code,
+        "was not attempted" in _read_json_body(resp)["error"],
+    ) == (
+        502,
+        True,
+    )
+
+
+def test_forward_to_remote_warns_once_per_unroutable_host(
+    registry_only_peers, subprocess_shim, caplog
+):
+    # Arrange — a host this process has never refused, then two sends to it
+    host = f"unrouted-{uuid.uuid4().hex[:8]}"
+    write_peer_token(peer_host=host, token="bearer-for-once")
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    caplog.set_level(logging.WARNING, logger=_fwd.__name__)
+    # Act
+    _forward(host)
+    _forward(host)
+    # Assert
+    warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING and f"'{host}'" in rec.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+# (c) the ``host-*`` test-loopback alias still takes the HTTP leg
+
+
+def test_forward_to_remote_posts_http_to_loopback_for_the_host_a_test_alias(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange — a real loopback listener stands in for "host-a"
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    with _loopback_json_server({"forwarded": "via-http"}) as (port, hits):
+        # Act
+        resp = _forward("host-a", target_port=port)
+    # Assert
+    assert (resp.status_code, _read_json_body(resp), hits) == (
+        200,
+        {"forwarded": "via-http"},
+        ["/agents/scitex-hub/message:send"],
+    )
+
+
+def test_is_test_loopback_alias_accepts_only_host_dash_labels():
+    # Arrange
+    probes = ("host-a", "host-b", "host-zz", "scitex-compute-03", "hosta", "")
+    # Act
+    verdicts = tuple(_fwd._is_test_loopback_alias(p) for p in probes)
+    # Assert
+    assert verdicts == (True, True, True, False, False, False)
+
+
+# (d) config.yaml glob keys keep resolving through the merged map
+
+
+def test_forward_to_remote_resolves_a_config_glob_key_through_the_merged_map(
+    registry_only_peers, subprocess_shim, env_save_restore, isolated_home
+):
+    # Arrange — a pattern key with blank ssh: PeersMap synthesises ssh=<name>
+    cfg = isolated_home / "glob-config.yaml"
+    cfg.write_text("peers:\n  'scitex-compute-*': {}\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    _forward("scitex-compute-02")
+    # Assert
+    assert subprocess_shim.argv_for("ssh")[-2] == "scitex-compute-02"
+
+
+# (e) a malformed config.yaml must not disable forwarding — the registry routes
+
+
+def test_forward_to_remote_still_routes_via_registry_when_config_yaml_is_malformed(
+    registry_only_peers, subprocess_shim, env_save_restore, isolated_home
+):
+    # Arrange — ``peers:`` as a list makes host_config.load raise ValueError
+    cfg = isolated_home / "broken-config.yaml"
+    cfg.write_text("peers:\n  - not\n  - a\n  - mapping\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    _forward("scitex-compute-03")
+    # Assert
+    assert subprocess_shim.argv_for("ssh")[-2] == "compute-03-via-registry"
+
+
+def test_forward_to_remote_refusal_carries_the_config_parse_failure(
+    registry_only_peers, subprocess_shim, env_save_restore, isolated_home
+):
+    # Arrange
+    cfg = isolated_home / "broken-config.yaml"
+    cfg.write_text("peers:\n  - not\n  - a\n  - mapping\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    error = _read_json_body(_forward("unrouted-host-z"))["error"]
+    # Assert
+    assert "broken-config.yaml failed to load" in error


### PR DESCRIPTION
## What was measured (2026-09-02)

- Cross-host a2a sends go through `sac listen`; when the target agent lives on another host, `_listen/_node_channel_forwarders.py::_forward_to_remote` picks a transport.
- It picked by reading the RAW `peers:` block of `~/.scitex/agent-container/config.yaml`. `scitex-compute-01` and `scitex-compute-03` have **no config.yaml at all**, so `peers` is `{}` there and every cross-host send silently took the plain-HTTP leg (`http://<host>:<agent-port>/...`).
- That leg can never work in production: every agent's bridge and sidecar bind `127.0.0.1` by default (`runtimes/_tui_turn_bridge_lifecycle.py` `DEFAULT_HOST`, `runtimes/a2a_sidecar.py`), and no fleet spec declares `spec.a2a.host`. Result today: `business` on compute-01 -> `scitex-hub` on compute-03 died with `All connection attempts failed`.
- The ssh + remote-curl leg works (verified live compute-04 -> compute-03 today), and the CLI verbs (`sac host probe` etc.) already resolve peers through `_state/_peer_resolve.py::peers_with_registry`, which merges the scitex-dev host registry's `ssh_alias`. On compute-01: raw peers `[]`, `peers_with_registry` resolves `scitex-compute-03 -> 'scitex-compute-03'`. The SSoT existed; the forwarder was not using it.

## Mechanism

`_forward_to_remote` gated on `cfg.peers.get(target_host)`; anything not in that raw map fell through to `_forward_via_http`, whose only legitimate use is the in-process two-listen test topology (`host-a` / `host-b` rewritten to `127.0.0.1`). A missing or empty config.yaml therefore turned every fleet destination into an HTTP attempt against a loopback-bound port on another machine.

## What the change does

- **Peer resolution uses the CLI's SSoT.** New `_resolve_ssh_peer` resolves the destination through `peers_with_registry(cfg.peers)` — config.yaml `peers:` (glob keys included, via `PeersMap`) UNION registry rows carrying an `ssh_alias` — and hands the alias to the unchanged ssh leg. Config entries still win over registry rows (that precedence lives in `_peer_resolve`, unchanged).
- **The HTTP leg is test-only, by a named predicate.** `_is_test_loopback_alias(host)` (`host-*`) is the ONLY gate to `_forward_via_http`; its docstring says it is the in-process test topology, never production. The `host-*` match is byte-for-byte the rewrite ADR-0015 froze.
- **Anything else fails loudly.** JSON 502 naming the host, stating that the fleet's agents bind loopback so a direct HTTP forward cannot work and was not attempted, and naming both fixes: an `ssh_alias` for the host in the scitex-dev host registry `hosts.yaml`, or `peers: {<host>: {ssh: <alias>}}` in the config.yaml THIS host resolved (the resolved path is in the message). A registry row with `ssh_alias: null` is not a route and refuses too. Logged at WARNING once per host per process so the forwarding host's listen journal (`journalctl -u sac-listen`) names it.
- **A malformed config.yaml still does not disable forwarding**: the existing exception handling stays, but the fallback is now the registry-merged map (with an empty config block) — not HTTP — and the parse failure is carried into the refusal text and the journal.
- Module docstring rewritten (the HTTP leg was described as a legacy production path). The `_forward_via_http` "surfaced as text" `stx-allow` reason now names where the tolerated body goes, so its entry leaves `FROZEN_UNNAMED_CLAIMS` in `tests/develop/test_delivery_claims_name_their_sink.py` (shrink-only list; the line had moved). One pre-existing ruff F541 in that file fixed in passing.

Not touched: the reachability probe (a sibling owns it), the ssh leg, `test_server.py`.

## How it was verified

New focused tests in `tests/scitex_agent_container/_listen/test__node_channel_forwarders.py` — no mocks: a real `hosts.yaml` at `$SCITEX_DIR/dev/` (the seam `test__peer_resolve.py` drives), an absent / malformed `config.yaml`, real peer-token files, the `ssh` shim on `$PATH` recording the argv production `subprocess.run` was handed, and a real `127.0.0.1` listener counting what ARRIVES for the "HTTP never attempted" claim.

- (a) host absent from raw config, present in the registry -> ssh leg dials the registry alias (`argv[-2] == "compute-03-via-registry"`)
- (b) host in neither -> 502; message names the host, `bind 127.0.0.1`, `ssh_alias` + `hosts.yaml`, `peers: {<host>: {ssh: <alias>}}`, the resolved config path; ssh not dialed; a loopback listener receives zero POSTs; WARNING once for two sends
- (c) `host-a` -> HTTP loopback leg still works against a real listener (200, body echoed, one POST arrived)
- (d) config glob key still resolves through the merged map
- (e) malformed config.yaml -> registry still routes; refusal text carries the parse failure

**Positive control** (source stashed, tests run against the unmodified module):

```
10 failed, 15 passed in 1.72s
```

The 5 new tests that also pass on the old code are regression guards for behaviour that did not change (the `host-a` loopback leg, config glob keys, and status-only 502s where the old code also 502'd — on a DNS failure rather than a refusal; the message tests discriminate).

**With the change** (`PYTHONPATH=<worktree>/src`, worktree source, not the editable install):

```
tests/scitex_agent_container/_listen/test__node_channel_forwarders.py + tests/develop/test_delivery_claims_name_their_sink.py
29 passed in 1.56s
```

Full listen suite (`tests/scitex_agent_container/_listen` + the claims guard):

```
712 passed, 304 skipped in 87.53s (0:01:27)
```

**Caveat, stated so it cannot be read as coverage:** `test_server.py` (the end-to-end cross-host suite, incl. the host-a/host-b HTTP loopback topology and the ssh-shim leg) is `68 skipped` in the container this was developed in — its `pg_schema` fixture found no reachable PostgreSQL at `127.0.0.1:55432` (and the fleet cluster is refused by system id on purpose). Those tests run on the self-hosted CI runners; the only destination label they forward to is `host-a` (4 instance rows), which is exactly the `_is_test_loopback_alias` case preserved here, and the ssh-shim fixture declares `host-a` in `peers:` so it stays on the ssh leg. CI is the vantage for that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adzed4bZzRxEDbMh9QoRtV
