### PR TITLE
fix(engines): a provider-backed engine clears the OAuth account the default engine pins

### DIFF
--- a/src/scitex_agent_container/config/_engine_types.py
+++ b/src/scitex_agent_container/config/_engine_types.py
@@ -242,8 +242,7 @@ def parse_engines(spec: Mapping) -> dict[str, EngineSpec]:
     if not isinstance(block, Mapping):
         return {}
     return {
-        str(key): parse_engine_entry(str(key), value)
-        for key, value in block.items()
+        str(key): parse_engine_entry(str(key), value) for key, value in block.items()
     }
 
 
@@ -351,6 +350,17 @@ def apply_engine(config: Any, engine: EngineSpec) -> None:
     if claude is not None:
         claude.model = engine.model
         claude.provider = engine.provider
+        # A provider-backed engine authenticates with the provider's API key;
+        # the OAuth account the DEFAULT engine pins is not this start's, and
+        # the runtime refuses the two together (_apptainer_provider:
+        # "provider and account are mutually exclusive"). Measured
+        # 2026-09-05: `business --engine qwen38-27b` was refused on the peer
+        # with exactly that message while its spec was correct -- the fold
+        # had left the account in place. Clearing it here keeps the rule
+        # true for what actually runs; an engine without a provider keeps
+        # the account, because OAuth is then the only auth it has.
+        if engine.provider is not None:
+            claude.account = ""
     if engine.env:
         merged = dict(getattr(config, "env", {}) or {})
         merged.update(engine.env)

--- a/tests/scitex_agent_container/config/test__engine_types.py
+++ b/tests/scitex_agent_container/config/test__engine_types.py
@@ -22,6 +22,7 @@ from scitex_agent_container.config import load_config
 from scitex_agent_container.config._engine_types import (
     EngineDefaultError,
     UnknownEngineError,
+    apply_engine,
     default_engine,
     legacy_conflict_messages,
     parse_engines,
@@ -444,3 +445,37 @@ def test_a_known_harness_inside_an_engine_entry_is_accepted():
     errors = validate_raw(doc, "spec.yaml")
     # Assert
     assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# A provider-backed engine clears the OAuth account the default engine pins.
+# Measured 2026-09-05: `business --engine qwen38-27b` was refused at runtime
+# ("provider and account are mutually exclusive") while its spec was correct,
+# because the fold left spec.claude.account in place.
+# ---------------------------------------------------------------------------
+def test_selecting_a_provider_engine_clears_the_oauth_account(tmp_path):
+    # Arrange
+    path = _write(
+        tmp_path,
+        "eng-prov-acct",
+        {"engines": _two_engines(), "claude": {"account": "acct-a"}},
+    )
+    config = load_config(path)
+    # Act
+    apply_engine(config, select_engine(config.engines, "qwen38-27b"))
+    # Assert
+    assert config.claude.account == ""
+
+
+def test_selecting_the_oauth_engine_keeps_the_account(tmp_path):
+    # Arrange
+    path = _write(
+        tmp_path,
+        "eng-oauth-acct",
+        {"engines": _two_engines(), "claude": {"account": "acct-a"}},
+    )
+    config = load_config(path)
+    # Act
+    apply_engine(config, select_engine(config.engines, "claude"))
+    # Assert
+    assert config.claude.account == "acct-a"


### PR DESCRIPTION
## Why

`sac agents restart business --engine qwen38-27b` reached the peer with its login shell and its key (#1291, #1292) and was refused one step later, at runtime:

```
spec.claude.provider and spec.claude.account are mutually exclusive — a provider backend uses an API key, not Anthropic OAuth
```

The spec is correct — a `claude` engine on an OAuth account and a `qwen38-27b` engine on the local gateway. The fold was incomplete: `apply_engine()` writes the engine's model and provider onto `spec.claude` but leaves `spec.claude.account` (the **default** engine's OAuth account) in place, so every provider-backed engine trips the exclusivity check in `_apptainer_provider.provider_env_flags`. Any spec declaring both kinds of engine could never start on the provider one.

## What

`apply_engine` clears the account when the selected engine carries a provider (the key is its auth); an engine without a provider keeps it (OAuth is then its only auth). Two tests pin both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXfFia9RNQ4P9ZWYX8qhR2
