### PR TITLE
fix(codex): the codex home is created and bound where the image has a mount point

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_codex_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_codex_env.py
@@ -66,17 +66,27 @@ __all__ = [
     "codex_env_flags",
     "codex_harness_active",
     "codex_provider_key_flags",
+    "container_codex_home",
     "resolve_codex_home",
 ]
 
 #: The env var the ``codex`` binary reads its config+creds directory from.
 CODEX_HOME_ENV = "CODEX_HOME"
 
-#: Path INSIDE the container the host's codex home is bound to. Fixed
-#: rather than mirroring the host path so the in-container ``CODEX_HOME``
-#: is the same string on every host (the agent's own ``$HOME`` differs
-#: per-agent; the credential directory should not have to).
-CONTAINER_CODEX_HOME = "/home/agent/.codex"
+#: Prefix of the path INSIDE the container the host's codex home is bound
+#: to: ``/tmp/sac-<name>-codex-home``. Under ``/tmp`` — which exists in the
+#: image — because apptainer refuses a bind whose DESTINATION is absent
+#: ("destination /home/agent/.codex doesn't exist in container", measured
+#: on the first live codex start, handyman-01, 2026-09-05 08:59 UTC), and
+#: per agent so two codex agents on one host never share a session store.
+#: The same shape ``_apptainer_provider_cfg.container_config_dir`` uses.
+CONTAINER_CODEX_HOME_PREFIX = "/tmp/sac-"
+
+
+def container_codex_home(name: str) -> str:
+    """The in-container ``CODEX_HOME`` for agent ``name``."""
+    return f"{CONTAINER_CODEX_HOME_PREFIX}{name}-codex-home"
+
 
 #: API-key env vars, in resolution order. ``SAC_CODEX_API_KEY`` is sac's
 #: own override; ``CODEX_API_KEY`` is the binary's; ``OPENAI_API_KEY`` is
@@ -151,16 +161,20 @@ def codex_harness_active(config: AgentConfig) -> bool:
     return resolve_agent_harness(config) == "codex"
 
 
-def resolve_codex_home() -> Path:
-    """The HOST directory holding ``auth.json`` + ``config.toml``.
+def resolve_codex_home(state_dir: Path | None = None) -> Path:
+    """The HOST directory holding codex's config, auth and session rollouts.
 
     ``$CODEX_HOME`` when exported (the binary's own override — honoured
     so an operator who already relocated it does not have to say so
-    twice), else ``~/.codex``.
+    twice), else the agent's own ``<state_dir>/codex-home`` (2026-09-05:
+    per agent, like the provider config dir, so sessions never mix), else
+    ``~/.codex`` when no state dir is known.
     """
     override = os.environ.get(CODEX_HOME_ENV, "").strip()
     if override:
         return Path(override).expanduser()
+    if state_dir is not None:
+        return Path(state_dir).expanduser() / "codex-home"
     return Path.home() / ".codex"
 
 
@@ -204,14 +218,20 @@ def codex_env_flags(config: AgentConfig, state_dir: Path) -> list[str]:
             "about who runs the loop. Remove one of the two declarations."
         )
 
-    del state_dir  # codex creds live in CODEX_HOME, not the agent state dir
-
-    codex_home = resolve_codex_home()
+    codex_home = resolve_codex_home(state_dir)
+    # The bind SOURCE must exist or apptainer refuses the whole container
+    # ("mount source ... no such file or directory", measured on the first
+    # live codex start, handyman-01, 2026-09-05 08:57 UTC: the host had never
+    # run codex, so the directory was absent and the pane died before boot).
+    # This is the directory codex itself would create on first run; sac
+    # creates it, private to the user, so a fresh host starts like a used one.
+    codex_home.mkdir(parents=True, exist_ok=True, mode=0o700)
+    inside = container_codex_home(config.name)
     argv: list[str] = [
         "--bind",
-        f"{codex_home}:{CONTAINER_CODEX_HOME}",
+        f"{codex_home}:{inside}",
         "--env",
-        f"{CODEX_HOME_ENV}={CONTAINER_CODEX_HOME}",
+        f"{CODEX_HOME_ENV}={inside}",
     ]
 
     for env_name in _KEY_ENVS:

--- a/tests/scitex_agent_container/config/test__harness_registry_codex.py
+++ b/tests/scitex_agent_container/config/test__harness_registry_codex.py
@@ -297,7 +297,7 @@ def test_codex_env_flags_bind_the_codex_home_directory(
     # Act
     argv = codex_env.codex_env_flags(config, tmp_path)
     # Assert
-    assert f"{codex_home}:{codex_env.CONTAINER_CODEX_HOME}" in argv
+    assert f"{codex_home}:{codex_env.container_codex_home('t')}" in argv
 
 
 def test_codex_env_flags_export_the_in_container_codex_home(
@@ -309,7 +309,7 @@ def test_codex_env_flags_export_the_in_container_codex_home(
     # Act
     argv = codex_env.codex_env_flags(config, tmp_path)
     # Assert
-    assert f"{codex_env.CODEX_HOME_ENV}={codex_env.CONTAINER_CODEX_HOME}" in argv
+    assert f"{codex_env.CODEX_HOME_ENV}={codex_env.container_codex_home('t')}" in argv
 
 
 @pytest.fixture
@@ -414,3 +414,33 @@ def test_the_two_axis_refusal_message_names_the_harness_axis(
         message = str(exc)
     # Assert
     assert "spec.harness: codex" in message
+
+
+def test_codex_env_flags_create_the_codex_home_when_absent(
+    tmp_path, no_harness_override
+):
+    # Arrange -- a host that has never run codex: the bind source is absent
+    # (no CODEX_HOME override, so the agent's own state-dir home is used).
+    previous = os.environ.pop(codex_env.CODEX_HOME_ENV, None)
+    config = AgentConfig(name="t", harness="codex")
+    # Act
+    try:
+        codex_env.codex_env_flags(config, tmp_path)
+    finally:
+        if previous is not None:
+            os.environ[codex_env.CODEX_HOME_ENV] = previous
+    # Assert
+    assert (tmp_path / "codex-home").is_dir()
+
+
+def test_codex_env_flags_bind_into_tmp_where_the_image_has_a_mount_point(
+    tmp_path, no_harness_override, codex_home
+):
+    # Arrange -- apptainer refuses a bind whose destination is absent in the
+    # image; /tmp exists, /home/agent/.codex did not (handyman-01, 08:59Z).
+    config = AgentConfig(name="hm", harness="codex")
+    # Act
+    argv = codex_env.codex_env_flags(config, tmp_path)
+    # Assert
+    assert argv[argv.index("--bind") + 1].endswith(":/tmp/sac-hm-codex-home")
+

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
@@ -363,4 +363,4 @@ def test_codex_harness_binds_codex_home(tmp_path, env_save_restore):
     # Act
     env = _env_of(auth_argv(config, tmp_path))
     # Assert
-    assert env["CODEX_HOME"] == "/home/agent/.codex"
+    assert env["CODEX_HOME"] == "/tmp/sac-hm-codex-home"


### PR DESCRIPTION
The first live start of the codex harness (handyman-01, 2026-09-05 08:57 UTC) failed twice in the `CODEX_HOME` bind that #1047 added and nothing had exercised until today:

1. `mount source /home/ywatanabe/.codex: no such file or directory` — the host had never run codex.
2. `destination /home/agent/.codex doesn't exist in container` — apptainer refuses a bind whose destination is absent in the image.

The bind now lands at `/tmp/sac-<name>-codex-home` (`/tmp` exists in the image; the same shape `_apptainer_provider_cfg.container_config_dir` uses) and is per agent, so two codex agents on one host never share a session store. The host source becomes `<state_dir>/codex-home` unless `CODEX_HOME` is exported (the binary's own override, still honoured), and sac creates it (0700) before binding — what codex itself would do on first run.

Tests: the bind-shape assertions follow the new destination; two new tests pin the mkdir and the `/tmp` mount point. 60 passed across the codex env, auth and argv suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GE7KVBrKkcQNJvk2RYJcFf