### PR TITLE
fix(dispatch): a preamble peer can opt into the login shell (PeerSpec.login_shell)

### DIFF
--- a/src/scitex_agent_container/_state/_host_ssh.py
+++ b/src/scitex_agent_container/_state/_host_ssh.py
@@ -138,8 +138,10 @@ def build_ssh_argv(
     of them under ``bash -lc``. An agent START on a peer needs those (the
     engine's ``auth_token_env``, the bot tokens), so the two lifecycle
     dispatchers ask for it; probes and file copies do not. A peer WITH a
-    preamble keeps the ``bash -c`` wrapper regardless -- the HPC bashrc
-    kill described below is why -- and its preamble owns the env.
+    preamble keeps the ``bash -c`` wrapper unless its entry says
+    ``login_shell: true`` -- the compute hosts, whose preamble only fixes
+    PATH and whose profile carries the secrets -- because the HPC bashrc
+    kill described below is what the default protects against.
 
     Multi-hop is handled via OpenSSH's ``-J`` (ProxyJump) flag, which
     chains intermediate hosts without sac needing its own ssh tunnel
@@ -248,7 +250,12 @@ def build_ssh_argv(
         # two agree is the fix; quoting here and not there is what made a
         # peer's behaviour depend on whether it happened to carry a preamble.
         inner = f"{preamble} && {' '.join(command)}"
-        argv.append(f"bash -c {shlex.quote(inner)}")
+        # A preamble peer sources its login profile only when BOTH the
+        # caller asks (login=True: an agent start needs the fleet secrets)
+        # AND the peer says its profile is safe (login_shell: true in
+        # config.yaml). HPC peers never set it -- see the docstring.
+        flag = "-lc" if (login and peer.login_shell) else "-c"
+        argv.append(f"bash {flag} {shlex.quote(inner)}")
     elif login:
         # Same single-element, space-joined contract as the preamble branch
         # (see above for why the join is a space, never shlex.join); only the

--- a/src/scitex_agent_container/_state/host_config.py
+++ b/src/scitex_agent_container/_state/host_config.py
@@ -116,6 +116,15 @@ class PeerSpec:
     static fallback — Phase 2 will decide the precedence rule. See
     :class:`ResolveSpec` for the field shape.
 
+    ``login_shell`` (default False) says the peer's login profile may be
+    sourced by an agent start/restart dispatched to it. On this fleet the
+    profile is the ONLY carrier of ~/.bash.d/secrets (measured 2026-09-05
+    on scitex-compute-01: zero CCT_* / no gateway key under a bare or
+    ``bash -c`` command, all of them under ``bash -lc``), so a peer that
+    also needs an ``env_preamble`` for PATH must opt in here or every
+    engine with an ``auth_token_env`` is refused there as "unset". HPC
+    peers stay False: sourcing their profile kills the login.
+
     ``reverse_ssh`` names the PEER's ssh route back to the master; the
     push-config renderer falls back to the master's name when empty.
     """
@@ -125,6 +134,10 @@ class PeerSpec:
     via: tuple[str, ...] = ()  # ssh ProxyJump chain by peer name
     env_preamble: tuple[str, ...] = ()  # remote shell snippets joined by &&
     resolve: ResolveSpec | None = None  # dispatch-time target resolution
+    # A preamble peer whose LOGIN profile is safe to source and carries the
+    # fleet secrets (the compute hosts). False keeps the preamble branch on a
+    # plain `bash -c` -- the HPC compute-node bashrc kill (see _host_ssh).
+    login_shell: bool = False
     reverse_ssh: str = ""  # peer→master ssh target (sac host push-config)
 
     @classmethod
@@ -151,6 +164,7 @@ class PeerSpec:
             env_preamble=_parse_env_preamble(name, spec.get("env_preamble")),
             resolve=_parse_resolve(name, spec.get("resolve")),
             reverse_ssh=str(spec.get("reverse_ssh") or ""),
+            login_shell=bool(spec.get("login_shell", False)),
         )
 
     def jump_chain(self, peers: dict[str, "PeerSpec"]) -> list[str]:

--- a/tests/scitex_agent_container/_state/test__host_ssh.py
+++ b/tests/scitex_agent_container/_state/test__host_ssh.py
@@ -43,6 +43,7 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container._state._host_ssh import build_ssh_argv
+from scitex_agent_container._state.host_config import PeerSpec
 from scitex_agent_container._state.host_config import load as load_host_config
 
 _PREAMBLE_PEER = "withpreamble"
@@ -221,3 +222,72 @@ def test_login_off_is_the_pre_existing_bare_shape(peers):
 
     # Assert
     assert argv[argv.index("--") + 1 :][-3:] == ["sac", "agents", "list"]
+
+
+# ---------------------------------------------------------------------------
+# login_shell: a PREAMBLE peer can opt into the login profile (the compute
+# hosts: preamble = PATH only, profile = the fleet secrets). Default stays off
+# for HPC peers, whose profile kills the login. Measured 2026-09-05: the
+# business restart on scitex-compute-01 was refused as "auth env unset" because
+# its PATH preamble kept the dispatch on `bash -c`.
+# ---------------------------------------------------------------------------
+_OPTED_IN = PeerSpec(
+    name="opted-in", ssh="host-opted-in", env_preamble=(_PREAMBLE,), login_shell=True
+)
+
+
+def test_an_opted_in_preamble_peer_gets_the_login_shell(peers):
+    # Arrange
+    table = {**peers, "opted-in": _OPTED_IN}
+    command = ["sac", "agents", "restart", "business", "--yes", "--json"]
+
+    # Act
+    argv = build_ssh_argv("opted-in", command, table, login=True)
+
+    # Assert
+    assert argv[-1].startswith("bash -lc ")
+
+
+def test_an_opted_in_preamble_peer_keeps_its_preamble_first(peers):
+    # Arrange
+    table = {**peers, "opted-in": _OPTED_IN}
+    command = ["sac", "agents", "restart", "business", "--yes", "--json"]
+
+    # Act
+    inner = shlex.split(build_ssh_argv("opted-in", command, table, login=True)[-1])[2]
+
+    # Assert
+    assert inner.startswith(_PREAMBLE + " && ")
+
+
+def test_an_opted_in_peer_without_login_asked_stays_on_the_plain_shell(peers):
+    # Arrange -- a probe or a file copy never asks for the profile
+    table = {**peers, "opted-in": _OPTED_IN}
+
+    # Act
+    argv = build_ssh_argv("opted-in", ["sac", "agents", "list"], table)
+
+    # Assert
+    assert argv[-1].startswith("bash -c ")
+
+
+def test_login_shell_is_parsed_from_the_peer_mapping():
+    # Arrange
+    spec = {"ssh": "h", "env_preamble": ["export PATH=/x:$PATH"], "login_shell": True}
+
+    # Act
+    peer = PeerSpec.from_dict(spec, name="h")
+
+    # Assert
+    assert peer.login_shell is True
+
+
+def test_login_shell_defaults_to_false():
+    # Arrange
+    spec = {"ssh": "h", "env_preamble": ["export PATH=/x:$PATH"]}
+
+    # Act
+    peer = PeerSpec.from_dict(spec, name="h")
+
+    # Assert
+    assert peer.login_shell is False


### PR DESCRIPTION
## Why

#1291 wrapped a remote agent start in `bash -lc` for peers **without** an `env_preamble`. The four compute hosts all **have** one (`export PATH=…` so `sac` is found over ssh, added 2026-08-12 for exactly the rc=127 a bare non-login ssh produces), so their dispatch stayed on the preamble branch's `bash -c`, the login profile was never sourced, and the business restart on scitex-compute-01 was refused again with "auth_token_env … unset on this host". Measured from the failed run's own argv: `-- 'bash -c '"'"'export PATH=…`.

The preamble branch's `bash -c` is deliberate for HPC peers (sourcing their profile kills the login), so the choice belongs to the peer entry.

## What

- `PeerSpec.login_shell: bool = False`, parsed from the `peers:` mapping.
- `build_ssh_argv(..., login=True)` uses `bash -lc '<preamble> && <cmd>'` for an opted-in preamble peer, `bash -c` otherwise; calls that do not ask for login (probes, stops, copies) are unchanged.
- Tests: opted-in shape, preamble kept first, no-login unchanged, parse with default.

```yaml
peers:
  scitex-compute-01:
    ssh: scitex-compute-01
    env_preamble: 'export PATH="$HOME/.env-sac/bin:$PATH"'
    login_shell: true
```

The config entries for the four compute hosts follow in dotfiles (tracked copy) and on the dispatching host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXfFia9RNQ4P9ZWYX8qhR2
