### PR TITLE
fix(provider): seed the config dir a provider engine points Claude Code at

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -53,7 +53,9 @@ from ._apptainer_provider import (
     openai_harness_active,
     provider_active,
     provider_env_flags,
+    resolve_provider_api_key,
 )
+from ._apptainer_provider_cfg import provider_config_dir_flags
 
 
 def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
@@ -85,10 +87,27 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
 
     if provider_active(config):
         # Provider backend: API key, no OAuth. The provider helper owns
-        # ANTHROPIC_BASE_URL + SAC_ANTHROPIC_API_KEY + a clean
-        # CLAUDE_CONFIG_DIR (the last-wins conflict-breaker). The OAuth
-        # creds bind is intentionally NOT emitted.
-        return engine_flags + provider_env_flags(config)
+        # ANTHROPIC_BASE_URL + SAC_ANTHROPIC_API_KEY + a per-agent
+        # CLAUDE_CONFIG_DIR (the last-wins conflict-breaker); the cfg helper
+        # seeds that dir on the host (onboarding gate + approved key) and
+        # binds it there, so the TUI boots to the prompt instead of the
+        # first-run sign-in screen. The OAuth creds bind is intentionally
+        # NOT emitted.
+        workdir = (
+            getattr(config, "expanded_workdir", "")
+            or getattr(config, "workdir", "")
+            or "/tmp"
+        )
+        return (
+            engine_flags
+            + provider_env_flags(config)
+            + provider_config_dir_flags(
+                state_dir=state_dir,
+                name=config.name,
+                workdir=str(workdir),
+                api_key=resolve_provider_api_key(config),
+            )
+        )
 
     argv: list[str] = list(engine_flags)
 

--- a/src/scitex_agent_container/runtimes/_apptainer_provider.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_provider.py
@@ -117,6 +117,7 @@ from scitex_config import PriorityConfig, load_dotenv
 
 from ..config import AgentConfig
 from ..config._harness_registry import known_harnesses
+from ._apptainer_provider_cfg import container_config_dir
 
 
 class ProviderEnvError(RuntimeError):
@@ -138,6 +139,47 @@ def provider_active(config: AgentConfig) -> bool:
     """
     provider = _provider_spec(config)
     return bool(provider is not None and getattr(provider, "base_url", ""))
+
+
+def resolve_provider_api_key(config: AgentConfig) -> str:
+    """Resolve the provider API key VALUE for ``config`` (fail-loud).
+
+    Shared by :func:`provider_env_flags` (which injects it into the
+    container env) and :mod:`._apptainer_provider_cfg` (which pre-approves
+    it in the config dir), so the two can never disagree about which key
+    the agent runs on. Raises :class:`ProviderEnvError` when
+    ``provider.auth_token_env`` is empty or resolves to nothing after the
+    scitex-config cascade (see module docstring). The value is never
+    logged by sac.
+    """
+    provider = _provider_spec(config)
+    auth_token_env = getattr(provider, "auth_token_env", "")
+    if not auth_token_env:
+        raise ProviderEnvError(
+            "spec.claude.provider.auth_token_env is empty; cannot resolve "
+            "the backend API key. Set it to the NAME of the host env var "
+            "holding the key (e.g. DEEPSEEK_API_KEY)."
+        )
+
+    # SciTeX-ecosystem precedence: shell-export > $HOME/.env > default.
+    # load_dotenv() is no-op-safe — already-set process env always wins,
+    # so calling it on every provider-env resolution is cheap and
+    # idempotent. Path is pinned to $HOME/.env to avoid the cwd-first
+    # surprise of the default load_dotenv() search order.
+    load_dotenv(dotenv_path=str(Path.home() / ".env"))
+    resolver = PriorityConfig(auto_uppercase=False)
+    api_key = resolver.resolve(key=auth_token_env, default="")
+    if not api_key:
+        raise ProviderEnvError(
+            f"spec.claude.provider.auth_token_env='{auth_token_env}' could "
+            "not be resolved through scitex-config (direct → config → env "
+            "→ default cascade). Set the key by EITHER exporting "
+            f"{auth_token_env} in the shell that runs `sac agents start` "
+            f"OR adding the line `{auth_token_env}=...` to $HOME/.env "
+            "(chmod 0600). sac reads the value at start and never logs "
+            "it; PriorityConfig auto-masks it in the resolution log."
+        )
+    return api_key
 
 
 def provider_env_flags(config: AgentConfig) -> list[str]:
@@ -167,36 +209,11 @@ def provider_env_flags(config: AgentConfig) -> list[str]:
         )
 
     base_url = getattr(provider, "base_url", "")
-    auth_token_env = getattr(provider, "auth_token_env", "")
-    if not auth_token_env:
-        raise ProviderEnvError(
-            "spec.claude.provider.auth_token_env is empty; cannot resolve "
-            "the backend API key. Set it to the NAME of the host env var "
-            "holding the key (e.g. DEEPSEEK_API_KEY)."
-        )
-
-    # SciTeX-ecosystem precedence: shell-export > $HOME/.env > default.
-    # load_dotenv() is no-op-safe — already-set process env always wins,
-    # so calling it on every provider-env resolution is cheap and
-    # idempotent. Path is pinned to $HOME/.env to avoid the cwd-first
-    # surprise of the default load_dotenv() search order.
-    load_dotenv(dotenv_path=str(Path.home() / ".env"))
-    resolver = PriorityConfig(auto_uppercase=False)
-    api_key = resolver.resolve(key=auth_token_env, default="")
-    if not api_key:
-        raise ProviderEnvError(
-            f"spec.claude.provider.auth_token_env='{auth_token_env}' could "
-            "not be resolved through scitex-config (direct → config → env "
-            "→ default cascade). Set the key by EITHER exporting "
-            f"{auth_token_env} in the shell that runs `sac agents start` "
-            f"OR adding the line `{auth_token_env}=...` to $HOME/.env "
-            "(chmod 0600). sac reads the value at start and never logs "
-            "it; PriorityConfig auto-masks it in the resolution log."
-        )
+    api_key = resolve_provider_api_key(config)
 
     # Per-agent clean config dir — the conflict-breaker. Distinct from the
     # OAuth path's /tmp/sac-claude so a stale OAuth bind can never win.
-    config_dir = f"/tmp/sac-{config.name}-provider-cfg"
+    config_dir = container_config_dir(config.name)
     flags = [
         "--env",
         f"ANTHROPIC_BASE_URL={base_url}",
@@ -440,5 +457,6 @@ __all__ = [
     "openai_harness_active",
     "provider_active",
     "provider_env_flags",
+    "resolve_provider_api_key",
     "resolve_agent_harness",
 ]

--- a/src/scitex_agent_container/runtimes/_apptainer_provider_cfg.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_provider_cfg.py
@@ -1,0 +1,175 @@
+"""The config dir a provider-backed engine points Claude Code at — seeded.
+
+``provider_env_flags`` redirects the in-container ``claude`` to a per-agent
+``CLAUDE_CONFIG_DIR`` (the last-wins conflict-breaker against the OAuth
+bind). Claude Code reads its ``.claude.json`` from THAT dir, not from
+``$HOME`` — so the onboarding seed sac writes into ``<home>/.claude.json``
+(:mod:`.onboarding`) never reaches a provider agent, and the TUI runs its
+first-run wizard. The wizard's login step ignores ``ANTHROPIC_API_KEY``:
+
+    Browser didn't open? Use the url below to sign in ...
+    The recommended sign-in isn't available on this machine
+    (ANTHROPIC_API_KEY is set in this environment), so this sign-in
+    will create an API key.  Paste code here if prompted >
+
+Measured 2026-09-05 (business on scitex-compute-01, Claude Code 2.1.261):
+the container carried the gateway URL, the model and the key, and parked
+there until ``runtime.start()`` gave up. The one provider agent that ran
+(handyman-01) had been signed in BY HAND once — its config dir held a
+minted ``primaryApiKey`` and the env key sat in ``customApiKeyResponses.
+rejected`` — and only worked because the proxy of the day checked no key.
+
+This module makes the dir sac's own:
+
+* it lives on the HOST at ``<state_dir>/provider-cfg`` and is bind-mounted
+  at :func:`container_config_dir`, so it exists in every tmpfs mode (the
+  old location survived restarts only because sac happened to relocate
+  the container ``/tmp`` onto ``<state_dir>/tmp-scratch/tmp``);
+* before launch it is seeded with the same global-onboarding gate and
+  workspace-trust entry the home gets, so the TUI boots straight to the
+  prompt;
+* the provider key is pre-APPROVED in ``customApiKeyResponses`` (Claude
+  Code identifies a key by its last 20 characters) and a stale rejection
+  of the same key is dropped — the spec declares the key; an answer given
+  at a prompt must not override it.
+
+A dir left at the legacy scratch location is moved into place once, so an
+agent's history and file-history survive the change.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from .onboarding import ensure_project_onboarding
+
+logger = logging.getLogger(__name__)
+
+#: Sub-directory of the agent's state dir that backs the container config dir.
+HOST_DIRNAME = "provider-cfg"
+
+#: Claude Code records an approved / rejected key by its trailing 20 chars.
+KEY_SUFFIX_LEN = 20
+
+
+def container_config_dir(name: str) -> str:
+    """The in-container ``CLAUDE_CONFIG_DIR`` for agent ``name``.
+
+    Distinct from the OAuth path's ``/tmp/sac-claude`` so a stale OAuth
+    bind can never win.
+    """
+    return f"/tmp/sac-{name}-provider-cfg"
+
+
+def host_config_dir(state_dir: Path) -> Path:
+    """The host dir bound at :func:`container_config_dir`."""
+    return Path(state_dir).expanduser() / HOST_DIRNAME
+
+
+def legacy_scratch_config_dir(state_dir: Path, name: str) -> Path:
+    """Where the dir landed before it was bound: the relocated container ``/tmp``."""
+    return (
+        Path(state_dir).expanduser()
+        / "tmp-scratch"
+        / "tmp"
+        / f"sac-{name}-provider-cfg"
+    )
+
+
+def approve_api_key(claude_json: Path, api_key: str) -> bool:
+    """Record ``api_key`` as approved in ``customApiKeyResponses``.
+
+    Adds the key's suffix to ``approved`` when absent and removes it from
+    ``rejected`` when present; every other key in the file is kept. Never
+    raises — an unreadable or unwritable file is logged and left alone.
+
+    Returns:
+        True iff the file was rewritten.
+    """
+    suffix = api_key[-KEY_SUFFIX_LEN:]
+    try:
+        data: dict = {}
+        if claude_json.exists():
+            with claude_json.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        responses = data.get("customApiKeyResponses")
+        if not isinstance(responses, dict):
+            responses = {}
+        approved = [s for s in responses.get("approved", []) if isinstance(s, str)]
+        rejected = [s for s in responses.get("rejected", []) if isinstance(s, str)]
+        changed = False
+        if suffix not in approved:
+            approved.append(suffix)
+            changed = True
+        if suffix in rejected:
+            rejected = [s for s in rejected if s != suffix]
+            changed = True
+        if not changed:
+            return False
+        data["customApiKeyResponses"] = {
+            **responses,
+            "approved": approved,
+            "rejected": rejected,
+        }
+        tmp_path = claude_json.with_suffix(".json.tmp")
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, claude_json)
+        return True
+    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        logger.warning("cannot approve the provider key in %s: %s", claude_json, exc)
+        return False
+
+
+def seed_provider_config_dir(
+    *, state_dir: Path, name: str, workdir: str, api_key: str
+) -> Path:
+    """Materialise and seed the host config dir for a provider agent.
+
+    Idempotent: seeds only what is absent, so the TUI's own writes
+    (session stats, history, a machine id) survive every start.
+
+    Returns:
+        The host dir to bind at :func:`container_config_dir`.
+    """
+    host = host_config_dir(state_dir)
+    legacy = legacy_scratch_config_dir(state_dir, name)
+    if not host.exists() and legacy.is_dir():
+        host.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(legacy), str(host))
+        logger.info("moved provider config dir %s -> %s", legacy, host)
+    host.mkdir(parents=True, exist_ok=True)
+    ensure_project_onboarding(workdir, home=host)
+    approve_api_key(host / ".claude.json", api_key)
+    return host
+
+
+def provider_config_dir_flags(
+    *, state_dir: Path, name: str, workdir: str, api_key: str
+) -> list[str]:
+    """Seed the host dir and render the ``--bind`` that mounts it.
+
+    Writable: Claude Code keeps its history and stats there.
+    """
+    host = seed_provider_config_dir(
+        state_dir=state_dir, name=name, workdir=workdir, api_key=api_key
+    )
+    return ["--bind", f"{host}:{container_config_dir(name)}:rw"]
+
+
+__all__ = [
+    "HOST_DIRNAME",
+    "KEY_SUFFIX_LEN",
+    "approve_api_key",
+    "container_config_dir",
+    "host_config_dir",
+    "legacy_scratch_config_dir",
+    "provider_config_dir_flags",
+    "seed_provider_config_dir",
+]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
@@ -19,6 +19,7 @@ and a descriptive name (TQ003).
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -113,6 +114,34 @@ def test_provider_argv_omits_oauth_config_dir(
     argv = auth_argv(cfg, state_dir=tmp_path / "state")
     # Assert
     assert "CLAUDE_CONFIG_DIR=/tmp/sac-claude" not in argv
+
+
+def test_provider_argv_binds_the_seeded_config_dir(
+    tmp_path: Path, home_redirect: Path, env_save_restore
+):
+    # Arrange — the per-agent CLAUDE_CONFIG_DIR must be backed by a host dir,
+    # or the TUI boots into an empty one and runs first-run onboarding.
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config(tmp_path / "wd")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    assert f"{tmp_path / 'state' / 'provider-cfg'}:/tmp/sac-ds-provider-cfg:rw" in argv
+
+
+def test_provider_argv_seeds_onboarding_into_that_dir(
+    tmp_path: Path, home_redirect: Path, env_save_restore
+):
+    # Arrange
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config(tmp_path / "wd")
+    # Act
+    auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    seeded = json.loads(
+        (tmp_path / "state" / "provider-cfg" / ".claude.json").read_text()
+    )
+    assert seeded["hasCompletedOnboarding"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__apptainer_provider_cfg.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_provider_cfg.py
@@ -1,0 +1,255 @@
+"""Tests for ``runtimes._apptainer_provider_cfg`` (the seeded provider config dir).
+
+A provider-backed engine points Claude Code at a per-agent
+``CLAUDE_CONFIG_DIR``. Measured 2026-09-05: left unseeded, the TUI ran its
+first-run wizard and parked on the OAuth sign-in screen with the gateway
+URL, model and key all present in its environment. These tests pin the
+seed: the onboarding gate, the workspace-trust entry, the pre-approved key,
+the one-time move of a legacy dir, and the bind that mounts the result.
+
+Real seams only (no mocks): real directories under ``tmp_path``, real JSON.
+One observable fact per test, AAA markers, descriptive names.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container.runtimes._apptainer_provider_cfg import (
+    KEY_SUFFIX_LEN,
+    approve_api_key,
+    container_config_dir,
+    host_config_dir,
+    legacy_scratch_config_dir,
+    provider_config_dir_flags,
+    seed_provider_config_dir,
+)
+
+KEY = "sk-fleet-gateway-0123456789abcdefghijklmnopqrstuvwxyz"
+
+
+def _seed(tmp_path: Path, name: str = "biz", key: str = KEY) -> Path:
+    return seed_provider_config_dir(
+        state_dir=tmp_path / "state",
+        name=name,
+        workdir=str(tmp_path / "wd"),
+        api_key=key,
+    )
+
+
+def _read(host: Path) -> dict:
+    return json.loads((host / ".claude.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def test_the_container_dir_is_namespaced_by_agent_name():
+    # Arrange
+    name = "bulk7"
+    # Act
+    path = container_config_dir(name)
+    # Assert
+    assert path == "/tmp/sac-bulk7-provider-cfg"
+
+
+def test_the_host_dir_lives_under_the_state_dir(tmp_path: Path):
+    # Arrange
+    state = tmp_path / "state"
+    # Act
+    path = host_config_dir(state)
+    # Assert
+    assert path == state / "provider-cfg"
+
+
+# ---------------------------------------------------------------------------
+# Seeding
+# ---------------------------------------------------------------------------
+
+
+def test_seed_creates_the_host_dir(tmp_path: Path):
+    # Arrange
+    state = tmp_path / "state"
+    # Act
+    _seed(tmp_path)
+    # Assert
+    assert (state / "provider-cfg").is_dir()
+
+
+def test_seed_marks_global_onboarding_complete(tmp_path: Path):
+    # Arrange
+    state = tmp_path / "state"
+    # Act
+    _seed(tmp_path)
+    # Assert
+    assert _read(host_config_dir(state))["hasCompletedOnboarding"] is True
+
+
+def test_seed_marks_the_workspace_trusted(tmp_path: Path):
+    # Arrange
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    # Act
+    host = _seed(tmp_path)
+    # Assert
+    entry = _read(host)["projects"][str(workdir.resolve())]
+    assert entry["hasTrustDialogAccepted"] is True
+
+
+def test_seed_approves_the_key_by_its_trailing_characters(tmp_path: Path):
+    # Arrange
+    state = tmp_path / "state"
+    # Act
+    _seed(tmp_path)
+    # Assert
+    approved = _read(host_config_dir(state))["customApiKeyResponses"]["approved"]
+    assert approved == [KEY[-KEY_SUFFIX_LEN:]]
+
+
+def test_seed_drops_a_stale_rejection_of_the_same_key(tmp_path: Path):
+    # Arrange — handyman-01's measured shape: the env key sat in ``rejected``.
+    host = host_config_dir(tmp_path / "state")
+    host.mkdir(parents=True)
+    (host / ".claude.json").write_text(
+        json.dumps(
+            {
+                "customApiKeyResponses": {
+                    "approved": [],
+                    "rejected": [KEY[-20:], "other-key-suffix"],
+                }
+            }
+        )
+    )
+    # Act
+    _seed(tmp_path)
+    # Assert
+    assert _read(host)["customApiKeyResponses"]["rejected"] == ["other-key-suffix"]
+
+
+def test_seed_lists_the_approved_suffix_once_across_starts(tmp_path: Path):
+    # Arrange
+    _seed(tmp_path)
+    # Act
+    host = _seed(tmp_path)
+    # Assert
+    assert _read(host)["customApiKeyResponses"]["approved"].count(KEY[-20:]) == 1
+
+
+def test_seed_keeps_what_the_tui_already_wrote(tmp_path: Path):
+    # Arrange — the TUI's own first-run stub (measured: machineID etc.).
+    host = host_config_dir(tmp_path / "state")
+    host.mkdir(parents=True)
+    (host / ".claude.json").write_text(
+        json.dumps({"machineID": "m-1", "numStartups": 7})
+    )
+    # Act
+    _seed(tmp_path)
+    # Assert
+    data = _read(host)
+    assert (data["machineID"], data["numStartups"]) == ("m-1", 7)
+
+
+def test_seed_writes_the_config_file_owner_only(tmp_path: Path):
+    # Arrange
+    state = tmp_path / "state"
+    # Act
+    _seed(tmp_path)
+    # Assert
+    mode = (host_config_dir(state) / ".claude.json").stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Legacy location (the relocated container /tmp)
+# ---------------------------------------------------------------------------
+
+
+def test_a_legacy_scratch_dir_is_moved_into_the_state_dir(tmp_path: Path):
+    # Arrange — an agent that ran before the bind kept its history there.
+    legacy = legacy_scratch_config_dir(tmp_path / "state", "biz")
+    legacy.mkdir(parents=True)
+    (legacy / "history.jsonl").write_text('{"display":"hello"}\n')
+    # Act
+    host = _seed(tmp_path)
+    # Assert
+    assert (host / "history.jsonl").read_text() == '{"display":"hello"}\n'
+
+
+def test_the_legacy_dir_is_gone_after_the_move(tmp_path: Path):
+    # Arrange
+    legacy = legacy_scratch_config_dir(tmp_path / "state", "biz")
+    legacy.mkdir(parents=True)
+    (legacy / "history.jsonl").write_text("x\n")
+    # Act
+    _seed(tmp_path)
+    # Assert
+    assert not legacy.exists()
+
+
+def test_an_existing_host_dir_is_never_replaced_by_the_legacy_one(tmp_path: Path):
+    # Arrange — both exist; the host dir is the live one and must win.
+    host = host_config_dir(tmp_path / "state")
+    host.mkdir(parents=True)
+    (host / "history.jsonl").write_text("live\n")
+    legacy = legacy_scratch_config_dir(tmp_path / "state", "biz")
+    legacy.mkdir(parents=True)
+    (legacy / "history.jsonl").write_text("stale\n")
+    # Act
+    _seed(tmp_path)
+    # Assert
+    assert (host / "history.jsonl").read_text() == "live\n"
+
+
+# ---------------------------------------------------------------------------
+# approve_api_key on its own
+# ---------------------------------------------------------------------------
+
+
+def test_approve_creates_the_file_when_absent(tmp_path: Path):
+    # Arrange
+    target = tmp_path / ".claude.json"
+    # Act
+    approve_api_key(target, KEY)
+    # Assert
+    assert json.loads(target.read_text())["customApiKeyResponses"]["approved"] == [
+        KEY[-20:]
+    ]
+
+
+def test_approve_reports_no_change_when_already_approved(tmp_path: Path):
+    # Arrange
+    target = tmp_path / ".claude.json"
+    approve_api_key(target, KEY)
+    # Act
+    changed = approve_api_key(target, KEY)
+    # Assert
+    assert changed is False
+
+
+def test_approve_leaves_an_unparseable_file_alone(tmp_path: Path):
+    # Arrange
+    target = tmp_path / ".claude.json"
+    target.write_text("{not json")
+    # Act
+    approve_api_key(target, KEY)
+    # Assert
+    assert target.read_text() == "{not json"
+
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+
+
+def test_flags_bind_the_host_dir_at_the_container_config_dir(tmp_path: Path):
+    # Arrange
+    state = tmp_path / "state"
+    # Act
+    flags = provider_config_dir_flags(
+        state_dir=state, name="biz", workdir=str(tmp_path / "wd"), api_key=KEY
+    )
+    # Assert
+    assert flags == ["--bind", f"{state / 'provider-cfg'}:/tmp/sac-biz-provider-cfg:rw"]


### PR DESCRIPTION
## Measured

business on scitex-compute-01, `--engine qwen38-27b`, 2026-09-05 04:13 UTC. The container carried `ANTHROPIC_BASE_URL=http://100.64.0.1:18772`, `ANTHROPIC_MODEL=qwen38-27b`, `SAC_ENGINE=qwen38-27b` and the fleet key — and Claude Code 2.1.261 parked here until `runtime.start()` gave up:

```
Browser didn't open? Use the url below to sign in ...
The recommended sign-in isn't available on this machine (ANTHROPIC_API_KEY is
set in this environment), so this sign-in will create an API key.
Paste code here if prompted >
```

**Why.** `provider_env_flags()` redirects the TUI to `CLAUDE_CONFIG_DIR=/tmp/sac-<name>-provider-cfg` (the last-wins conflict-breaker against the OAuth bind) and nothing seeds that dir. Claude Code reads `.claude.json` from `CLAUDE_CONFIG_DIR`, finds no `hasCompletedOnboarding`, and runs the first-run wizard, whose login step ignores the API-key env. sac's onboarding seed (`runtimes/onboarding.py`) goes to `<home>/.claude.json`, which a provider agent never reads.

On the host: business's dir held a 571-byte `.claude.json` written **by the TUI** at 04:13 with no onboarding key. handyman-01's held a 39 KB file — onboarded, `lastOnboardingVersion 2.1.233`, a minted `primaryApiKey`, and the env key in `customApiKeyResponses.rejected` — i.e. it had been signed in by hand once and "worked" only because the loose proxy checked no key.

## Fix

The dir becomes sac's:

- **Host-backed.** `<state_dir>/provider-cfg` is bind-mounted at the container path, so it exists in every tmpfs mode (the old location survived restarts only because sac relocates the container `/tmp` onto `<state_dir>/tmp-scratch/tmp`).
- **Seeded before launch** with the same onboarding gate + workspace-trust entry the home gets (`ensure_project_onboarding`), so the TUI boots to the prompt.
- **Key pre-approved** in `customApiKeyResponses` (Claude Code identifies a key by its last 20 chars); a stale rejection of the same key is dropped — the spec declares the key, an answer given at a prompt must not override it.
- **Legacy dir moved once** from the scratch location so an agent's history survives.
- `resolve_provider_api_key()` is factored out of `provider_env_flags()` so the env injection and the approval can never disagree about which key the agent runs on.

## Tests

19 new in `test__apptainer_provider_cfg.py` (seed, approval, idempotence, legacy move, bind shape, owner-only mode, unparseable file left alone) + 2 in `test__apptainer_auth.py`. Real dirs and JSON under `tmp_path`; no mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXfFia9RNQ4P9ZWYX8qhR2
