### PR TITLE
fix(codex): an MCP server inherits the WHOLE pane environment

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_codex_exec.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_codex_exec.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from .._logging import get_logger
 
 __all__ = [
+    "EXCLUDED_ENV_NAMES",
+    "EXCLUDED_ENV_PREFIXES",
     "adapt_hook_commands",
     "inherited_env_names",
     "main",
@@ -128,29 +130,48 @@ def _servers(document: object) -> dict[str, dict]:
     )
 
 
-#: Prefixes of the fleet variables an MCP server may read from its inherited
-#: environment. Claude Code hands its own environment to every stdio MCP
-#: server it spawns; Codex passes ONLY the declared ``env`` plus the names in
-#: ``env_vars``, so a server that reads an inherited variable dies. Measured
-#: on the first codex pane (handyman-01, 2026-09-05 10:10 UTC): the
-#: telegrammer server exited with "No database connection string. Set
-#: SCITEX_STORE_DSN (the fleet-wide switch) or CCT_STORE_DSN" although
-#: SCITEX_STORE_DSN was present in the pane. Names only ever reach the argv.
-INHERITED_ENV_PREFIXES = ("SCITEX_", "CCT_", "SAC_")
+#: Names the child must NOT be handed: the ones Codex sets for the child
+#: itself, and the ones that mean nothing outside the shell that exported
+#: them. Everything else in the pane is forwarded by name.
+#:
+#: Claude Code hands its OWN environment to every stdio MCP server it spawns;
+#: Codex passes ONLY the declared ``env`` plus the names in ``env_vars``. A
+#: hand-picked allowlist therefore turns every variable it forgets into a
+#: separate production incident, discovered one at a time. Three in one
+#: morning on handyman-01 (2026-09-05): unexpanded ``${VAR}`` placeholders
+#: (#1302); ``SCITEX_STORE_DSN`` absent, so the telegrammer exited with "No
+#: database connection string" (#1303); then ``PGUSER`` and ``PGPASSFILE``
+#: absent, so the scitex-cards channel connected to pgbouncer as the wrong
+#: user and every drain tick failed with "FATAL: bouncer config error" —
+#: measured at 11:12 UTC as 27 variables in the child against 55 in the pane.
+#: Forwarding everything ends the class instead of its third instance.
+EXCLUDED_ENV_PREFIXES = ("CODEX_", "BASH_FUNC_")
+EXCLUDED_ENV_NAMES = frozenset({"_", "OLDPWD", "PWD", "SHLVL"})
+
+#: An exported shell FUNCTION is not a variable name (bash spells it
+#: ``BASH_FUNC_x%%``); forwarding one would put a name Codex cannot read in
+#: the argv.
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def inherited_env_names(environ: dict | None = None) -> list[str]:
-    """Fleet variable NAMES present in this pane, for Codex's ``env_vars``."""
+    """Every pane variable NAME an MCP server inherits, as Claude Code does."""
     source = os.environ if environ is None else environ
-    return sorted(name for name in source if name.startswith(INHERITED_ENV_PREFIXES))
+    return sorted(
+        name
+        for name in source
+        if _ENV_NAME.match(name)
+        and name not in EXCLUDED_ENV_NAMES
+        and not name.startswith(EXCLUDED_ENV_PREFIXES)
+    )
 
 
 def mcp_overrides(documents: list[object], *, environ: dict | None = None) -> list[str]:
     """``-c mcp_servers.<name>.<field>=<toml>`` flags for every server given.
 
-    ``environ`` is the pane environment whose fleet variable NAMES are
-    forwarded to each server (default: this process's). Injectable so a test
-    states the environment it means instead of inheriting the runner's.
+    ``environ`` is the pane environment whose variable NAMES are forwarded
+    to each server (default: this process's). Injectable so a test states the
+    environment it means instead of inheriting the runner's.
     """
     flags: list[str] = []
     for document in documents:
@@ -176,9 +197,9 @@ def mcp_overrides(documents: list[object], *, environ: dict | None = None) -> li
             literal, forwarded = split_env_placeholders(entry.get("env") or {})
             if literal:
                 flags += ["-c", f"{key}.env={_toml(literal)}"]
-            # The declared placeholders PLUS the fleet variables this pane
+            # The declared placeholders PLUS every variable this pane
             # carries, so a server that reads an inherited variable behaves as
-            # it does under Claude Code (see INHERITED_ENV_PREFIXES).
+            # it does under Claude Code (see EXCLUDED_ENV_PREFIXES).
             names = sorted(set(forwarded) | set(inherited_env_names(environ)))
             if names:
                 flags += ["-c", f"{key}.env_vars={_toml(names)}"]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_codex_exec.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_codex_exec.py
@@ -234,21 +234,50 @@ def test_other_hooks_are_copied_unchanged():
     assert adapted == hooks
 
 
-def test_fleet_variable_names_are_collected_for_forwarding():
-    # Arrange -- a pane environment shaped like the real one.
+def test_every_pane_variable_name_is_collected_for_forwarding():
+    # Arrange -- a pane environment shaped like the real one. PGUSER is the
+    # variable whose absence broke the scitex-cards channel under Codex.
     environ = {
         "SCITEX_STORE_DSN": "x",
         "CCT_AGENT_ID": "y",
         "SAC_NAME": "z",
+        "PGUSER": "ywatanabe__handyman-01",
         "PATH": "/bin",
     }
     # Act
     names = inherited_env_names(environ)
-    # Assert -- fleet names only; PATH and friends are Codex's own business.
-    assert names == ["CCT_AGENT_ID", "SAC_NAME", "SCITEX_STORE_DSN"]
+    # Assert
+    assert names == ["CCT_AGENT_ID", "PATH", "PGUSER", "SAC_NAME", "SCITEX_STORE_DSN"]
 
 
-def test_mcp_env_vars_include_the_inherited_fleet_names():
+def test_codex_own_variables_are_not_forwarded_back_to_it():
+    # Arrange -- CODEX_HOME is Codex's to set for the child.
+    environ = {"CODEX_HOME": "/tmp/sac-x-codex-home", "SAC_NAME": "x"}
+    # Act
+    names = inherited_env_names(environ)
+    # Assert
+    assert names == ["SAC_NAME"]
+
+
+def test_an_exported_shell_function_is_not_a_forwardable_name():
+    # Arrange -- bash exports a function under a name with '%' in it.
+    environ = {"BASH_FUNC_which%%": "() { ... }", "SAC_NAME": "x"}
+    # Act
+    names = inherited_env_names(environ)
+    # Assert
+    assert names == ["SAC_NAME"]
+
+
+def test_shell_bookkeeping_names_are_not_forwarded():
+    # Arrange -- PWD and friends mean nothing to a child started elsewhere.
+    environ = {"PWD": "/home/agent", "SHLVL": "2", "_": "/bin/env", "SAC_NAME": "x"}
+    # Act
+    names = inherited_env_names(environ)
+    # Assert
+    assert names == ["SAC_NAME"]
+
+
+def test_mcp_env_vars_include_the_inherited_pane_names():
     # Arrange -- Codex passes only what is declared, so a server that reads an
     # inherited variable (the telegrammer's SCITEX_STORE_DSN) must get its name.
     document = {


### PR DESCRIPTION
Claude Code hands its own environment to every stdio MCP server it spawns. Codex passes **only** the declared `env` plus the names listed in `env_vars`, so the shim must name what a child may read — and it named three prefixes (`SCITEX_`, `CCT_`, `SAC_`).

Every variable that allowlist forgot became its own production incident, found one at a time. All three landed on handyman-01 this morning:

| # | missing | symptom |
|---|---|---|
| #1302 | unexpanded `${VAR}` placeholders | the server received the literal string |
| #1303 | `SCITEX_STORE_DSN` | telegrammer: "No database connection string" |
| this | `PGUSER`, `PGPASSFILE` | channel drain: `FATAL: bouncer config error`, every 5 s |

Measured at 11:12 UTC from `/proc/<pid>/environ`:

```
codex parent   55 variables   (PGUSER=ywatanabe__handyman-01, PGPASSFILE set)
MCP child      27 variables   (neither present)
```

The store, the role and the DSN were all healthy — that same role connects 5/5 from another container, and `scitex`/`postgres` are both served by pgbouncer. The child simply arrived as the container's OS user with no password, which is what `bouncer config error` reports.

So this fixes the shape rather than the third name. An allowlist hides what it excludes: the forgotten name is invisible until something breaks. A denylist writes the exclusions down. The pane's whole environment is now forwarded by name, minus what Codex sets for the child itself (`CODEX_*`), bash's exported functions (`BASH_FUNC_x%%` — not a usable variable name), and shell bookkeeping (`PWD`, `OLDPWD`, `SHLVL`, `_`). That is parity with Claude Code.

Four tests: every pane name is collected; Codex's own variables are not handed back to it; an exported shell function is not a forwardable name; shell bookkeeping is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GE7KVBrKkcQNJvk2RYJcFf