### PR TITLE
fix(provider): a provider agent's config dir shares the container home's conversation store

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -56,6 +56,19 @@ from ._apptainer_provider import (
     resolve_provider_api_key,
 )
 from ._apptainer_provider_cfg import provider_config_dir_flags
+from ._to_home_overlay import resolve_container_home
+
+
+def _transcript_home(config: AgentConfig) -> Path | None:
+    """The host dir backing the container home, most specific first, or None.
+
+    Reuses the TUI argv gate's candidate list so the place a provider agent's
+    conversation store is linked to is the same place ``-c`` looks for one.
+    """
+    from ._apptainer_inner_argv_tui import _candidate_transcript_homes
+
+    homes = _candidate_transcript_homes(config)
+    return Path(homes[0]) if homes else None
 
 
 def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
@@ -106,6 +119,8 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
                 name=config.name,
                 workdir=str(workdir),
                 api_key=resolve_provider_api_key(config),
+                container_home=resolve_container_home(config),
+                transcript_home=_transcript_home(config),
             )
         )
 

--- a/src/scitex_agent_container/runtimes/_apptainer_provider_cfg.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_provider_cfg.py
@@ -35,6 +35,15 @@ This module makes the dir sac's own:
 
 A dir left at the legacy scratch location is moved into place once, so an
 agent's history and file-history survive the change.
+
+The CONVERSATION STORE is shared, not seeded. Claude Code keeps transcripts
+under ``$CLAUDE_CONFIG_DIR/projects``; a provider config dir would start with
+none, so a spec pinned to ``session: resume`` exits at boot with "No
+conversation found with session ID" (measured 2026-09-05 04:44 UTC, business:
+its 129 MB transcript sat in the overlay home's ``.claude/projects``). The seed
+therefore makes ``projects`` a symlink to ``<container_home>/.claude/projects``
+-- the store every other engine writes -- so a conversation survives an
+engine switch in both directions.
 """
 
 from __future__ import annotations
@@ -45,6 +54,7 @@ import os
 import shutil
 from pathlib import Path
 
+from ._to_home_overlay import DEFAULT_CONTAINER_HOME
 from .onboarding import ensure_project_onboarding
 
 logger = logging.getLogger(__name__)
@@ -127,8 +137,50 @@ def approve_api_key(claude_json: Path, api_key: str) -> bool:
         return False
 
 
+def link_conversation_store(
+    host: Path, container_home: str, transcript_home: Path | None = None
+) -> bool:
+    """Make ``<host>/projects`` resolve to the agent's own transcript store.
+
+    The link targets the CONTAINER path ``<container_home>/.claude/projects``
+    (it dangles on the host by design). ``transcript_home`` is the host dir
+    backing the container home, when known; its ``.claude/projects`` is
+    created so the link never dangles inside the container either -- Node's
+    recursive mkdir refuses to create a directory through a dangling link,
+    which would strand a provider agent that has never run another engine.
+
+    A real ``projects`` directory already present (an agent that ran on a
+    provider before the bind) is left alone: its conversations live there.
+
+    Returns:
+        True iff the link was created by this call.
+    """
+    if transcript_home is not None:
+        try:
+            (Path(transcript_home) / ".claude" / "projects").mkdir(
+                parents=True, exist_ok=True
+            )
+        except OSError as exc:
+            logger.warning(
+                "cannot create the transcript store under %s: %s", transcript_home, exc
+            )
+    link = host / "projects"
+    if link.exists() or link.is_symlink():
+        return False
+    target = f"{container_home.rstrip('/')}/.claude/projects"
+    link.symlink_to(target, target_is_directory=True)
+    logger.info("provider config dir %s: projects -> %s", host, target)
+    return True
+
+
 def seed_provider_config_dir(
-    *, state_dir: Path, name: str, workdir: str, api_key: str
+    *,
+    state_dir: Path,
+    name: str,
+    workdir: str,
+    api_key: str,
+    container_home: str = DEFAULT_CONTAINER_HOME,
+    transcript_home: Path | None = None,
 ) -> Path:
     """Materialise and seed the host config dir for a provider agent.
 
@@ -147,18 +199,30 @@ def seed_provider_config_dir(
     host.mkdir(parents=True, exist_ok=True)
     ensure_project_onboarding(workdir, home=host)
     approve_api_key(host / ".claude.json", api_key)
+    link_conversation_store(host, container_home, transcript_home)
     return host
 
 
 def provider_config_dir_flags(
-    *, state_dir: Path, name: str, workdir: str, api_key: str
+    *,
+    state_dir: Path,
+    name: str,
+    workdir: str,
+    api_key: str,
+    container_home: str = DEFAULT_CONTAINER_HOME,
+    transcript_home: Path | None = None,
 ) -> list[str]:
     """Seed the host dir and render the ``--bind`` that mounts it.
 
     Writable: Claude Code keeps its history and stats there.
     """
     host = seed_provider_config_dir(
-        state_dir=state_dir, name=name, workdir=workdir, api_key=api_key
+        state_dir=state_dir,
+        name=name,
+        workdir=workdir,
+        api_key=api_key,
+        container_home=container_home,
+        transcript_home=transcript_home,
     )
     return ["--bind", f"{host}:{container_config_dir(name)}:rw"]
 
@@ -170,6 +234,7 @@ __all__ = [
     "container_config_dir",
     "host_config_dir",
     "legacy_scratch_config_dir",
+    "link_conversation_store",
     "provider_config_dir_flags",
     "seed_provider_config_dir",
 ]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
@@ -20,6 +20,7 @@ and a descriptive name (TQ003).
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -142,6 +143,20 @@ def test_provider_argv_seeds_onboarding_into_that_dir(
         (tmp_path / "state" / "provider-cfg" / ".claude.json").read_text()
     )
     assert seeded["hasCompletedOnboarding"] is True
+
+
+def test_provider_argv_links_the_conversation_store(
+    tmp_path: Path, home_redirect: Path, env_save_restore
+):
+    # Arrange — a resume-pinned spec must find its transcript under the
+    # provider config dir, i.e. the container home's own store.
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config(tmp_path / "wd")
+    # Act
+    auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    link = tmp_path / "state" / "provider-cfg" / "projects"
+    assert os.readlink(link) == "/home/agent/.claude/projects"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__apptainer_provider_cfg.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_provider_cfg.py
@@ -14,6 +14,7 @@ One observable fact per test, AAA markers, descriptive names.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from scitex_agent_container.runtimes._apptainer_provider_cfg import (
@@ -22,6 +23,7 @@ from scitex_agent_container.runtimes._apptainer_provider_cfg import (
     container_config_dir,
     host_config_dir,
     legacy_scratch_config_dir,
+    link_conversation_store,
     provider_config_dir_flags,
     seed_provider_config_dir,
 )
@@ -201,6 +203,78 @@ def test_an_existing_host_dir_is_never_replaced_by_the_legacy_one(tmp_path: Path
     _seed(tmp_path)
     # Assert
     assert (host / "history.jsonl").read_text() == "live\n"
+
+
+# ---------------------------------------------------------------------------
+# Conversation store (the transcripts every engine shares)
+# ---------------------------------------------------------------------------
+
+
+def test_seed_links_projects_to_the_container_homes_store(tmp_path: Path):
+    # Arrange
+    state = tmp_path / "state"
+    # Act
+    _seed(tmp_path)
+    # Assert
+    assert (
+        os.readlink(host_config_dir(state) / "projects")
+        == "/home/agent/.claude/projects"
+    )
+
+
+def test_seed_honours_a_relaxed_container_home(tmp_path: Path):
+    # Arrange
+    state = tmp_path / "state"
+    # Act
+    seed_provider_config_dir(
+        state_dir=state,
+        name="biz",
+        workdir=str(tmp_path / "wd"),
+        api_key=KEY,
+        container_home="/home/ywatanabe",
+    )
+    # Assert
+    assert (
+        os.readlink(host_config_dir(state) / "projects")
+        == "/home/ywatanabe/.claude/projects"
+    )
+
+
+def test_seed_creates_the_store_in_the_transcript_home(tmp_path: Path):
+    # Arrange — a fresh provider agent whose overlay home has no .claude yet.
+    transcript_home = tmp_path / "overlay" / "upper" / "home" / "agent"
+    # Act
+    seed_provider_config_dir(
+        state_dir=tmp_path / "state",
+        name="biz",
+        workdir=str(tmp_path / "wd"),
+        api_key=KEY,
+        transcript_home=transcript_home,
+    )
+    # Assert
+    assert (transcript_home / ".claude" / "projects").is_dir()
+
+
+def test_an_existing_real_projects_dir_is_left_alone(tmp_path: Path):
+    # Arrange — handyman-01's shape: conversations already in the config dir.
+    host = host_config_dir(tmp_path / "state")
+    (host / "projects" / "-wd").mkdir(parents=True)
+    (host / "projects" / "-wd" / "abc.jsonl").write_text("{}\n")
+    # Act
+    _seed(tmp_path)
+    # Assert
+    assert (host / "projects").is_symlink() is False
+
+
+def test_link_reports_no_change_when_already_linked(tmp_path: Path):
+    # Arrange
+    host = tmp_path / "cfg"
+    host.mkdir()
+    link_conversation_store(host, "/home/agent")
+    # Act
+    created = link_conversation_store(host, "/home/agent")
+    # Assert
+    assert created is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Measured

With #1295 deployed, business (scitex-compute-01, `--engine qwen38-27b`) booted past onboarding — the seeded `provider-cfg/.claude.json` reads onboarded, key approved, workspace trusted — and exited at once. Its spec pins `session: resume` / `resume_id: d3f1702b-…`, and that transcript (129 MB) lives in the overlay home:

```
containers/overlays/business/upper/home/agent/.claude/projects/-home-ywatanabe-proj-business/d3f1702b-….jsonl
```

Under the provider engine Claude Code looks in `$CLAUDE_CONFIG_DIR/projects` — the seeded dir, which held no conversation store. `claude --resume <id>` prints "No conversation found with session ID" and exits; tmux closes; sac reports `runtime.start() False` with an empty pane. sac already gates `-c` on a transcript existing (`_apptainer_inner_argv_tui`); `--resume` under a provider had no such path.

## Fix

The seed makes `provider-cfg/projects` a **symlink to `<container_home>/.claude/projects`** — the store every other engine writes — so a conversation survives an engine switch in both directions.

- The target is the container path (the link dangles on the host by design).
- The seed `mkdir -p`s that store on the host side of the container home (first candidate from `_candidate_transcript_homes`) so it never dangles inside the container: Node's recursive mkdir refuses to create a directory through a dangling link, which would strand a provider agent that has never run another engine.
- A real `projects` dir already present (an agent that ran on a provider before the bind — handyman-01) is left alone.
- The container home comes from `resolve_container_home` (honours a relaxed `--home`).

Operator's standing rule applies: resume, never fresh — the conversation is carried, not discarded.

## Tests

5 new in `test__apptainer_provider_cfg.py` (link target, relaxed home, store created in the transcript home, real dir kept, idempotent) + 1 in `test__apptainer_auth.py`. Real dirs under `tmp_path`; no mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXfFia9RNQ4P9ZWYX8qhR2
