### PR TITLE
fix(codex): the boot drain's OWN registry learns the codex pickers

### DIFF
--- a/src/scitex_agent_container/runtimes/prompts.py
+++ b/src/scitex_agent_container/runtimes/prompts.py
@@ -282,18 +282,72 @@ def _detect_resume_session(content: str) -> bool:
     )
 
 
-def _detect_done(content: str) -> bool:
-    """Check if claude is at the main input prompt (all TUI prompts done).
+def _detect_codex_dir_trust(content: str) -> bool:
+    """Codex's first-boot directory-trust picker (harness codex, 2026-09-05).
 
-    The status bar shows "bypass permissions" when ready.
+    "Do you trust the contents of this directory? ... 1. Yes, continue /
+    2. No, quit / Press enter to continue" — the cursor already sits on
+    option 1, so Enter alone accepts.
     """
-    return "bypass permissions" in content and "Enter to confirm" not in content
+    return (
+        "Do you trust the contents of this directory" in content
+        and "1. Yes, continue" in content
+    )
+
+
+def _detect_codex_hooks_review(content: str) -> bool:
+    """Codex's "Hooks need review" picker (harness codex, 2026-09-05).
+
+    Shown once sac has copied the fleet's hooks into CODEX_HOME/hooks.json,
+    and again whenever one of them changes. The hooks ARE the fleet's own
+    (~/.claude/hooks, the same files the Claude pane runs), so option 2 is
+    the correct answer; option 3 would run the agent without them, silently.
+    """
+    return "Hooks need review" in content and "2. Trust all and continue" in content
+
+
+def _detect_codex_done(content: str) -> bool:
+    """Codex is at its input prompt: its banner is up and no picker remains.
+
+    The Codex TUI never prints Claude's "bypass permissions" status line; its
+    ready state is the "OpenAI Codex (vX)" box with a permissions row ("YOLO
+    mode" when sac turns the sandbox off).
+    """
+    return (
+        "OpenAI Codex (v" in content
+        and "permissions:" in content
+        and "Press enter to continue" not in content
+        and "Press enter to confirm" not in content
+    )
+
+
+def _detect_done(content: str) -> bool:
+    """Check if the TUI is at its main input prompt (all prompts done).
+
+    Claude's status bar shows "bypass permissions" when ready; Codex has its
+    own banner (:func:`_detect_codex_done`).
+    """
+    if "bypass permissions" in content and "Enter to confirm" not in content:
+        return True
+    return _detect_codex_done(content)
 
 
 # Default prompt handlers — checked by priority, order-agnostic.
 # Detection uses numbered options + prompt text for reliability.
 # To add a new prompt, append a PromptHandler or call register_prompt().
 PROMPT_HANDLERS: list[PromptHandler] = [
+    PromptHandler(
+        name="codex-dir-trust",
+        detect=_detect_codex_dir_trust,
+        keys=["Enter"],  # cursor already on "1. Yes, continue"
+        priority=1,
+    ),
+    PromptHandler(
+        name="codex-hooks-review",
+        detect=_detect_codex_hooks_review,
+        keys=["2", "Enter"],  # "2. Trust all and continue" — the fleet's own hooks
+        priority=1,
+    ),
     PromptHandler(
         name="bypass-permissions",
         detect=_detect_bypass_permissions,

--- a/tests/scitex_agent_container/runtimes/test_prompts_codex_registry.py
+++ b/tests/scitex_agent_container/runtimes/test_prompts_codex_registry.py
@@ -1,0 +1,82 @@
+"""The codex pickers must live in the registry the BOOT DRAIN reads.
+
+``runtimes/_tui_drain`` imports ``runtimes.prompts``; ``_runners/_tmux/prompts``
+is a second, separate registry. #1300/#1301 taught only the latter, so a live
+restart sat on Codex's "Hooks need review" picker until its window expired
+(handyman-01, 2026-09-05 10:05-10:09 UTC) even though the handler existed.
+These tests pin the handlers to the module the drain actually consults.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.runtimes import _tui_drain
+from scitex_agent_container.runtimes.prompts import detect, is_ready
+
+_TRUST = """
+> You are in /home/ywatanabe/proj/local-coder
+  Do you trust the contents of this directory? Working with untrusted contents
+› 1. Yes, continue
+  2. No, quit
+  Press enter to continue
+"""
+
+_HOOKS = """
+  Hooks need review
+  49 hooks are new or changed.
+› 1. Review hooks
+  2. Trust all and continue
+  3. Continue without trusting (hooks won't run)
+  Press enter to confirm or esc to go back
+"""
+
+_READY = """
+│ >_ OpenAI Codex (v0.147.0)                    │
+│ model:       qwen38-27b   /model to change    │
+│ permissions: YOLO mode                        │
+› Explain this codebase
+"""
+
+
+def test_the_drain_reads_this_registry():
+    # Arrange -- the import that made the earlier fix ineffective.
+    module = _tui_drain._prompts
+    # Act
+    name = module.__name__
+    # Assert
+    assert name.endswith("runtimes.prompts")
+
+
+def test_the_trust_picker_is_detected_here():
+    # Arrange
+    content = _TRUST
+    # Act
+    modal = detect(content)
+    # Assert
+    assert modal == "codex-dir-trust"
+
+
+def test_the_hooks_picker_is_detected_here():
+    # Arrange
+    content = _HOOKS
+    # Act
+    modal = detect(content)
+    # Assert
+    assert modal == "codex-hooks-review"
+
+
+def test_the_hooks_picker_is_not_ready():
+    # Arrange -- its footer says "confirm", not "continue".
+    content = _HOOKS
+    # Act
+    ready = is_ready(content)
+    # Assert
+    assert ready is False
+
+
+def test_the_codex_banner_is_ready_here():
+    # Arrange -- Codex never prints Claude's status line.
+    content = _READY
+    # Act
+    ready = is_ready(content)
+    # Assert
+    assert ready is True


### PR DESCRIPTION
#1300/#1301 taught the codex pickers to `_runners/_tmux/prompts.py`. The boot drain reads a **different** module: `runtimes/_tui_drain` imports `runtimes.prompts`, a second registry with its own `PROMPT_HANDLERS` and its own `is_ready`.

So the handlers existed, were deployed, and were never consulted. Measured on handyman-01 (2026-09-05 10:05–10:09 UTC): `sac agents restart` sat on "Hooks need review" for four minutes and reported "never signalled ready" while the pane was up and the handler was present in the running checkout (grep-confirmed on the host).

This adds the two pickers (directory trust; hooks review) and the Codex ready banner to the module the drain actually consults, and pins that import in a test so the next reader cannot repeat the mistake.

The duplication itself is the deeper defect — two registries with the same job, one of them dead for this path — and is recorded on the fleet card as a follow-up rather than folded into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GE7KVBrKkcQNJvk2RYJcFf