### PR TITLE
feat(codex): the boot drain trusts the copied hooks

### DIFF
--- a/src/scitex_agent_container/_runners/_tmux/prompts.py
+++ b/src/scitex_agent_container/_runners/_tmux/prompts.py
@@ -285,6 +285,20 @@ def _detect_codex_dir_trust(content: str) -> bool:
     )
 
 
+def _detect_codex_hooks_review(content: str) -> bool:
+    """Codex's "Hooks need review" picker (harness codex, 2026-09-05).
+
+    Shown once the shim has copied the fleet's hooks into CODEX_HOME/hooks.json:
+    "49 hooks are new or changed. Hooks can run outside the sandbox after you
+    trust them. 1. Review hooks / 2. Trust all and continue / 3. Continue
+    without trusting (hooks won't run)". The hooks ARE the fleet's own
+    (~/.claude/hooks, the same files the Claude pane runs), so option 2 is
+    the correct answer; option 3 would silently run the agent without them.
+    Measured on handyman-01 at 09:36 UTC.
+    """
+    return "Hooks need review" in content and "2. Trust all and continue" in content
+
+
 def _detect_codex_done(content: str) -> bool:
     """Codex is at its input prompt: the banner box is up and no picker remains.
 
@@ -360,6 +374,12 @@ PROMPT_HANDLERS: list[PromptHandler] = [
         name="codex-dir-trust",
         detect=_detect_codex_dir_trust,
         keys=["Enter"],  # cursor already on "1. Yes, continue"
+        priority=1,
+    ),
+    PromptHandler(
+        name="codex-hooks-review",
+        detect=_detect_codex_hooks_review,
+        keys=["2", "Enter"],  # "2. Trust all and continue" — the fleet's own hooks
         priority=1,
     ),
     PromptHandler(

--- a/tests/scitex_agent_container/_runners/_tmux/test_prompts_codex.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_prompts_codex.py
@@ -63,3 +63,41 @@ def test_codex_banner_is_ready():
     ready = is_ready(content)
     # Assert
     assert ready is True
+
+
+_HOOKS_SCREEN = """
+  Hooks need review
+  49 hooks are new or changed.
+  Hooks can run outside the sandbox after you trust them.
+› 1. Review hooks
+  2. Trust all and continue
+  3. Continue without trusting (hooks won't run)
+  Press enter to confirm or esc to go back
+"""
+
+
+def test_codex_hooks_review_picker_is_detected():
+    # Arrange -- the screen after the shim copied the fleet's hooks in.
+    handler = _handler("codex-hooks-review")
+    # Act
+    seen = handler.detect(_HOOKS_SCREEN)
+    # Assert
+    assert seen is True
+
+
+def test_codex_hooks_review_picker_trusts_all():
+    # Arrange -- option 3 would run the agent without its hooks, silently.
+    handler = _handler("codex-hooks-review")
+    # Act
+    keys = handler.keys
+    # Assert
+    assert keys == ["2", "Enter"]
+
+
+def test_codex_hooks_review_screen_is_not_ready():
+    # Arrange
+    content = _HOOKS_SCREEN
+    # Act
+    ready = is_ready(content)
+    # Assert
+    assert ready is False


### PR DESCRIPTION
With #1300 the shim copies the fleet's hooks into `CODEX_HOME/hooks.json`, and Codex answers with a picker at boot — measured on handyman-01, 2026-09-05 09:36 UTC:

```
Hooks need review
49 hooks are new or changed.
Hooks can run outside the sandbox after you trust them.
› 1. Review hooks
  2. Trust all and continue
  3. Continue without trusting (hooks won't run)
```

That is the proof the copy is read: 49 entries, the fleet's own `~/.claude/hooks`. The drain now answers option 2; option 3 would run the agent without its hooks, silently, which is the one outcome the migration must never produce. Three tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GE7KVBrKkcQNJvk2RYJcFf