### PR TITLE
fix(tui): a Codex pane is ready after its boot banner scrolls away

### DIFF
--- a/src/scitex_agent_container/runtimes/_pane_acceptance.py
+++ b/src/scitex_agent_container/runtimes/_pane_acceptance.py
@@ -37,7 +37,9 @@ from .prompts import is_ready
 #: on the spinner's word: "Slithering", "Bunning" and the rest ROTATE, so a
 #: vocabulary-based detector works right up until the word changes and then
 #: fails silently in the direction that loses work.
-_BUSY_MARKERS = ("tokens)", "without interrupting")
+#: Claude's two mid-turn shapes, and Codex's: its working line ends in
+#: "esc to interrupt" (measured 2026-09-05 on handyman-01).
+_BUSY_MARKERS = ("tokens)", "without interrupting", "esc to interrupt")
 
 #: Claude Code parks input typed while it is working and says so in the pane. A
 #: pane in this state ACCEPTS keystrokes and does not run them, which is the

--- a/src/scitex_agent_container/runtimes/prompts.py
+++ b/src/scitex_agent_container/runtimes/prompts.py
@@ -12,6 +12,7 @@ Add new handlers by appending to PROMPT_HANDLERS or calling register_prompt().
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Callable
 
@@ -306,19 +307,34 @@ def _detect_codex_hooks_review(content: str) -> bool:
     return "Hooks need review" in content and "2. Trust all and continue" in content
 
 
-def _detect_codex_done(content: str) -> bool:
-    """Codex is at its input prompt: its banner is up and no picker remains.
+#: The Codex composer row and the footer under it, as they look once the boot
+#: banner has scrolled away: ``› Use /skills to list available skills`` over
+#: ``qwen38-27b default · /home/ywatanabe/proj/local-coder``. The footer's
+#: second word is the reasoning effort Codex is running with.
+_CODEX_COMPOSER_MARKER = "\u203a"
+_CODEX_FOOTER = re.compile(
+    r"^\s*\S+ (?:default|minimal|low|medium|high|xhigh) \u00b7 /", re.M
+)
+_CODEX_TAIL_ROWS = 8
 
-    The Codex TUI never prints Claude's "bypass permissions" status line; its
-    ready state is the "OpenAI Codex (vX)" box with a permissions row ("YOLO
-    mode" when sac turns the sandbox off).
+
+def _detect_codex_done(content: str) -> bool:
+    """Codex is at its input prompt and no picker remains.
+
+    Two shapes, both measured. At boot the "OpenAI Codex (vX)" box with a
+    permissions row ("YOLO mode" when sac turns the sandbox off) is on screen.
+    After the first turn that box has scrolled away for good, and the idle
+    screen is the composer row (``›``) with the model/effort/cwd footer under
+    it. Until 2026-09-05 only the first shape counted, so every dispatch to a
+    Codex agent after its first turn was refused as "a modal is blocking the
+    input" — measured on handyman-01, which had been idle at its composer.
     """
-    return (
-        "OpenAI Codex (v" in content
-        and "permissions:" in content
-        and "Press enter to continue" not in content
-        and "Press enter to confirm" not in content
-    )
+    if "Press enter to continue" in content or "Press enter to confirm" in content:
+        return False
+    if "OpenAI Codex (v" in content and "permissions:" in content:
+        return True
+    tail = "\n".join(content.rstrip().splitlines()[-_CODEX_TAIL_ROWS:])
+    return _CODEX_COMPOSER_MARKER in tail and _CODEX_FOOTER.search(tail) is not None
 
 
 def _detect_done(content: str) -> bool:

--- a/tests/scitex_agent_container/runtimes/test_prompts_codex_steady_state.py
+++ b/tests/scitex_agent_container/runtimes/test_prompts_codex_steady_state.py
@@ -1,0 +1,67 @@
+"""The Codex pane counts as ready after its boot banner has scrolled away."""
+
+from scitex_agent_container.runtimes._pane_acceptance import is_accepting
+from scitex_agent_container.runtimes.prompts import is_ready
+
+# Captured from handyman-01 on 2026-09-05 15:45Z (tmux capture-pane), idle.
+_IDLE_AFTER_FIRST_TURN = """
+\u203a hello?
+
+
+\u25a0 unexpected status 502 Bad Gateway: No inference upstream answered: All inference
+upstreams are cooling down. Configured inference upstreams (2): http://127.0.0.1:18773,
+http://127.0.0.1:18774. An upstream that produced no response is out of rotation for 30
+s., url: http://127.0.0.1:18772/v1/responses
+
+
+\u203a Use /skills to list available skills
+
+  qwen38-27b default \u00b7 /home/ywatanabe/proj/local-coder
+"""
+
+
+def test_the_idle_composer_with_the_footer_is_ready_without_the_boot_banner() -> None:
+    # Arrange
+    pane = _IDLE_AFTER_FIRST_TURN
+
+    # Act
+    ready = is_ready(pane)
+
+    # Assert
+    assert ready is True
+
+
+def test_a_confirm_picker_over_the_composer_is_not_ready() -> None:
+    # Arrange -- the same screen with a modal footer on it.
+    pane = _IDLE_AFTER_FIRST_TURN + "\n  Press enter to confirm \u00b7 Esc to cancel\n"
+
+    # Act
+    ready = is_ready(pane)
+
+    # Assert
+    assert ready is False
+
+
+def test_a_working_codex_pane_is_not_accepting() -> None:
+    # Arrange -- Codex mid-turn: its working line offers esc to interrupt.
+    pane = _IDLE_AFTER_FIRST_TURN.replace(
+        "\u203a Use /skills to list available skills",
+        "\u2022 Working (12s \u00b7 esc to interrupt)",
+    )
+
+    # Act
+    accepting = is_accepting(pane)
+
+    # Assert
+    assert accepting is False
+
+
+def test_the_boot_banner_shape_still_counts_as_ready() -> None:
+    # Arrange
+    pane = "OpenAI Codex (v0.44.0)\n  permissions: YOLO mode\n\n\u203a \n"
+
+    # Act
+    ready = is_ready(pane)
+
+    # Assert
+    assert ready is True


### PR DESCRIPTION
The Codex readiness detector (`prompts._detect_codex_done`) knew one shape: the **boot banner** ("OpenAI Codex (vX)" + permissions row). After the first turn that banner has scrolled away for good and the idle screen is the composer row (`›`) over the `<model> <effort> · <cwd>` footer. So every dispatch to a Codex agent after its first turn was refused as `a modal is blocking the input (not at the main prompt)`.

Measured today on handyman-01 (Codex × Qwen): idle at its composer, operator attached, `tmux #{pane_in_mode}` = 0, three `sac agents send` attempts refused. A tmux paste into the same composer was accepted and the pane went to `• Working (3s • esc to interrupt)` — which is also where the new busy marker comes from.

- `_detect_codex_done` also accepts the steady state: `›` plus a footer matching `<model> (default|minimal|low|medium|high|xhigh) · /` in the last 8 rows; confirm pickers still refuse first; the boot-banner shape still counts.
- `is_busy` learns Codex's working line (`esc to interrupt`).
- Four tests on the captured pane.

Deploy: pull the host checkouts (compute-04 first — the bridge runs from the host venv); a running bridge loads it at the agent's next restart, which for handyman-01 waits until its current task ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsMm3cJpEtocFt5mf1m9HL