### PR TITLE
feat(scratch): bind /uvwork from the host scratch volume, not the overlay upper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`/uvwork` is bound from the host scratch volume instead of accumulating in
+  the apptainer overlay upper on the root LV** (ADR-0024; operator directive
+  2026-09-02 「ディスクは /scratch 使ってくださいね」). Ninety of the 123 agent
+  specs point `TMPDIR`, `UV_CACHE_DIR`, `UV_INSTALL_DIR` and the agent venv at
+  `/uvwork`; the base image creates that directory and **nothing bound it**, so
+  every byte went to `overlays/<agent>/upper/uvwork` on the host's ROOT volume.
+  Measured on `scitex-compute-04` 2026-09-03: 11.7 GB (`sac`), 3.3 GB
+  (`scitex-dev`), 3.0 GB (`scitex-hub`), 2.5 GB (`scitex-cards`), 1.9 GB
+  (`scitex-storage`) — and the root LV filled to 0 **four times** on
+  2026-09-02, while `/scratch` on the same host is a separate 3.0 T volume with
+  2.8 T free.
+  Each start now resolves the host scratch root once, creates
+  `<root>/sac/agents/<agent>/uvwork` (mode 0700, idempotent across restarts)
+  and appends `--bind <that>:/uvwork:rw` in the argv finalize layer, after
+  every spec-declared bind so a spec that binds `/uvwork` itself still wins.
+  No spec changes: `binds:` and `startup_commands` are untouched fleetwide.
+- **`scratch_root:` (and `scratch_root_reason:`) in the per-host
+  `config.yaml`.** An absolute path, or the literal `none` — the written
+  decision that this host keeps `/uvwork` in the overlay, which is **refused
+  without a stated reason**, as is a `scratch_root_reason:` with no
+  `scratch_root:` beside it. With no declaration the default `/scratch` is
+  probed (compute-01 and compute-03 have no `config.yaml` at all, so the
+  default has to work without one); with neither a declaration nor a
+  `/scratch`, sac **REFUSES to start the agent** naming the missing path, the
+  config key, the config file and all three fixes. There is no env-var knob:
+  falling back to the overlay silently is the bug this replaces.
+- **`sac agents scratch-migrate [--agent NAME]… [--apply] [--json]`** — moves
+  each STOPPED agent's `overlays/<agent>/upper/uvwork` to
+  `<scratch_root>/sac/agents/<agent>/uvwork`, so the historical copy stops
+  occupying the root LV and the next start finds uv and the venv already in
+  place. **Dry-run by default**, printing per-agent sizes, per-agent decisions
+  and the total it would move. A RUNNING agent is refused by name (its
+  container has the overlay mounted) and so is one whose liveness the runtime
+  adapter could not determine — "unknown" is not "stopped". Applying copies,
+  **verifies** every path, size and symlink target against the source, and only
+  then removes the overlay copy; a verification mismatch keeps the source and
+  says so. Exit codes: 0 sound, 1 the plan does not describe the sweep, 2
+  refused.
+  Two refusals come straight out of the first real dry-run, which found both:
+  **(a)** run from inside an agent container, the probe called the agent
+  executing it "stopped" and offered its 10.3 GiB — `is_running` is a pid file
+  plus `os.kill(pid, 0)`, the recorded pid was 3190806 and the container's
+  `/proc` topped out at 74275, because the container has its own PID namespace.
+  The verb now abstains whenever `APPTAINER_CONTAINER` /
+  `SINGULARITY_CONTAINER` is set, naming the vantage and saying to run it on
+  the host; sizes still print, since the overlays are read through a bind mount.
+  **(b)** `scitex-hub` and `scitex-hub-mobile-ux` declare ONE `--overlay`, as do
+  `scitex-cards` / `scitex-todo` and eight `handyman-*` specs, so one 2.6 GiB
+  tree was listed as movable twice. Shared sources are now refused on every
+  claiming row, each naming the others, with ownership computed over the whole
+  roster rather than the `--agent` subset.
+
 ### Removed
 - **`state_db.DEFAULT_DB_PATH`, and the ~4900-times-per-run test ceremony that
   rebound it.** The engine deletion below left the PATH behind — a `Path`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,19 @@ versioning follows [SemVer](https://semver.org/).
   (`scitex-storage`) — and the root LV filled to 0 **four times** on
   2026-09-02, while `/scratch` on the same host is a separate 3.0 T volume with
   2.8 T free.
-  Each start now resolves the host scratch root once, creates
-  `<root>/sac/agents/<agent>/uvwork` (mode 0700, idempotent across restarts)
-  and appends `--bind <that>:/uvwork:rw` in the argv finalize layer, after
-  every spec-declared bind so a spec that binds `/uvwork` itself still wins.
+  Each start now resolves the host scratch root once and appends
+  `--bind <root>/sac/agents/<agent>/uvwork:/uvwork:rw` in the argv finalize
+  layer, after every spec-declared bind so a spec that binds `/uvwork` itself
+  still wins. The directory (mode 0700, idempotent across restarts) is created
+  on the REAL launch path only — `build_run_argv` is also what `sac agents
+  explain` and `sac agents start --dry-run` call, and a read-only command must
+  neither write to the host nor fail on a launch-time host condition; on a
+  host with no scratch root those two show the refusal a start would hit
+  instead of raising it. The per-agent directory is derived by ONE function
+  (`scratch_uvwork_dir_for`, keyed on the effective `config.name`) that the
+  launch bind and `scratch-migrate` both call, so the two cannot disagree —
+  they would for every `hosts:` spec, whose effective id carries a
+  `-<hostname>` suffix its spec directory name does not.
   No spec changes: `binds:` and `startup_commands` are untouched fleetwide.
 - **`scratch_root:` (and `scratch_root_reason:`) in the per-host
   `config.yaml`.** An absolute path, or the literal `none` — the written

--- a/docs/adr/0024-uvwork-on-the-host-scratch-volume.md
+++ b/docs/adr/0024-uvwork-on-the-host-scratch-volume.md
@@ -111,14 +111,39 @@ write the `none` decision down).
 
 ### 2.3 The bind
 
-When a root resolves, `runtimes/_apptainer_scratch` creates
+When a root resolves, `runtimes/_apptainer_scratch` appends
+`--bind <that>:/uvwork:rw` to the flag argv, where *that* is
 
 ```
 <scratch_root>/sac/agents/<agent-name>/uvwork      mode 0700
 ```
 
-before exec and appends `--bind <that>:/uvwork:rw` to the flag argv. Notes
-that are decisions rather than details:
+and creates it — but the two halves happen at different moments, which is a
+decision, not an implementation detail. Notes that are decisions rather than
+details:
+
+* **The `<agent-name>` in that path is the EFFECTIVE id (`config.name`), and
+  exactly one function spells it** — `scratch_uvwork_dir_for`. The launch
+  bind and `sac agents scratch-migrate` both call it. They must, because for
+  a `hosts:` spec the effective id carries a `-<hostname>` suffix that the
+  spec *directory* name does not: two independent spellings would send the
+  migration's bytes to a path no launch ever mounts, and every step would
+  report success.
+* **The argv layer emits the bind READ-ONLY; the launch creates and
+  refuses.** `build_run_argv` is also what `sac agents explain` and
+  `sac agents start --dry-run` call, and neither starts anything. So
+  emitting the flag creates no directory and never raises on a host
+  condition: a host with no resolvable root gets a `WARNING`, an argv
+  without the bind, and an `explain` plan that names the refusal a real
+  start would hit. The mkdir and the `ScratchRootError` live in
+  `ensure_uvwork_for_launch`, called from `_apptainer_runtime.start` and
+  `tui_session.start` past their `dry_run` return — the placement
+  `verify_tmpfs_headroom` and `reconcile_overlay_venv_for_launch` already
+  use, for the reason the first of those records: a launch-time check inside
+  argv assembly made `explain` fail on exactly the full host it would have
+  diagnosed. The directory created is the one *that argv mounts* (the bind
+  source is read back out of it), so a spec that declared its own `/uvwork`
+  bind is left to its owner.
 
 * **Per agent.** An agent's venv, uv cache and `TMPDIR` are its private
   working set; two agents sharing one directory would share a venv.

--- a/docs/adr/0024-uvwork-on-the-host-scratch-volume.md
+++ b/docs/adr/0024-uvwork-on-the-host-scratch-volume.md
@@ -1,0 +1,233 @@
+# ADR-0024: `/uvwork` lives on the host scratch volume, not the root LV
+
+**Status:** Accepted (2026-09-03).
+**Operator directive** (Telegram, 2026-09-02): 「ディスクは /scratch
+使ってくださいね」 — the disk is `/scratch`; use it.
+**Relates to:** ADR-0003 (runtime home directory) and ADR-0006 (`to_home`
+materialization), which placed the container `$HOME` in the overlay upper.
+This ADR takes the one tree that does *not* belong there back out again.
+
+## 1. The failure
+
+The root logical volume on `scitex-compute-04` filled to **0 bytes four
+times on 2026-09-02**.
+
+Nothing about that is mysterious once the mechanism is named. Ninety of the
+123 agent specs point their build tooling at `/uvwork`:
+
+```yaml
+    startup_commands:
+      - export TMPDIR=/uvwork/tmp
+      - export UV_CACHE_DIR=/uvwork/uv-cache
+      - export UV_INSTALL_DIR=/uvwork/bin
+      - export UV_PROJECT_ENVIRONMENT=/uvwork/venv-agent
+```
+
+The base image *creates* `/uvwork` (`containers/apptainer-base.def`) and
+**nothing bound it**. An apptainer container's writes to an unbound path go
+to the overlay's upper layer, and every agent's overlay lives under the sac
+state root on the host's **root LV**. So the uv binary, the uv cache, the
+agent venv and every temporary file each agent has ever written have been
+accumulating in `overlays/<agent>/upper/uvwork`.
+
+Measured on compute-04, 2026-09-03:
+
+| agent | `overlays/<agent>/upper/uvwork` |
+| --- | --- |
+| `sac` | 11.7 GB |
+| `scitex-dev` | 3.3 GB |
+| `scitex-hub` | 3.0 GB |
+| `scitex-cards` | 2.5 GB |
+| `scitex-storage` | 1.9 GB |
+
+Meanwhile `/scratch` is a **separate** logical volume on the same hosts, and
+it is empty by comparison:
+
+| host | `/scratch` size | free |
+| --- | --- | --- |
+| compute-04 | 3.0 T | 2.8 T |
+| compute-03 | 3.0 T | 2.8 T |
+| compute-01 | 295 G | 243 G |
+
+114 of the 123 specs **already** bind `/scratch:/scratch:rw`. The volume was
+mounted, bound, and unused for the one thing that was filling the disk.
+
+(The 123 counts every spec directory on compute-04; `sac agents
+scratch-migrate` reports 116, which is the same roster after
+`fleet_spec_paths` drops `_`-prefixed scaffolding and directories with no
+`spec.yaml`. Neither number is wrong; they count different things.)
+
+The shape of the bug is not "uv is big". It is: **a write path that nobody
+declared went wherever the container's writable layer happened to be**, and
+the writable layer happened to be on the volume that must not fill.
+
+## 2. Decision
+
+### 2.1 One knob: `scratch_root:` in `config.yaml`
+
+Where `/uvwork` lives is a **per-host** fact, so it is declared in the
+per-host `config.yaml` and nowhere else. No environment variable selects it;
+there is one dish.
+
+```yaml
+scratch_root: /scratch          # an absolute path that must EXIST
+```
+
+or, for a host that genuinely should keep `/uvwork` in the overlay:
+
+```yaml
+scratch_root: none
+scratch_root_reason: root LV is 8T and there is no scratch volume here
+```
+
+`none` **requires** a reason. Keeping gigabytes of build state on the root
+volume is exactly the failure above, so it may be a decision, but it may not
+be an accident: a reason-less `none` is refused at config load, and so is a
+`scratch_root_reason:` with no `scratch_root:` beside it.
+
+### 2.2 The resolution table, and the fourth row
+
+`_state/host_scratch.resolve_scratch_root()` answers once per start with a
+fixed shape — `ScratchRoot(root, source, reason)`, where `root is None`
+exactly when `source == "none"`:
+
+| config.yaml | on this host | result |
+| --- | --- | --- |
+| `scratch_root: /abs` | `/abs` is a directory | `source=config`, `root=/abs` |
+| `scratch_root: /abs` | `/abs` is absent | **REFUSE** |
+| `scratch_root: none` + reason | — | `source=none`, `root=None` |
+| *(nothing)* | `/scratch` is a mount point or directory | `source=default`, `root=/scratch` |
+| *(nothing)* | no `/scratch` | **REFUSE** |
+
+The default matters because **compute-01 and compute-03 have no
+`config.yaml` at all** — a design that needed one on every host would have
+been a design that does not ship.
+
+The refusals matter more. The alternative to refusing is falling back to the
+overlay, which is the original bug wearing a shrug: correct-looking,
+silent, and back on the root LV. A refusal names the missing path, the
+config key, the config file, and all three fixes (mount it, declare it, or
+write the `none` decision down).
+
+### 2.3 The bind
+
+When a root resolves, `runtimes/_apptainer_scratch` creates
+
+```
+<scratch_root>/sac/agents/<agent-name>/uvwork      mode 0700
+```
+
+before exec and appends `--bind <that>:/uvwork:rw` to the flag argv. Notes
+that are decisions rather than details:
+
+* **Per agent.** An agent's venv, uv cache and `TMPDIR` are its private
+  working set; two agents sharing one directory would share a venv.
+* **0700 on creation, and never on an existing directory.** Restarts are
+  idempotent, so an operator who tightened or loosened the mode is not
+  silently overruled every time the agent restarts.
+* **Emitted in `_apptainer_argv_finalize`, after `raw_args` and every
+  spec-declared bind.** apptainer keeps the *first* bind to a destination,
+  so a spec that binds `/uvwork` itself wins — the same rule the package
+  already applies to its other fleet-default binds — and that case is
+  logged, not silent. It is emitted *before* the secret-env lift so the
+  credentials bind keeps its last-bind position.
+* The spec's own `[ -x /uvwork/bin/uv ] || …` steps are unchanged. They now
+  run against scratch, and rebuild there once on the first start after this
+  lands, unless the migration below moved the existing tree across first.
+
+### 2.4 `sac agents scratch-migrate`
+
+The bind alone leaves the historical copy stranded in the overlay: shadowed,
+never read again, still 11.7 GB on the root LV. The verb moves it.
+
+```
+sac agents scratch-migrate                     # dry-run — the DEFAULT
+sac agents scratch-migrate --agent sac --json
+sac agents scratch-migrate --apply             # the deliberate act
+```
+
+* **Dry-run is the default**, printing per-agent sizes, per-agent decisions
+  and the total it would move.
+* **Only a provably STOPPED agent is moved.** A running agent has the
+  overlay mounted; it is refused *by name* with the command to stop it. An
+  agent whose liveness the runtime adapter could not determine is refused
+  too — "unknown" is not "stopped". The probe is the same adapter
+  `sac agents status` uses, never a second opinion.
+* **And only from a vantage where "stopped" means anything.** The first real
+  dry-run, run from inside the `scitex-agent-container` agent, reported that
+  agent — the one executing the probe — as *stopped*, and offered its
+  10.3 GiB. `is_running` is a pid file plus `os.kill(pid, 0)`; the recorded
+  pid was 3190806 while `/proc` inside the container topped out at 74275,
+  because the container has its own PID namespace. Neither the pid file nor
+  the adapter is wrong — the vantage is. So the verb now abstains outright
+  when `APPTAINER_CONTAINER` / `SINGULARITY_CONTAINER` is set: every agent
+  comes back UNKNOWN, which is a refusal, and the message says to run it on
+  the host. Sizes still print, because the overlays are read through a bind
+  mount and *that* reading is faithful.
+* **An overlay two agents declare is refused, naming the others.** Also from
+  the first dry-run: `scitex-hub` and `scitex-hub-mobile-ux` name one
+  `--overlay`, as do `scitex-cards` / `scitex-todo` and eight `handyman-*`
+  specs sharing `local-coder`. One 2.6 GiB tree was listed as movable twice.
+  Applying that would move it for the first agent, hand the second a source
+  that no longer exists, and file a shared tree into one agent's private
+  directory. Which agent owns a shared overlay is a fleet decision sac may
+  not make, so both rows refuse. Ownership is computed over the whole
+  roster, never the `--agent` subset — sharing that only an unselected spec
+  reveals is exactly what a narrow invocation would walk into.
+* **Copy → verify → remove.** The overlay copy is deleted only after every
+  path, size and symlink target in the destination has been compared with
+  the source. A mismatch keeps the source and says so.
+* A destination that is **already populated** is refused: the agent has
+  restarted under the new bind and rebuilt there, which makes the overlay
+  copy the older of the two.
+* Exit codes: `0` sound, `1` the plan does not describe the sweep (no roster
+  searched, an unreadable spec, an unknown `--agent`), `2` refused.
+
+## 3. Consequences
+
+* **Every start now depends on a resolvable scratch root.** On a host with
+  neither `/scratch` nor a `scratch_root:` line, agents refuse to start
+  until an operator makes a decision. That is the intended trade: an agent
+  that will not start is visible, and an agent quietly refilling the root LV
+  is not.
+* The spec corpus is **untouched**. No `binds:` entry, no `startup_commands`
+  edit, no per-agent migration — the bind is emitted by the runtime for
+  every agent at once.
+* `/uvwork` is still `/uvwork` inside the container, so `TMPDIR`,
+  `UV_CACHE_DIR`, `UV_INSTALL_DIR`, `UV_PROJECT_ENVIRONMENT`,
+  `_apptainer_listen_env`, `cli_pkg/_whoami` and `_dev_jobs_backend` all
+  keep working with no change.
+* **Jailed capsules get the same bind as everyone else**, deliberately: a
+  jailed agent's uv cache is exactly as unwelcome on the root LV as anyone
+  else's. Two facts make that safe rather than convenient. First,
+  `runtimes/_apptainer_jail.enforce_jail` checks *operator-controlled* bind
+  sources — `spec.apptainer.binds`, `raw_args --bind`, and the
+  `APPTAINER_BIND` family — and this bind is emitted by sac itself, so it
+  sits with the credentials, workspace-home and overlay-upper-home binds
+  that were already outside that check. Second, `/scratch` is not one of the
+  forbidden prefixes (`/data/gpfs`, `/data/scratch`, `/home`) anyway, so
+  even a spec that declared it by hand would pass.
+  The honest edge: a host that declares `scratch_root:` at a path *under*
+  `/home` gives its jailed capsules a `/home`-backed bind that
+  `enforce_jail` will not see, because sac's own binds are not the thing
+  that check polices. On a host with no separate volume, `scratch_root:
+  none` with a written reason is the better answer than a `/home` path.
+* The host registry row (`_state/host_registry`) is **not** extended. Where
+  scratch lives is per-host configuration, and ADR-0022's rule is that
+  configuration lives in files under git, not in the state database.
+
+## 4. What was rejected
+
+* **A `scratch:` field on the host registry row.** It is configuration, not
+  state (ADR-0022), and the registry is synchronised between hosts — a
+  per-host path is precisely the wrong thing to replicate.
+* **An environment variable (`SAC_SCRATCH_ROOT`).** Two knobs for one fact
+  is how a host ends up with a `config.yaml` that describes a launch nobody
+  is performing.
+* **Silently falling back to the overlay when `/scratch` is missing.** This
+  is the bug, restated as a feature.
+* **Binding `<scratch>/uvwork` shared by all agents.** One venv, many
+  writers.
+* **Deleting the overlay copies instead of moving them.** Every agent would
+  then rebuild uv and its venv on the next start, for no gain over a copy
+  that takes seconds on the same host.

--- a/docs/directories.md
+++ b/docs/directories.md
@@ -7,7 +7,8 @@ Configuration is separated into user-scope and project-scope. Project-scope (`.s
 ```
 ~/.scitex/agent-container/ or <project>/.scitex/agent-container/
 ├── config.yaml                ← host identity, host.aliases, peers (F-CS12),
-│                                listen.{host,port}, a2a.port_range
+│                                listen.{host,port}, a2a.port_range,
+│                                scratch_root (+ scratch_root_reason)
 ├── agents/<name>/             ← per-agent declarations (you write these)
 │   ├── spec.yaml              ← v3 Agent definition (the SSoT)
 │   └── to_home/               ← optional: mirrored into the agent $HOME at start.
@@ -53,6 +54,23 @@ Configuration is separated into user-scope and project-scope. Project-scope (`.s
     │   └── <agent>.jsonl
     └── cache/                   snapshot cache for the dashboard / `sac agents diff`
         └── <agent>.{latest,prev,diff}.json
+```
+
+Not under this root, and deliberately so — the SCRATCH volume (ADR-0024):
+
+```
+<scratch_root>/                ← `scratch_root:` in config.yaml, else /scratch
+└── sac/agents/<name>/uvwork   ← bound at /uvwork inside the container (0700).
+                                 uv itself, the uv cache, TMPDIR and the agent
+                                 venv (/uvwork/venv-agent). It lives HERE rather
+                                 than in the overlay upper because the overlay
+                                 is on the host's ROOT LV, which filled to 0
+                                 four times on scitex-compute-04 on 2026-09-02
+                                 (11.7 GB of it was one agent's /uvwork).
+                                 Regenerable: the spec rebuilds it on the next
+                                 start if it is missing. Move an existing
+                                 overlay copy across with
+                                 `sac agents scratch-migrate`.
 ```
 
 ## Configuration cascade

--- a/src/scitex_agent_container/_maintenance/_scratch_migrate.py
+++ b/src/scitex_agent_container/_maintenance/_scratch_migrate.py
@@ -1,0 +1,388 @@
+"""Move ``overlays/<agent>/upper/uvwork`` onto the host scratch volume.
+
+The migration half of ADR-0024. Once ``/uvwork`` is bound from
+``<scratch_root>/sac/agents/<agent>/uvwork`` (:mod:`..runtimes._apptainer_scratch`),
+the copy that accumulated in each agent's overlay upper is dead weight on the
+root LV: shadowed by the bind, never read again, and — measured on
+scitex-compute-04 on 2026-09-03 — 11.7 GB for sac, 3.3 GB for scitex-dev,
+3.0 GB for scitex-hub, 2.5 GB for scitex-cards, 1.9 GB for scitex-storage.
+Moving it across (rather than deleting it) means the next start finds uv and
+the venv already in place and skips the rebuild.
+
+The plan is a VALUE built without writing anything (:func:`plan_scratch_migration`);
+applying it (:func:`apply_scratch_migration`) does, per agent: copy the tree,
+verify every path and byte count against the source, and only then remove the
+overlay copy. A verification mismatch keeps the source and says so.
+
+What the plan refuses, and names:
+
+* a RUNNING agent — its container has the overlay mounted; pulling the tree
+  out from under it is not a migration. Stop it first.
+* an agent whose liveness could not be determined — "unknown" is not
+  "stopped". That includes running this verb from somewhere the probe cannot
+  see host processes; see :mod:`._scratch_migrate_liveness`.
+* a destination already populated — the agent has started under the new
+  bind and rebuilt there; the overlay copy is now the older of the two, and
+  overwriting fresh with old is not what "migrate" means.
+* an overlay TWO agents declare — moving it into one agent's private scratch
+  directory takes it away from the other (:func:`_refuse_shared_sources`).
+* an image (loopback) overlay — its upper is inside an ext3 image the host
+  cannot walk.
+
+A spec that cannot be loaded is ``unreadable`` and makes the plan unsafe, the
+same distinction :mod:`._layers_migration_model` draws: a refusal is a spec the
+sweep looked at and declined; unreadable means the plan does not describe the
+sweep.
+
+The two instruments live beside this module, one responsibility each:
+:mod:`._scratch_migrate_measure` (``tree_size`` / ``verify_copy``) and
+:mod:`._scratch_migrate_liveness` (``agent_liveness`` / ``liveness_vantage``).
+Both are re-exported here, so this module stays the single import site.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+from .._state.host_scratch import ScratchRoot
+from ..runtimes._apptainer_scratch import UVWORK_DIR_MODE, scratch_uvwork_dir
+from ._roster_state import RosterState, inspect_roster
+from ._scratch_migrate_liveness import (  # noqa: F401
+    CONTAINER_MARKER_ENV,
+    agent_liveness,
+    liveness_vantage,
+)
+from ._scratch_migrate_measure import tree_size, verify_copy  # noqa: F401
+
+#: What the plan decides per agent.
+ACTIONS = ("move", "nothing", "refuse")
+
+#: Where the overlay copy sits, relative to the overlay root.
+OVERLAY_UVWORK_RELPATH = ("upper", "uvwork")
+
+
+@dataclass(frozen=True)
+class UvworkRow:
+    """One agent's overlay ``uvwork`` and what the sweep would do with it."""
+
+    agent: str
+    spec_path: Path
+    source: Path | None
+    dest: Path | None
+    bytes: int
+    files: int
+    running: bool | None
+    action: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if self.action not in ACTIONS:
+            raise ValueError(f"action must be one of {ACTIONS}, got {self.action!r}")
+
+    def to_dict(self) -> dict:
+        return {
+            "agent": self.agent,
+            "spec_path": str(self.spec_path),
+            "source": None if self.source is None else str(self.source),
+            "dest": None if self.dest is None else str(self.dest),
+            "bytes": self.bytes,
+            "files": self.files,
+            "running": self.running,
+            "action": self.action,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class MoveResult:
+    """What :func:`move_uvwork` did for one row."""
+
+    agent: str
+    source: Path
+    dest: Path
+    bytes: int
+    files: int
+    moved: bool
+    detail: str
+
+    def to_dict(self) -> dict:
+        return {
+            "agent": self.agent,
+            "source": str(self.source),
+            "dest": str(self.dest),
+            "bytes": self.bytes,
+            "files": self.files,
+            "moved": self.moved,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class ScratchPlan:
+    """Every agent the sweep looked at, plus the roster it looked in."""
+
+    rows: tuple[UvworkRow, ...]
+    roster: RosterState
+    scratch: ScratchRoot
+    unknown: tuple[str, ...]
+    unreadable: tuple[str, ...]
+
+    @property
+    def movable(self) -> tuple[UvworkRow, ...]:
+        return tuple(r for r in self.rows if r.action == "move")
+
+    @property
+    def refused(self) -> tuple[UvworkRow, ...]:
+        return tuple(r for r in self.rows if r.action == "refuse")
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(r.bytes for r in self.movable)
+
+    @property
+    def safe_to_apply(self) -> bool:
+        """The plan describes the sweep: populated roster, every spec read,
+        every ``--agent`` name found."""
+        return self.roster.is_populated and not self.unreadable and not self.unknown
+
+    def summary(self) -> str:
+        return (
+            f"{len(self.movable)} agent(s) to move, {self.total_bytes} bytes; "
+            f"{len(self.refused)} refused; "
+            f"{sum(1 for r in self.rows if r.action == 'nothing')} with nothing to move"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Planning — reads only
+# ---------------------------------------------------------------------------
+
+
+def _overlay_uvwork(config) -> tuple[Path | None, str]:
+    """``(overlay upper uvwork, reason-if-None)`` for ``config``."""
+    from ..runtimes._apptainer_overlay import (
+        is_image_overlay,
+        resolve_overlay_declaration,
+    )
+
+    root = resolve_overlay_declaration(config)
+    if root is None:
+        return None, "spec declares no overlay"
+    ap = getattr(config, "apptainer", None)
+    size = (getattr(ap, "overlay_size", "") or "") if ap is not None else ""
+    if is_image_overlay(root, size):
+        return None, f"image (loopback) overlay {root}; its upper cannot be walked from the host"
+    return root.joinpath(*OVERLAY_UVWORK_RELPATH), ""
+
+
+def _row_for(
+    agent: str, spec_path: Path, config, scratch_root: Path, liveness
+) -> UvworkRow:
+    source, why = _overlay_uvwork(config)
+    dest = scratch_uvwork_dir(scratch_root, agent)
+    if source is None:
+        return UvworkRow(agent, spec_path, None, dest, 0, 0, None, "nothing", why)
+    if not source.is_dir():
+        return UvworkRow(
+            agent, spec_path, source, dest, 0, 0, None, "nothing",
+            f"no uvwork in the overlay upper ({source} is absent)",
+        )
+    size, files = tree_size(source)
+    running, detail = liveness(config)
+    if running is None:
+        return UvworkRow(
+            agent, spec_path, source, dest, size, files, None, "refuse",
+            f"liveness unknown ({detail}); only a provably STOPPED agent is moved",
+        )
+    if running:
+        return UvworkRow(
+            agent, spec_path, source, dest, size, files, True, "refuse",
+            f"RUNNING ({detail}); stop it first: sac agents stop {agent}",
+        )
+    if dest.is_dir() and any(dest.iterdir()):
+        return UvworkRow(
+            agent, spec_path, source, dest, size, files, False, "refuse",
+            f"destination {dest} is already populated — the agent has rebuilt "
+            f"/uvwork on scratch under the new bind, so the overlay copy is "
+            f"the older of the two; remove {source} by hand once you agree",
+        )
+    return UvworkRow(
+        agent, spec_path, source, dest, size, files, False, "move",
+        f"stopped; {size} bytes in {files} file(s) move to {dest}",
+    )
+
+
+def _refuse_shared_sources(
+    rows: Sequence[UvworkRow], owners: dict[Path, list[str]]
+) -> tuple[UvworkRow, ...]:
+    """Turn every ``move`` whose source another agent also declares into a refusal.
+
+    MEASURED on the live fleet 2026-09-03: ``scitex-hub`` and
+    ``scitex-hub-mobile-ux`` declare the SAME ``--overlay`` directory, as do
+    ``scitex-cards`` / ``scitex-todo`` and eight ``handyman-*`` specs sharing
+    ``local-coder``. The plan listed one 2.6 GiB tree as movable TWICE —
+    identical byte counts on two rows. Applying that would move the tree for
+    the first agent and then hand the second a source that no longer exists
+    (``copytree`` raising mid-sweep), and would file a tree two agents read
+    into ONE agent's private per-agent directory, taking it from the other.
+
+    sac cannot pick a winner: which agent owns a shared overlay is a fleet
+    decision. So both rows are refused, each naming the others, and the
+    operator settles it in the specs.
+    """
+    out: list[UvworkRow] = []
+    for row in rows:
+        others = (
+            [a for a in owners.get(row.source, ()) if a != row.agent]
+            if row.source is not None
+            else []
+        )
+        if row.action == "move" and others:
+            out.append(
+                replace(
+                    row,
+                    action="refuse",
+                    reason=(
+                        f"{row.source} is ALSO declared by "
+                        f"{', '.join(sorted(others))}; moving it into "
+                        f"{row.dest} would take it away from them. Give each "
+                        f"agent its own overlay, or move this tree by hand."
+                    ),
+                )
+            )
+        else:
+            out.append(row)
+    return tuple(out)
+
+
+def plan_scratch_migration(
+    scratch: ScratchRoot,
+    *,
+    agents_root: Path | None = None,
+    only: Sequence[str] = (),
+    liveness: Callable = agent_liveness,
+) -> ScratchPlan:
+    """Build the plan over the fleet roster (or the ``only`` subset). NO writes.
+
+    ``scratch`` must carry a root: a host that decided ``scratch_root: none``
+    has nowhere to migrate to, and the CLI refuses before reaching here.
+
+    EVERY spec is loaded, including the ones ``only`` filters out, because
+    :func:`_refuse_shared_sources` needs the whole ownership map: two specs
+    can name one overlay, and a narrow ``--agent`` run must still be told.
+    Only SELECTED agents get a row, a tree walk or a liveness probe, and only
+    a SELECTED spec that will not load makes the plan unsafe.
+    """
+    if scratch.root is None:
+        raise ValueError(
+            f"plan_scratch_migration needs a scratch root; this host resolved "
+            f"source='none' ({scratch.reason})"
+        )
+    from .._reconcile._pass import fleet_agents_dir, fleet_spec_paths
+    from ..config import load_config
+
+    root = agents_root if agents_root is not None else fleet_agents_dir()
+    spec_paths = fleet_spec_paths(root)
+    roster = inspect_roster(root, spec_paths)
+    wanted = set(only)
+    seen: set[str] = set()
+    rows: list[UvworkRow] = []
+    unreadable: list[str] = []
+    owners: dict[Path, list[str]] = {}
+    for spec_path in spec_paths:
+        agent = spec_path.parent.name
+        selected = not wanted or agent in wanted
+        if selected:
+            seen.add(agent)
+        try:
+            config = load_config(str(spec_path))
+        except Exception as exc:  # stx-allow: fallback (reason: one unreadable spec must not abort the sweep; a SELECTED one is recorded and makes the plan unsafe, an unselected one simply stakes no ownership claim)
+            if selected:
+                unreadable.append(
+                    f"{agent}: {type(exc).__name__}: {' '.join(str(exc).split())[:200]}"
+                )
+            continue
+        source, _why = _overlay_uvwork(config)
+        if source is not None:
+            owners.setdefault(source, []).append(agent)
+        if selected:
+            rows.append(_row_for(agent, spec_path, config, scratch.root, liveness))
+    unknown = tuple(sorted(wanted - seen))
+    return ScratchPlan(
+        rows=_refuse_shared_sources(rows, owners),
+        roster=roster,
+        scratch=scratch,
+        unknown=unknown,
+        unreadable=tuple(unreadable),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Applying — copy, verify, then remove the overlay copy
+# ---------------------------------------------------------------------------
+
+
+def move_uvwork(row: UvworkRow) -> MoveResult:
+    """Copy ``row.source`` to ``row.dest``, verify, remove the source.
+
+    The source is removed ONLY after :func:`verify_copy` finds no
+    difference. On any failure the overlay copy stays and ``detail`` names
+    what went wrong; a partial destination is left for inspection rather
+    than deleted (it is on scratch, where space is not the problem).
+    """
+    assert row.action == "move" and row.source is not None and row.dest is not None
+    source, dest = row.source, row.dest
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copytree(source, dest, symlinks=True, dirs_exist_ok=True)
+    except shutil.Error as exc:  # stx-allow: fallback (reason: copytree aggregates per-file errors; the source is KEPT, and the count plus the first three failing paths go into this MoveResult.detail — printed by cli_pkg/_agents_scratch_migrate._render_apply and carried in the --json payload's results[]/failed[])
+        errs = getattr(exc, "args", [[]])[0]
+        first = "; ".join(f"{s} -> {d}: {why}" for s, d, why in list(errs)[:3])
+        return MoveResult(
+            row.agent, source, dest, row.bytes, row.files, False,
+            f"copy failed on {len(errs)} path(s); overlay copy KEPT: {first}",
+        )
+    os.chmod(dest, UVWORK_DIR_MODE)
+    problems = verify_copy(source, dest)
+    if problems:
+        head = "; ".join(problems[:3])
+        return MoveResult(
+            row.agent, source, dest, row.bytes, row.files, False,
+            f"verification found {len(problems)} difference(s); overlay copy KEPT: {head}",
+        )
+    shutil.rmtree(source)
+    return MoveResult(
+        row.agent, source, dest, row.bytes, row.files, True,
+        f"moved {row.bytes} bytes in {row.files} file(s); overlay copy removed",
+    )
+
+
+def apply_scratch_migration(plan: ScratchPlan) -> list[MoveResult]:
+    """Move every ``move`` row of ``plan``, in plan order."""
+    return [move_uvwork(row) for row in plan.movable]
+
+
+def total_bytes(rows: Iterable[UvworkRow]) -> int:
+    return sum(r.bytes for r in rows)
+
+
+__all__ = [
+    "ACTIONS",
+    "CONTAINER_MARKER_ENV",
+    "OVERLAY_UVWORK_RELPATH",
+    "MoveResult",
+    "ScratchPlan",
+    "UvworkRow",
+    "agent_liveness",
+    "apply_scratch_migration",
+    "liveness_vantage",
+    "move_uvwork",
+    "plan_scratch_migration",
+    "total_bytes",
+    "tree_size",
+    "verify_copy",
+]

--- a/src/scitex_agent_container/_maintenance/_scratch_migrate.py
+++ b/src/scitex_agent_container/_maintenance/_scratch_migrate.py
@@ -29,6 +29,13 @@ What the plan refuses, and names:
 * an image (loopback) overlay — its upper is inside an ext3 image the host
   cannot walk.
 
+The destination is NOT computed here. It comes from
+:func:`..runtimes._apptainer_scratch.scratch_uvwork_dir_for`, the same call the
+launch bind makes, so "where the migration puts it" and "where the launch
+mounts from" cannot be two answers. They were: this module keyed on the spec
+DIRECTORY name while the bind keyed on the effective ``config.name``, which
+differ for every ``hosts:`` spec (``-<hostname>`` suffix).
+
 A spec that cannot be loaded is ``unreadable`` and makes the plan unsafe, the
 same distinction :mod:`._layers_migration_model` draws: a refusal is a spec the
 sweep looked at and declined; unreadable means the plan does not describe the
@@ -49,7 +56,7 @@ from pathlib import Path
 from typing import Callable, Iterable, Sequence
 
 from .._state.host_scratch import ScratchRoot
-from ..runtimes._apptainer_scratch import UVWORK_DIR_MODE, scratch_uvwork_dir
+from ..runtimes._apptainer_scratch import UVWORK_DIR_MODE, scratch_uvwork_dir_for
 from ._roster_state import RosterState, inspect_roster
 from ._scratch_migrate_liveness import (  # noqa: F401
     CONTAINER_MARKER_ENV,
@@ -183,7 +190,15 @@ def _row_for(
     agent: str, spec_path: Path, config, scratch_root: Path, liveness
 ) -> UvworkRow:
     source, why = _overlay_uvwork(config)
-    dest = scratch_uvwork_dir(scratch_root, agent)
+    # The destination is derived from the CONFIG, through the same function the
+    # launch bind calls — never re-spelled from ``agent`` (the spec DIRECTORY
+    # name). The two are the same string for a ``host:`` spec and DIFFERENT for
+    # a ``hosts:`` one, whose effective id carries a ``-<hostname>`` suffix, so
+    # keying the destination on the directory name moved every multi-instance
+    # agent's tree to a path no launch would ever mount: copy verified, overlay
+    # original deleted, "migrated" reported, and the next start rebuilding uv
+    # and the venv from scratch anyway. See ``_apptainer_scratch``'s docstring.
+    dest = scratch_uvwork_dir_for(scratch_root, config)
     if source is None:
         return UvworkRow(agent, spec_path, None, dest, 0, 0, None, "nothing", why)
     if not source.is_dir():

--- a/src/scitex_agent_container/_maintenance/_scratch_migrate_liveness.py
+++ b/src/scitex_agent_container/_maintenance/_scratch_migrate_liveness.py
@@ -1,0 +1,99 @@
+"""Is this agent running — and may the answer be believed from HERE?
+
+The liveness half of the ADR-0024 migration (:mod:`._scratch_migrate`), split
+out of it so each file holds one responsibility. The sweep ``rmtree``s an
+agent's ``/uvwork``, so "stopped" is the single most consequential word in the
+plan and it gets its own module.
+
+Two questions, deliberately separate:
+
+* :func:`agent_liveness` asks the agent's DECLARED runtime adapter — the same
+  one ``sac agents status`` uses (:func:`.._lifecycle._runtime_select._get_runtime`),
+  never a second opinion, so the verb and the status command can never
+  disagree about who is running.
+* :func:`liveness_vantage` asks whether this process is even in a position to
+  read that answer. It is the guard a live dry-run proved necessary; the
+  measurement is in its docstring.
+
+``None`` is a first-class answer here. The plan treats it as a refusal, never
+as "stopped", so every path that cannot produce a trustworthy verdict lands
+there rather than inventing one.
+"""
+
+from __future__ import annotations
+
+import os
+
+#: Set by apptainer/singularity inside every container it runs.
+CONTAINER_MARKER_ENV = ("APPTAINER_CONTAINER", "SINGULARITY_CONTAINER")
+
+
+def liveness_vantage(env: dict | None = None) -> str:
+    """``""`` when host pids are resolvable from here; else WHY they are not.
+
+    MEASURED 2026-09-03, from inside the ``scitex-agent-container`` agent —
+    the agent that was running the probe:
+
+        runtime/scitex-agent-container/apptainer_pid   3190806
+        max pid visible in this container's /proc         74275
+        os.kill(3190806, 0)                    ProcessLookupError
+
+    The adapter's ``is_running`` is ``_read_pid`` + ``os.kill(pid, 0)``. In a
+    container with its own PID namespace that pid belongs to nobody, so the
+    probe answered **False** — "stopped" — for an agent whose own turn was
+    executing the call. A sweep that believed it would ``rmtree`` the
+    ``/uvwork`` of a live container while its overlay is mounted.
+
+    The pid file is not wrong and the adapter is not wrong; the VANTAGE is.
+    So this is not a better heuristic — it is an abstention. Every agent's
+    liveness comes back UNKNOWN, and UNKNOWN is a refusal (never "stopped"),
+    with the fix in the message: run the verb on the host. Sizes still print,
+    because the overlays are read through a bind mount and that reading IS
+    faithful; only the pid probe is not.
+
+    ``env`` defaults to ``os.environ``; pass a dict in tests.
+    """
+    values = os.environ if env is None else env
+    for key in CONTAINER_MARKER_ENV:
+        image = (values.get(key) or "").strip()
+        if image:
+            return (
+                f"this process runs INSIDE a container ({key}={image}), which "
+                f"has its own PID namespace, so an agent's recorded host pid "
+                f"resolves to nobody here and every agent reads as 'stopped'. "
+                f"Run `sac agents scratch-migrate` on the HOST instead."
+            )
+    return ""
+
+
+def agent_liveness(config) -> tuple[bool | None, str]:
+    """``(running, detail)`` via the agent's DECLARED runtime adapter.
+
+    ``None`` means the instrument could not answer, and ``detail`` says which
+    instrument and why — the plan treats that as a refusal, never as
+    "stopped". Same selection as ``sac agents status``.
+
+    Abstains up front when :func:`liveness_vantage` says the probe cannot see
+    host processes from here: an answer the vantage cannot support is worse
+    than no answer, because this one authorises a delete.
+    """
+    blind = liveness_vantage()
+    if blind:
+        return None, blind
+    # stx-allow: fallback (reason: an adapter that cannot be selected or that
+    # raises is an ABSTENTION recorded with its cause, not a crash of the
+    # whole sweep and not a "stopped" verdict)
+    try:
+        from .._lifecycle._runtime_select import _get_runtime
+
+        runtime = _get_runtime(config)
+    except Exception as exc:  # stx-allow: fallback (reason: see above)
+        return None, f"runtime select: {exc}"
+    label = type(runtime).__name__
+    try:
+        return bool(runtime.is_running(config)), label
+    except Exception as exc:  # stx-allow: fallback (reason: see above)
+        return None, f"{label}.is_running: {exc}"
+
+
+__all__ = ["CONTAINER_MARKER_ENV", "agent_liveness", "liveness_vantage"]

--- a/src/scitex_agent_container/_maintenance/_scratch_migrate_measure.py
+++ b/src/scitex_agent_container/_maintenance/_scratch_migrate_measure.py
@@ -1,0 +1,94 @@
+"""How big is that tree, and is the copy of it the same tree?
+
+The two MEASURING instruments of the ADR-0024 migration
+(:mod:`._scratch_migrate`), split out of it so each file holds one
+responsibility. Pure reads — nothing here writes, moves or deletes anything.
+
+They answer the two questions the operator's decision rests on:
+
+* :func:`tree_size` — the number in the preview. It must match what the
+  operator will get back on the root LV, so hard-linked files (a uv cache is
+  full of them) are counted ONCE, exactly as ``du`` counts them. Counting
+  them per-link would promise space the move cannot free.
+* :func:`verify_copy` — the instrument that licenses the ``rmtree``. The
+  overlay copy is removed only after this returns empty, so it has to be able
+  to say NO: a missing path, a short file, a symlink pointing elsewhere, or a
+  device node the copy quietly skipped.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def tree_size(path: Path) -> tuple[int, int]:
+    """``(bytes, files)`` under ``path`` — ``lstat``, no symlink following,
+    hard-linked files counted ONCE (as ``du`` counts them).
+
+    Symlinks count as files at their own (link) size. Directories, sockets
+    and device nodes contribute no bytes. A missing path is ``(0, 0)``.
+    """
+    if not path.is_dir():
+        return (0, 0)
+    seen: set[tuple[int, int]] = set()
+    total = 0
+    files = 0
+    for dirpath, _dirnames, filenames in os.walk(path):
+        for name in filenames:
+            st = os.lstat(os.path.join(dirpath, name))
+            files += 1
+            key = (st.st_dev, st.st_ino)
+            if key in seen:
+                continue
+            seen.add(key)
+            total += st.st_size
+    return (total, files)
+
+
+def _tree_manifest(root: Path) -> dict[str, tuple[str, object]]:
+    """``{relpath: (kind, size | link target)}`` for every entry under ``root``.
+
+    The verification instrument: two trees are the same tree when their
+    manifests are equal — every directory, every regular file at the same
+    size, every symlink with the same target. Anything else (a device node,
+    a socket) is recorded by kind so it can never match a copy that skipped
+    it.
+    """
+    out: dict[str, tuple[str, object]] = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        base = Path(dirpath)
+        for d in dirnames:
+            p = base / d
+            rel = str(p.relative_to(root))
+            out[rel] = ("symlink", os.readlink(p)) if p.is_symlink() else ("dir", 0)
+        for f in filenames:
+            p = base / f
+            rel = str(p.relative_to(root))
+            st = os.lstat(p)
+            if p.is_symlink():
+                out[rel] = ("symlink", os.readlink(p))
+            elif os.path.isfile(p):
+                out[rel] = ("file", st.st_size)
+            else:
+                out[rel] = ("special", st.st_mode)
+    return out
+
+
+def verify_copy(source: Path, dest: Path) -> list[str]:
+    """Differences between ``source`` and ``dest``; empty means verified."""
+    src = _tree_manifest(source)
+    dst = _tree_manifest(dest)
+    problems: list[str] = []
+    for rel, want in sorted(src.items()):
+        got = dst.get(rel)
+        if got is None:
+            problems.append(f"missing in copy: {rel}")
+        elif got != want:
+            problems.append(f"differs: {rel} source={want} copy={got}")
+    for rel in sorted(set(dst) - set(src)):
+        problems.append(f"extra in copy: {rel}")
+    return problems
+
+
+__all__ = ["tree_size", "verify_copy"]

--- a/src/scitex_agent_container/_state/_host_config_blocks.py
+++ b/src/scitex_agent_container/_state/_host_config_blocks.py
@@ -1,4 +1,5 @@
-"""The optional typed blocks of ``config.yaml`` — ``resolve:`` and ``lead:``.
+"""The optional typed blocks of ``config.yaml`` — ``resolve:``, ``lead:`` and
+``scratch_root:``.
 
 Extracted from :mod:`.host_config` so that file stays under the project's
 512-line ceiling (it had 8 lines of headroom left, which is not headroom).
@@ -171,10 +172,103 @@ def _parse_resolve(name: str, raw) -> ResolveSpec | None:
     return ResolveSpec(source=source, reservation=reservation)
 
 
+#: The literal ``scratch_root:`` value that means "this host keeps ``/uvwork``
+#: in the apptainer overlay upper" — a WRITTEN decision, never a default.
+SCRATCH_ROOT_NONE = "none"
+
+
+@dataclass(frozen=True)
+class ScratchBlock:
+    """``scratch_root:`` (+ ``scratch_root_reason:``) — where ``/uvwork`` lives.
+
+    Every agent's ``/uvwork`` (uv itself, the agent venv, ``TMPDIR``, the uv
+    cache) is bound from ``<scratch_root>/sac/agents/<agent>/uvwork`` on the
+    host (see :mod:`..runtimes._apptainer_scratch`). Without that bind it
+    lands in the apptainer overlay upper on the ROOT volume — the volume that
+    filled to 0 four times on ``scitex-compute-04`` on 2026-09-02, with
+    ``overlays/<agent>/upper/uvwork`` measured at 11.7 GB (sac), 3.3 GB
+    (scitex-dev), 3.0 GB (scitex-hub), 2.5 GB (scitex-cards).
+
+    Two shapes, both explicit:
+
+      scratch_root: /scratch              # an ABSOLUTE path that exists
+      scratch_root: none                  # keep /uvwork in the overlay ...
+      scratch_root_reason: <why>          # ... which needs a stated reason
+
+    A host with NO ``scratch_root:`` line resolves the default ``/scratch``
+    when that is a mount point or directory, and REFUSES to start any agent
+    otherwise — see :func:`.host_scratch.resolve_scratch_root`. The literal
+    ``none`` exists so that keeping ``/uvwork`` on the root volume is a
+    decision someone wrote down, not the shape a missing line falls into.
+    """
+
+    root: str
+    """Absolute path, or the literal :data:`SCRATCH_ROOT_NONE`."""
+
+    reason: str = ""
+    """Free text; REQUIRED when ``root`` is ``none``, optional otherwise."""
+
+    @property
+    def is_none(self) -> bool:
+        return self.root == SCRATCH_ROOT_NONE
+
+
+def _parse_scratch(raw_root, raw_reason, *, source_path: Path) -> ScratchBlock | None:
+    """Normalize ``scratch_root:`` / ``scratch_root_reason:`` into a block.
+
+    Missing ``scratch_root:`` → ``None`` (the resolver then probes the
+    default ``/scratch``). Present → strict: a non-empty string that is
+    either an absolute path or the literal ``none``; ``none`` additionally
+    requires a non-empty ``scratch_root_reason:``. A ``scratch_root_reason:``
+    with no ``scratch_root:`` is an orphan and is refused too — it reads as a
+    decision that was half-written. Every refusal names ``source_path`` and
+    the offending value so the fix is a one-line edit of that file.
+    """
+    key = "scratch_root"
+    if raw_root is None:
+        if raw_reason is not None:
+            raise ValueError(
+                f"config.yaml at {source_path}: 'scratch_root_reason' is set "
+                f"but 'scratch_root' is not — the reason belongs to a "
+                f"'scratch_root: none' line; add that line or drop the reason"
+            )
+        return None
+    if not isinstance(raw_root, str) or not raw_root.strip():
+        raise ValueError(
+            f"config.yaml at {source_path}: '{key}' must be an absolute path "
+            f"or the literal 'none' (got {raw_root!r})"
+        )
+    root = raw_root.strip()
+    if raw_reason is not None and not isinstance(raw_reason, str):
+        raise ValueError(
+            f"config.yaml at {source_path}: 'scratch_root_reason' must be a "
+            f"string (got {type(raw_reason).__name__})"
+        )
+    reason = (raw_reason or "").strip()
+    if root == SCRATCH_ROOT_NONE:
+        if not reason:
+            raise ValueError(
+                f"config.yaml at {source_path}: '{key}: none' keeps every "
+                f"agent's /uvwork in the apptainer overlay upper on this "
+                f"host's root volume; that is a written decision and needs a "
+                f"'scratch_root_reason: <why>' line next to it"
+            )
+        return ScratchBlock(root=SCRATCH_ROOT_NONE, reason=reason)
+    if not root.startswith("/"):
+        raise ValueError(
+            f"config.yaml at {source_path}: '{key}' must be an absolute path "
+            f"or the literal 'none' (got {root!r})"
+        )
+    return ScratchBlock(root=root, reason=reason)
+
+
 __all__ = [
     "LeadConfig",
     "ResolveSpec",
+    "SCRATCH_ROOT_NONE",
+    "ScratchBlock",
     "_RESOLVE_ALLOWED_SOURCES",
     "_parse_lead",
     "_parse_resolve",
+    "_parse_scratch",
 ]

--- a/src/scitex_agent_container/_state/host_config.py
+++ b/src/scitex_agent_container/_state/host_config.py
@@ -33,6 +33,13 @@ while addressing a different host. :mod:`.moving_alias` holds the registry and
       host: mba                     # Peer key for transport + peer-tokens.
       a2a_port: 8642                # Lead's sac listen port (host-bound).
 
+    scratch_root: /scratch          # ADR-0024 — where every agent's /uvwork is
+                                    #   bound from (<root>/sac/agents/<agent>/
+                                    #   uvwork). Absent: /scratch if it exists,
+                                    #   else REFUSE to start. The literal
+                                    #   `none` keeps /uvwork in the overlay and
+                                    #   requires `scratch_root_reason:`.
+
 Resolution chain for the local canonical hostname (used by every
 state.db write so cross-host queries scope correctly):
 
@@ -67,8 +74,10 @@ from .._env import getenv as _sac_env
 from ._host_config_blocks import (  # noqa: F401
     LeadConfig,
     ResolveSpec,
+    ScratchBlock,
     _parse_lead,
     _parse_resolve,
+    _parse_scratch,
 )
 from .moving_alias import MovingAliasError, moving_alias_hint
 
@@ -176,6 +185,7 @@ class Config:
     host: HostBlock = field(default_factory=HostBlock)
     peers: dict[str, PeerSpec] = field(default_factory=dict)
     lead: LeadConfig | None = None
+    scratch: ScratchBlock | None = None  # scratch_root: / scratch_root_reason:
     source_path: Path | None = None
 
     def canonical_host(self) -> str:
@@ -358,8 +368,11 @@ def load(path: Path | None = None) -> Config:
         peers[str(name)] = PeerSpec.from_dict(spec, name=str(name))
 
     lead = _parse_lead(raw.get("lead"), source_path=p)
+    scratch = _parse_scratch(
+        raw.get("scratch_root"), raw.get("scratch_root_reason"), source_path=p
+    )
 
-    cfg = Config(host=host, peers=peers, lead=lead, source_path=p)
+    cfg = Config(host=host, peers=peers, lead=lead, scratch=scratch, source_path=p)
     if _key is not None:
         # Bounded: one entry per (path, mtime, size) actually parsed. In
         # practice one live entry plus a short tail of superseded ones after an

--- a/src/scitex_agent_container/_state/host_scratch.py
+++ b/src/scitex_agent_container/_state/host_scratch.py
@@ -1,0 +1,148 @@
+"""Where does ``/uvwork`` live on THIS host? — the scratch-root resolver.
+
+ADR-0024. Every agent spec points ``TMPDIR``, ``UV_CACHE_DIR``,
+``UV_INSTALL_DIR`` and the agent venv at ``/uvwork``, a directory the base
+image creates and NOTHING binds. So all of it lands in the apptainer overlay
+upper — ``overlays/<agent>/upper/uvwork`` — which sits on the host's ROOT
+volume. Measured on ``scitex-compute-04`` on 2026-09-03: 11.7 GB (sac),
+3.3 GB (scitex-dev), 3.0 GB (scitex-hub), 2.5 GB (scitex-cards), 1.9 GB
+(scitex-storage); the root LV filled to 0 four times on 2026-09-02. Meanwhile
+``/scratch`` is a separate 3.0 TB LV with 2.8 TB free on that host, and on
+compute-03 (3.0 TB) and compute-01 (295 GB) alike.
+
+This module answers ONE question, once per start: which host directory backs
+``/uvwork``. The answer is a fixed shape (:class:`ScratchRoot`) whose
+``source`` says how it was reached, so the argv record and the CLI can both
+state it:
+
+  ``config``   ``config.yaml`` declares ``scratch_root: /abs/path``
+  ``default``  no declaration; ``/scratch`` is a mount point or directory here
+  ``none``     ``config.yaml`` declares ``scratch_root: none`` WITH a reason —
+               this host keeps ``/uvwork`` in the overlay, on purpose
+
+There is no fourth state. A host that declares nothing and has no ``/scratch``
+gets :class:`ScratchRootError` naming the missing path, the config key, and
+both fixes — because the silent alternative is exactly the overlay upper on the
+root volume this exists to stop, and compute-01 / compute-03 have NO
+``config.yaml`` at all, so the default has to work without one.
+
+ONE DISH: the only knob is ``scratch_root:`` in ``config.yaml``. No env var
+selects the root; the ``probe`` parameter below is a seam for tests to point the
+DEFAULT probe at a temporary path (a host that has ``/scratch`` could not
+otherwise exercise the "default absent" row hermetically), and no production
+caller passes it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .host_config import Config, _default_config_path
+from .host_config import load as _load_host_config
+
+#: The path probed when ``config.yaml`` declares no ``scratch_root:``.
+DEFAULT_SCRATCH_ROOT = Path("/scratch")
+
+#: The closed set of ways a root can be reached.
+SCRATCH_SOURCES = ("config", "default", "none")
+
+#: The config key, spelled once so every message names the same thing.
+CONFIG_KEY = "scratch_root"
+
+
+class ScratchRootError(RuntimeError):
+    """No scratch root could be honoured on this host — refuse to start.
+
+    Carries the path that was missing, the ``config.yaml`` that was read and
+    both fixes, so the operator's next action is a mount or a one-line edit,
+    never a guess.
+    """
+
+
+@dataclass(frozen=True)
+class ScratchRoot:
+    """The resolved answer: ``root`` is ``None`` exactly when ``source`` is
+    ``"none"`` (the written decision to keep ``/uvwork`` in the overlay)."""
+
+    root: Path | None
+    source: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if self.source not in SCRATCH_SOURCES:
+            raise ValueError(
+                f"ScratchRoot.source must be one of {SCRATCH_SOURCES}, "
+                f"got {self.source!r}"
+            )
+        if (self.root is None) != (self.source == "none"):
+            raise ValueError(
+                f"ScratchRoot: root={self.root!r} is inconsistent with "
+                f"source={self.source!r} (root is None iff source is 'none')"
+            )
+
+
+def resolve_scratch_root(
+    config: Config | None = None,
+    *,
+    probe: Path = DEFAULT_SCRATCH_ROOT,
+) -> ScratchRoot:
+    """Resolve this host's scratch root from ``config.yaml``, else the default.
+
+    ``config`` defaults to :func:`host_config.load` (the same cached parse
+    every other config reader uses). ``probe`` is the default candidate —
+    :data:`DEFAULT_SCRATCH_ROOT` in production; tests pass a tmp path.
+
+    Raises :class:`ScratchRootError` when a declared path is not a directory
+    on this host (a declaration that cannot be honoured is a refusal, not a
+    silent detour into the overlay), and when nothing is declared and the
+    probe path is neither a mount point nor a directory.
+    """
+    cfg = config if config is not None else _load_host_config()
+    where = cfg.source_path if cfg.source_path is not None else _default_config_path()
+    declared = cfg.scratch
+    if declared is not None:
+        if declared.is_none:
+            return ScratchRoot(root=None, source="none", reason=declared.reason)
+        root = Path(declared.root)
+        if not root.is_dir():
+            raise ScratchRootError(
+                f"config.yaml at {where} declares {CONFIG_KEY}: {root}, but "
+                f"that is not a directory on this host, so /uvwork has nowhere "
+                f"to live off the root volume. Fix ONE of: mount or create "
+                f"{root}; or change the '{CONFIG_KEY}:' line in {where} to a "
+                f"directory that exists (or to 'none' with a "
+                f"'scratch_root_reason:' if this host is to keep /uvwork in "
+                f"the overlay upper on its root volume)."
+            )
+        return ScratchRoot(
+            root=root, source="config", reason=f"{where} declares {CONFIG_KEY}: {root}"
+        )
+    if probe.is_dir():
+        how = "a mount point" if probe.is_mount() else "an existing directory"
+        return ScratchRoot(
+            root=probe,
+            source="default",
+            reason=f"{probe} is {how} on this host and {where} declares no {CONFIG_KEY}:",
+        )
+    raise ScratchRootError(
+        f"cannot resolve where /uvwork lives on this host: {probe} is neither "
+        f"a mount point nor a directory, and {where} declares no "
+        f"'{CONFIG_KEY}:'. Without a scratch root, every agent's /uvwork (uv, "
+        f"the agent venv, TMPDIR, the uv cache) lands in the apptainer overlay "
+        f"upper on the ROOT volume — the volume that filled to 0 four times on "
+        f"2026-09-02. Fix ONE of: (1) mount or create {probe} on this host; "
+        f"(2) add '{CONFIG_KEY}: /abs/path' to {where}; or, as a written "
+        f"decision, add '{CONFIG_KEY}: none' together with "
+        f"'scratch_root_reason: <why this host keeps /uvwork in the overlay>'."
+    )
+
+
+__all__ = [
+    "CONFIG_KEY",
+    "DEFAULT_SCRATCH_ROOT",
+    "SCRATCH_SOURCES",
+    "ScratchRoot",
+    "ScratchRootError",
+    "resolve_scratch_root",
+]

--- a/src/scitex_agent_container/cli_pkg/_agents_scratch_migrate.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_scratch_migrate.py
@@ -1,0 +1,268 @@
+"""``sac agents scratch-migrate`` — move overlay ``uvwork`` onto scratch.
+
+The operator-facing half of the ADR-0024 migration. What an agent had
+accumulated under ``/uvwork`` before the scratch bind existed sits in
+``overlays/<agent>/upper/uvwork`` on the root LV; this verb moves it to
+``<scratch_root>/sac/agents/<agent>/uvwork``, where the bind now looks, so
+the next start finds uv and the venv in place and the root LV gets its
+space back (11.7 GB for sac alone, measured 2026-09-03).
+
+**Dry-run is the DEFAULT.** It prints, per agent, the overlay copy's size
+and the decision, then the total it would move. ``--apply`` is the deliberate
+act, and even then only a provably STOPPED agent is touched: a running one
+is refused BY NAME (its container has the overlay mounted), as is one whose
+liveness the runtime adapter could not determine.
+
+Registered onto ``sac agents`` by :func:`register`, exactly as
+``migrate-layers`` is.
+
+**Exit codes**:
+
+  0  the plan is sound and (with ``--apply``) every selected move verified
+  1  the plan does not describe the sweep — no roster was searched, a spec
+     is unreadable, or a ``--agent`` names nobody
+  2  refused: the host keeps ``/uvwork`` in the overlay (``scratch_root:
+     none``), a selected agent is running / undeterminable / already
+     migrated, or a move failed verification (its overlay copy is KEPT)
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+from rich.markup import escape
+
+from .._maintenance._scratch_migrate import (
+    ScratchPlan,
+    apply_scratch_migration,
+    liveness_vantage,
+    plan_scratch_migration,
+)
+from .._state.host_scratch import ScratchRootError, resolve_scratch_root
+from ._helpers import _json_flag, console
+
+_EXIT_OK = 0
+_EXIT_PLAN_UNSOUND = 1
+_EXIT_REFUSED = 2
+
+
+def _lit(text) -> str:
+    """Every dynamic value goes through rich's escaper — a path or reason
+    containing ``[...]`` would otherwise be parsed as a style tag."""
+    return escape(str(text))
+
+
+def human_bytes(n: int) -> str:
+    """``11.7 GiB`` / ``512.0 MiB`` / ``3 B`` — the unit the operator measured in."""
+    value = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            return f"{int(value)} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{n} B"  # pragma: no cover — the loop above always returns
+
+
+def _payload(plan: ScratchPlan, *, mode: str) -> dict:
+    return {
+        "mode": mode,
+        "scratch_root": str(plan.scratch.root),
+        "scratch_source": plan.scratch.source,
+        "root": str(plan.roster.root),
+        "roster": plan.roster.state,
+        "specs": len(plan.rows) + len(plan.unreadable),
+        "rows": [r.to_dict() for r in plan.rows],
+        "would_move": [r.agent for r in plan.movable],
+        "refused": [{"agent": r.agent, "reason": r.reason} for r in plan.refused],
+        "unknown": list(plan.unknown),
+        "unreadable": list(plan.unreadable),
+        "total_bytes": plan.total_bytes,
+        "total_human": human_bytes(plan.total_bytes),
+        "safe_to_apply": plan.safe_to_apply,
+        # Empty string = host pids are resolvable here, so "stopped" may be
+        # believed. Non-empty = every row is UNKNOWN and nothing can move;
+        # see _scratch_migrate_liveness.liveness_vantage.
+        "liveness_vantage": liveness_vantage(),
+        "summary": plan.summary(),
+    }
+
+
+def _render_plan(plan: ScratchPlan) -> None:
+    if not plan.roster.is_populated:
+        console.print(f"[red]NO ROSTER SEARCHED[/red] — {_lit(plan.roster.describe())}")
+        return
+    console.print(
+        f"scratch root: [bold]{_lit(plan.scratch.root)}[/bold] "
+        f"[dim]({_lit(plan.scratch.source)}: {_lit(plan.scratch.reason)})[/dim]"
+    )
+    # Said ONCE at the top rather than only inside 17 identical row reasons:
+    # from a blind vantage nothing can move, and that is the headline.
+    blind = liveness_vantage()
+    if blind:
+        console.print(
+            f"[yellow]LIVENESS UNREADABLE FROM HERE[/yellow] — {_lit(blind)}\n"
+            "Sizes below are real (the overlays are read through a bind "
+            "mount); every agent is refused because no agent can be shown "
+            "to be stopped.",
+            soft_wrap=True,
+        )
+    console.print(
+        f"[bold]{len(plan.rows) + len(plan.unreadable)} spec(s)[/bold] under "
+        f"{_lit(plan.roster.root)}\n"
+    )
+    for row in plan.rows:
+        if row.action == "move":
+            tag = "[green]MOVE   [/green]"
+        elif row.action == "refuse":
+            tag = "[yellow]REFUSED[/yellow]"
+        else:
+            tag = "[dim]nothing[/dim]"
+        size = human_bytes(row.bytes) if row.source is not None else "-"
+        console.print(
+            f"  {tag} {_lit(row.agent):<32} {_lit(size):>10}  {_lit(row.reason)}",
+            soft_wrap=True,
+        )
+    for name in plan.unknown:
+        console.print(f"\n[red]UNKNOWN[/red] --agent {_lit(name)}: no such spec under {_lit(plan.roster.root)}")
+    for entry in plan.unreadable:
+        console.print(f"\n[red]UNREADABLE[/red] {_lit(entry)}", soft_wrap=True)
+    console.print(
+        f"\n[bold]{len(plan.movable)} agent(s), {human_bytes(plan.total_bytes)} "
+        f"({plan.total_bytes} bytes) would move from the overlay upper to "
+        f"{_lit(plan.scratch.root)}[/bold]"
+    )
+    if plan.refused:
+        console.print(
+            f"[yellow]{len(plan.refused)} refused[/yellow]: "
+            + ", ".join(_lit(r.agent) for r in plan.refused)
+        )
+
+
+def _render_apply(results) -> None:
+    for res in results:
+        tag = "[green]MOVED [/green]" if res.moved else "[red]FAILED[/red]"
+        console.print(f"  {tag} {_lit(res.agent):<32} {_lit(res.detail)}", soft_wrap=True)
+    moved = [r for r in results if r.moved]
+    console.print(
+        f"\n[bold]{len(moved)}/{len(results)} moved, "
+        f"{human_bytes(sum(r.bytes for r in moved))} freed from the overlay upper[/bold]"
+    )
+
+
+@click.command(name="scratch-migrate")
+@click.option(
+    "--agent",
+    "agents",
+    multiple=True,
+    metavar="NAME",
+    help="Only this agent (repeatable). Default: every spec in the fleet roster.",
+)
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="ACTUALLY move the trees. Without this, nothing is written.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def scratch_migrate(ctx: click.Context, agents: tuple[str, ...], apply: bool, as_json: bool) -> None:
+    """Move each STOPPED agent's overlay /uvwork onto the host scratch volume.
+
+    Copies ``overlays/<agent>/upper/uvwork`` to
+    ``<scratch_root>/sac/agents/<agent>/uvwork`` (where sac now binds /uvwork
+    from), verifies every path and byte count, then removes the overlay copy.
+    Dry-run by default; running agents are refused by name.
+
+    \b
+    Preview (read-only — the DEFAULT):
+      $ sac agents scratch-migrate
+      $ sac agents scratch-migrate --agent sac --json
+    \b
+    Move:
+      $ sac agents scratch-migrate --apply
+    """
+    want_json = _json_flag(ctx, as_json)
+    mode = "apply" if apply else "dry-run"
+
+    try:
+        scratch = resolve_scratch_root()
+    except ScratchRootError as exc:
+        _emit_refusal(want_json, mode, f"no scratch root: {exc}")
+        raise SystemExit(_EXIT_REFUSED)
+    if scratch.root is None:
+        _emit_refusal(
+            want_json,
+            mode,
+            f"this host keeps /uvwork in the overlay (scratch_root: none — "
+            f"{scratch.reason}); there is nowhere to migrate to",
+        )
+        raise SystemExit(_EXIT_REFUSED)
+
+    plan = plan_scratch_migration(scratch, only=list(agents))
+    payload = _payload(plan, mode=mode)
+
+    if not apply:
+        code = _EXIT_OK if plan.safe_to_apply else _EXIT_PLAN_UNSOUND
+        payload["exit_code"] = code
+        if want_json:
+            click.echo(json.dumps(payload, indent=2))
+            raise SystemExit(code)
+        console.print("[bold]sac agents scratch-migrate[/bold]  dry-run (read-only)\n")
+        _render_plan(plan)
+        if plan.movable:
+            console.print(
+                "\nNothing was moved — this is a dry-run. To act:\n"
+                "    sac agents scratch-migrate --apply"
+            )
+        raise SystemExit(code)
+
+    if not plan.safe_to_apply:
+        payload["exit_code"] = _EXIT_PLAN_UNSOUND
+        payload["apply_refused"] = f"plan is not safe to apply: {plan.summary()}"
+        if want_json:
+            click.echo(json.dumps(payload, indent=2))
+            raise SystemExit(_EXIT_PLAN_UNSOUND)
+        console.print("[bold]sac agents scratch-migrate[/bold]  apply\n")
+        _render_plan(plan)
+        console.print(
+            "\n[red]REFUSED[/red] — nothing was moved. A plan that cannot "
+            "describe every selected spec does not describe the sweep."
+        )
+        raise SystemExit(_EXIT_PLAN_UNSOUND)
+
+    results = apply_scratch_migration(plan)
+    failed = [r for r in results if not r.moved]
+    code = _EXIT_REFUSED if (plan.refused or failed) else _EXIT_OK
+    payload["exit_code"] = code
+    payload["results"] = [r.to_dict() for r in results]
+    payload["moved"] = [r.agent for r in results if r.moved]
+    payload["failed"] = [r.to_dict() for r in failed]
+    if want_json:
+        click.echo(json.dumps(payload, indent=2))
+        raise SystemExit(code)
+    console.print("[bold]sac agents scratch-migrate[/bold]  apply\n")
+    _render_plan(plan)
+    console.print("")
+    _render_apply(results)
+    raise SystemExit(code)
+
+
+def _emit_refusal(want_json: bool, mode: str, reason: str) -> None:
+    if want_json:
+        click.echo(
+            json.dumps(
+                {"mode": mode, "apply_refused": reason, "exit_code": _EXIT_REFUSED},
+                indent=2,
+            )
+        )
+        return
+    console.print(f"[red]REFUSED[/red] — {_lit(reason)}", soft_wrap=True)
+
+
+def register(agent_group) -> None:
+    """Attach ``scratch-migrate`` to the parent ``agents`` Click group."""
+    agent_group.add_command(scratch_migrate)
+
+
+__all__ = ["human_bytes", "register", "scratch_migrate"]

--- a/src/scitex_agent_container/cli_pkg/_explain.py
+++ b/src/scitex_agent_container/cli_pkg/_explain.py
@@ -85,6 +85,23 @@ def _annotate(src: str, dst: str) -> str:
     return ""
 
 
+def _uvwork_line(config: AgentConfig) -> str:
+    """One line saying where ``/uvwork`` comes from — ADR-0024.
+
+    ``explain`` renders binds by walking the argv, so the ONE outcome it could
+    not show is the one that emits no bind: a host with no resolvable scratch
+    root. That is precisely the case an operator needs named, because
+    ``start`` will REFUSE on it (``_apptainer_scratch.ensure_uvwork_for_launch``)
+    while ``explain`` stays read-only. So the plan states the decision itself
+    rather than leaving the reader to notice an absence.
+    """
+    from ..runtimes._apptainer_scratch import plan_uvwork_bind
+
+    plan = plan_uvwork_bind(config)
+    prefix = "⚠ /uvwork — `start` WILL REFUSE" if plan.refused else "/uvwork"
+    return f"{prefix}: {plan.reason}"
+
+
 def _pwd_is_backed(pwd: str, binds: list[tuple[str, str, str]]) -> bool:
     """True iff ``--pwd`` is at/under some bind target (so the cwd exists)."""
     for _src, dst, _mode in binds:
@@ -230,6 +247,9 @@ def render_plan(config: AgentConfig, *, spec_path: Path | None = None) -> str:
         note = _annotate(src, dst)
         note = f"   [{note}]" if note else ""
         lines.append(f"  {src:<{width}}  →  {dst}  ({mode}){note}")
+
+    lines.append("")
+    lines.append(_uvwork_line(config))
 
     envs = _envs(argv)
     if envs:

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -80,6 +80,7 @@ class _AgentsGroup(HelpRecursiveGroup):
                 "refresh-acl",
                 "declare-a2a-host",
                 "migrate-layers",
+                "scratch-migrate",
             ],
         ),
     ]
@@ -290,6 +291,15 @@ agent_group.add_command(_refresh_acl_impl)
 from ._agents_migrate_layers import register as _register_migrate_layers  # noqa: E402
 
 _register_migrate_layers(agent_group)
+
+# `scratch-migrate` — ADR-0024: move each STOPPED agent's overlay-upper
+# ``/uvwork`` (11.7 GB for sac alone on the root LV, measured 2026-09-03)
+# onto the host scratch volume where sac now binds ``/uvwork`` from. Same
+# shape as `migrate-layers`: dry-run by default, `--apply` is the act,
+# running agents refused by name, `--json` for machines.
+from ._agents_scratch_migrate import register as _register_scratch_migrate  # noqa: E402
+
+_register_scratch_migrate(agent_group)
 
 # `declare-a2a-host` — one-shot fleet sweep making every spec state its own
 # a2a bind address instead of inheriting one from a code default. Sits beside

--- a/src/scitex_agent_container/runtimes/_apptainer_argv_finalize.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_argv_finalize.py
@@ -18,12 +18,16 @@ those invariants only hold if the whole region is already present.
    never used for scitex).
 3. **Bind the overlay upper-home** over the container ``$HOME``, after
    ``raw_args`` so it wins over a raw-arg ``--home`` tmpfs.
-4. **Lift secret-shaped ``--env`` into a 0600 env-file**, after every
+4. **Bind ``/uvwork`` from the host scratch volume** (ADR-0024), after
+   every spec-declared bind so an explicit spec bind to ``/uvwork`` wins,
+   and once per start — the resolver refuses the launch outright when
+   the host has no scratch root and no written decision to go without.
+5. **Lift secret-shaped ``--env`` into a 0600 env-file**, after every
    ``--env`` source so nothing is missed, before the creds bind so that
    bind stays last.
-5. **Emit the designated credentials bind last**, so no earlier bind can
+6. **Emit the designated credentials bind last**, so no earlier bind can
    shadow it.
-6. **Validate the flag region** as a whole, which is only meaningful once
+7. **Validate the flag region** as a whole, which is only meaningful once
    it is complete.
 
 ``finalize_flag_argv`` is pure with respect to its ``argv`` argument (a
@@ -106,6 +110,23 @@ def finalize_flag_argv(
 
         container_home = resolve_container_home(config)
         argv += ["--bind", f"{upper_home}:{container_home}"]
+
+    # /uvwork → the host SCRATCH volume, not the overlay upper (ADR-0024).
+    # Every spec's startup_commands put uv, the uv cache, TMPDIR and the
+    # agent venv under /uvwork; the image creates that directory and
+    # nothing bound it, so all of it accumulated in overlays/<agent>/upper
+    # on the host's ROOT LV — measured 11.7 GB for sac alone, and the root
+    # LV on scitex-compute-04 filled to 0 four times on 2026-09-02. The
+    # resolver reads config.yaml's `scratch_root:` (else probes /scratch,
+    # else REFUSES the start naming both fixes); the helper creates
+    # <root>/sac/agents/<name>/uvwork (0700) and emits the bind. Placed
+    # after raw_args and the spec binds so an explicit spec bind to
+    # /uvwork still wins (first bind to a destination wins in apptainer),
+    # and before the secret lift so the creds bind below stays LAST. The
+    # bind reaches the on-disk argv record with every other bind.
+    from ._apptainer_scratch import uvwork_bind_flags
+
+    argv += uvwork_bind_flags(config, argv)
 
     # SECURITY (P1 credential fix): lift secret-shaped ``--env KEY=VALUE``
     # pairs out of the WORLD-READABLE argv (it becomes a tmux ``bash -c``

--- a/src/scitex_agent_container/runtimes/_apptainer_argv_finalize.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_argv_finalize.py
@@ -19,9 +19,10 @@ those invariants only hold if the whole region is already present.
 3. **Bind the overlay upper-home** over the container ``$HOME``, after
    ``raw_args`` so it wins over a raw-arg ``--home`` tmpfs.
 4. **Bind ``/uvwork`` from the host scratch volume** (ADR-0024), after
-   every spec-declared bind so an explicit spec bind to ``/uvwork`` wins,
-   and once per start — the resolver refuses the launch outright when
-   the host has no scratch root and no written decision to go without.
+   every spec-declared bind so an explicit spec bind to ``/uvwork`` wins.
+   READ-ONLY here — the source directory is created, and a host with no
+   scratch root refused, on the real launch path only
+   (``_apptainer_scratch.ensure_uvwork_for_launch``).
 5. **Lift secret-shaped ``--env`` into a 0600 env-file**, after every
    ``--env`` source so nothing is missed, before the creds bind so that
    bind stays last.
@@ -117,13 +118,25 @@ def finalize_flag_argv(
     # nothing bound it, so all of it accumulated in overlays/<agent>/upper
     # on the host's ROOT LV — measured 11.7 GB for sac alone, and the root
     # LV on scitex-compute-04 filled to 0 four times on 2026-09-02. The
-    # resolver reads config.yaml's `scratch_root:` (else probes /scratch,
-    # else REFUSES the start naming both fixes); the helper creates
-    # <root>/sac/agents/<name>/uvwork (0700) and emits the bind. Placed
-    # after raw_args and the spec binds so an explicit spec bind to
+    # resolver reads config.yaml's `scratch_root:` (else probes /scratch)
+    # and the helper emits `--bind <root>/sac/agents/<name>/uvwork:/uvwork`.
+    # Placed after raw_args and the spec binds so an explicit spec bind to
     # /uvwork still wins (first bind to a destination wins in apptainer),
     # and before the secret lift so the creds bind below stays LAST. The
     # bind reaches the on-disk argv record with every other bind.
+    #
+    # READ-ONLY, deliberately. This function is on `build_run_argv`, which
+    # `sac agents explain` and `sac agents start --dry-run` also call, and
+    # neither starts anything: the call below creates no directory, and a
+    # host with no resolvable scratch root gets a WARNING plus an argv with
+    # no /uvwork bind rather than an exception. The REFUSAL — the point of
+    # ADR-0024 — and the mkdir both live in
+    # `_apptainer_scratch.ensure_uvwork_for_launch`, called from
+    # `_apptainer_runtime.start` and `tui_session.start` past their dry_run
+    # return. That is where `verify_tmpfs_headroom` and
+    # `reconcile_overlay_venv_for_launch` already sit, for the reason
+    # `_apptainer_tmpfs` records: a launch-time check inside argv assembly
+    # made `explain` fail on exactly the full host it would have diagnosed.
     from ._apptainer_scratch import uvwork_bind_flags
 
     argv += uvwork_bind_flags(config, argv)

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -219,6 +219,19 @@ class ApptainerContainerRuntime(RuntimeBase):
 
         verify_tmpfs_headroom(config, state_dir)
 
+        # /uvwork LIVES ON SCRATCH (ADR-0024) — create the bind source, and
+        # REFUSE when this host has nowhere to put it.
+        #
+        # HERE for the same reason as the two neighbours: `build_run_argv`
+        # emitted the bind read-only (it is reached by `sac agents explain`
+        # and by the dry-run path above), so the mkdir and the refusal both
+        # belong past the dry_run return. The directory created is the one
+        # THIS argv mounts — the source is read back out of `argv` — so a
+        # spec that declared its own /uvwork bind is left to its owner.
+        from ._apptainer_scratch import ensure_uvwork_for_launch
+
+        ensure_uvwork_for_launch(config, argv)
+
         # OVERLAY VENV INVALIDATION CONTRACT — an image rebuild must invalidate
         # the `venv-sac` slice of this agent's overlay, or the overlay's stale
         # site-packages shadow the new image forever. Contract, measurement and

--- a/src/scitex_agent_container/runtimes/_apptainer_scratch.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_scratch.py
@@ -6,8 +6,8 @@
 the directory (``containers/apptainer-base.def``) and until this module nothing
 bound it, so every byte written there went to the apptainer overlay upper on
 the host's root volume. The resolver in :mod:`.._state.host_scratch` says which
-host directory should back it instead; this module makes that directory exist
-and emits the bind.
+host directory should back it instead; this module decides the bind and, on a
+real launch only, makes that directory exist.
 
 Per agent: ``<scratch_root>/sac/agents/<agent>/uvwork``, created 0700 (the
 venv and cache are one agent's private working set; nothing else on the host
@@ -19,19 +19,49 @@ own ``[ -x /uvwork/bin/uv ] || curl ...`` / ``[ -x /uvwork/venv-agent/bin/python
 after this lands they rebuild there once, unless ``sac agents scratch-migrate``
 moved the overlay copy across first.
 
-Called from :func:`._apptainer_argv_finalize.finalize_flag_argv`, after every
-spec-declared bind, so that a spec which binds ``/uvwork`` explicitly wins:
-apptainer keeps the FIRST bind to a destination and skips later duplicates
-("already in mount point list"), and the rule this package already applies to
-its fleet-default binds (``_p3a_default_binds``) is that an explicit spec entry
-to the same destination overrides the default. That case is logged, never
-silent.
+ONE derivation of the per-agent directory. :func:`scratch_uvwork_dir_for` is
+the ONLY place the agent's identity becomes a path component, and both halves
+of ADR-0024 call it: the launch bind here, and ``sac agents scratch-migrate``
+(:mod:`..._maintenance._scratch_migrate`) when it picks a destination. They
+used to spell it independently — the migration keyed on the spec DIRECTORY
+name, the bind on ``config.name`` — which are the SAME string for a ``host:``
+spec and DIFFERENT for a ``hosts:`` one, whose effective id carries a
+``-<hostname>`` suffix (``config._loaders.compose_effective_name``). For every
+multi-instance agent the migration therefore copied gigabytes to a path no
+launch would ever mount, verified the copy, deleted the overlay original, and
+reported success. Deriving both from one function makes that divergence
+unrepresentable.
+
+TWO PHASES, because ``build_run_argv`` is not a launch.
+:func:`uvwork_bind_flags` runs during argv assembly, which ``sac agents
+explain`` and ``sac agents start --dry-run`` also reach; it therefore READS
+ONLY — it creates nothing, and a host with no resolvable scratch root gets a
+visible ``WARNING`` and an argv without the bind, not an exception. The
+refusal that is the point of ADR-0024 lives in
+:func:`ensure_uvwork_for_launch`, called from the two real launch paths
+(``_apptainer_runtime.start`` / ``tui_session.start``) PAST their ``dry_run``
+return, where it re-raises that same :class:`ScratchRootError` and creates the
+bind source. This is the placement ``_apptainer_tmpfs`` already chose for
+``verify_tmpfs_headroom`` and ``_apptainer_runtime`` for
+``reconcile_overlay_venv_for_launch``, for the reason stated there: a
+READ-ONLY command must neither move files nor fail on a launch-time host
+condition. ``verify_tmpfs_headroom`` records what happens otherwise — a full
+disk made ``explain`` unusable on exactly the host it would have diagnosed.
+
+The bind is emitted from :func:`._apptainer_argv_finalize.finalize_flag_argv`
+after every spec-declared bind, so that a spec which binds ``/uvwork``
+explicitly wins: apptainer keeps the FIRST bind to a destination and skips
+later duplicates ("already in mount point list"), and the rule this package
+already applies to its fleet-default binds (``_p3a_default_binds``) is that an
+explicit spec entry to the same destination overrides the default. That case
+is logged, never silent.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 from .._state.host_scratch import ScratchRoot, ScratchRootError, resolve_scratch_root
@@ -48,6 +78,17 @@ UVWORK_DIR_MODE = 0o700
 SCRATCH_AGENTS_SUBDIR = ("sac", "agents")
 
 
+def uvwork_agent_key(config) -> str:
+    """The agent identity that becomes a scratch path component for ``config``.
+
+    The EFFECTIVE id (``config.name``), not the spec directory name — they
+    differ for a ``hosts:`` spec, and the effective id is what every other
+    per-agent runtime path already keys on. Spelled once, here, so the launch
+    bind and the migration cannot pick different answers.
+    """
+    return getattr(config, "name", "") or ""
+
+
 def scratch_uvwork_dir(root: Path, agent: str) -> Path:
     """The host directory that backs ``/uvwork`` for ``agent`` under ``root``.
 
@@ -62,15 +103,18 @@ def scratch_uvwork_dir(root: Path, agent: str) -> Path:
     return root.joinpath(*SCRATCH_AGENTS_SUBDIR, agent, "uvwork")
 
 
-def ensure_scratch_uvwork(root: Path, agent: str) -> Path:
-    """Create ``<root>/sac/agents/<agent>/uvwork`` (0700) if missing; return it.
+def scratch_uvwork_dir_for(root: Path, config) -> Path:
+    """The host directory that backs ``/uvwork`` for ``config`` under ``root``.
 
-    Idempotent: an existing directory is returned untouched. A path that
-    exists but is not a directory is a refusal naming the path — a file
-    sitting where the bind source must be would make apptainer FATAL with a
-    far less useful message.
+    THE single derivation — see this module's docstring. Every caller that
+    needs "where does this agent's /uvwork live on scratch" calls this and
+    never composes the path itself.
     """
-    target = scratch_uvwork_dir(root, agent)
+    return scratch_uvwork_dir(root, uvwork_agent_key(config))
+
+
+def _ensure_uvwork_dir(target: Path, agent: str) -> Path:
+    """Create ``target`` 0700 if missing; return it. WRITES — launch only."""
     if target.is_dir():
         return target
     if target.exists():
@@ -83,8 +127,20 @@ def ensure_scratch_uvwork(root: Path, agent: str) -> Path:
     return target
 
 
-def _argv_already_binds_uvwork(argv: list[str]) -> str | None:
-    """The earlier ``--bind`` spec string targeting ``/uvwork``, if any."""
+def ensure_scratch_uvwork(root: Path, agent: str) -> Path:
+    """Create ``<root>/sac/agents/<agent>/uvwork`` (0700) if missing; return it.
+
+    Idempotent: an existing directory is returned untouched. A path that
+    exists but is not a directory is a refusal naming the path — a file
+    sitting where the bind source must be would make apptainer FATAL with a
+    far less useful message.
+    """
+    return _ensure_uvwork_dir(scratch_uvwork_dir(root, agent), agent)
+
+
+def _argv_uvwork_bind(argv: list[str]) -> tuple[str, str] | None:
+    """``(source, whole bind spec)`` of the first ``--bind`` whose DESTINATION
+    is ``/uvwork``, or ``None``."""
     for i, arg in enumerate(argv):
         if arg != "--bind" or i + 1 >= len(argv):
             continue
@@ -92,8 +148,102 @@ def _argv_already_binds_uvwork(argv: list[str]) -> str | None:
         parts = spec.split(":")
         dst = parts[1] if len(parts) > 1 else parts[0]
         if dst.rstrip("/") == UVWORK_CONTAINER_PATH:
-            return spec
+            return parts[0], spec
     return None
+
+
+def _argv_already_binds_uvwork(argv: list[str]) -> str | None:
+    """The earlier ``--bind`` spec string targeting ``/uvwork``, if any."""
+    found = _argv_uvwork_bind(argv)
+    return None if found is None else found[1]
+
+
+@dataclass(frozen=True)
+class UvworkBind:
+    """What ``/uvwork`` resolves to for one agent on this host — a VALUE.
+
+    Built without touching the filesystem, so the read-only surfaces can state
+    the outcome and the launch path can act on it, from the same decision.
+
+    ``host_dir`` is set exactly when sac emits its own bind; it is ``None`` for
+    the written ``scratch_root: none`` decision, for a spec that binds
+    ``/uvwork`` itself, and when ``error`` holds the resolver's refusal.
+    ``reason`` always says which of those it was.
+    """
+
+    agent: str
+    host_dir: Path | None
+    flags: tuple[str, ...]
+    reason: str
+    error: ScratchRootError | None = None
+
+    @property
+    def refused(self) -> bool:
+        """True when a real launch must refuse rather than start."""
+        return self.error is not None
+
+
+def plan_uvwork_bind(
+    config,
+    argv: list[str] | None = None,
+    *,
+    scratch: ScratchRoot | None = None,
+) -> UvworkBind:
+    """Decide ``/uvwork`` for ``config`` WITHOUT writing anything.
+
+    Never raises for a HOST condition: a scratch root that cannot be resolved
+    comes back in ``error`` so a read-only caller can print it and a launch
+    caller can raise it. A malformed AGENT NAME still raises ``ValueError``
+    immediately — that is a config fault, true on every host, and it should
+    surface the moment the spec is read (the same line
+    ``_apptainer_tmpfs._resolve_scratch`` draws for an unparseable
+    ``tmpfs_size``).
+
+    ``scratch`` lets a caller that already resolved the host root pass it in.
+    """
+    agent = uvwork_agent_key(config)
+    if scratch is not None:
+        resolved: ScratchRoot = scratch
+    else:
+        try:
+            resolved = resolve_scratch_root()
+        except ScratchRootError as exc:
+            return UvworkBind(
+                agent=agent,
+                host_dir=None,
+                flags=(),
+                reason=f"no scratch root on this host: {exc}",
+                error=exc,
+            )
+    if resolved.root is None:
+        return UvworkBind(
+            agent=agent,
+            host_dir=None,
+            flags=(),
+            reason=(
+                f"kept in the overlay by a written decision "
+                f"(scratch_root: none — {resolved.reason})"
+            ),
+        )
+    if argv is not None:
+        explicit = _argv_already_binds_uvwork(argv)
+        if explicit is not None:
+            return UvworkBind(
+                agent=agent,
+                host_dir=None,
+                flags=(),
+                reason=(
+                    f"the spec binds {UVWORK_CONTAINER_PATH} itself ({explicit}); "
+                    f"the spec wins and the scratch bind is not emitted"
+                ),
+            )
+    host_dir = scratch_uvwork_dir_for(resolved.root, config)
+    return UvworkBind(
+        agent=agent,
+        host_dir=host_dir,
+        flags=("--bind", f"{host_dir}:{UVWORK_CONTAINER_PATH}:rw"),
+        reason=f"{host_dir} (source={resolved.source}: {resolved.reason})",
+    )
 
 
 def uvwork_bind_flags(
@@ -104,51 +254,77 @@ def uvwork_bind_flags(
 ) -> list[str]:
     """``["--bind", "<host>:/uvwork:rw"]`` for ``config``, or ``[]``.
 
-    ``[]`` in exactly two cases, both stated: the host's resolved source is
-    ``none`` (a written ``scratch_root: none``), or ``argv`` already carries a
-    ``--bind`` to ``/uvwork`` from the spec (logged, the spec wins). Any other
-    outcome is a bind whose source directory this call has just made exist,
-    or a :class:`ScratchRootError` from the resolver — never a silent skip.
-
-    ``scratch`` lets a caller that already resolved the host root pass it in;
-    the runtime does not, and resolves once per start here.
+    READ-ONLY — it creates no directory and raises no host-condition error,
+    because ``sac agents explain`` and ``sac agents start --dry-run`` reach it
+    (see this module's docstring). ``[]`` in exactly three cases, each stated:
+    the host's resolved source is ``none``, ``argv`` already carries a
+    ``--bind`` to ``/uvwork`` from the spec, or no scratch root resolves at all
+    — the last logged at ``WARNING`` so it reaches stderr through Python's
+    last-resort handler even with no logging configured, rather than being a
+    silently absent bind. The real launch turns that third case into a refusal
+    in :func:`ensure_uvwork_for_launch`.
     """
-    resolved = scratch if scratch is not None else resolve_scratch_root()
-    agent = getattr(config, "name", "") or ""
-    if resolved.root is None:
-        logger.info(
-            "uvwork: agent %s keeps /uvwork in the overlay (scratch_root: none — %s)",
-            agent,
-            resolved.reason,
+    plan = plan_uvwork_bind(config, argv, scratch=scratch)
+    if plan.refused:
+        logger.warning(
+            "uvwork: agent %s would REFUSE to start — %s", plan.agent, plan.reason
         )
-        return []
-    if argv is not None:
-        explicit = _argv_already_binds_uvwork(argv)
-        if explicit is not None:
-            logger.info(
-                "uvwork: agent %s declares its own bind to %s (%s); the spec "
-                "wins and the scratch bind is not emitted",
-                agent,
-                UVWORK_CONTAINER_PATH,
-                explicit,
-            )
-            return []
-    host_dir = ensure_scratch_uvwork(resolved.root, agent)
-    logger.info(
-        "uvwork: agent %s -> %s (source=%s: %s)",
-        agent,
-        host_dir,
-        resolved.source,
-        resolved.reason,
-    )
-    return ["--bind", f"{host_dir}:{UVWORK_CONTAINER_PATH}:rw"]
+    else:
+        logger.info("uvwork: agent %s -> %s", plan.agent, plan.reason)
+    return list(plan.flags)
+
+
+def ensure_uvwork_for_launch(
+    config,
+    argv: list[str],
+    *,
+    scratch: ScratchRoot | None = None,
+) -> Path | None:
+    """Make the ``/uvwork`` bind source exist, or REFUSE the launch. Writes.
+
+    CALL THIS ONLY ON A REAL LAUNCH PATH, past the ``dry_run`` return — it
+    creates a directory on the host and raises :class:`ScratchRootError` when
+    this host has nowhere to put ``/uvwork``, which is the whole point of
+    ADR-0024 and is exactly wrong on a read-only surface.
+
+    ``argv`` is the FINISHED launch argv, and the directory created is the one
+    that argv will actually mount: the bind source is read back out of it and
+    created only when it matches the source this host resolves to. Same
+    reasoning as ``tui_session`` reading the SIF out of the launch argv rather
+    than re-resolving it — deriving from what launches makes divergence
+    impossible, and it keeps sac from creating a path some SPEC declared and
+    sac does not own. Returns the directory, or ``None`` when no bind of ours
+    is in play (written ``none`` decision, or the spec's own bind won).
+    """
+    plan = plan_uvwork_bind(config, scratch=scratch)
+    if plan.error is not None:
+        raise plan.error
+    if plan.host_dir is None:
+        logger.info("uvwork: agent %s -> %s", plan.agent, plan.reason)
+        return None
+    bound = _argv_uvwork_bind(argv)
+    if bound is None or bound[0] != str(plan.host_dir):
+        logger.info(
+            "uvwork: agent %s launches with %s, not sac's %s; leaving it to "
+            "whoever declared it",
+            plan.agent,
+            "no /uvwork bind" if bound is None else bound[1],
+            plan.host_dir,
+        )
+        return None
+    return _ensure_uvwork_dir(plan.host_dir, plan.agent)
 
 
 __all__ = [
     "SCRATCH_AGENTS_SUBDIR",
     "UVWORK_CONTAINER_PATH",
     "UVWORK_DIR_MODE",
+    "UvworkBind",
     "ensure_scratch_uvwork",
+    "ensure_uvwork_for_launch",
+    "plan_uvwork_bind",
     "scratch_uvwork_dir",
+    "scratch_uvwork_dir_for",
+    "uvwork_agent_key",
     "uvwork_bind_flags",
 ]

--- a/src/scitex_agent_container/runtimes/_apptainer_scratch.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_scratch.py
@@ -1,0 +1,154 @@
+"""Bind ``/uvwork`` from the host scratch volume — the launch half of ADR-0024.
+
+``/uvwork`` is where every spec's ``startup_commands`` put uv, the uv cache,
+``TMPDIR`` and the agent venv (``/uvwork/venv-agent`` — see
+``_apptainer_listen_env``'s ``UV_PROJECT_ENVIRONMENT``). The base image creates
+the directory (``containers/apptainer-base.def``) and until this module nothing
+bound it, so every byte written there went to the apptainer overlay upper on
+the host's root volume. The resolver in :mod:`.._state.host_scratch` says which
+host directory should back it instead; this module makes that directory exist
+and emits the bind.
+
+Per agent: ``<scratch_root>/sac/agents/<agent>/uvwork``, created 0700 (the
+venv and cache are one agent's private working set; nothing else on the host
+needs to read them), bound read-write at ``/uvwork``. Idempotent across
+restarts — an existing directory is left exactly as it is, mode included, so an
+operator who tightened or loosened it is not silently overruled. The spec's
+own ``[ -x /uvwork/bin/uv ] || curl ...`` / ``[ -x /uvwork/venv-agent/bin/python
+] || uv venv ...`` steps then run against scratch unchanged: on the first start
+after this lands they rebuild there once, unless ``sac agents scratch-migrate``
+moved the overlay copy across first.
+
+Called from :func:`._apptainer_argv_finalize.finalize_flag_argv`, after every
+spec-declared bind, so that a spec which binds ``/uvwork`` explicitly wins:
+apptainer keeps the FIRST bind to a destination and skips later duplicates
+("already in mount point list"), and the rule this package already applies to
+its fleet-default binds (``_p3a_default_binds``) is that an explicit spec entry
+to the same destination overrides the default. That case is logged, never
+silent.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from .._state.host_scratch import ScratchRoot, ScratchRootError, resolve_scratch_root
+
+logger = logging.getLogger(__name__)
+
+#: The in-container path every spec's uv / venv / TMPDIR wiring targets.
+UVWORK_CONTAINER_PATH = "/uvwork"
+
+#: Owner-only: one agent's venv, uv cache and TMPDIR are its private working set.
+UVWORK_DIR_MODE = 0o700
+
+#: ``<scratch_root>/sac/agents/<agent>/uvwork`` — the per-agent layout.
+SCRATCH_AGENTS_SUBDIR = ("sac", "agents")
+
+
+def scratch_uvwork_dir(root: Path, agent: str) -> Path:
+    """The host directory that backs ``/uvwork`` for ``agent`` under ``root``.
+
+    Pure — no filesystem access. ``agent`` becomes ONE path component, so a
+    name that is empty, ``.``/``..`` or carries a separator is refused here
+    rather than resolving to somebody else's directory.
+    """
+    if not agent or agent in (".", "..") or "/" in agent or os.sep in agent:
+        raise ValueError(
+            f"agent name {agent!r} cannot be a scratch path component under {root}"
+        )
+    return root.joinpath(*SCRATCH_AGENTS_SUBDIR, agent, "uvwork")
+
+
+def ensure_scratch_uvwork(root: Path, agent: str) -> Path:
+    """Create ``<root>/sac/agents/<agent>/uvwork`` (0700) if missing; return it.
+
+    Idempotent: an existing directory is returned untouched. A path that
+    exists but is not a directory is a refusal naming the path — a file
+    sitting where the bind source must be would make apptainer FATAL with a
+    far less useful message.
+    """
+    target = scratch_uvwork_dir(root, agent)
+    if target.is_dir():
+        return target
+    if target.exists():
+        raise ScratchRootError(
+            f"{target} exists and is not a directory; it must be the directory "
+            f"that backs /uvwork for agent {agent!r}. Move it aside or delete it."
+        )
+    target.mkdir(parents=True, exist_ok=True)
+    os.chmod(target, UVWORK_DIR_MODE)
+    return target
+
+
+def _argv_already_binds_uvwork(argv: list[str]) -> str | None:
+    """The earlier ``--bind`` spec string targeting ``/uvwork``, if any."""
+    for i, arg in enumerate(argv):
+        if arg != "--bind" or i + 1 >= len(argv):
+            continue
+        spec = argv[i + 1]
+        parts = spec.split(":")
+        dst = parts[1] if len(parts) > 1 else parts[0]
+        if dst.rstrip("/") == UVWORK_CONTAINER_PATH:
+            return spec
+    return None
+
+
+def uvwork_bind_flags(
+    config,
+    argv: list[str] | None = None,
+    *,
+    scratch: ScratchRoot | None = None,
+) -> list[str]:
+    """``["--bind", "<host>:/uvwork:rw"]`` for ``config``, or ``[]``.
+
+    ``[]`` in exactly two cases, both stated: the host's resolved source is
+    ``none`` (a written ``scratch_root: none``), or ``argv`` already carries a
+    ``--bind`` to ``/uvwork`` from the spec (logged, the spec wins). Any other
+    outcome is a bind whose source directory this call has just made exist,
+    or a :class:`ScratchRootError` from the resolver — never a silent skip.
+
+    ``scratch`` lets a caller that already resolved the host root pass it in;
+    the runtime does not, and resolves once per start here.
+    """
+    resolved = scratch if scratch is not None else resolve_scratch_root()
+    agent = getattr(config, "name", "") or ""
+    if resolved.root is None:
+        logger.info(
+            "uvwork: agent %s keeps /uvwork in the overlay (scratch_root: none — %s)",
+            agent,
+            resolved.reason,
+        )
+        return []
+    if argv is not None:
+        explicit = _argv_already_binds_uvwork(argv)
+        if explicit is not None:
+            logger.info(
+                "uvwork: agent %s declares its own bind to %s (%s); the spec "
+                "wins and the scratch bind is not emitted",
+                agent,
+                UVWORK_CONTAINER_PATH,
+                explicit,
+            )
+            return []
+    host_dir = ensure_scratch_uvwork(resolved.root, agent)
+    logger.info(
+        "uvwork: agent %s -> %s (source=%s: %s)",
+        agent,
+        host_dir,
+        resolved.source,
+        resolved.reason,
+    )
+    return ["--bind", f"{host_dir}:{UVWORK_CONTAINER_PATH}:rw"]
+
+
+__all__ = [
+    "SCRATCH_AGENTS_SUBDIR",
+    "UVWORK_CONTAINER_PATH",
+    "UVWORK_DIR_MODE",
+    "ensure_scratch_uvwork",
+    "scratch_uvwork_dir",
+    "uvwork_bind_flags",
+]

--- a/src/scitex_agent_container/runtimes/_tui_launch_gate.py
+++ b/src/scitex_agent_container/runtimes/_tui_launch_gate.py
@@ -1,0 +1,76 @@
+"""The TUI launch gate — what runs AFTER the dry-run return, BEFORE tmux.
+
+Extracted from :mod:`.tui_session` (which is at the 512-line per-file cap),
+and one cohesive responsibility rather than an arbitrary cut: every step here
+shares a single placement invariant. Each is a LAUNCH-time act — it writes to
+the host, spawns a probe, or refuses to start — and each therefore belongs
+past ``start``'s ``dry_run`` return and past its duplicate-session guard, never
+inside ``build_run_argv``. ``sac agents explain`` and ``sac agents start
+--dry-run`` both reach that argv builder and start nothing; a read-only
+command must neither move files nor fail on a launch-time host condition.
+``_apptainer_tmpfs.verify_tmpfs_headroom`` records what happens when that line
+is crossed — a full disk made ``explain`` unusable on exactly the host it
+would have diagnosed, and wired ~21 argv-building test modules to ambient free
+disk. The SDK runtime (``_apptainer_runtime.start``) runs the same steps at
+the same point; this module is the TUI half.
+
+The order is load-bearing:
+
+1. **``/uvwork`` on scratch** (ADR-0024) — create the bind source, or REFUSE
+   when this host has no scratch root and no written decision to go without.
+   First, because it is the only step that can refuse, and a refusal must not
+   land after the overlay has already been rewritten.
+2. **Overlay venv reconcile** — an image rebuild must invalidate the
+   ``venv-sac`` slice of this agent's overlay or the stale site-packages
+   shadow the new image forever (contract: ``_maintenance/
+   _overlay_venv_model.py``). Before the probe below, so the probe measures
+   the RECONCILED union rather than the stale one.
+3. **Entry-point probe** — the console script must RUN in the union about to
+   launch, not merely import in the image.
+
+Steps 1 and 2 both derive their input FROM THE LAUNCH ARGV rather than
+re-resolving it: the ``/uvwork`` bind source and the SIF are read back out of
+the very list ``tmux`` will exec. A second resolution is free to drift from
+the one that actually launches — reconciling against a DIFFERENT image than
+the container mounts would stamp the overlay with an identity it never ran on,
+which then reads as reconciled forever, and creating a directory the argv does
+not mount would leave the launch to FATAL on a missing bind source. Deriving
+makes both divergences unrepresentable.
+
+Imports are function-local, as they were at the call site, so the module stays
+cheap to import and each dependency is patchable at its own source module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def run_launch_gate(config: Any, argv: list[str], *, state_dir: Path) -> None:
+    """Run every launch-time gate for ``config``, in the order above.
+
+    ``argv`` is the FINISHED launch argv and ``state_dir`` this agent's state
+    directory. Raises rather than returning a verdict — a gate that declines
+    is a launch that must not happen, and the caller has nothing useful to do
+    with a soft ``False`` (see ``_state.host_scratch.ScratchRootError`` and
+    ``_entry_point_gate``'s own error for the two that can fire).
+    """
+    from ._apptainer_scratch import ensure_uvwork_for_launch
+
+    ensure_uvwork_for_launch(config, argv)
+
+    from .._maintenance._overlay_venv_invalidate import (
+        reconcile_overlay_venv_for_launch,
+    )
+
+    launch_sif = next((a for a in argv if str(a).endswith(".sif")), None)
+    if launch_sif is not None:
+        reconcile_overlay_venv_for_launch(config, launch_sif, state_dir)
+
+    from ._entry_point_gate import assert_entry_point_runs
+
+    assert_entry_point_runs(config.name, argv)
+
+
+__all__ = ["run_launch_gate"]

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -294,35 +294,15 @@ class TuiSessionRuntime(
             write_redacted_argv(state_dir / "apptainer_run.argv.txt", argv)
             return True
 
-        # OVERLAY VENV INVALIDATION CONTRACT — parity with the SDK runtime (see
-        # ``_apptainer_runtime.start`` for the full why-here). Past the
-        # duplicate-session guard above, so no container of this agent holds the
-        # overlay mounted; past the dry-run return, so ``--dry-run`` mutates
-        # nothing; and BEFORE the entry-point probe below, so that probe
-        # measures the RECONCILED union rather than the stale one.
-        # The SIF is read OUT OF THE LAUNCH ARGV rather than re-resolved. Same
-        # reasoning as ``_entry_point_gate.probe_argv_from_launch``: a second
-        # resolution is free to drift from the one that actually launches, and
-        # reconciling against a DIFFERENT image than the container mounts would
-        # stamp the overlay with an identity it never ran on — which then reads
-        # as reconciled forever. Deriving it makes divergence impossible.
-        from .._maintenance._overlay_venv_invalidate import (
-            reconcile_overlay_venv_for_launch,
-        )
+        # LAUNCH GATE — the /uvwork scratch bind (ADR-0024), the overlay-venv
+        # reconcile and the entry-point probe. All three are launch-time acts
+        # that write to the host or refuse to start, so all three live past the
+        # dry-run return and past the duplicate-session guard above, never
+        # inside ``build_run_argv`` (which ``sac agents explain`` also calls).
+        # Order and derivation rationale: :mod:`._tui_launch_gate`.
+        from ._tui_launch_gate import run_launch_gate
 
-        launch_sif = next((a for a in argv if str(a).endswith(".sif")), None)
-        if launch_sif is not None:
-            reconcile_overlay_venv_for_launch(
-                config, launch_sif, state_dir_for_config(config)
-            )
-
-        # The console script must RUN in the union we are about to launch, not
-        # merely import in the image. Called after argv exists (so the probe
-        # inherits the real overlay) and after the dry-run return (so
-        # ``--dry-run`` stays subprocess-free).
-        from ._entry_point_gate import assert_entry_point_runs
-
-        assert_entry_point_runs(config.name, argv)
+        run_launch_gate(config, argv, state_dir=state_dir_for_config(config))
 
         # The host workdir is only the tmux launch cwd — the agent's real cwd is
         # ``--pwd`` inside the SIF; no session HOME/env (the container sets its own).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,6 +195,30 @@ os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(_SAC_STATE_FLOOR / "regi
 # touch the LIVE `sac listen` PIDFILE. It now honours this same variable.
 os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(_SAC_STATE_FLOOR / "runtime")
 
+# --- NEVER let a test create an agent's /uvwork under the REAL /scratch ------
+# ADR-0024: every `build_run_argv` resolves the host scratch root and CREATES
+# `<root>/sac/agents/<name>/uvwork` before emitting the bind. With no
+# `config.yaml` in reach the resolver probes the real `/scratch` — present on
+# every compute host and inside every agent container — so ~20 test modules
+# that assemble a launch argv would each leave `sac/agents/agt/uvwork` on the
+# operator's scratch volume; and on a box WITHOUT `/scratch` the same tests
+# would refuse the launch instead, which is the resolver doing its job on the
+# wrong population. Both are answered by the ONE knob the resolver reads: a
+# per-worker `config.yaml` declaring `scratch_root:` inside the floor, reached
+# through the same `$SCITEX_AGENT_CONTAINER_CONFIG` override the config tests
+# already use (a test that sets it itself still wins — its fixture runs later).
+# The declared root must EXIST (a declaration that cannot be honoured is a
+# refusal by design), so it is created here too. Force-set like its siblings.
+_SAC_SCRATCH_FLOOR = _SAC_STATE_FLOOR / "scratch"
+_SAC_SCRATCH_FLOOR.mkdir(parents=True, exist_ok=True)
+_SAC_CONFIG_FLOOR = _SAC_STATE_FLOOR / "config.yaml"
+_SAC_CONFIG_FLOOR.write_text(
+    "# written by tests/conftest.py — the per-worker test floor, never a source\n"
+    f"scratch_root: {_SAC_SCRATCH_FLOOR}\n",
+    encoding="utf-8",
+)
+os.environ["SCITEX_AGENT_CONTAINER_CONFIG"] = str(_SAC_CONFIG_FLOOR)
+
 # --- NEVER let a test touch the REAL card board ---------------------------
 # INCIDENT 2026-07-20: the fleet's live board went from ~2777 cards to SIX.
 # Five of the six survivors were OUR fixtures — `other-agent-card-0/1` and

--- a/tests/scitex_agent_container/_helpers/scratch_agent.py
+++ b/tests/scitex_agent_container/_helpers/scratch_agent.py
@@ -1,0 +1,78 @@
+"""One real ``/uvwork`` agent spec, shared by the two ADR-0024 launch suites.
+
+``runtimes/test__apptainer_scratch.py`` (the layout and the emitted bind) and
+``runtimes/test__apptainer_scratch_launch.py`` (the read-only / launch split)
+both need a real, loadable spec whose NAME is what the bind path is keyed on.
+Written once here so the two suites cannot drift onto differently-shaped
+specs — a split-behaviour test that passes over a different agent than the
+bind test is worth very little.
+
+Nothing here is a mock (PA-306): a real v3 spec file on disk, read back by
+the real loader.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+__all__ = ["UVWORK_AGENT_NAME", "load_uvwork_agent", "uvwork_binds"]
+
+#: The spec DIRECTORY name, which for this ``host:`` spec is also its
+#: effective id — so a path built from either spelling looks the same here.
+#: The case where they DIFFER is a ``hosts:`` spec, covered in
+#: ``_maintenance/test__scratch_migrate.py``.
+UVWORK_AGENT_NAME = "agt"
+
+_BASE_SPEC = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: t
+    sac-builtin: "off"
+spec:
+  runtime: tui
+  host: ${HOSTNAME}
+  workdir: /tmp/agt-work
+  apptainer:
+    image: /x.sif
+    binds: []
+  health:
+    enabled: true
+    interval: 60
+  restart:
+    policy: on-failure
+    max_retries: 3
+  claude:
+    model: claude-opus-4-8[1m]
+    flags:
+      - --dangerously-skip-permissions
+"""
+
+
+def load_uvwork_agent(tmp_path: Path):
+    """A real, loadable spec named ``agt`` (the directory name is the name)."""
+    from scitex_agent_container.config import load_config
+
+    spec_dir = tmp_path / "agents" / UVWORK_AGENT_NAME
+    spec_dir.mkdir(parents=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(explicitize_yaml(_BASE_SPEC), encoding="utf-8")
+    return load_config(str(spec))
+
+
+def uvwork_binds(argv: list[str]) -> list[str]:
+    """Every ``--bind`` value in ``argv`` whose DESTINATION is ``/uvwork``."""
+    from scitex_agent_container.runtimes._apptainer_scratch import (
+        UVWORK_CONTAINER_PATH,
+    )
+
+    out = []
+    for i, arg in enumerate(argv):
+        if arg == "--bind" and i + 1 < len(argv):
+            parts = argv[i + 1].split(":")
+            if (parts[1] if len(parts) > 1 else parts[0]) == UVWORK_CONTAINER_PATH:
+                out.append(argv[i + 1])
+    return out

--- a/tests/scitex_agent_container/_helpers/scratch_fleet.py
+++ b/tests/scitex_agent_container/_helpers/scratch_fleet.py
@@ -38,6 +38,7 @@ def write_scratch_agent(
     overlay: bool = True,
     overlay_size: str = "",
     overlay_dir: Path | None = None,
+    multi_host: bool = False,
 ) -> Path:
     """A real spec plus (optionally) a real overlay upper with real files.
 
@@ -46,6 +47,12 @@ def write_scratch_agent(
     fleet. ``overlay_size`` makes it a loopback IMAGE overlay, whose upper
     the host cannot walk. Returns the overlay's ``upper/uvwork`` path — the
     tree the sweep would move.
+
+    ``multi_host=True`` writes ``hosts:`` instead of ``host:`` — the
+    multi-instance shape, whose EFFECTIVE id is ``<dir>-<hostname>`` and so
+    differs from the spec directory name. That difference is the whole point
+    of the fixture: it is the only shape in which "keyed on the directory
+    name" and "keyed on the effective name" can disagree.
     """
     agent_dir = agents_dir / name
     agent_dir.mkdir(parents=True)
@@ -55,7 +62,10 @@ def write_scratch_agent(
         ap["overlay"] = str(overlay_root)
     if overlay_size:
         ap["overlay_size"] = overlay_size
-    doc = explicit_doc({"runtime": "tui", "workdir": str(agent_dir), "apptainer": ap})
+    spec: dict = {"runtime": "tui", "workdir": str(agent_dir), "apptainer": ap}
+    if multi_host:
+        spec["hosts"] = ["${HOSTNAME}"]
+    doc = explicit_doc(spec)
     (agent_dir / "spec.yaml").write_text(yaml.safe_dump(doc, sort_keys=False))
     source = overlay_root / "upper" / "uvwork"
     if uvwork is not None:

--- a/tests/scitex_agent_container/_helpers/scratch_fleet.py
+++ b/tests/scitex_agent_container/_helpers/scratch_fleet.py
@@ -1,0 +1,72 @@
+"""A real tmp fleet for the ADR-0024 scratch-migration suites.
+
+Shared by ``_maintenance/test__scratch_migrate.py`` (planning) and
+``_maintenance/test__scratch_migrate_apply.py`` (moving), so the two can
+never disagree about what a fleet looks like — a planning test that passes
+over a differently-shaped corpus than the apply test walks is worth very
+little.
+
+Nothing here is a mock: :func:`write_scratch_agent` writes a real, loadable
+v3 spec and a real overlay upper with real files, and the real loader reads
+it back. The liveness constants are the module's documented ``liveness``
+seam, whose whole shape is ``(running, detail)`` — a test cannot make a real
+agent run, and the thing under test is the plan's arithmetic over that
+answer, not the probe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+#: Liveness seams — ``(running, detail)``, exactly the adapter's answer shape.
+STOPPED = lambda config: (False, "ApptainerRuntime")  # noqa: E731
+RUNNING = lambda config: (True, "ApptainerRuntime")  # noqa: E731
+UNKNOWN = lambda config: (None, "ApptainerRuntime.is_running: boom")  # noqa: E731
+
+__all__ = ["RUNNING", "STOPPED", "UNKNOWN", "row_for", "write_scratch_agent"]
+
+
+def write_scratch_agent(
+    agents_dir: Path,
+    name: str,
+    *,
+    uvwork: dict[str, str] | None = None,
+    overlay: bool = True,
+    overlay_size: str = "",
+    overlay_dir: Path | None = None,
+) -> Path:
+    """A real spec plus (optionally) a real overlay upper with real files.
+
+    ``overlay_dir`` points the spec at a SHARED overlay — the shape eight
+    ``handyman-*`` specs and the ``scitex-hub`` pair are really in on the
+    fleet. ``overlay_size`` makes it a loopback IMAGE overlay, whose upper
+    the host cannot walk. Returns the overlay's ``upper/uvwork`` path — the
+    tree the sweep would move.
+    """
+    agent_dir = agents_dir / name
+    agent_dir.mkdir(parents=True)
+    overlay_root = agent_dir / "overlay" if overlay_dir is None else overlay_dir
+    ap: dict = {"image": "/x.sif", "binds": []}
+    if overlay:
+        ap["overlay"] = str(overlay_root)
+    if overlay_size:
+        ap["overlay_size"] = overlay_size
+    doc = explicit_doc({"runtime": "tui", "workdir": str(agent_dir), "apptainer": ap})
+    (agent_dir / "spec.yaml").write_text(yaml.safe_dump(doc, sort_keys=False))
+    source = overlay_root / "upper" / "uvwork"
+    if uvwork is not None:
+        source.mkdir(parents=True, exist_ok=True)
+        for rel, text in uvwork.items():
+            path = source / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+    return source
+
+
+def row_for(plan, agent: str):
+    """The one row ``plan`` holds for ``agent``; raises if it holds none."""
+    return next(r for r in plan.rows if r.agent == agent)

--- a/tests/scitex_agent_container/_maintenance/test__scratch_migrate.py
+++ b/tests/scitex_agent_container/_maintenance/test__scratch_migrate.py
@@ -353,3 +353,71 @@ def test_an_unselected_unreadable_spec_does_not_make_the_plan_unsafe(
     assert plan.safe_to_apply is True
 
 
+# ---------------------------------------------------------------------------
+# The destination is the LAUNCH's bind source — one derivation, not two
+# ---------------------------------------------------------------------------
+#
+# A ``hosts:`` spec's EFFECTIVE id carries a ``-<hostname>`` suffix, so its
+# spec DIRECTORY name and its ``config.name`` are different strings. The plan
+# used to key the destination on the directory name while the launch bind
+# keyed on ``config.name``: for every multi-instance agent on the fleet the
+# sweep would copy the tree to a path no launch will ever mount, verify the
+# copy against its source, delete the overlay original and report success.
+# Nothing fails; the next start just rebuilds uv and the venv from nothing.
+#
+# Three rows, one fact each: the fixture really is the divergent shape, the
+# destination really is the launch's bind source, and the ``host:`` shape —
+# where the two names coincide, and so where a same-key bug would hide —
+# still agrees.
+
+
+def _launch_bind_source(config, scratch: ScratchRoot) -> str:
+    """The ``--bind`` SOURCE the real argv builder would mount at /uvwork."""
+    from scitex_agent_container.runtimes._apptainer_scratch import uvwork_bind_flags
+
+    flags = uvwork_bind_flags(config, [], scratch=scratch)
+    return flags[1].split(":")[0]
+
+
+def test_a_hosts_spec_has_an_effective_name_the_directory_name_is_not(
+    fleet: Path,
+) -> None:
+    # Arrange — the positive control for the two rows below: without this
+    # difference they would pass against the very bug they exist to catch.
+    from scitex_agent_container.config import load_config
+
+    _write_agent(fleet, "multi", uvwork={"bin/uv": "x"}, multi_host=True)
+    # Act
+    config = load_config(str(fleet / "multi" / "spec.yaml"))
+    # Assert
+    assert config.name != "multi"
+
+
+def test_the_destination_for_a_hosts_spec_is_the_launch_bind_source(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    from scitex_agent_container.config import load_config
+
+    _write_agent(fleet, "multi", uvwork={"bin/uv": "x"}, multi_host=True)
+    config = load_config(str(fleet / "multi" / "spec.yaml"))
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert str(_row(plan, "multi").dest) == _launch_bind_source(config, scratch)
+
+
+def test_the_destination_for_a_host_spec_is_the_launch_bind_source(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — the singleton shape, where directory name == effective name.
+    from scitex_agent_container.config import load_config
+
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    config = load_config(str(fleet / "alpha" / "spec.yaml"))
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert str(_row(plan, "alpha").dest) == _launch_bind_source(config, scratch)
+
+

--- a/tests/scitex_agent_container/_maintenance/test__scratch_migrate.py
+++ b/tests/scitex_agent_container/_maintenance/test__scratch_migrate.py
@@ -1,0 +1,355 @@
+"""PLANNING the move of ``overlays/<agent>/upper/uvwork`` onto scratch.
+
+The read-only half of ADR-0024, over a real corpus of real spec files with
+real trees on disk. What an operator reads before letting anything delete
+11.7 GB is the PLAN, so the properties under test are the ones that decide
+whether reading it is worth anything — above all that the not-moving
+outcomes stay APART:
+
+* a RUNNING agent is refused; its container has the overlay mounted;
+* an UNDETERMINABLE one is refused too — "unknown" is never "stopped";
+* an overlay TWO agents declare is refused, naming the others (measured on
+  the fleet: one 2.6 GiB tree appeared as movable twice); and
+* an agent with nothing under ``/uvwork`` is simply ``nothing``.
+
+Collapsing any two of those is how a sweep deletes a live agent's venv and
+calls it housekeeping. Applying, and the "the plan writes nothing" proof,
+live in ``test__scratch_migrate_apply.py``; the measuring and liveness
+instruments have their own files beside this one.
+
+The liveness probe is injected through the module's documented ``liveness``
+parameter — the same seam ``_worktree_gc`` uses for its ``gh`` lookup. That
+is not a mock of the thing under test: the thing under test is the PLAN's
+arithmetic over a liveness answer, and a test cannot make a real agent run.
+Everything else is real (PA-306): real specs, read by the real loader.
+STX-TQ002 AAA markers; one fact per test (PA-307).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._maintenance._scratch_migrate import (
+    plan_scratch_migration,
+)
+from scitex_agent_container._state.host_scratch import ScratchRoot
+from tests.scitex_agent_container._helpers.scratch_fleet import (
+    RUNNING,
+    STOPPED,
+    UNKNOWN,
+)
+from tests.scitex_agent_container._helpers.scratch_fleet import row_for as _row
+from tests.scitex_agent_container._helpers.scratch_fleet import (
+    write_scratch_agent as _write_agent,
+)
+
+
+@pytest.fixture
+def fleet(tmp_path: Path) -> Path:
+    """An empty tmp fleet roster."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    return agents_dir
+
+
+@pytest.fixture
+def scratch(tmp_path: Path) -> ScratchRoot:
+    """A resolved scratch root standing in for this host's ``/scratch``."""
+    root = tmp_path / "scratch"
+    root.mkdir()
+    return ScratchRoot(root=root, source="config", reason="test config declares it")
+
+
+# ---------------------------------------------------------------------------
+# Planning — reads only, and the refusals stay apart
+# ---------------------------------------------------------------------------
+
+
+def test_a_stopped_agent_with_an_overlay_uvwork_is_planned_to_move(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x" * 10})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert _row(plan, "alpha").action == "move"
+
+
+def test_the_plan_carries_the_measured_byte_count(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x" * 10})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert plan.total_bytes == 10
+
+
+def test_the_plan_names_the_destination_on_scratch(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert _row(plan, "alpha").dest == scratch.root / "sac/agents/alpha/uvwork"
+
+
+def test_a_running_agent_is_refused(fleet: Path, scratch: ScratchRoot) -> None:
+    # Arrange — its container has the overlay mounted RIGHT NOW.
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=RUNNING)
+    # Assert
+    assert _row(plan, "alpha").action == "refuse"
+
+
+def test_the_running_refusal_names_the_stop_command(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=RUNNING)
+    # Assert
+    assert "sac agents stop alpha" in _row(plan, "alpha").reason
+
+
+def test_a_running_agent_contributes_no_bytes_to_the_total(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — the headline number must not promise space held by a
+    # refusal.
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x" * 10})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=RUNNING)
+    # Assert
+    assert plan.total_bytes == 0
+
+
+def test_undeterminable_liveness_is_refused_not_read_as_stopped(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — "the instrument could not answer" must never become "no".
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=UNKNOWN)
+    # Assert
+    assert _row(plan, "alpha").action == "refuse"
+
+
+def test_the_undeterminable_refusal_names_the_instrument(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=UNKNOWN)
+    # Assert
+    assert "ApptainerRuntime.is_running" in _row(plan, "alpha").reason
+
+
+def test_an_agent_with_no_overlay_uvwork_has_nothing_to_move(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — an overlay, but nothing ever written under /uvwork.
+    _write_agent(fleet, "alpha", uvwork=None)
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert _row(plan, "alpha").action == "nothing"
+
+
+def test_a_spec_with_no_overlay_has_nothing_to_move(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", overlay=False)
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert _row(plan, "alpha").reason == "spec declares no overlay"
+
+
+def test_an_image_overlay_is_not_walked(fleet: Path, scratch: ScratchRoot) -> None:
+    # Arrange — a loopback ext3 image's upper is not a host directory.
+    _write_agent(fleet, "alpha", overlay_size="4096")
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert "image (loopback) overlay" in _row(plan, "alpha").reason
+
+
+def test_an_already_populated_destination_is_refused(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — the agent already restarted under the new bind, so the
+    # overlay copy is now the OLDER of the two.
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "old"})
+    dest = scratch.root / "sac/agents/alpha/uvwork"
+    dest.mkdir(parents=True)
+    (dest / "bin").mkdir()
+    (dest / "bin" / "uv").write_text("new", encoding="utf-8")
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert _row(plan, "alpha").action == "refuse"
+
+
+def test_an_empty_destination_directory_does_not_block_the_move(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — the positive control: the bind's own mkdir ran, nothing more.
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    (scratch.root / "sac/agents/alpha/uvwork").mkdir(parents=True)
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert _row(plan, "alpha").action == "move"
+
+
+def test_only_the_named_agent_is_planned(fleet: Path, scratch: ScratchRoot) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"f": "x"})
+    _write_agent(fleet, "beta", uvwork={"f": "x"})
+    # Act
+    plan = plan_scratch_migration(
+        scratch, agents_root=fleet, only=["alpha"], liveness=STOPPED
+    )
+    # Assert
+    assert [r.agent for r in plan.rows] == ["alpha"]
+
+
+def test_an_unknown_named_agent_makes_the_plan_unsafe(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — a plan that cannot describe every selected spec does not
+    # describe the sweep.
+    _write_agent(fleet, "alpha", uvwork={"f": "x"})
+    # Act
+    plan = plan_scratch_migration(
+        scratch, agents_root=fleet, only=["ghost"], liveness=STOPPED
+    )
+    # Assert
+    assert plan.safe_to_apply is False
+
+
+def test_an_empty_roster_is_not_a_sound_plan(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — "0 to move" over a roster nobody found is not a fact.
+    missing = fleet / "not-a-roster"
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=missing, liveness=STOPPED)
+    # Assert
+    assert plan.safe_to_apply is False
+
+
+def test_a_host_that_keeps_uvwork_in_the_overlay_cannot_be_planned(
+    fleet: Path,
+) -> None:
+    # Arrange — there is nowhere to migrate TO.
+    decided = ScratchRoot(root=None, source="none", reason="root LV is 8T")
+    # Act
+    raised = pytest.raises(ValueError, match="needs a scratch root")
+    # Assert
+    with raised:
+        plan_scratch_migration(decided, agents_root=fleet, liveness=STOPPED)
+
+
+# ---------------------------------------------------------------------------
+# One overlay, two agents — measured on the fleet, refused by name
+# ---------------------------------------------------------------------------
+
+
+def test_an_overlay_two_agents_declare_is_refused(
+    fleet: Path, scratch: ScratchRoot, tmp_path: Path
+) -> None:
+    # Arrange — the real shape: scitex-hub and scitex-hub-mobile-ux name ONE
+    # --overlay, so the sweep saw one 2.6 GiB tree as movable twice.
+    shared = tmp_path / "shared-overlay"
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"}, overlay_dir=shared)
+    _write_agent(fleet, "beta", uvwork={"bin/uv": "x"}, overlay_dir=shared)
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert [r.action for r in plan.rows] == ["refuse", "refuse"]
+
+
+def test_the_shared_overlay_refusal_names_the_other_agent(
+    fleet: Path, scratch: ScratchRoot, tmp_path: Path
+) -> None:
+    # Arrange — the operator has to know WHO else reads that tree.
+    shared = tmp_path / "shared-overlay"
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"}, overlay_dir=shared)
+    _write_agent(fleet, "beta", uvwork={"bin/uv": "x"}, overlay_dir=shared)
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert "beta" in _row(plan, "alpha").reason
+
+
+def test_a_shared_overlay_contributes_no_bytes_to_the_total(
+    fleet: Path, scratch: ScratchRoot, tmp_path: Path
+) -> None:
+    # Arrange — counting it twice was how one tree became 5.2 GiB of promise.
+    shared = tmp_path / "shared-overlay"
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x" * 10}, overlay_dir=shared)
+    _write_agent(fleet, "beta", uvwork={"bin/uv": "x" * 10}, overlay_dir=shared)
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert plan.total_bytes == 0
+
+
+def test_two_agents_with_their_own_overlays_both_move(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — the positive control: the guard must key on the SHARED path,
+    # not simply refuse whenever two agents are present.
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    _write_agent(fleet, "beta", uvwork={"bin/uv": "x"})
+    # Act
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert [r.action for r in plan.rows] == ["move", "move"]
+
+
+def test_sharing_is_detected_even_when_only_one_agent_is_named(
+    fleet: Path, scratch: ScratchRoot, tmp_path: Path
+) -> None:
+    # Arrange — `--agent alpha` alone must not walk into the shared tree
+    # just because the other claimant was filtered out of the plan.
+    shared = tmp_path / "shared-overlay"
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"}, overlay_dir=shared)
+    _write_agent(fleet, "beta", uvwork={"bin/uv": "x"}, overlay_dir=shared)
+    # Act
+    plan = plan_scratch_migration(
+        scratch, agents_root=fleet, only=["alpha"], liveness=STOPPED
+    )
+    # Assert
+    assert _row(plan, "alpha").action == "refuse"
+
+
+def test_an_unselected_unreadable_spec_does_not_make_the_plan_unsafe(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — loading every spec for the ownership map must not turn some
+    # unrelated broken spec into this invocation's problem.
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "x"})
+    broken = fleet / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("{ not: [valid", encoding="utf-8")
+    # Act
+    plan = plan_scratch_migration(
+        scratch, agents_root=fleet, only=["alpha"], liveness=STOPPED
+    )
+    # Assert
+    assert plan.safe_to_apply is True
+
+

--- a/tests/scitex_agent_container/_maintenance/test__scratch_migrate_apply.py
+++ b/tests/scitex_agent_container/_maintenance/test__scratch_migrate_apply.py
@@ -1,0 +1,189 @@
+"""Applying the ADR-0024 sweep: copy → VERIFY → remove, in that order.
+
+Split from ``test__scratch_migrate.py`` (planning) because these are the only
+tests in the suite that DELETE anything, and the order they pin is the whole
+safety argument: the overlay copy is removed only after ``verify_copy``
+compares every path, size and symlink target against the source. A failure
+anywhere before that leaves the copy exactly where it was — measured here by
+reading the file back off disk, not by trusting the returned message.
+
+The dry-run half is here too, for the same reason: "the plan writes nothing"
+is a claim about the filesystem, so it is asserted against the filesystem.
+
+Real specs, the real loader, real trees, the real ``copytree`` and the real
+``rmtree`` (PA-306). Only liveness is injected, through the module's
+documented seam — a test cannot make a real agent run.
+STX-TQ002 AAA markers; one fact per test (PA-307).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._maintenance._scratch_migrate import (
+    apply_scratch_migration,
+    move_uvwork,
+    plan_scratch_migration,
+)
+from scitex_agent_container._state.host_scratch import ScratchRoot
+from tests.scitex_agent_container._helpers.scratch_fleet import RUNNING, STOPPED
+from tests.scitex_agent_container._helpers.scratch_fleet import (
+    write_scratch_agent as _write_agent,
+)
+
+
+@pytest.fixture
+def fleet(tmp_path: Path) -> Path:
+    """An empty tmp fleet roster."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    return agents_dir
+
+
+@pytest.fixture
+def scratch(tmp_path: Path) -> ScratchRoot:
+    """A resolved scratch root standing in for this host's ``/scratch``."""
+    root = tmp_path / "scratch"
+    root.mkdir()
+    return ScratchRoot(root=root, source="config", reason="test config declares it")
+
+
+# ---------------------------------------------------------------------------
+# The plan writes NOTHING
+# ---------------------------------------------------------------------------
+
+
+def test_planning_leaves_the_overlay_copy_in_place(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    source = _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    # Act
+    plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert (source / "bin" / "uv").read_text(encoding="utf-8") == "payload"
+
+
+def test_planning_does_not_create_the_destination(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    dest = scratch.root / "sac/agents/alpha/uvwork"
+    # Act
+    plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Assert
+    assert not dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# Applying — copy, verify, THEN remove
+# ---------------------------------------------------------------------------
+
+
+def test_apply_reports_the_move_as_done(fleet: Path, scratch: ScratchRoot) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Act
+    results = apply_scratch_migration(plan)
+    # Assert
+    assert [r.moved for r in results] == [True]
+
+
+def test_apply_writes_the_tree_onto_scratch(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Act
+    apply_scratch_migration(plan)
+    # Assert
+    dest = scratch.root / "sac/agents/alpha/uvwork/bin/uv"
+    assert dest.read_text(encoding="utf-8") == "payload"
+
+
+def test_apply_removes_the_overlay_copy(fleet: Path, scratch: ScratchRoot) -> None:
+    # Arrange — this is the whole point: the root LV gets its space back.
+    source = _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Act
+    apply_scratch_migration(plan)
+    # Assert
+    assert not source.exists()
+
+
+def test_apply_preserves_a_symlink_as_a_symlink(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — a venv is mostly symlinks; dereferencing them would both
+    # inflate the copy and break the interpreter.
+    source = _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    (source / "bin" / "python").symlink_to("uv")
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    # Act
+    apply_scratch_migration(plan)
+    # Assert
+    assert (scratch.root / "sac/agents/alpha/uvwork/bin/python").is_symlink()
+
+
+def test_apply_leaves_a_refused_agents_overlay_copy_alone(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — a running agent is in the plan, just not in ``movable``.
+    source = _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=RUNNING)
+    # Act
+    apply_scratch_migration(plan)
+    # Assert
+    assert (source / "bin" / "uv").read_text(encoding="utf-8") == "payload"
+
+
+def test_a_failed_verification_keeps_the_overlay_copy(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — plan the move, then grow the source so the copy taken from
+    # it can no longer match: verification must veto the delete.
+    source = _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    row = plan.movable[0]
+    dest = row.dest
+    dest.mkdir(parents=True)
+    (dest / "stowaway").write_text("not in the source", encoding="utf-8")
+    # Act
+    result = move_uvwork(row)
+    # Assert
+    assert result.moved is False
+
+
+def test_the_failed_move_says_the_overlay_copy_was_kept(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    row = plan.movable[0]
+    row.dest.mkdir(parents=True)
+    (row.dest / "stowaway").write_text("not in the source", encoding="utf-8")
+    # Act
+    result = move_uvwork(row)
+    # Assert
+    assert "KEPT" in result.detail
+
+
+def test_a_failed_move_really_leaves_the_source_on_disk(
+    fleet: Path, scratch: ScratchRoot
+) -> None:
+    # Arrange — the message and the disk must agree.
+    source = _write_agent(fleet, "alpha", uvwork={"bin/uv": "payload"})
+    plan = plan_scratch_migration(scratch, agents_root=fleet, liveness=STOPPED)
+    row = plan.movable[0]
+    row.dest.mkdir(parents=True)
+    (row.dest / "stowaway").write_text("not in the source", encoding="utf-8")
+    # Act
+    move_uvwork(row)
+    # Assert
+    assert (source / "bin" / "uv").read_text(encoding="utf-8") == "payload"

--- a/tests/scitex_agent_container/_maintenance/test__scratch_migrate_liveness.py
+++ b/tests/scitex_agent_container/_maintenance/test__scratch_migrate_liveness.py
@@ -1,0 +1,126 @@
+"""Is the agent running — and may the answer be believed from HERE?
+
+The guard in this module exists because a REAL dry-run produced a real false
+negative. Running `sac agents scratch-migrate` from inside the
+`scitex-agent-container` agent on scitex-compute-04, 2026-09-03:
+
+    runtime/scitex-agent-container/apptainer_pid   3190806
+    highest pid visible in that container's /proc     74275
+    the plan said                                   "stopped"
+
+— about the agent whose own turn was executing the probe, and it offered to
+move its 10.3 GiB `/uvwork` out from under a mounted overlay. The adapter is
+right and the pid file is right; the VANTAGE is wrong, and a wrong answer
+that authorises a delete is worse than no answer.
+
+So the tests here are about ABSTENTION, not about a cleverer probe: inside a
+container the instrument must decline, and on a host it must not decline for
+no reason (the positive control — a guard that always fires would pass the
+first half of this file while making the verb useless).
+
+``liveness_vantage`` takes its environment as a parameter precisely so both
+sides are reachable without a test having to be run twice on two machines.
+STX-TQ002 AAA markers; one fact per test (PA-307).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._maintenance._scratch_migrate_liveness import (
+    CONTAINER_MARKER_ENV,
+    liveness_vantage,
+)
+
+_IN_APPTAINER = {"APPTAINER_CONTAINER": "/x/sac-base.sif"}
+_IN_SINGULARITY = {"SINGULARITY_CONTAINER": "/x/sac-base.sif"}
+
+
+# ---------------------------------------------------------------------------
+# A vantage that CAN see host pids — the positive control
+# ---------------------------------------------------------------------------
+
+
+def test_a_bare_host_vantage_is_not_blind() -> None:
+    # Arrange — no container marker: this is the host, where the pid probe
+    # means what it says. A guard that fired here would refuse every agent
+    # forever.
+    env: dict = {}
+    # Act
+    blind = liveness_vantage(env)
+    # Assert
+    assert blind == ""
+
+
+def test_an_unrelated_environment_is_not_blind() -> None:
+    # Arrange — only the two markers count; other variables say nothing.
+    env = {"HOME": "/home/ywatanabe", "APPTAINER_BIND": "/scratch"}
+    # Act
+    blind = liveness_vantage(env)
+    # Assert
+    assert blind == ""
+
+
+def test_an_empty_marker_value_is_not_blind() -> None:
+    # Arrange — an exported-but-empty variable is not evidence of a
+    # container, and treating it as one would refuse every host run whose
+    # shell happened to export the name.
+    env = {"APPTAINER_CONTAINER": "   "}
+    # Act
+    blind = liveness_vantage(env)
+    # Assert
+    assert blind == ""
+
+
+# ---------------------------------------------------------------------------
+# A vantage that CANNOT — abstain, loudly
+# ---------------------------------------------------------------------------
+
+
+def test_inside_an_apptainer_container_the_vantage_is_blind() -> None:
+    # Arrange — the measured case.
+    # Act
+    blind = liveness_vantage(_IN_APPTAINER)
+    # Assert
+    assert blind != ""
+
+
+def test_inside_a_singularity_container_the_vantage_is_blind() -> None:
+    # Arrange — the older spelling of the same marker.
+    # Act
+    blind = liveness_vantage(_IN_SINGULARITY)
+    # Assert
+    assert blind != ""
+
+
+def test_the_blind_reason_names_the_pid_namespace() -> None:
+    # Arrange — the reason has to explain WHY the pid probe cannot work,
+    # not merely that something is off.
+    # Act
+    blind = liveness_vantage(_IN_APPTAINER)
+    # Assert
+    assert "PID namespace" in blind
+
+
+def test_the_blind_reason_names_the_variable_that_gave_it_away() -> None:
+    # Arrange
+    # Act
+    blind = liveness_vantage(_IN_APPTAINER)
+    # Assert
+    assert "APPTAINER_CONTAINER=/x/sac-base.sif" in blind
+
+
+def test_the_blind_reason_names_the_fix() -> None:
+    # Arrange — the operator's next action must be in the message.
+    # Act
+    blind = liveness_vantage(_IN_APPTAINER)
+    # Assert
+    assert "on the HOST" in blind
+
+
+def test_both_container_markers_are_watched() -> None:
+    # Arrange — apptainer sets both spellings; watching one would leave a
+    # container that only exports the other reading as a host.
+    expected = ("APPTAINER_CONTAINER", "SINGULARITY_CONTAINER")
+    # Act
+    watched = CONTAINER_MARKER_ENV
+    # Assert
+    assert watched == expected

--- a/tests/scitex_agent_container/_maintenance/test__scratch_migrate_measure.py
+++ b/tests/scitex_agent_container/_maintenance/test__scratch_migrate_measure.py
@@ -1,0 +1,194 @@
+"""The two measuring instruments of the ADR-0024 migration.
+
+``tree_size`` produces the number an operator decides on and ``verify_copy``
+is the instrument that licenses the ``rmtree``, so each is tested from BOTH
+sides: it must be able to say "same" (the positive control) and it must
+actually catch the specific difference it exists to catch.
+
+Real directories, real files, real hard links and real symlinks on disk — a
+faked stat would test our idea of the filesystem, which is the idea that
+would be wrong. STX-TQ002 AAA markers; one fact per test (PA-307).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from scitex_agent_container._maintenance._scratch_migrate_measure import (
+    tree_size,
+    verify_copy,
+)
+
+
+# ---------------------------------------------------------------------------
+# tree_size — the number in the preview
+# ---------------------------------------------------------------------------
+
+
+def test_tree_size_counts_the_bytes_it_would_move(tmp_path: Path) -> None:
+    # Arrange
+    root = tmp_path / "t"
+    (root / "bin").mkdir(parents=True)
+    (root / "bin" / "uv").write_text("x" * 40, encoding="utf-8")
+    # Act
+    size, _files = tree_size(root)
+    # Assert
+    assert size == 40
+
+
+def test_tree_size_counts_the_files_it_would_move(tmp_path: Path) -> None:
+    # Arrange
+    root = tmp_path / "t"
+    root.mkdir()
+    (root / "a").write_text("a", encoding="utf-8")
+    (root / "b").write_text("b", encoding="utf-8")
+    # Act
+    _size, files = tree_size(root)
+    # Assert
+    assert files == 2
+
+
+def test_tree_size_counts_a_hard_link_once(tmp_path: Path) -> None:
+    # Arrange — a uv cache is full of hard links; counting them per-link
+    # would promise the operator space the move cannot free.
+    root = tmp_path / "t"
+    root.mkdir()
+    (root / "a").write_text("x" * 100, encoding="utf-8")
+    os.link(root / "a", root / "b")
+    # Act
+    size, _files = tree_size(root)
+    # Assert
+    assert size == 100
+
+
+def test_two_separate_files_of_the_same_size_are_both_counted(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the positive control for the row above: the de-duplication
+    # keys on the inode, not on the size.
+    root = tmp_path / "t"
+    root.mkdir()
+    (root / "a").write_text("x" * 100, encoding="utf-8")
+    (root / "b").write_text("y" * 100, encoding="utf-8")
+    # Act
+    size, _files = tree_size(root)
+    # Assert
+    assert size == 200
+
+
+def test_tree_size_of_an_absent_tree_is_zero(tmp_path: Path) -> None:
+    # Arrange
+    root = tmp_path / "never-created"
+    # Act
+    measured = tree_size(root)
+    # Assert
+    assert measured == (0, 0)
+
+
+def test_tree_size_of_a_file_is_zero(tmp_path: Path) -> None:
+    # Arrange — the source must be a DIRECTORY; a file is not a tree.
+    path = tmp_path / "f"
+    path.write_text("x" * 10, encoding="utf-8")
+    # Act
+    measured = tree_size(path)
+    # Assert
+    assert measured == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# verify_copy — the instrument that licenses the delete
+# ---------------------------------------------------------------------------
+
+
+def test_verify_reports_nothing_for_an_identical_tree(tmp_path: Path) -> None:
+    # Arrange — the positive control: the instrument can say "same".
+    src, dst = tmp_path / "s", tmp_path / "d"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "f").write_text("data", encoding="utf-8")
+    (dst / "sub").mkdir(parents=True)
+    (dst / "sub" / "f").write_text("data", encoding="utf-8")
+    # Act
+    problems = verify_copy(src, dst)
+    # Assert
+    assert problems == []
+
+
+def test_verify_reports_a_file_missing_from_the_copy(tmp_path: Path) -> None:
+    # Arrange
+    src, dst = tmp_path / "s", tmp_path / "d"
+    src.mkdir()
+    dst.mkdir()
+    (src / "f").write_text("data", encoding="utf-8")
+    # Act
+    problems = verify_copy(src, dst)
+    # Assert
+    assert problems == ["missing in copy: f"]
+
+
+def test_verify_reports_a_file_that_differs_in_size(tmp_path: Path) -> None:
+    # Arrange — a truncated copy is the failure a byte count catches.
+    src, dst = tmp_path / "s", tmp_path / "d"
+    src.mkdir()
+    dst.mkdir()
+    (src / "f").write_text("data", encoding="utf-8")
+    (dst / "f").write_text("dat", encoding="utf-8")
+    # Act
+    problems = verify_copy(src, dst)
+    # Assert
+    assert problems[0].startswith("differs: f")
+
+
+def test_verify_reports_a_missing_directory(tmp_path: Path) -> None:
+    # Arrange — an empty directory carries no bytes, so only the manifest
+    # can notice it went missing.
+    src, dst = tmp_path / "s", tmp_path / "d"
+    (src / "empty").mkdir(parents=True)
+    dst.mkdir()
+    # Act
+    problems = verify_copy(src, dst)
+    # Assert
+    assert problems == ["missing in copy: empty"]
+
+
+def test_verify_reports_a_symlink_retargeted_by_the_copy(tmp_path: Path) -> None:
+    # Arrange — a venv is mostly symlinks; one pointing elsewhere is a
+    # broken interpreter, not a smaller file.
+    src, dst = tmp_path / "s", tmp_path / "d"
+    src.mkdir()
+    dst.mkdir()
+    (src / "python").symlink_to("uv")
+    (dst / "python").symlink_to("somewhere-else")
+    # Act
+    problems = verify_copy(src, dst)
+    # Assert
+    assert problems[0].startswith("differs: python")
+
+
+def test_verify_reports_a_symlink_the_copy_dereferenced(tmp_path: Path) -> None:
+    # Arrange — copying with ``symlinks=False`` turns a link into a file,
+    # which inflates the tree and must not read as verified.
+    src, dst = tmp_path / "s", tmp_path / "d"
+    src.mkdir()
+    dst.mkdir()
+    (src / "uv").write_text("payload", encoding="utf-8")
+    (src / "python").symlink_to("uv")
+    (dst / "uv").write_text("payload", encoding="utf-8")
+    (dst / "python").write_text("payload", encoding="utf-8")
+    # Act
+    problems = verify_copy(src, dst)
+    # Assert
+    assert problems[0].startswith("differs: python")
+
+
+def test_verify_reports_an_extra_path_in_the_copy(tmp_path: Path) -> None:
+    # Arrange — a destination with someone else's files in it is not this
+    # tree, and must not be mistaken for a verified copy of it.
+    src, dst = tmp_path / "s", tmp_path / "d"
+    src.mkdir()
+    dst.mkdir()
+    (dst / "stowaway").write_text("not in the source", encoding="utf-8")
+    # Act
+    problems = verify_copy(src, dst)
+    # Assert
+    assert problems == ["extra in copy: stowaway"]

--- a/tests/scitex_agent_container/_state/test_host_config_scratch.py
+++ b/tests/scitex_agent_container/_state/test_host_config_scratch.py
@@ -1,0 +1,203 @@
+"""``scratch_root:`` / ``scratch_root_reason:`` in config.yaml (ADR-0024).
+
+Pins :func:`_host_config_blocks._parse_scratch` through the real loader.
+The block decides where every agent's ``/uvwork`` is bound from, so the
+properties under test are the ones that keep a half-written decision from
+reading as a whole one:
+
+* a MISSING block stays optional — the resolver then probes the default, and
+  compute-01 / compute-03 have no ``config.yaml`` at all;
+* ``none`` — the written decision to keep ``/uvwork`` in the apptainer
+  overlay upper on the root volume — is refused WITHOUT a stated reason,
+  because a decision with no reason is indistinguishable from an omission; and
+* an orphan ``scratch_root_reason:`` is refused too, since a reason with no
+  root is a decision someone started writing and did not finish.
+
+No mocks (PA-306): every test writes a real YAML file at ``tmp_path`` and
+lets the real loader read it through the documented env override.
+STX-TQ002 AAA markers; one fact per test (PA-307).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state._host_config_blocks import (
+    SCRATCH_ROOT_NONE,
+    ScratchBlock,
+)
+from scitex_agent_container._state.host_config import load
+
+
+@pytest.fixture
+def cfg_path(tmp_path: Path, env_save_restore) -> Path:
+    """Real config.yaml under tmp_path, surfaced via the env override."""
+    p = tmp_path / "config.yaml"
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(p))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Absent — the shape compute-01 and compute-03 are actually in
+# ---------------------------------------------------------------------------
+
+
+def test_a_config_without_the_key_carries_no_scratch_block(cfg_path: Path) -> None:
+    # Arrange — two hosts in this fleet have NO config.yaml key at all.
+    cfg_path.write_text("host:\n  name: somewhere\n")
+    # Act
+    scratch = load().scratch
+    # Assert
+    assert scratch is None
+
+
+def test_an_empty_config_carries_no_scratch_block(cfg_path: Path) -> None:
+    # Arrange — the positive control for the row above: nothing at all.
+    cfg_path.write_text("")
+    # Act
+    scratch = load().scratch
+    # Assert
+    assert scratch is None
+
+
+# ---------------------------------------------------------------------------
+# A declared path
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_absolute_path_parses_into_a_block(cfg_path: Path) -> None:
+    # Arrange
+    cfg_path.write_text("scratch_root: /scratch\n")
+    # Act
+    scratch = load().scratch
+    # Assert
+    assert scratch == ScratchBlock(root="/scratch", reason="")
+
+
+def test_a_declared_path_is_not_the_none_decision(cfg_path: Path) -> None:
+    # Arrange
+    cfg_path.write_text("scratch_root: /scratch\n")
+    # Act
+    is_none = load().scratch.is_none
+    # Assert
+    assert is_none is False
+
+
+def test_a_declared_path_keeps_an_optional_reason(cfg_path: Path) -> None:
+    # Arrange — a reason is welcome on a path, just not required.
+    cfg_path.write_text("scratch_root: /scratch\nscratch_root_reason: the 3T LV\n")
+    # Act
+    reason = load().scratch.reason
+    # Assert
+    assert reason == "the 3T LV"
+
+
+def test_a_relative_scratch_root_is_refused(cfg_path: Path) -> None:
+    # Arrange — a relative root would resolve against whatever CWD sac
+    # happened to start in, which is the class of bug ADR-0024 ends.
+    cfg_path.write_text("scratch_root: scratch\n")
+    # Act
+    raised = pytest.raises(ValueError, match="absolute path")
+    # Assert
+    with raised:
+        load()
+
+
+def test_the_relative_root_refusal_names_the_config_file(cfg_path: Path) -> None:
+    # Arrange — the fix is a one-line edit of a file that must be named.
+    cfg_path.write_text("scratch_root: scratch\n")
+    # Act
+    raised = pytest.raises(ValueError, match=re.escape(str(cfg_path)))
+    # Assert
+    with raised:
+        load()
+
+
+def test_a_non_string_scratch_root_is_refused(cfg_path: Path) -> None:
+    # Arrange
+    cfg_path.write_text("scratch_root: 42\n")
+    # Act
+    raised = pytest.raises(ValueError, match="scratch_root")
+    # Assert
+    with raised:
+        load()
+
+
+def test_an_empty_scratch_root_is_refused(cfg_path: Path) -> None:
+    # Arrange — a quoted empty string is a declaration that declares nothing.
+    cfg_path.write_text("scratch_root: ''\n")
+    # Act
+    raised = pytest.raises(ValueError, match="absolute path")
+    # Assert
+    with raised:
+        load()
+
+
+# ---------------------------------------------------------------------------
+# `none` — a written decision, never the shape a missing line falls into
+# ---------------------------------------------------------------------------
+
+
+def test_none_with_a_reason_parses_into_a_block(cfg_path: Path) -> None:
+    # Arrange
+    cfg_path.write_text("scratch_root: none\nscratch_root_reason: root LV is 8T\n")
+    # Act
+    scratch = load().scratch
+    # Assert
+    assert scratch == ScratchBlock(root=SCRATCH_ROOT_NONE, reason="root LV is 8T")
+
+
+def test_none_with_a_reason_reports_itself_as_the_none_decision(
+    cfg_path: Path,
+) -> None:
+    # Arrange
+    cfg_path.write_text("scratch_root: none\nscratch_root_reason: root LV is 8T\n")
+    # Act
+    is_none = load().scratch.is_none
+    # Assert
+    assert is_none is True
+
+
+def test_none_without_a_reason_is_refused(cfg_path: Path) -> None:
+    # Arrange — keeping /uvwork on the root volume is the failure mode; it
+    # must never be reachable by a bare word.
+    cfg_path.write_text("scratch_root: none\n")
+    # Act
+    raised = pytest.raises(ValueError, match="scratch_root_reason")
+    # Assert
+    with raised:
+        load()
+
+
+def test_none_with_a_whitespace_reason_is_refused(cfg_path: Path) -> None:
+    # Arrange — the positive control for the row above: a reason that says
+    # nothing is not a reason.
+    cfg_path.write_text("scratch_root: none\nscratch_root_reason: '   '\n")
+    # Act
+    raised = pytest.raises(ValueError, match="scratch_root_reason")
+    # Assert
+    with raised:
+        load()
+
+
+def test_a_reason_without_a_root_is_refused(cfg_path: Path) -> None:
+    # Arrange — half a decision reads exactly like a whole one later.
+    cfg_path.write_text("scratch_root_reason: root LV is 8T\n")
+    # Act
+    raised = pytest.raises(ValueError, match="scratch_root_reason")
+    # Assert
+    with raised:
+        load()
+
+
+def test_a_non_string_reason_is_refused(cfg_path: Path) -> None:
+    # Arrange
+    cfg_path.write_text("scratch_root: none\nscratch_root_reason: 7\n")
+    # Act
+    raised = pytest.raises(ValueError, match="must be a string")
+    # Assert
+    with raised:
+        load()

--- a/tests/scitex_agent_container/_state/test_host_scratch.py
+++ b/tests/scitex_agent_container/_state/test_host_scratch.py
@@ -1,0 +1,323 @@
+"""The scratch-root RESOLUTION TABLE — where ``/uvwork`` lives on this host.
+
+ADR-0024. Four rows, and the fourth is the whole point:
+
+    config path      ``scratch_root: /abs`` and it exists   -> source=config
+    config none      ``scratch_root: none`` + a reason      -> source=none
+    default present  nothing declared, ``/scratch`` there   -> source=default
+    default absent   nothing declared, no ``/scratch``      -> REFUSE
+
+A resolver that answered the fourth row with "well, the overlay then" would
+put every agent's uv cache and venv back on the host ROOT volume — the volume
+that filled to 0 four times on scitex-compute-04 on 2026-09-02 — and would
+say nothing while doing it. So the refusal is a tested property, not an
+incidental exception, and its message is tested for naming the missing path,
+the config key and both fixes.
+
+The DEFAULT rows cannot be exercised against the real ``/scratch``: it exists
+on every compute host and inside every agent container, so "default absent"
+would be unreachable there and "default present" would pass for the wrong
+reason on a laptop. Hence the ``probe`` seam — the resolver's documented
+test seam for the default candidate, and the ONE dish: no env var selects a
+root, only ``config.yaml``. The production value is pinned separately below
+so the seam cannot drift away from what ships.
+
+No mocks (PA-306): real YAML at ``tmp_path`` through the real loader, real
+directories on disk. STX-TQ002 AAA markers; one fact per test (PA-307).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state.host_config import load
+from scitex_agent_container._state.host_scratch import (
+    CONFIG_KEY,
+    DEFAULT_SCRATCH_ROOT,
+    SCRATCH_SOURCES,
+    ScratchRoot,
+    ScratchRootError,
+    resolve_scratch_root,
+)
+
+
+@pytest.fixture
+def cfg_path(tmp_path: Path, env_save_restore) -> Path:
+    """Real config.yaml under tmp_path, surfaced via the env override."""
+    p = tmp_path / "config.yaml"
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(p))
+    return p
+
+
+@pytest.fixture
+def absent_probe(tmp_path: Path) -> Path:
+    """A path that is NOT a directory — the 'no /scratch on this host' row."""
+    return tmp_path / "no-such-scratch"
+
+
+@pytest.fixture
+def present_probe(tmp_path: Path) -> Path:
+    """A real directory standing in for a host's ``/scratch``."""
+    p = tmp_path / "scratch"
+    p.mkdir()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Row 1 — config.yaml declares a path
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_existing_root_is_the_resolved_root(
+    cfg_path: Path, present_probe: Path, absent_probe: Path
+) -> None:
+    # Arrange — declared, and the default probe deliberately absent so a
+    # pass cannot come from the default leg.
+    cfg_path.write_text(f"{CONFIG_KEY}: {present_probe}\n")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=absent_probe)
+    # Assert
+    assert resolved.root == present_probe
+
+
+def test_a_declared_root_reports_the_config_source(
+    cfg_path: Path, present_probe: Path, absent_probe: Path
+) -> None:
+    # Arrange
+    cfg_path.write_text(f"{CONFIG_KEY}: {present_probe}\n")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=absent_probe)
+    # Assert
+    assert resolved.source == "config"
+
+
+def test_a_declared_root_beats_a_present_default(
+    cfg_path: Path, present_probe: Path, tmp_path: Path
+) -> None:
+    # Arrange — both legs available; the declaration must win.
+    declared = tmp_path / "declared"
+    declared.mkdir()
+    cfg_path.write_text(f"{CONFIG_KEY}: {declared}\n")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=present_probe)
+    # Assert
+    assert resolved.root == declared
+
+
+def test_a_declared_root_that_is_not_a_directory_refuses(
+    cfg_path: Path, absent_probe: Path, present_probe: Path
+) -> None:
+    # Arrange — a declaration that cannot be honoured must FAIL, never
+    # quietly fall through to the default.
+    cfg_path.write_text(f"{CONFIG_KEY}: {absent_probe}\n")
+    # Act
+    raised = pytest.raises(ScratchRootError, match=re.escape(str(absent_probe)))
+    # Assert
+    with raised:
+        resolve_scratch_root(load(), probe=present_probe)
+
+
+def test_the_unhonourable_declaration_refusal_names_the_config_file(
+    cfg_path: Path, absent_probe: Path, present_probe: Path
+) -> None:
+    # Arrange
+    cfg_path.write_text(f"{CONFIG_KEY}: {absent_probe}\n")
+    # Act
+    raised = pytest.raises(ScratchRootError, match=re.escape(str(cfg_path)))
+    # Assert
+    with raised:
+        resolve_scratch_root(load(), probe=present_probe)
+
+
+# ---------------------------------------------------------------------------
+# Row 2 — the written decision to keep /uvwork in the overlay
+# ---------------------------------------------------------------------------
+
+
+def test_the_none_decision_resolves_to_no_root(
+    cfg_path: Path, present_probe: Path
+) -> None:
+    # Arrange — present_probe would otherwise supply a default.
+    cfg_path.write_text(f"{CONFIG_KEY}: none\n{CONFIG_KEY}_reason: root LV is 8T\n")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=present_probe)
+    # Assert
+    assert resolved.root is None
+
+
+def test_the_none_decision_reports_the_none_source(
+    cfg_path: Path, present_probe: Path
+) -> None:
+    # Arrange
+    cfg_path.write_text(f"{CONFIG_KEY}: none\n{CONFIG_KEY}_reason: root LV is 8T\n")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=present_probe)
+    # Assert
+    assert resolved.source == "none"
+
+
+def test_the_none_decision_carries_the_written_reason(
+    cfg_path: Path, present_probe: Path
+) -> None:
+    # Arrange — the reason is what a later reader has instead of a guess.
+    cfg_path.write_text(f"{CONFIG_KEY}: none\n{CONFIG_KEY}_reason: root LV is 8T\n")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=present_probe)
+    # Assert
+    assert resolved.reason == "root LV is 8T"
+
+
+# ---------------------------------------------------------------------------
+# Row 3 — no declaration, the default probe is there
+# ---------------------------------------------------------------------------
+
+
+def test_an_undeclared_host_with_a_present_probe_uses_it(
+    cfg_path: Path, present_probe: Path
+) -> None:
+    # Arrange — compute-01 and compute-03 have no config.yaml at all.
+    cfg_path.write_text("")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=present_probe)
+    # Assert
+    assert resolved.root == present_probe
+
+
+def test_an_undeclared_host_with_a_present_probe_reports_the_default_source(
+    cfg_path: Path, present_probe: Path
+) -> None:
+    # Arrange
+    cfg_path.write_text("")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=present_probe)
+    # Assert
+    assert resolved.source == "default"
+
+
+def test_the_default_reason_names_the_probed_path(
+    cfg_path: Path, present_probe: Path
+) -> None:
+    # Arrange
+    cfg_path.write_text("")
+    # Act
+    resolved = resolve_scratch_root(load(), probe=present_probe)
+    # Assert
+    assert str(present_probe) in resolved.reason
+
+
+# ---------------------------------------------------------------------------
+# Row 4 — no declaration and no probe: REFUSE
+# ---------------------------------------------------------------------------
+
+
+def test_an_undeclared_host_without_a_probe_refuses(
+    cfg_path: Path, absent_probe: Path
+) -> None:
+    # Arrange — the row the whole module exists for.
+    cfg_path.write_text("")
+    # Act
+    raised = pytest.raises(ScratchRootError)
+    # Assert
+    with raised:
+        resolve_scratch_root(load(), probe=absent_probe)
+
+
+def test_the_refusal_names_the_missing_path(
+    cfg_path: Path, absent_probe: Path
+) -> None:
+    # Arrange
+    cfg_path.write_text("")
+    # Act
+    raised = pytest.raises(ScratchRootError, match=re.escape(str(absent_probe)))
+    # Assert
+    with raised:
+        resolve_scratch_root(load(), probe=absent_probe)
+
+
+def test_the_refusal_names_the_config_key(cfg_path: Path, absent_probe: Path) -> None:
+    # Arrange — fix #2 is a one-line edit; the message must spell the key.
+    cfg_path.write_text("")
+    # Act
+    raised = pytest.raises(ScratchRootError, match=CONFIG_KEY)
+    # Assert
+    with raised:
+        resolve_scratch_root(load(), probe=absent_probe)
+
+
+def test_the_refusal_names_the_config_file_to_edit(
+    cfg_path: Path, absent_probe: Path
+) -> None:
+    # Arrange
+    cfg_path.write_text("")
+    # Act
+    raised = pytest.raises(ScratchRootError, match=re.escape(str(cfg_path)))
+    # Assert
+    with raised:
+        resolve_scratch_root(load(), probe=absent_probe)
+
+
+def test_the_refusal_offers_the_written_none_decision_as_a_fix(
+    cfg_path: Path, absent_probe: Path
+) -> None:
+    # Arrange — fix #3: the escape hatch must be discoverable from the error.
+    cfg_path.write_text("")
+    # Act
+    raised = pytest.raises(ScratchRootError, match=f"{CONFIG_KEY}_reason")
+    # Assert
+    with raised:
+        resolve_scratch_root(load(), probe=absent_probe)
+
+
+# ---------------------------------------------------------------------------
+# The answer SHAPE, and the production default the seam stands in for
+# ---------------------------------------------------------------------------
+
+
+def test_the_production_default_probe_is_slash_scratch() -> None:
+    # Arrange — the seam above must not drift from what actually ships.
+    expected = Path("/scratch")
+    # Act
+    default = DEFAULT_SCRATCH_ROOT
+    # Assert
+    assert default == expected
+
+
+def test_the_sources_are_a_closed_set_of_three() -> None:
+    # Arrange
+    expected = ("config", "default", "none")
+    # Act
+    sources = SCRATCH_SOURCES
+    # Assert
+    assert sources == expected
+
+
+def test_an_unknown_source_is_refused_by_the_answer_shape() -> None:
+    # Arrange
+    root = Path("/scratch")
+    # Act
+    raised = pytest.raises(ValueError, match="source must be one of")
+    # Assert
+    with raised:
+        ScratchRoot(root=root, source="guessed", reason="")
+
+
+def test_a_rootless_answer_must_say_none(tmp_path: Path) -> None:
+    # Arrange — "no root" and "source=none" are one fact, not two.
+    # Act
+    raised = pytest.raises(ValueError, match="inconsistent")
+    # Assert
+    with raised:
+        ScratchRoot(root=None, source="default", reason="")
+
+
+def test_a_none_answer_must_not_carry_a_root(tmp_path: Path) -> None:
+    # Arrange — the positive control for the row above, from the other side.
+    root = tmp_path
+    # Act
+    raised = pytest.raises(ValueError, match="inconsistent")
+    # Assert
+    with raised:
+        ScratchRoot(root=root, source="none", reason="written")

--- a/tests/scitex_agent_container/cli_pkg/test__agents_scratch_migrate.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_scratch_migrate.py
@@ -1,0 +1,362 @@
+"""``sac agents scratch-migrate`` — the CLI surface of the ADR-0024 sweep.
+
+Real ``CliRunner`` against the real click command, over a real tmp fleet of
+real spec files, with a real ``config.yaml`` declaring a real scratch root —
+every seam pinned inside ``tmp_path`` so no test can read or delete the
+operator's overlays.
+
+What only the CLI owns, and what these pin:
+
+* **dry-run is the DEFAULT** — the safety property of a verb that deletes
+  gigabytes, measured by asserting the overlay tree is still on disk;
+* the exit-code contract: a named REFUSAL (this host keeps ``/uvwork`` in the
+  overlay) is 2, a plan that cannot describe the sweep is 1, and a sound
+  preview is 0; and
+* that ``--json`` names the scratch root and how it was reached, because an
+  operator reading the preview is deciding on THAT directory.
+
+Liveness is the REAL runtime adapter here, not a seam: an agent that has
+never started has no ``apptainer_pid`` under its sandboxed state dir, so
+``is_running`` answers False from disk — deterministic, and the same code
+path ``sac agents status`` walks.
+
+That is only true from a HOST vantage, so the fleet fixture clears the two
+apptainer container markers: this suite frequently runs inside an agent
+container, where the vantage guard (rightly) abstains for every agent and no
+row could ever be movable. The guard's own behaviour is pinned here too, by
+setting a marker back — and in full in
+``_maintenance/test__scratch_migrate_liveness.py``.
+
+No mocks (PA-306). STX-TQ002 AAA markers; one fact per test (PA-307).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from scitex_agent_container._maintenance._scratch_migrate_liveness import (
+    CONTAINER_MARKER_ENV,
+)
+from scitex_agent_container.cli_pkg._agents_scratch_migrate import (
+    human_bytes,
+    scratch_migrate,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+
+@pytest.fixture
+def fleet(tmp_path: Path, env_save_restore) -> Path:
+    """A tmp fleet roster plus a config.yaml declaring a tmp scratch root."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(f"scratch_root: {scratch}\n", encoding="utf-8")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_AGENTS_DIR", str(agents_dir))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(tmp_path / "rt"))
+    for key in CONTAINER_MARKER_ENV:
+        env_save_restore.set(key, "")
+    return agents_dir
+
+
+@pytest.fixture
+def overlay_host(tmp_path: Path, env_save_restore) -> Path:
+    """A host whose written decision is to keep ``/uvwork`` in the overlay."""
+    agents_dir = tmp_path / "agents-none"
+    agents_dir.mkdir()
+    cfg = tmp_path / "config-none.yaml"
+    cfg.write_text(
+        "scratch_root: none\nscratch_root_reason: root LV is 8T\n", encoding="utf-8"
+    )
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_AGENTS_DIR", str(agents_dir))
+    return agents_dir
+
+
+def _write_agent(agents_dir: Path, name: str, files: dict[str, str]) -> Path:
+    """A real spec with a real directory overlay holding a real uvwork tree."""
+    agent_dir = agents_dir / name
+    agent_dir.mkdir(parents=True)
+    overlay = agent_dir / "overlay"
+    doc = explicit_doc(
+        {
+            "runtime": "tui",
+            "workdir": str(agent_dir),
+            "apptainer": {"image": "/x.sif", "binds": [], "overlay": str(overlay)},
+        }
+    )
+    (agent_dir / "spec.yaml").write_text(yaml.safe_dump(doc, sort_keys=False))
+    source = overlay / "upper" / "uvwork"
+    source.mkdir(parents=True)
+    for rel, text in files.items():
+        path = source / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    return source
+
+
+def _run(*args):
+    """Assert on ``result.stdout``, never ``result.output``.
+
+    ``Result.output`` merges stderr into stdout; the scheduled form of this
+    command is ``--json`` piped to a parser, where a single log line on
+    stderr would break ``json.loads`` on a command that behaved perfectly.
+    """
+    return CliRunner().invoke(scratch_migrate, list(args), catch_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run is the DEFAULT
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_invocation_moves_nothing(fleet: Path) -> None:
+    # Arrange — the single most important property of a verb that deletes.
+    source = _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    _run()
+    # Assert
+    assert (source / "bin" / "uv").read_text(encoding="utf-8") == "payload"
+
+
+def test_the_default_invocation_creates_no_destination(fleet: Path) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    _run()
+    # Assert
+    assert not (fleet.parent / "scratch" / "sac").exists()
+
+
+def test_the_default_invocation_reports_dry_run_mode(fleet: Path) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["mode"] == "dry-run"
+
+
+def test_the_dry_run_lists_the_agent_it_would_move(fleet: Path) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["would_move"] == ["alpha"]
+
+
+def test_the_dry_run_totals_the_bytes_it_would_move(fleet: Path) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", {"bin/uv": "x" * 32})
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["total_bytes"] == 32
+
+
+def test_the_dry_run_names_the_scratch_root_it_would_write_to(fleet: Path) -> None:
+    # Arrange — the operator is deciding about THAT directory.
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["scratch_root"] == str(fleet.parent / "scratch")
+
+
+def test_the_dry_run_says_how_the_root_was_reached(fleet: Path) -> None:
+    # Arrange — config, default probe or written decision are not the same
+    # fact, and the preview must not blur them.
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["scratch_source"] == "config"
+
+
+def test_a_sound_preview_exits_zero(fleet: Path) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--json")
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_only_the_named_agent_is_previewed(fleet: Path) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    _write_agent(fleet, "beta", {"bin/uv": "payload"})
+    # Act
+    result = _run("--agent", "alpha", "--json")
+    # Assert
+    assert [r["agent"] for r in json.loads(result.stdout)["rows"]] == ["alpha"]
+
+
+def test_the_human_preview_tells_the_operator_it_moved_nothing(fleet: Path) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run()
+    # Assert
+    assert "Nothing was moved" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Exit codes — a REFUSAL is not an unsound plan
+# ---------------------------------------------------------------------------
+
+
+def test_a_host_that_keeps_uvwork_in_the_overlay_is_refused(
+    overlay_host: Path,
+) -> None:
+    # Arrange — there is nowhere to migrate TO, in writing.
+    # Act
+    result = _run("--json")
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_the_overlay_host_refusal_states_the_written_reason(
+    overlay_host: Path,
+) -> None:
+    # Arrange
+    # Act
+    result = _run("--json")
+    # Assert
+    assert "root LV is 8T" in json.loads(result.stdout)["apply_refused"]
+
+
+def test_the_overlay_host_refusal_moves_nothing_even_with_apply(
+    overlay_host: Path,
+) -> None:
+    # Arrange — the positive control: --apply does not get past the refusal.
+    source = _write_agent(overlay_host, "alpha", {"bin/uv": "payload"})
+    # Act
+    _run("--apply", "--json")
+    # Assert
+    assert (source / "bin" / "uv").read_text(encoding="utf-8") == "payload"
+
+
+def test_an_unknown_agent_makes_the_plan_unsound(fleet: Path) -> None:
+    # Arrange — a plan that cannot describe every selected spec is not a
+    # description of the sweep.
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--agent", "ghost", "--json")
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_an_unknown_agent_is_named_in_the_payload(fleet: Path) -> None:
+    # Arrange
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--agent", "ghost", "--json")
+    # Assert
+    assert json.loads(result.stdout)["unknown"] == ["ghost"]
+
+
+def test_an_unsound_plan_is_not_applied(fleet: Path) -> None:
+    # Arrange
+    source = _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    _run("--agent", "alpha", "--agent", "ghost", "--apply", "--json")
+    # Assert
+    assert (source / "bin" / "uv").read_text(encoding="utf-8") == "payload"
+
+
+def test_a_roster_that_was_never_searched_is_not_a_sound_plan(
+    fleet: Path, env_save_restore
+) -> None:
+    # Arrange — the container-vs-host $HOME bug: 0 specs because the root
+    # does not exist, which is NOT an empty fleet.
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_AGENTS_DIR", str(fleet.parent / "nowhere")
+    )
+    # Act
+    result = _run("--json")
+    # Assert
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# A vantage that cannot read liveness moves nothing, and says why once
+# ---------------------------------------------------------------------------
+
+
+def test_a_host_vantage_reports_no_blindness(fleet: Path) -> None:
+    # Arrange — the positive control for the two rows below.
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["liveness_vantage"] == ""
+
+
+def test_inside_a_container_nothing_is_movable(
+    fleet: Path, env_save_restore
+) -> None:
+    # Arrange — MEASURED 2026-09-03: from inside an agent container the pid
+    # probe called a RUNNING agent "stopped" and offered its 10.3 GiB.
+    env_save_restore.set("APPTAINER_CONTAINER", "/x/sac-base.sif")
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["would_move"] == []
+
+
+def test_inside_a_container_apply_moves_nothing(
+    fleet: Path, env_save_restore
+) -> None:
+    # Arrange — the abstention has to survive the deliberate act, not only
+    # the preview.
+    env_save_restore.set("APPTAINER_CONTAINER", "/x/sac-base.sif")
+    source = _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    _run("--apply", "--json")
+    # Assert
+    assert (source / "bin" / "uv").read_text(encoding="utf-8") == "payload"
+
+
+def test_the_container_vantage_is_named_once_in_the_preview(
+    fleet: Path, env_save_restore
+) -> None:
+    # Arrange — 17 identical row reasons are not a headline.
+    env_save_restore.set("APPTAINER_CONTAINER", "/x/sac-base.sif")
+    _write_agent(fleet, "alpha", {"bin/uv": "payload"})
+    # Act
+    result = _run()
+    # Assert
+    assert "LIVENESS UNREADABLE FROM HERE" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# The unit the operator measured in
+# ---------------------------------------------------------------------------
+
+
+def test_gigabytes_are_reported_in_the_unit_the_overlays_were_measured_in() -> None:
+    # Arrange — 11.7 GB of sac's overlay is the number in the incident.
+    raw = int(11.7 * 1024**3)
+    # Act
+    rendered = human_bytes(raw)
+    # Assert
+    assert rendered == "11.7 GiB"
+
+
+def test_small_trees_are_reported_in_bytes() -> None:
+    # Arrange
+    raw = 3
+    # Act
+    rendered = human_bytes(raw)
+    # Assert
+    assert rendered == "3 B"

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -2455,12 +2455,7 @@ def test_default_listen_url_injected_when_no_config(tmp_path: Path) -> None:
 def test_config_listen_port_propagates_to_env(tmp_path: Path, env_save_restore) -> None:
     # Arrange
     cfg_yaml = tmp_path / "config.yaml"
-    # This test writes its OWN config.yaml and so overrides the conftest
-    # scratch_root floor. build_run_argv now resolves where /uvwork lives
-    # and REFUSES when neither /scratch nor a declared root exists -- that
-    # refusal is the point of the change, and CI has no /scratch. Declaring
-    # a root the test owns keeps it hermetic on any host.
-    cfg_yaml.write_text(f"scratch_root: {tmp_path}\nlisten:\n  port: 9090\n")
+    cfg_yaml.write_text("listen:\n  port: 9090\n")
     env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg_yaml))
     rt = ApptainerContainerRuntime()
     cfg = _config(tmp_path)
@@ -2475,10 +2470,7 @@ def test_config_listen_port_propagates_to_env(tmp_path: Path, env_save_restore) 
 def test_config_listen_host_propagates_to_env(tmp_path: Path, env_save_restore) -> None:
     # Arrange
     cfg_yaml = tmp_path / "config.yaml"
-    # Same reason as the port test above: own config, own scratch_root.
-    cfg_yaml.write_text(
-        f"scratch_root: {tmp_path}\nlisten:\n  host: 100.64.1.2\n  port: 7878\n"
-    )
+    cfg_yaml.write_text("listen:\n  host: 100.64.1.2\n  port: 7878\n")
     env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg_yaml))
     rt = ApptainerContainerRuntime()
     cfg = _config(tmp_path)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -2455,7 +2455,12 @@ def test_default_listen_url_injected_when_no_config(tmp_path: Path) -> None:
 def test_config_listen_port_propagates_to_env(tmp_path: Path, env_save_restore) -> None:
     # Arrange
     cfg_yaml = tmp_path / "config.yaml"
-    cfg_yaml.write_text("listen:\n  port: 9090\n")
+    # This test writes its OWN config.yaml and so overrides the conftest
+    # scratch_root floor. build_run_argv now resolves where /uvwork lives
+    # and REFUSES when neither /scratch nor a declared root exists -- that
+    # refusal is the point of the change, and CI has no /scratch. Declaring
+    # a root the test owns keeps it hermetic on any host.
+    cfg_yaml.write_text(f"scratch_root: {tmp_path}\nlisten:\n  port: 9090\n")
     env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg_yaml))
     rt = ApptainerContainerRuntime()
     cfg = _config(tmp_path)
@@ -2470,7 +2475,10 @@ def test_config_listen_port_propagates_to_env(tmp_path: Path, env_save_restore) 
 def test_config_listen_host_propagates_to_env(tmp_path: Path, env_save_restore) -> None:
     # Arrange
     cfg_yaml = tmp_path / "config.yaml"
-    cfg_yaml.write_text("listen:\n  host: 100.64.1.2\n  port: 7878\n")
+    # Same reason as the port test above: own config, own scratch_root.
+    cfg_yaml.write_text(
+        f"scratch_root: {tmp_path}\nlisten:\n  host: 100.64.1.2\n  port: 7878\n"
+    )
     env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg_yaml))
     rt = ApptainerContainerRuntime()
     cfg = _config(tmp_path)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_scratch.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_scratch.py
@@ -21,6 +21,12 @@ detail:
   first bind to a destination and this default must behave like every other
   fleet default.
 
+Emitting the bind is READ-ONLY — one row here pins that no directory appears
+under the scratch root — and the rest of that split (the launch hook that
+creates the source and REFUSES on a host with nowhere to put it, and what a
+host with no scratch root at all does to each surface) lives in
+``test__apptainer_scratch_launch.py`` beside this file.
+
 No mocks (PA-306): real spec files, the real loader, real directories, the
 real argv builder. The only injected value is ``ScratchRoot`` — the
 resolver's own answer type, passed through the documented ``scratch``
@@ -36,7 +42,6 @@ from pathlib import Path
 
 import pytest
 
-from scitex_agent_container.config import load_config
 from scitex_agent_container._state.host_scratch import ScratchRoot, ScratchRootError
 from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
 from scitex_agent_container.runtimes._apptainer_scratch import (
@@ -46,43 +51,16 @@ from scitex_agent_container.runtimes._apptainer_scratch import (
     scratch_uvwork_dir,
     uvwork_bind_flags,
 )
-from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
-
-_BASE_SPEC = """\
-apiVersion: scitex-agent-container/v3
-kind: Agent
-metadata:
-  labels:
-    project: t
-    sac-builtin: "off"
-spec:
-  runtime: tui
-  host: ${HOSTNAME}
-  workdir: /tmp/agt-work
-  apptainer:
-    image: /x.sif
-    binds: []
-  health:
-    enabled: true
-    interval: 60
-  restart:
-    policy: on-failure
-    max_retries: 3
-  claude:
-    model: claude-opus-4-8[1m]
-    flags:
-      - --dangerously-skip-permissions
-"""
+from tests.scitex_agent_container._helpers.scratch_agent import (
+    load_uvwork_agent,
+    uvwork_binds,
+)
 
 
 @pytest.fixture
 def agent_config(tmp_path: Path):
     """A real, loadable spec named ``agt`` (the directory name is the name)."""
-    spec_dir = tmp_path / "agents" / "agt"
-    spec_dir.mkdir(parents=True)
-    spec = spec_dir / "spec.yaml"
-    spec.write_text(explicitize_yaml(_BASE_SPEC), encoding="utf-8")
-    return load_config(str(spec))
+    return load_uvwork_agent(tmp_path)
 
 
 @pytest.fixture
@@ -233,17 +211,6 @@ def test_the_flags_bind_the_per_agent_directory_read_write(
     assert flags == ["--bind", expected]
 
 
-def test_emitting_the_flags_creates_the_source(
-    agent_config, scratch: ScratchRoot
-) -> None:
-    # Arrange — a bind whose source does not exist is a FATAL at exec.
-    target = scratch.root / "sac" / "agents" / "agt" / "uvwork"
-    # Act
-    uvwork_bind_flags(agent_config, [], scratch=scratch)
-    # Assert
-    assert target.is_dir()
-
-
 def test_a_written_none_decision_emits_no_bind(
     agent_config, no_scratch: ScratchRoot
 ) -> None:
@@ -304,17 +271,6 @@ def test_a_bind_whose_SOURCE_is_uvwork_does_not_suppress_the_default(
 # ---------------------------------------------------------------------------
 
 
-def _uvwork_binds(argv: list[str]) -> list[str]:
-    """Every ``--bind`` value in ``argv`` whose DESTINATION is ``/uvwork``."""
-    out = []
-    for i, arg in enumerate(argv):
-        if arg == "--bind" and i + 1 < len(argv):
-            parts = argv[i + 1].split(":")
-            if (parts[1] if len(parts) > 1 else parts[0]) == UVWORK_CONTAINER_PATH:
-                out.append(argv[i + 1])
-    return out
-
-
 @pytest.fixture
 def host_declares_scratch(tmp_path: Path, env_save_restore) -> Path:
     """A real config.yaml declaring a real scratch root for THIS host."""
@@ -350,7 +306,7 @@ def test_build_run_argv_binds_uvwork_from_the_host_scratch_root(
         tui=True,
     )
     # Assert
-    assert _uvwork_binds(argv) == [expected]
+    assert uvwork_binds(argv) == [expected]
 
 
 def test_build_run_argv_emits_no_uvwork_bind_on_a_none_host(
@@ -366,4 +322,22 @@ def test_build_run_argv_emits_no_uvwork_bind_on_a_none_host(
         tui=True,
     )
     # Assert
-    assert _uvwork_binds(argv) == []
+    assert uvwork_binds(argv) == []
+
+
+def test_build_run_argv_creates_nothing_under_the_scratch_root(
+    agent_config, tmp_path: Path, host_declares_scratch: Path
+) -> None:
+    # Arrange — `sac agents explain` and `sac agents start --dry-run` both
+    # call this builder and start nothing. The rest of that split, and the
+    # host with no scratch root at all, are in
+    # ``test__apptainer_scratch_launch.py`` beside this file.
+    # Act
+    build_run_argv(
+        agent_config,
+        state_dir=tmp_path / "state3",
+        sif_path=Path("/img/sac.sif"),
+        tui=True,
+    )
+    # Assert
+    assert list(host_declares_scratch.rglob("uvwork")) == []

--- a/tests/scitex_agent_container/runtimes/test__apptainer_scratch.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_scratch.py
@@ -1,0 +1,369 @@
+"""``/uvwork`` is bound from the host scratch volume — the launch half.
+
+ADR-0024. Nothing bound ``/uvwork``, so uv, the uv cache, ``TMPDIR`` and the
+agent venv all landed in ``overlays/<agent>/upper/uvwork`` on the host's ROOT
+volume: 11.7 GB for sac alone, measured on scitex-compute-04 on 2026-09-03,
+on the volume that filled to 0 four times the day before.
+
+What these pin, and why each is a property rather than an implementation
+detail:
+
+* the bind exists AT ALL in the argv a real ``build_run_argv`` produces —
+  with the RED CONTROL right beside it: the same spec on a host that decided
+  ``scratch_root: none`` emits no ``/uvwork`` bind, so a green here cannot
+  come from some other layer happening to mention the path;
+* the source is ``<root>/sac/agents/<agent>/uvwork``, one directory per
+  agent, so two agents can never share a venv;
+* that directory is created 0700 — an agent's venv, cache and TMPDIR are its
+  private working set — and an EXISTING one is left alone, mode included, so
+  restarts never overrule an operator who tightened or loosened it; and
+* a spec that binds ``/uvwork`` itself WINS, because apptainer keeps the
+  first bind to a destination and this default must behave like every other
+  fleet default.
+
+No mocks (PA-306): real spec files, the real loader, real directories, the
+real argv builder. The only injected value is ``ScratchRoot`` — the
+resolver's own answer type, passed through the documented ``scratch``
+parameter so a test need not own the host's ``/scratch``.
+STX-TQ002 AAA markers; one fact per test (PA-307).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import load_config
+from scitex_agent_container._state.host_scratch import ScratchRoot, ScratchRootError
+from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
+from scitex_agent_container.runtimes._apptainer_scratch import (
+    UVWORK_CONTAINER_PATH,
+    UVWORK_DIR_MODE,
+    ensure_scratch_uvwork,
+    scratch_uvwork_dir,
+    uvwork_bind_flags,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+_BASE_SPEC = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: t
+    sac-builtin: "off"
+spec:
+  runtime: tui
+  host: ${HOSTNAME}
+  workdir: /tmp/agt-work
+  apptainer:
+    image: /x.sif
+    binds: []
+  health:
+    enabled: true
+    interval: 60
+  restart:
+    policy: on-failure
+    max_retries: 3
+  claude:
+    model: claude-opus-4-8[1m]
+    flags:
+      - --dangerously-skip-permissions
+"""
+
+
+@pytest.fixture
+def agent_config(tmp_path: Path):
+    """A real, loadable spec named ``agt`` (the directory name is the name)."""
+    spec_dir = tmp_path / "agents" / "agt"
+    spec_dir.mkdir(parents=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(explicitize_yaml(_BASE_SPEC), encoding="utf-8")
+    return load_config(str(spec))
+
+
+@pytest.fixture
+def scratch(tmp_path: Path) -> ScratchRoot:
+    """A resolved root standing in for this host's ``/scratch``."""
+    root = tmp_path / "scratch"
+    root.mkdir()
+    return ScratchRoot(root=root, source="config", reason="test config declares it")
+
+
+@pytest.fixture
+def no_scratch() -> ScratchRoot:
+    """The written decision: this host keeps ``/uvwork`` in the overlay."""
+    return ScratchRoot(root=None, source="none", reason="root LV is 8T")
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+# ---------------------------------------------------------------------------
+# The per-agent layout
+# ---------------------------------------------------------------------------
+
+
+def test_the_host_directory_is_per_agent_under_sac_agents(tmp_path: Path) -> None:
+    # Arrange
+    root = tmp_path / "scratch"
+    # Act
+    target = scratch_uvwork_dir(root, "agt")
+    # Assert
+    assert target == root / "sac" / "agents" / "agt" / "uvwork"
+
+
+def test_two_agents_never_share_a_uvwork_directory(tmp_path: Path) -> None:
+    # Arrange — the venv and uv cache are per-agent state.
+    root = tmp_path / "scratch"
+    # Act
+    first, second = scratch_uvwork_dir(root, "a"), scratch_uvwork_dir(root, "b")
+    # Assert
+    assert first != second
+
+
+def test_an_agent_name_with_a_separator_is_refused(tmp_path: Path) -> None:
+    # Arrange — a name is ONE path component; "../x" must not escape.
+    root = tmp_path / "scratch"
+    # Act
+    raised = pytest.raises(ValueError, match="path component")
+    # Assert
+    with raised:
+        scratch_uvwork_dir(root, "../elsewhere")
+
+
+def test_an_empty_agent_name_is_refused(tmp_path: Path) -> None:
+    # Arrange
+    root = tmp_path / "scratch"
+    # Act
+    raised = pytest.raises(ValueError, match="path component")
+    # Assert
+    with raised:
+        scratch_uvwork_dir(root, "")
+
+
+# ---------------------------------------------------------------------------
+# Creating the bind source
+# ---------------------------------------------------------------------------
+
+
+def test_the_bind_source_directory_is_created(tmp_path: Path) -> None:
+    # Arrange — apptainer needs the source to exist before exec.
+    root = tmp_path / "scratch"
+    root.mkdir()
+    # Act
+    target = ensure_scratch_uvwork(root, "agt")
+    # Assert
+    assert target.is_dir()
+
+
+def test_the_created_directory_is_owner_only(tmp_path: Path) -> None:
+    # Arrange
+    root = tmp_path / "scratch"
+    root.mkdir()
+    # Act
+    target = ensure_scratch_uvwork(root, "agt")
+    # Assert
+    assert _mode(target) == UVWORK_DIR_MODE
+
+
+def test_the_owner_only_mode_is_0700(tmp_path: Path) -> None:
+    # Arrange — spelled out so a silent widening of the constant fails here.
+    expected = 0o700
+    # Act
+    mode = UVWORK_DIR_MODE
+    # Assert
+    assert mode == expected
+
+
+def test_an_existing_directory_keeps_the_mode_it_had(tmp_path: Path) -> None:
+    # Arrange — restarts must not overrule an operator's own chmod.
+    root = tmp_path / "scratch"
+    existing = root / "sac" / "agents" / "agt" / "uvwork"
+    existing.mkdir(parents=True)
+    os.chmod(existing, 0o755)
+    # Act
+    ensure_scratch_uvwork(root, "agt")
+    # Assert
+    assert _mode(existing) == 0o755
+
+
+def test_an_existing_directorys_contents_survive_a_restart(tmp_path: Path) -> None:
+    # Arrange — the venv already built there must still be there.
+    root = tmp_path / "scratch"
+    existing = root / "sac" / "agents" / "agt" / "uvwork"
+    existing.mkdir(parents=True)
+    (existing / "marker").write_text("venv", encoding="utf-8")
+    # Act
+    ensure_scratch_uvwork(root, "agt")
+    # Assert
+    assert (existing / "marker").read_text(encoding="utf-8") == "venv"
+
+
+def test_a_file_where_the_directory_belongs_is_refused(tmp_path: Path) -> None:
+    # Arrange — apptainer's own message for this is far less useful.
+    root = tmp_path / "scratch"
+    target = root / "sac" / "agents" / "agt" / "uvwork"
+    target.parent.mkdir(parents=True)
+    target.write_text("not a directory", encoding="utf-8")
+    # Act
+    raised = pytest.raises(ScratchRootError, match="not a directory")
+    # Assert
+    with raised:
+        ensure_scratch_uvwork(root, "agt")
+
+
+# ---------------------------------------------------------------------------
+# The emitted flags
+# ---------------------------------------------------------------------------
+
+
+def test_the_flags_bind_the_per_agent_directory_read_write(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    expected = f"{scratch.root}/sac/agents/agt/uvwork:{UVWORK_CONTAINER_PATH}:rw"
+    # Act
+    flags = uvwork_bind_flags(agent_config, [], scratch=scratch)
+    # Assert
+    assert flags == ["--bind", expected]
+
+
+def test_emitting_the_flags_creates_the_source(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange — a bind whose source does not exist is a FATAL at exec.
+    target = scratch.root / "sac" / "agents" / "agt" / "uvwork"
+    # Act
+    uvwork_bind_flags(agent_config, [], scratch=scratch)
+    # Assert
+    assert target.is_dir()
+
+
+def test_a_written_none_decision_emits_no_bind(
+    agent_config, no_scratch: ScratchRoot
+) -> None:
+    # Arrange — the host chose the overlay, in writing.
+    # Act
+    flags = uvwork_bind_flags(agent_config, [], scratch=no_scratch)
+    # Assert
+    assert flags == []
+
+
+def test_a_spec_bind_to_uvwork_wins_over_the_default(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange — apptainer keeps the FIRST bind to a destination.
+    argv = ["--bind", f"/somewhere/else:{UVWORK_CONTAINER_PATH}"]
+    # Act
+    flags = uvwork_bind_flags(agent_config, argv, scratch=scratch)
+    # Assert
+    assert flags == []
+
+
+def test_a_spec_bind_to_uvwork_with_a_mode_also_wins(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange — the three-field spelling is the same declaration.
+    argv = ["--bind", f"/somewhere/else:{UVWORK_CONTAINER_PATH}:ro"]
+    # Act
+    flags = uvwork_bind_flags(agent_config, argv, scratch=scratch)
+    # Assert
+    assert flags == []
+
+
+def test_an_unrelated_bind_does_not_suppress_the_default(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange — the positive control for the two rows above.
+    argv = ["--bind", "/scratch:/scratch:rw", "--bind", "/data:/data"]
+    # Act
+    flags = uvwork_bind_flags(agent_config, argv, scratch=scratch)
+    # Assert
+    assert flags[0] == "--bind"
+
+
+def test_a_bind_whose_SOURCE_is_uvwork_does_not_suppress_the_default(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange — only the DESTINATION decides; a source named /uvwork is
+    # a different bind entirely.
+    argv = ["--bind", f"{UVWORK_CONTAINER_PATH}:/elsewhere"]
+    # Act
+    flags = uvwork_bind_flags(agent_config, argv, scratch=scratch)
+    # Assert
+    assert flags[0] == "--bind"
+
+
+# ---------------------------------------------------------------------------
+# End to end — the argv a real launch would receive
+# ---------------------------------------------------------------------------
+
+
+def _uvwork_binds(argv: list[str]) -> list[str]:
+    """Every ``--bind`` value in ``argv`` whose DESTINATION is ``/uvwork``."""
+    out = []
+    for i, arg in enumerate(argv):
+        if arg == "--bind" and i + 1 < len(argv):
+            parts = argv[i + 1].split(":")
+            if (parts[1] if len(parts) > 1 else parts[0]) == UVWORK_CONTAINER_PATH:
+                out.append(argv[i + 1])
+    return out
+
+
+@pytest.fixture
+def host_declares_scratch(tmp_path: Path, env_save_restore) -> Path:
+    """A real config.yaml declaring a real scratch root for THIS host."""
+    root = tmp_path / "host-scratch"
+    root.mkdir()
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(f"scratch_root: {root}\n", encoding="utf-8")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return root
+
+
+@pytest.fixture
+def host_declares_none(tmp_path: Path, env_save_restore) -> Path:
+    """A real config.yaml recording the decision to stay in the overlay."""
+    cfg = tmp_path / "config-none.yaml"
+    cfg.write_text(
+        "scratch_root: none\nscratch_root_reason: red control\n", encoding="utf-8"
+    )
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return cfg
+
+
+def test_build_run_argv_binds_uvwork_from_the_host_scratch_root(
+    agent_config, tmp_path: Path, host_declares_scratch: Path
+) -> None:
+    # Arrange
+    expected = f"{host_declares_scratch}/sac/agents/agt/uvwork:{UVWORK_CONTAINER_PATH}:rw"
+    # Act
+    argv = build_run_argv(
+        agent_config,
+        state_dir=tmp_path / "state",
+        sif_path=Path("/img/sac.sif"),
+        tui=True,
+    )
+    # Assert
+    assert _uvwork_binds(argv) == [expected]
+
+
+def test_build_run_argv_emits_no_uvwork_bind_on_a_none_host(
+    agent_config, tmp_path: Path, host_declares_none: Path
+) -> None:
+    # Arrange — the RED CONTROL for the row above: same spec, same builder,
+    # only the host's written decision differs.
+    # Act
+    argv = build_run_argv(
+        agent_config,
+        state_dir=tmp_path / "state2",
+        sif_path=Path("/img/sac.sif"),
+        tui=True,
+    )
+    # Assert
+    assert _uvwork_binds(argv) == []

--- a/tests/scitex_agent_container/runtimes/test__apptainer_scratch_launch.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_scratch_launch.py
@@ -1,0 +1,328 @@
+"""``/uvwork``: assembling the argv is not launching — the ADR-0024 split.
+
+``build_run_argv`` is reached by ``sac agents explain`` and by ``sac agents
+start --dry-run``, neither of which starts anything. So the ADR-0024 work
+divides in two, and these rows pin BOTH halves on BOTH kinds of host, because
+either half alone passes just as well while the other behaviour is exactly
+inverted:
+
+* **Emitting the bind writes nothing and refuses nothing.** No directory is
+  created on the host, and a host with no resolvable scratch root gets a
+  ``WARNING`` plus an argv without the bind — never an exception. A refusal
+  here made two READ-ONLY commands fail on a host condition, which is how
+  ``verify_tmpfs_headroom`` came to carry its own warning: a full disk made
+  ``explain`` unusable on exactly the host it would have diagnosed.
+* **The real launch creates the source and refuses.** ``ensure_uvwork_for_
+  launch`` — called from ``_apptainer_runtime.start`` and ``tui_session.start``
+  past their ``dry_run`` return — makes the bind source exist 0700 and raises
+  ``ScratchRootError`` naming the missing path. That refusal is the point of
+  ADR-0024 and these rows exist so it cannot be softened by accident.
+* **`explain` says which of those it is.** The plan renders binds by walking
+  the argv, so the one outcome it could not otherwise show is the one that
+  emits no bind — precisely the case where a start WILL refuse.
+
+The bind's shape, the per-agent layout and the spec-wins rule live in
+``test__apptainer_scratch.py`` beside this file; the shared spec is
+``_helpers/scratch_agent.py`` so the two suites cannot drift apart.
+
+No mocks (PA-306): real spec files, the real loader, real config.yaml files,
+real directories, the real argv builder. STX-TQ002 AAA markers; one fact per
+test (PA-307).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state.host_scratch import ScratchRoot, ScratchRootError
+from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
+from scitex_agent_container.runtimes._apptainer_scratch import (
+    UVWORK_CONTAINER_PATH,
+    UVWORK_DIR_MODE,
+    ensure_uvwork_for_launch,
+    uvwork_bind_flags,
+)
+from tests.scitex_agent_container._helpers.scratch_agent import (
+    load_uvwork_agent,
+    uvwork_binds,
+)
+
+
+@pytest.fixture
+def agent_config(tmp_path: Path):
+    """A real, loadable spec named ``agt``."""
+    return load_uvwork_agent(tmp_path)
+
+
+@pytest.fixture
+def scratch(tmp_path: Path) -> ScratchRoot:
+    """A resolved root standing in for this host's ``/scratch``."""
+    root = tmp_path / "scratch"
+    root.mkdir()
+    return ScratchRoot(root=root, source="config", reason="test config declares it")
+
+
+@pytest.fixture
+def no_scratch() -> ScratchRoot:
+    """The written decision: this host keeps ``/uvwork`` in the overlay."""
+    return ScratchRoot(root=None, source="none", reason="root LV is 8T")
+
+
+@pytest.fixture
+def host_declares_scratch(tmp_path: Path, env_save_restore) -> Path:
+    """A real config.yaml declaring a real scratch root for THIS host."""
+    root = tmp_path / "host-scratch"
+    root.mkdir()
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(f"scratch_root: {root}\n", encoding="utf-8")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return root
+
+
+@pytest.fixture
+def host_declares_a_missing_root(tmp_path: Path, env_save_restore) -> Path:
+    """A real config.yaml naming a scratch root that is not on this host."""
+    missing = tmp_path / "not-mounted"
+    cfg = tmp_path / "config-missing.yaml"
+    cfg.write_text(f"scratch_root: {missing}\n", encoding="utf-8")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return missing
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+# ---------------------------------------------------------------------------
+# Half one — assembling the argv writes nothing
+# ---------------------------------------------------------------------------
+
+
+def test_emitting_the_flags_creates_NOTHING(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange — this call is on `build_run_argv`, which `sac agents explain`
+    # and `--dry-run` also reach; a read-only command must not write.
+    target = scratch.root / "sac" / "agents" / "agt" / "uvwork"
+    # Act
+    uvwork_bind_flags(agent_config, [], scratch=scratch)
+    # Assert
+    assert not target.exists()
+
+
+def test_build_run_argv_creates_nothing_under_the_scratch_root(
+    agent_config, tmp_path: Path, host_declares_scratch: Path
+) -> None:
+    # Arrange — the same property through the REAL builder, on a real host
+    # config, because that is the surface `explain` actually calls.
+    # Act
+    build_run_argv(
+        agent_config,
+        state_dir=tmp_path / "state",
+        sif_path=Path("/img/sac.sif"),
+        tui=True,
+    )
+    # Assert
+    assert list(host_declares_scratch.rglob("uvwork")) == []
+
+
+# ---------------------------------------------------------------------------
+# Half one, continued — a host with NO scratch root states it, never raises
+# ---------------------------------------------------------------------------
+
+
+def test_build_run_argv_does_not_raise_when_no_scratch_root_resolves(
+    agent_config, tmp_path: Path, host_declares_a_missing_root: Path
+) -> None:
+    # Arrange — a read-only command must not fail on a launch-time host
+    # condition. A raise here is the regression this row exists to catch.
+    # Act
+    argv = build_run_argv(
+        agent_config,
+        state_dir=tmp_path / "state",
+        sif_path=Path("/img/sac.sif"),
+        tui=True,
+    )
+    # Assert
+    assert uvwork_binds(argv) == []
+
+
+# The instrument here is the process's own STDERR, read back at the file
+# descriptor (``capfd``) — not ``caplog`` and not a handler this test attaches
+# to the logger by name. Measured 2026-09-03, twice: both of those reported an
+# EMPTY record list in the full suite while pytest's own "Captured stderr" and
+# "Captured log call" sections printed the very WARNING they claimed was
+# absent. An instrument that says "nothing was emitted" about a message it is
+# simultaneously displaying is the one thing a visibility test must not use.
+# Stderr is also the property being claimed: the diagnostic must REACH A HUMAN
+# running `sac agents explain` on a host with no scratch root, which is a
+# statement about the terminal, not about a logging record.
+
+
+def test_an_unresolvable_root_reaches_stderr_not_a_silent_absence(
+    agent_config, host_declares_a_missing_root: Path, capfd
+) -> None:
+    # Arrange — logged at WARNING so it lands on stderr through the handler
+    # sac installs, and through Python's last-resort handler without one.
+    uvwork_bind_flags(agent_config, [])
+    # Act
+    err = capfd.readouterr().err
+    # Assert
+    assert "/uvwork" in err
+
+
+def test_the_stderr_diagnostic_names_the_agent_whose_start_would_refuse(
+    agent_config, host_declares_a_missing_root: Path, capfd
+) -> None:
+    # Arrange — a diagnostic that does not say WHICH agent is no diagnostic
+    # on a host running ninety of them.
+    uvwork_bind_flags(agent_config, [])
+    # Act
+    err = capfd.readouterr().err
+    # Assert
+    assert agent_config.name in err
+
+
+def test_the_stderr_diagnostic_names_the_path_that_is_missing(
+    agent_config, host_declares_a_missing_root: Path, capfd
+) -> None:
+    # Arrange — the operator's next action is a mount, and the message has
+    # to say of what.
+    uvwork_bind_flags(agent_config, [])
+    # Act
+    err = capfd.readouterr().err
+    # Assert
+    assert str(host_declares_a_missing_root) in err
+
+
+def test_a_resolvable_root_raises_no_stderr_alarm(
+    agent_config, host_declares_scratch: Path, capfd
+) -> None:
+    # Arrange — the positive control: the same call on a healthy host must
+    # NOT print a refusal, or the alarm means nothing when it does fire.
+    uvwork_bind_flags(agent_config, [])
+    # Act
+    err = capfd.readouterr().err
+    # Assert
+    assert "REFUSE" not in err
+
+
+def test_the_explain_line_names_the_refusal_a_start_would_hit(
+    agent_config, host_declares_a_missing_root: Path
+) -> None:
+    # Arrange — `explain` renders binds by walking the argv, so the one
+    # outcome it cannot show is the one that emits no bind. It says so.
+    from scitex_agent_container.cli_pkg._explain import _uvwork_line
+
+    # Act
+    line = _uvwork_line(agent_config)
+    # Assert
+    assert "REFUSE" in line
+
+
+def test_the_explain_line_names_the_source_when_the_root_resolves(
+    agent_config, host_declares_scratch: Path
+) -> None:
+    # Arrange — the positive control for the row above: same call, a host
+    # that CAN resolve, and the line names where /uvwork comes from.
+    from scitex_agent_container.cli_pkg._explain import _uvwork_line
+
+    # Act
+    line = _uvwork_line(agent_config)
+    # Assert
+    assert str(host_declares_scratch) in line
+
+
+def test_the_explain_line_cries_REFUSE_only_when_it_would(
+    agent_config, host_declares_scratch: Path
+) -> None:
+    # Arrange — the alarm must not fire on a healthy host, or it says
+    # nothing on an unhealthy one.
+    from scitex_agent_container.cli_pkg._explain import _uvwork_line
+
+    # Act
+    line = _uvwork_line(agent_config)
+    # Assert
+    assert "REFUSE" not in line
+
+
+# ---------------------------------------------------------------------------
+# Half two — the real launch creates the source, and refuses
+# ---------------------------------------------------------------------------
+
+
+def test_the_launch_hook_creates_the_source(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange — a bind whose source does not exist is a FATAL at exec, so
+    # the real launch path makes it exist.
+    argv = uvwork_bind_flags(agent_config, [], scratch=scratch)
+    target = scratch.root / "sac" / "agents" / "agt" / "uvwork"
+    # Act
+    ensure_uvwork_for_launch(agent_config, argv, scratch=scratch)
+    # Assert
+    assert target.is_dir()
+
+
+def test_the_launch_hook_creates_the_source_owner_only(
+    agent_config, scratch: ScratchRoot
+) -> None:
+    # Arrange
+    argv = uvwork_bind_flags(agent_config, [], scratch=scratch)
+    # Act
+    target = ensure_uvwork_for_launch(agent_config, argv, scratch=scratch)
+    # Assert
+    assert _mode(target) == UVWORK_DIR_MODE
+
+
+def test_the_launch_hook_leaves_a_spec_declared_bind_to_its_owner(
+    agent_config, scratch: ScratchRoot, tmp_path: Path
+) -> None:
+    # Arrange — the spec bound /uvwork itself and won, so sac emitted
+    # nothing; creating its source is not sac's to do.
+    argv = ["--bind", f"{tmp_path}/theirs:{UVWORK_CONTAINER_PATH}:rw"]
+    # Act
+    created = ensure_uvwork_for_launch(agent_config, argv, scratch=scratch)
+    # Assert
+    assert created is None
+
+
+def test_the_launch_hook_creates_nothing_on_a_written_none_decision(
+    agent_config, no_scratch: ScratchRoot
+) -> None:
+    # Arrange — the host keeps /uvwork in the overlay, in writing.
+    # Act
+    created = ensure_uvwork_for_launch(agent_config, [], scratch=no_scratch)
+    # Assert
+    assert created is None
+
+
+def test_the_launch_hook_refuses_when_no_scratch_root_resolves(
+    agent_config, host_declares_a_missing_root: Path
+) -> None:
+    # Arrange — undiminished: the start still refuses.
+    argv: list[str] = []
+    # Act
+    raised = pytest.raises(ScratchRootError)
+    # Assert
+    with raised:
+        ensure_uvwork_for_launch(agent_config, argv)
+
+
+def test_the_launch_refusal_names_the_missing_path(
+    agent_config, host_declares_a_missing_root: Path
+) -> None:
+    # Arrange — an operator's next action must be a mount, not a guess.
+    missing = str(host_declares_a_missing_root)
+    # Act
+    try:
+        ensure_uvwork_for_launch(agent_config, [])
+        message = "<no refusal was raised>"
+    except ScratchRootError as exc:
+        message = str(exc)
+    # Assert
+    assert missing in message


### PR DESCRIPTION
## The mechanism

Ninety of the 123 agent specs point `TMPDIR`, `UV_CACHE_DIR`, `UV_INSTALL_DIR`
and the agent venv (`/uvwork/venv-agent`) at `/uvwork`. The base image *creates*
that directory (`containers/apptainer-base.def`) and **nothing bound it** — so
an apptainer container's writes to it go to the overlay's **upper layer**, and
every agent's overlay lives on the host's **root logical volume**.

Measured on `scitex-compute-04`, 2026-09-03, in `overlays/<agent>/upper/uvwork`:

| agent | size |
| --- | --- |
| `sac` | 11.7 GB |
| `scitex-dev` | 3.3 GB |
| `scitex-hub` | 3.0 GB |
| `scitex-cards` | 2.5 GB |
| `scitex-storage` | 1.9 GB |

That root LV **filled to 0 four times on 2026-09-02**. `/scratch` on the same
host is a separate 3.0 T volume with 2.8 T free (compute-03 3.0 T / 2.8 T,
compute-01 295 G / 243 G), and **114 of the 123 specs already bind
`/scratch:/scratch:rw`**. The volume was mounted, bound, and unused for the one
thing filling the disk.

Operator directive, Telegram 2026-09-02: 「ディスクは /scratch 使ってくださいね」.

## What this does

1. **One knob, `scratch_root:` in the per-host `config.yaml`** — an absolute
   path, or the literal `none` (this host keeps `/uvwork` in the overlay), which
   is **refused without a `scratch_root_reason:`** beside it. No env var
   selects it. Absent, the default `/scratch` is probed — compute-01 and
   compute-03 have no `config.yaml` at all. With neither a declaration nor a
   `/scratch`, sac **refuses to start the agent**, naming the missing path, the
   key, the file and all three fixes. Falling back to the overlay silently is
   the bug being replaced.
2. **The bind.** Each start creates `<root>/sac/agents/<agent>/uvwork` (0700,
   idempotent — an existing directory keeps its mode and contents) and appends
   `--bind <that>:/uvwork:rw` in `_apptainer_argv_finalize`, after every
   spec-declared bind so a spec that binds `/uvwork` itself still wins, and
   before the secret lift so the credentials bind keeps its last-bind position.
   **No spec is edited**; `binds:` and `startup_commands` are untouched fleetwide.
3. **`sac agents scratch-migrate`** moves each STOPPED agent's stranded overlay
   copy across. Dry-run by default; `--apply` is the deliberate act; copy →
   **verify** every path, size and symlink target → only then remove the source.
   Exit codes: 0 sound, 1 the plan does not describe the sweep, 2 refused.
4. **ADR-0024** records the decision, the rejected alternatives, and the honest
   edge (a `scratch_root:` under `/home` gives jailed capsules a bind
   `enforce_jail` does not police, because sac's own binds never were in scope
   for that check).

## Two defects the first real dry-run found

Running it for real is why this PR is what it is.

**(a) The probe called the agent running it "stopped."** From inside the
`scitex-agent-container` agent, `is_running` (a pid file plus
`os.kill(pid, 0)`) reported the agent *executing the probe* as stopped and
offered its 10.3 GiB. The recorded pid was `3190806`; that container's `/proc`
tops out at `74275`, because the container has its own PID namespace. Neither
the pid file nor the adapter is wrong — the **vantage** is. So the verb now
abstains outright when `APPTAINER_CONTAINER` / `SINGULARITY_CONTAINER` is set:
every agent comes back UNKNOWN, which is a refusal, and the message says to run
it on the host. Sizes still print, because the overlays are read through a bind
mount and *that* reading is faithful.

**(b) One tree, listed as movable twice.** `scitex-hub` and
`scitex-hub-mobile-ux` declare the **same** `--overlay`, as do `scitex-cards` /
`scitex-todo` and eight `handyman-*` specs sharing `local-coder`. Applying that
would move the tree for the first agent, hand the second a source that no longer
exists, and file a shared tree into one agent's private directory. Which agent
owns a shared overlay is a fleet decision sac may not make, so **both** rows
refuse, each naming the others. Ownership is computed over the whole roster,
never the `--agent` subset.

Together they took the headline from a wrong **28.1 GiB across 17 agents** to a
truthful **8.1 GiB across 12**.

## The real dry-run (read-only), from the host vantage

`sac agents scratch-migrate` over the live 116-spec roster on
scitex-compute-04. `nothing` rows elided; nothing was written.

```
sac agents scratch-migrate  dry-run (read-only)

scratch root: /scratch (default: /scratch is a mount point on this host and
/home/ywatanabe/.scitex/agent-container/config.yaml declares no scratch_root:)
116 spec(s) under /home/ywatanabe/.scitex/agent-container/agents

  MOVE    canary-resume-test                 53.7 MiB  stopped; 56350248 bytes in 33 file(s) move to /scratch/sac/agents/canary-resume-test/uvwork
  MOVE    claude-code-telegrammer            89.7 MiB  stopped; 94069889 bytes in 1129 file(s) move to /scratch/sac/agents/claude-code-telegrammer/uvwork
  MOVE    figrecipe                         566.5 MiB  stopped; 594006840 bytes in 20763 file(s) move to /scratch/sac/agents/figrecipe/uvwork
  REFUSED scitex-agent-container             10.3 GiB  RUNNING (TuiSessionRuntime); stop it first: sac agents stop scitex-agent-container
  MOVE    scitex-agent-container-04         534.7 MiB  stopped; 560716126 bytes in 27551 file(s) move to /scratch/sac/agents/scitex-agent-container-04/uvwork
  MOVE    scitex-app                         64.6 MiB  stopped; 67748138 bytes in 1985 file(s) move to /scratch/sac/agents/scitex-app/uvwork
  REFUSED scitex-cards                        2.3 GiB  RUNNING (TuiSessionRuntime); stop it first: sac agents stop scitex-cards
  MOVE    scitex-cards-gui                  214.5 MiB  stopped; 224971247 bytes in 25486 file(s) move to /scratch/sac/agents/scitex-cards-gui/uvwork
  MOVE    scitex-db                           1.6 GiB  stopped; 1734531125 bytes in 122972 file(s) move to /scratch/sac/agents/scitex-db/uvwork
  MOVE    scitex-dev                          2.6 GiB  stopped; 2826297786 bytes in 209435 file(s) move to /scratch/sac/agents/scitex-dev/uvwork
  MOVE    scitex-hpc                        137.9 MiB  stopped; 144617303 bytes in 14439 file(s) move to /scratch/sac/agents/scitex-hpc/uvwork
  REFUSED scitex-hub                          2.6 GiB  /home/ywatanabe/.scitex/agent-container/containers/overlays/scitex-hub/upper/uvwork is ALSO declared by scitex-hub-mobile-ux; moving it into /scratch/sac/agents/scitex-hub/uvwork would take it away from them. Give each agent its own overlay, or move this tree by hand.
  REFUSED scitex-hub-mobile-ux                2.6 GiB  /home/ywatanabe/.scitex/agent-container/containers/overlays/scitex-hub/upper/uvwork is ALSO declared by scitex-hub; moving it into /scratch/sac/agents/scitex-hub-mobile-ux/uvwork would take it away from them. Give each agent its own overlay, or move this tree by hand.
  MOVE    scitex-live-paper                 592.8 MiB  stopped; 621556616 bytes in 4116 file(s) move to /scratch/sac/agents/scitex-live-paper/uvwork
  MOVE    scitex-storage                      1.6 GiB  stopped; 1667501297 bytes in 236732 file(s) move to /scratch/sac/agents/scitex-storage/uvwork
  REFUSED scitex-todo                         2.3 GiB  /home/ywatanabe/.scitex/agent-container/containers/overlays/scitex-cards/upper/uvwork is ALSO declared by scitex-cards; moving it into /scratch/sac/agents/scitex-todo/uvwork would take it away from them. Give each agent its own overlay, or move this tree by hand.
  MOVE    scitex-ui                          91.0 MiB  stopped; 95406435 bytes in 15385 file(s) move to /scratch/sac/agents/scitex-ui/uvwork

12 agent(s), 8.1 GiB (8687773050 bytes) would move from the overlay upper to
/scratch
5 refused: scitex-agent-container, scitex-cards, scitex-hub,
scitex-hub-mobile-ux, scitex-todo

Nothing was moved — this is a dry-run. To act:
    sac agents scratch-migrate --apply
```

`--json` on the same run: `scratch_source: "default"`, `liveness_vantage: ""`
(host), `roster: "populated"`, `specs: 116`, `safe_to_apply: true`,
`total_bytes: 8687773050`, `exit_code: 0`.

**`--apply` was NOT run against the real overlays.**

The same command from *inside* an agent container, for contrast — the guard
doing its job:

```
LIVENESS UNREADABLE FROM HERE — this process runs INSIDE a container
(APPTAINER_CONTAINER=…/sac-base-2026-0902-195723.sif), which has its own PID
namespace, so an agent's recorded host pid resolves to nobody here and every
agent reads as 'stopped'. Run `sac agents scratch-migrate` on the HOST instead.

0 agent(s), 0 B (0 bytes) would move from the overlay upper to /scratch
17 refused: canary-resume-test, claude-code-telegrammer, figrecipe,
scitex-agent-container, …
```

## Positive controls

Every new behaviour was shown to FAIL without its production code. Each control
patched one thing, ran the suite, and reverted; the summaries are the red ones.

| control | change | red |
| --- | --- | --- |
| A | drop `argv += uvwork_bind_flags(...)` | `test_build_run_argv_binds_uvwork_from_the_host_scratch_root` — 1 failed, 18 passed |
| B | resolver falls back to the overlay instead of refusing | 5 failed, 16 passed (all four refusal-message rows) |
| C | `scratch_root: none` no longer needs a reason | 2 failed, 13 passed |
| D | undeterminable liveness read as "stopped" | 2 failed, 32 passed |
| E | remove the overlay copy without verifying | 3 failed, 31 passed |
| F | CLI applies by default | 4 failed, 15 passed |
| G | create the bind source 0755 | `test_the_created_directory_is_owner_only` — 1 failed, 18 passed |
| H | the container vantage guard never fires | 8 failed, 24 passed |
| I | a shared overlay is moved for whoever comes first | 4 failed, 19 passed |

Control A's companion red control (`…emits_no_uvwork_bind_on_a_none_host`)
stays green under A by design — it is the control, not the assertion.

## Tests

New: `_state/test_host_scratch.py` (the resolution table, all four rows plus the
answer shape), `_state/test_host_config_scratch.py` (block parsing, the
reason-less `none` and the orphan reason), `runtimes/test__apptainer_scratch.py`
(layout, 0700, idempotence, spec-bind-wins, and the bind in a real
`build_run_argv` argv with a red control), `_maintenance/test__scratch_migrate*.py`
(planning, applying, measuring, liveness) and
`cli_pkg/test__agents_scratch_migrate.py` (dry-run default, exit codes, the
vantage). No mocks anywhere: real specs, the real loader, real trees, the real
`copytree` and `rmtree`. Only liveness is injected, through the module's
documented seam — a test cannot make a real agent run.

`_scratch_migrate.py` crossed the 512-line ceiling while gaining the two guards
and was split by responsibility into `_scratch_migrate_measure.py` (`tree_size`
/ `verify_copy`) and `_scratch_migrate_liveness.py` (`agent_liveness` /
`liveness_vantage`), both re-exported so the import site is unchanged. The test
files split to match, sharing `tests/.../_helpers/scratch_fleet.py`.

## Note on `tests/conftest.py`

The suite floor now writes a per-worker `config.yaml` declaring a `scratch_root`
inside the sandbox. Without it, ~20 test modules that assemble a launch argv
would each create `sac/agents/agt/uvwork` on the operator's real `/scratch`
(present on every compute host and inside every agent container), and on a box
*without* `/scratch` the same tests would refuse the launch instead — the
resolver doing its job on the wrong population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adzed4bZzRxEDbMh9QoRtV
