### PR TITLE
fix(dispatch): remote agent start and restart run under the peer login shell

### DIFF
--- a/src/scitex_agent_container/_state/_host_ssh.py
+++ b/src/scitex_agent_container/_state/_host_ssh.py
@@ -125,8 +125,21 @@ def build_ssh_argv(
     *,
     ssh_binary: str = "ssh",
     extra_opts: list[str] | None = None,
+    login: bool = False,
 ) -> list[str]:
     """Render the ssh argv that runs ``command`` on ``peer_name``.
+
+    ``login=True`` runs the command under ``bash -lc`` on a peer WITHOUT an
+    ``env_preamble``, so the remote user's login profile is sourced first.
+    A bare ``ssh host cmd`` sources neither .bash_profile nor .bashrc, and
+    on this fleet that profile is the ONLY carrier of the secrets in
+    ``~/.bash.d/secrets`` -- measured 2026-09-05 on scitex-compute-01: 0
+    ``CCT_*`` variables and no gateway key under a bare ssh command, all
+    of them under ``bash -lc``. An agent START on a peer needs those (the
+    engine's ``auth_token_env``, the bot tokens), so the two lifecycle
+    dispatchers ask for it; probes and file copies do not. A peer WITH a
+    preamble keeps the ``bash -c`` wrapper regardless -- the HPC bashrc
+    kill described below is why -- and its preamble owns the env.
 
     Multi-hop is handled via OpenSSH's ``-J`` (ProxyJump) flag, which
     chains intermediate hosts without sac needing its own ssh tunnel
@@ -236,6 +249,12 @@ def build_ssh_argv(
         # peer's behaviour depend on whether it happened to carry a preamble.
         inner = f"{preamble} && {' '.join(command)}"
         argv.append(f"bash -c {shlex.quote(inner)}")
+    elif login:
+        # Same single-element, space-joined contract as the preamble branch
+        # (see above for why the join is a space, never shlex.join); only the
+        # shell flag differs, and it differs on purpose: -l sources the
+        # remote login profile, which is where the fleet keeps its secrets.
+        argv.append(f"bash -lc {shlex.quote(' '.join(command))}")
     else:
         argv += list(command)
     return argv

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -186,7 +186,9 @@ def _dispatch_remote_start(
     remote_argv = ["sac", "agents", "start", name, "--no-redispatch", "--json"]
     if engine:
         remote_argv += ["--engine", engine]
-    ssh_argv = build_ssh_argv(peer, remote_argv, peers_map)
+    # login=True for the same reason as the restart dispatch: an agent start
+    # on the peer needs the secrets only its login profile carries.
+    ssh_argv = build_ssh_argv(peer, remote_argv, peers_map, login=True)
     ssh_result = subprocess.run(
         ssh_argv,
         capture_output=True,
@@ -355,9 +357,7 @@ def try_dispatch(
     except Exception:
         # The failure is re-raised UNCHANGED — this only adds the sentence the
         # operator needs to attribute it. See :func:`_explain_pinned_hop_failure`.
-        _explain_pinned_hop_failure(
-            config.name, config.hosts_spec.host, dispatch_peer
-        )
+        _explain_pinned_hop_failure(config.name, config.hosts_spec.host, dispatch_peer)
         raise
     return True
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -167,8 +167,8 @@ def _dispatch_remote_start(
     # env_preamble is honoured by build_ssh_argv (bash -lc wrapper).
     import json as _json
 
-    from ..._state.host_config import build_ssh_argv
     from ..._state._remote_sac_hint import remote_sac_not_found_hint
+    from ..._state.host_config import build_ssh_argv
     from ..._state.host_config import load as _load_host_config
     from ..._state.state_db import record_instance_start
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart_remote.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart_remote.py
@@ -139,7 +139,12 @@ def _dispatch_remote_restart(
     (no-silent-fallback rule). Returns the parsed JSON envelope from the
     peer's stdout.
     """
-    ssh_argv = build_ssh_argv(peer, remote_restart_argv(name, engine), peers)
+    # login=True: the peer's login profile carries the fleet secrets the
+    # restart needs (the engine's auth_token_env among them); a bare ssh
+    # command sees none of them and the peer refuses the engine as "unset".
+    ssh_argv = build_ssh_argv(
+        peer, remote_restart_argv(name, engine), peers, login=True
+    )
     result = subprocess.run(
         ssh_argv,
         capture_output=True,

--- a/tests/scitex_agent_container/_state/test__host_ssh.py
+++ b/tests/scitex_agent_container/_state/test__host_ssh.py
@@ -160,3 +160,64 @@ def test_a_bare_peer_gets_no_preamble_wrapper(peers):
     argv = build_ssh_argv(_BARE_PEER, command, peers)
     # Assert
     assert not argv[-1].startswith("bash -c ")
+
+
+# ---------------------------------------------------------------------------
+# login=True: an agent start on a peer runs under the peer's LOGIN profile.
+# Measured 2026-09-05 on scitex-compute-01: a bare `ssh host cmd` carries no
+# ~/.bash.d/secrets variable at all (0 CCT_*, no gateway key); `bash -lc`
+# carries every one. The engine honour check on the peer read "unset".
+# ---------------------------------------------------------------------------
+def test_login_wraps_a_bare_peers_command_in_a_login_shell(peers):
+    # Arrange
+    command = ["sac", "agents", "restart", "business", "--yes", "--json"]
+
+    # Act
+    argv = build_ssh_argv(_BARE_PEER, command, peers, login=True)
+
+    # Assert
+    assert argv[-1].startswith("bash -lc ")
+
+
+def test_login_keeps_the_command_intact_inside_the_login_shell(peers):
+    # Arrange
+    command = ["sac", "agents", "restart", "business", "--yes", "--json"]
+
+    # Act
+    inner = shlex.split(build_ssh_argv(_BARE_PEER, command, peers, login=True)[-1])[2]
+
+    # Assert
+    assert inner.endswith("sac agents restart business --yes --json")
+
+
+def test_login_is_one_argv_element_so_ssh_cannot_split_it(peers):
+    # Arrange
+    command = ["sac", "agents", "start", "business", "--engine", "qwen38-27b"]
+
+    # Act
+    argv = build_ssh_argv(_BARE_PEER, command, peers, login=True)
+
+    # Assert
+    assert argv[argv.index("--") + 1 :] == [argv[-1]]
+
+
+def test_login_leaves_a_preamble_peer_on_the_plain_shell(peers):
+    # Arrange -- the HPC bashrc kill is why a preamble peer never gets -l
+    command = ["sac", "agents", "start", "spartan-dev"]
+
+    # Act
+    argv = build_ssh_argv(_PREAMBLE_PEER, command, peers, login=True)
+
+    # Assert
+    assert argv[-1].startswith("bash -c ")
+
+
+def test_login_off_is_the_pre_existing_bare_shape(peers):
+    # Arrange
+    command = ["sac", "agents", "list"]
+
+    # Act
+    argv = build_ssh_argv(_BARE_PEER, command, peers)
+
+    # Assert
+    assert argv[argv.index("--") + 1 :][-3:] == ["sac", "agents", "list"]

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -48,6 +49,7 @@ def _instances_store(pg_schema: str):
     happens to point at.
     """
     yield
+
 
 # ---------------------------------------------------------------------------
 # Shim helpers — dual-behavior rsync (dry-run vs real) plus a fake ssh.
@@ -277,6 +279,7 @@ _PEER_DRIFTED = f"{'0' * 32}  ./spec.yaml\n"
 
 _OK_JSON = '{"a2a_port": 47213, "started_at": "2026-05-16T00:00:00Z"}'
 
+
 def _peer_that_delivers(**start_kwargs) -> dict[str, Any]:
     """A peer whose handoff genuinely succeeds, varying only its start reply.
 
@@ -299,7 +302,9 @@ _SK_OK = _peer_that_delivers(stdout=_OK_JSON, exit=0)
 
 
 class TestDispatchDriftBlocksWithoutForce:
-    def test_drift_without_force_raises_runtime_error(self, spec_dir, shim_bin, registered_peer, capsys):
+    def test_drift_without_force_raises_runtime_error(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange — the peer holds a DIFFERENT spec.yaml.
         sk = dict(peer_manifest=_PEER_DRIFTED)
         # Act
@@ -307,7 +312,9 @@ class TestDispatchDriftBlocksWithoutForce:
         # Assert
         assert isinstance(scen.raised, RuntimeError)
 
-    def test_drift_message_mentions_spec_drift(self, spec_dir, shim_bin, registered_peer, capsys):
+    def test_drift_message_mentions_spec_drift(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange
         sk = dict(peer_manifest=_PEER_DRIFTED)
         # Act
@@ -315,7 +322,9 @@ class TestDispatchDriftBlocksWithoutForce:
         # Assert
         assert "Spec drift" in scen.message
 
-    def test_drift_message_names_the_differing_file(self, spec_dir, shim_bin, registered_peer, capsys):
+    def test_drift_message_names_the_differing_file(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange
         sk = dict(peer_manifest=_PEER_DRIFTED)
         # Act
@@ -348,7 +357,9 @@ class TestDispatchDriftBlocksWithoutForce:
 
 
 class TestDispatchDryRunMode:
-    def test_dry_run_mode_does_not_raise(self, spec_dir, shim_bin, registered_peer, capsys):
+    def test_dry_run_mode_does_not_raise(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange
         sk = dict(peer_manifest="")
         # Act
@@ -356,7 +367,9 @@ class TestDispatchDryRunMode:
         # Assert
         assert scen.raised is None
 
-    def test_dry_run_mode_returns_zero_exit(self, spec_dir, shim_bin, registered_peer, capsys):
+    def test_dry_run_mode_returns_zero_exit(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange
         sk = dict(peer_manifest="")
         # Act
@@ -364,7 +377,9 @@ class TestDispatchDryRunMode:
         # Assert
         assert scen.returned == 0
 
-    def test_dry_run_mode_prints_dispatch_marker(self, spec_dir, shim_bin, registered_peer, capsys):
+    def test_dry_run_mode_prints_dispatch_marker(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange
         sk = dict(peer_manifest="")
         # Act
@@ -372,7 +387,9 @@ class TestDispatchDryRunMode:
         # Assert
         assert "[dispatch] dry-run" in scen.captured_stdout
 
-    def test_dry_run_mode_ships_nothing(self, spec_dir, shim_bin, registered_peer, capsys):
+    def test_dry_run_mode_ships_nothing(
+        self, spec_dir, shim_bin, registered_peer, capsys
+    ):
         # Arrange
         sk = dict(peer_manifest="")
         # Act
@@ -978,7 +995,15 @@ class TestTryDispatchClassification:
         # verb (the earlier calls are the manifest read, the transfer and the
         # post-transfer verification).
         ssh_calls = _ssh_invocations(shim_bin)
-        assert out is True and ssh_calls[-1][-6:] == [
+        # Since 2026-09-05 the verb rides inside ONE `bash -lc '<cmd>'`
+        # element so the peer's login profile (its secrets) is sourced first.
+        last = ssh_calls[-1][-1]
+        inner = (
+            shlex.split(last)[2]
+            if last.startswith("bash -lc ")
+            else " ".join(ssh_calls[-1])
+        )
+        assert out is True and inner.split()[-6:] == [
             "sac",
             "agents",
             "start",

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
@@ -447,14 +447,26 @@ def test_cross_host_restart_ssh_argv_carries_restart_verb(
     assert "sac agents restart zeta" in argv
 
 
+def _remote_command_line(argv: list[str]) -> str:
+    """What the peer's shell runs: the `bash -lc` payload when wrapped, else the tail."""
+    import shlex as _shlex
+
+    if argv and argv[-1].startswith("bash -lc "):
+        return _shlex.split(argv[-1])[2]
+    return " ".join(argv[argv.index("--") + 1 :]) if "--" in argv else " ".join(argv)
+
+
 def test_cross_host_restart_ssh_argv_includes_json_flag(remote_row_for_zeta, ssh_shim):
-    # Arrange
+    # Arrange -- since 2026-09-05 the remote verb rides inside ONE
+    # `bash -lc '<cmd>'` element (the peer's login profile carries the fleet
+    # secrets an engine needs), so the flag is asserted on that inner command.
     runner = CliRunner()
     # Act
     runner.invoke(restart, ["zeta", "-y"])
     argv = _ssh_invocations(ssh_shim)[-1]
+    inner = _remote_command_line(argv)
     # Assert
-    assert "--json" in argv
+    assert "--json" in inner.split()
 
 
 def test_cross_host_restart_does_not_call_local_agent_restart(


### PR DESCRIPTION
## Why

`sac agents restart business --engine qwen38-27b` from compute-04 was refused **by the peer**: `$SCITEX_GENAI_GATEWAY_API_KEY … is unset on this host`. The key is on compute-01 — in a login shell. Measured there:

| command on compute-01 | result |
|---|---|
| `ssh compute-01 'printf %s ${KEY:+set}'` | *(empty)* |
| `ssh compute-01 'bash -lc "printf %s ${KEY:+set}"'` | `set` |
| `ssh compute-01 'env \| grep -c ^CCT_'` | `0` |

A bare `ssh host cmd` sources neither `.bash_profile` nor `.bashrc`, and on this fleet the login profile (`~/.bash.d/secrets`, `export NAME=value` lines) is the **only** carrier of every secret an agent start needs — the engine's `auth_token_env`, the bot tokens. Both lifecycle dispatchers sent the remote `sac` command bare, so no engine with an auth env could ever be honoured on a peer, and the refusal blamed the host.

## What

- `build_ssh_argv(..., login=True)` — wraps the command as one argv element `bash -lc '<space-joined command>'`, the same single-element/space-join contract the `env_preamble` branch already uses. A peer **with** a preamble keeps `bash -c` (the HPC bashrc-kill hazard documented there); its preamble owns that env.
- `_dispatch._dispatch_remote_start` and `_restart_remote._dispatch_remote_restart` pass `login=True`. Every other caller (probes, stop, delete, file copies) is unchanged.
- Tests in `test__host_ssh.py`: wrapper prefix, command intact inside it, single element, preamble peer unaffected, default shape unchanged.

## Deploy

The host CLI on compute-04 runs from the checkout; a pull of develop after merge is the deploy. Verified next by the business restart itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adzed4bZzRxEDbMh9QoRtV
