### PR TITLE
fix(launch): retire telegrammer pid records left by a previous container

### DIFF
--- a/src/scitex_agent_container/runtimes/_stale_poller_pidfiles.py
+++ b/src/scitex_agent_container/runtimes/_stale_poller_pidfiles.py
@@ -1,0 +1,74 @@
+"""Clear telegrammer poller pidfiles left by a PREVIOUS container incarnation.
+
+Why this exists (measured 2026-09-05, scitex-compute-04, agent scitex-cards):
+claude-code-telegrammer keeps a per-bot-token pidfile in the agent's state dir
+(``~/.scitex/claude-code-telegrammer/runtime/<agent>/poller-<token>.pid``), and
+that dir lives in the overlay home, which survives a container restart. The
+container's pid namespace does not. A restarted container hands its low pids out
+again within seconds, in the very burst that spawns the MCP servers, so the pid
+in the stale file was reassigned - to the telegram MCP server itself - and the
+new poller's takeover SIGTERMed it. Two restarts in one day died that way; the
+one that lived had read a pid above the burst.
+
+The telegrammer is being fixed to verify identity before it signals. This guard
+closes the window from sac's side, and it is correct on its own terms: sac only
+enters the start path when the agent is NOT running, and the previous
+container's poller died with that container, so at this moment a pidfile here
+can only name a pid the new namespace is about to reuse. It never describes a
+live process. Removing it turns the poller's next start into the
+"no prior poller recorded" path, which signals nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .._logging import get_logger
+
+__all__ = [
+    "POLLER_PIDFILE_GLOB",
+    "SERVER_LOCKFILE_NAME",
+    "TELEGRAMMER_RUNTIME_REL",
+    "clear_stale_poller_pidfiles",
+]
+
+#: Where claude-code-telegrammer keeps its per-agent state, relative to $HOME.
+TELEGRAMMER_RUNTIME_REL = Path(".scitex") / "claude-code-telegrammer" / "runtime"
+#: One file per bot token, written by lib/takeover.ts.
+POLLER_PIDFILE_GLOB = "poller-*.pid"
+#: The MCP server's single-instance lock (lib/lock.ts) - the same "newest wins,
+#: SIGTERM the recorded pid" protocol, so the same stale-namespace hazard.
+SERVER_LOCKFILE_NAME = "claude-code-telegrammer-mcp.lock"
+
+_log = get_logger(__name__)
+
+
+def clear_stale_poller_pidfiles(home: Path) -> list[Path]:
+    """Remove every telegrammer pid record under ``home``; return what was removed.
+
+    Two kinds, both written as "<pid>" by a previous incarnation and both
+    consumed by a "newest wins" takeover that signals the recorded pid: the
+    per-token poller pidfile and the MCP server's single-instance lock.
+
+    Runs at launch, before the harness starts. Missing directories are a
+    no-op. Every removal is logged by name so a reader of the boot log can
+    see which previous incarnation's record was retired.
+    """
+    runtime = Path(home) / TELEGRAMMER_RUNTIME_REL
+    if not runtime.is_dir():
+        return []
+    removed: list[Path] = []
+    candidates = sorted(runtime.glob(f"*/{POLLER_PIDFILE_GLOB}")) + sorted(
+        runtime.glob(f"*/{SERVER_LOCKFILE_NAME}")
+    )
+    for pidfile in candidates:
+        try:
+            pidfile.unlink()
+        except FileNotFoundError:
+            continue
+        removed.append(pidfile)
+        _log.info(
+            "launch: retired a poller pidfile from a previous container incarnation: %s",
+            pidfile,
+        )
+    return removed

--- a/src/scitex_agent_container/runtimes/_tui_workspace.py
+++ b/src/scitex_agent_container/runtimes/_tui_workspace.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from ..config import AgentConfig
 from ._skills_boot_log import log_effective_skills
+from ._stale_poller_pidfiles import clear_stale_poller_pidfiles
 from ._to_home import deploy_to_home
 from ._to_home_overlay import deploy_to_home_overlay, resolve_overlay_upper_home
 from .claude_md import setup_claude_md
@@ -76,6 +77,10 @@ def materialize_workspace(
         return None
     home_dir = state_dir_for_config(config) / "home"
     home_dir.mkdir(parents=True, exist_ok=True)
+    # A previous incarnation's telegrammer pidfile can only name a pid the new
+    # container is about to reuse - clear it before anything in the new
+    # namespace can be mistaken for a poller (see _stale_poller_pidfiles).
+    clear_stale_poller_pidfiles(home_dir)
     setup_claude_md(config, str(home_dir))
     deploy_to_home(config, str(home_dir))
     log_effective_skills(config, home_dir)
@@ -90,6 +95,7 @@ def materialize_workspace(
     ensure_project_onboarding(workdir, home=home_dir)
     upper_home = resolve_overlay_upper_home(config)
     if upper_home is not None and upper_home.is_dir():
+        clear_stale_poller_pidfiles(upper_home)
         ensure_project_onboarding(workdir, home=upper_home)
         setup_settings_json(config, str(upper_home), filename="settings.json")
     return home_dir

--- a/tests/scitex_agent_container/runtimes/test__stale_poller_pidfiles.py
+++ b/tests/scitex_agent_container/runtimes/test__stale_poller_pidfiles.py
@@ -1,0 +1,77 @@
+"""Launch retires telegrammer poller pidfiles left by a previous container.
+
+Measured 2026-09-05 (scitex-compute-04, scitex-cards): the per-token pidfile in
+the overlay home survives a restart, the pid namespace does not, and the new
+poller SIGTERMed whatever had been handed the stale pid - the MCP server. Real
+directories, no mocks. One assertion per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container.runtimes._stale_poller_pidfiles import (
+    SERVER_LOCKFILE_NAME,
+    TELEGRAMMER_RUNTIME_REL,
+    clear_stale_poller_pidfiles,
+)
+
+
+def _runtime(home: Path, agent: str) -> Path:
+    d = home / TELEGRAMMER_RUNTIME_REL / agent
+    d.mkdir(parents=True)
+    return d
+
+
+def test_a_previous_incarnations_pidfile_is_removed(tmp_path: Path):
+    # Arrange -- the shape the telegrammer writes: "<pid>\n<startMs>\n".
+    pidfile = _runtime(tmp_path, "scitex-cards") / "poller-ece7d6cc.pid"
+    pidfile.write_text("179\n1788598000000\n")
+    # Act
+    clear_stale_poller_pidfiles(tmp_path)
+    # Assert
+    assert not pidfile.exists()
+
+
+def test_the_removed_files_are_reported_by_path(tmp_path: Path):
+    # Arrange
+    pidfile = _runtime(tmp_path, "scitex-cards") / "poller-ece7d6cc.pid"
+    pidfile.write_text("179\n1\n")
+    # Act
+    removed = clear_stale_poller_pidfiles(tmp_path)
+    # Assert
+    assert removed == [pidfile]
+
+
+def test_the_pollers_log_and_database_are_left_alone(tmp_path: Path):
+    # Arrange -- the same dir holds the message store and the poller log.
+    runtime = _runtime(tmp_path, "scitex-cards")
+    (runtime / "poller-ece7d6cc.pid").write_text("179\n1\n")
+    survivors = [
+        runtime / "poller-ece7d6cc.log",
+        runtime / "claude-code-telegrammer.db",
+    ]
+    for path in survivors:
+        path.write_text("keep")
+    # Act
+    clear_stale_poller_pidfiles(tmp_path)
+    # Assert
+    assert all(path.exists() for path in survivors)
+
+
+def test_a_home_with_no_telegrammer_state_is_a_no_op(tmp_path: Path):
+    # Arrange -- nothing under the home at all.
+    # Act
+    removed = clear_stale_poller_pidfiles(tmp_path)
+    # Assert
+    assert removed == []
+
+
+def test_the_mcp_servers_single_instance_lock_is_removed_too(tmp_path: Path):
+    # Arrange -- lib/lock.ts writes "<pid>" and SIGTERMs it on the next start.
+    lock = _runtime(tmp_path, "scitex-cards") / SERVER_LOCKFILE_NAME
+    lock.write_text("171")
+    # Act
+    clear_stale_poller_pidfiles(tmp_path)
+    # Assert
+    assert not lock.exists()


### PR DESCRIPTION
claude-code-telegrammer keeps two "newest wins" pid records in the agent's state dir — the per-token poller pidfile (`lib/takeover.ts`) and the MCP server's single-instance lock (`lib/lock.ts`) — and both are consumed at the next start by a takeover that SIGTERMs the recorded pid. That state dir is in the overlay home, which survives a container restart. The container's pid namespace does not.

**Measured 2026-09-05, scitex-compute-04, agent scitex-cards:** the restarted container reissued the stale pid within seconds to the telegram MCP server itself, and its own poller SIGTERMed it ~1 s after start. Two of three restarts that day died that way (the third had read a stale pid above the spawn burst). The agent lost its operator channel until the server was reconnected from the session.

The telegrammer is being fixed to verify identity before it signals (companion PR there). This is the guard on sac's side, and it stands on its own: sac only enters the start path when the agent is not running, and the previous container's processes died with it, so at that moment a record here can only name a pid the new namespace is about to reuse. Removing it turns the poller's next start into the "no prior poller recorded" path, which signals nothing.

`clear_stale_poller_pidfiles(home)` runs in the TUI workspace preparation for both the workspace home and the overlay upper home, before the harness launches, and logs each retired record by path. Five tests on real directories. Runtimes suite: 2221 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsMm3cJpEtocFt5mf1m9HL