### PR TITLE
feat(a2a): a scheduled fleet-wide reachability probe of the cross-host a2a transport

### DIFF
--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -21,7 +21,18 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs(*, executable: str | None = None) -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Ten jobs today:
+    Thirteen jobs today (the accounts, maintenance, liveness and
+    reachability groups — one module each):
+
+    * ``scitex-agent-container-a2a-reachability`` (``kind="timer"``) — the
+      every-15-minutes probe of the CROSS-HOST a2a transport, from this host
+      to every peer the fleet knows: ssh to the peer's alias, curl the
+      peer's loopback listen with the peer's bearer — the same leg ``sac
+      listen``'s forwarder takes for a cross-host send. Three-valued per
+      host and never counts UNKNOWN as reachable. MEASURED 2026-09-02: two
+      hosts with no ``config.yaml`` had been sending every cross-host
+      message down a leg that cannot work in production, and nothing said
+      so until a send was tried by hand. See :mod:`._specs_reachability`.
 
     * ``sac.accounts-keepalive`` (``kind="timer"``) — the DISTRIBUTION half
       of the single-refresher model, and the sibling of
@@ -238,6 +249,7 @@ def provide_jobs(*, executable: str | None = None) -> "list[JobSpec]":
     from ._specs_accounts import accounts_jobs
     from ._specs_liveness import liveness_jobs
     from ._specs_maintenance import maintenance_jobs
+    from ._specs_reachability import reachability_jobs
 
     # Each group is one operational concern a reader checks as a unit, and
     # each resolves its own absolute `sac` through :mod:`._sac_bin`. Spliced
@@ -251,6 +263,9 @@ def provide_jobs(*, executable: str | None = None) -> "list[JobSpec]":
         # other covers (corpses vs live-but-wedged), so they are unreadable
         # apart.
         *liveness_jobs(executable=executable),
+        # The cross-host a2a transport probe — appended LAST so every
+        # positional reader above keeps its index.
+        *reachability_jobs(executable=executable),
     ]
 
 

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -148,6 +148,12 @@ BORN_CANONICAL: frozenset[str] = frozenset(
         # which is precisely why a rate-limited fleet stayed stopped for
         # 1h46m. Nothing for a migration to displace.
         "scitex-agent-container-resume-rate-limited-agents",
+        # Added 2026-09-02. Born canonical: no host has ever carried any unit
+        # for it — cross-host a2a reachability was never probed by anything
+        # before this job, which is how two hosts with no config.yaml sent
+        # every cross-host message down a leg that cannot work in
+        # production and nobody knew until a send was tried by hand.
+        "scitex-agent-container-a2a-reachability",
     }
 )
 

--- a/src/scitex_agent_container/_jobs/_specs_reachability.py
+++ b/src/scitex_agent_container/_jobs/_specs_reachability.py
@@ -1,0 +1,86 @@
+"""The cross-host a2a REACHABILITY probe, as a scheduled job.
+
+Split into its own module like :mod:`._specs_liveness` and
+:mod:`._specs_maintenance`: one operational concern a reader checks as a
+unit. It REPORTS, never repairs — the remedy for an unreachable peer is a
+config change (an ssh alias, a peer token) that a timer must not make.
+
+WHY A TIMER, AND NOT A CHECK ON SEND
+    The transport a cross-host ``a2a_send`` rides — ssh to the peer's alias,
+    curl on the peer's loopback with the peer's bearer — depends on three
+    per-host facts (alias, token, ssh connectivity) that drift SILENTLY:
+    nothing fails until an agent actually sends, and when it does the sender
+    sees ``All connection attempts failed`` with no indication which of the
+    three is missing. MEASURED 2026-09-02: ``scitex-compute-01`` and
+    ``scitex-compute-03`` had no ``config.yaml`` at all, so every cross-host
+    send from them took a leg that cannot work in production. Nobody knew
+    until a send was tried by hand. A probe that runs on its own beat
+    reports the gap before an agent pays for it, and records it where the
+    other unattended passes record (sac's event log).
+
+CADENCE
+    Every 15 minutes: an alias or token gap is a config fact that stays
+    broken until fixed, so a faster tick buys only more identical records;
+    slower, and a peer can be silently unreachable for most of an hour. A
+    pass is one ssh+curl per peer, run in parallel, bounded per host by the
+    verb's ``--timeout`` (10 s curl + 15 s ssh), so the 180 s command bound
+    covers the whole fleet including every peer being down at once.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scitex_dev.jobs import JobSpec
+
+__all__ = ["reachability_jobs"]
+
+
+def reachability_jobs(*, executable: str | None = None) -> "list[JobSpec]":
+    """The a2a-reachability JobSpec.
+
+    ``executable`` is the same test seam :func:`._sac_bin.sac_bin` exposes,
+    threaded through so a test can resolve the payload against a venv-shaped
+    tree it built on disk rather than asserting an environmental fact.
+    """
+    from scitex_dev.jobs import JobSpec
+
+    from ._sac_bin import sac_bin
+
+    # ABSOLUTE, resolved per host -- see :mod:`._sac_bin` for the measurement.
+    sac = sac_bin(executable=executable)
+
+    return [
+        JobSpec(
+            name="scitex-agent-container-a2a-reachability",
+            schedule="*/15 * * * *",  # every 15min (cron form; timer cadence below)
+            # SELF-BOUNDING (180s). Peers are probed in parallel and each
+            # leg is capped at 10s curl + 15s ssh connect, so a fleet where
+            # EVERY peer is down still finishes well inside the bound; the
+            # bound exists for the case where ssh itself hangs past its own
+            # timeouts (a wedged ControlMaster), never for a legitimate run.
+            command=(
+                f"/usr/bin/timeout 180 {sac} a2a reachability --all --json --record"
+            ),
+            description=(
+                "Probes the cross-host a2a transport from this host to every "
+                "peer the fleet knows (config.yaml peers + the host registry): "
+                "ssh to the peer's alias, curl 127.0.0.1:7878/v1/health on the "
+                "peer with that peer's bearer — the SAME leg sac listen's "
+                "forwarder takes for a cross-host send. Three-valued per host "
+                "(reachable / unreachable / unknown — no alias, no peer token, "
+                "or this host); unknown is never counted as reachable. Records "
+                "each verdict in sac's event log (subsystem a2a-reachability) "
+                "and the full report to runtime/a2a-reachability.json for "
+                "`sac a2a reachability --last`. Exit 0 all reachable, 1 any "
+                "unreachable, 3 nothing measurable. Mutates nothing on any peer."
+            ),
+            kind="timer",
+            # 5min after boot: the listen and ssh agent have settled, and a
+            # host that just came up is exactly the one whose peers want
+            # checking. Then every 15min — see the module docstring.
+            on_boot_sec="5min",
+            on_unit_active_sec="15min",
+        ),
+    ]

--- a/src/scitex_agent_container/_jobs/_specs_reachability.py
+++ b/src/scitex_agent_container/_jobs/_specs_reachability.py
@@ -20,11 +20,22 @@ WHY A TIMER, AND NOT A CHECK ON SEND
 
 CADENCE
     Every 15 minutes: an alias or token gap is a config fact that stays
-    broken until fixed, so a faster tick buys only more identical records;
-    slower, and a peer can be silently unreachable for most of an hour. A
-    pass is one ssh+curl per peer, run in parallel, bounded per host by the
-    verb's ``--timeout`` (10 s curl + 15 s ssh), so the 180 s command bound
-    covers the whole fleet including every peer being down at once.
+    broken until fixed, so a faster tick buys nothing (per-host event
+    records are written on TRANSITION only; the ``--record`` file carries
+    every pass); slower, and a peer can be silently unreachable for most of
+    an hour. A pass is one ssh+curl per peer, run in parallel, bounded per
+    host by the verb's ``--timeout`` (10 s curl + 15 s ssh), so the 180 s
+    command bound covers the whole fleet including every peer being down at
+    once.
+
+WHAT "REACHABLE" PROVES
+    The probe hits the peer listen's ``/v1/health``, a PUBLIC path
+    (``BearerAuthMiddleware.PUBLIC_PATHS``) answered before the bearer is
+    checked. Reachable therefore means: the ssh alias resolves (through the
+    forwarder's own resolver), the tunnel connects, and a ``sac-listen`` is
+    up on the peer's loopback. It does NOT prove the peer token is valid —
+    a stale ``peer-tokens/<host>.token`` reads reachable here and 401s on a
+    real send. An authenticated probe path is the proposed follow-up.
 """
 
 from __future__ import annotations
@@ -65,16 +76,20 @@ def reachability_jobs(*, executable: str | None = None) -> "list[JobSpec]":
             ),
             description=(
                 "Probes the cross-host a2a transport from this host to every "
-                "peer the fleet knows (config.yaml peers + the host registry): "
-                "ssh to the peer's alias, curl 127.0.0.1:7878/v1/health on the "
-                "peer with that peer's bearer — the SAME leg sac listen's "
-                "forwarder takes for a cross-host send. Three-valued per host "
-                "(reachable / unreachable / unknown — no alias, no peer token, "
-                "or this host); unknown is never counted as reachable. Records "
-                "each verdict in sac's event log (subsystem a2a-reachability) "
-                "and the full report to runtime/a2a-reachability.json for "
-                "`sac a2a reachability --last`. Exit 0 all reachable, 1 any "
-                "unreachable, 3 nothing measurable. Mutates nothing on any peer."
+                "peer the fleet knows, resolving each peer's ssh alias through "
+                "sac listen's forwarder's OWN resolver (config.yaml peers + the "
+                "host registry): ssh to that alias, curl 127.0.0.1:7878/v1/health "
+                "on the peer with that peer's bearer — the SAME leg a cross-host "
+                "send takes. Three-valued per host (reachable / unreachable / "
+                "unknown — no alias, no peer token, or this host); unknown is "
+                "never counted as reachable. /v1/health is a PUBLIC listen path, "
+                "so reachable proves alias + tunnel + listen up, NOT that the "
+                "peer token is valid. Records state TRANSITIONS per host in sac's "
+                "event log (subsystem a2a-reachability) plus a pass-completed "
+                "record every pass, and the full report to "
+                "runtime/a2a-reachability.json for `sac a2a reachability --last`. "
+                "Exit 0 all reachable, 1 any unreachable, 3 nothing measurable. "
+                "Mutates nothing on any peer."
             ),
             kind="timer",
             # 5min after boot: the listen and ssh agent have settled, and a

--- a/src/scitex_agent_container/_listen/_node_channel_forwarders.py
+++ b/src/scitex_agent_container/_listen/_node_channel_forwarders.py
@@ -5,14 +5,35 @@ Holds the WI-4 cross-host forward path that the node-comms routes in
 host. Three callables make up the surface:
 
 * :func:`_forward_to_remote` — entry point + transport selector. Reads
-  the per-host bearer registry and the operator's ``peers:`` block,
-  then dispatches to the HTTP or ssh leg.
-* :func:`_forward_via_http` — legacy HTTP transport (Stage 1). Used
-  when the destination host is NOT in ``host_config.peers``; matches
-  the two-listen test topology's loopback rewrite.
-* :func:`_forward_via_ssh_curl` — ADR-0015 Stage 2 transport. ssh +
-  remote curl into ``127.0.0.1:<port>`` on the destination, reusing
-  the same helper as the ``/v1/turn`` direct-ssh path.
+  the per-host bearer registry, resolves the destination through the
+  SAME peer map the CLI verbs use (config.yaml ``peers:`` UNION the
+  scitex-dev host registry — :func:`~.._state._peer_resolve.peers_with_registry`),
+  and dispatches to the ssh leg. A destination that is not an ssh peer
+  is REFUSED with a 502 that names the fix; it is never guessed at.
+* :func:`_forward_via_ssh_curl` — ADR-0015 Stage 2 transport, the ONLY
+  production transport. ssh + remote curl into ``127.0.0.1:<port>`` on
+  the destination, reusing the same helper as the ``/v1/turn``
+  direct-ssh path.
+* :func:`_forward_via_http` — the in-process TEST transport. Reached
+  only for the ``host-*`` loopback aliases the two-listen suite in
+  ``test_server.py`` stamps on its ``instances`` rows
+  (:func:`_is_test_loopback_alias`); never for a fleet host.
+
+Why there is no HTTP leg for production (measured 2026-09-02)
+--------------------------------------------------------------
+Every agent's bridge and sidecar bind ``127.0.0.1`` by default
+(``runtimes/_tui_turn_bridge_lifecycle.py`` ``DEFAULT_HOST``,
+``runtimes/a2a_sidecar.py`` host default) and no spec on the fleet
+declares ``spec.a2a.host``, so ``http://<host>:<agent-port>/...`` can
+never connect from another machine. This module used to take that leg
+whenever the destination was absent from the RAW ``peers:`` block of
+``~/.scitex/agent-container/config.yaml`` — and ``scitex-compute-01`` /
+``scitex-compute-03`` have no such file at all, so every cross-host send
+from those hosts silently posted plain HTTP and died with ``All
+connection attempts failed``. The CLI verbs (``sac host probe`` and
+friends) had already stopped gating on the raw block and resolve peers
+through the host registry's ``ssh_alias``; the forwarder simply was not
+using the same SSoT. Now it does, and the only fallback is a loud one.
 
 The split keeps the route handlers in :mod:`._node_channel` under the
 per-file LOC cap; ``_node_channel`` re-exports
@@ -24,6 +45,8 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import logging
+from dataclasses import dataclass
 from typing import Any
 
 from starlette.responses import JSONResponse, Response
@@ -32,7 +55,138 @@ __all__ = [
     "_forward_to_remote",
     "_forward_via_http",
     "_forward_via_ssh_curl",
+    "_is_test_loopback_alias",
 ]
+
+log = logging.getLogger(__name__)
+
+#: Hosts this process has already refused with the "not an ssh peer" 502.
+#: The 502 body carries the whole remedy on EVERY call; the WARNING line is
+#: written once per host so the FORWARDING host's listen journal
+#: (``journalctl -u sac-listen`` — the unit's stderr) names the fault
+#: without repeating it for every retry the sender makes.
+_WARNED_UNROUTABLE_HOSTS: set[str] = set()
+
+
+def _is_test_loopback_alias(target_host: str) -> bool:
+    """True only for the in-process two-listen TEST topology's host labels.
+
+    ``host-a`` / ``host-b`` (any ``host-*``) are the labels
+    ``tests/scitex_agent_container/_listen/test_server.py`` stamps on
+    ``instances`` rows so two real ``uvicorn`` listens on ONE machine can
+    play two hosts; :func:`_forward_via_http` rewrites them to
+    ``127.0.0.1``. No fleet host is named this way (fleet names are
+    ``scitex-<kind>-NN``), and this predicate is the ONLY gate under which
+    the forwarder ever posts plain HTTP — it is the test topology, never
+    production. The match is byte-for-byte the rewrite ADR-0015 froze
+    ("do not broaden or tighten the ``host-*`` loopback rewrite").
+    """
+    return target_host.startswith("host-")
+
+
+@dataclass(frozen=True)
+class _PeerRoute:
+    """What :func:`_resolve_ssh_peer` decided about one destination host.
+
+    ``ssh_target`` is the alias to dial (``None`` when the host is not an
+    ssh peer); ``config_path`` names the config.yaml THIS host resolved
+    so the refusal can point at the file to edit; ``reason`` says, in
+    operator terms, why no ssh route exists (empty when one does).
+    """
+
+    ssh_target: str | None
+    config_path: str
+    reason: str = ""
+
+
+def _resolve_ssh_peer(target_host: str) -> _PeerRoute:
+    """Resolve ``target_host`` to an ssh alias through the CLI's SSoT.
+
+    Same map ``sac host probe`` / ``sac host exec`` dispatch on:
+    config.yaml ``peers:`` (glob keys included — ``PeersMap`` resolves
+    them) UNION the scitex-dev host registry rows that carry an
+    ``ssh_alias``. A registry row WITHOUT an alias (inbound ssh not
+    possible) is deliberately not a route, so it lands in the refusal.
+
+    A config.yaml that fails to parse must not disable forwarding: the
+    registry-merged map is still consulted (with an empty config block)
+    and the parse failure is carried into any refusal's ``reason`` so the
+    operator sees BOTH facts in the 502.
+    """
+    from .._state._peer_resolve import peers_with_registry
+    from .._state.host_config import MovingAliasError, _default_config_path
+    from .._state.host_config import load as _load_host_config
+
+    config_note = ""
+    try:
+        _cfg = _load_host_config()
+        raw_peers = _cfg.peers
+        config_path = str(_cfg.source_path or _default_config_path())
+    except Exception as exc:  # noqa: BLE001  # stx-allow: fallback (reason: a malformed config.yaml must not disable cross-host forwarding — the registry-merged map still routes, and the parse failure is carried into the 502 body and this host's listen journal (journalctl -u sac-listen) via the warning below)
+        raw_peers = {}
+        config_path = str(_default_config_path())
+        config_note = f"{config_path} failed to load ({exc}); "
+        log.warning(
+            "cross-host forward: %s failed to load (%s); resolving peers "
+            "from the scitex-dev host registry alone",
+            config_path,
+            exc,
+        )
+
+    peers = peers_with_registry(raw_peers)
+    try:
+        spec = peers[target_host]
+    except MovingAliasError as exc:
+        return _PeerRoute(None, config_path, f"{config_note}{exc}")
+    except KeyError:
+        spec = None
+
+    if spec is not None and spec.ssh:
+        return _PeerRoute(spec.ssh, config_path)
+    if spec is not None:
+        reason = (
+            f"{config_note}{config_path} declares peer {target_host!r} "
+            f"but its ssh: target is empty"
+        )
+    else:
+        from scitex_config._ecosystem import local_state as _local_state
+
+        hosts_yaml = _local_state.user_path("dev", "hosts.yaml")
+        reason = (
+            f"{config_note}it is in neither the peers: block of {config_path} "
+            f"nor the scitex-dev host registry ({hosts_yaml}) with an ssh_alias"
+        )
+    return _PeerRoute(None, config_path, reason)
+
+
+def _refuse_unroutable(
+    *,
+    target_host: str,
+    target_port: int,
+    target_name: str,
+    route: _PeerRoute,
+) -> Response:
+    """The loud 502 for a destination that is not an ssh peer.
+
+    Names the host, states why plain HTTP is not attempted (the fleet's
+    agents bind loopback), and names BOTH fixes. Logged at WARNING once
+    per host per process (see :data:`_WARNED_UNROUTABLE_HOSTS`).
+    """
+    message = (
+        f"cross-host forward to {target_name!r} on host {target_host!r} "
+        f"refused: {target_host!r} is not resolvable to an ssh peer on this "
+        f"host — {route.reason}. The fleet's agents bind 127.0.0.1 (bridge "
+        f"and sidecar default host), so a direct HTTP forward to "
+        f"http://{target_host}:{target_port} cannot work and was not "
+        f"attempted. Fix one of: (1) declare {target_host!r} with an "
+        f"ssh_alias in the scitex-dev host registry hosts.yaml; "
+        f"(2) add `peers: {{{target_host}: {{ssh: <alias>}}}}` to "
+        f"{route.config_path} on this host."
+    )
+    if target_host not in _WARNED_UNROUTABLE_HOSTS:
+        _WARNED_UNROUTABLE_HOSTS.add(target_host)
+        log.warning("%s", message)
+    return JSONResponse({"error": message}, status_code=502)
 
 
 async def _forward_to_remote(
@@ -67,14 +221,15 @@ async def _forward_to_remote(
     the receiving host (handoff §4 acceptance "ACL is enforced at
     the receiving host").
 
-    **Transport selector (ADR-0015 Stage 2)**: when ``target_host``
-    is a member of ``host_config.peers`` (including via glob keys
-    like ``spartan-*``), the forward leg is ssh + remote curl
-    instead of plain HTTP — a WAN hostname like ``ywata-note-win``
-    is rarely routable directly between hosts, but the operator's
-    existing ssh trust to that host is. Hosts NOT in ``peers:`` keep
-    the legacy HTTP path verbatim, including the ``host-*`` loopback
-    alias rewrite the two-listen tests depend on.
+    **Transport selector**: ``target_host`` is resolved through
+    :func:`_resolve_ssh_peer` — config.yaml ``peers:`` (glob keys
+    included) UNION the scitex-dev host registry, the same SSoT the
+    CLI verbs dispatch on. A resolvable host takes the ssh + remote
+    curl leg. A ``host-*`` test-loopback alias
+    (:func:`_is_test_loopback_alias`) takes the in-process HTTP leg.
+    Anything else is refused with a 502 that names the host and both
+    fixes — plain HTTP to a fleet host cannot connect (agents bind
+    loopback) and is never attempted.
     """
     if not target_port:
         return JSONResponse(
@@ -97,34 +252,31 @@ async def _forward_to_remote(
             status_code=502,
         )
 
-    # ADR-0015 transport selector. Resolve ``target_host`` against the
-    # operator's ``peers:`` block (with glob fallback via PeersMap). If
-    # the destination is a known peer, ssh-tunnel the POST; otherwise
-    # fall through to the legacy HTTP path.
-    from .._state.host_config import load as _load_host_config
-
-    try:
-        _cfg = _load_host_config()
-        peer_spec = _cfg.peers.get(target_host)
-    except Exception:  # noqa: BLE001  # stx-allow: fallback (reason: a malformed config.yaml must not silently disable the HTTP fallback)
-        peer_spec = None
-
-    if peer_spec is not None and peer_spec.ssh:
+    route = _resolve_ssh_peer(target_host)
+    if route.ssh_target:
         return await _forward_via_ssh_curl(
             target_host=target_host,
             target_port=target_port,
             target_name=target_name,
             body=body,
             peer_bearer=peer_bearer,
-            ssh_target=peer_spec.ssh,
+            ssh_target=route.ssh_target,
         )
 
-    return await _forward_via_http(
+    if _is_test_loopback_alias(target_host):
+        return await _forward_via_http(
+            target_host=target_host,
+            target_port=target_port,
+            target_name=target_name,
+            body=body,
+            peer_bearer=peer_bearer,
+        )
+
+    return _refuse_unroutable(
         target_host=target_host,
         target_port=target_port,
         target_name=target_name,
-        body=body,
-        peer_bearer=peer_bearer,
+        route=route,
     )
 
 
@@ -136,22 +288,25 @@ async def _forward_via_http(
     body: dict[str, Any],
     peer_bearer: str,
 ) -> Response:
-    """Legacy HTTP-only cross-host forward (Stage 1). Used when
-    ``target_host`` is NOT in ``host_config.peers`` — typically the
-    in-process two-listen test topology, or a deployment where overlay
-    routing makes the canonical host name directly reachable.
+    """In-process TEST transport: plain HTTP to the loopback listen.
+
+    Reached only when :func:`_forward_to_remote` found no ssh peer AND
+    ``target_host`` is a ``host-*`` test-loopback alias
+    (:func:`_is_test_loopback_alias`). Production never lands here:
+    fleet agents bind ``127.0.0.1``, so a direct HTTP forward to
+    another machine cannot connect, and the selector refuses such a
+    host with a 502 instead of calling this.
     """
     import httpx as _httpx
 
     forward_url = (
         f"http://{target_host}:{target_port}/agents/{target_name}/message:send"
     )
-    # In our test loopback both hosts live on 127.0.0.1; the canonical
+    # In the test loopback both hosts live on 127.0.0.1; the canonical
     # host name is a label, not a routable address. Rewrite to
-    # 127.0.0.1 when the resolved host is a known-loopback alias so
-    # the test fixtures can drive both legs on one machine. Real
-    # deployments use ssh-alias / tunnel hostnames and route as-is.
-    if target_host in ("host-a", "host-b") or target_host.startswith("host-"):
+    # 127.0.0.1 for the known-loopback aliases so the test fixtures can
+    # drive both legs on one machine.
+    if _is_test_loopback_alias(target_host):
         forward_url = (
             f"http://127.0.0.1:{target_port}/agents/{target_name}/message:send"
         )
@@ -174,7 +329,7 @@ async def _forward_via_http(
 
     try:
         return JSONResponse(resp.json(), status_code=resp.status_code)
-    except Exception:  # noqa: BLE001  # stx-allow: fallback (reason: non-JSON destination body is tolerated; surfaced as text)
+    except Exception:  # noqa: BLE001  # stx-allow: fallback (reason: a non-JSON destination body is tolerated and returned verbatim as forwarded_body_text in the a2a response the sender receives)
         return JSONResponse(
             {"forwarded_body_text": resp.text}, status_code=resp.status_code
         )

--- a/src/scitex_agent_container/_network/_reachability.py
+++ b/src/scitex_agent_container/_network/_reachability.py
@@ -14,31 +14,56 @@ WHY THIS EXISTS (measured 2026-09-02)
     failed`` until somebody tried one by hand.
 
     This module asks that question ROUTINELY, per peer, through the SAME
-    transport: :func:`.._network._ssh_curl._get_via_ssh_curl` shares its
-    ssh argv with the forwarder's POST, the bearer is the same
-    ``read_peer_token`` value, and the target is the peer's listen
-    ``/v1/health`` — the loopback bind the forwarder must reach.
+    leg — the same RESOLVER and the same TRANSPORT, both imported from the
+    forwarder's side rather than re-implemented here:
+
+    * the ssh alias for a host is whatever
+      :func:`.._listen._node_channel_forwarders._resolve_ssh_peer` answers
+      — config.yaml ``peers:`` UNION the scitex-dev host registry, the one
+      callable the forwarder dials by. Review round 2 of PR #1285 found the
+      first cut resolving through a look-alike (the merged map, while the
+      forwarder on develop still read the RAW config block), which is
+      exactly how a probe reports "reachable" for a peer the forwarder
+      cannot route. The parity test in ``test__reachability.py`` pins the
+      callable identity, not just the answer;
+    * :func:`.._network._ssh_curl._get_via_ssh_curl` shares its ssh argv
+      with the forwarder's POST, the bearer is the same ``read_peer_token``
+      value, and the target is the peer's listen ``/v1/health`` — the
+      loopback bind the forwarder must reach.
 
 WHAT ``reachable`` MEANS, AND WHAT IT DOES NOT
     ``True`` means: from THIS host, ssh to the peer's alias worked, curl on
     the peer reached ``127.0.0.1:<listen port>/v1/health``, and a
     ``sac-listen`` answered 200. That is the transport the forwarder uses,
-    end to end, with the bearer it would carry.
+    end to end, with the bearer it would carry: ssh alias + tunnel + a
+    listen that is up.
 
-    It does NOT say a particular AGENT's port is up on that peer (the
-    forwarder targets the agent's a2a port, not the listen's), and — because
-    ``/v1/health`` is a PUBLIC path on the listen — it does not prove the
-    bearer would be ACCEPTED by an authenticated route. A missing bearer is
-    still reported (as UNKNOWN), because the forwarder refuses to send
-    without one.
+    It does NOT prove the bearer is VALID. ``/v1/health`` is a PUBLIC path
+    on the listen (``BearerAuthMiddleware.PUBLIC_PATHS``), answered before
+    the bearer is looked at, so a stale or wrong ``peer-tokens/<host>.token``
+    still yields ``True`` here and a 401 on the forwarder's real
+    ``message:send``. A missing bearer is still reported (as UNKNOWN),
+    because the forwarder refuses to send without one; an authenticated
+    probe path is the proposed next step (see the PR body). Nor does
+    ``True`` say a particular AGENT's port is up on that peer — the
+    forwarder targets the agent's a2a port, which the peer's listen
+    reaches from its own loopback.
 
 THREE VALUES, NEVER TWO
-    ``reachable`` is ``True`` / ``False`` / ``None``. ``None`` is UNKNOWN —
-    the probe could not be run at all (no ssh alias in the registry, no
-    peer token, or the host is this machine) — and it is NEVER counted as
-    reachable and NEVER as unreachable. A pass in which every host is
-    unknown measured nothing, and says so with its own exit code
-    (:data:`EXIT_NOTHING_MEASURABLE`) rather than reporting "all clear".
+    See :mod:`._reachability_report`, which owns the row / report / exit-code
+    shape. ``None`` is UNKNOWN (no alias, no peer token, or this host) and is
+    never counted as reachable or unreachable; a pass where nothing was
+    measurable exits :data:`EXIT_NOTHING_MEASURABLE`, not 0.
+
+ONE DEFINITION OF "THIS HOST"
+    A row is this machine when :func:`resolve_targets` says so — the
+    ``local`` flag on :class:`Target`, decided against the caller's
+    ``local_names`` (the CLI passes ``_local_host_names()``, which pivots
+    through the host registry so ``DXP480TPLUS-994`` and ``scitex-nas-03``
+    are one machine). That flag is CARRIED into the row and the report
+    (:attr:`~._reachability_report.HostReachability.local`) so every
+    consumer — the alarm above all — skips the self row by the same
+    decision instead of re-deriving it from a name spelled differently.
 
 CONSUMERS
     * ``sac a2a reachability`` renders a :class:`ReachabilityReport` and
@@ -47,8 +72,9 @@ CONSUMERS
       ``~/.scitex/dev/runtime/periodic-executions.jsonl``.
     * ``--record`` writes the report to :func:`default_report_path`
       (``runtime_root()/a2a-reachability.json``); ``sac a2a reachability
-      --last`` reads it back through :func:`read_report`.
-    * :mod:`._reachability_alarm` routes each row into sac's event log —
+      --last`` reads it back through :func:`read_report`. That file is the
+      full per-pass picture.
+    * :mod:`._reachability_alarm` routes TRANSITIONS into sac's event log —
       the rail ``fleet-reconcile`` and ``host-sync-check`` already record to.
 """
 
@@ -60,16 +86,31 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Mapping
+from typing import Iterable
 
 from .._listen._config import DEFAULT_LISTEN_PORT
+
+# THE forwarder's resolver — imported, never re-implemented, so the alias
+# the probe dials and the alias a cross-host send dials cannot diverge.
+from .._listen._node_channel_forwarders import _resolve_ssh_peer
 from .._listen.peer_tokens import PeerTokenError, read_peer_token
 from .._state._peer_resolve import peers_with_registry
 from .._state.host_registry import registry_hosts
+from ._reachability_report import (
+    EXIT_ALL_REACHABLE,
+    EXIT_NOTHING_MEASURABLE,
+    EXIT_UNREACHABLE,
+    REPORT_FILENAME,
+    TRANSPORT_NONE,
+    TRANSPORT_SSH,
+    HostReachability,
+    ReachabilityReport,
+    default_report_path,
+    exit_code_for,
+    read_report,
+    write_report,
+)
 from ._ssh_curl import _get_via_ssh_curl, split_status_line
-
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    from .._state.host_config import PeerSpec
 
 __all__ = [
     "DEFAULT_LISTEN_PORT",
@@ -77,6 +118,7 @@ __all__ = [
     "EXIT_NOTHING_MEASURABLE",
     "EXIT_UNREACHABLE",
     "HEALTH_PATH",
+    "LOCAL_HOST_REASON",
     "REPORT_FILENAME",
     "TRANSPORT_NONE",
     "TRANSPORT_SSH",
@@ -89,31 +131,18 @@ __all__ = [
     "probe_targets",
     "read_report",
     "resolve_targets",
+    "run_probe",
     "write_report",
 ]
 
-#: The route probed on the peer's listen. Public (no bearer needed to answer),
-#: which is why a 200 here proves the TRANSPORT and not the bearer's validity.
+#: The route probed on the peer's listen. PUBLIC — ``BearerAuthMiddleware``
+#: answers it before looking at the bearer — which is why a 200 here proves
+#: the TRANSPORT (alias + tunnel + listen up) and not the bearer's validity.
 HEALTH_PATH = "/v1/health"
 
 #: The value the listen's health body carries; anything else answering 200 on
 #: the port is not the daemon the forwarder needs.
 _EXPECTED_SERVICE = "sac-listen"
-
-#: ``transport`` values. ``ssh`` = the probe ran (or was refused only for a
-#: missing token) over the forwarder's ssh leg; ``none`` = there is no leg to
-#: run — no alias, or the host is this machine.
-TRANSPORT_SSH = "ssh"
-TRANSPORT_NONE = "none"
-
-#: Exit codes. Documented in the verb's help; 2 is deliberately NOT used, it
-#: stays Click's usage-error code and carries no domain meaning here.
-EXIT_ALL_REACHABLE = 0
-EXIT_UNREACHABLE = 1
-EXIT_NOTHING_MEASURABLE = 3
-
-#: Where ``--record`` lands the report, relative to sac's runtime root.
-REPORT_FILENAME = "a2a-reachability.json"
 
 #: Why this machine's own row is UNKNOWN: there is no leg to probe.
 LOCAL_HOST_REASON = (
@@ -122,183 +151,91 @@ LOCAL_HOST_REASON = (
 
 
 @dataclass(frozen=True)
-class HostReachability:
-    """One host's verdict. The fixed answer shape ``--json`` emits per host.
-
-    ``reachable`` is three-valued (see the module docstring); ``elapsed_ms``
-    is ``None`` whenever nothing was dispatched; ``error`` is ``None`` only
-    for ``reachable=True`` and otherwise names what stopped the probe, with
-    the file or value to fix when there is one.
-    """
-
-    host: str
-    ssh_alias: str | None
-    transport: str
-    reachable: bool | None
-    elapsed_ms: int | None
-    error: str | None
-
-    def __post_init__(self) -> None:
-        if self.transport not in (TRANSPORT_SSH, TRANSPORT_NONE):
-            raise ValueError(
-                f"HostReachability({self.host!r}).transport must be "
-                f"{TRANSPORT_SSH!r} or {TRANSPORT_NONE!r}, got {self.transport!r}"
-            )
-        if self.reachable is not None and not isinstance(self.reachable, bool):
-            raise ValueError(
-                f"HostReachability({self.host!r}).reachable must be True, False "
-                f"or None, got {self.reachable!r}"
-            )
-        if self.transport == TRANSPORT_NONE and self.reachable is not None:
-            raise ValueError(
-                f"HostReachability({self.host!r}): transport 'none' cannot carry "
-                f"a measured verdict ({self.reachable!r}) — nothing was dispatched"
-            )
-        if self.reachable is None and not self.error:
-            raise ValueError(
-                f"HostReachability({self.host!r}): an UNKNOWN row must say why"
-            )
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "host": self.host,
-            "ssh_alias": self.ssh_alias,
-            "transport": self.transport,
-            "reachable": self.reachable,
-            "elapsed_ms": self.elapsed_ms,
-            "error": self.error,
-        }
-
-    @classmethod
-    def from_dict(cls, raw: Mapping[str, Any]) -> "HostReachability":
-        return cls(
-            host=str(raw["host"]),
-            ssh_alias=raw.get("ssh_alias"),
-            transport=str(raw["transport"]),
-            reachable=raw.get("reachable"),
-            elapsed_ms=raw.get("elapsed_ms"),
-            error=raw.get("error"),
-        )
-
-
-def exit_code_for(rows: Iterable[HostReachability]) -> int:
-    """Map a pass's rows onto the three documented exit codes.
-
-    * :data:`EXIT_UNREACHABLE` (1) — at least one host measured ``False``.
-    * :data:`EXIT_NOTHING_MEASURABLE` (3) — no host measured anything: every
-      row is UNKNOWN, or there are no rows. This is NOT success; a pass
-      that could not look must not read as a pass that looked and found
-      nothing wrong.
-    * :data:`EXIT_ALL_REACHABLE` (0) — every MEASURED host is ``True``.
-      UNKNOWN rows alongside measured ones do not turn 0 into 3: the
-      measured hosts are still a real answer, and the unknown ones are
-      listed by name in the report.
-    """
-    measured = [row.reachable for row in rows if row.reachable is not None]
-    if not measured:
-        return EXIT_NOTHING_MEASURABLE
-    if any(value is False for value in measured):
-        return EXIT_UNREACHABLE
-    return EXIT_ALL_REACHABLE
-
-
-@dataclass(frozen=True)
-class ReachabilityReport:
-    """The whole pass: every row plus where and when it was taken from."""
-
-    probed_from: str
-    port: int
-    started_at_utc: str
-    elapsed_ms: int
-    rows: tuple[HostReachability, ...]
-
-    @property
-    def exit_code(self) -> int:
-        return exit_code_for(self.rows)
-
-    def counts(self) -> dict[str, int]:
-        return {
-            "hosts": len(self.rows),
-            "reachable": sum(1 for r in self.rows if r.reachable is True),
-            "unreachable": sum(1 for r in self.rows if r.reachable is False),
-            "unknown": sum(1 for r in self.rows if r.reachable is None),
-        }
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "probed_from": self.probed_from,
-            "port": self.port,
-            "started_at_utc": self.started_at_utc,
-            "elapsed_ms": self.elapsed_ms,
-            "exit_code": self.exit_code,
-            "counts": self.counts(),
-            "hosts": [row.to_dict() for row in self.rows],
-        }
-
-    @classmethod
-    def from_dict(cls, raw: Mapping[str, Any]) -> "ReachabilityReport":
-        return cls(
-            probed_from=str(raw["probed_from"]),
-            port=int(raw["port"]),
-            started_at_utc=str(raw["started_at_utc"]),
-            elapsed_ms=int(raw["elapsed_ms"]),
-            rows=tuple(HostReachability.from_dict(r) for r in raw.get("hosts", [])),
-        )
-
-
-@dataclass(frozen=True)
 class Target:
-    """A host to probe, resolved but not yet dispatched to."""
+    """A host to probe, resolved but not yet dispatched to.
+
+    ``ssh_alias`` and ``no_route_reason`` are the forwarder's own answer for
+    this host (:func:`~.._listen._node_channel_forwarders._resolve_ssh_peer`):
+    the alias it would dial, or — when there is none — the sentence its 502
+    would carry saying why.
+    """
 
     host: str
     ssh_alias: str | None
     local: bool
+    no_route_reason: str = ""
+
+
+def _known_host_names() -> list[str]:
+    """Every host the fleet knows, sorted — the ENUMERATION half.
+
+    The forwarder never enumerates (its destination comes from the
+    ``instances`` row), so this is the probe's own question: config.yaml
+    ``peers:`` UNION the host registry, read through the same
+    :func:`.._state._peer_resolve.peers_with_registry` the resolver merges
+    by, PLUS registry rows with no ``ssh_alias`` — those are not routes, so
+    the merged map drops them, but they must SURFACE here as UNKNOWN rather
+    than vanish. Glob peers (``spartan-*``) are templates, not hosts.
+    """
+    from .._state.host_config import load as _load_host_config
+
+    names: set[str] = set()
+    for name in peers_with_registry(dict(_load_host_config().peers)):
+        if any(ch in name for ch in "*?["):
+            continue
+        names.add(name)
+    for row in registry_hosts():
+        names.add(row.name)
+    return sorted(names)
 
 
 def resolve_targets(
     *,
-    peers: Mapping[str, "PeerSpec"],
     local_names: Iterable[str],
     only: Iterable[str] | None = None,
 ) -> list[Target]:
-    """Every host the fleet knows, with the alias the forwarder would use.
+    """Every host the fleet knows, with the alias the forwarder would dial.
 
-    The alias comes from :func:`.._state._peer_resolve.peers_with_registry`
-    — config.yaml ``peers:`` first, the scitex-dev host registry filling
-    the gaps — which is the SSoT the CLI verbs already route by. Registry
-    rows that declare NO ``ssh_alias`` are still listed (alias ``None``) so
-    they surface as UNKNOWN rather than silently vanishing from the report;
-    glob peers (``spartan-*``) are templates, not hosts, and are skipped.
+    The alias is NOT derived here. Each name is put to
+    :func:`~.._listen._node_channel_forwarders._resolve_ssh_peer` — the
+    callable ``sac listen``'s cross-host forwarder resolves a destination
+    with (config.yaml ``peers:`` UNION the scitex-dev host registry, config
+    winning) — so the probe dials exactly what a send would dial, and a host
+    the forwarder would refuse is listed with the forwarder's refusal reason
+    as an UNKNOWN row rather than silently dropped.
+
+    ``local_names`` is every spelling of THIS machine; the matching row is
+    flagged ``local`` here, once, and that flag rides through the report.
 
     ``only`` restricts the answer to those names and FAILS LOUDLY on a name
     nothing declares — a typo that probed nothing and exited 3 would read
     as "the fleet is unknown" instead of "you misspelled a host".
     """
-    merged = peers_with_registry(dict(peers))
-    aliases: dict[str, str | None] = {}
-    for name, spec in merged.items():
-        if any(ch in name for ch in "*?["):
-            continue
-        aliases[name] = spec.ssh or None
-    for row in registry_hosts():
-        aliases.setdefault(row.name, row.ssh_alias or None)
-
-    lower_local = {n.lower() for n in local_names if n}
+    known = _known_host_names()
     if only is not None:
         wanted = list(dict.fromkeys(only))
-        missing = [name for name in wanted if name not in aliases]
+        missing = [name for name in wanted if name not in known]
         if missing:
             raise KeyError(
-                f"unknown host(s) {missing}; known: "
-                + (", ".join(sorted(aliases)) or "(none)")
+                f"unknown host(s) {missing}; known: " + (", ".join(known) or "(none)")
             )
         names = wanted
     else:
-        names = sorted(aliases)
-    return [
-        Target(host=name, ssh_alias=aliases[name], local=name.lower() in lower_local)
-        for name in names
-    ]
+        names = known
+
+    lower_local = {n.lower() for n in local_names if n}
+    targets: list[Target] = []
+    for name in names:
+        route = _resolve_ssh_peer(name)
+        targets.append(
+            Target(
+                host=name,
+                ssh_alias=route.ssh_target or None,
+                local=name.lower() in lower_local,
+                no_route_reason=route.reason,
+            )
+        )
+    return targets
 
 
 def _unknown(target: Target, *, transport: str, error: str) -> HostReachability:
@@ -309,6 +246,7 @@ def _unknown(target: Target, *, transport: str, error: str) -> HostReachability:
         reachable=None,
         elapsed_ms=None,
         error=error,
+        local=target.local,
     )
 
 
@@ -321,23 +259,29 @@ def probe_target(
 ) -> HostReachability:
     """Probe ONE host over the forwarder's transport. Never raises.
 
-    The order of refusals is the forwarder's own: no alias → no leg; no
-    peer token → the forwarder would refuse before dispatching; then the
-    ssh+curl leg itself. Each refusal is UNKNOWN with the file to fix
-    named; only a dispatched leg can yield ``True`` or ``False``.
+    The order of refusals is the forwarder's own: this host → no leg; no
+    alias → no leg; no peer token → the forwarder would refuse before
+    dispatching; then the ssh+curl leg itself. Each refusal is UNKNOWN with
+    the file to fix named; only a dispatched leg can yield ``True`` or
+    ``False``. The local check comes FIRST and is not a shortcut: a local
+    row with an alias and a token would otherwise ssh to itself.
     """
     if target.local:
         return _unknown(target, transport=TRANSPORT_NONE, error=LOCAL_HOST_REASON)
     if not target.ssh_alias:
+        # The forwarder's own refusal sentence, so the operator reads here
+        # exactly what a cross-host send to this host would 502 with.
+        why = target.no_route_reason or (
+            "the host registry (hosts.yaml) declares ssh_alias: null and "
+            "config.yaml peers: does not name it"
+        )
         return _unknown(
             target,
             transport=TRANSPORT_NONE,
             error=(
-                f"no ssh alias for {target.host!r}: not in config.yaml peers and "
-                "the host registry (hosts.yaml) declares ssh_alias: null — "
-                "inbound ssh is not possible, so the forwarder cannot reach it "
-                "either. Add `ssh_alias` to its hosts.yaml row or a peers: "
-                "entry in config.yaml if it is reachable."
+                f"no ssh alias for {target.host!r}: {why} — the forwarder cannot "
+                "reach it either. Add `ssh_alias` to its hosts.yaml row or a "
+                "peers: entry in config.yaml if it is reachable."
             ),
         )
     try:
@@ -428,7 +372,6 @@ def probe_targets(
 
 def run_probe(
     *,
-    peers: Mapping[str, "PeerSpec"],
     local_names: Iterable[str],
     probed_from: str,
     only: Iterable[str] | None = None,
@@ -436,10 +379,15 @@ def run_probe(
     timeout_s: float = 10.0,
     tokens_dir: Path | None = None,
 ) -> ReachabilityReport:
-    """Resolve, probe, and assemble one :class:`ReachabilityReport`."""
+    """Resolve, probe, and assemble one :class:`ReachabilityReport`.
+
+    The peer map is not a parameter: the forwarder's resolver reads
+    config.yaml and the registry itself, and handing it a different map
+    here is how the two diverged in the first place.
+    """
     started_at = datetime.now(tz=timezone.utc)
     t0 = time.monotonic()
-    targets = resolve_targets(peers=peers, local_names=local_names, only=only)
+    targets = resolve_targets(local_names=local_names, only=only)
     rows = probe_targets(targets, port=port, timeout_s=timeout_s, tokens_dir=tokens_dir)
     return ReachabilityReport(
         probed_from=probed_from,
@@ -448,40 +396,3 @@ def run_probe(
         elapsed_ms=int((time.monotonic() - t0) * 1000),
         rows=tuple(rows),
     )
-
-
-def default_report_path() -> Path:
-    """``runtime_root()/a2a-reachability.json`` — resolved per call."""
-    from .._state.state_paths import runtime_root
-
-    return runtime_root() / REPORT_FILENAME
-
-
-def write_report(report: ReachabilityReport, *, path: Path | None = None) -> Path:
-    """Persist ``report`` atomically (tmp + rename). Raises on failure.
-
-    Deliberately NOT fail-open: ``--record`` is the scheduled job's whole
-    reason to run, and a report that silently did not land would leave the
-    consumer reading a stale one that says the fleet was fine.
-    """
-    target = Path(path) if path is not None else default_report_path()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    tmp = target.with_name(target.name + ".tmp")
-    tmp.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
-    tmp.replace(target)
-    return target
-
-
-def read_report(*, path: Path | None = None) -> ReachabilityReport | None:
-    """The last recorded report, or ``None`` when none has been recorded.
-
-    A file that exists but does not parse raises — a corrupt record is not
-    "no record", and pretending otherwise would hide a broken writer.
-    """
-    target = Path(path) if path is not None else default_report_path()
-    if not target.is_file():
-        return None
-    raw = json.loads(target.read_text(encoding="utf-8"))
-    if not isinstance(raw, dict):
-        raise ValueError(f"{target} does not hold a reachability report object")
-    return ReachabilityReport.from_dict(raw)

--- a/src/scitex_agent_container/_network/_reachability.py
+++ b/src/scitex_agent_container/_network/_reachability.py
@@ -1,0 +1,487 @@
+"""Cross-host a2a REACHABILITY — can this host's forwarder reach each peer?
+
+WHY THIS EXISTS (measured 2026-09-02)
+    A cross-host ``a2a_send`` leaves this host through ``sac listen``'s
+    forwarder (:mod:`.._listen._node_channel_forwarders`): ssh into the
+    peer's alias, then ``curl 127.0.0.1:<port>`` on the peer with that peer's
+    bearer from ``peer-tokens/<host>.token``. Every agent's sidecar binds
+    127.0.0.1, so that ssh leg is the ONLY transport that can work in
+    production — and whether it works depends on three per-host facts
+    nothing was checking: an ssh alias for the peer, a peer token for it,
+    and an ssh that actually connects. On ``scitex-compute-01`` the first
+    was missing (no ``config.yaml``, so the forwarder saw no peers) and every
+    send to ``scitex-compute-03`` failed with ``All connection attempts
+    failed`` until somebody tried one by hand.
+
+    This module asks that question ROUTINELY, per peer, through the SAME
+    transport: :func:`.._network._ssh_curl._get_via_ssh_curl` shares its
+    ssh argv with the forwarder's POST, the bearer is the same
+    ``read_peer_token`` value, and the target is the peer's listen
+    ``/v1/health`` — the loopback bind the forwarder must reach.
+
+WHAT ``reachable`` MEANS, AND WHAT IT DOES NOT
+    ``True`` means: from THIS host, ssh to the peer's alias worked, curl on
+    the peer reached ``127.0.0.1:<listen port>/v1/health``, and a
+    ``sac-listen`` answered 200. That is the transport the forwarder uses,
+    end to end, with the bearer it would carry.
+
+    It does NOT say a particular AGENT's port is up on that peer (the
+    forwarder targets the agent's a2a port, not the listen's), and — because
+    ``/v1/health`` is a PUBLIC path on the listen — it does not prove the
+    bearer would be ACCEPTED by an authenticated route. A missing bearer is
+    still reported (as UNKNOWN), because the forwarder refuses to send
+    without one.
+
+THREE VALUES, NEVER TWO
+    ``reachable`` is ``True`` / ``False`` / ``None``. ``None`` is UNKNOWN —
+    the probe could not be run at all (no ssh alias in the registry, no
+    peer token, or the host is this machine) — and it is NEVER counted as
+    reachable and NEVER as unreachable. A pass in which every host is
+    unknown measured nothing, and says so with its own exit code
+    (:data:`EXIT_NOTHING_MEASURABLE`) rather than reporting "all clear".
+
+CONSUMERS
+    * ``sac a2a reachability`` renders a :class:`ReachabilityReport` and
+      exits with :meth:`ReachabilityReport.exit_code`; the scitex-dev
+      supervisor's ``PeriodicRunner`` persists that exit code per run in
+      ``~/.scitex/dev/runtime/periodic-executions.jsonl``.
+    * ``--record`` writes the report to :func:`default_report_path`
+      (``runtime_root()/a2a-reachability.json``); ``sac a2a reachability
+      --last`` reads it back through :func:`read_report`.
+    * :mod:`._reachability_alarm` routes each row into sac's event log —
+      the rail ``fleet-reconcile`` and ``host-sync-check`` already record to.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterable, Mapping
+
+from .._listen._config import DEFAULT_LISTEN_PORT
+from .._listen.peer_tokens import PeerTokenError, read_peer_token
+from .._state._peer_resolve import peers_with_registry
+from .._state.host_registry import registry_hosts
+from ._ssh_curl import _get_via_ssh_curl, split_status_line
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .._state.host_config import PeerSpec
+
+__all__ = [
+    "DEFAULT_LISTEN_PORT",
+    "EXIT_ALL_REACHABLE",
+    "EXIT_NOTHING_MEASURABLE",
+    "EXIT_UNREACHABLE",
+    "HEALTH_PATH",
+    "REPORT_FILENAME",
+    "TRANSPORT_NONE",
+    "TRANSPORT_SSH",
+    "HostReachability",
+    "ReachabilityReport",
+    "Target",
+    "default_report_path",
+    "exit_code_for",
+    "probe_target",
+    "probe_targets",
+    "read_report",
+    "resolve_targets",
+    "write_report",
+]
+
+#: The route probed on the peer's listen. Public (no bearer needed to answer),
+#: which is why a 200 here proves the TRANSPORT and not the bearer's validity.
+HEALTH_PATH = "/v1/health"
+
+#: The value the listen's health body carries; anything else answering 200 on
+#: the port is not the daemon the forwarder needs.
+_EXPECTED_SERVICE = "sac-listen"
+
+#: ``transport`` values. ``ssh`` = the probe ran (or was refused only for a
+#: missing token) over the forwarder's ssh leg; ``none`` = there is no leg to
+#: run — no alias, or the host is this machine.
+TRANSPORT_SSH = "ssh"
+TRANSPORT_NONE = "none"
+
+#: Exit codes. Documented in the verb's help; 2 is deliberately NOT used, it
+#: stays Click's usage-error code and carries no domain meaning here.
+EXIT_ALL_REACHABLE = 0
+EXIT_UNREACHABLE = 1
+EXIT_NOTHING_MEASURABLE = 3
+
+#: Where ``--record`` lands the report, relative to sac's runtime root.
+REPORT_FILENAME = "a2a-reachability.json"
+
+#: Why this machine's own row is UNKNOWN: there is no leg to probe.
+LOCAL_HOST_REASON = (
+    "this host — the forwarder never ssh-es to itself, so there is nothing to probe"
+)
+
+
+@dataclass(frozen=True)
+class HostReachability:
+    """One host's verdict. The fixed answer shape ``--json`` emits per host.
+
+    ``reachable`` is three-valued (see the module docstring); ``elapsed_ms``
+    is ``None`` whenever nothing was dispatched; ``error`` is ``None`` only
+    for ``reachable=True`` and otherwise names what stopped the probe, with
+    the file or value to fix when there is one.
+    """
+
+    host: str
+    ssh_alias: str | None
+    transport: str
+    reachable: bool | None
+    elapsed_ms: int | None
+    error: str | None
+
+    def __post_init__(self) -> None:
+        if self.transport not in (TRANSPORT_SSH, TRANSPORT_NONE):
+            raise ValueError(
+                f"HostReachability({self.host!r}).transport must be "
+                f"{TRANSPORT_SSH!r} or {TRANSPORT_NONE!r}, got {self.transport!r}"
+            )
+        if self.reachable is not None and not isinstance(self.reachable, bool):
+            raise ValueError(
+                f"HostReachability({self.host!r}).reachable must be True, False "
+                f"or None, got {self.reachable!r}"
+            )
+        if self.transport == TRANSPORT_NONE and self.reachable is not None:
+            raise ValueError(
+                f"HostReachability({self.host!r}): transport 'none' cannot carry "
+                f"a measured verdict ({self.reachable!r}) — nothing was dispatched"
+            )
+        if self.reachable is None and not self.error:
+            raise ValueError(
+                f"HostReachability({self.host!r}): an UNKNOWN row must say why"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "host": self.host,
+            "ssh_alias": self.ssh_alias,
+            "transport": self.transport,
+            "reachable": self.reachable,
+            "elapsed_ms": self.elapsed_ms,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "HostReachability":
+        return cls(
+            host=str(raw["host"]),
+            ssh_alias=raw.get("ssh_alias"),
+            transport=str(raw["transport"]),
+            reachable=raw.get("reachable"),
+            elapsed_ms=raw.get("elapsed_ms"),
+            error=raw.get("error"),
+        )
+
+
+def exit_code_for(rows: Iterable[HostReachability]) -> int:
+    """Map a pass's rows onto the three documented exit codes.
+
+    * :data:`EXIT_UNREACHABLE` (1) — at least one host measured ``False``.
+    * :data:`EXIT_NOTHING_MEASURABLE` (3) — no host measured anything: every
+      row is UNKNOWN, or there are no rows. This is NOT success; a pass
+      that could not look must not read as a pass that looked and found
+      nothing wrong.
+    * :data:`EXIT_ALL_REACHABLE` (0) — every MEASURED host is ``True``.
+      UNKNOWN rows alongside measured ones do not turn 0 into 3: the
+      measured hosts are still a real answer, and the unknown ones are
+      listed by name in the report.
+    """
+    measured = [row.reachable for row in rows if row.reachable is not None]
+    if not measured:
+        return EXIT_NOTHING_MEASURABLE
+    if any(value is False for value in measured):
+        return EXIT_UNREACHABLE
+    return EXIT_ALL_REACHABLE
+
+
+@dataclass(frozen=True)
+class ReachabilityReport:
+    """The whole pass: every row plus where and when it was taken from."""
+
+    probed_from: str
+    port: int
+    started_at_utc: str
+    elapsed_ms: int
+    rows: tuple[HostReachability, ...]
+
+    @property
+    def exit_code(self) -> int:
+        return exit_code_for(self.rows)
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "hosts": len(self.rows),
+            "reachable": sum(1 for r in self.rows if r.reachable is True),
+            "unreachable": sum(1 for r in self.rows if r.reachable is False),
+            "unknown": sum(1 for r in self.rows if r.reachable is None),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "probed_from": self.probed_from,
+            "port": self.port,
+            "started_at_utc": self.started_at_utc,
+            "elapsed_ms": self.elapsed_ms,
+            "exit_code": self.exit_code,
+            "counts": self.counts(),
+            "hosts": [row.to_dict() for row in self.rows],
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "ReachabilityReport":
+        return cls(
+            probed_from=str(raw["probed_from"]),
+            port=int(raw["port"]),
+            started_at_utc=str(raw["started_at_utc"]),
+            elapsed_ms=int(raw["elapsed_ms"]),
+            rows=tuple(HostReachability.from_dict(r) for r in raw.get("hosts", [])),
+        )
+
+
+@dataclass(frozen=True)
+class Target:
+    """A host to probe, resolved but not yet dispatched to."""
+
+    host: str
+    ssh_alias: str | None
+    local: bool
+
+
+def resolve_targets(
+    *,
+    peers: Mapping[str, "PeerSpec"],
+    local_names: Iterable[str],
+    only: Iterable[str] | None = None,
+) -> list[Target]:
+    """Every host the fleet knows, with the alias the forwarder would use.
+
+    The alias comes from :func:`.._state._peer_resolve.peers_with_registry`
+    — config.yaml ``peers:`` first, the scitex-dev host registry filling
+    the gaps — which is the SSoT the CLI verbs already route by. Registry
+    rows that declare NO ``ssh_alias`` are still listed (alias ``None``) so
+    they surface as UNKNOWN rather than silently vanishing from the report;
+    glob peers (``spartan-*``) are templates, not hosts, and are skipped.
+
+    ``only`` restricts the answer to those names and FAILS LOUDLY on a name
+    nothing declares — a typo that probed nothing and exited 3 would read
+    as "the fleet is unknown" instead of "you misspelled a host".
+    """
+    merged = peers_with_registry(dict(peers))
+    aliases: dict[str, str | None] = {}
+    for name, spec in merged.items():
+        if any(ch in name for ch in "*?["):
+            continue
+        aliases[name] = spec.ssh or None
+    for row in registry_hosts():
+        aliases.setdefault(row.name, row.ssh_alias or None)
+
+    lower_local = {n.lower() for n in local_names if n}
+    if only is not None:
+        wanted = list(dict.fromkeys(only))
+        missing = [name for name in wanted if name not in aliases]
+        if missing:
+            raise KeyError(
+                f"unknown host(s) {missing}; known: "
+                + (", ".join(sorted(aliases)) or "(none)")
+            )
+        names = wanted
+    else:
+        names = sorted(aliases)
+    return [
+        Target(host=name, ssh_alias=aliases[name], local=name.lower() in lower_local)
+        for name in names
+    ]
+
+
+def _unknown(target: Target, *, transport: str, error: str) -> HostReachability:
+    return HostReachability(
+        host=target.host,
+        ssh_alias=target.ssh_alias,
+        transport=transport,
+        reachable=None,
+        elapsed_ms=None,
+        error=error,
+    )
+
+
+def probe_target(
+    target: Target,
+    *,
+    port: int = DEFAULT_LISTEN_PORT,
+    timeout_s: float = 10.0,
+    tokens_dir: Path | None = None,
+) -> HostReachability:
+    """Probe ONE host over the forwarder's transport. Never raises.
+
+    The order of refusals is the forwarder's own: no alias → no leg; no
+    peer token → the forwarder would refuse before dispatching; then the
+    ssh+curl leg itself. Each refusal is UNKNOWN with the file to fix
+    named; only a dispatched leg can yield ``True`` or ``False``.
+    """
+    if target.local:
+        return _unknown(target, transport=TRANSPORT_NONE, error=LOCAL_HOST_REASON)
+    if not target.ssh_alias:
+        return _unknown(
+            target,
+            transport=TRANSPORT_NONE,
+            error=(
+                f"no ssh alias for {target.host!r}: not in config.yaml peers and "
+                "the host registry (hosts.yaml) declares ssh_alias: null — "
+                "inbound ssh is not possible, so the forwarder cannot reach it "
+                "either. Add `ssh_alias` to its hosts.yaml row or a peers: "
+                "entry in config.yaml if it is reachable."
+            ),
+        )
+    try:
+        bearer = read_peer_token(peer_host=target.host, tokens_dir=tokens_dir)
+    except PeerTokenError as exc:
+        # The forwarder refuses a send with exactly this message (502), so a
+        # missing token is a real gap — but it is UNKNOWN, not False: the
+        # transport was never exercised.
+        return _unknown(target, transport=TRANSPORT_SSH, error=str(exc))
+
+    started = time.monotonic()
+    try:
+        rc, stdout, stderr = _get_via_ssh_curl(
+            host=target.ssh_alias,
+            port=port,
+            path=HEALTH_PATH,
+            bearer=bearer,
+            timeout_s=timeout_s,
+        )
+    except ValueError as exc:
+        return _unknown(target, transport=TRANSPORT_SSH, error=str(exc))
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+
+    def measured(ok: bool, error: str | None) -> HostReachability:
+        return HostReachability(
+            host=target.host,
+            ssh_alias=target.ssh_alias,
+            transport=TRANSPORT_SSH,
+            reachable=ok,
+            elapsed_ms=elapsed_ms,
+            error=error,
+        )
+
+    where = f"ssh://{target.ssh_alias} (→127.0.0.1:{port}{HEALTH_PATH})"
+    if rc != 0:
+        tail = stderr.decode("utf-8", errors="replace").strip()[-300:]
+        return measured(False, f"{where} failed (rc={rc}): {tail or '(no stderr)'}")
+    status, body = split_status_line(stdout)
+    if status is None:
+        return measured(
+            False,
+            f"{where}: curl printed no status line — stdout was "
+            f"{body[:200]!r}; the remote shell did not run the probe as sent",
+        )
+    if status != 200:
+        return measured(False, f"{where} answered HTTP {status}: {body[:200]}")
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        payload = None
+    service = payload.get("service") if isinstance(payload, dict) else None
+    if service != _EXPECTED_SERVICE:
+        return measured(
+            False,
+            f"{where} answered 200 but not from {_EXPECTED_SERVICE}: {body[:200]!r}",
+        )
+    return measured(True, None)
+
+
+def probe_targets(
+    targets: Iterable[Target],
+    *,
+    port: int = DEFAULT_LISTEN_PORT,
+    timeout_s: float = 10.0,
+    tokens_dir: Path | None = None,
+    max_workers: int = 8,
+) -> list[HostReachability]:
+    """Probe every target, in parallel, returning rows in target order.
+
+    Parallel because the worst case is additive otherwise: an unreachable
+    peer waits its ssh ``ConnectTimeout`` plus curl's ``--max-time``, and
+    eight of those in series would outrun the scheduled job's own bound.
+    """
+    items = list(targets)
+    if not items:
+        return []
+    workers = max(1, min(max_workers, len(items)))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        return list(
+            pool.map(
+                lambda t: probe_target(
+                    t, port=port, timeout_s=timeout_s, tokens_dir=tokens_dir
+                ),
+                items,
+            )
+        )
+
+
+def run_probe(
+    *,
+    peers: Mapping[str, "PeerSpec"],
+    local_names: Iterable[str],
+    probed_from: str,
+    only: Iterable[str] | None = None,
+    port: int = DEFAULT_LISTEN_PORT,
+    timeout_s: float = 10.0,
+    tokens_dir: Path | None = None,
+) -> ReachabilityReport:
+    """Resolve, probe, and assemble one :class:`ReachabilityReport`."""
+    started_at = datetime.now(tz=timezone.utc)
+    t0 = time.monotonic()
+    targets = resolve_targets(peers=peers, local_names=local_names, only=only)
+    rows = probe_targets(targets, port=port, timeout_s=timeout_s, tokens_dir=tokens_dir)
+    return ReachabilityReport(
+        probed_from=probed_from,
+        port=port,
+        started_at_utc=started_at.isoformat(),
+        elapsed_ms=int((time.monotonic() - t0) * 1000),
+        rows=tuple(rows),
+    )
+
+
+def default_report_path() -> Path:
+    """``runtime_root()/a2a-reachability.json`` — resolved per call."""
+    from .._state.state_paths import runtime_root
+
+    return runtime_root() / REPORT_FILENAME
+
+
+def write_report(report: ReachabilityReport, *, path: Path | None = None) -> Path:
+    """Persist ``report`` atomically (tmp + rename). Raises on failure.
+
+    Deliberately NOT fail-open: ``--record`` is the scheduled job's whole
+    reason to run, and a report that silently did not land would leave the
+    consumer reading a stale one that says the fleet was fine.
+    """
+    target = Path(path) if path is not None else default_report_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(target.name + ".tmp")
+    tmp.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+    tmp.replace(target)
+    return target
+
+
+def read_report(*, path: Path | None = None) -> ReachabilityReport | None:
+    """The last recorded report, or ``None`` when none has been recorded.
+
+    A file that exists but does not parse raises — a corrupt record is not
+    "no record", and pretending otherwise would hide a broken writer.
+    """
+    target = Path(path) if path is not None else default_report_path()
+    if not target.is_file():
+        return None
+    raw = json.loads(target.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{target} does not hold a reachability report object")
+    return ReachabilityReport.from_dict(raw)

--- a/src/scitex_agent_container/_network/_reachability_alarm.py
+++ b/src/scitex_agent_container/_network/_reachability_alarm.py
@@ -1,4 +1,4 @@
-"""Record ``sac a2a reachability`` verdicts in sac's own event log.
+"""Record ``sac a2a reachability`` TRANSITIONS in sac's own event log.
 
 The probe (:mod:`._reachability`) answers, per peer, whether the cross-host
 forwarder's transport works from this host. An answer that only sets an exit
@@ -10,16 +10,42 @@ DURABLE on the rail every other unattended pass already records to —
 (:mod:`.._hostsync._alarm`) write — under its own ``subsystem`` axis so a
 reader filtering the log sees the three passes as three passes.
 
+TRANSITIONS, NOT A HEARTBEAT PER HOST (review round 2 of PR #1285)
+    The shared rail re-records a DEGRADED or UNKNOWN subject on EVERY pass,
+    by design: for a pass whose only durable output is the log, a subject
+    mentioned once and then never again cannot be told from a pass that
+    died. This pass has TWO other durable outputs that settle that question
+    — the ``--record`` report file (the full per-pass picture, every host,
+    every pass; ``sac a2a reachability --last`` reads it) and the
+    PASS_COMPLETED record written every pass with the counts. So here a
+    host is recorded only when its state DIFFERS from the last state this
+    module recorded for it, plus once at first observation. Measured on
+    compute-04 before this: ten ``subject-unknown`` records every fifteen
+    minutes, forever, for ten peers whose only fact was "no token yet".
+
+    The memory is a small JSON map beside the event log
+    (:func:`last_state_path`), in the same posture as the rail's own
+    degraded set: an OPTIMISATION OF THE RECORD, never an input to a
+    decision. Losing it re-records every bad host once and costs nothing
+    else.
+
 Three-state honest, exactly as the probe is:
 
 * ``reachable=False`` → a DEGRADED record naming the peer and the leg that
-  failed. Re-recorded every pass while it stands.
-* ``reachable=None`` → an UNKNOWN record. "I could not probe" is never
-  rendered as "it was fine". The one exception is THIS host's own row: it
-  is unknown because there is no leg to probe, not because sac failed to
-  look, and re-recording that every 15 minutes forever would say nothing.
+  failed, on the pass it first fails and on every CHANGE thereafter.
+* ``reachable=None`` → an UNKNOWN record, likewise. "I could not probe" is
+  never rendered as "it was fine".
 * ``reachable=True`` → a RECOVERED record, if and only if this peer was
-  previously recorded as degraded — the transition, not a heartbeat.
+  previously recorded as degraded or unknown — the transition. A host that
+  has been reachable since first sight writes nothing per host; the
+  PASS_COMPLETED counts are its evidence.
+
+THIS host's own row is skipped by the ``local`` flag the probe carried into
+the row — the SAME decision :func:`._reachability.resolve_targets` made —
+never by comparing the row's name to ``probed_from``. Those two spellings
+can differ (``canonical_host()`` may say ``DXP480TPLUS-994`` where the
+registry says ``scitex-nas-03``), and a name comparison recorded the self
+row as unknown every pass on such a host.
 
 Recording is a SIDE rail: a write failure is printed loudly by the log rail
 itself and never crashes the probe that feeds it.
@@ -27,6 +53,8 @@ itself and never crashes the probe that feeds it.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 from .._events import (
@@ -36,14 +64,82 @@ from .._events import (
     emit_subject_verdicts,
     log_pass_completed,
 )
-from ._reachability import HostReachability, ReachabilityReport
+from .._events._log import event_log_path
+from .._events._verdicts import _warn
+from ._reachability_report import HostReachability, ReachabilityReport
 
-__all__ = ["SUBSYSTEM", "record_pass_completed", "record_report"]
+__all__ = [
+    "SUBSYSTEM",
+    "last_state_path",
+    "record_pass_completed",
+    "record_report",
+]
 
 #: The pass this module speaks for — the axis a reader filters the log on.
 SUBSYSTEM = "a2a-reachability"
 
 _SUBJECT_KIND = "host"
+
+
+def last_state_path(*, path: Path | None = None) -> Path:
+    """Where the last RECORDED state per host is remembered.
+
+    Beside the event log — like the rail's own ``-degraded.json`` — so
+    redirecting the log (a test, an operator's host) carries the memory
+    with it. Its own file rather than the rail's set because the rail
+    remembers only "bad or not", and unknown→degraded is a transition worth
+    a record.
+    """
+    base = Path(path) if path is not None else event_log_path()
+    return base.parent / f"sac-events-{SUBSYSTEM}-last-state.json"
+
+
+def _load_last(target: Path, *, err_stream: Any) -> dict[str, str]:
+    """The remembered host→state map. A MISSING file is a normal empty start.
+
+    A file that exists but cannot be read is NOT normal, and says so loudly:
+    every host will be re-recorded once as newly observed.
+    """
+    if not target.exists():
+        return {}
+    # stx-allow: fallback (reason: a corrupt memory file must degrade to
+    # "remember nothing" rather than crash the pass — the cost is one
+    # duplicated record per host, reported loudly right here.)
+    try:
+        loaded = json.loads(target.read_text(encoding="utf-8"))
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        _warn(
+            f"could not read {target} — {exc}. Every host will be recorded "
+            f"again as newly observed.",
+            err_stream=err_stream,
+        )
+        return {}
+    if not isinstance(loaded, dict):
+        _warn(
+            f"{target} is not a host→state map — ignoring it. Every host will "
+            f"be recorded again as newly observed.",
+            err_stream=err_stream,
+        )
+        return {}
+    return {str(k): str(v) for k, v in loaded.items()}
+
+
+def _save_last(target: Path, states: dict[str, str], *, err_stream: Any) -> None:
+    """Persist the memory atomically (tmp + rename). Never raises."""
+    # stx-allow: fallback (reason: this file is an optimisation of the RECORD,
+    # never an input to a fleet decision — failing to persist it can only
+    # cause a duplicate record next pass, so it must not crash the pass.)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_name(target.name + ".tmp")
+        tmp.write_text(json.dumps(states, indent=2, sort_keys=True), encoding="utf-8")
+        tmp.replace(target)
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        _warn(
+            f"could not persist {target} — {exc}. Hosts recorded this pass may "
+            f"be recorded again next pass.",
+            err_stream=err_stream,
+        )
 
 
 def _facts(row: HostReachability) -> dict[str, Any]:
@@ -62,8 +158,7 @@ def _verdict_for(row: HostReachability) -> SubjectVerdict:
             state=SubjectState.DEGRADED,
             verdict="unreachable",
             detail=(
-                f"cross-host a2a to {row.host} is DOWN from this host — "
-                f"{row.error}"
+                f"cross-host a2a to {row.host} is DOWN from this host — {row.error}"
             ),
             subject_kind=_SUBJECT_KIND,
             extra=_facts(row),
@@ -100,20 +195,42 @@ def record_report(
     now: float | None = None,
     err_stream: Any = None,
 ) -> EmitOutcome:
-    """Record one event per peer in ``report``. Never raises.
+    """Record one event per peer whose state CHANGED since last recorded.
 
-    This host's own row (``report.probed_from``) is skipped — see the
-    module docstring. ``path`` / ``now`` / ``err_stream`` are the test
-    seams the shared routing exposes: a real temp log, a fixed clock, a
-    replacement stderr.
+    Never raises. This host's own row (``row.local``) is skipped — see the
+    module docstring. A host is offered to the shared rail only when its
+    state differs from the one remembered for it (or nothing is remembered);
+    the rail then applies its own rule (DEGRADED / UNKNOWN written, HEALTHY
+    written as RECOVERED only after a remembered bad state). The memory is
+    advanced for every host the pass saw except those whose record failed to
+    land, so an unwritten transition is retried next pass rather than lost.
+
+    ``path`` / ``now`` / ``err_stream`` are the test seams the shared routing
+    exposes: a real temp log, a fixed clock, a replacement stderr.
     """
-    local = report.probed_from.lower()
-    verdicts = [
-        _verdict_for(row) for row in report.rows if row.host.lower() != local
-    ]
-    return emit_subject_verdicts(
+    memory = last_state_path(path=path)
+    last = _load_last(memory, err_stream=err_stream)
+
+    seen: dict[str, str] = {}
+    verdicts: list[SubjectVerdict] = []
+    for row in report.rows:
+        if row.local:
+            continue
+        verdict = _verdict_for(row)
+        seen[row.host] = verdict.state.value
+        if last.get(row.host) == verdict.state.value:
+            continue  # unchanged — the --record report carries this pass
+        verdicts.append(verdict)
+
+    outcome = emit_subject_verdicts(
         SUBSYSTEM, verdicts, path=path, now=now, err_stream=err_stream
     )
+    for host, state in seen.items():
+        if host in outcome.failed:
+            continue
+        last[host] = state
+    _save_last(memory, last, err_stream=err_stream)
+    return outcome
 
 
 def record_pass_completed(
@@ -128,9 +245,11 @@ def record_pass_completed(
 
     Written on EVERY pass, above all on one where every peer was reachable:
     "all reachable" is the record that distinguishes a healthy fleet from a
-    probe that stopped running. ``mode`` is ``"all"`` for the scheduled
-    fleet-wide sweep and ``"subset"`` for a hand-run ``--host`` probe, so a
-    reader does not mistake a partial by-hand run for the timer being alive.
+    probe that stopped running — and, now that per-host records are
+    transitions only, it is the per-pass liveness signal for this rail.
+    ``mode`` is ``"all"`` for the scheduled fleet-wide sweep and
+    ``"subset"`` for a hand-run ``--host`` probe, so a reader does not
+    mistake a partial by-hand run for the timer being alive.
     """
     return log_pass_completed(
         subsystem=SUBSYSTEM,

--- a/src/scitex_agent_container/_network/_reachability_alarm.py
+++ b/src/scitex_agent_container/_network/_reachability_alarm.py
@@ -1,0 +1,146 @@
+"""Record ``sac a2a reachability`` verdicts in sac's own event log.
+
+The probe (:mod:`._reachability`) answers, per peer, whether the cross-host
+forwarder's transport works from this host. An answer that only sets an exit
+code is an alarm nobody hears: the scheduled run's status lands in the
+supervisor's execution log and nothing else. This module makes each verdict
+DURABLE on the rail every other unattended pass already records to —
+:mod:`.._events`, the same append-only ``sac-events.jsonl`` that
+``fleet-reconcile`` (:mod:`.._reconcile._alarm`) and ``host-sync-check``
+(:mod:`.._hostsync._alarm`) write — under its own ``subsystem`` axis so a
+reader filtering the log sees the three passes as three passes.
+
+Three-state honest, exactly as the probe is:
+
+* ``reachable=False`` → a DEGRADED record naming the peer and the leg that
+  failed. Re-recorded every pass while it stands.
+* ``reachable=None`` → an UNKNOWN record. "I could not probe" is never
+  rendered as "it was fine". The one exception is THIS host's own row: it
+  is unknown because there is no leg to probe, not because sac failed to
+  look, and re-recording that every 15 minutes forever would say nothing.
+* ``reachable=True`` → a RECOVERED record, if and only if this peer was
+  previously recorded as degraded — the transition, not a heartbeat.
+
+Recording is a SIDE rail: a write failure is printed loudly by the log rail
+itself and never crashes the probe that feeds it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .._events import (
+    EmitOutcome,
+    SubjectState,
+    SubjectVerdict,
+    emit_subject_verdicts,
+    log_pass_completed,
+)
+from ._reachability import HostReachability, ReachabilityReport
+
+__all__ = ["SUBSYSTEM", "record_pass_completed", "record_report"]
+
+#: The pass this module speaks for — the axis a reader filters the log on.
+SUBSYSTEM = "a2a-reachability"
+
+_SUBJECT_KIND = "host"
+
+
+def _facts(row: HostReachability) -> dict[str, Any]:
+    """The structured facts, as fields — queryable, unlike a sentence."""
+    return {
+        "ssh_alias": row.ssh_alias,
+        "transport": row.transport,
+        "elapsed_ms": row.elapsed_ms,
+    }
+
+
+def _verdict_for(row: HostReachability) -> SubjectVerdict:
+    if row.reachable is False:
+        return SubjectVerdict(
+            subject=row.host,
+            state=SubjectState.DEGRADED,
+            verdict="unreachable",
+            detail=(
+                f"cross-host a2a to {row.host} is DOWN from this host — "
+                f"{row.error}"
+            ),
+            subject_kind=_SUBJECT_KIND,
+            extra=_facts(row),
+        )
+    if row.reachable is None:
+        return SubjectVerdict(
+            subject=row.host,
+            state=SubjectState.UNKNOWN,
+            verdict="unknown",
+            detail=(
+                f"cross-host a2a to {row.host} could not be probed — "
+                f"{row.error}; its reachability is unobserved, not absent"
+            ),
+            subject_kind=_SUBJECT_KIND,
+            extra=_facts(row),
+        )
+    return SubjectVerdict(
+        subject=row.host,
+        state=SubjectState.HEALTHY,
+        verdict="reachable",
+        detail=(
+            f"cross-host a2a to {row.host} is up from this host "
+            f"({row.elapsed_ms} ms over ssh://{row.ssh_alias})"
+        ),
+        subject_kind=_SUBJECT_KIND,
+        extra=_facts(row),
+    )
+
+
+def record_report(
+    report: ReachabilityReport,
+    *,
+    path: Any = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> EmitOutcome:
+    """Record one event per peer in ``report``. Never raises.
+
+    This host's own row (``report.probed_from``) is skipped — see the
+    module docstring. ``path`` / ``now`` / ``err_stream`` are the test
+    seams the shared routing exposes: a real temp log, a fixed clock, a
+    replacement stderr.
+    """
+    local = report.probed_from.lower()
+    verdicts = [
+        _verdict_for(row) for row in report.rows if row.host.lower() != local
+    ]
+    return emit_subject_verdicts(
+        SUBSYSTEM, verdicts, path=path, now=now, err_stream=err_stream
+    )
+
+
+def record_pass_completed(
+    report: ReachabilityReport,
+    *,
+    mode: str,
+    path: Any = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> bool:
+    """Record that a reachability pass RAN. Returns did-write; never raises.
+
+    Written on EVERY pass, above all on one where every peer was reachable:
+    "all reachable" is the record that distinguishes a healthy fleet from a
+    probe that stopped running. ``mode`` is ``"all"`` for the scheduled
+    fleet-wide sweep and ``"subset"`` for a hand-run ``--host`` probe, so a
+    reader does not mistake a partial by-hand run for the timer being alive.
+    """
+    return log_pass_completed(
+        subsystem=SUBSYSTEM,
+        mode=mode,
+        counts=report.counts(),
+        detail=(
+            f"a2a-reachability {mode} pass completed on {report.probed_from} "
+            f"(exit {report.exit_code})"
+        ),
+        path=path,
+        now=now,
+        err_stream=err_stream,
+    )

--- a/src/scitex_agent_container/_network/_reachability_report.py
+++ b/src/scitex_agent_container/_network/_reachability_report.py
@@ -1,0 +1,238 @@
+"""The ANSWER SHAPE of ``sac a2a reachability`` — rows, report, exit codes, file.
+
+Split out of :mod:`._reachability` (the probe) so the shape a consumer parses
+is one module and the leg that produces it is another. Everything here is
+re-exported from :mod:`._reachability`, so ``from ._reachability import
+HostReachability`` keeps resolving.
+
+THREE VALUES, NEVER TWO
+    :attr:`HostReachability.reachable` is ``True`` / ``False`` / ``None``.
+    ``None`` is UNKNOWN — the probe could not be run at all — and it is NEVER
+    counted as reachable and NEVER as unreachable. A pass in which every host
+    is unknown measured nothing, and :func:`exit_code_for` says so with its
+    own code (:data:`EXIT_NOTHING_MEASURABLE`) rather than 0.
+
+THE ``local`` FLAG
+    Exactly one row per pass is THIS machine, and which one is decided ONCE,
+    at resolution (:func:`._reachability.resolve_targets`, against the
+    caller's ``local_names``). The decision is carried here as
+    :attr:`HostReachability.local` so every consumer — the alarm above all —
+    skips the self row by the same decision instead of re-deriving it from
+    a host name that may be spelled differently (``DXP480TPLUS-994`` is
+    ``scitex-nas-03``; ``canonical_host()`` may say either).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+__all__ = [
+    "EXIT_ALL_REACHABLE",
+    "EXIT_NOTHING_MEASURABLE",
+    "EXIT_UNREACHABLE",
+    "REPORT_FILENAME",
+    "TRANSPORT_NONE",
+    "TRANSPORT_SSH",
+    "HostReachability",
+    "ReachabilityReport",
+    "default_report_path",
+    "exit_code_for",
+    "read_report",
+    "write_report",
+]
+
+#: ``transport`` values. ``ssh`` = the probe ran (or was refused only for a
+#: missing token) over the forwarder's ssh leg; ``none`` = there is no leg to
+#: run — no alias, or the host is this machine.
+TRANSPORT_SSH = "ssh"
+TRANSPORT_NONE = "none"
+
+#: Exit codes. Documented in the verb's help; 2 is deliberately NOT used, it
+#: stays Click's usage-error code and carries no domain meaning here.
+EXIT_ALL_REACHABLE = 0
+EXIT_UNREACHABLE = 1
+EXIT_NOTHING_MEASURABLE = 3
+
+#: Where ``--record`` lands the report, relative to sac's runtime root.
+REPORT_FILENAME = "a2a-reachability.json"
+
+
+@dataclass(frozen=True)
+class HostReachability:
+    """One host's verdict. The fixed answer shape ``--json`` emits per host.
+
+    ``reachable`` is three-valued (see the module docstring); ``elapsed_ms``
+    is ``None`` whenever nothing was dispatched; ``error`` is ``None`` only
+    for ``reachable=True`` and otherwise names what stopped the probe, with
+    the file or value to fix when there is one. ``local`` is True for the
+    one row that is THIS machine — decided once, at resolution, and carried
+    here so no consumer re-derives it from the host's spelling.
+    """
+
+    host: str
+    ssh_alias: str | None
+    transport: str
+    reachable: bool | None
+    elapsed_ms: int | None
+    error: str | None
+    local: bool = False
+
+    def __post_init__(self) -> None:
+        if self.transport not in (TRANSPORT_SSH, TRANSPORT_NONE):
+            raise ValueError(
+                f"HostReachability({self.host!r}).transport must be "
+                f"{TRANSPORT_SSH!r} or {TRANSPORT_NONE!r}, got {self.transport!r}"
+            )
+        if self.reachable is not None and not isinstance(self.reachable, bool):
+            raise ValueError(
+                f"HostReachability({self.host!r}).reachable must be True, False "
+                f"or None, got {self.reachable!r}"
+            )
+        if self.transport == TRANSPORT_NONE and self.reachable is not None:
+            raise ValueError(
+                f"HostReachability({self.host!r}): transport 'none' cannot carry "
+                f"a measured verdict ({self.reachable!r}) — nothing was dispatched"
+            )
+        if self.reachable is None and not self.error:
+            raise ValueError(
+                f"HostReachability({self.host!r}): an UNKNOWN row must say why"
+            )
+        if self.local and self.transport != TRANSPORT_NONE:
+            raise ValueError(
+                f"HostReachability({self.host!r}): this host has no leg to probe, "
+                f"so a local row cannot carry transport {self.transport!r}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "host": self.host,
+            "ssh_alias": self.ssh_alias,
+            "transport": self.transport,
+            "reachable": self.reachable,
+            "elapsed_ms": self.elapsed_ms,
+            "error": self.error,
+            "local": self.local,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "HostReachability":
+        return cls(
+            host=str(raw["host"]),
+            ssh_alias=raw.get("ssh_alias"),
+            transport=str(raw["transport"]),
+            reachable=raw.get("reachable"),
+            elapsed_ms=raw.get("elapsed_ms"),
+            error=raw.get("error"),
+            local=bool(raw.get("local", False)),
+        )
+
+
+def exit_code_for(rows: Iterable[HostReachability]) -> int:
+    """Map a pass's rows onto the three documented exit codes.
+
+    * :data:`EXIT_UNREACHABLE` (1) — at least one host measured ``False``.
+    * :data:`EXIT_NOTHING_MEASURABLE` (3) — no host measured anything: every
+      row is UNKNOWN, or there are no rows. This is NOT success; a pass
+      that could not look must not read as a pass that looked and found
+      nothing wrong.
+    * :data:`EXIT_ALL_REACHABLE` (0) — every MEASURED host is ``True``.
+      UNKNOWN rows alongside measured ones do not turn 0 into 3: the
+      measured hosts are still a real answer, and the unknown ones are
+      listed by name in the report.
+    """
+    measured = [row.reachable for row in rows if row.reachable is not None]
+    if not measured:
+        return EXIT_NOTHING_MEASURABLE
+    if any(value is False for value in measured):
+        return EXIT_UNREACHABLE
+    return EXIT_ALL_REACHABLE
+
+
+@dataclass(frozen=True)
+class ReachabilityReport:
+    """The whole pass: every row plus where and when it was taken from.
+
+    This is what ``--record`` persists and ``--last`` reads back: the FULL
+    per-pass picture, every host every pass. The event log deliberately does
+    not carry that (it records transitions — see :mod:`._reachability_alarm`),
+    so "what did the last pass see?" is answered here, not there.
+    """
+
+    probed_from: str
+    port: int
+    started_at_utc: str
+    elapsed_ms: int
+    rows: tuple[HostReachability, ...]
+
+    @property
+    def exit_code(self) -> int:
+        return exit_code_for(self.rows)
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "hosts": len(self.rows),
+            "reachable": sum(1 for r in self.rows if r.reachable is True),
+            "unreachable": sum(1 for r in self.rows if r.reachable is False),
+            "unknown": sum(1 for r in self.rows if r.reachable is None),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "probed_from": self.probed_from,
+            "port": self.port,
+            "started_at_utc": self.started_at_utc,
+            "elapsed_ms": self.elapsed_ms,
+            "exit_code": self.exit_code,
+            "counts": self.counts(),
+            "hosts": [row.to_dict() for row in self.rows],
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "ReachabilityReport":
+        return cls(
+            probed_from=str(raw["probed_from"]),
+            port=int(raw["port"]),
+            started_at_utc=str(raw["started_at_utc"]),
+            elapsed_ms=int(raw["elapsed_ms"]),
+            rows=tuple(HostReachability.from_dict(r) for r in raw.get("hosts", [])),
+        )
+
+
+def default_report_path() -> Path:
+    """``runtime_root()/a2a-reachability.json`` — resolved per call."""
+    from .._state.state_paths import runtime_root
+
+    return runtime_root() / REPORT_FILENAME
+
+
+def write_report(report: ReachabilityReport, *, path: Path | None = None) -> Path:
+    """Persist ``report`` atomically (tmp + rename). Raises on failure.
+
+    Deliberately NOT fail-open: ``--record`` is the scheduled job's whole
+    reason to run, and a report that silently did not land would leave the
+    consumer reading a stale one that says the fleet was fine.
+    """
+    target = Path(path) if path is not None else default_report_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(target.name + ".tmp")
+    tmp.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+    tmp.replace(target)
+    return target
+
+
+def read_report(*, path: Path | None = None) -> ReachabilityReport | None:
+    """The last recorded report, or ``None`` when none has been recorded.
+
+    A file that exists but does not parse raises — a corrupt record is not
+    "no record", and pretending otherwise would hide a broken writer.
+    """
+    target = Path(path) if path is not None else default_report_path()
+    if not target.is_file():
+        return None
+    raw = json.loads(target.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{target} does not hold a reachability report object")
+    return ReachabilityReport.from_dict(raw)

--- a/src/scitex_agent_container/_network/_ssh_curl.py
+++ b/src/scitex_agent_container/_network/_ssh_curl.py
@@ -1,10 +1,13 @@
-"""Generic ``ssh + remote curl`` POST helper (ADR-0015 Stage 2).
+"""Generic ``ssh + remote curl`` helpers (ADR-0015 Stage 2): POST and GET.
 
 A single function that does what both the ``/v1/turn`` direct-ssh path
 and the cross-host ``message:send`` forwarder need: open an ssh
 connection (with ControlMaster reuse), invoke ``curl`` on the remote,
 pipe a JSON body into curl's stdin, and surface the curl exit + stdout
-+ stderr to the caller.
++ stderr to the caller. :func:`_get_via_ssh_curl` is its GET sibling —
+same ssh argv (:func:`_ssh_argv`), same bearer discipline — so the
+reachability probe (:mod:`._reachability`) can exercise the forwarder's
+transport rather than an ad-hoc look-alike of it.
 
 Why split this out of :mod:`peer`:
 
@@ -77,9 +80,20 @@ from __future__ import annotations
 import logging
 import subprocess
 
-__all__ = ["_post_via_ssh_curl"]
+__all__ = [
+    "STATUS_MARKER",
+    "_get_via_ssh_curl",
+    "_post_via_ssh_curl",
+    "split_status_line",
+]
 
 log = logging.getLogger(__name__)
+
+#: The line the GET snippet appends after the response body, carrying the
+#: HTTP status curl saw. A marker rather than a bare number because peer
+#: motd/rc noise on stdout can never be mistaken for a status — the same
+#: discipline :mod:`.._hostsync._push_tokens_io` uses for its probe.
+STATUS_MARKER = "SAC_SSH_CURL status="
 
 #: Characters a bearer may not contain, and why. ``\n``/``\r`` would break
 #: the stdin FRAMING (the token is the first line, the body is the rest), so
@@ -191,10 +205,23 @@ def _post_via_ssh_curl(
         )
         stdin_payload = bearer.encode("utf-8") + b"\n" + body
 
+    return _run_ssh(_ssh_argv(host, remote_curl), stdin_payload, timeout_s=timeout_s)
+
+
+def _ssh_argv(host: str, remote_command: str) -> list[str]:
+    """The ONE ssh argv both transports use — byte-identical by construction.
+
+    ``-o BatchMode=yes -o ConnectTimeout=15`` plus
+    :func:`scitex_agent_container._state.host_config.ssh_control_options`,
+    matching the ``/v1/turn`` direct-ssh path verbatim so the same
+    ControlMaster socket is reused by every leg. Shared between the POST
+    and the GET sibling so a probe of the cross-host transport exercises
+    exactly the argv the forwarder dispatches, not a look-alike.
+    """
     # Connection multiplexing — same options as the ``/v1/turn`` path.
     from .._state.host_config import ssh_control_options
 
-    ssh_cmd = [
+    return [
         "ssh",
         "-o",
         "BatchMode=yes",
@@ -202,9 +229,14 @@ def _post_via_ssh_curl(
         "ConnectTimeout=15",
         *ssh_control_options(),
         host,
-        remote_curl,
+        remote_command,
     ]
 
+
+def _run_ssh(
+    ssh_cmd: list[str], stdin_payload: bytes, *, timeout_s: float
+) -> tuple[int, bytes, bytes]:
+    """Run the ssh leg; ``(rc, stdout, stderr)``, rc=124 on a local timeout."""
     try:
         proc = subprocess.run(
             ssh_cmd,
@@ -222,3 +254,95 @@ def _post_via_ssh_curl(
         return (124, exc.stdout or b"", stderr)
 
     return (int(proc.returncode), proc.stdout or b"", proc.stderr or b"")
+
+
+def _remote_curl_get(*, port: int, path: str, timeout_s: float, bearer: bool) -> str:
+    """The remote snippet for a GET. Carries no token in either form.
+
+    With ``bearer=True`` the Authorization header comes from ``curl
+    --config -`` on stdin (the whole stdin stream IS the curl config,
+    there is no body to share it with — the shape
+    :func:`.._hostsync._push_tokens_io.probe_peer_listen_auth` established).
+    ``-w`` appends :data:`STATUS_MARKER` + the HTTP status on its own line
+    AFTER the response body, so the caller gets both the body and the
+    status without a second request.
+    """
+    auth = "--config - " if bearer else ""
+    return (
+        f"curl -sS --max-time {int(timeout_s)} {auth}"
+        f'-w "\\n{STATUS_MARKER}%{{http_code}}\\n" '
+        f"http://127.0.0.1:{port}{path}"
+    )
+
+
+def _get_via_ssh_curl(
+    *,
+    host: str,
+    port: int,
+    path: str,
+    bearer: str | None = None,
+    timeout_s: float = 15.0,
+) -> tuple[int, bytes, bytes]:
+    """ssh into ``host`` and GET ``127.0.0.1:port{path}``. The POST's sibling.
+
+    Same return contract as :func:`_post_via_ssh_curl` — ``(rc, stdout,
+    stderr)`` with rc the ssh process exit (124 on a local timeout) — and
+    the SAME ssh argv via :func:`_ssh_argv`, which is the point: a caller
+    probing whether the cross-host forwarder's transport works must
+    dispatch the argv the forwarder dispatches. ``stdout`` carries the
+    response body followed by a :data:`STATUS_MARKER` line; split it with
+    :func:`split_status_line`.
+
+    ``bearer`` never reaches an argv on either host: it rides stdin as a
+    curl config file (``header = "Authorization: Bearer <value>"``) and a
+    value containing ``"``, ``\\`` or a newline is refused rather than
+    sent mangled, exactly as the POST sibling refuses it.
+    """
+    if not host:
+        raise ValueError("_get_via_ssh_curl: host must be non-empty")
+    if not port or port <= 0:
+        raise ValueError(f"_get_via_ssh_curl: port must be positive (got {port!r})")
+    if not path or not path.startswith("/"):
+        raise ValueError(f"_get_via_ssh_curl: path must start with '/' (got {path!r})")
+
+    stdin_payload = b""
+    if bearer is not None:
+        bad = [ch for ch in _BEARER_FORBIDDEN if ch in bearer]
+        if bad:
+            raise ValueError(
+                "_get_via_ssh_curl: bearer must not contain "
+                + ", ".join(repr(ch) for ch in bad)
+                + " — the value is read into a curl config header on stdin, "
+                "and these characters would break the header parse. (The "
+                "value itself is withheld from this message.)"
+            )
+        stdin_payload = f'header = "Authorization: Bearer {bearer}"\n'.encode("utf-8")
+
+    remote_curl = _remote_curl_get(
+        port=port, path=path, timeout_s=timeout_s, bearer=bearer is not None
+    )
+    return _run_ssh(_ssh_argv(host, remote_curl), stdin_payload, timeout_s=timeout_s)
+
+
+def split_status_line(stdout: bytes) -> tuple[int | None, str]:
+    """``(http_status, body_text)`` from a :func:`_get_via_ssh_curl` stdout.
+
+    ``None`` for the status when no marker line is present — curl never
+    ran, or the remote shell printed something that was not curl's output.
+    That is an UNKNOWN answer the caller must keep distinct from a
+    non-2xx status, which is a measured one. Body is everything before
+    the marker, stripped of the trailing newline ``-w`` inserted.
+    """
+    text = stdout.decode("utf-8", errors="replace")
+    status: int | None = None
+    body_lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(STATUS_MARKER):
+            try:
+                status = int(stripped[len(STATUS_MARKER) :])
+            except ValueError:
+                status = None
+            continue
+        body_lines.append(line)
+    return status, "\n".join(body_lines).strip()

--- a/src/scitex_agent_container/cli_pkg/_a2a_acl_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/_a2a_acl_cmds.py
@@ -1,0 +1,258 @@
+"""``sac a2a {grant,unblock,block,revoke,grants}`` — the cross-group ACL verbs.
+
+Extracted from :mod:`.a2a_group` (over the per-file cap) and registered
+onto it by :func:`register`, the same way :mod:`._host_sync` attaches to
+``sac host``. Thin click wrappers over the cross-group ACL primitives in
+``_state.state_db_nodes`` (``grant_send`` / ``revoke_send`` /
+``list_comms_grants``). Operators previously had to drop into a Python
+REPL to amend the comms-grants table — a footgun (silently granting too
+much on wrong argument order). The CLI makes it auditable and validates
+the positional order at the Click layer.
+
+Imports happen inside the callbacks (not at module import) to keep the
+Click cold-start cheap: ``sac --help`` and tab-completion press should
+never load a database driver. The same lazy pattern used by
+``host_group`` / ``peer_group`` for state_db consumers.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+__all__ = [
+    "a2a_block",
+    "a2a_grant",
+    "a2a_grants",
+    "a2a_revoke",
+    "a2a_unblock",
+    "register",
+]
+
+
+def _do_unblock(sender: str, target: str, note: str | None) -> None:
+    """Shared implementation for both ``grant`` (legacy) and ``unblock``.
+
+    Task #27 PR B: dispatches via
+    :func:`_a2a_acl_dispatch.dispatch_acl_decision` which routes
+    in-SIF → host listen HTTP (so the write lands on the host's
+    state.db) and bare-host → local DB helpers directly.
+    """
+    from ._a2a_acl_dispatch import dispatch_acl_decision
+
+    try:
+        result = dispatch_acl_decision(
+            "unblock", sender=sender, target=target, note=note
+        )
+    except click.ClickException:
+        raise
+    except ValueError as exc:
+        click.echo(f"error: {exc}", err=True)
+        raise SystemExit(2) from exc
+    except Exception as exc:
+        # In-SIF broker raised an AclBrokerError (or transport
+        # error). Surface as a clean ClickException so the
+        # operator sees a single-line stderr instead of a
+        # traceback.
+        raise click.ClickException(str(exc)) from exc
+    from ._helpers import console
+
+    extras = []
+    if result.get("unblocked"):
+        extras.append("removed block")
+    if result.get("cleared_pending"):
+        extras.append("cleared pending prompt")
+    tail = f" [dim]({'; '.join(extras)})[/dim]" if extras else ""
+    console.print(f"[green]ok[/green]  unblocked  {sender}  ->  {target}{tail}")
+
+
+@click.command("grant")
+@click.argument("sender")
+@click.argument("target")
+@click.option(
+    "--note",
+    default=None,
+    help="Free-form audit annotation (e.g. ticket / handoff that authorised this).",
+)
+def a2a_grant(sender: str, target: str, note: str | None) -> None:
+    """Grant ``SENDER`` permission to send messages to ``TARGET``.
+
+    Legacy alias of ``sac a2a unblock <SENDER> <TARGET>``. Writes the
+    ``comms_grants`` row, removes any ``comms_blocks`` row, and
+    clears the pending-prompt row for the pair. Re-granting an
+    already-granted pair is a no-op on the timestamp.
+
+    Argument order matters: ``SENDER → TARGET`` is directional. To
+    allow bidirectional cross-group traffic, run the command twice.
+
+    \b
+    Example:
+      $ sac a2a grant worker-a worker-b
+      $ sac a2a grant worker-a worker-b --note "ticket-PA-512"
+    """
+    _do_unblock(sender, target, note)
+
+
+@click.command("unblock")
+@click.argument("sender")
+@click.argument("target")
+@click.option(
+    "--note",
+    default=None,
+    help=(
+        "Free-form audit annotation (e.g. the approval-prompt msg_id this "
+        "responds to)."
+    ),
+)
+def a2a_unblock(sender: str, target: str, note: str | None) -> None:
+    """UNBLOCK ``SENDER`` — allow this sender's future messages to ``TARGET``.
+
+    Task #27 receiver-facing verb. Embedded in the approve-prompt
+    push the receiver sees on a denied cross-group send. Writes the
+    ``comms_grants`` row, removes any ``comms_blocks`` row, and
+    clears the pending-prompt row. The sender's original denied
+    message is NOT replayed — they resend if needed.
+
+    \b
+    Example:
+      $ sac a2a unblock worker-a lead
+      $ sac a2a unblock worker-a lead --note "prompt msg_id abc123"
+    """
+    _do_unblock(sender, target, note)
+
+
+@click.command("block")
+@click.argument("sender")
+@click.argument("target")
+@click.option(
+    "--note",
+    default=None,
+    help=(
+        "Free-form audit annotation (e.g. the approval-prompt msg_id this "
+        "responds to)."
+    ),
+)
+def a2a_block(sender: str, target: str, note: str | None) -> None:
+    """BLOCK ``SENDER`` — silently drop this sender's future attempts to ``TARGET``.
+
+    Task #27 receiver-facing verb. Embedded in the approve-prompt
+    push as the silence-this-sender alternative to ``unblock``.
+    Writes the ``comms_blocks`` row, clears the pending-prompt row.
+    Future sends from ``SENDER`` to ``TARGET`` are silently dropped
+    by :func:`_listen._acl.check_send_acl` (no receiver push, no
+    approve-prompt re-fire). The sender still gets a 403 — they
+    learn their send did not land — but the receiver sees nothing.
+
+    Idempotent: re-blocking is a no-op on the existing row's
+    timestamp. Block precedence: if the pair also has a grant,
+    BLOCK wins.
+
+    \b
+    Example:
+      $ sac a2a block worker-a lead
+      $ sac a2a block worker-a lead --note "prompt msg_id abc123"
+    """
+    from ._a2a_acl_dispatch import dispatch_acl_decision
+
+    try:
+        result = dispatch_acl_decision("block", sender=sender, target=target, note=note)
+    except click.ClickException:
+        raise
+    except ValueError as exc:
+        click.echo(f"error: {exc}", err=True)
+        raise SystemExit(2) from exc
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    from ._helpers import console
+
+    tail = (
+        " [dim](cleared pending prompt)[/dim]" if result.get("cleared_pending") else ""
+    )
+    console.print(f"[yellow]ok[/yellow]  blocked  {sender}  ->  {target}{tail}")
+
+
+@click.command("revoke")
+@click.argument("sender")
+@click.argument("target")
+def a2a_revoke(sender: str, target: str) -> None:
+    """Revoke ``SENDER``'s permission to send messages to ``TARGET``.
+
+    Thin wrapper over ``_state.state_db_nodes.revoke_send`` — removes
+    the single ``sender → target`` row in ``comms_grants``. No
+    confirmation prompt: the operation is narrow (one row, one
+    direction) and idempotent — revoking a non-existent grant prints
+    ``no-op`` and exits 0.
+
+    \b
+    Example:
+      $ sac a2a revoke worker-a worker-b
+    """
+    if not sender or not target:
+        click.echo(
+            "error: SENDER and TARGET must both be non-empty",
+            err=True,
+        )
+        raise SystemExit(2)
+    from .._state.state_db_nodes import revoke_send
+    from ._helpers import console
+
+    removed = revoke_send(sender=sender, target=target)
+    if removed:
+        console.print(f"[green]ok[/green]  revoked  {sender}  ->  {target}")
+    else:
+        console.print(f"[dim]no-op[/dim]  no grant  {sender}  ->  {target}")
+
+
+@click.command("grants")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a JSON array instead of a rich table (scripting-friendly).",
+)
+def a2a_grants(as_json: bool) -> None:
+    """List every row in the ``comms_grants`` table.
+
+    Thin wrapper over ``_state.state_db_nodes.list_comms_grants``.
+    Rows are emitted in insertion order with their audit ``note`` (if
+    any). Empty table renders as ``(no grants)`` in rich mode and
+    ``[]`` in JSON mode.
+
+    \b
+    Example:
+      $ sac a2a grants
+      $ sac a2a grants --json | jq '.[] | select(.sender == "worker-a")'
+    """
+    from .._state.state_db_nodes import list_comms_grants
+
+    rows = list_comms_grants()
+    if as_json:
+        click.echo(json.dumps(rows, ensure_ascii=False))
+        return
+    from ._helpers import console
+
+    if not rows:
+        console.print("[dim](no grants)[/dim]")
+        return
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("sender")
+    table.add_column("target")
+    table.add_column("created_at", justify="right")
+    table.add_column("note", overflow="fold")
+    for r in rows:
+        table.add_row(
+            str(r["sender"]),
+            str(r["target"]),
+            f"{r['created_at']:.0f}",
+            r["note"] if r["note"] is not None else "",
+        )
+    console.print(table)
+
+
+def register(a2a_group) -> None:
+    """Attach the five ACL verbs to the parent ``a2a`` Click group."""
+    for command in (a2a_grant, a2a_unblock, a2a_block, a2a_revoke, a2a_grants):
+        a2a_group.add_command(command)

--- a/src/scitex_agent_container/cli_pkg/_a2a_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_a2a_list_cmd.py
@@ -1,0 +1,105 @@
+"""``sac a2a list`` — every peer registered on the local ``sac listen``.
+
+Extracted from :mod:`.a2a_group` (over the per-file cap) and registered
+onto it by :func:`register`, the same way :mod:`._host_sync` attaches to
+``sac host``. The fetch itself lives in :mod:`._a2a_list_fetch`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+__all__ = ["a2a_list", "register"]
+
+
+@click.command("list")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a JSON array instead of a rich table (scripting-friendly).",
+)
+@click.option(
+    "--url",
+    "base_url",
+    default=None,
+    help=("Listen base URL. Default: $SAC_LISTEN_BASE_URL or http://127.0.0.1:7878."),
+)
+def a2a_list(as_json: bool, base_url: str | None) -> None:
+    """List every peer registered on the local ``sac listen`` (the a2a registry).
+
+    Queries ``GET /agents`` on the local listen server -- the SAME source
+    the ``a2a_peers`` MCP tool reads. Shows container agents (Registry)
+    AND self-registered comms-nodes: any process that holds the sac MCP
+    and self-registers at startup (e.g. ``sac mcp channel --name lead``).
+
+    Fail-loud: aborts with a clear message if no listen bearer token is
+    found or the listen server is unreachable -- no silent empty result.
+
+    \b
+    Example:
+      $ sac a2a list
+      $ sac a2a list --json | jq '.[] | select(.kind == "comms-node")'
+    """
+    import os
+
+    from .._listen.tokens import default_token_path, read_token
+
+    url = base_url or os.environ.get("SAC_LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    token = os.environ.get("SAC_LISTEN_BEARER")
+    if not token:
+        token = read_token(default_token_path())
+    if not token:
+        raise SystemExit(
+            "sac a2a list: no listen bearer token found "
+            f"($SAC_LISTEN_BEARER unset and {default_token_path()} absent). "
+            "Is `sac listen` running on this host?"
+        )
+
+    # Fail-loud, no raw traceback: fetch_agents maps every reach/read/parse
+    # failure (URLError, socket timeout, OSError, non-JSON / odd body) to one
+    # clean A2aListError. The inline version only caught URLError, so a socket
+    # timeout on a loaded runner or a non-JSON body crashed UNHANDLED and broke
+    # callers shelling out to `sac a2a list --json` (scitex-dev 2026-06-17:
+    # Spartan runner bm159 → todo /fleet/mesh 500'd → CI blocked).
+    from ._a2a_list_fetch import A2aListError, fetch_agents
+
+    try:
+        agents = fetch_agents(url, token)
+    except A2aListError as exc:
+        raise SystemExit(f"sac a2a list: {exc}") from exc
+    if as_json:
+        click.echo(json.dumps(agents, ensure_ascii=False))
+        return
+
+    from ._helpers import console
+
+    if not agents:
+        console.print("[dim](no a2a peers)[/dim]")
+        return
+
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("name")
+    table.add_column("kind")
+    table.add_column("host")
+    table.add_column("a2a_port", justify="right")
+    table.add_column("turn_url", overflow="fold")
+    for a in agents:
+        port = a.get("a2a_port")
+        table.add_row(
+            str(a.get("name", "")),
+            str(a.get("kind", "agent")),
+            str(a.get("host", "")),
+            "" if port is None else str(port),
+            str(a.get("turn_url") or ""),
+        )
+    console.print(table)
+
+
+def register(a2a_group) -> None:
+    """Attach ``list`` to the parent ``a2a`` Click group."""
+    a2a_group.add_command(a2a_list)

--- a/src/scitex_agent_container/cli_pkg/_a2a_reachability.py
+++ b/src/scitex_agent_container/cli_pkg/_a2a_reachability.py
@@ -1,0 +1,250 @@
+"""``sac a2a reachability`` — is the cross-host a2a transport up, per peer?
+
+Split out of :mod:`.a2a_group` (over the per-file cap) and registered onto
+it by :func:`register`, exactly as :mod:`._host_sync` attaches to ``sac
+host``. The probe itself lives in :mod:`.._network._reachability`; this
+module is the operator's window onto it and the scheduled job's entry
+point (``scitex-agent-container-a2a-reachability``, every 15 minutes).
+
+Rendering rule, inherited from ``sac host sync``: **there is no quiet
+path.** Every host gets a line saying what was concluded and WHY —
+including, above all, the ones that could not be probed. An UNKNOWN row
+rendered as nothing is how a fleet with no peer tokens reads as healthy.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from ._helpers import _json_flag, console
+
+#: Colour per three-valued verdict. Anything that is not a measured
+#: success is loud on purpose.
+_STYLE = {
+    True: ("green", "REACHABLE"),
+    False: ("red", "UNREACHABLE"),
+    None: ("magenta", "UNKNOWN"),
+}
+
+
+def _print_row(row) -> None:
+    colour, label = _STYLE[row.reachable]
+    ms = f"{row.elapsed_ms} ms" if row.elapsed_ms is not None else "-"
+    alias = f"ssh://{row.ssh_alias}" if row.ssh_alias else "(no ssh alias)"
+    # soft_wrap: a wrapped host name is one you cannot grep out of a log.
+    console.print(
+        f"[{colour}]{label:<12}[/{colour}] {row.host:<20} {alias:<28} {ms}",
+        soft_wrap=True,
+    )
+    if row.error:
+        console.print(f"    [dim]{row.error}[/dim]", soft_wrap=True)
+
+
+def _print_report(report, *, alarm_line: str | None) -> None:
+    console.print(
+        f"[bold]sac a2a reachability[/bold]  from {report.probed_from} "
+        f"-> {len(report.rows)} host(s), listen port {report.port}\n"
+    )
+    for row in report.rows:
+        _print_row(row)
+    counts = report.counts()
+    console.print("")
+    if report.exit_code == 3:
+        console.print(
+            "[magenta]nothing measurable[/magenta] — every host is UNKNOWN, so "
+            "this pass proves nothing about the fleet. Fix the reasons above "
+            "(peer tokens: `sac host add-peer <host> <token>`; aliases: "
+            "hosts.yaml / config.yaml peers)."
+        )
+    elif report.exit_code == 1:
+        down = [r.host for r in report.rows if r.reachable is False]
+        console.print(
+            f"[red]cross-host a2a is DOWN to {len(down)} host(s):[/red] "
+            f"{', '.join(down)} — a2a_send to agents there fails from here."
+        )
+    else:
+        console.print(
+            f"[green]all {counts['reachable']} measured host(s) reachable[/green] "
+            f"[dim]({counts['unknown']} unknown, listed above)[/dim]"
+        )
+    if alarm_line:
+        console.print(f"[dim]{alarm_line}[/dim]")
+
+
+@click.command("reachability")
+@click.option(
+    "--host",
+    "hosts",
+    multiple=True,
+    help="Probe only this host (repeatable). Default: --all.",
+)
+@click.option(
+    "--all",
+    "all_hosts",
+    is_flag=True,
+    default=False,
+    help="Every host the fleet knows (config.yaml peers + the host registry).",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=7878,
+    show_default=True,
+    help="The PEER's `sac listen` port to curl on its loopback.",
+)
+@click.option(
+    "--timeout",
+    "timeout_s",
+    type=float,
+    default=10.0,
+    show_default=True,
+    help="Per-host curl deadline on the peer (s); ssh gets 15 s on top.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the report as JSON.")
+@click.option(
+    "--record",
+    is_flag=True,
+    default=False,
+    help=(
+        "Also write the report to the sac runtime dir "
+        "(runtime/a2a-reachability.json) for `--last` to read back."
+    ),
+)
+@click.option(
+    "--last",
+    "show_last",
+    is_flag=True,
+    default=False,
+    help="Print the last --record'ed report instead of probing; exits with ITS code.",
+)
+@click.pass_context
+def a2a_reachability(
+    ctx: click.Context,
+    hosts: tuple[str, ...],
+    all_hosts: bool,
+    port: int,
+    timeout_s: float,
+    as_json: bool,
+    record: bool,
+    show_last: bool,
+) -> None:
+    """Probe the cross-host a2a transport to every peer, from THIS host.
+
+    Exercises exactly what ``sac listen``'s forwarder does for a cross-host
+    send — ssh to the peer's alias, curl ``127.0.0.1:<port>/v1/health`` on
+    the peer with that peer's bearer from ``peer-tokens/<host>.token`` —
+    and reports one three-valued row per host.
+
+    \b
+    Verdicts, per host:
+      REACHABLE    the leg worked end to end and a sac-listen answered
+      UNREACHABLE  the leg was dispatched and failed (ssh, curl, or a bad answer)
+      UNKNOWN      the leg could not be dispatched: no ssh alias in the host
+                   registry, no peer token, or the host is this machine.
+                   NEVER counted as reachable.
+    \b
+    Exit codes:
+      0  every measured host is REACHABLE
+      1  at least one host is UNREACHABLE
+      3  nothing measurable — every host is UNKNOWN (not a success)
+      (2 is Click's usage error and carries no fleet meaning)
+    \b
+    Every run also records each verdict in sac's own event log
+    (runtime/sac-events.jsonl, subsystem a2a-reachability): unreachable and
+    unknown hosts on every pass, a recovery on the transition back.
+    \b
+    Examples:
+      $ sac a2a reachability
+      $ sac a2a reachability --host scitex-compute-03 --json
+      $ sac a2a reachability --all --json --record     # the scheduled form
+      $ sac a2a reachability --last
+    """
+    from .._network._reachability import (
+        read_report,
+        run_probe,
+        write_report,
+    )
+    from .._network._reachability_alarm import record_pass_completed, record_report
+
+    if hosts and all_hosts:
+        raise click.UsageError("give either --host ... or --all, not both")
+    if show_last and (hosts or all_hosts or record):
+        raise click.UsageError(
+            "--last reads the recorded report; it takes no probe options"
+        )
+    if port <= 0:
+        raise click.UsageError(f"--port must be positive (got {port})")
+    if timeout_s <= 0:
+        raise click.UsageError(f"--timeout must be positive (got {timeout_s})")
+
+    if show_last:
+        report = read_report()
+        if report is None:
+            from .._network._reachability import default_report_path
+
+            raise click.ClickException(
+                f"no recorded report at {default_report_path()} — run "
+                "`sac a2a reachability --all --record` first"
+            )
+        if _json_flag(ctx, as_json):
+            click.echo(json.dumps(report.to_dict(), indent=2))
+        else:
+            _print_report(report, alarm_line=None)
+        raise SystemExit(report.exit_code)
+
+    from .._state.host_config import load as _load_cfg
+    from .lifecycle._host_identity import _local_host_names
+
+    cfg = _load_cfg()
+    probed_from = cfg.canonical_host()
+    try:
+        report = run_probe(
+            peers=cfg.peers,
+            local_names=_local_host_names(probed_from),
+            probed_from=probed_from,
+            only=list(hosts) if hosts else None,
+            port=port,
+            timeout_s=timeout_s,
+        )
+    except KeyError as exc:
+        raise click.UsageError(str(exc.args[0]) if exc.args else str(exc)) from exc
+
+    # Make the shout DURABLE, in both output modes: the record is independent
+    # of whatever the console prints. A subset run only touches the hosts it
+    # probed, so a by-hand `--host x` can never record a recovery for a peer
+    # it did not look at.
+    mode = "subset" if hosts else "all"
+    outcome = record_report(report)
+    record_pass_completed(report, mode=mode)
+
+    recorded_to = None
+    if record:
+        recorded_to = write_report(report)
+
+    if _json_flag(ctx, as_json):
+        payload = report.to_dict()
+        payload["alarm"] = {
+            "degraded": list(outcome.degraded),
+            "unknown": list(outcome.unknown),
+            "recovered": list(outcome.recovered),
+            "failed": list(outcome.failed),
+        }
+        payload["recorded_to"] = str(recorded_to) if recorded_to else None
+        click.echo(json.dumps(payload, indent=2))
+        raise SystemExit(report.exit_code)
+
+    line = outcome.summary_line()
+    if recorded_to:
+        line += f"; report -> {recorded_to}"
+    _print_report(report, alarm_line=line)
+    raise SystemExit(report.exit_code)
+
+
+def register(a2a_group) -> None:
+    """Attach ``reachability`` to the parent ``a2a`` Click group."""
+    a2a_group.add_command(a2a_reachability)
+
+
+__all__ = ["a2a_reachability", "register"]

--- a/src/scitex_agent_container/cli_pkg/_a2a_reachability.py
+++ b/src/scitex_agent_container/cli_pkg/_a2a_reachability.py
@@ -32,7 +32,10 @@ _STYLE = {
 def _print_row(row) -> None:
     colour, label = _STYLE[row.reachable]
     ms = f"{row.elapsed_ms} ms" if row.elapsed_ms is not None else "-"
-    alias = f"ssh://{row.ssh_alias}" if row.ssh_alias else "(no ssh alias)"
+    if row.local:
+        alias = "(this host)"
+    else:
+        alias = f"ssh://{row.ssh_alias}" if row.ssh_alias else "(no ssh alias)"
     # soft_wrap: a wrapped host name is one you cannot grep out of a log.
     console.print(
         f"[{colour}]{label:<12}[/{colour}] {row.host:<20} {alias:<28} {ms}",
@@ -133,9 +136,10 @@ def a2a_reachability(
     """Probe the cross-host a2a transport to every peer, from THIS host.
 
     Exercises exactly what ``sac listen``'s forwarder does for a cross-host
-    send — ssh to the peer's alias, curl ``127.0.0.1:<port>/v1/health`` on
-    the peer with that peer's bearer from ``peer-tokens/<host>.token`` —
-    and reports one three-valued row per host.
+    send — the peer's ssh alias from the forwarder's OWN resolver
+    (config.yaml peers + the host registry), then curl
+    ``127.0.0.1:<port>/v1/health`` on the peer with that peer's bearer from
+    ``peer-tokens/<host>.token`` — and reports one three-valued row per host.
 
     \b
     Verdicts, per host:
@@ -145,15 +149,24 @@ def a2a_reachability(
                    registry, no peer token, or the host is this machine.
                    NEVER counted as reachable.
     \b
+    What REACHABLE proves — and does not: /v1/health is a PUBLIC path on the
+    listen (answered before the bearer is checked), so REACHABLE means the
+    ssh alias, the tunnel and the peer's listen are up. It does NOT prove the
+    peer token is VALID: a stale token still reads REACHABLE here and 401s
+    on a real send. A missing token is still UNKNOWN (the forwarder refuses
+    to send without one).
+    \b
     Exit codes:
       0  every measured host is REACHABLE
       1  at least one host is UNREACHABLE
       3  nothing measurable — every host is UNKNOWN (not a success)
       (2 is Click's usage error and carries no fleet meaning)
     \b
-    Every run also records each verdict in sac's own event log
-    (runtime/sac-events.jsonl, subsystem a2a-reachability): unreachable and
-    unknown hosts on every pass, a recovery on the transition back.
+    Every run also records in sac's own event log (runtime/sac-events.jsonl,
+    subsystem a2a-reachability) — per host on TRANSITION only: the first time
+    a host is seen unreachable or unknown, every change of state after, and
+    a recovery on the way back; plus one pass-completed record with counts
+    every pass. The full per-pass picture is the --record file.
     \b
     Examples:
       $ sac a2a reachability
@@ -197,11 +210,11 @@ def a2a_reachability(
     from .._state.host_config import load as _load_cfg
     from .lifecycle._host_identity import _local_host_names
 
-    cfg = _load_cfg()
-    probed_from = cfg.canonical_host()
+    probed_from = _load_cfg().canonical_host()
     try:
+        # No peer map is handed in: the probe resolves each host through the
+        # forwarder's own resolver, which reads config.yaml + the registry.
         report = run_probe(
-            peers=cfg.peers,
             local_names=_local_host_names(probed_from),
             probed_from=probed_from,
             only=list(hosts) if hosts else None,
@@ -212,9 +225,10 @@ def a2a_reachability(
         raise click.UsageError(str(exc.args[0]) if exc.args else str(exc)) from exc
 
     # Make the shout DURABLE, in both output modes: the record is independent
-    # of whatever the console prints. A subset run only touches the hosts it
-    # probed, so a by-hand `--host x` can never record a recovery for a peer
-    # it did not look at.
+    # of whatever the console prints. Per host it is a TRANSITION record (see
+    # _reachability_alarm); the full pass is the --record file. A subset run
+    # only touches the hosts it probed, so a by-hand `--host x` can never
+    # record a recovery for a peer it did not look at.
     mode = "subset" if hosts else "all"
     outcome = record_report(report)
     record_pass_completed(report, mode=mode)

--- a/src/scitex_agent_container/cli_pkg/a2a_group.py
+++ b/src/scitex_agent_container/cli_pkg/a2a_group.py
@@ -1,4 +1,9 @@
-"""``sac a2a {serve,doctor,grant,revoke,grants}`` CLI subcommands — A2A protocol surface.
+"""``sac a2a {serve,doctor,grant,unblock,block,revoke,grants,list,reachability}``.
+
+The A2A protocol surface. This module holds the ``a2a`` group itself plus
+the two protocol verbs; the rest live in sibling modules (this file sat
+over the per-file cap) and are registered at the bottom, the same way
+``_host_sync`` attaches to ``sac host``:
 
 * :func:`a2a_serve` boots the stdlib HTTP A2A server for one or more
   agent YAMLs.
@@ -6,14 +11,16 @@
   declared by ``spec.a2a`` in its YAML) and reports liveness +
   round-trip latency. Useful for ops or as ``spec.health.method:
   a2a-card`` from outside the agent process.
-* :func:`a2a_grant` / :func:`a2a_revoke` / :func:`a2a_grants` are
-  thin click wrappers over the cross-group ACL primitives in
-  ``_state.state_db_nodes`` (``grant_send`` / ``revoke_send`` /
-  ``list_comms_grants``). Operators previously had to drop into a
-  Python REPL to amend the comms-grants table — a footgun
-  (silently granting too much on wrong argument order). The CLI
-  makes it auditable and validates the positional order at the
-  Click layer.
+* ``grant`` / ``unblock`` / ``block`` / ``revoke`` / ``grants``
+  (:mod:`._a2a_acl_cmds`) are thin click wrappers over the cross-group
+  ACL primitives in ``_state.state_db_nodes``. Operators previously had
+  to drop into a Python REPL to amend the comms-grants table — a footgun
+  (silently granting too much on wrong argument order). The CLI makes it
+  auditable and validates the positional order at the Click layer.
+* ``list`` (:mod:`._a2a_list_cmd`) lists every peer registered on the
+  local ``sac listen``.
+* ``reachability`` (:mod:`._a2a_reachability`) probes the cross-host a2a
+  transport to every peer, from this host.
 
 Examples::
 
@@ -25,6 +32,7 @@ Examples::
     sac a2a grant worker-a worker-b --note "ticket-123"
     sac a2a revoke worker-a worker-b
     sac a2a grants --json
+    sac a2a reachability --all --json
 """
 
 from __future__ import annotations
@@ -249,311 +257,37 @@ def _emit(result: dict, as_json: bool) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Cross-group ACL verbs — thin wrappers over state_db_nodes primitives.
-#
-# Imports happen inside the callback (not at module import) to keep the
-# Click cold-start cheap: ``sac --help`` and tab-completion press should
-# never load a database driver. The same lazy pattern used by ``host_group`` /
-# ``peer_group`` for state_db consumers.
+# Verbs that live in sibling modules (this file sat over the per-file cap),
+# registered here the way ``_host_sync`` attaches to ``sac host``. The verb
+# names are re-exported so ``from .a2a_group import a2a_grant`` keeps
+# resolving for any caller written against the pre-split layout.
 # ---------------------------------------------------------------------------
-
-
-def _do_unblock(sender: str, target: str, note: str | None) -> None:
-    """Shared implementation for both ``grant`` (legacy) and ``unblock``.
-
-    Task #27 PR B: dispatches via
-    :func:`_a2a_acl_dispatch.dispatch_acl_decision` which routes
-    in-SIF → host listen HTTP (so the write lands on the host's
-    state.db) and bare-host → local DB helpers directly.
-    """
-    from ._a2a_acl_dispatch import dispatch_acl_decision
-
-    try:
-        result = dispatch_acl_decision(
-            "unblock", sender=sender, target=target, note=note
-        )
-    except click.ClickException:
-        raise
-    except ValueError as exc:
-        click.echo(f"error: {exc}", err=True)
-        raise SystemExit(2) from exc
-    except Exception as exc:
-        # In-SIF broker raised an AclBrokerError (or transport
-        # error). Surface as a clean ClickException so the
-        # operator sees a single-line stderr instead of a
-        # traceback.
-        raise click.ClickException(str(exc)) from exc
-    from ._helpers import console
-
-    extras = []
-    if result.get("unblocked"):
-        extras.append("removed block")
-    if result.get("cleared_pending"):
-        extras.append("cleared pending prompt")
-    tail = f" [dim]({'; '.join(extras)})[/dim]" if extras else ""
-    console.print(f"[green]ok[/green]  unblocked  {sender}  ->  {target}{tail}")
-
-
-@a2a.command("grant")
-@click.argument("sender")
-@click.argument("target")
-@click.option(
-    "--note",
-    default=None,
-    help="Free-form audit annotation (e.g. ticket / handoff that authorised this).",
+from ._a2a_acl_cmds import (  # noqa: E402
+    a2a_block,
+    a2a_grant,
+    a2a_grants,
+    a2a_revoke,
+    a2a_unblock,
 )
-def a2a_grant(sender: str, target: str, note: str | None) -> None:
-    """Grant ``SENDER`` permission to send messages to ``TARGET``.
+from ._a2a_acl_cmds import register as _register_acl  # noqa: E402
+from ._a2a_list_cmd import a2a_list  # noqa: E402
+from ._a2a_list_cmd import register as _register_list  # noqa: E402
+from ._a2a_reachability import a2a_reachability  # noqa: E402
+from ._a2a_reachability import register as _register_reachability  # noqa: E402
 
-    Legacy alias of ``sac a2a unblock <SENDER> <TARGET>``. Writes the
-    ``comms_grants`` row, removes any ``comms_blocks`` row, and
-    clears the pending-prompt row for the pair. Re-granting an
-    already-granted pair is a no-op on the timestamp.
+_register_acl(a2a)
+_register_list(a2a)
+_register_reachability(a2a)
 
-    Argument order matters: ``SENDER → TARGET`` is directional. To
-    allow bidirectional cross-group traffic, run the command twice.
-
-    \b
-    Example:
-      $ sac a2a grant worker-a worker-b
-      $ sac a2a grant worker-a worker-b --note "ticket-PA-512"
-    """
-    _do_unblock(sender, target, note)
-
-
-@a2a.command("unblock")
-@click.argument("sender")
-@click.argument("target")
-@click.option(
-    "--note",
-    default=None,
-    help="Free-form audit annotation (e.g. the approval-prompt msg_id this responds to).",
-)
-def a2a_unblock(sender: str, target: str, note: str | None) -> None:
-    """UNBLOCK ``SENDER`` — allow this sender's future messages to ``TARGET``.
-
-    Task #27 receiver-facing verb. Embedded in the approve-prompt
-    push the receiver sees on a denied cross-group send. Writes the
-    ``comms_grants`` row, removes any ``comms_blocks`` row, and
-    clears the pending-prompt row. The sender's original denied
-    message is NOT replayed — they resend if needed.
-
-    \b
-    Example:
-      $ sac a2a unblock worker-a lead
-      $ sac a2a unblock worker-a lead --note "prompt msg_id abc123"
-    """
-    _do_unblock(sender, target, note)
-
-
-@a2a.command("block")
-@click.argument("sender")
-@click.argument("target")
-@click.option(
-    "--note",
-    default=None,
-    help="Free-form audit annotation (e.g. the approval-prompt msg_id this responds to).",
-)
-def a2a_block(sender: str, target: str, note: str | None) -> None:
-    """BLOCK ``SENDER`` — silently drop this sender's future attempts to ``TARGET``.
-
-    Task #27 receiver-facing verb. Embedded in the approve-prompt
-    push as the silence-this-sender alternative to ``unblock``.
-    Writes the ``comms_blocks`` row, clears the pending-prompt row.
-    Future sends from ``SENDER`` to ``TARGET`` are silently dropped
-    by :func:`_listen._acl.check_send_acl` (no receiver push, no
-    approve-prompt re-fire). The sender still gets a 403 — they
-    learn their send did not land — but the receiver sees nothing.
-
-    Idempotent: re-blocking is a no-op on the existing row's
-    timestamp. Block precedence: if the pair also has a grant,
-    BLOCK wins.
-
-    \b
-    Example:
-      $ sac a2a block worker-a lead
-      $ sac a2a block worker-a lead --note "prompt msg_id abc123"
-    """
-    from ._a2a_acl_dispatch import dispatch_acl_decision
-
-    try:
-        result = dispatch_acl_decision("block", sender=sender, target=target, note=note)
-    except click.ClickException:
-        raise
-    except ValueError as exc:
-        click.echo(f"error: {exc}", err=True)
-        raise SystemExit(2) from exc
-    except Exception as exc:
-        raise click.ClickException(str(exc)) from exc
-    from ._helpers import console
-
-    tail = (
-        " [dim](cleared pending prompt)[/dim]" if result.get("cleared_pending") else ""
-    )
-    console.print(f"[yellow]ok[/yellow]  blocked  {sender}  ->  {target}{tail}")
-
-
-@a2a.command("revoke")
-@click.argument("sender")
-@click.argument("target")
-def a2a_revoke(sender: str, target: str) -> None:
-    """Revoke ``SENDER``'s permission to send messages to ``TARGET``.
-
-    Thin wrapper over ``_state.state_db_nodes.revoke_send`` — removes
-    the single ``sender → target`` row in ``comms_grants``. No
-    confirmation prompt: the operation is narrow (one row, one
-    direction) and idempotent — revoking a non-existent grant prints
-    ``no-op`` and exits 0.
-
-    \b
-    Example:
-      $ sac a2a revoke worker-a worker-b
-    """
-    if not sender or not target:
-        click.echo(
-            "error: SENDER and TARGET must both be non-empty",
-            err=True,
-        )
-        raise SystemExit(2)
-    from .._state.state_db_nodes import revoke_send
-    from ._helpers import console
-
-    removed = revoke_send(sender=sender, target=target)
-    if removed:
-        console.print(f"[green]ok[/green]  revoked  {sender}  ->  {target}")
-    else:
-        console.print(f"[dim]no-op[/dim]  no grant  {sender}  ->  {target}")
-
-
-@a2a.command("grants")
-@click.option(
-    "--json",
-    "as_json",
-    is_flag=True,
-    help="Emit a JSON array instead of a rich table (scripting-friendly).",
-)
-def a2a_grants(as_json: bool) -> None:
-    """List every row in the ``comms_grants`` table.
-
-    Thin wrapper over ``_state.state_db_nodes.list_comms_grants``.
-    Rows are emitted in insertion order with their audit ``note`` (if
-    any). Empty table renders as ``(no grants)`` in rich mode and
-    ``[]`` in JSON mode.
-
-    \b
-    Example:
-      $ sac a2a grants
-      $ sac a2a grants --json | jq '.[] | select(.sender == "worker-a")'
-    """
-    from .._state.state_db_nodes import list_comms_grants
-
-    rows = list_comms_grants()
-    if as_json:
-        click.echo(json.dumps(rows, ensure_ascii=False))
-        return
-    from ._helpers import console
-
-    if not rows:
-        console.print("[dim](no grants)[/dim]")
-        return
-    from rich.table import Table
-
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("sender")
-    table.add_column("target")
-    table.add_column("created_at", justify="right")
-    table.add_column("note", overflow="fold")
-    for r in rows:
-        table.add_row(
-            str(r["sender"]),
-            str(r["target"]),
-            f"{r['created_at']:.0f}",
-            r["note"] if r["note"] is not None else "",
-        )
-    console.print(table)
-
-
-@a2a.command("list")
-@click.option(
-    "--json",
-    "as_json",
-    is_flag=True,
-    help="Emit a JSON array instead of a rich table (scripting-friendly).",
-)
-@click.option(
-    "--url",
-    "base_url",
-    default=None,
-    help=("Listen base URL. Default: $SAC_LISTEN_BASE_URL or http://127.0.0.1:7878."),
-)
-def a2a_list(as_json: bool, base_url: str | None) -> None:
-    """List every peer registered on the local ``sac listen`` (the a2a registry).
-
-    Queries ``GET /agents`` on the local listen server -- the SAME source
-    the ``a2a_peers`` MCP tool reads. Shows container agents (Registry)
-    AND self-registered comms-nodes: any process that holds the sac MCP
-    and self-registers at startup (e.g. ``sac mcp channel --name lead``).
-
-    Fail-loud: aborts with a clear message if no listen bearer token is
-    found or the listen server is unreachable -- no silent empty result.
-
-    \b
-    Example:
-      $ sac a2a list
-      $ sac a2a list --json | jq '.[] | select(.kind == "comms-node")'
-    """
-    import os
-
-    from .._listen.tokens import default_token_path, read_token
-
-    url = base_url or os.environ.get("SAC_LISTEN_BASE_URL", "http://127.0.0.1:7878")
-    token = os.environ.get("SAC_LISTEN_BEARER")
-    if not token:
-        token = read_token(default_token_path())
-    if not token:
-        raise SystemExit(
-            "sac a2a list: no listen bearer token found "
-            f"($SAC_LISTEN_BEARER unset and {default_token_path()} absent). "
-            "Is `sac listen` running on this host?"
-        )
-
-    # Fail-loud, no raw traceback: fetch_agents maps every reach/read/parse
-    # failure (URLError, socket timeout, OSError, non-JSON / odd body) to one
-    # clean A2aListError. The inline version only caught URLError, so a socket
-    # timeout on a loaded runner or a non-JSON body crashed UNHANDLED and broke
-    # callers shelling out to `sac a2a list --json` (scitex-dev 2026-06-17:
-    # Spartan runner bm159 → todo /fleet/mesh 500'd → CI blocked).
-    from ._a2a_list_fetch import A2aListError, fetch_agents
-
-    try:
-        agents = fetch_agents(url, token)
-    except A2aListError as exc:
-        raise SystemExit(f"sac a2a list: {exc}") from exc
-    if as_json:
-        click.echo(json.dumps(agents, ensure_ascii=False))
-        return
-
-    from ._helpers import console
-
-    if not agents:
-        console.print("[dim](no a2a peers)[/dim]")
-        return
-
-    from rich.table import Table
-
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("name")
-    table.add_column("kind")
-    table.add_column("host")
-    table.add_column("a2a_port", justify="right")
-    table.add_column("turn_url", overflow="fold")
-    for a in agents:
-        port = a.get("a2a_port")
-        table.add_row(
-            str(a.get("name", "")),
-            str(a.get("kind", "agent")),
-            str(a.get("host", "")),
-            "" if port is None else str(port),
-            str(a.get("turn_url") or ""),
-        )
-    console.print(table)
+__all__ = [
+    "a2a",
+    "a2a_block",
+    "a2a_doctor",
+    "a2a_grant",
+    "a2a_grants",
+    "a2a_list",
+    "a2a_reachability",
+    "a2a_revoke",
+    "a2a_serve",
+    "a2a_unblock",
+]

--- a/tests/develop/test_delivery_claims_name_their_sink.py
+++ b/tests/develop/test_delivery_claims_name_their_sink.py
@@ -178,7 +178,9 @@ FROZEN_UNNAMED_CLAIMS = frozenset(
         "scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py:375",
         "scitex_agent_container/_listen/_deploy_freshness.py:227",
         "scitex_agent_container/_listen/_liveness_tick.py:123",
-        "scitex_agent_container/_listen/_node_channel_forwarders.py:177",
+        # _node_channel_forwarders.py LEFT THIS SET 2026-09-02 — the reason
+        # now names where the tolerated non-JSON body goes (the a2a response
+        # the sender receives) instead of claiming it is "surfaced".
         "scitex_agent_container/_maintenance/_install_integrity_pointers.py:193",
         "scitex_agent_container/_maintenance/_install_integrity_pointers.py:226",
         "scitex_agent_container/_maintenance/_venv_dist_assertion.py:120",
@@ -312,7 +314,7 @@ def test_no_new_unnamed_delivery_claim():
         "These `stx-allow` reasons claim the failure is logged/alerted/"
         "reported but name no sink. Name the path or channel in the comment "
         "(e.g. 'logged to runtime/logs/<name>.log') so the claim can be "
-        f"re-checked later:\n  " + "\n  ".join(sorted(new))
+        "re-checked later:\n  " + "\n  ".join(sorted(new))
     )
 
 

--- a/tests/scitex_agent_container/_jobs/test__specs_reachability.py
+++ b/tests/scitex_agent_container/_jobs/test__specs_reachability.py
@@ -1,0 +1,86 @@
+"""The cross-host a2a REACHABILITY JobSpec, pinned.
+
+Mirrors the split of :mod:`scitex_agent_container._jobs._specs_reachability`
+on the source side. What these protect: the job is DISCOVERED by the real
+``provide_jobs()`` (a job declared in a module nothing splices in is the
+inert-feature shape ``_jobs_audit`` exists to catch), its command is exactly
+the fleet-wide, recording, JSON form the supervisor's execution log expects,
+its kind lowers onto the supervisor at all, and its cadence is the 15 minutes
+the design argues for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+from scitex_agent_container._jobs._jobs_audit import Verdict, audit_jobs  # noqa: E402
+
+from ._jobspec_helpers import _job, _split_command  # noqa: E402
+
+NAME = "scitex-agent-container-a2a-reachability"
+
+
+def test_a2a_reachability_job_is_discovered_by_the_provider() -> None:
+    # Arrange — `_job` raises unless exactly one declared spec carries NAME.
+    # Act
+    job = _job(NAME)
+    # Assert
+    assert job.name == NAME
+
+
+def test_a2a_reachability_job_kind_is_timer() -> None:
+    # Arrange — a wrong kind raises at construction and `ecosystem up` then
+    # silently DROPS sac's whole provider.
+    # Act
+    job = _job(NAME)
+    # Assert
+    assert job.kind == "timer"
+
+
+def test_a2a_reachability_command_is_the_fleet_wide_recording_form() -> None:
+    # Arrange — EXACT equality on purpose: dropping --all silently probes
+    # nothing, dropping --record leaves `--last` reading a stale report,
+    # dropping --json leaves the supervisor's log holding a rich table.
+    # Act
+    job = _job(NAME)
+    # Assert
+    bound, _payload, rest = _split_command(job.command)
+    assert (bound, rest) == (
+        "/usr/bin/timeout 180",
+        "a2a reachability --all --json --record",
+    )
+
+
+def test_a2a_reachability_cadence_is_every_15_minutes() -> None:
+    # Arrange — an alias/token gap is a config fact; 15min bounds how long
+    # a peer stays silently unreachable without flooding the log.
+    # Act
+    job = _job(NAME)
+    # Assert
+    assert job.on_unit_active_sec == "15min"
+
+
+def test_a2a_reachability_cron_form_matches_the_timer_cadence() -> None:
+    # Arrange — `PeriodicRunner` reads on_unit_active_sec first and falls
+    # back to `schedule`; both must say the same thing.
+    # Act
+    job = _job(NAME)
+    # Assert
+    assert job.schedule == "*/15 * * * *"
+
+
+def test_a2a_reachability_job_has_a_live_counterpart_per_the_audit() -> None:
+    # Arrange — the inert-feature detector, run against the REAL provider and
+    # the REAL entry-point aggregation.
+    report = audit_jobs()
+    # Act
+    inert_for_us = [
+        f for f in report.findings if f.subject == NAME and f.verdict is Verdict.INERT
+    ]
+    # Assert
+    assert inert_for_us == []

--- a/tests/scitex_agent_container/_listen/test__node_channel_forwarders.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel_forwarders.py
@@ -16,17 +16,25 @@ shape as the rest of the package (PA-307).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import logging
 import os
+import textwrap
+import threading
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
 from starlette.responses import JSONResponse
 
+from scitex_agent_container._listen import _node_channel_forwarders as _fwd
 from scitex_agent_container._listen._node_channel_forwarders import (
     _forward_to_remote,
     _forward_via_ssh_curl,
 )
+from scitex_agent_container._listen.peer_tokens import write_peer_token
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
 
@@ -115,7 +123,6 @@ def test_forward_to_remote_502_when_peer_token_file_is_absent(isolated_home):
 # rc!=0 / empty-stdout / non-JSON / ACL-error / non-ACL-error / bearer-
 # validation branches that the loopback ssh_http_shim happy-path tests
 # don't reach, so codecov/patch >= 80% on the diff.
-
 
 
 def test_forward_via_ssh_curl_502s_when_ssh_shim_returns_nonzero_rc(
@@ -289,3 +296,337 @@ def test_forward_via_ssh_curl_502s_when_helper_raises_value_error(
     )
     # Assert
     assert resp.status_code == 502
+
+
+# --- Transport selector: the registry is the SSoT, HTTP is test-only ---------
+#
+# MEASURED 2026-09-02: scitex-compute-01 and scitex-compute-03 have NO
+# ~/.scitex/agent-container/config.yaml, so ``host_config.load().peers`` is
+# ``{}`` there and every cross-host send silently took the plain-HTTP leg —
+# which cannot connect to a fleet host (agents bind 127.0.0.1) — and died with
+# "All connection attempts failed". ``sac host probe`` on the same box already
+# resolved the destination through the scitex-dev host registry's
+# ``ssh_alias``. These tests pin the forwarder to that same SSoT.
+#
+# NO MOCKS: a real ``hosts.yaml`` at the real ``$SCITEX_DIR/dev/`` location
+# (the same seam ``test__peer_resolve.py`` drives), a real absent/malformed
+# ``config.yaml``, real peer-token files, the ``ssh`` shim on ``$PATH`` so the
+# production ``subprocess.run`` records the argv it was handed, and — for the
+# "HTTP is never attempted" claim — a real listener on 127.0.0.1 counting what
+# ARRIVES, because a claim about arrival is settled at the receiving end.
+
+_REGISTRY_ONLY_HOSTS_YAML = textwrap.dedent(
+    """\
+    hosts:
+      scitex-compute-03:
+        kind: workstation
+        ssh_alias: compute-03-via-registry
+        scitex_root: "~/.scitex"
+      scitex-laptop-02:
+        kind: workstation
+        ssh_alias: null
+        scitex_root: "~/.scitex"
+    """
+)
+
+_BODY = {"method": "SendMessage", "params": {}}
+
+
+@pytest.fixture
+def registry_only_peers(isolated_home: Path, env_save_restore):
+    """The measured compute-01 / compute-03 topology: a host registry with
+    ssh aliases and NO config.yaml at all.
+
+    ``SCITEX_AGENT_CONTAINER_CONFIG`` points at a file that does not
+    exist (``host_config.load`` is missing-tolerant → ``peers == {}``);
+    ``SCITEX_DIR`` points at a real ``dev/hosts.yaml`` written here, which
+    is the location both the ``scitex_dev.hosts`` port and sac's degraded
+    YAML reader resolve. Peer tokens are seeded for every host a test
+    below targets so the bearer lookup (which runs FIRST) never masks
+    the transport decision under test.
+    """
+    scitex_dir = isolated_home / "scitex-dir"
+    (scitex_dir / "dev").mkdir(parents=True)
+    (scitex_dir / "dev" / "hosts.yaml").write_text(_REGISTRY_ONLY_HOSTS_YAML)
+    env_save_restore.set("SCITEX_DIR", str(scitex_dir))
+    env_save_restore.delete("SCITEX_DEV_HOSTS_YAML")
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_CONFIG", str(isolated_home / "absent-config.yaml")
+    )
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(isolated_home / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    for host in (
+        "scitex-compute-03",
+        "scitex-laptop-02",
+        "scitex-compute-02",
+        "unrouted-host-z",
+        "127.0.0.1",
+        "host-a",
+    ):
+        write_peer_token(peer_host=host, token=f"bearer-for-{host}")
+    return scitex_dir
+
+
+def _forward(target_host: str, target_port: int = 19008) -> JSONResponse:
+    return asyncio.run(
+        _forward_to_remote(
+            request=None,
+            body=_BODY,
+            target_host=target_host,
+            target_port=target_port,
+            target_name="scitex-hub",
+        )
+    )
+
+
+@contextlib.contextmanager
+def _loopback_json_server(payload: dict):
+    """A real HTTP server on 127.0.0.1 answering every POST with ``payload``.
+
+    Yields ``(port, hits)``; ``hits`` gains one entry per POST that
+    actually arrived, so a test can assert on delivery — or its absence
+    — at the receiving end.
+    """
+    hits: list[str] = []
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 — http.server's fixed method name
+            self.rfile.read(int(self.headers.get("Content-Length") or 0))
+            hits.append(self.path)
+            data = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, *_args):  # keep pytest output clean
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1], hits
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+# (a) absent from raw config, present in the registry → ssh leg, registry alias
+
+
+def test_forward_to_remote_dials_the_registry_alias_when_config_yaml_is_absent(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    _forward("scitex-compute-03")
+    # Assert — the ssh host argument sits right before the remote curl snippet
+    assert subprocess_shim.argv_for("ssh")[-2] == "compute-03-via-registry"
+
+
+def test_forward_to_remote_returns_the_ssh_legs_response_for_a_registry_host(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout='{"ok": true}', stderr="")
+    # Act
+    resp = _forward("scitex-compute-03")
+    # Assert
+    assert (resp.status_code, _read_json_body(resp)) == (200, {"ok": True})
+
+
+# (b) absent from both → loud 502, HTTP never attempted
+
+
+def test_forward_to_remote_502s_for_a_host_in_neither_config_nor_registry(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    resp = _forward("unrouted-host-z")
+    # Assert
+    assert resp.status_code == 502
+
+
+def test_forward_to_remote_refusal_names_the_host_and_the_loopback_bind(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    error = _read_json_body(_forward("unrouted-host-z"))["error"]
+    # Assert
+    assert "'unrouted-host-z'" in error and "bind 127.0.0.1" in error
+
+
+def test_forward_to_remote_refusal_names_both_fixes(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    error = _read_json_body(_forward("unrouted-host-z"))["error"]
+    # Assert — the registry fix AND the config.yaml fix on THIS host
+    assert (
+        "ssh_alias" in error
+        and "hosts.yaml" in error
+        and ("peers: {unrouted-host-z: {ssh: <alias>}}" in error)
+    )
+
+
+def test_forward_to_remote_refusal_names_the_config_path_this_host_resolved(
+    registry_only_peers, subprocess_shim, isolated_home
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    error = _read_json_body(_forward("unrouted-host-z"))["error"]
+    # Assert
+    assert str(isolated_home / "absent-config.yaml") in error
+
+
+def test_forward_to_remote_never_posts_http_to_an_unroutable_host(
+    registry_only_peers, subprocess_shim
+):
+    """Settled at the RECEIVING end. ``127.0.0.1`` as the destination
+    label is neither a peer nor a ``host-*`` alias, so the pre-fix HTTP
+    leg would have posted straight into this listener; the refusal must
+    leave it untouched."""
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    with _loopback_json_server({"reached": True}) as (port, hits):
+        # Act
+        resp = _forward("127.0.0.1", target_port=port)
+    # Assert
+    assert (resp.status_code, hits) == (502, [])
+
+
+def test_forward_to_remote_does_not_dial_ssh_for_an_unroutable_host(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    _forward("unrouted-host-z")
+    # Assert
+    assert subprocess_shim.call_count("ssh") == 0
+
+
+def test_forward_to_remote_502s_for_a_registry_row_without_an_ssh_alias(
+    registry_only_peers, subprocess_shim
+):
+    """A registry row with ``ssh_alias: null`` (inbound ssh impossible) is
+    NOT a route — it must refuse, never pass through to HTTP."""
+    # Arrange
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    resp = _forward("scitex-laptop-02")
+    # Assert — the REFUSAL, not the HTTP leg's own connection failure
+    assert (
+        resp.status_code,
+        "was not attempted" in _read_json_body(resp)["error"],
+    ) == (
+        502,
+        True,
+    )
+
+
+def test_forward_to_remote_warns_once_per_unroutable_host(
+    registry_only_peers, subprocess_shim, caplog
+):
+    # Arrange — a host this process has never refused, then two sends to it
+    host = f"unrouted-{uuid.uuid4().hex[:8]}"
+    write_peer_token(peer_host=host, token="bearer-for-once")
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    caplog.set_level(logging.WARNING, logger=_fwd.__name__)
+    # Act
+    _forward(host)
+    _forward(host)
+    # Assert
+    warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING and f"'{host}'" in rec.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+# (c) the ``host-*`` test-loopback alias still takes the HTTP leg
+
+
+def test_forward_to_remote_posts_http_to_loopback_for_the_host_a_test_alias(
+    registry_only_peers, subprocess_shim
+):
+    # Arrange — a real loopback listener stands in for "host-a"
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    with _loopback_json_server({"forwarded": "via-http"}) as (port, hits):
+        # Act
+        resp = _forward("host-a", target_port=port)
+    # Assert
+    assert (resp.status_code, _read_json_body(resp), hits) == (
+        200,
+        {"forwarded": "via-http"},
+        ["/agents/scitex-hub/message:send"],
+    )
+
+
+def test_is_test_loopback_alias_accepts_only_host_dash_labels():
+    # Arrange
+    probes = ("host-a", "host-b", "host-zz", "scitex-compute-03", "hosta", "")
+    # Act
+    verdicts = tuple(_fwd._is_test_loopback_alias(p) for p in probes)
+    # Assert
+    assert verdicts == (True, True, True, False, False, False)
+
+
+# (d) config.yaml glob keys keep resolving through the merged map
+
+
+def test_forward_to_remote_resolves_a_config_glob_key_through_the_merged_map(
+    registry_only_peers, subprocess_shim, env_save_restore, isolated_home
+):
+    # Arrange — a pattern key with blank ssh: PeersMap synthesises ssh=<name>
+    cfg = isolated_home / "glob-config.yaml"
+    cfg.write_text("peers:\n  'scitex-compute-*': {}\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    _forward("scitex-compute-02")
+    # Assert
+    assert subprocess_shim.argv_for("ssh")[-2] == "scitex-compute-02"
+
+
+# (e) a malformed config.yaml must not disable forwarding — the registry routes
+
+
+def test_forward_to_remote_still_routes_via_registry_when_config_yaml_is_malformed(
+    registry_only_peers, subprocess_shim, env_save_restore, isolated_home
+):
+    # Arrange — ``peers:`` as a list makes host_config.load raise ValueError
+    cfg = isolated_home / "broken-config.yaml"
+    cfg.write_text("peers:\n  - not\n  - a\n  - mapping\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    _forward("scitex-compute-03")
+    # Assert
+    assert subprocess_shim.argv_for("ssh")[-2] == "compute-03-via-registry"
+
+
+def test_forward_to_remote_refusal_carries_the_config_parse_failure(
+    registry_only_peers, subprocess_shim, env_save_restore, isolated_home
+):
+    # Arrange
+    cfg = isolated_home / "broken-config.yaml"
+    cfg.write_text("peers:\n  - not\n  - a\n  - mapping\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    subprocess_shim.install("ssh", exit=0, stdout="{}", stderr="")
+    # Act
+    error = _read_json_body(_forward("unrouted-host-z"))["error"]
+    # Assert
+    assert "broken-config.yaml failed to load" in error

--- a/tests/scitex_agent_container/_network/test__reachability.py
+++ b/tests/scitex_agent_container/_network/test__reachability.py
@@ -4,15 +4,22 @@ The properties that must never regress:
 
 * the exit-code mapping is THREE-valued: UNKNOWN is never reachable and never
   unreachable, and a pass with nothing measured is 3, not 0;
-* per-host resolution takes the alias from the same SSoT the CLI routes by
-  (config.yaml peers UNION the host registry), lists alias-less registry
-  rows as UNKNOWN rather than dropping them, and never probes THIS host;
+* per-host resolution takes the alias from THE forwarder's own resolver
+  (``_listen._node_channel_forwarders._resolve_ssh_peer`` — the same
+  callable, not a look-alike), lists alias-less registry rows as UNKNOWN
+  rather than dropping them, and never probes THIS host — even when this
+  host has an alias AND a peer token, i.e. when nothing but the local skip
+  stands between the probe and an ssh to itself;
 * the probe's refusals are UNKNOWN with the file to fix named, and only a
-  DISPATCHED leg can produce True or False.
+  DISPATCHED leg can produce True or False;
+* the ``local`` decision is carried into the row, so the alarm can skip the
+  self row by the same decision instead of by name.
 
 No mocks. The registry is a real ``hosts.yaml`` under a real ``$SCITEX_DIR``;
-the ssh leg is a fake ``ssh`` binary on PATH (``subprocess_shim``) so the real
-``subprocess.run`` runs; peer tokens are real files under a temp dir.
+config.yaml is a real file (or a real absence) under
+``SCITEX_AGENT_CONTAINER_CONFIG``; the ssh leg is a fake ``ssh`` binary on
+PATH (``subprocess_shim``) so the real ``subprocess.run`` runs; peer tokens
+are real files under a temp dir.
 """
 
 from __future__ import annotations
@@ -22,7 +29,9 @@ from pathlib import Path
 
 import pytest
 
+from scitex_agent_container._listen import _node_channel_forwarders as _fwd
 from scitex_agent_container._listen.peer_tokens import write_peer_token
+from scitex_agent_container._network import _reachability as _probe
 from scitex_agent_container._network._reachability import (
     EXIT_ALL_REACHABLE,
     EXIT_NOTHING_MEASURABLE,
@@ -39,7 +48,6 @@ from scitex_agent_container._network._reachability import (
     write_report,
 )
 from scitex_agent_container._network._ssh_curl import STATUS_MARKER
-from scitex_agent_container._state.host_config import PeerSpec
 
 _HOSTS_YAML = textwrap.dedent(
     """\
@@ -62,15 +70,35 @@ _HOSTS_YAML = textwrap.dedent(
 
 @pytest.fixture
 def registry(tmp_path: Path, env_save_restore) -> Path:
-    """A real hosts.yaml at the real resolved location ($SCITEX_DIR/dev/)."""
+    """A real hosts.yaml at the real resolved location ($SCITEX_DIR/dev/),
+    and NO config.yaml — ``SCITEX_AGENT_CONTAINER_CONFIG`` names a file that
+    does not exist (``host_config.load`` is missing-tolerant → no peers), so
+    the operator's real config is never read. ``config()`` below writes one.
+    """
     hosts_dir = tmp_path / "scitex" / "dev"
     hosts_dir.mkdir(parents=True)
     (hosts_dir / "hosts.yaml").write_text(_HOSTS_YAML)
     env_save_restore.set("SCITEX_DIR", str(tmp_path / "scitex"))
+    env_save_restore.delete("SCITEX_DEV_HOSTS_YAML")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(tmp_path / "config.yaml"))
     return hosts_dir / "hosts.yaml"
 
 
-def _row(host: str, reachable, transport: str = TRANSPORT_SSH) -> HostReachability:
+@pytest.fixture
+def config(tmp_path: Path, registry):
+    """Write a real config.yaml at the path the ``registry`` fixture pinned."""
+
+    def _write(peers_block: str) -> Path:
+        path = tmp_path / "config.yaml"
+        path.write_text("host:\n  canonical: probe-box\npeers:\n" + peers_block)
+        return path
+
+    return _write
+
+
+def _row(
+    host: str, reachable, transport: str = TRANSPORT_SSH, *, local: bool = False
+) -> HostReachability:
     return HostReachability(
         host=host,
         ssh_alias=None if transport == TRANSPORT_NONE else host,
@@ -78,6 +106,7 @@ def _row(host: str, reachable, transport: str = TRANSPORT_SSH) -> HostReachabili
         reachable=reachable,
         elapsed_ms=None if reachable is None else 12,
         error=None if reachable is True else "why",
+        local=local,
     )
 
 
@@ -146,15 +175,45 @@ def test_exit_code_never_uses_two():
 # ---------------------------------------------------------------------------
 
 
-def test_row_to_dict_carries_exactly_the_six_declared_fields():
+def test_row_to_dict_carries_exactly_the_seven_declared_fields():
     # Arrange
     row = _row("a", True)
     # Act
     keys = set(row.to_dict())
     # Assert
     assert keys == {
-        "host", "ssh_alias", "transport", "reachable", "elapsed_ms", "error"
+        "host",
+        "ssh_alias",
+        "transport",
+        "reachable",
+        "elapsed_ms",
+        "error",
+        "local",
     }
+
+
+def test_local_row_round_trips_its_flag_through_the_dict_shape():
+    # Arrange — the alarm reads this flag back from --record'ed reports too.
+    row = _row("me", None, TRANSPORT_NONE, local=True)
+    # Act
+    loaded = HostReachability.from_dict(row.to_dict())
+    # Assert
+    assert loaded.local is True
+
+
+def test_a_local_row_cannot_claim_the_ssh_transport():
+    # Arrange — this host has no leg; a local row that says "ssh" is a lie.
+    kwargs = dict(host="me", ssh_alias="me", reachable=None, elapsed_ms=None)
+
+    # Act
+    def _build():
+        return HostReachability(
+            transport=TRANSPORT_SSH, error="why", local=True, **kwargs
+        )
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
 
 
 def test_row_with_no_transport_cannot_claim_a_measured_verdict():
@@ -190,7 +249,7 @@ def test_report_round_trips_through_its_json_file(tmp_path: Path):
         port=7878,
         started_at_utc="2026-09-02T00:00:00+00:00",
         elapsed_ms=5,
-        rows=(_row("a", False), _row("me", None, TRANSPORT_NONE)),
+        rows=(_row("a", False), _row("me", None, TRANSPORT_NONE, local=True)),
     )
     target = tmp_path / "a2a-reachability.json"
     # Act
@@ -214,50 +273,50 @@ def test_read_report_is_none_when_nothing_was_recorded(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_registry_alias_is_the_ssh_target_when_config_has_no_peers(registry):
+def _targets(**kwargs) -> dict[str, Target]:
+    return {t.host: t for t in resolve_targets(local_names=set(), **kwargs)}
+
+
+def test_registry_alias_is_the_ssh_target_when_config_is_absent(registry):
     # Arrange — THE measured gap: hosts with no config.yaml still know their
-    # peers through the registry the CLI verbs already route by.
-    peers: dict[str, PeerSpec] = {}
+    # peers through the registry the forwarder now routes by.
     # Act
-    targets = {t.host: t for t in resolve_targets(peers=peers, local_names=set())}
+    targets = _targets()
     # Assert
     assert targets["peer-with-alias"].ssh_alias == "peer-with-alias-ssh"
 
 
 def test_registry_row_without_alias_is_listed_with_no_ssh_target(registry):
     # Arrange — it must SURFACE (as unknown), not vanish from the report.
-    peers: dict[str, PeerSpec] = {}
     # Act
-    targets = {t.host: t for t in resolve_targets(peers=peers, local_names=set())}
+    targets = _targets()
     # Assert
     assert targets["peer-without-alias"].ssh_alias is None
 
 
-def test_config_peer_wins_over_the_registry_alias(registry):
+def test_config_peer_wins_over_the_registry_alias(config):
     # Arrange — config.yaml carries via:/env_preamble the registry cannot.
-    peers = {"peer-with-alias": PeerSpec(name="peer-with-alias", ssh="cfg-route")}
+    config("  peer-with-alias:\n    ssh: cfg-route\n")
     # Act
-    targets = {t.host: t for t in resolve_targets(peers=peers, local_names=set())}
+    targets = _targets()
     # Assert
     assert targets["peer-with-alias"].ssh_alias == "cfg-route"
 
 
-def test_glob_peer_templates_are_not_hosts(registry):
+def test_glob_peer_templates_are_not_hosts(config):
     # Arrange — `spartan-*` is a template for ephemeral nodes, not a host.
-    peers = {"spartan-*": PeerSpec(name="spartan-*", ssh="")}
+    config("  spartan-*:\n    ssh: ''\n    via: [spartan]\n")
     # Act
-    names = [t.host for t in resolve_targets(peers=peers, local_names=set())]
+    names = [t.host for t in resolve_targets(local_names=set())]
     # Assert
     assert "spartan-*" not in names
 
 
 def test_local_host_is_flagged_local(registry):
     # Arrange
-    peers: dict[str, PeerSpec] = {}
+    local_names = {"probe-box"}
     # Act
-    targets = {
-        t.host: t for t in resolve_targets(peers=peers, local_names={"probe-box"})
-    }
+    targets = {t.host: t for t in resolve_targets(local_names=local_names)}
     # Assert
     assert targets["probe-box"].local is True
 
@@ -265,15 +324,59 @@ def test_local_host_is_flagged_local(registry):
 def test_only_with_an_unknown_name_fails_loudly(registry):
     # Arrange — a typo that probed nothing would exit 3 and read as
     # "the fleet is unknown"; it must name the misspelling instead.
-    peers: dict[str, PeerSpec] = {}
+    only = ["peer-typo"]
 
     # Act
     def _resolve():
-        return resolve_targets(peers=peers, local_names=set(), only=["peer-typo"])
+        return resolve_targets(local_names=set(), only=only)
 
     # Assert
     with pytest.raises(KeyError):
         _resolve()
+
+
+# ---------------------------------------------------------------------------
+# PARITY with the forwarder — the same resolver, not a look-alike
+# ---------------------------------------------------------------------------
+#
+# Review round 2 of PR #1285: the first cut resolved aliases through the
+# merged peer map while the forwarder on develop read the RAW config block,
+# so the probe could report "reachable" for a peer a real send could not
+# route. The fix is structural — the probe IMPORTS the forwarder's resolver —
+# and these tests pin both the identity of the callable and, on a fixture
+# where config.yaml and the registry disagree, the answer.
+
+
+def test_probe_resolves_aliases_through_the_forwarders_own_callable():
+    # Arrange — identity, not equivalence: a faithful re-implementation would
+    # pass an answer-comparison today and drift tomorrow.
+    forwarder_resolver = _fwd._resolve_ssh_peer
+    # Act
+    probe_resolver = _probe._resolve_ssh_peer
+    # Assert
+    assert probe_resolver is forwarder_resolver
+
+
+def test_probe_alias_equals_the_forwarders_route_for_every_host(config):
+    # Arrange — config overrides one registry alias; the registry supplies
+    # another; a third row has none. All three must answer identically.
+    config("  peer-with-alias:\n    ssh: cfg-route\n")
+    hosts = ["peer-with-alias", "peer-without-alias", "probe-box"]
+    # Act
+    probe_answers = {t.host: t.ssh_alias for t in resolve_targets(local_names=set())}
+    forwarder_answers = {h: _fwd._resolve_ssh_peer(h).ssh_target for h in hosts}
+    # Assert
+    assert {h: probe_answers[h] for h in hosts} == forwarder_answers
+
+
+def test_unroutable_host_carries_the_forwarders_own_refusal_reason(registry):
+    # Arrange — the UNKNOWN row must say what a real send would 502 with.
+    target = _targets()["peer-without-alias"]
+    expected_reason = _fwd._resolve_ssh_peer("peer-without-alias").reason
+    # Act
+    row = probe_target(target)
+    # Assert
+    assert expected_reason and expected_reason in (row.error or "")
 
 
 # ---------------------------------------------------------------------------
@@ -298,14 +401,40 @@ _HEALTHY = f'{{"ok": true, "service": "sac-listen", "v": 1}}\n{STATUS_MARKER}200
 def test_local_host_is_unknown_and_never_dispatched(
     tmp_path, env_save_restore, subprocess_shim, tokens_dir
 ):
-    # Arrange — an ssh on PATH that would record any dispatch.
+    # Arrange — this host has an alias AND a peer token, so NOTHING but the
+    # local skip stands between the probe and an ssh to itself; the ssh on
+    # PATH would answer as a healthy listen and record the dispatch. (Review
+    # round 2: without the token the row went unknown for the wrong reason
+    # and the test stayed green with the skip removed.)
     _pin_ssh_env(tmp_path, env_save_restore)
-    subprocess_shim.install("ssh", exit=0, stdout="")
+    write_peer_token(peer_host="probe-box", token="t0k3n", tokens_dir=tokens_dir)
+    subprocess_shim.install("ssh", exit=0, stdout=_HEALTHY)
     target = Target(host="probe-box", ssh_alias="probe-box", local=True)
     # Act
     row = probe_target(target, tokens_dir=tokens_dir)
-    # Assert — the shape says unknown AND the leg was never run.
-    assert (row.reachable, subprocess_shim.call_count("ssh")) == (None, 0)
+    # Assert — unknown over NO transport, and the leg was never run.
+    assert (row.reachable, row.transport, subprocess_shim.call_count("ssh")) == (
+        None,
+        TRANSPORT_NONE,
+        0,
+    )
+
+
+def test_local_host_row_carries_the_local_flag(tokens_dir):
+    # Arrange — the alarm skips the self row by this flag, not by name.
+    target = Target(host="probe-box", ssh_alias="probe-box", local=True)
+    # Act
+    row = probe_target(target, tokens_dir=tokens_dir)
+    # Assert
+    assert row.local is True
+
+
+def test_a_peer_row_does_not_carry_the_local_flag(tokens_dir):
+    # Arrange
+    # Act
+    row = probe_target(_PEER, tokens_dir=tokens_dir)
+    # Assert
+    assert row.local is False
 
 
 def test_host_without_alias_is_unknown_over_no_transport(tokens_dir):

--- a/tests/scitex_agent_container/_network/test__reachability.py
+++ b/tests/scitex_agent_container/_network/test__reachability.py
@@ -1,0 +1,405 @@
+"""Tests for ``_network/_reachability`` — the three-valued cross-host probe.
+
+The properties that must never regress:
+
+* the exit-code mapping is THREE-valued: UNKNOWN is never reachable and never
+  unreachable, and a pass with nothing measured is 3, not 0;
+* per-host resolution takes the alias from the same SSoT the CLI routes by
+  (config.yaml peers UNION the host registry), lists alias-less registry
+  rows as UNKNOWN rather than dropping them, and never probes THIS host;
+* the probe's refusals are UNKNOWN with the file to fix named, and only a
+  DISPATCHED leg can produce True or False.
+
+No mocks. The registry is a real ``hosts.yaml`` under a real ``$SCITEX_DIR``;
+the ssh leg is a fake ``ssh`` binary on PATH (``subprocess_shim``) so the real
+``subprocess.run`` runs; peer tokens are real files under a temp dir.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._listen.peer_tokens import write_peer_token
+from scitex_agent_container._network._reachability import (
+    EXIT_ALL_REACHABLE,
+    EXIT_NOTHING_MEASURABLE,
+    EXIT_UNREACHABLE,
+    TRANSPORT_NONE,
+    TRANSPORT_SSH,
+    HostReachability,
+    ReachabilityReport,
+    Target,
+    exit_code_for,
+    probe_target,
+    read_report,
+    resolve_targets,
+    write_report,
+)
+from scitex_agent_container._network._ssh_curl import STATUS_MARKER
+from scitex_agent_container._state.host_config import PeerSpec
+
+_HOSTS_YAML = textwrap.dedent(
+    """\
+    hosts:
+      probe-box:
+        kind: workstation
+        ssh_alias: probe-box
+        scitex_root: "~/.scitex"
+      peer-with-alias:
+        kind: workstation
+        ssh_alias: peer-with-alias-ssh
+        scitex_root: "~/.scitex"
+      peer-without-alias:
+        kind: workstation
+        ssh_alias: null
+        scitex_root: "~/.scitex"
+    """
+)
+
+
+@pytest.fixture
+def registry(tmp_path: Path, env_save_restore) -> Path:
+    """A real hosts.yaml at the real resolved location ($SCITEX_DIR/dev/)."""
+    hosts_dir = tmp_path / "scitex" / "dev"
+    hosts_dir.mkdir(parents=True)
+    (hosts_dir / "hosts.yaml").write_text(_HOSTS_YAML)
+    env_save_restore.set("SCITEX_DIR", str(tmp_path / "scitex"))
+    return hosts_dir / "hosts.yaml"
+
+
+def _row(host: str, reachable, transport: str = TRANSPORT_SSH) -> HostReachability:
+    return HostReachability(
+        host=host,
+        ssh_alias=None if transport == TRANSPORT_NONE else host,
+        transport=transport,
+        reachable=reachable,
+        elapsed_ms=None if reachable is None else 12,
+        error=None if reachable is True else "why",
+    )
+
+
+# ---------------------------------------------------------------------------
+# exit codes — three values, never two
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_is_nothing_measurable_when_there_are_no_rows():
+    # Arrange
+    rows: list[HostReachability] = []
+    # Act
+    code = exit_code_for(rows)
+    # Assert
+    assert code == EXIT_NOTHING_MEASURABLE
+
+
+def test_exit_code_is_nothing_measurable_when_every_row_is_unknown():
+    # Arrange — THE rule: unknown is not reachable. A pass that could not
+    # look must not read as a pass that looked and found nothing wrong.
+    rows = [_row("a", None, TRANSPORT_NONE), _row("b", None)]
+    # Act
+    code = exit_code_for(rows)
+    # Assert
+    assert code == EXIT_NOTHING_MEASURABLE
+
+
+def test_exit_code_is_zero_when_every_measured_row_is_reachable():
+    # Arrange
+    rows = [_row("a", True), _row("b", True)]
+    # Act
+    code = exit_code_for(rows)
+    # Assert
+    assert code == EXIT_ALL_REACHABLE
+
+
+def test_exit_code_stays_zero_when_unknown_rows_sit_beside_reachable_ones():
+    # Arrange — the measured hosts are a real answer; unknown ones are listed.
+    rows = [_row("a", True), _row("me", None, TRANSPORT_NONE)]
+    # Act
+    code = exit_code_for(rows)
+    # Assert
+    assert code == EXIT_ALL_REACHABLE
+
+
+def test_exit_code_is_one_when_any_row_is_unreachable():
+    # Arrange — one bad host is never hidden behind good ones.
+    rows = [_row("a", True), _row("b", False), _row("c", None)]
+    # Act
+    code = exit_code_for(rows)
+    # Assert
+    assert code == EXIT_UNREACHABLE
+
+
+def test_exit_code_never_uses_two():
+    # Arrange — 2 is Click's usage-error code and carries no domain meaning.
+    combos = [[], [_row("a", None)], [_row("a", True)], [_row("a", False)]]
+    # Act
+    codes = {exit_code_for(rows) for rows in combos}
+    # Assert
+    assert 2 not in codes
+
+
+# ---------------------------------------------------------------------------
+# the fixed answer shape
+# ---------------------------------------------------------------------------
+
+
+def test_row_to_dict_carries_exactly_the_six_declared_fields():
+    # Arrange
+    row = _row("a", True)
+    # Act
+    keys = set(row.to_dict())
+    # Assert
+    assert keys == {
+        "host", "ssh_alias", "transport", "reachable", "elapsed_ms", "error"
+    }
+
+
+def test_row_with_no_transport_cannot_claim_a_measured_verdict():
+    # Arrange — nothing was dispatched, so nothing can have been measured.
+    kwargs = dict(host="a", ssh_alias=None, transport=TRANSPORT_NONE, elapsed_ms=None)
+
+    # Act
+    def _build():
+        return HostReachability(reachable=True, error=None, **kwargs)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
+
+
+def test_unknown_row_must_state_its_reason():
+    # Arrange — an UNKNOWN with no reason is the silence this shape forbids.
+    kwargs = dict(host="a", ssh_alias=None, transport=TRANSPORT_NONE, elapsed_ms=None)
+
+    # Act
+    def _build():
+        return HostReachability(reachable=None, error=None, **kwargs)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
+
+
+def test_report_round_trips_through_its_json_file(tmp_path: Path):
+    # Arrange
+    report = ReachabilityReport(
+        probed_from="probe-box",
+        port=7878,
+        started_at_utc="2026-09-02T00:00:00+00:00",
+        elapsed_ms=5,
+        rows=(_row("a", False), _row("me", None, TRANSPORT_NONE)),
+    )
+    target = tmp_path / "a2a-reachability.json"
+    # Act
+    write_report(report, path=target)
+    loaded = read_report(path=target)
+    # Assert
+    assert loaded == report
+
+
+def test_read_report_is_none_when_nothing_was_recorded(tmp_path: Path):
+    # Arrange
+    target = tmp_path / "absent.json"
+    # Act
+    loaded = read_report(path=target)
+    # Assert
+    assert loaded is None
+
+
+# ---------------------------------------------------------------------------
+# per-host resolution — alias present / absent / local host
+# ---------------------------------------------------------------------------
+
+
+def test_registry_alias_is_the_ssh_target_when_config_has_no_peers(registry):
+    # Arrange — THE measured gap: hosts with no config.yaml still know their
+    # peers through the registry the CLI verbs already route by.
+    peers: dict[str, PeerSpec] = {}
+    # Act
+    targets = {t.host: t for t in resolve_targets(peers=peers, local_names=set())}
+    # Assert
+    assert targets["peer-with-alias"].ssh_alias == "peer-with-alias-ssh"
+
+
+def test_registry_row_without_alias_is_listed_with_no_ssh_target(registry):
+    # Arrange — it must SURFACE (as unknown), not vanish from the report.
+    peers: dict[str, PeerSpec] = {}
+    # Act
+    targets = {t.host: t for t in resolve_targets(peers=peers, local_names=set())}
+    # Assert
+    assert targets["peer-without-alias"].ssh_alias is None
+
+
+def test_config_peer_wins_over_the_registry_alias(registry):
+    # Arrange — config.yaml carries via:/env_preamble the registry cannot.
+    peers = {"peer-with-alias": PeerSpec(name="peer-with-alias", ssh="cfg-route")}
+    # Act
+    targets = {t.host: t for t in resolve_targets(peers=peers, local_names=set())}
+    # Assert
+    assert targets["peer-with-alias"].ssh_alias == "cfg-route"
+
+
+def test_glob_peer_templates_are_not_hosts(registry):
+    # Arrange — `spartan-*` is a template for ephemeral nodes, not a host.
+    peers = {"spartan-*": PeerSpec(name="spartan-*", ssh="")}
+    # Act
+    names = [t.host for t in resolve_targets(peers=peers, local_names=set())]
+    # Assert
+    assert "spartan-*" not in names
+
+
+def test_local_host_is_flagged_local(registry):
+    # Arrange
+    peers: dict[str, PeerSpec] = {}
+    # Act
+    targets = {
+        t.host: t for t in resolve_targets(peers=peers, local_names={"probe-box"})
+    }
+    # Assert
+    assert targets["probe-box"].local is True
+
+
+def test_only_with_an_unknown_name_fails_loudly(registry):
+    # Arrange — a typo that probed nothing would exit 3 and read as
+    # "the fleet is unknown"; it must name the misspelling instead.
+    peers: dict[str, PeerSpec] = {}
+
+    # Act
+    def _resolve():
+        return resolve_targets(peers=peers, local_names=set(), only=["peer-typo"])
+
+    # Assert
+    with pytest.raises(KeyError):
+        _resolve()
+
+
+# ---------------------------------------------------------------------------
+# probe_target — refusals are UNKNOWN; only a dispatched leg measures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tokens_dir(tmp_path: Path) -> Path:
+    return tmp_path / "peer-tokens"
+
+
+def _pin_ssh_env(tmp_path, env_save_restore) -> None:
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+
+
+_PEER = Target(host="peer-with-alias", ssh_alias="peer-with-alias-ssh", local=False)
+_HEALTHY = f'{{"ok": true, "service": "sac-listen", "v": 1}}\n{STATUS_MARKER}200\n'
+
+
+def test_local_host_is_unknown_and_never_dispatched(
+    tmp_path, env_save_restore, subprocess_shim, tokens_dir
+):
+    # Arrange — an ssh on PATH that would record any dispatch.
+    _pin_ssh_env(tmp_path, env_save_restore)
+    subprocess_shim.install("ssh", exit=0, stdout="")
+    target = Target(host="probe-box", ssh_alias="probe-box", local=True)
+    # Act
+    row = probe_target(target, tokens_dir=tokens_dir)
+    # Assert — the shape says unknown AND the leg was never run.
+    assert (row.reachable, subprocess_shim.call_count("ssh")) == (None, 0)
+
+
+def test_host_without_alias_is_unknown_over_no_transport(tokens_dir):
+    # Arrange
+    target = Target(host="peer-without-alias", ssh_alias=None, local=False)
+    # Act
+    row = probe_target(target, tokens_dir=tokens_dir)
+    # Assert
+    assert (row.reachable, row.transport) == (None, TRANSPORT_NONE)
+
+
+def test_host_without_peer_token_is_unknown_and_names_the_fix(tokens_dir):
+    # Arrange — the forwarder refuses to send without one; so does the probe.
+    # Act
+    row = probe_target(_PEER, tokens_dir=tokens_dir)
+    # Assert
+    assert row.reachable is None and "sac host add-peer" in (row.error or "")
+
+
+def test_failed_ssh_leg_is_unreachable_not_unknown(
+    tmp_path, env_save_restore, subprocess_shim, tokens_dir
+):
+    # Arrange — a dispatched leg that fails is a MEASURED False.
+    _pin_ssh_env(tmp_path, env_save_restore)
+    write_peer_token(peer_host=_PEER.host, token="t0k3n", tokens_dir=tokens_dir)
+    subprocess_shim.install("ssh", exit=255, stderr="ssh: connect: refused")
+    # Act
+    row = probe_target(_PEER, tokens_dir=tokens_dir)
+    # Assert
+    assert row.reachable is False
+
+
+def test_failed_ssh_leg_names_the_alias_it_dialled(
+    tmp_path, env_save_restore, subprocess_shim, tokens_dir
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    write_peer_token(peer_host=_PEER.host, token="t0k3n", tokens_dir=tokens_dir)
+    subprocess_shim.install("ssh", exit=255, stderr="ssh: connect: refused")
+    # Act
+    row = probe_target(_PEER, tokens_dir=tokens_dir)
+    # Assert
+    assert "ssh://peer-with-alias-ssh" in (row.error or "")
+
+
+def test_non_200_answer_is_unreachable(
+    tmp_path, env_save_restore, subprocess_shim, tokens_dir
+):
+    # Arrange — something answered on the port, but not a healthy listen.
+    _pin_ssh_env(tmp_path, env_save_restore)
+    write_peer_token(peer_host=_PEER.host, token="t0k3n", tokens_dir=tokens_dir)
+    subprocess_shim.install("ssh", exit=0, stdout=f"not found\n{STATUS_MARKER}404\n")
+    # Act
+    row = probe_target(_PEER, tokens_dir=tokens_dir)
+    # Assert
+    assert row.reachable is False
+
+
+def test_a_200_that_is_not_sac_listen_is_unreachable(
+    tmp_path, env_save_restore, subprocess_shim, tokens_dir
+):
+    # Arrange — a stray service on 7878 must not pass as the listen.
+    _pin_ssh_env(tmp_path, env_save_restore)
+    write_peer_token(peer_host=_PEER.host, token="t0k3n", tokens_dir=tokens_dir)
+    subprocess_shim.install(
+        "ssh", exit=0, stdout=f"<html>hi</html>\n{STATUS_MARKER}200\n"
+    )
+    # Act
+    row = probe_target(_PEER, tokens_dir=tokens_dir)
+    # Assert
+    assert row.reachable is False
+
+
+def test_a_sac_listen_health_answer_is_reachable(
+    tmp_path, env_save_restore, subprocess_shim, tokens_dir
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    write_peer_token(peer_host=_PEER.host, token="t0k3n", tokens_dir=tokens_dir)
+    subprocess_shim.install("ssh", exit=0, stdout=_HEALTHY)
+    # Act
+    row = probe_target(_PEER, tokens_dir=tokens_dir)
+    # Assert
+    assert row.reachable is True
+
+
+def test_a_reachable_row_records_how_long_the_leg_took(
+    tmp_path, env_save_restore, subprocess_shim, tokens_dir
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    write_peer_token(peer_host=_PEER.host, token="t0k3n", tokens_dir=tokens_dir)
+    subprocess_shim.install("ssh", exit=0, stdout=_HEALTHY)
+    # Act
+    row = probe_target(_PEER, tokens_dir=tokens_dir)
+    # Assert
+    assert isinstance(row.elapsed_ms, int) and row.elapsed_ms >= 0

--- a/tests/scitex_agent_container/_network/test__reachability_alarm.py
+++ b/tests/scitex_agent_container/_network/test__reachability_alarm.py
@@ -1,0 +1,177 @@
+"""Tests for ``_network/_reachability_alarm`` — verdicts into sac's event log.
+
+No mocks: real :class:`HostReachability` rows and a REAL temporary JSONL
+event log passed through the module's own ``path=`` seam; every assertion
+reads the bytes back through the production :func:`read_events` — the same
+rail ``fleet-reconcile`` and ``host-sync-check`` record to.
+
+The behaviours that matter:
+
+* unreachable → a DEGRADED record naming the host, under this pass's own
+  subsystem axis;
+* unknown → its OWN event, never rendered as healthy;
+* THIS host's row is skipped — unknown by construction, not by failure;
+* reachable after a remembered degraded → RECOVERED, once; reachable on a
+  clean slate → nothing (a transition, not a heartbeat);
+* every pass writes a PASS_COMPLETED record carrying the counts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._events import (
+    PASS_COMPLETED,
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    SUBJECT_UNKNOWN,
+    read_events,
+)
+from scitex_agent_container._network._reachability import (
+    TRANSPORT_NONE,
+    TRANSPORT_SSH,
+    HostReachability,
+    ReachabilityReport,
+)
+from scitex_agent_container._network._reachability_alarm import (
+    SUBSYSTEM,
+    record_pass_completed,
+    record_report,
+)
+
+#: A fixed clock, so no test can be flaky on time.
+NOW = 1_800_000_000.0
+
+
+def _row(host: str, reachable, transport: str = TRANSPORT_SSH) -> HostReachability:
+    return HostReachability(
+        host=host,
+        ssh_alias=None if transport == TRANSPORT_NONE else f"{host}-ssh",
+        transport=transport,
+        reachable=reachable,
+        elapsed_ms=None if reachable is None else 12,
+        error=None if reachable is True else "ssh: connect: refused",
+    )
+
+
+def _report(*rows: HostReachability) -> ReachabilityReport:
+    return ReachabilityReport(
+        probed_from="probe-box",
+        port=7878,
+        started_at_utc="2026-09-02T00:00:00+00:00",
+        elapsed_ms=5,
+        rows=tuple(rows),
+    )
+
+
+@pytest.fixture
+def log(tmp_path: Path) -> Path:
+    return tmp_path / "sac-events.jsonl"
+
+
+def _events(log: Path, event: str):
+    return [e for e in read_events(path=log) if e.event == event]
+
+
+def test_unreachable_host_is_recorded_degraded(log):
+    # Arrange
+    report = _report(_row("peer-a", False))
+    # Act
+    record_report(report, path=log, now=NOW)
+    # Assert
+    assert [e.subject for e in _events(log, SUBJECT_DEGRADED)] == ["peer-a"]
+
+
+def test_degraded_record_speaks_under_this_pass_own_subsystem(log):
+    # Arrange — a reader filters the shared log on this axis first.
+    report = _report(_row("peer-a", False))
+    # Act
+    record_report(report, path=log, now=NOW)
+    # Assert
+    assert _events(log, SUBJECT_DEGRADED)[0].subsystem == SUBSYSTEM
+
+
+def test_degraded_record_is_written_again_on_the_next_pass(log):
+    # Arrange — an ongoing problem is an ongoing fact.
+    report = _report(_row("peer-a", False))
+    # Act
+    record_report(report, path=log, now=NOW)
+    record_report(report, path=log, now=NOW + 900)
+    # Assert
+    assert len(_events(log, SUBJECT_DEGRADED)) == 2
+
+
+def test_unknown_host_is_recorded_as_unknown_not_healthy(log):
+    # Arrange
+    report = _report(_row("peer-b", None))
+    # Act
+    record_report(report, path=log, now=NOW)
+    # Assert
+    assert [e.subject for e in _events(log, SUBJECT_UNKNOWN)] == ["peer-b"]
+
+
+def test_this_host_own_row_writes_no_record(log):
+    # Arrange — unknown by construction, not by failure to look.
+    report = _report(_row("probe-box", None, TRANSPORT_NONE))
+    # Act
+    record_report(report, path=log, now=NOW)
+    # Assert
+    assert read_events(path=log) == []
+
+
+def test_reachable_on_a_clean_slate_writes_nothing(log):
+    # Arrange — a transition rail, not a per-host heartbeat.
+    report = _report(_row("peer-a", True))
+    # Act
+    record_report(report, path=log, now=NOW)
+    # Assert
+    assert read_events(path=log) == []
+
+
+def test_reachable_after_degraded_records_the_recovery(log):
+    # Arrange
+    record_report(_report(_row("peer-a", False)), path=log, now=NOW)
+    # Act
+    record_report(_report(_row("peer-a", True)), path=log, now=NOW + 900)
+    # Assert
+    assert [e.subject for e in _events(log, SUBJECT_RECOVERED)] == ["peer-a"]
+
+
+def test_recovery_is_recorded_once_not_on_every_later_pass(log):
+    # Arrange
+    record_report(_report(_row("peer-a", False)), path=log, now=NOW)
+    record_report(_report(_row("peer-a", True)), path=log, now=NOW + 900)
+    # Act
+    record_report(_report(_row("peer-a", True)), path=log, now=NOW + 1800)
+    # Assert
+    assert len(_events(log, SUBJECT_RECOVERED)) == 1
+
+
+def test_outcome_names_what_reached_the_log(log):
+    # Arrange
+    report = _report(_row("peer-a", False), _row("peer-b", None), _row("me", True))
+    # Act
+    outcome = record_report(report, path=log, now=NOW)
+    # Assert
+    assert (outcome.degraded, outcome.unknown) == (("peer-a",), ("peer-b",))
+
+
+def test_pass_completed_record_carries_the_counts(log):
+    # Arrange
+    report = _report(_row("peer-a", False), _row("peer-b", None), _row("peer-c", True))
+    # Act
+    record_pass_completed(report, mode="all", path=log, now=NOW)
+    counts = _events(log, PASS_COMPLETED)[0].raw["counts"]
+    # Assert
+    assert counts == {"hosts": 3, "reachable": 1, "unreachable": 1, "unknown": 1}
+
+
+def test_pass_completed_record_carries_the_mode(log):
+    # Arrange — a by-hand subset run must not read as the timer being alive.
+    report = _report(_row("peer-a", True))
+    # Act
+    record_pass_completed(report, mode="subset", path=log, now=NOW)
+    # Assert
+    assert _events(log, PASS_COMPLETED)[0].verdict == "subset"

--- a/tests/scitex_agent_container/_network/test__reachability_alarm.py
+++ b/tests/scitex_agent_container/_network/test__reachability_alarm.py
@@ -10,7 +10,13 @@ The behaviours that matter:
 * unreachable → a DEGRADED record naming the host, under this pass's own
   subsystem axis;
 * unknown → its OWN event, never rendered as healthy;
-* THIS host's row is skipped — unknown by construction, not by failure;
+* per host, a record on TRANSITION only: two identical passes write one
+  record; a change of state writes one more (review round 2 of PR #1285 —
+  the shared rail's every-pass re-record put ten unknown records into the
+  log every fifteen minutes on compute-04);
+* THIS host's row is skipped by the ``local`` flag the probe carried — NOT
+  by comparing its name to ``probed_from``, which can be spelled differently
+  on the same machine;
 * reachable after a remembered degraded → RECOVERED, once; reachable on a
   clean slate → nothing (a transition, not a heartbeat);
 * every pass writes a PASS_COMPLETED record carrying the counts.
@@ -37,6 +43,7 @@ from scitex_agent_container._network._reachability import (
 )
 from scitex_agent_container._network._reachability_alarm import (
     SUBSYSTEM,
+    last_state_path,
     record_pass_completed,
     record_report,
 )
@@ -45,7 +52,9 @@ from scitex_agent_container._network._reachability_alarm import (
 NOW = 1_800_000_000.0
 
 
-def _row(host: str, reachable, transport: str = TRANSPORT_SSH) -> HostReachability:
+def _row(
+    host: str, reachable, transport: str = TRANSPORT_SSH, *, local: bool = False
+) -> HostReachability:
     return HostReachability(
         host=host,
         ssh_alias=None if transport == TRANSPORT_NONE else f"{host}-ssh",
@@ -53,12 +62,15 @@ def _row(host: str, reachable, transport: str = TRANSPORT_SSH) -> HostReachabili
         reachable=reachable,
         elapsed_ms=None if reachable is None else 12,
         error=None if reachable is True else "ssh: connect: refused",
+        local=local,
     )
 
 
-def _report(*rows: HostReachability) -> ReachabilityReport:
+def _report(
+    *rows: HostReachability, probed_from: str = "probe-box"
+) -> ReachabilityReport:
     return ReachabilityReport(
-        probed_from="probe-box",
+        probed_from=probed_from,
         port=7878,
         started_at_utc="2026-09-02T00:00:00+00:00",
         elapsed_ms=5,
@@ -93,16 +105,6 @@ def test_degraded_record_speaks_under_this_pass_own_subsystem(log):
     assert _events(log, SUBJECT_DEGRADED)[0].subsystem == SUBSYSTEM
 
 
-def test_degraded_record_is_written_again_on_the_next_pass(log):
-    # Arrange — an ongoing problem is an ongoing fact.
-    report = _report(_row("peer-a", False))
-    # Act
-    record_report(report, path=log, now=NOW)
-    record_report(report, path=log, now=NOW + 900)
-    # Assert
-    assert len(_events(log, SUBJECT_DEGRADED)) == 2
-
-
 def test_unknown_host_is_recorded_as_unknown_not_healthy(log):
     # Arrange
     report = _report(_row("peer-b", None))
@@ -112,9 +114,98 @@ def test_unknown_host_is_recorded_as_unknown_not_healthy(log):
     assert [e.subject for e in _events(log, SUBJECT_UNKNOWN)] == ["peer-b"]
 
 
+# --- transitions, not a heartbeat per host ----------------------------------
+
+
+def test_two_identical_degraded_passes_write_one_record(log):
+    # Arrange — an unchanged fact is in the --record file; the log holds
+    # the change.
+    report = _report(_row("peer-a", False))
+    # Act
+    record_report(report, path=log, now=NOW)
+    record_report(report, path=log, now=NOW + 900)
+    # Assert
+    assert len(_events(log, SUBJECT_DEGRADED)) == 1
+
+
+def test_two_identical_unknown_passes_write_one_record(log):
+    # Arrange — THE measured noise: ten unknown peers, re-recorded every tick.
+    report = _report(_row("peer-b", None))
+    # Act
+    record_report(report, path=log, now=NOW)
+    record_report(report, path=log, now=NOW + 900)
+    # Assert
+    assert len(_events(log, SUBJECT_UNKNOWN)) == 1
+
+
+def test_a_change_from_unknown_to_degraded_writes_one_more_record(log):
+    # Arrange — a token arrived and the leg was dispatched and failed: a
+    # different fact, so a second record.
+    record_report(_report(_row("peer-a", None)), path=log, now=NOW)
+    # Act
+    record_report(_report(_row("peer-a", False)), path=log, now=NOW + 900)
+    # Assert
+    assert [e.event for e in read_events(path=log)] == [
+        SUBJECT_UNKNOWN,
+        SUBJECT_DEGRADED,
+    ]
+
+
+def test_a_change_from_degraded_to_unknown_writes_one_more_record(log):
+    # Arrange — the token was removed: "could not probe" is not "still down".
+    record_report(_report(_row("peer-a", False)), path=log, now=NOW)
+    # Act
+    record_report(_report(_row("peer-a", None)), path=log, now=NOW + 900)
+    # Assert
+    assert [e.event for e in read_events(path=log)] == [
+        SUBJECT_DEGRADED,
+        SUBJECT_UNKNOWN,
+    ]
+
+
+def test_a_host_unchanged_across_three_passes_is_still_recorded_once(log):
+    # Arrange
+    report = _report(_row("peer-a", False), _row("peer-b", None))
+    # Act
+    for tick in range(3):
+        record_report(report, path=log, now=NOW + 900 * tick)
+    # Assert
+    assert len(read_events(path=log)) == 2
+
+
+def test_a_lost_memory_re_records_the_host_once_and_nothing_worse(log):
+    # Arrange — the memory is an optimisation of the record: losing it
+    # costs one duplicate, never a missed change.
+    report = _report(_row("peer-a", False))
+    record_report(report, path=log, now=NOW)
+    last_state_path(path=log).unlink()
+    # Act
+    record_report(report, path=log, now=NOW + 900)
+    record_report(report, path=log, now=NOW + 1800)
+    # Assert
+    assert len(_events(log, SUBJECT_DEGRADED)) == 2
+
+
+# --- this host: skipped by the carried flag, never by name ------------------
+
+
 def test_this_host_own_row_writes_no_record(log):
     # Arrange — unknown by construction, not by failure to look.
-    report = _report(_row("probe-box", None, TRANSPORT_NONE))
+    report = _report(_row("probe-box", None, TRANSPORT_NONE, local=True))
+    # Act
+    record_report(report, path=log, now=NOW)
+    # Assert
+    assert read_events(path=log) == []
+
+
+def test_this_host_is_skipped_by_its_local_flag_not_by_its_name(log):
+    # Arrange — the measured divergence: canonical_host() says the factory
+    # hostname, the registry (which decided `local`) says the fleet name.
+    # A name comparison would record this row as unknown every pass.
+    report = _report(
+        _row("scitex-nas-03", None, TRANSPORT_NONE, local=True),
+        probed_from="DXP480TPLUS-994",
+    )
     # Act
     record_report(report, path=log, now=NOW)
     # Assert

--- a/tests/scitex_agent_container/_network/test__ssh_curl_get.py
+++ b/tests/scitex_agent_container/_network/test__ssh_curl_get.py
@@ -1,0 +1,307 @@
+"""Unit + end-to-end coverage for ``_network/_ssh_curl._get_via_ssh_curl``.
+
+The GET sibling of ``_post_via_ssh_curl`` exists so the reachability probe
+can exercise the cross-host forwarder's TRANSPORT rather than a look-alike
+of it. Two properties matter and both are pinned here:
+
+* the ssh argv is the POST's argv (host, BatchMode, ControlMaster options),
+  and the bearer never reaches any argv element — it rides stdin as a curl
+  config, the house shape;
+* the remote snippet really works: the end-to-end tests install an ``ssh``
+  that executes the remote command LOCALLY (no mock; a real ``/bin/sh``
+  runs the real ``curl`` against a real ``http.server``), and assert on the
+  status line + body the production parser reads back.
+
+No ``unittest.mock``; ``subprocess_shim`` / ``ssh_exec_shim`` install fake
+binaries on PATH and production code calls the real ``subprocess.run``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._network._ssh_curl import (
+    STATUS_MARKER,
+    _get_via_ssh_curl,
+    split_status_line,
+)
+
+#: A FAKE, token-shaped value. Never a real credential — asserted ABSENT.
+_FAKE_BEARER = "FAKE-BEARER-VALUE-4f2a9c1e-NOT-A-REAL-TOKEN"
+
+#: An ``ssh`` that runs the LAST argv element (the remote command) locally,
+#: with stdin passed through — what sshd does with the post-host argv. The
+#: shared ``ssh_exec_shim`` script insists on a ``--`` separator, which the
+#: forwarder's argv (and therefore this GET's) deliberately does not carry.
+_LOCAL_EXEC_SSH = """#!/bin/sh
+for __a in "$@"; do __cmd="$__a"; done
+exec sh -c "$__cmd"
+"""
+
+
+def _pin_ssh_env(tmp_path, env_save_restore) -> None:
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+
+
+# ---------------------------------------------------------------------------
+# argv shape — the POST's argv, with the bearer kept out of it
+# ---------------------------------------------------------------------------
+
+
+def test_get_via_ssh_curl_includes_target_host_in_argv(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    # Act
+    _get_via_ssh_curl(host="example.invalid", port=7878, path="/v1/health")
+    argv = subprocess_shim.argv_for("ssh")
+    # Assert
+    assert "example.invalid" in argv
+
+
+def test_get_via_ssh_curl_keeps_bearer_out_of_every_argv_element(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange — a token in the argv is world-readable in /proc on BOTH hosts.
+    _pin_ssh_env(tmp_path, env_save_restore)
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    # Act
+    _get_via_ssh_curl(
+        host="example.invalid", port=7878, path="/v1/health", bearer=_FAKE_BEARER
+    )
+    leaked = [part for part in subprocess_shim.argv_for("ssh") if _FAKE_BEARER in part]
+    # Assert — count, never the matching text.
+    assert len(leaked) == 0
+
+
+def test_get_via_ssh_curl_takes_the_bearer_from_a_curl_config_on_stdin(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    # Act
+    _get_via_ssh_curl(
+        host="example.invalid", port=7878, path="/v1/health", bearer=_FAKE_BEARER
+    )
+    remote = subprocess_shim.argv_for("ssh")[-1]
+    # Assert
+    assert "--config -" in remote
+
+
+def test_get_via_ssh_curl_omits_the_config_read_when_bearer_is_none(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    # Act
+    _get_via_ssh_curl(host="example.invalid", port=7878, path="/v1/health")
+    remote = subprocess_shim.argv_for("ssh")[-1]
+    # Assert
+    assert "--config" not in remote
+
+
+def test_get_via_ssh_curl_uses_batch_mode_like_the_forwarder(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange — the whole point of the sibling: the SAME ssh options.
+    _pin_ssh_env(tmp_path, env_save_restore)
+    subprocess_shim.install("ssh", exit=0, stdout="{}")
+    # Act
+    _get_via_ssh_curl(host="example.invalid", port=7878, path="/v1/health")
+    argv = subprocess_shim.argv_for("ssh")
+    # Assert
+    assert "BatchMode=yes" in argv
+
+
+def test_get_via_ssh_curl_refuses_a_bearer_that_would_break_the_header():
+    # Arrange — a quote would corrupt the curl config line, not authenticate.
+    bad = 'abc"def'
+
+    # Act
+    def _call():
+        return _get_via_ssh_curl(
+            host="example.invalid", port=7878, path="/v1/health", bearer=bad
+        )
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_get_via_ssh_curl_reports_a_non_zero_ssh_exit(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    subprocess_shim.install("ssh", exit=255, stderr="ssh: connect: refused")
+    # Act
+    rc, _out, _err = _get_via_ssh_curl(
+        host="example.invalid", port=7878, path="/v1/health"
+    )
+    # Assert
+    assert rc == 255
+
+
+# ---------------------------------------------------------------------------
+# split_status_line — the parser the probe reads the answer through
+# ---------------------------------------------------------------------------
+
+
+def test_split_status_line_reads_the_status_after_the_body():
+    # Arrange
+    stdout = f'{{"ok": true}}\n{STATUS_MARKER}200\n'.encode()
+    # Act
+    status, _body = split_status_line(stdout)
+    # Assert
+    assert status == 200
+
+
+def test_split_status_line_keeps_the_body_without_the_marker():
+    # Arrange
+    stdout = f'{{"ok": true}}\n{STATUS_MARKER}200\n'.encode()
+    # Act
+    _status, body = split_status_line(stdout)
+    # Assert
+    assert body == '{"ok": true}'
+
+
+def test_split_status_line_is_none_when_no_marker_was_printed():
+    # Arrange — a remote shell that printed a banner and never ran curl.
+    stdout = b"Welcome to somewhere\n"
+    # Act
+    status, _body = split_status_line(stdout)
+    # Assert — UNKNOWN, never a fabricated status.
+    assert status is None
+
+
+# ---------------------------------------------------------------------------
+# End to end: real sh, real curl, real HTTP server — the ssh leg stands in
+# ---------------------------------------------------------------------------
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        srv = self.server
+        srv.seen_auth.append(self.headers.get("Authorization"))  # type: ignore[attr-defined]
+        if self.path == "/v1/health":
+            body = json.dumps({"ok": True, "service": "sac-listen", "v": 1}).encode()
+            self.send_response(200)
+        else:
+            body = b'{"error": "not found"}'
+            self.send_response(404)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture
+def health_server() -> Iterator[Any]:
+    port = _free_port()
+    server = HTTPServer(("127.0.0.1", port), _HealthHandler)
+    server.seen_auth = []  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    server.port = port  # type: ignore[attr-defined]
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+_needs_curl = pytest.mark.skipif(
+    shutil.which("curl") is None, reason="curl is not installed on this host"
+)
+
+
+@_needs_curl
+def test_get_via_ssh_curl_end_to_end_reads_a_200_from_a_real_listen_shaped_server(
+    tmp_path, env_save_restore, ssh_exec_shim, health_server
+):
+    # Arrange — the shim executes the real remote snippet with real curl.
+    _pin_ssh_env(tmp_path, env_save_restore)
+    ssh_exec_shim.install_binary("ssh", _LOCAL_EXEC_SSH)
+    # Act
+    _rc, stdout, _stderr = _get_via_ssh_curl(
+        host="peer.invalid",
+        port=health_server.port,
+        path="/v1/health",
+        bearer=_FAKE_BEARER,
+        timeout_s=5,
+    )
+    status, _body = split_status_line(stdout)
+    # Assert
+    assert status == 200
+
+
+@_needs_curl
+def test_get_via_ssh_curl_end_to_end_delivers_the_body_the_listen_sent(
+    tmp_path, env_save_restore, ssh_exec_shim, health_server
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    ssh_exec_shim.install_binary("ssh", _LOCAL_EXEC_SSH)
+    # Act
+    _rc, stdout, _stderr = _get_via_ssh_curl(
+        host="peer.invalid", port=health_server.port, path="/v1/health", timeout_s=5
+    )
+    _status, body = split_status_line(stdout)
+    # Assert
+    assert json.loads(body)["service"] == "sac-listen"
+
+
+@_needs_curl
+def test_get_via_ssh_curl_end_to_end_bearer_arrives_as_the_authorization_header(
+    tmp_path, env_save_restore, ssh_exec_shim, health_server
+):
+    # Arrange — the value is in no argv, yet the server must still receive it.
+    _pin_ssh_env(tmp_path, env_save_restore)
+    ssh_exec_shim.install_binary("ssh", _LOCAL_EXEC_SSH)
+    # Act
+    _get_via_ssh_curl(
+        host="peer.invalid",
+        port=health_server.port,
+        path="/v1/health",
+        bearer=_FAKE_BEARER,
+        timeout_s=5,
+    )
+    # Assert
+    assert health_server.seen_auth == [f"Bearer {_FAKE_BEARER}"]
+
+
+@_needs_curl
+def test_get_via_ssh_curl_end_to_end_reports_a_404_as_its_status(
+    tmp_path, env_save_restore, ssh_exec_shim, health_server
+):
+    # Arrange
+    _pin_ssh_env(tmp_path, env_save_restore)
+    ssh_exec_shim.install_binary("ssh", _LOCAL_EXEC_SSH)
+    # Act
+    _rc, stdout, _stderr = _get_via_ssh_curl(
+        host="peer.invalid", port=health_server.port, path="/nowhere", timeout_s=5
+    )
+    status, _body = split_status_line(stdout)
+    # Assert
+    assert status == 404

--- a/tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py
+++ b/tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py
@@ -80,10 +80,10 @@ def fleet(tmp_path: Path, env_save_restore) -> Path:
     return home
 
 
-def _seed_token(home: Path) -> None:
-    """Give ``peer-with-alias`` a peer token, so its leg gets DISPATCHED."""
+def _seed_token(home: Path, host: str = "peer-with-alias") -> None:
+    """Give ``host`` a peer token, so its leg gets DISPATCHED."""
     write_peer_token(
-        peer_host="peer-with-alias",
+        peer_host=host,
         token="t0k3n",
         tokens_dir=home / ".scitex" / "agent-container" / "peer-tokens",
     )
@@ -130,6 +130,29 @@ def test_this_host_is_reported_unknown_over_no_transport(fleet):
     assert _rows(result)["probe-box"]["transport"] == "none"
 
 
+def test_this_host_row_says_local(fleet):
+    # Arrange — the alarm skips the self row by this flag, not by name.
+    args = ["--all", "--json"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert _rows(result)["probe-box"]["local"] is True
+
+
+def test_this_host_is_never_dialled_even_with_an_alias_and_a_token(
+    fleet, subprocess_shim
+):
+    # Arrange — probe-box has a registry alias AND now a peer token, so only
+    # the local skip stands between the verb and an ssh to itself. No other
+    # host has a token, so any ssh on PATH is a self-dial.
+    _seed_token(fleet, "probe-box")
+    subprocess_shim.install("ssh", exit=0, stdout=_HEALTHY)
+    # Act
+    result = _run(["--all", "--json"])
+    # Assert
+    assert (subprocess_shim.call_count("ssh"), result.exit_code) == (0, 3)
+
+
 def test_a_registry_row_without_alias_is_unknown_and_names_the_registry(fleet):
     # Arrange
     args = ["--all", "--json"]
@@ -148,7 +171,7 @@ def test_a_missing_peer_token_is_unknown_and_names_the_add_peer_fix(fleet):
     assert "sac host add-peer" in _rows(result)["peer-with-alias"]["error"]
 
 
-def test_each_json_row_carries_exactly_the_six_declared_fields(fleet):
+def test_each_json_row_carries_exactly_the_seven_declared_fields(fleet):
     # Arrange
     args = ["--all", "--json"]
     # Act
@@ -157,7 +180,15 @@ def test_each_json_row_carries_exactly_the_six_declared_fields(fleet):
     # Assert
     assert shapes == {
         frozenset(
-            {"host", "ssh_alias", "transport", "reachable", "elapsed_ms", "error"}
+            {
+                "host",
+                "ssh_alias",
+                "transport",
+                "reachable",
+                "elapsed_ms",
+                "error",
+                "local",
+            }
         )
     }
 
@@ -200,6 +231,40 @@ def test_ssh_leg_dials_the_registry_alias_not_the_host_name(fleet, subprocess_sh
     _run(["--host", "peer-with-alias", "--json", "--timeout", "1"])
     # Assert
     assert "peer-with-alias-ssh" in subprocess_shim.argv_for("ssh")
+
+
+def test_ssh_leg_dials_the_alias_config_yaml_overrides_exactly_as_the_forwarder(
+    fleet, subprocess_shim, tmp_path
+):
+    # Arrange — config.yaml wins over the registry for the forwarder; the
+    # probe must dial the same override, because it asks the same resolver.
+    (tmp_path / "config.yaml").write_text(
+        _CONFIG_YAML + "peers:\n  peer-with-alias:\n    ssh: cfg-route\n"
+    )
+    _seed_token(fleet)
+    subprocess_shim.install("ssh", exit=255, stderr="refused")
+    # Act
+    _run(["--host", "peer-with-alias", "--json", "--timeout", "1"])
+    # Assert
+    assert "cfg-route" in subprocess_shim.argv_for("ssh")
+
+
+def test_a_repeated_failed_leg_is_recorded_degraded_once_not_per_pass(
+    fleet, subprocess_shim
+):
+    # Arrange — two scheduled ticks seeing the same unreachable peer.
+    _seed_token(fleet)
+    subprocess_shim.install("ssh", exit=255, stderr="ssh: connect: refused")
+    # Act
+    _run(["--all", "--json", "--timeout", "1"])
+    _run(["--all", "--json", "--timeout", "1"])
+    degraded = [
+        e
+        for e in read_events(path=Path(os.environ[EVENT_LOG_ENV]))
+        if e.event == SUBJECT_DEGRADED
+    ]
+    # Assert
+    assert len(degraded) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py
+++ b/tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py
@@ -1,0 +1,277 @@
+"""``sac a2a reachability`` end to end — real Click, real registry, real ssh leg.
+
+The verb is the scheduled job's entry point, so what is pinned here is the
+CONTRACT the supervisor's execution log reads: the exit codes (0 / 1 / 3),
+the ``--json`` shape, the ``--record`` file and its ``--last`` reader, and
+the event-log records every run leaves behind.
+
+No mocks and no monkeypatching. The registry is a real ``hosts.yaml`` under
+a real ``$SCITEX_DIR``; the config is a real file under
+``SCITEX_AGENT_CONTAINER_CONFIG`` (read from ``_state/host_config.py``, not
+guessed — the wrong name would silently load the OPERATOR'S config and ssh
+every fleet peer); peer tokens are real files under a temp ``HOME``; the
+ssh leg is a fake ``ssh`` on PATH so production calls the real
+``subprocess.run``; the event log is the per-test file the suite's autouse
+fixture already points ``SAC_EVENT_LOG`` at.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._events import EVENT_LOG_ENV, SUBJECT_DEGRADED, read_events
+from scitex_agent_container._listen.peer_tokens import write_peer_token
+from scitex_agent_container._network._ssh_curl import STATUS_MARKER
+from scitex_agent_container.cli_pkg.a2a_group import a2a
+
+_HOSTS_YAML = textwrap.dedent(
+    """\
+    hosts:
+      probe-box:
+        kind: workstation
+        ssh_alias: probe-box
+        scitex_root: "~/.scitex"
+      peer-with-alias:
+        kind: workstation
+        ssh_alias: peer-with-alias-ssh
+        scitex_root: "~/.scitex"
+      peer-without-alias:
+        kind: workstation
+        ssh_alias: null
+        scitex_root: "~/.scitex"
+    """
+)
+
+_CONFIG_YAML = "host:\n  canonical: probe-box\n"
+
+_HEALTHY = f'{{"ok": true, "service": "sac-listen", "v": 1}}\n{STATUS_MARKER}200\n'
+
+
+@pytest.fixture
+def fleet(tmp_path: Path, env_save_restore) -> Path:
+    """A three-host fleet seen from ``probe-box``, with NO peer tokens yet."""
+    home = tmp_path / "home"
+    home.mkdir()
+    scitex_dir = tmp_path / "scitex"
+    (scitex_dir / "dev").mkdir(parents=True)
+    (scitex_dir / "dev" / "hosts.yaml").write_text(_HOSTS_YAML)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_CONFIG_YAML)
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.set("SCITEX_DIR", str(scitex_dir))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(tmp_path / "runtime")
+    )
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    for key in (
+        "SAC_HOST",
+        "SCITEX_AGENT_CONTAINER_HOST",
+        "SCITEX_AGENT_CONTAINER_HOSTNAME",
+        "SAC_SSH_CONTROL_MASTER",
+    ):
+        env_save_restore.delete(key)
+    return home
+
+
+def _seed_token(home: Path) -> None:
+    """Give ``peer-with-alias`` a peer token, so its leg gets DISPATCHED."""
+    write_peer_token(
+        peer_host="peer-with-alias",
+        token="t0k3n",
+        tokens_dir=home / ".scitex" / "agent-container" / "peer-tokens",
+    )
+
+
+def _run(args):
+    return CliRunner().invoke(a2a, ["reachability", *args], catch_exceptions=False)
+
+
+def _rows(result) -> dict[str, dict]:
+    return {row["host"]: row for row in json.loads(result.output)["hosts"]}
+
+
+# ---------------------------------------------------------------------------
+# exit 3 — nothing measurable
+# ---------------------------------------------------------------------------
+
+
+def test_verb_exits_three_when_every_host_is_unknown(fleet):
+    # Arrange — aliases exist but no peer token does, and one row has no
+    # alias, and one row is this host: nothing can be dispatched.
+    args = ["--all", "--json"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert result.exit_code == 3
+
+
+def test_all_unknown_report_lists_every_host_as_unknown(fleet):
+    # Arrange
+    args = ["--all", "--json"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert {r["reachable"] for r in _rows(result).values()} == {None}
+
+
+def test_this_host_is_reported_unknown_over_no_transport(fleet):
+    # Arrange
+    args = ["--all", "--json"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert _rows(result)["probe-box"]["transport"] == "none"
+
+
+def test_a_registry_row_without_alias_is_unknown_and_names_the_registry(fleet):
+    # Arrange
+    args = ["--all", "--json"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert "hosts.yaml" in _rows(result)["peer-without-alias"]["error"]
+
+
+def test_a_missing_peer_token_is_unknown_and_names_the_add_peer_fix(fleet):
+    # Arrange
+    args = ["--host", "peer-with-alias", "--json"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert "sac host add-peer" in _rows(result)["peer-with-alias"]["error"]
+
+
+def test_each_json_row_carries_exactly_the_six_declared_fields(fleet):
+    # Arrange
+    args = ["--all", "--json"]
+    # Act
+    result = _run(args)
+    shapes = {frozenset(row) for row in _rows(result).values()}
+    # Assert
+    assert shapes == {
+        frozenset(
+            {"host", "ssh_alias", "transport", "reachable", "elapsed_ms", "error"}
+        )
+    }
+
+
+# ---------------------------------------------------------------------------
+# exit 1 — a dispatched leg that failed
+# ---------------------------------------------------------------------------
+
+
+def test_verb_exits_one_when_a_dispatched_leg_fails(fleet, subprocess_shim):
+    # Arrange — a peer token exists, so the leg is dispatched; ssh refuses.
+    _seed_token(fleet)
+    subprocess_shim.install("ssh", exit=255, stderr="ssh: connect: refused")
+    # Act
+    result = _run(["--all", "--json", "--timeout", "1"])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_failed_leg_is_recorded_degraded_in_the_event_log(fleet, subprocess_shim):
+    # Arrange
+    _seed_token(fleet)
+    subprocess_shim.install("ssh", exit=255, stderr="ssh: connect: refused")
+    # Act
+    _run(["--all", "--json", "--timeout", "1"])
+    degraded = [
+        e.subject
+        for e in read_events(path=Path(os.environ[EVENT_LOG_ENV]))
+        if e.event == SUBJECT_DEGRADED
+    ]
+    # Assert
+    assert degraded == ["peer-with-alias"]
+
+
+def test_ssh_leg_dials_the_registry_alias_not_the_host_name(fleet, subprocess_shim):
+    # Arrange — the forwarder routes by alias; so must the probe.
+    _seed_token(fleet)
+    subprocess_shim.install("ssh", exit=255, stderr="refused")
+    # Act
+    _run(["--host", "peer-with-alias", "--json", "--timeout", "1"])
+    # Assert
+    assert "peer-with-alias-ssh" in subprocess_shim.argv_for("ssh")
+
+
+# ---------------------------------------------------------------------------
+# exit 0 — a dispatched leg that answered as a listen
+# ---------------------------------------------------------------------------
+
+
+def test_verb_exits_zero_when_every_dispatched_leg_reaches_a_listen(
+    fleet, subprocess_shim
+):
+    # Arrange — unknown rows (this host, the alias-less row) sit beside the
+    # one measured host; the measured host is a real answer.
+    _seed_token(fleet)
+    subprocess_shim.install("ssh", exit=0, stdout=_HEALTHY)
+    # Act
+    result = _run(["--all", "--json"])
+    # Assert
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# --record / --last — the report file and its reader
+# ---------------------------------------------------------------------------
+
+
+def test_record_writes_the_report_into_the_runtime_dir(fleet, tmp_path):
+    # Arrange
+    args = ["--all", "--json", "--record"]
+    # Act
+    _run(args)
+    # Assert
+    assert (tmp_path / "runtime" / "a2a-reachability.json").is_file()
+
+
+def test_last_replays_the_recorded_report_with_its_exit_code(fleet, subprocess_shim):
+    # Arrange — record a pass that measured an unreachable host ...
+    _seed_token(fleet)
+    subprocess_shim.install("ssh", exit=255, stderr="refused")
+    _run(["--all", "--json", "--record", "--timeout", "1"])
+    # Act — ... then read it back without probing.
+    result = _run(["--last", "--json"])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_last_without_a_recorded_report_fails_loudly(fleet):
+    # Arrange
+    args = ["--last"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert result.exit_code != 0 and "no recorded report" in result.output
+
+
+# ---------------------------------------------------------------------------
+# usage errors stay Click's exit 2 — never a fleet verdict
+# ---------------------------------------------------------------------------
+
+
+def test_host_and_all_together_is_a_usage_error(fleet):
+    # Arrange
+    args = ["--host", "peer-with-alias", "--all"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_an_unknown_host_name_is_a_usage_error_naming_the_known_hosts(fleet):
+    # Arrange — a typo must not become "exit 3, the fleet is unknown".
+    args = ["--host", "peer-typo", "--json"]
+    # Act
+    result = _run(args)
+    # Assert
+    assert result.exit_code == 2 and "peer-with-alias" in result.output


### PR DESCRIPTION
## What was measured

A cross-host `a2a_send` leaves a host through `sac listen`'s forwarder (`_listen/_node_channel_forwarders.py`). Every agent sidecar/bridge binds `127.0.0.1`, so the ONLY transport that can work in production is the forwarder's ssh leg: ssh to the peer's alias, then `curl 127.0.0.1:<port>` on the peer with that peer's bearer from `peer-tokens/<host>.token`. Whether that leg works depends on three per-host facts that drift silently — an ssh alias for the peer, a peer token for it, and an ssh that connects. Nothing checked them: a gap only surfaced when an agent actually sent, as `All connection attempts failed` with no indication of which fact was missing. On 2026-09-02 `scitex-compute-01` and `scitex-compute-03` had no `config.yaml` at all, so every cross-host send from them took a leg that cannot work, and nobody knew until a send was tried by hand.

## The mechanism

`sac a2a reachability` exercises the forwarder's transport, per peer, from this host:

- **Targets** come from `peers_with_registry(load().peers)` — config.yaml `peers:` first, the scitex-dev host registry (`hosts.yaml` `ssh_alias`) filling the gaps — the same SSoT `sac host probe` routes by. Registry rows with `ssh_alias: null` are still listed (as UNKNOWN) so they surface instead of vanishing; glob templates (`spartan-*`) are skipped; this host is listed as UNKNOWN and never dialled.
- **Transport** is a new GET sibling of `_post_via_ssh_curl` in `_network/_ssh_curl.py` (`_get_via_ssh_curl`). Both share one ssh argv (`_ssh_argv`: `BatchMode`, `ConnectTimeout=15`, the ControlMaster options) so the probe dispatches exactly what the forwarder dispatches, not a look-alike. The bearer is `read_peer_token(peer_host=...)`, riding stdin as a `curl --config -` header — never an argv element on either host (the house rule from `_push_tokens_io`). Target: the peer's listen `/v1/health` (default port 7878); a 200 whose body says `service: sac-listen` is reachable.
- **Fixed answer shape**, one row per host: `{host, ssh_alias, transport ('ssh'|'none'), reachable (True/False/None), elapsed_ms, error}`. `None` is UNKNOWN — no ssh alias, no peer token, or this host — and is NEVER counted as reachable or unreachable; an UNKNOWN row must state its reason and names the file to fix (`sac host add-peer <host> <token>`, `hosts.yaml`). A `transport: none` row cannot carry a measured verdict (validated at construction).
- **Exit codes**: `0` every measured host reachable, `1` at least one unreachable, `3` nothing measurable (every host unknown — not a success). `2` stays Click's usage error and carries no fleet meaning. Documented in `--help`.
- **Operator-visible record**: every run routes each verdict through `_events.emit_subject_verdicts` — the same rail `fleet-reconcile` (`_reconcile/_alarm.py`) and `host-sync-check` (`_hostsync/_alarm.py`) record to, `runtime/sac-events.jsonl` — under its own `subsystem: a2a-reachability`. Unreachable → DEGRADED and unknown → UNKNOWN on every pass; reachable → RECOVERED on the transition out of a remembered degraded state; plus a PASS_COMPLETED record with counts (`mode: all|subset`). No scitex-cards import.
- **`--record`** writes the report atomically to `runtime_root()/a2a-reachability.json`; **`--last`** reads it back and exits with its recorded code. Consumers named in the module docstring: the supervisor's `PeriodicRunner` persists the exit code per run in `~/.scitex/dev/runtime/periodic-executions.jsonl`; `--last` reads the JSON; the event log holds the verdicts.
- **JobSpec** `scitex-agent-container-a2a-reachability` in `_jobs/_specs_reachability.py`: `kind="timer"`, `*/15 * * * *` / `on_unit_active_sec="15min"`, `command=/usr/bin/timeout 180 {sac} a2a reachability --all --json --record`. Spliced into `provide_jobs` LAST (positional readers keep their index), added to `BORN_CANONICAL` in `_jobs/_migrate/_renames.py` (no host has ever carried a unit for it), passes `_jobs_audit` (LIVE via the real `discover_jobs` entry point).

`cli_pkg/a2a_group.py` was already over the 512-line cap (559), so the ACL verbs (`grant/unblock/block/revoke/grants`) and `list` were extracted into `cli_pkg/_a2a_acl_cmds.py` / `cli_pkg/_a2a_list_cmd.py` as a pure extraction; every verb name is re-exported from `a2a_group`, and the three sibling modules register onto the group the way `_host_sync` attaches to `sac host`. `a2a_group.py` is now 293 lines. `_node_channel_forwarders.py` was untouched in round 1; round 2 merges the sibling fix (#1284) into this branch and builds on it — see below.

## Live run on scitex-compute-04 (this host) against the fleet

Run on the HOST (not in the container) with this branch's `src` on `PYTHONPATH` — the module path was echoed to confirm which code ran (`.worktrees/.../src/scitex_agent_container/_network/_reachability.py`). Only `scitex-compute-01` and `scitex-compute-03` have peer tokens on this host, which is exactly what the report says:

```json
{
  "probed_from": "scitex-compute-04",
  "port": 7878,
  "started_at_utc": "2026-09-02T19:51:17.952184+00:00",
  "elapsed_ms": 855,
  "exit_code": 0,
  "counts": {"hosts": 13, "reachable": 2, "unreachable": 0, "unknown": 11},
  "hosts": [
    {"host": "mba", "ssh_alias": "bastion-mba", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'mba' at /home/ywatanabe/.scitex/agent-container/peer-tokens/mba.token. Add one with: sac host add-peer mba <token>"},
    {"host": "nas-03", "ssh_alias": "scitex-nas-03", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'nas-03' at /home/ywatanabe/.scitex/agent-container/peer-tokens/nas-03.token. Add one with: sac host add-peer nas-03 <token>"},
    {"host": "scitex-compute-01", "ssh_alias": "scitex-compute-01", "transport": "ssh", "reachable": true, "elapsed_ms": 845, "error": null},
    {"host": "scitex-compute-02", "ssh_alias": "scitex-compute-02", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'scitex-compute-02' at /home/ywatanabe/.scitex/agent-container/peer-tokens/scitex-compute-02.token. Add one with: sac host add-peer scitex-compute-02 <token>"},
    {"host": "scitex-compute-03", "ssh_alias": "scitex-compute-03", "transport": "ssh", "reachable": true, "elapsed_ms": 652, "error": null},
    {"host": "scitex-compute-04", "ssh_alias": "scitex-compute-04", "transport": "none", "reachable": null, "elapsed_ms": null, "error": "this host — the forwarder never ssh-es to itself, so there is nothing to probe"},
    {"host": "scitex-laptop-01", "ssh_alias": "scitex-laptop-01", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'scitex-laptop-01' at /home/ywatanabe/.scitex/agent-container/peer-tokens/scitex-laptop-01.token. Add one with: sac host add-peer scitex-laptop-01 <token>"},
    {"host": "scitex-laptop-02", "ssh_alias": "scitex-laptop-02", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'scitex-laptop-02' at /home/ywatanabe/.scitex/agent-container/peer-tokens/scitex-laptop-02.token. Add one with: sac host add-peer scitex-laptop-02 <token>"},
    {"host": "scitex-nas-01", "ssh_alias": "scitex-nas-01", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'scitex-nas-01' at /home/ywatanabe/.scitex/agent-container/peer-tokens/scitex-nas-01.token. Add one with: sac host add-peer scitex-nas-01 <token>"},
    {"host": "scitex-nas-02", "ssh_alias": "scitex-nas-02", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'scitex-nas-02' at /home/ywatanabe/.scitex/agent-container/peer-tokens/scitex-nas-02.token. Add one with: sac host add-peer scitex-nas-02 <token>"},
    {"host": "scitex-nas-03", "ssh_alias": "scitex-nas-03", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'scitex-nas-03' at /home/ywatanabe/.scitex/agent-container/peer-tokens/scitex-nas-03.token. Add one with: sac host add-peer scitex-nas-03 <token>"},
    {"host": "spartan", "ssh_alias": "spartan", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'spartan' at /home/ywatanabe/.scitex/agent-container/peer-tokens/spartan.token. Add one with: sac host add-peer spartan <token>"},
    {"host": "ywata-note-win", "ssh_alias": "ywata-note-win-net", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'ywata-note-win' at /home/ywatanabe/.scitex/agent-container/peer-tokens/ywata-note-win.token. Add one with: sac host add-peer ywata-note-win <token>"}
  ],
  "alarm": {"degraded": [], "unknown": ["mba", "nas-03", "scitex-compute-02", "scitex-laptop-01", "scitex-laptop-02", "scitex-nas-01", "scitex-nas-02", "scitex-nas-03", "spartan", "ywata-note-win"], "recovered": [], "failed": []},
  "recorded_to": null
}
```

The two measured legs are real ssh+curl round trips to the peers' loopback listens (845 ms / 652 ms). The ten `unknown` rows are the actionable finding: from compute-04 the forwarder can only reach compute-01 and compute-03 today, because those are the only peer tokens present.

## How it was verified

New tests (72, no mocks — real `hosts.yaml` under `$SCITEX_DIR`, real config under `SCITEX_AGENT_CONTAINER_CONFIG`, real peer-token files, a fake `ssh` on PATH so production calls the real `subprocess.run`, a real `http.server` + real `curl` for the end-to-end GET):

```
tests/scitex_agent_container/_network/test__ssh_curl_get.py
tests/scitex_agent_container/_network/test__reachability.py
tests/scitex_agent_container/_network/test__reachability_alarm.py
tests/scitex_agent_container/_jobs/test__specs_reachability.py
tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py
============================== 72 passed in 5.00s ==============================
```

Positive controls (each behaviour broken on purpose, then reverted):

- UNKNOWN counted as reachable in `exit_code_for`, the local host dialled instead of skipped, the bearer spliced into the ssh argv, and this host's row recorded in the alarm — all four at once:
  ```
  FAILED tests/scitex_agent_container/_network/test__ssh_curl_get.py::test_get_via_ssh_curl_keeps_bearer_out_of_every_argv_element
  FAILED tests/scitex_agent_container/_network/test__ssh_curl_get.py::test_get_via_ssh_curl_takes_the_bearer_from_a_curl_config_on_stdin
  FAILED tests/scitex_agent_container/_network/test__reachability.py::test_exit_code_is_nothing_measurable_when_every_row_is_unknown
  FAILED tests/scitex_agent_container/_network/test__reachability_alarm.py::test_this_host_own_row_writes_no_record
  FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_verb_exits_three_when_every_host_is_unknown
  FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_this_host_is_reported_unknown_over_no_transport
  ========================= 6 failed, 60 passed in 3.22s =========================
  ```
- the JobSpec unspliced from `provide_jobs`:
  ```
  FAILED tests/scitex_agent_container/_jobs/test__specs_reachability.py::test_a2a_reachability_job_is_discovered_by_the_provider
  FAILED tests/scitex_agent_container/_jobs/test__specs_reachability.py::test_a2a_reachability_job_kind_is_timer
  FAILED tests/scitex_agent_container/_jobs/test__specs_reachability.py::test_a2a_reachability_command_is_the_fleet_wide_recording_form
  FAILED tests/scitex_agent_container/_jobs/test__specs_reachability.py::test_a2a_reachability_cadence_is_every_15_minutes
  FAILED tests/scitex_agent_container/_jobs/test__specs_reachability.py::test_a2a_reachability_cron_form_matches_the_timer_cadence
  FAILED tests/scitex_agent_container/_jobs/_migrate/test__renames.py::test_born_canonical_names_are_actually_declared
  ========================= 6 failed, 46 passed in 0.36s =========================
  ```

Existing suites after the `a2a_group.py` split (`cli_pkg/test_a2a_group.py`, `_listen/test__acl_approve_flow.py`, `_network/test__ssh_curl.py`, all of `_jobs/`, `cli_pkg/test__dev_jobs_apply.py`): `311 passed, 32 skipped in 16.07s`.

Regression run over `tests/scitex_agent_container/{_listen,_network,_jobs,_events,_reconcile,_hostsync}`, `cli_pkg/test_a2a_group.py`, `cli_pkg/test__a2a_reachability.py`, `cli_pkg/test__a2a_list_fetch.py`, `cli_pkg/test__dev_jobs_apply.py`, `test_cli.py` (`-n 8`): `1656 passed, 476 skipped in 54.08s` — the listen suite (incl. `test_server.py`'s host-a/host-b HTTP loopback topology and `test__node_channel_forwarders.py`) stays green.

`ruff check --select F401,F811,E,F,W,I` on every new/changed file: `All checks passed!`.

## Note for the operator: this host's disk

`scitex-compute-04`'s volume (`/dev/mapper/ubuntu--vg-ubuntu--lv`, 393G) sat at 100% during this work; free space oscillated between 0 and ~1.5G as CI runs on this host (`/tmp/ci-*` scratch) came and went, and several writes here failed with ENOSPC before being retried. I removed only stale scratch of COMPLETED runs on the host (`/tmp/ci-scitex_dev-33646504624-1-3.11`, three `publish-scitex_dev-*` dirs from Aug 28-31; ~1.4G). `sac worktree gc --all` dry-run would reclaim nothing (361 kept / 0 removable). The underlying consumer (373G used) was not identified from inside the container; that needs a host-level `du`.

## Review round 2

Adversarial findings from reviewers who ran the code; each re-measured, then fixed at the mechanism. `origin/fix/cross-host-forward-resolves-peers-from-the-registry-and-never-falls-back-silently` (#1284) is **merged into this branch** (`ea2bb519`), so the sentence above saying `_node_channel_forwarders.py` is untouched no longer holds: this PR now carries #1284's forwarder and builds on it.

| Finding | What changed |
|---|---|
| **BLOCKER 1** — the probe resolved the alias through a look-alike (`peers_with_registry` in the probe vs the RAW `peers:` block in the forwarder on develop). | The probe now **imports** `_listen._node_channel_forwarders._resolve_ssh_peer` — #1284's named resolver — and puts every host name to it. `resolve_targets()` / `run_probe()` no longer accept a `peers` map (handing the probe a different map is how the divergence happened); enumeration is the probe's own question (config peers ∪ registry, alias-less rows kept), routing is the forwarder's. An unroutable host's UNKNOWN row carries the forwarder's own refusal sentence. Parity is pinned twice in `test__reachability.py`: identity (`_reachability._resolve_ssh_peer is _fwd._resolve_ssh_peer`) and answer (config.yaml overriding a registry alias → same alias for every host), plus a CLI test that the ssh argv dials the config override. |
| **BLOCKER 2** — `test_local_host_is_unknown_and_never_dispatched` stayed green with the skip removed (no token → unknown for the wrong reason). | The fixture gives this host an alias **and** a peer token; the `ssh` on PATH answers as a healthy listen; the assertion is `(reachable, transport, ssh call count) == (None, "none", 0)`. Same at CLI level (`test_this_host_is_never_dialled_even_with_an_alias_and_a_token`). Red without the skip — see controls. |
| **MAJOR 1** — the alarm skipped the self row by `row.host == probed_from` while the probe marked it via `_local_host_names()` (registry pivot); on a host whose canonical name differs from its registry name the self row was recorded UNKNOWN every pass. | ONE definition of local: the `local` flag `resolve_targets` decides is carried into `HostReachability` (seventh field; validated — a local row cannot claim the ssh transport), into `--json` and the `--record` file, and the alarm skips by that flag. `test_this_host_is_skipped_by_its_local_flag_not_by_its_name` uses `probed_from="DXP480TPLUS-994"` with a local row named `scitex-nas-03`. |
| **MAJOR 2** — UNKNOWN peers re-recorded every pass (10 records per 15-minute tick on compute-04). | Per-host records are now **transitions only**: the alarm remembers the last recorded state per host in `sac-events-a2a-reachability-last-state.json` beside the event log and offers the shared rail only hosts whose state differs, plus first observation. Two identical passes → one record; unknown→degraded, degraded→unknown, →healthy each → one more; memory lost → one duplicate, never a missed change. The full per-pass picture stays in the `--record` file (`--last` reads it); PASS_COMPLETED (with counts) is still written every pass and is the rail's liveness signal. |
| **NOTE** — `/v1/health` is PUBLIC (`BearerAuthMiddleware.PUBLIC_PATHS`). | Stated in the verb help (`--help`), the JobSpec docstring and `description`, and the module docstring: REACHABLE proves ssh alias + tunnel + listen up, **not** bearer validity; a stale token reads REACHABLE here and 401s on a real send. A missing token stays UNKNOWN. |
| Port | Unchanged: the probe targets the peer's **listen** port (7878); the per-agent port is reached from the peer's own loopback by its listen. |

`_reachability.py` crossed the 512-line cap carrying the flag, so the answer shape (rows, report, exit codes, the report file) moved to `_network/_reachability_report.py`; `_reachability` re-exports every name, so existing imports resolve unchanged.

**Follow-up proposed (not in this PR):** an authenticated probe path — a bearer-gated no-op route on the listen (e.g. `GET /v1/whoami` returning the caller class) — so the probe can distinguish "listen up" from "this peer token is accepted", turning a stale `peer-tokens/<host>.token` into a measured UNREACHABLE-with-reason instead of a REACHABLE that 401s on the first real send.

### Positive controls (round 2)

Each behaviour removed on purpose in the worktree source, the tests run, the file restored byte-for-byte (verified with `cmp`).

Parity — the probe re-implements the resolver (registry-only) instead of importing the forwarder's callable:
```
FAILED tests/scitex_agent_container/_network/test__reachability.py::test_config_peer_wins_over_the_registry_alias
FAILED tests/scitex_agent_container/_network/test__reachability.py::test_probe_resolves_aliases_through_the_forwarders_own_callable
FAILED tests/scitex_agent_container/_network/test__reachability.py::test_probe_alias_equals_the_forwarders_route_for_every_host
FAILED tests/scitex_agent_container/_network/test__reachability.py::test_unroutable_host_carries_the_forwarders_own_refusal_reason
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_ssh_leg_dials_the_alias_config_yaml_overrides_exactly_as_the_forwarder
========================= 5 failed, 47 passed in 1.17s =========================
```

Local skip — the `if target.local: return _unknown(...)` removed from `probe_target`:
```
FAILED tests/scitex_agent_container/_network/test__reachability.py::test_local_host_is_unknown_and_never_dispatched
FAILED tests/scitex_agent_container/_network/test__reachability.py::test_local_host_row_carries_the_local_flag
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_verb_exits_three_when_every_host_is_unknown
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_all_unknown_report_lists_every_host_as_unknown
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_this_host_is_reported_unknown_over_no_transport
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_this_host_row_says_local
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_this_host_is_never_dialled_even_with_an_alias_and_a_token
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_a_registry_row_without_alias_is_unknown_and_names_the_registry
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_each_json_row_carries_exactly_the_seven_declared_fields
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_verb_exits_one_when_a_dispatched_leg_fails
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_failed_leg_is_recorded_degraded_in_the_event_log
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_a_repeated_failed_leg_is_recorded_degraded_once_not_per_pass
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_verb_exits_zero_when_every_dispatched_leg_reaches_a_listen
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_record_writes_the_report_into_the_runtime_dir
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_last_replays_the_recorded_report_with_its_exit_code
======================== 15 failed, 37 passed in 2.29s =========================
```
(15, not 2: once the verb ssh-es to itself the self row becomes a measured verdict, which flips the exit code and the row shape for every CLI test that lists this host.)

Transition — the unchanged-state filter removed from `record_report`:
```
FAILED tests/scitex_agent_container/_network/test__reachability_alarm.py::test_two_identical_degraded_passes_write_one_record
FAILED tests/scitex_agent_container/_network/test__reachability_alarm.py::test_two_identical_unknown_passes_write_one_record
FAILED tests/scitex_agent_container/_network/test__reachability_alarm.py::test_a_host_unchanged_across_three_passes_is_still_recorded_once
FAILED tests/scitex_agent_container/_network/test__reachability_alarm.py::test_a_lost_memory_re_records_the_host_once_and_nothing_worse
FAILED tests/scitex_agent_container/cli_pkg/test__a2a_reachability.py::test_a_repeated_failed_leg_is_recorded_degraded_once_not_per_pass
========================= 5 failed, 31 passed in 1.20s =========================
```

Self row — the alarm skips by name comparison (`row.host.lower() == report.probed_from.lower()`) instead of the carried flag:
```
FAILED tests/scitex_agent_container/_network/test__reachability_alarm.py::test_this_host_is_skipped_by_its_local_flag_not_by_its_name
========================= 1 failed, 35 passed in 1.19s =========================
```

### Test runs (round 2)

Touched modules (`_network/test__reachability.py`, `_network/test__reachability_alarm.py`, `cli_pkg/test__a2a_reachability.py`, `_jobs/test__specs_reachability.py`, `_network/test__ssh_curl_get.py`): `89 passed in 3.65s`.

`tests/scitex_agent_container/{_listen,_network,_jobs,_events}` + `cli_pkg/test__a2a_reachability.py` + `cli_pkg/test_a2a_group.py` (`-n 8`): `1256 passed, 367 skipped in 49.11s` — including #1284's forwarder suite and `test_server.py`'s host-a/host-b loopback topology.

`ruff check --select F401,F811,E,F,W,I` on every changed file: `All checks passed!`.

### Live runs on scitex-compute-04 (round 2, this branch's `src` on `PYTHONPATH`)

Three consecutive passes, sharing the host's event log (`/home/ywatanabe/.scitex/agent-container/runtime/sac-events.jsonl`) — which is the transition rule, live:

1. From this agent's container (`HOME=/home/agent`, no peer tokens, 11 hosts in its config): `exit 3`, 11 unknown, `alarm.unknown` = 10 peers (first observation).
2. Same command again, identical picture: `exit 3`, `"alarm": {"degraded": [], "unknown": [], "recovered": [], "failed": []}` — **nothing re-recorded**.
3. On the HOST (operator's `HOME`, tokens for compute-01 and compute-03, 13 hosts) — trimmed:

```json
{
  "probed_from": "scitex-compute-04", "port": 7878,
  "started_at_utc": "2026-09-03T00:19:13.690267+00:00", "elapsed_ms": 75, "exit_code": 0,
  "counts": {"hosts": 13, "reachable": 2, "unreachable": 0, "unknown": 11},
  "hosts": [
    {"host": "scitex-compute-01", "ssh_alias": "scitex-compute-01", "transport": "ssh", "reachable": true, "elapsed_ms": 23, "error": null, "local": false},
    {"host": "scitex-compute-03", "ssh_alias": "scitex-compute-03", "transport": "ssh", "reachable": true, "elapsed_ms": 19, "error": null, "local": false},
    {"host": "scitex-compute-04", "ssh_alias": "scitex-compute-04", "transport": "none", "reachable": null, "elapsed_ms": null, "error": "this host — the forwarder never ssh-es to itself, so there is nothing to probe", "local": true},
    {"host": "scitex-laptop-01", "ssh_alias": "scitex-laptop-01", "transport": "ssh", "reachable": null, "elapsed_ms": null, "error": "no peer token for host 'scitex-laptop-01' at /home/ywatanabe/.scitex/agent-container/peer-tokens/scitex-laptop-01.token. Add one with: sac host add-peer scitex-laptop-01 <token>", "local": false},
    "... 9 more UNKNOWN rows of the same 'no peer token' shape: mba, nas-03, scitex-compute-02, scitex-laptop-02, scitex-nas-01, scitex-nas-02, scitex-nas-03, spartan, ywata-note-win"
  ],
  "alarm": {"degraded": [], "unknown": ["scitex-laptop-01", "scitex-laptop-02"], "recovered": ["scitex-compute-01", "scitex-compute-03"], "failed": []},
  "recorded_to": null
}
```

Pass 3 recorded exactly the changes: the two laptops (absent from the container's config, so first seen here) as unknown, compute-01/-03 (unknown in passes 1–2, measured reachable now) as recovered, and skipped the 8 peers still unknown. The remembered state after the three passes:

```json
{"mba": "unknown", "nas-03": "unknown", "scitex-compute-01": "healthy", "scitex-compute-02": "unknown",
 "scitex-compute-03": "healthy", "scitex-laptop-01": "unknown", "scitex-laptop-02": "unknown",
 "scitex-nas-01": "unknown", "scitex-nas-02": "unknown", "scitex-nas-03": "unknown",
 "spartan": "unknown", "ywata-note-win": "unknown"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adzed4bZzRxEDbMh9QoRtV

