### PR TITLE
fix(codex): MCP servers inherit the pane's fleet environment

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_codex_exec.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_codex_exec.py
@@ -35,6 +35,7 @@ from .._logging import get_logger
 
 __all__ = [
     "adapt_hook_commands",
+    "inherited_env_names",
     "main",
     "mcp_overrides",
     "resolve_codex_binary",
@@ -127,6 +128,23 @@ def _servers(document: object) -> dict[str, dict]:
     )
 
 
+#: Prefixes of the fleet variables an MCP server may read from its inherited
+#: environment. Claude Code hands its own environment to every stdio MCP
+#: server it spawns; Codex passes ONLY the declared ``env`` plus the names in
+#: ``env_vars``, so a server that reads an inherited variable dies. Measured
+#: on the first codex pane (handyman-01, 2026-09-05 10:10 UTC): the
+#: telegrammer server exited with "No database connection string. Set
+#: SCITEX_STORE_DSN (the fleet-wide switch) or CCT_STORE_DSN" although
+#: SCITEX_STORE_DSN was present in the pane. Names only ever reach the argv.
+INHERITED_ENV_PREFIXES = ("SCITEX_", "CCT_", "SAC_")
+
+
+def inherited_env_names(environ: dict | None = None) -> list[str]:
+    """Fleet variable NAMES present in this pane, for Codex's ``env_vars``."""
+    source = os.environ if environ is None else environ
+    return sorted(name for name in source if name.startswith(INHERITED_ENV_PREFIXES))
+
+
 def mcp_overrides(documents: list[object]) -> list[str]:
     """``-c mcp_servers.<name>.<field>=<toml>`` flags for every server given."""
     flags: list[str] = []
@@ -153,8 +171,12 @@ def mcp_overrides(documents: list[object]) -> list[str]:
             literal, forwarded = split_env_placeholders(entry.get("env") or {})
             if literal:
                 flags += ["-c", f"{key}.env={_toml(literal)}"]
-            if forwarded:
-                flags += ["-c", f"{key}.env_vars={_toml(forwarded)}"]
+            # The declared placeholders PLUS the fleet variables this pane
+            # carries, so a server that reads an inherited variable behaves as
+            # it does under Claude Code (see INHERITED_ENV_PREFIXES).
+            names = sorted(set(forwarded) | set(inherited_env_names()))
+            if names:
+                flags += ["-c", f"{key}.env_vars={_toml(names)}"]
     return flags
 
 

--- a/src/scitex_agent_container/runtimes/_apptainer_codex_exec.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_codex_exec.py
@@ -145,8 +145,13 @@ def inherited_env_names(environ: dict | None = None) -> list[str]:
     return sorted(name for name in source if name.startswith(INHERITED_ENV_PREFIXES))
 
 
-def mcp_overrides(documents: list[object]) -> list[str]:
-    """``-c mcp_servers.<name>.<field>=<toml>`` flags for every server given."""
+def mcp_overrides(documents: list[object], *, environ: dict | None = None) -> list[str]:
+    """``-c mcp_servers.<name>.<field>=<toml>`` flags for every server given.
+
+    ``environ`` is the pane environment whose fleet variable NAMES are
+    forwarded to each server (default: this process's). Injectable so a test
+    states the environment it means instead of inheriting the runner's.
+    """
     flags: list[str] = []
     for document in documents:
         for name, entry in _servers(document).items():
@@ -174,7 +179,7 @@ def mcp_overrides(documents: list[object]) -> list[str]:
             # The declared placeholders PLUS the fleet variables this pane
             # carries, so a server that reads an inherited variable behaves as
             # it does under Claude Code (see INHERITED_ENV_PREFIXES).
-            names = sorted(set(forwarded) | set(inherited_env_names()))
+            names = sorted(set(forwarded) | set(inherited_env_names(environ)))
             if names:
                 flags += ["-c", f"{key}.env_vars={_toml(names)}"]
     return flags

--- a/tests/scitex_agent_container/runtimes/test__apptainer_codex_exec.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_codex_exec.py
@@ -19,9 +19,17 @@ from scitex_agent_container.runtimes._apptainer_codex_exec import (
 )
 
 
-def _flags(documents: list[object]) -> dict[str, str]:
+def _flags(documents: list[object], environ: dict | None = None) -> dict[str, str]:
+    """Rendered flags for ``documents`` under a STATED pane environment.
+
+    The default is an EMPTY environment. The inherited-name forwarding reads
+    the pane's variables, so a test that inherits the RUNNER's environment
+    asserts something different on a developer box and on CI — measured
+    2026-09-05: two exact-equality assertions passed locally and failed in CI
+    for exactly that reason.
+    """
     out: dict[str, str] = {}
-    flags = mcp_overrides(documents)
+    flags = mcp_overrides(documents, environ={} if environ is None else environ)
     for i, a in enumerate(flags):
         if a == "-c" and i + 1 < len(flags):
             k, _, v = flags[i + 1].partition("=")
@@ -84,8 +92,8 @@ def test_documents_are_merged_in_order():
     second = {"two": {"command": "two"}}
     # Act
     seen = _flags([first, second])
-    # Assert
-    assert sorted(k.split(".")[1] for k in seen) == ["one", "two"]
+    # Assert -- both documents contributed a server (each renders >1 flag).
+    assert sorted({k.split(".")[1] for k in seen}) == ["one", "two"]
 
 
 def test_an_operator_set_binary_path_wins(env_save_restore):
@@ -240,16 +248,15 @@ def test_fleet_variable_names_are_collected_for_forwarding():
     assert names == ["CCT_AGENT_ID", "SAC_NAME", "SCITEX_STORE_DSN"]
 
 
-def test_mcp_env_vars_include_the_inherited_fleet_names(env_save_restore):
+def test_mcp_env_vars_include_the_inherited_fleet_names():
     # Arrange -- Codex passes only what is declared, so a server that reads an
     # inherited variable (the telegrammer's SCITEX_STORE_DSN) must get its name.
-    env_save_restore.set("SCITEX_STORE_DSN", "postgresql://example/db")
     document = {
         "mcpServers": {
             "tg": {"command": "bun", "env": {"CCT_AGENT_ID": "${CCT_AGENT_ID}"}}
         }
     }
     # Act
-    seen = _flags([document])
+    seen = _flags([document], {"SCITEX_STORE_DSN": "postgresql://example/db"})
     # Assert
-    assert "SCITEX_STORE_DSN" in seen["mcp_servers.tg.env_vars"]
+    assert seen["mcp_servers.tg.env_vars"] == '["CCT_AGENT_ID", "SCITEX_STORE_DSN"]'

--- a/tests/scitex_agent_container/runtimes/test__apptainer_codex_exec.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_codex_exec.py
@@ -11,6 +11,7 @@ import json
 from scitex_agent_container.runtimes._apptainer_codex_exec import (
     CODEX_BIN_ENV,
     adapt_hook_commands,
+    inherited_env_names,
     mcp_overrides,
     resolve_codex_binary,
     split_env_placeholders,
@@ -223,3 +224,32 @@ def test_other_hooks_are_copied_unchanged():
     adapted = adapt_hook_commands(hooks)
     # Assert
     assert adapted == hooks
+
+
+def test_fleet_variable_names_are_collected_for_forwarding():
+    # Arrange -- a pane environment shaped like the real one.
+    environ = {
+        "SCITEX_STORE_DSN": "x",
+        "CCT_AGENT_ID": "y",
+        "SAC_NAME": "z",
+        "PATH": "/bin",
+    }
+    # Act
+    names = inherited_env_names(environ)
+    # Assert -- fleet names only; PATH and friends are Codex's own business.
+    assert names == ["CCT_AGENT_ID", "SAC_NAME", "SCITEX_STORE_DSN"]
+
+
+def test_mcp_env_vars_include_the_inherited_fleet_names(env_save_restore):
+    # Arrange -- Codex passes only what is declared, so a server that reads an
+    # inherited variable (the telegrammer's SCITEX_STORE_DSN) must get its name.
+    env_save_restore.set("SCITEX_STORE_DSN", "postgresql://example/db")
+    document = {
+        "mcpServers": {
+            "tg": {"command": "bun", "env": {"CCT_AGENT_ID": "${CCT_AGENT_ID}"}}
+        }
+    }
+    # Act
+    seen = _flags([document])
+    # Assert
+    assert "SCITEX_STORE_DSN" in seen["mcp_servers.tg.env_vars"]


### PR DESCRIPTION
Claude Code hands its own environment to every stdio MCP server it spawns; Codex passes **only** the server's declared `env` plus the names listed in `env_vars`. Measured on the first codex pane (handyman-01, 2026-09-05 10:10 UTC) from Codex's own log of the server's stderr:

```
[WARN] claude-code-telegrammer disabled for agent "telegram": CCT_BOT_TOKEN empty …
uncaught exception: Error: No database connection string. Set SCITEX_STORE_DSN (the fleet-wide switch) or CCT_STORE_DSN
```

`SCITEX_STORE_DSN` was present in the pane; it simply never reached the child. Every MCP server now receives, by NAME, the fleet variables the pane carries (`SCITEX_*`, `CCT_*`, `SAC_*`), alongside the placeholders it declared. Names only ever reach the argv; Codex reads the values from the pane environment.

Follows #1302 (whole-`${VAR}` placeholders forwarded by name), which fixed the *declared* env and revealed this second, inherited one. Two tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GE7KVBrKkcQNJvk2RYJcFf