### PR TITLE
fix(handoff): archive dirs (.old/) are neither shipped to a peer nor drift

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_spec_handoff.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_spec_handoff.py
@@ -99,11 +99,17 @@ __all__ = [
 #: Directory names never shipped and never compared — peer-side runtime
 #: state and build caches. Matched at ANY depth, which is what rsync's
 #: ``--exclude=runtime/`` did too.
+#:
+#: ``.old`` is the fleet's archive-on-edit convention (``.old/<timestamp>/``).
+#: An archive is superseded by definition, so the peer never needs it -- and
+#: comparing it is how a start got refused for "drift" in a snapshot while
+#: the spec itself was identical on both hosts (2026-09-05, business).
 EXCLUDED_NAMES: tuple[str, ...] = (
     "runtime",
     "__pycache__",
     ".pytest_cache",
     "_sphinx_html",
+    ".old",
 )
 
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__spec_handoff.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__spec_handoff.py
@@ -172,6 +172,27 @@ def test_an_excluded_directory_is_pruned_at_any_depth(tmp_path):
     assert sorted(manifest) == ["spec.yaml"]
 
 
+def test_a_differing_archive_snapshot_is_not_drift(tmp_path):
+    # Arrange -- the same tracked spec on both hosts; only an archived copy
+    # under .old/ differs (the measured 2026-09-05 refusal).
+    lead = tmp_path / "lead" / "business"
+    peer = tmp_path / "peer" / "business"
+    for root, snapshot in ((lead, "lead's snapshot"), (peer, "peer's snapshot")):
+        (root / ".old" / "20260905T0500Z").mkdir(parents=True)
+        (root / "spec.yaml").write_text("kind: Agent\n")
+        (root / ".old" / "20260905T0500Z" / "spec.yaml.bak").write_text(snapshot)
+    proc = subprocess.run(
+        ["sh", "-c", manifest_script(str(peer))],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Act
+    plan = plan_handoff(local_manifest(lead), parse_manifest(proc.stdout))
+    # Assert
+    assert plan.drift is False
+
+
 def test_a_symlink_is_absent_from_the_manifest(spec_src):
     """``find -type f`` on the peer skips symlinks, so this side must too, or
     every spec dir holding one would verify as mis-delivered."""


### PR DESCRIPTION
## Measured

`sac agents start business --engine qwen38-27b` from the lead, 2026-09-05 04:11 UTC:

```
Spec drift between lead and 'scitex-compute-01' for agent 'business' — the peer's copy of these files differs from the lead's:
  .old/20260905T0500Z/spec.yaml.bak-pre-authenv-20260905
```

`spec.yaml` was byte-identical on both hosts (sha256 `129c0e56…`). The only differing file was an archive-on-edit snapshot under `.old/` — walked by `local_manifest()` (rglob over the whole agent dir) and listed by the peer's `manifest_script()`, so it counted as drift and refused the start. An hour earlier the same gate had refused on differing top-level `.bak` files; moving those into `.old/` (the archive convention) then tripped it again.

## Fix

An archive is superseded by definition — nothing on the peer reads it — so shipping it is waste and comparing it is a false gate. `.old` joins `EXCLUDED_NAMES` next to `runtime/` and the caches. Both halves honour the tuple already (the walker's `rel.parts` check and the `find -prune` script), so the parametrized exclusion tests pick the entry up; one new test builds the measured shape end to end (identical spec, differing `.old/` copy, real `sh` manifest script) and asserts `plan.drift is False`.

Not a fix for the snapshots themselves: for a git-tracked spec they are prohibited (git is the archive) and were deleted on both hosts. This makes the gate judge the spec, not the clutter around it.

## Tests

`test__spec_handoff.py` + `test__dispatch.py` under the worktree interpreter; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXfFia9RNQ4P9ZWYX8qhR2
