### PR TITLE
feat(rate-limit): recognise the per-model budget banner as a cap, not an auth failure

### DIFF
--- a/src/scitex_agent_container/_account/rate_limit_signals.py
+++ b/src/scitex_agent_container/_account/rate_limit_signals.py
@@ -152,6 +152,26 @@ DEFAULT_TEXTUAL_PATTERNS: tuple[str, ...] = (
     r"organization .*? rate limit",
     # Generic "quota exhausted" / "quota exceeded".
     r"quota (?:exhausted|exceeded|reached)",
+    # PER-MODEL budget, distinct from the subscription windows above.
+    # Measured 2026-09-03: a session was stopped by
+    #   "You've reached your Fable limit. Run /usage-credits to continue
+    #    or switch models with /model."
+    # and NONE of the patterns above match it -- it says "limit", not
+    # "quota"; "Fable", not "weekly" or "usage". So the cap check fell
+    # through and the supervisor's NEXT classifier saw the wreckage, which
+    # is auth-shaped: subagents reported "Login expired - Please run
+    # /login" while the account was healthy and answering. Catching it here
+    # matters because this check runs BEFORE that auth classification, so
+    # one data line is the difference between "capped" and an afternoon
+    # spent re-authenticating a working credential.
+    #
+    # Model-agnostic on purpose: the same sentence is issued per model, and
+    # tying it to one name guarantees a re-fix on the next one.
+    r"reached your \w+ limit",
+    # The remedy the same banner offers, as a second, independent marker.
+    # A cap detector that depends on one sentence surviving a copy edit is
+    # one A/B test away from silence.
+    r"/usage-credits",
 )
 
 

--- a/tests/scitex_agent_container/_account/test_rate_limit_classifier.py
+++ b/tests/scitex_agent_container/_account/test_rate_limit_classifier.py
@@ -28,7 +28,10 @@ from scitex_agent_container._account.rate_limit_classifier import (
     Mode,
     classify_rate_limit_signal,
 )
-from scitex_agent_container._account.rate_limit_signals import RateLimitSignal
+from scitex_agent_container._account.rate_limit_signals import (
+    RateLimitSignal,
+    detect_signal_from_text,
+)
 
 # ---------------------------------------------------------------------------
 # Mode enum — value contract
@@ -241,5 +244,25 @@ def test_auth_event_at_zero_usage_still_returns_rotate():
     snapshot = AccountUsageSnapshot()
     # Act
     mode = classify_rate_limit_signal(RateLimitSignal.AUTH_EVENT, snapshot)
+    # Assert
+    assert mode is Mode.ROTATE
+
+
+def test_per_model_limit_banner_reaches_the_rotate_action():
+    # Arrange — the end-to-end wiring the operator asked about: a regex in
+    # rate_limit_signals, and the action taken when it matches. The usage
+    # snapshot is deliberately HEALTHY (17% / 80%, the real reading taken
+    # minutes after a Fable limit fired) because the per-model budget is
+    # invisible to those subscription windows. If this signal were gated on
+    # usage% the way HTTP_429 is, a genuine cap would be classified as a
+    # transient burst and retried straight back into the same wall.
+    text = (
+        "You have reached your Fable limit. Run /usage-credits to "
+        "continue or switch models with /model."
+    )
+    signal = detect_signal_from_text(text)
+    usage = AccountUsageSnapshot(used_pct_5h=17.0, used_pct_7d=80.0)
+    # Act
+    mode = classify_rate_limit_signal(signal[0], usage)
     # Assert
     assert mode is Mode.ROTATE

--- a/tests/scitex_agent_container/_account/test_rate_limit_signals.py
+++ b/tests/scitex_agent_container/_account/test_rate_limit_signals.py
@@ -311,3 +311,50 @@ def test_detect_signal_from_text_returns_the_matched_pattern():
     result = detect_signal_from_text(text)
     # Assert
     assert result is not None and result[1] == "overloaded_error"
+
+
+def test_per_model_limit_banner_is_a_cap_not_an_auth_failure():
+    # Arrange — the exact banner that stopped a session on 2026-09-03.
+    # Before this pattern existed nothing here matched it, so the cap
+    # check fell through and the supervisor's NEXT classifier judged the
+    # auth-shaped wreckage instead.
+    text = (
+        "You have reached your Fable limit. Run /usage-credits to "
+        "continue or switch models with /model."
+    )
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.TEXTUAL_MATCH
+
+
+def test_per_model_limit_pattern_is_not_tied_to_one_model_name():
+    # Arrange — the same sentence is issued per model; pinning the name
+    # guarantees a re-fix on the next one.
+    text = "You have reached your Mythos limit."
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.TEXTUAL_MATCH
+
+
+def test_the_remedy_link_is_an_independent_second_marker():
+    # Arrange — a detector resting on one sentence is one copy edit away
+    # from silence, so the remedy the banner offers is matched too.
+    text = "Run /usage-credits to continue."
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.TEXTUAL_MATCH
+
+
+def test_an_auth_banner_alone_is_still_not_a_cap():
+    # Arrange — the control. "Login expired" accompanies this cap, but it
+    # also accompanies a REAL expired credential. If the cap scan claimed
+    # it, every genuine auth failure would be misrouted to backoff/rotate
+    # and the credential would never be refreshed.
+    text = "Login expired - Please run /login"
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is None


### PR DESCRIPTION
## What happened

A session was stopped on 2026-09-03 by:

```
You've reached your Fable limit. Run /usage-credits to continue
or switch models with /model.
```

**None of `DEFAULT_TEXTUAL_PATTERNS` matched it.** It says *limit*, not *quota*;
*Fable*, not *weekly* or *usage*. So the cap scan fell through — and the
supervisor's **next** classifier judged what was left, which is auth-shaped.
Four workflow subagents came back as:

```
[implement]           failed: Login expired · Please run /login
[verify:correctness]  failed: Login expired · Please run /login
[verify:constraints]  failed: Login expired · Please run /login
[verify:operations]   failed: Login expired · Please run /login
```

The account was healthy throughout — `sac accounts status` returned tier and
quota with exit 0, and the same account resumed minutes later on a different
model. An agent that believes that line re-authenticates a credential that was
never broken.

**The ordering is why one data line is worth this much.** Per
`_rate_limit_reactive`, the cap check is the supervisor's *second* recovery
check and runs **before** the auth-expired classification. Which classifier
claims the event decides whether the fleet reads "capped" or spends an afternoon
on a working credential.

## The change

Two patterns, not one:

| pattern | why |
|---|---|
| `reached your \w+ limit` | the banner, **model-agnostic on purpose** — the same sentence is issued per model, and pinning the name guarantees a re-fix on the next one |
| `/usage-credits` | the remedy the same banner offers, as an independent second marker. A cap detector resting on one sentence is one copy edit away from silence |

## No action-layer change is needed

Verified in the code rather than the docstring: `classify_rate_limit_signal`
maps `TEXTUAL_MATCH` to `Mode.ROTATE` **unconditionally**, not gated on usage%.

That matters more than usual here, because **the usage snapshot is blind to this
event**. Read minutes after the limit fired it said 5h 16–17%, 7d 80% — both far
from exhaustion, because those are *subscription* windows and this is a separate
*per-model* budget. Had this signal been gated on usage the way `HTTP_429` is, a
genuine cap would have been classified as a transient burst and retried straight
back into the same wall. A test pins that end to end.

## Tests

Four new, and the fourth is the one that decides whether this is safe:

- the banner classifies as a cap
- the pattern is not tied to one model name
- the remedy link is an independent marker
- **an auth banner alone is still NOT a cap** — "Login expired" accompanies this
  event, but it also accompanies a genuinely expired credential. If the cap scan
  claimed it, every real auth failure would be misrouted to backoff/rotate and
  the credential would never be refreshed.

`703 passed` across `tests/scitex_agent_container/_account/`, run against this
worktree's source.

## Related

`.dotfiles` #397 adds a transcript hook for the same event. That covers the case
this cannot: a Claude Code session **not** under sac supervision, where nothing
external is watching the pane. This PR is the primary mechanism — it works from
outside a stalled session, whereas the hook cannot fire until a human has
already restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adzed4bZzRxEDbMh9QoRtV
