### PR TITLE
feat(harness): the codex TUI launches through the lifecycle

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_runtime_select.py
+++ b/src/scitex_agent_container/_lifecycle/_runtime_select.py
@@ -37,6 +37,7 @@ from ..config import AgentConfig
 from ..config._harness_registry import (
     CLAUDE_AGENT_SDK,
     CLAUDE_CODE_TUI,
+    CODEX_TUI,
     resolve_harness_key,
     runtime_spellings_for,
 )
@@ -95,6 +96,16 @@ def _get_runtime(config: AgentConfig):
     # that keeps the message — and a per-read stderr line would
     # contaminate CliRunner-captured ``--json`` output (the same ruling
     # that placed the deprecation warnings below on the start path).
+    if getattr(config, "kind", "Agent") == "AgentProxy":
+        # A proxy is not a harness: resolve by launch mode alone (an
+        # empty mapping states no harness, so only ``runtime`` selects).
+        key = resolve_harness_key({"runtime": runtime})
+    else:
+        # The key first, so the guard can be told which entry this path
+        # launches; an unknown ``runtime`` spelling raises
+        # UnmappableHarnessError (a ValueError) naming both spec values
+        # and the v4 card.
+        key = resolve_harness_key(config)
     ensure_harness_matches_claude_launch(
         config,
         launching=(
@@ -103,17 +114,14 @@ def _get_runtime(config: AgentConfig):
             else "ClaudeSessionRuntime (the headless claude-agent-sdk runner)"
         ),
         log=False,
+        launching_key=key,
     )
-    if getattr(config, "kind", "Agent") == "AgentProxy":
-        # A proxy is not a harness: resolve by launch mode alone (an
-        # empty mapping states no harness, so only ``runtime`` selects).
-        key = resolve_harness_key({"runtime": runtime})
-    else:
-        # Post-guard the harness is Anthropic-family, so the key is one
-        # of the two Claude entries; an unknown ``runtime`` spelling
-        # raises UnmappableHarnessError (a ValueError) naming both spec
-        # values and the v4 card.
-        key = resolve_harness_key(config)
+    if key == CODEX_TUI:
+        # The same tmux-backed pane runtime as the Claude TUI; the registry
+        # entry owns the argv shape (codex binary + `-c` overrides).
+        from ..runtimes.tui_session import TuiSessionRuntime
+
+        return TuiSessionRuntime()
     if key == CLAUDE_CODE_TUI:
         from ..runtimes.tui_session import TuiSessionRuntime
 

--- a/src/scitex_agent_container/config/_harness_callables.py
+++ b/src/scitex_agent_container/config/_harness_callables.py
@@ -150,6 +150,25 @@ def _codex_sdk_inner_argv(
     return _session_runner_inner_argv(config, CODEX_SESSION_RUNNER, options)
 
 
+def _codex_tui_inner_argv(
+    config: "AgentConfig", options: "Mapping[str, object] | None" = None
+) -> list[str]:
+    """Inner argv for the interactive ``codex`` TUI (pre-shell-wrap).
+
+    Takes the SAME option keys as the Claude TUI entry (the workspace
+    ``.mcp.json`` path and the inline channel-subscriber JSON) so the
+    TUI branch of ``build_inner_argv`` dispatches both entries alike.
+    """
+    options = options or {}
+    from ..runtimes._apptainer_inner_argv_codex import codex_tui_argv
+
+    return codex_tui_argv(
+        config,
+        mcp_config=options.get("tui_mcp_config"),  # type: ignore[arg-type]
+        channel_mcp=options.get("tui_channel_mcp"),  # type: ignore[arg-type]
+    )
+
+
 # ---------------------------------------------------------------------------
 # env_and_binds
 # ---------------------------------------------------------------------------

--- a/src/scitex_agent_container/config/_harness_registry.py
+++ b/src/scitex_agent_container/config/_harness_registry.py
@@ -69,6 +69,7 @@ __all__ = [
     "CLAUDE_AGENT_SDK",
     "CLAUDE_CODE_TUI",
     "CODEX_SDK",
+    "CODEX_TUI",
     "HARNESS_DESCRIPTORS",
     "HarnessDescriptor",
     "OPENAI_AGENTS",
@@ -112,6 +113,13 @@ OPENAI_AGENTS = "openai-agents"
 #: ``runtimes._apptainer_codex_env.codex_env_flags``).
 CODEX_SDK = "codex-sdk"
 
+#: The interactive ``codex`` TUI in a tmux PTY (``spec.harness: codex`` with
+#: ``spec.runtime: tui`` / unset). The shape 107 of 119 fleet specs run
+#: Claude Code in, opened to the codex harness on 2026-09-05 (operator
+#: ruling: the fleet prepares to leave Claude Code, gradually). Renders
+#: through ``runtimes._apptainer_inner_argv_codex``.
+CODEX_TUI = "codex-tui"
+
 
 class UnmappableHarnessError(ValueError):
     """``spec.harness`` + ``spec.runtime`` select no registered harness.
@@ -149,6 +157,7 @@ from ._harness_callables import (  # noqa: F401 (re-export)
     _claude_tui_inner_argv,
     _codex_env_and_binds,
     _codex_sdk_inner_argv,
+    _codex_tui_inner_argv,
     _noop_prepare_home,
     _openai_agents_inner_argv,
     _openai_env_and_binds,
@@ -262,11 +271,28 @@ HARNESS_DESCRIPTORS: dict[str, HarnessDescriptor] = {
             env_and_binds=_openai_env_and_binds,
         ),
         HarnessDescriptor(
+            key=CODEX_TUI,
+            spec_harness="codex",
+            # Mirrors claude-code-tui: an unset ``runtime`` selects the
+            # interactive pane (operator directive 2026-06-15), so a spec
+            # that flips ``harness: anthropic`` to ``codex`` keeps its shape.
+            spec_runtimes=frozenset({"", "tui"}),
+            runner_module=None,  # inner process is the `codex` binary
+            inner_argv=_codex_tui_inner_argv,
+            hosted="external",
+            beat_writer="host-probe",  # pane-activity epoch, host-stamped
+            can_resume=True,  # `codex resume <id>` / `resume --last`
+            env_and_binds=_codex_env_and_binds,
+        ),
+        HarnessDescriptor(
             key=CODEX_SDK,
             spec_harness="codex",
-            # Sole entry of its family, like openai-agents: the runtime
-            # axis spells ANTHROPIC launch modes ("tui" / the legacy
-            # container-engine values), so it cannot discriminate here.
+            # No longer the sole entry of its family (codex-tui above), and
+            # still without a lifecycle adapter: it claims NO runtime
+            # spelling, so an unset / "tui" ``runtime`` selects the pane and
+            # nothing on the runtime axis can select this headless runner
+            # until the adapter that launches it exists (a2a.handler /
+            # ``python -m`` remain its entry, as before).
             spec_runtimes=frozenset(),
             runner_module=_CODEX_SESSION_RUNNER,
             inner_argv=_codex_sdk_inner_argv,
@@ -340,9 +366,7 @@ def resolve_harness_key(spec: "Mapping | AgentConfig") -> str:
         from ._harness_types import DEFAULT_AGENT_HARNESS
 
         harness = (
-            str(getattr(spec, "harness", "") or DEFAULT_AGENT_HARNESS)
-            .strip()
-            .lower()
+            str(getattr(spec, "harness", "") or DEFAULT_AGENT_HARNESS).strip().lower()
         )
         runtime = str(getattr(spec, "runtime", "") or "")
 
@@ -363,9 +387,7 @@ def resolve_harness_key(spec: "Mapping | AgentConfig") -> str:
     for descriptor in family:
         if runtime in descriptor.spec_runtimes:
             return descriptor.key
-    mappings = "; ".join(
-        f"{sorted(d.spec_runtimes)} → {d.key!r}" for d in family
-    )
+    mappings = "; ".join(f"{sorted(d.spec_runtimes)} → {d.key!r}" for d in family)
     raise UnmappableHarnessError(
         f"Unsupported runtime: spec.runtime={runtime!r} maps to no "
         f"registered harness under spec.harness={harness!r}. Accepted "

--- a/src/scitex_agent_container/config/_harness_types.py
+++ b/src/scitex_agent_container/config/_harness_types.py
@@ -114,9 +114,7 @@ class HarnessRuntimeMismatchError(RuntimeError):
 #: The v4 card tracking harness-aware runtime dispatch (migration step 4,
 #: the descriptor registry). Until it lands, sac VALIDATES ``harness:
 #: openai`` but cannot LAUNCH it through the lifecycle runtime path.
-V4_HARNESS_DISPATCH_CARD = (
-    "sac-v4-layering-refactor-harness-runtime-inference-20260813"
-)
+V4_HARNESS_DISPATCH_CARD = "sac-v4-layering-refactor-harness-runtime-inference-20260813"
 
 
 def is_known_harness(name: str) -> bool:
@@ -221,7 +219,7 @@ def _harness_logger():
 
 
 def ensure_harness_matches_claude_launch(
-    config, *, launching: str, log: bool = True
+    config, *, launching: str, log: bool = True, launching_key: str = ""
 ) -> None:
     """Refuse LOUDLY when ``config.harness`` is non-Anthropic but the
     calling code path is about to launch ``launching`` — a Claude-family
@@ -258,13 +256,21 @@ def ensure_harness_matches_claude_launch(
     (d) the v4 gap card id.
     """
     harness = (
-        str(getattr(config, "harness", "") or DEFAULT_AGENT_HARNESS)
-        .strip()
-        .lower()
+        str(getattr(config, "harness", "") or DEFAULT_AGENT_HARNESS).strip().lower()
     )
     if harness == DEFAULT_AGENT_HARNESS:
         return
     if getattr(config, "kind", "Agent") == "AgentProxy":
+        return
+    # 2026-09-05: the first non-Anthropic entry with a full launch path.
+    # The caller states WHICH registry entry it is about to launch
+    # (``launching_key``); a codex spec headed for the codex TUI is a
+    # correct routing, not a wrong-vendor one. Every other non-Anthropic
+    # combination still refuses below — the predicate stays "is the
+    # declared harness what this path launches?", answered per entry.
+    from ._harness_registry import CODEX_TUI
+
+    if harness == "codex" and launching_key == CODEX_TUI:
         return
     caller = sys._getframe(1)
     site = f"{caller.f_code.co_filename}:{caller.f_lineno}"

--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -47,6 +47,11 @@ from ._apptainer_auth_bind import (  # noqa: F401 (re-export — see module docs
     credentials_file_bind,
     ensure_credentials_bind_target,
 )
+from ._apptainer_codex_env import (
+    codex_env_flags,
+    codex_harness_active,
+    codex_provider_key_flags,
+)
 from ._apptainer_provider import (
     engine_env_flags,
     openai_env_flags,
@@ -89,6 +94,18 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # branch order already documents. Empty for every legacy
     # single-backend spec, so their argv is unchanged.
     engine_flags = engine_env_flags(config)
+
+    if codex_harness_active(config):
+        # codex harness (2026-09-05): CODEX_HOME bind + the binary's own
+        # key names, plus the engine's resolved provider key under the
+        # env name the rendered config.toml points at (env_key). No
+        # Anthropic OAuth env, no ANTHROPIC_BASE_URL — Codex reads its
+        # provider from config only (OPENAI_BASE_URL is ignored).
+        return (
+            engine_flags
+            + codex_env_flags(config, state_dir)
+            + codex_provider_key_flags(config)
+        )
 
     if openai_harness_active(config):
         # openai agent-SDK family (openai-compat-3): OPENAI_* columns

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -93,15 +93,21 @@ def build_run_argv(
     # function reads ``config.harness`` CORRECTLY. That split-brain is
     # exactly the bug this guard retires: OPENAI_* auth env provisioned,
     # Claude runner launched, no error anywhere.
+    from ..config._harness_registry import CODEX_TUI
     from ..config._harness_types import ensure_harness_matches_claude_launch
+    from ._apptainer_codex_env import codex_harness_active
 
+    codex_pane = bool(tui) and codex_harness_active(config)
     ensure_harness_matches_claude_launch(
         config,
         launching=(
-            "the interactive claude TUI"
+            "the interactive codex TUI"
+            if codex_pane
+            else "the interactive claude TUI"
             if tui
             else f"runner module {RUNNER_MODULE!r}"
         ),
+        launching_key=CODEX_TUI if codex_pane else "",
     )
 
     # Hardened isolation by default — see _apptainer_iso_flags for the

--- a/src/scitex_agent_container/runtimes/_apptainer_codex_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_codex_env.py
@@ -53,12 +53,19 @@ import os
 from pathlib import Path
 
 from ..config._types import AgentConfig
-from ._apptainer_provider import ProviderEnvError, provider_active, resolve_agent_harness
+from ._apptainer_provider import (
+    ProviderEnvError,
+    _provider_spec,
+    provider_active,
+    resolve_agent_harness,
+    resolve_provider_api_key,
+)
 
 __all__ = [
     "CODEX_HOME_ENV",
     "codex_env_flags",
     "codex_harness_active",
+    "codex_provider_key_flags",
     "resolve_codex_home",
 ]
 
@@ -93,6 +100,50 @@ _ROUTING_ENVS = (
     "SAC_CODEX_MODEL_PROVIDER",
     "SAC_CODEX_SANDBOX",
 )
+
+
+def _is_registry_codex_backend(config: AgentConfig) -> bool:
+    """True when the active provider IS ``spec.claude.provider: codex``.
+
+    That named backend is the scitex-genai gateway translating Anthropic
+    Messages to a ChatGPT Codex subscription with Claude Code driving —
+    the two-axis collision the docstring above describes. An INLINE
+    provider (``base_url`` + ``auth_token_env``, the engines surface) is
+    the opposite case: it is the inference endpoint the codex harness
+    itself is pointed at (2026-09-05), so it composes.
+    """
+    from ..config._provider_registry import resolve_provider
+
+    named = resolve_provider("codex")
+    active = _provider_spec(config)
+    if named is None or active is None:
+        return False
+    named_url = (
+        named.get("base_url", "")
+        if isinstance(named, dict)
+        else getattr(named, "base_url", "")
+    )
+    return str(getattr(active, "base_url", "")).rstrip("/") == str(named_url).rstrip(
+        "/"
+    )
+
+
+def codex_provider_key_flags(config: AgentConfig) -> list[str]:
+    """``--env SAC_CODEX_API_KEY=<key>`` from the engine's provider block.
+
+    The rendered Codex config names this env var as the provider's
+    ``env_key`` (``_apptainer_inner_argv_codex.CODEX_KEY_ENV``); the value
+    is the same resolved key the Claude path would put in
+    ANTHROPIC_API_KEY. Empty when no inline provider is active — then the
+    binary's own key names (``_KEY_ENVS``) are all there is.
+    """
+    if not codex_harness_active(config) or not provider_active(config):
+        return []
+    if _is_registry_codex_backend(config):
+        return []
+    from ._apptainer_inner_argv_codex import CODEX_KEY_ENV
+
+    return ["--env", f"{CODEX_KEY_ENV}={resolve_provider_api_key(config)}"]
 
 
 def codex_harness_active(config: AgentConfig) -> bool:
@@ -139,7 +190,7 @@ def codex_env_flags(config: AgentConfig, state_dir: Path) -> list[str]:
     if not codex_harness_active(config):
         return []
 
-    if provider_active(config):
+    if provider_active(config) and _is_registry_codex_backend(config):
         raise ProviderEnvError(
             "spec.harness: codex cannot compose with an active "
             "spec.claude.provider backend override — the nested override "

--- a/src/scitex_agent_container/runtimes/_apptainer_codex_exec.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_codex_exec.py
@@ -1,0 +1,163 @@
+"""In-container exec shim for the ``codex`` TUI (see ``_apptainer_inner_argv_codex``).
+
+Runs INSIDE the agent container as the tail of the pane's ``bash -lc``: it
+resolves the ``codex`` binary from the image's own venv, translates the MCP
+server files the Claude TUI receives as ``--mcp-config`` flags into Codex's
+``-c mcp_servers.*`` overrides, and ``execv``s the binary in place — so the
+pane holds ``codex`` itself, not a python parent.
+
+    python3 -m scitex_agent_container.runtimes._apptainer_codex_exec \\
+        [--mcp-config PATH]... [--mcp-json JSON]... -- <codex args...>
+
+Why here and not on the host: ``~/.mcp.json`` and the inline channel JSON
+exist only in the container, and ``codex_cli_bin.bundled_codex_path()`` on
+the host names the HOST venv, which is not the path inside the image.
+
+Codex's MCP shape (``codex mcp add`` writes the same keys):
+``mcp_servers.<name>.command`` / ``.args`` / ``.env`` for stdio servers,
+``mcp_servers.<name>.url`` (+ ``.bearer_token_env_var``) for streamable
+HTTP. Claude's ``.mcp.json`` uses ``mcpServers.<name>.{command,args,env}``
+and ``{type: "http", url, headers}``; the translation below covers both.
+Diagnostics go through sac's logger (the house rule for ``src/``); they land
+on the pane's stderr, which the boot-stderr log captures.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from .._logging import get_logger
+
+__all__ = ["main", "mcp_overrides", "resolve_codex_binary"]
+
+_log = get_logger(__name__)
+
+#: An operator-set absolute path wins; the bundled binary is the default.
+CODEX_BIN_ENV = "SAC_CODEX_BIN"
+
+
+def resolve_codex_binary() -> str:
+    override = os.environ.get(CODEX_BIN_ENV, "").strip()
+    if override:
+        return override
+    try:
+        from codex_cli_bin import bundled_codex_path
+
+        return str(bundled_codex_path())
+    except Exception:  # noqa: BLE001 — the fallback names the gap loudly below
+        return "codex"
+
+
+def _toml(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml(v) for v in value) + "]"
+    if isinstance(value, dict):
+        return (
+            "{ "
+            + ", ".join(f"{json.dumps(str(k))} = {_toml(v)}" for k, v in value.items())
+            + " }"
+        )
+    return json.dumps(str(value))
+
+
+def _servers(document: object) -> dict[str, dict]:
+    if not isinstance(document, dict):
+        return {}
+    servers = document.get("mcpServers", document)
+    return (
+        {str(name): entry for name, entry in servers.items() if isinstance(entry, dict)}
+        if isinstance(servers, dict)
+        else {}
+    )
+
+
+def mcp_overrides(documents: list[object]) -> list[str]:
+    """``-c mcp_servers.<name>.<field>=<toml>`` flags for every server given."""
+    flags: list[str] = []
+    for document in documents:
+        for name, entry in _servers(document).items():
+            key = f"mcp_servers.{name}"
+            url = entry.get("url")
+            if url:
+                flags += ["-c", f"{key}.url={_toml(url)}"]
+                headers = entry.get("headers") or {}
+                token_env = entry.get("bearer_token_env_var")
+                if token_env:
+                    flags += ["-c", f"{key}.bearer_token_env_var={_toml(token_env)}"]
+                elif headers:
+                    flags += ["-c", f"{key}.http_headers={_toml(headers)}"]
+                continue
+            command = entry.get("command")
+            if not command:
+                continue
+            flags += ["-c", f"{key}.command={_toml(command)}"]
+            args = entry.get("args") or []
+            if args:
+                flags += ["-c", f"{key}.args={_toml(list(args))}"]
+            env = entry.get("env") or {}
+            if env:
+                flags += ["-c", f"{key}.env={_toml(dict(env))}"]
+    return flags
+
+
+def _load_documents(paths: list[str], inline: list[str]) -> list[object]:
+    documents: list[object] = []
+    for path in paths:
+        p = Path(path)
+        if not p.is_file():
+            _log.warning("codex-exec: mcp config %s is absent; skipping", path)
+            continue
+        try:
+            documents.append(json.loads(p.read_text(encoding="utf-8")))
+        except ValueError as exc:
+            _log.warning(
+                "codex-exec: mcp config %s is not JSON (%s); skipping", path, exc
+            )
+    for text in inline:
+        try:
+            documents.append(json.loads(text))
+        except ValueError as exc:
+            _log.warning("codex-exec: inline mcp json is not JSON (%s); skipping", exc)
+    return documents
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    paths: list[str] = []
+    inline: list[str] = []
+    while args and args[0] != "--":
+        flag = args.pop(0)
+        if flag == "--mcp-config" and args:
+            paths.append(args.pop(0))
+        elif flag == "--mcp-json" and args:
+            inline.append(args.pop(0))
+        else:
+            _log.error("codex-exec: unexpected argument %r", flag)
+            return 2
+    if args and args[0] == "--":
+        args.pop(0)
+    binary = resolve_codex_binary()
+    codex_argv = [binary, *args, *mcp_overrides(_load_documents(paths, inline))]
+    try:
+        os.execv(binary, codex_argv)
+    except OSError as exc:
+        _log.error(
+            "codex-exec: cannot exec %r: %s. Set %s to the codex binary, or install "
+            "openai-codex-cli-bin in the image venv.",
+            binary,
+            exc,
+            CODEX_BIN_ENV,
+        )
+        return 127
+    return 0  # pragma: no cover — execv does not return
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from ..config._harness_registry import (
     CLAUDE_AGENT_SDK,
     CLAUDE_CODE_TUI,
+    CODEX_TUI,
     HARNESS_DESCRIPTORS,
     OPENAI_AGENTS,
 )
@@ -168,26 +169,35 @@ def build_inner_argv(
     """
     kind = getattr(config, "kind", "Agent")
     if tui:
-        # Same v4 step-2 guard as the SDK branch below: the interactive
-        # claude TUI is just as wrong a vendor for a non-Anthropic
-        # harness (and this branch never had even the dead check).
-        ensure_harness_matches_claude_launch(
-            config, launching="the interactive claude TUI"
-        )
+        tui_options = {
+            "tui_mcp_config": tui_mcp_config,
+            "tui_channel_mcp": tui_channel_mcp,
+            "tui_dev_channels": tui_dev_channels,
+            "tui_settings": tui_settings,
+        }
         # v4 step 4: the registry entry owns the argv shape. The entry is
         # keyed by the caller's already-decided launch mode (``tui=True``
         # came from TuiSessionRuntime), never re-derived from the config —
         # direct/dry-run callers pass configs whose ``runtime`` field this
-        # builder must not second-guess.
-        runner_tail = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI].inner_argv(
-            config,
-            {
-                "tui_mcp_config": tui_mcp_config,
-                "tui_channel_mcp": tui_channel_mcp,
-                "tui_dev_channels": tui_dev_channels,
-                "tui_settings": tui_settings,
-            },
-        )
+        # builder must not second-guess. The HARNESS axis picks the pane's
+        # program: codex (2026-09-05) or Claude Code.
+        from ._apptainer_codex_env import codex_harness_active
+
+        if codex_harness_active(config):
+            ensure_harness_matches_claude_launch(
+                config, launching="the interactive codex TUI", launching_key=CODEX_TUI
+            )
+            runner_tail = HARNESS_DESCRIPTORS[CODEX_TUI].inner_argv(config, tui_options)
+        else:
+            # Same v4 step-2 guard as the SDK branch below: the interactive
+            # claude TUI is just as wrong a vendor for a non-Anthropic
+            # harness (and this branch never had even the dead check).
+            ensure_harness_matches_claude_launch(
+                config, launching="the interactive claude TUI"
+            )
+            runner_tail = HARNESS_DESCRIPTORS[CLAUDE_CODE_TUI].inner_argv(
+                config, tui_options
+            )
     elif kind == "AgentProxy":
         runner_tail = _TINI_PREFIX + [RUNNER_MODULE_PROXY] + _proxy_runner_argv(config)
     else:

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv_codex.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv_codex.py
@@ -1,0 +1,168 @@
+"""Inner argv for the interactive ``codex`` TUI (``spec.harness: codex``).
+
+WHY THIS EXISTS (2026-09-05, operator ruling): the fleet prepares to leave
+Claude Code for the Codex CLI, gradually, over the OpenAI protocol that the
+Qwen server speaks natively. 107 of 119 fleet specs run their harness as an
+interactive TUI in a tmux pane, so the codex harness needs the same shape —
+this module renders what that pane runs.
+
+TWO HALVES, and the split is deliberate:
+
+* HOST side (this module): the static Codex config overrides, rendered from
+  the spec — the model provider (``spec.engines.<key>.provider`` /
+  ``spec.claude.provider``: ``base_url`` + the key's env NAME), the model,
+  the sandbox, the context window and the session pin. Every override is a
+  ``-c key=value`` flag — Codex reads its config from ``config.toml`` and
+  from ``-c`` overrides ONLY (``OPENAI_BASE_URL`` is silently ignored;
+  measured against the 0.153 binary), so no file has to be written into
+  the agent's home and nothing is left behind on a harness switch.
+* CONTAINER side (:mod:`._apptainer_codex_exec`): the shim the pane
+  actually execs. It resolves the ``codex`` binary bundled in the image's
+  own venv (``codex_cli_bin.bundled_codex_path``) — resolving it on the
+  host would bake a host path into the argv — and translates the MCP
+  server files sac materialises for the Claude TUI (``~/.mcp.json`` plus
+  the inline channel-subscriber JSON) into ``-c mcp_servers.*`` overrides,
+  because those files exist only inside the container.
+
+MEASURED FACTS THE FLAGS REST ON (codex-cli 0.147.0 in the image, 0.153.4
+from npm; the fleet card carries the evidence):
+
+* ``wire_api``'s only accepted value is ``"responses"``; ``"chat"`` fails
+  config load. vLLM 0.22.0 serves ``/v1/responses`` natively, and the
+  scitex-genai gateway relays it since #42.
+* ``env_key`` is enough for a custom provider: no ChatGPT OAuth, no
+  ``auth.json``, no ``codex login``.
+* The sandbox is bubblewrap, which cannot nest inside apptainer: with the
+  default sandbox every tool call exits 1 WHILE THE MODEL REPORTS SUCCESS.
+  The container is already the boundary, so the sandbox is off here.
+* ``model_context_window`` and ``model_reasoning_effort`` are real config
+  keys in this version (27 and 26 occurrences in the binary);
+  ``model_max_output_tokens`` is not.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from ..config._session_continuity import SESSION_RESUME, wants_continue
+from ._apptainer_provider import ProviderEnvError, _provider_spec
+
+if TYPE_CHECKING:
+    from ..config import AgentConfig
+
+__all__ = [
+    "CODEX_EXEC_MODULE",
+    "CODEX_KEY_ENV",
+    "CODEX_PROVIDER_ID",
+    "codex_config_overrides",
+    "codex_tui_argv",
+]
+
+#: The in-container shim that resolves the binary and the MCP overrides.
+CODEX_EXEC_MODULE = "scitex_agent_container.runtimes._apptainer_codex_exec"
+
+#: The ``[model_providers.<id>]`` entry the overrides declare and select.
+CODEX_PROVIDER_ID = "sac"
+
+#: The env var Codex reads the provider key from (``env_key``). sac puts the
+#: engine's resolved key under this name — see
+#: :func:`._apptainer_codex_env.codex_provider_key_flags`.
+CODEX_KEY_ENV = "SAC_CODEX_API_KEY"
+
+#: The container is the boundary; Codex's own bubblewrap sandbox cannot nest
+#: inside apptainer (measured: tool calls exit 1, the model reports success).
+_SANDBOX = "danger-full-access"
+
+
+def _toml(value: object) -> str:
+    """A TOML literal for a string / int / bool — JSON's are valid TOML here."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    return json.dumps(str(value))
+
+
+def _override(key: str, value: object) -> list[str]:
+    return ["-c", f"{key}={_toml(value)}"]
+
+
+def codex_config_overrides(config: AgentConfig) -> list[str]:
+    """The static ``-c`` overrides for one agent, rendered from its spec."""
+    provider = _provider_spec(config)
+    base_url = str(getattr(provider, "base_url", "") or "").strip().rstrip("/")
+    if not base_url:
+        raise ProviderEnvError(
+            f"spec.harness: codex on agent {config.name!r} needs an inference "
+            "provider (spec.engines.<key>.provider with base_url + "
+            "auth_token_env, or spec.claude.provider): Codex reads its model "
+            "provider from config only, and sac refuses to point it at the "
+            "OpenAI-hosted default by silence."
+        )
+    claude = getattr(config, "claude", None)
+    model = str(
+        getattr(claude, "model", "") or getattr(config, "model", "") or ""
+    ).strip()
+    if not model:
+        raise ProviderEnvError(
+            f"spec.harness: codex on agent {config.name!r} names no model "
+            "(spec.engines.<key>.model / spec.claude.model) — Codex would fall "
+            "back to its OpenAI-hosted default silently."
+        )
+    pid = CODEX_PROVIDER_ID
+    flags: list[str] = []
+    flags += _override("model_provider", pid)
+    flags += _override(f"model_providers.{pid}.name", "scitex-genai gateway")
+    flags += _override(f"model_providers.{pid}.base_url", f"{base_url}/v1")
+    flags += _override(f"model_providers.{pid}.wire_api", "responses")
+    flags += _override(f"model_providers.{pid}.env_key", CODEX_KEY_ENV)
+    flags += _override(f"model_providers.{pid}.requires_openai_auth", False)
+    flags += _override("model", model)
+    flags += _override("sandbox_mode", _SANDBOX)
+    flags += _override("approval_policy", "never")
+    max_ctx = getattr(config, "max_context_tokens", None)
+    if max_ctx:
+        flags += _override("model_context_window", int(max_ctx))
+    effort = str(getattr(config, "reasoning_effort", "") or "").strip()
+    if effort:
+        flags += _override("model_reasoning_effort", effort)
+    return flags
+
+
+def _session_args(config: AgentConfig) -> list[str]:
+    """``resume <id>`` / ``resume --last`` from the spec's session mode."""
+    claude = getattr(config, "claude", None)
+    mode = str(getattr(claude, "session", "") or "").strip().lower()
+    if wants_continue(getattr(claude, "session", None)):
+        return ["resume", "--last"]
+    if mode == SESSION_RESUME:
+        resume_id = str(getattr(claude, "resume_id", "") or "").strip()
+        if resume_id:
+            return ["resume", resume_id]
+    return []
+
+
+def codex_tui_argv(
+    config: AgentConfig,
+    *,
+    mcp_config: str | None = None,
+    channel_mcp: str | None = None,
+) -> list[str]:
+    """Argv for the interactive ``codex`` TUI (pre-shell-wrap).
+
+    ``mcp_config`` is the in-container path of the workspace ``.mcp.json``
+    sac materialised; ``channel_mcp`` the inline JSON registering the
+    ``sac mcp channel`` subscriber. Both are handed to the in-container shim,
+    which turns them into ``-c mcp_servers.*`` overrides the way the Claude
+    TUI receives them as ``--mcp-config`` flags.
+    """
+    argv: list[str] = ["python3", "-m", CODEX_EXEC_MODULE]
+    if mcp_config:
+        argv += ["--mcp-config", mcp_config]
+    if channel_mcp:
+        argv += ["--mcp-json", channel_mcp]
+    argv.append("--")
+    argv += _session_args(config)
+    argv += codex_config_overrides(config)
+    return argv

--- a/tests/scitex_agent_container/_lifecycle/test__runtime_select.py
+++ b/tests/scitex_agent_container/_lifecycle/test__runtime_select.py
@@ -401,3 +401,46 @@ def test_get_runtime_returns_claude_session_for_anthropic_harness():
     rt = _get_runtime(config)
     # Assert
     assert isinstance(rt, ClaudeSessionRuntime)
+
+
+# ---------------------------------------------------------------------------
+# codex-tui (2026-09-05): the selector maps the codex pane to the TUI runtime
+# ---------------------------------------------------------------------------
+
+
+def test_get_runtime_returns_tui_session_for_harness_codex():
+    # Arrange -- a spec that only flipped harness: anthropic -> codex.
+    config = AgentConfig(name="hm", runtime="", workdir="/tmp/hm", harness="codex")
+    # Act
+    rt = _get_runtime(config)
+    # Assert
+    assert isinstance(rt, TuiSessionRuntime)
+
+
+def test_get_runtime_still_refuses_the_headless_codex_runner():
+    # Arrange -- registered but without a lifecycle adapter, the headless
+    # runner claims no runtime spelling, so its name is unmappable: loud.
+    config = AgentConfig(
+        name="hm", runtime="codex-sdk", workdir="/tmp/hm", harness="codex"
+    )
+    # Act
+    try:
+        _get_runtime(config)
+        message = ""
+    except ValueError as exc:
+        message = str(exc)
+    # Assert
+    assert "codex-sdk" in message
+
+
+def test_get_runtime_still_refuses_the_openai_harness():
+    # Arrange -- the vendor guard is untouched for every other family.
+    config = AgentConfig(name="oa", runtime="", workdir="/tmp/oa", harness="openai")
+    # Act
+    try:
+        _get_runtime(config)
+        raised = None
+    except HarnessRuntimeMismatchError as exc:
+        raised = exc
+    # Assert
+    assert isinstance(raised, HarnessRuntimeMismatchError)

--- a/tests/scitex_agent_container/config/test__harness_registry.py
+++ b/tests/scitex_agent_container/config/test__harness_registry.py
@@ -20,6 +20,7 @@ from scitex_agent_container.config._harness_registry import (
     CLAUDE_AGENT_SDK,
     CLAUDE_CODE_TUI,
     CODEX_SDK,
+    CODEX_TUI,
     HARNESS_DESCRIPTORS,
     OPENAI_AGENTS,
     UnmappableHarnessError,
@@ -260,13 +261,14 @@ def test_resolve_config_and_mapping_surfaces_agree():
 # ---------------------------------------------------------------------------
 
 
-def test_registry_has_exactly_the_four_real_entries():
+def test_registry_has_exactly_the_five_real_entries():
     # Arrange — CODEX_SDK joined on 2026-08-14 (card
     # sac-codex-python-sdk-harness-20260814), the first vendor added
     # since the registry landed. A closed-set assertion like this one is
     # deliberately allowed to break when a row is added: the break is
     # the review prompt asking whether the new entry was intended.
-    expected = {CLAUDE_CODE_TUI, CLAUDE_AGENT_SDK, OPENAI_AGENTS, CODEX_SDK}
+    # CODEX_TUI joined on 2026-09-05 (the operator's move off Claude Code).
+    expected = {CLAUDE_CODE_TUI, CLAUDE_AGENT_SDK, OPENAI_AGENTS, CODEX_SDK, CODEX_TUI}
     # Act
     keys = set(HARNESS_DESCRIPTORS)
     # Assert
@@ -698,3 +700,61 @@ def test_get_runtime_proxy_resolves_by_launch_mode_alone():
     adapter = _get_runtime(cfg)
     # Assert
     assert isinstance(adapter, TuiSessionRuntime)
+
+
+# ---------------------------------------------------------------------------
+# codex-tui (2026-09-05): the first non-Anthropic entry with a launch path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_harness_codex_maps_to_the_codex_tui_key():
+    # Arrange -- a spec that only flipped harness: anthropic -> codex.
+    spec = {"harness": "codex"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CODEX_TUI
+
+
+def test_resolve_harness_codex_runtime_tui_maps_to_the_codex_tui_key():
+    # Arrange
+    spec = {"harness": "codex", "runtime": "tui"}
+    # Act
+    key = resolve_harness_key(spec)
+    # Assert
+    assert key == CODEX_TUI
+
+
+def test_resolve_harness_codex_has_no_runtime_spelling_for_the_headless_runner():
+    # Arrange -- codex-sdk has no lifecycle adapter, so no spelling selects it.
+    spec = {"harness": "codex", "runtime": "codex-sdk"}
+    # Act
+    try:
+        resolve_harness_key(spec)
+        message = ""
+    except UnmappableHarnessError as exc:
+        message = str(exc)
+    # Assert
+    assert "codex-sdk" in message
+
+
+def test_resolve_harness_codex_legacy_apptainer_runtime_is_unmappable():
+    # Arrange -- "apptainer" spells the CLAUDE sdk runner, not a codex mode.
+    spec = {"harness": "codex", "runtime": "apptainer"}
+    # Act
+    try:
+        resolve_harness_key(spec)
+        message = ""
+    except UnmappableHarnessError as exc:
+        message = str(exc)
+    # Assert
+    assert "apptainer" in message
+
+
+def test_codex_tui_entry_is_host_probed_like_the_claude_tui():
+    # Arrange
+    descriptor = HARNESS_DESCRIPTORS[CODEX_TUI]
+    # Act
+    writer = descriptor.beat_writer
+    # Assert
+    assert writer == "host-probe"

--- a/tests/scitex_agent_container/config/test__harness_registry_codex.py
+++ b/tests/scitex_agent_container/config/test__harness_registry_codex.py
@@ -31,6 +31,7 @@ from scitex_agent_container.config._harness_registry import (
     CLAUDE_AGENT_SDK,
     CLAUDE_CODE_TUI,
     CODEX_SDK,
+    CODEX_TUI,
     HARNESS_DESCRIPTORS,
     OPENAI_AGENTS,
     UnmappableHarnessError,
@@ -161,8 +162,8 @@ def test_resolve_maps_the_codex_harness_to_its_key():
     spec = {"harness": "codex"}
     # Act
     key = resolve_harness_key(spec)
-    # Assert
-    assert key == CODEX_SDK
+    # Assert -- since 2026-09-05 the family's default is the pane, as for Claude.
+    assert key == CODEX_TUI
 
 
 def test_resolve_honours_the_legacy_provider_alias_for_codex():
@@ -172,7 +173,7 @@ def test_resolve_honours_the_legacy_provider_alias_for_codex():
     # Act
     key = resolve_harness_key(spec)
     # Assert
-    assert key == CODEX_SDK
+    assert key == CODEX_TUI
 
 
 def test_resolve_accepts_a_loaded_config_codex_harness():
@@ -181,7 +182,7 @@ def test_resolve_accepts_a_loaded_config_codex_harness():
     # Act
     key = resolve_harness_key(config)
     # Assert
-    assert key == CODEX_SDK
+    assert key == CODEX_TUI
 
 
 def test_resolve_refuses_the_registry_key_spelling_as_a_harness_name():
@@ -258,9 +259,11 @@ def test_adding_codex_did_not_widen_the_runtime_spellings():
     assert spellings == expected
 
 
-def test_the_registry_holds_exactly_the_four_known_harness_keys():
+def test_the_registry_holds_exactly_the_five_known_harness_keys():
     # Arrange
-    expected = sorted([CLAUDE_CODE_TUI, CLAUDE_AGENT_SDK, OPENAI_AGENTS, CODEX_SDK])
+    expected = sorted(
+        [CLAUDE_CODE_TUI, CLAUDE_AGENT_SDK, OPENAI_AGENTS, CODEX_SDK, CODEX_TUI]
+    )
     # Act
     keys = sorted(HARNESS_DESCRIPTORS)
     # Assert

--- a/tests/scitex_agent_container/config/test__harness_types.py
+++ b/tests/scitex_agent_container/config/test__harness_types.py
@@ -19,10 +19,11 @@ import dataclasses
 import pytest
 import yaml
 
-from scitex_agent_container.config import load_config
+from scitex_agent_container.config import AgentConfig, load_config
 from scitex_agent_container.config._explicit_validation import (
     explicit_spec_defaults,
 )
+from scitex_agent_container.config._harness_registry import CODEX_TUI
 from scitex_agent_container.config._harness_types import (
     DEFAULT_AGENT_HARNESS,
     V4_HARNESS_DISPATCH_CARD,
@@ -475,3 +476,52 @@ def test_the_guard_passes_an_anthropic_spec_untouched(tmp_path):
     exc = _refusal(config)
     # Assert
     assert exc is None
+
+
+# ---------------------------------------------------------------------------
+# The guard learns which entry the caller launches (codex-tui, 2026-09-05)
+# ---------------------------------------------------------------------------
+
+
+def test_guard_passes_a_codex_spec_headed_for_the_codex_tui():
+    # Arrange
+    config = AgentConfig(name="hm", runtime="", workdir="/tmp/hm", harness="codex")
+    # Act
+    outcome = ensure_harness_matches_claude_launch(
+        config,
+        launching="the interactive codex TUI",
+        launching_key=CODEX_TUI,
+        log=False,
+    )
+    # Assert
+    assert outcome is None
+
+
+def test_guard_still_refuses_a_codex_spec_headed_for_a_claude_launch():
+    # Arrange -- the same spec on a Claude code path is the wrong-vendor case.
+    config = AgentConfig(name="hm", runtime="", workdir="/tmp/hm", harness="codex")
+    # Act
+    try:
+        ensure_harness_matches_claude_launch(
+            config, launching="the interactive claude TUI", log=False
+        )
+        message = ""
+    except HarnessRuntimeMismatchError as exc:
+        message = str(exc)
+    # Assert
+    assert "codex" in message
+
+
+def test_guard_refuses_an_openai_spec_even_when_told_codex_tui():
+    # Arrange -- the early return is keyed on the harness AND the entry.
+    config = AgentConfig(name="oa", runtime="", workdir="/tmp/oa", harness="openai")
+    # Act
+    try:
+        ensure_harness_matches_claude_launch(
+            config, launching="x", launching_key=CODEX_TUI, log=False
+        )
+        raised = None
+    except HarnessRuntimeMismatchError as exc:
+        raised = exc
+    # Assert
+    assert isinstance(raised, HarnessRuntimeMismatchError)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
@@ -303,3 +303,64 @@ def test_default_family_argv_omits_openai_key(
     argv = auth_argv(cfg, state_dir=tmp_path / "state")
     # Assert
     assert not any(a.startswith("SAC_OPENAI_API_KEY=") for a in argv)
+
+
+# ---------------------------------------------------------------------------
+# The codex harness branch (2026-09-05)
+# ---------------------------------------------------------------------------
+
+
+def _codex_config(workdir: Path) -> AgentConfig:
+    claude = ClaudeSpec(
+        model="qwen38-27b",
+        provider=ProviderSpec(
+            base_url="http://100.64.0.1:18772", auth_token_env="FLEET_GATEWAY_KEY"
+        ),
+    )
+    return AgentConfig(
+        name="hm", runtime="tui", workdir=str(workdir), harness="codex", claude=claude
+    )
+
+
+def _env_of(flags: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for i, a in enumerate(flags):
+        if a == "--env" and i + 1 < len(flags):
+            k, _, v = flags[i + 1].partition("=")
+            out[k] = v
+    return out
+
+
+def test_codex_harness_gets_the_provider_key_under_the_env_key_name(
+    tmp_path, env_save_restore
+):
+    # Arrange -- the rendered config names SAC_CODEX_API_KEY as env_key.
+    env_save_restore.set("FLEET_GATEWAY_KEY", "fleet-secret")
+    env_save_restore.delete("SAC_PROVIDER")
+    config = _codex_config(tmp_path)
+    # Act
+    env = _env_of(auth_argv(config, tmp_path))
+    # Assert
+    assert env["SAC_CODEX_API_KEY"] == "fleet-secret"
+
+
+def test_codex_harness_gets_no_anthropic_base_url(tmp_path, env_save_restore):
+    # Arrange -- Codex reads its provider from config; no Anthropic routing env.
+    env_save_restore.set("FLEET_GATEWAY_KEY", "fleet-secret")
+    env_save_restore.delete("SAC_PROVIDER")
+    config = _codex_config(tmp_path)
+    # Act
+    env = _env_of(auth_argv(config, tmp_path))
+    # Assert
+    assert "ANTHROPIC_BASE_URL" not in env
+
+
+def test_codex_harness_binds_codex_home(tmp_path, env_save_restore):
+    # Arrange
+    env_save_restore.set("FLEET_GATEWAY_KEY", "fleet-secret")
+    env_save_restore.delete("SAC_PROVIDER")
+    config = _codex_config(tmp_path)
+    # Act
+    env = _env_of(auth_argv(config, tmp_path))
+    # Assert
+    assert env["CODEX_HOME"] == "/home/agent/.codex"

--- a/tests/scitex_agent_container/runtimes/test__apptainer_codex_exec.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_codex_exec.py
@@ -1,0 +1,100 @@
+"""Tests for ``runtimes/_apptainer_codex_exec`` — the in-container codex shim.
+
+Only the pure half is exercised here (the MCP translation and the binary
+resolution); ``execv`` replaces the process and is not called by a test.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.runtimes._apptainer_codex_exec import (
+    CODEX_BIN_ENV,
+    mcp_overrides,
+    resolve_codex_binary,
+)
+
+
+def _flags(documents: list[object]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    flags = mcp_overrides(documents)
+    for i, a in enumerate(flags):
+        if a == "-c" and i + 1 < len(flags):
+            k, _, v = flags[i + 1].partition("=")
+            out[k] = v
+    return out
+
+
+def test_stdio_server_command_is_translated():
+    # Arrange -- Claude's .mcp.json shape.
+    document = {
+        "mcpServers": {"scitex-cards": {"command": "scitex-cards", "args": ["mcp"]}}
+    }
+    # Act
+    seen = _flags([document])
+    # Assert
+    assert seen["mcp_servers.scitex-cards.command"] == '"scitex-cards"'
+
+
+def test_stdio_server_args_become_a_toml_array():
+    # Arrange
+    document = {"mcpServers": {"sac": {"command": "sac", "args": ["mcp", "serve"]}}}
+    # Act
+    seen = _flags([document])
+    # Assert
+    assert seen["mcp_servers.sac.args"] == '["mcp", "serve"]'
+
+
+def test_stdio_server_env_becomes_a_toml_inline_table():
+    # Arrange
+    document = {"mcpServers": {"sac": {"command": "sac", "env": {"SAC_NAME": "hm"}}}}
+    # Act
+    seen = _flags([document])
+    # Assert
+    assert seen["mcp_servers.sac.env"] == '{ "SAC_NAME" = "hm" }'
+
+
+def test_http_server_url_is_translated():
+    # Arrange -- the streamable-HTTP shape the channel subscriber may use.
+    document = {
+        "mcpServers": {"bus": {"type": "http", "url": "http://127.0.0.1:19001/mcp"}}
+    }
+    # Act
+    seen = _flags([document])
+    # Assert
+    assert seen["mcp_servers.bus.url"] == '"http://127.0.0.1:19001/mcp"'
+
+
+def test_bare_server_map_without_the_wrapper_key_is_accepted():
+    # Arrange -- the inline channel JSON may omit the mcpServers wrapper.
+    document = {"channel": {"command": "sac", "args": ["mcp", "channel"]}}
+    # Act
+    seen = _flags([document])
+    # Assert
+    assert seen["mcp_servers.channel.command"] == '"sac"'
+
+
+def test_documents_are_merged_in_order():
+    # Arrange -- the workspace file and the inline JSON both contribute.
+    first = {"mcpServers": {"one": {"command": "one"}}}
+    second = {"two": {"command": "two"}}
+    # Act
+    seen = _flags([first, second])
+    # Assert
+    assert sorted(k.split(".")[1] for k in seen) == ["one", "two"]
+
+
+def test_an_operator_set_binary_path_wins(env_save_restore):
+    # Arrange
+    env_save_restore.set(CODEX_BIN_ENV, "/opt/elsewhere/codex")
+    # Act
+    binary = resolve_codex_binary()
+    # Assert
+    assert binary == "/opt/elsewhere/codex"
+
+
+def test_the_bundled_binary_is_the_default(env_save_restore):
+    # Arrange -- the image venv ships openai-codex-cli-bin; nothing overrides it.
+    env_save_restore.delete(CODEX_BIN_ENV)
+    # Act
+    binary = resolve_codex_binary()
+    # Assert
+    assert binary.endswith("/codex")

--- a/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv_codex.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv_codex.py
@@ -1,0 +1,202 @@
+"""Tests for ``runtimes/_apptainer_inner_argv_codex`` — the codex TUI argv.
+
+Real seams only: real ``AgentConfig`` / ``ClaudeSpec`` / ``ProviderSpec``
+objects through the real builder. Each test pins one observable fact.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config import AgentConfig, ClaudeSpec, ProviderSpec
+from scitex_agent_container.runtimes._apptainer_inner_argv_codex import (
+    CODEX_EXEC_MODULE,
+    CODEX_KEY_ENV,
+    CODEX_PROVIDER_ID,
+    codex_config_overrides,
+    codex_tui_argv,
+)
+from scitex_agent_container.runtimes._apptainer_provider import ProviderEnvError
+
+
+def _config(**claude_kw) -> AgentConfig:
+    claude = ClaudeSpec(
+        model=claude_kw.pop("model", "qwen38-27b"),
+        provider=claude_kw.pop(
+            "provider",
+            ProviderSpec(
+                base_url="http://100.64.0.1:18772/",
+                auth_token_env="FLEET_GATEWAY_KEY",
+            ),
+        ),
+        **claude_kw,
+    )
+    return AgentConfig(
+        name="hm", runtime="tui", workdir="/tmp/hm-wd", harness="codex", claude=claude
+    )
+
+
+def _overrides(flags: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for i, a in enumerate(flags):
+        if a == "-c" and i + 1 < len(flags):
+            k, _, v = flags[i + 1].partition("=")
+            out[k] = v
+    return out
+
+
+def test_overrides_select_the_sac_provider():
+    # Arrange
+    config = _config()
+    # Act
+    seen = _overrides(codex_config_overrides(config))
+    # Assert
+    assert seen["model_provider"] == f'"{CODEX_PROVIDER_ID}"'
+
+
+def test_overrides_point_the_provider_at_the_gateway_v1_root():
+    # Arrange -- the spec's base_url is the Anthropic-style root; Codex wants /v1.
+    config = _config()
+    # Act
+    seen = _overrides(codex_config_overrides(config))
+    # Assert
+    assert (
+        seen[f"model_providers.{CODEX_PROVIDER_ID}.base_url"]
+        == '"http://100.64.0.1:18772/v1"'
+    )
+
+
+def test_overrides_speak_the_responses_api_only():
+    # Arrange -- measured: "responses" is the only wire_api the binary accepts.
+    config = _config()
+    # Act
+    seen = _overrides(codex_config_overrides(config))
+    # Assert
+    assert seen[f"model_providers.{CODEX_PROVIDER_ID}.wire_api"] == '"responses"'
+
+
+def test_overrides_name_the_key_env_sac_fills():
+    # Arrange
+    config = _config()
+    # Act
+    seen = _overrides(codex_config_overrides(config))
+    # Assert
+    assert seen[f"model_providers.{CODEX_PROVIDER_ID}.env_key"] == f'"{CODEX_KEY_ENV}"'
+
+
+def test_overrides_carry_the_engine_model():
+    # Arrange
+    config = _config(model="qwen38-27b")
+    # Act
+    seen = _overrides(codex_config_overrides(config))
+    # Assert
+    assert seen["model"] == '"qwen38-27b"'
+
+
+def test_overrides_disable_the_nested_sandbox():
+    # Arrange -- bubblewrap cannot nest inside apptainer; the container is the boundary.
+    config = _config()
+    # Act
+    seen = _overrides(codex_config_overrides(config))
+    # Assert
+    assert seen["sandbox_mode"] == '"danger-full-access"'
+
+
+def test_overrides_carry_the_declared_context_window():
+    # Arrange -- the engine fold leaves max_context_tokens on the config.
+    config = _config()
+    config.max_context_tokens = 1_048_576
+    # Act
+    seen = _overrides(codex_config_overrides(config))
+    # Assert
+    assert seen["model_context_window"] == "1048576"
+
+
+def test_overrides_omit_the_context_window_when_none_is_declared():
+    # Arrange
+    config = _config()
+    # Act
+    seen = _overrides(codex_config_overrides(config))
+    # Assert
+    assert "model_context_window" not in seen
+
+
+def test_overrides_refuse_a_config_without_a_provider():
+    # Arrange -- silence would mean Codex's OpenAI-hosted default.
+    config = _config(provider=None)
+    # Act
+    try:
+        codex_config_overrides(config)
+        message = ""
+    except ProviderEnvError as exc:
+        message = str(exc)
+    # Assert
+    assert "needs an inference provider" in message
+
+
+def test_overrides_refuse_a_config_without_a_model():
+    # Arrange
+    config = _config(model="")
+    config.model = ""
+    # Act
+    try:
+        codex_config_overrides(config)
+        message = ""
+    except ProviderEnvError as exc:
+        message = str(exc)
+    # Assert
+    assert "names no model" in message
+
+
+def test_argv_runs_the_in_container_exec_shim():
+    # Arrange -- the binary is resolved inside the container, not on the host.
+    config = _config()
+    # Act
+    argv = codex_tui_argv(config)
+    # Assert
+    assert argv[:3] == ["python3", "-m", CODEX_EXEC_MODULE]
+
+
+def test_argv_hands_the_mcp_files_to_the_shim():
+    # Arrange
+    config = _config()
+    # Act
+    argv = codex_tui_argv(
+        config, mcp_config="/home/agent/.mcp.json", channel_mcp='{"a":1}'
+    )
+    # Assert
+    assert argv[3:8] == [
+        "--mcp-config",
+        "/home/agent/.mcp.json",
+        "--mcp-json",
+        '{"a":1}',
+        "--",
+    ]
+
+
+def test_argv_resumes_a_pinned_session_by_id():
+    # Arrange -- spec.claude.session: resume + resume_id, like the Claude TUI.
+    config = _config(session="resume", resume_id="0f4c1e6a-2b6d-4d0e-9c5b-7a1b2c3d4e5f")
+    # Act
+    argv = codex_tui_argv(config)
+    # Assert
+    assert argv[argv.index("--") + 1 : argv.index("--") + 3] == [
+        "resume",
+        "0f4c1e6a-2b6d-4d0e-9c5b-7a1b2c3d4e5f",
+    ]
+
+
+def test_argv_continues_the_latest_session_for_continue_mode():
+    # Arrange
+    config = _config(session="continue")
+    # Act
+    argv = codex_tui_argv(config)
+    # Assert
+    assert argv[argv.index("--") + 1 : argv.index("--") + 3] == ["resume", "--last"]
+
+
+def test_argv_starts_fresh_without_a_session_directive():
+    # Arrange
+    config = _config()
+    # Act
+    argv = codex_tui_argv(config)
+    # Assert -- the first thing after the separator is an override, not `resume`.
+    assert argv[argv.index("--") + 1] == "-c"


### PR DESCRIPTION
Operator ruling 2026-09-05: the fleet prepares to migrate off Claude Code onto the Codex CLI, priority Codex > GPT > Qwen, gradually. Until now `spec.harness: codex` validated and then refused at three points in series — the vendor guard, the lifecycle adapter table, and `auth_argv` (no codex branch) — so no spec could start a Codex agent through the lifecycle at all. This PR gives the codex harness the shape 107 of 119 fleet specs already run: an interactive TUI in a tmux pane.

**Registry.** A fifth entry, `codex-tui` (`spec.harness: codex`, `spec.runtime: tui` / unset), host-probed like the Claude TUI and resumable via `codex resume`. `codex-sdk` stays registered and still claims no runtime spelling — it has no lifecycle adapter yet, and a declared harness with no working implementation must refuse, not start and do nothing.

**Argv, in two halves.** The host renders the static Codex config as `-c key=value` overrides from the spec's provider block and model (measured: Codex reads config.toml and `-c` only; `OPENAI_BASE_URL` is ignored): `model_provider` → a `[model_providers.sac]` entry with `base_url = <provider>/v1`, `wire_api = "responses"` (the only value the 0.153 binary accepts), `env_key = SAC_CODEX_API_KEY`, `sandbox_mode = danger-full-access` (bubblewrap cannot nest inside apptainer — with the default sandbox tool calls exit 1 while the model reports success; the container is the boundary), `model_context_window` from `max_context_tokens`, `model_reasoning_effort` from `reasoning_effort`, and `resume <id>` / `resume --last` from the session directive. An in-container shim (`_apptainer_codex_exec`) then resolves the binary already bundled in the image venv (`codex_cli_bin.bundled_codex_path`) and translates the MCP files sac materialises for the Claude TUI (`~/.mcp.json` plus the inline channel-subscriber JSON) into `-c mcp_servers.*` overrides, and `execv`s — the pane holds `codex` itself.

**Launch path.** `_get_runtime` maps `codex-tui` to `TuiSessionRuntime`; `build_inner_argv`'s TUI branch dispatches on the harness; `auth_argv` gains a codex branch (CODEX_HOME bind + the engine's resolved provider key under the `env_key` name, no Anthropic env). The guard keeps its predicate — "is the declared harness what this path launches?" — and now hears which entry the caller launches (`launching_key`): a codex spec headed for the codex pane passes, every other non-Anthropic combination still refuses with the same message. The old two-axis refusal in `codex_env_flags` narrows to the case it was written for (`spec.claude.provider: codex`, the registry backend); an inline provider is the endpoint the codex harness is pointed at and composes.

**Tests.** 15 for the argv builder, 8 for the shim, plus registry / guard / selector / auth cases; the closed-set registry tests are updated from four entries to five on purpose.

**Not in this PR, stated plainly.** No Codex agent has run through this path yet — the first live run is handyman-01 (smallest blast radius), and the first thing it must demonstrate is a hook firing and compaction triggering against our own server, both of which the research could not prove offline. Hooks and the channel rail are ported by the same mechanism Claude uses (MCP injection, Codex's own `PreToolUse` hooks engine), not by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GE7KVBrKkcQNJvk2RYJcFf
