### PR TITLE
feat(launch): the start log names a commands snapshot that differs from its source

### DIFF
--- a/src/scitex_agent_container/runtimes/_host_commands.py
+++ b/src/scitex_agent_container/runtimes/_host_commands.py
@@ -27,8 +27,10 @@ empty ``commands/`` dir fabricated). Non-``*.md`` entries (e.g.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import shutil
+from collections.abc import Iterable
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -103,4 +105,60 @@ def deploy_host_claude_commands(workspace_home: Path) -> None:
         logger.info("to_home: host command %s -> %s", src.name, dst)
 
 
-__all__ = ["deploy_host_claude_commands", "host_claude_commands_dir"]
+# --- Launch-time snapshot drift ----------------------------------------------
+
+
+def _hash_lines(path: Path) -> tuple[str, int]:
+    """Return (sha256-8, line count) of ``path`` (read-only).
+
+    The 8-hex prefix is the file identity the card measurement names
+    (af83523b / 879b6fff).
+    """
+    data = path.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()[:8]
+    count = len(data.decode("utf-8", errors="replace").splitlines())
+    return digest, count
+
+
+def snapshot_drift(pairs: Iterable[tuple[Path, Path]]) -> list[str]:
+    """One human line per (snapshot, source) pair that diverges.
+
+    ``snapshot`` is the file the agent will read (the materialized runtime
+    home); ``source`` is the dotfiles / host original it should match.
+    A pair with an identical sha256 contributes no line; a pair whose
+    source is missing gets a line saying so. Pure: reads files, writes
+    nothing, logs nothing.
+
+    Line shape (card sac-launch-compares-…-20260905)::
+
+        commands/constitution.md: snapshot 879b6fff (452 lines)
+          != source af83523b (449 lines) — restart to pick up
+    """
+    lines: list[str] = []
+    for snapshot, source in pairs:
+        label = f"commands/{snapshot.name}"
+        snap_hash, snap_count = _hash_lines(snapshot)
+        if not source.is_file():
+            lines.append(
+                f"{label}: snapshot {snap_hash} "
+                f"({snap_count} line{'s' if snap_count != 1 else ''}) — "
+                "source missing — restart to pick up"
+            )
+            continue
+        src_hash, src_count = _hash_lines(source)
+        if src_hash == snap_hash:
+            continue
+        lines.append(
+            f"{label}: snapshot {snap_hash} "
+            f"({snap_count} line{'s' if snap_count != 1 else ''}) != "
+            f"source {src_hash} ({src_count} "
+            f"line{'s' if src_count != 1 else ''}) — restart to pick up"
+        )
+    return lines
+
+
+__all__ = [
+    "deploy_host_claude_commands",
+    "host_claude_commands_dir",
+    "snapshot_drift",
+]

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -65,7 +65,11 @@ from ._cct_token_pool import ensure_cct_bot_token, prune_tokenless_telegrammer_m
 from ._envrc import fold_envrc_cascade_into_env, fold_envrc_into_env
 from ._github_token import ensure_github_token
 from ._hook_origin_manifest import write_hook_manifest
-from ._host_commands import deploy_host_claude_commands
+from ._host_commands import (
+    deploy_host_claude_commands,
+    host_claude_commands_dir,
+    snapshot_drift,
+)
 from ._host_skills import deploy_host_skills
 from ._symlink_resolve import DanglingToHomeSymlinkError, deref_copy_symlink
 from ._to_home_deployers import (
@@ -277,6 +281,20 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
         )
     if root is not None:
         _walk_and_apply(root, root, dest, config=config, composed_dsts=composed_dsts)
+    # Launch-time snapshot drift (card sac-launch-compares-the-copied-
+    # commands-snapshot-to-the-dotfiles-ref-and-logs-divergence-20260905):
+    # the commands the agent will read from the runtime home may differ
+    # from the operator's live host (dotfiles) commands of the same name
+    # — the cop copies once at launch and nothing refreshes until a
+    # restart. Name each divergent file in the start log, through the
+    # log the launcher already uses; print NOTHING when there is no
+    # drift. No re-copy into a running session and no periodic check:
+    # a live rewrite under a session that already read the file is
+    # worse than a stale one — the honest fix is "restart to pick up",
+    # said out loud.
+    for _drift_line in snapshot_drift(_command_source_pairs(dest)):
+        logger.warning("to_home: %s", _drift_line)
+
     # .envrc CASCADE (lowest → highest precedence): user-level shared baseline
     # → the spec's _shared baseline → the agent's workdir (the project's OWN
     # .envrc, e.g. ~/proj/<project>/.envrc) → the per-agent to_home. Each
@@ -371,6 +389,27 @@ def _apply_host_merge_with_drift_guard(config: AgentConfig, dest: Path) -> None:
             f"host deep-merge still drifted after re-materialize for agent "
             f"{config.name!r} at {dest}/.claude:\n  - {bullet}"
         )
+
+
+def _command_source_pairs(dest: Path) -> list[tuple[Path, Path]]:
+    """(snapshot, source) pairs for the launch-time snapshot-drift check.
+
+    Every ``*.md`` under the materialized ``.claude/commands/`` that has a
+    same-name file in the host ``~/.claude/commands/`` (the operator's live
+    dotfiles ref — the ``deploy_host_claude_commands`` source) yields one
+    pair. A command with no same-name host counterpart was copied from a
+    to_home layer and is byte-identical to that fresh copy, so it has no
+    host ref to name against and yields no pair.
+    """
+    cmd = dest / ".claude" / "commands"
+    host = host_claude_commands_dir()
+    if host is None or not cmd.is_dir():
+        return []
+    return [
+        (p, host / p.name)
+        for p in sorted(cmd.iterdir())
+        if p.suffix == ".md" and p.is_file() and (host / p.name).is_file()
+    ]
 
 
 # --- traversal -------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__host_commands.py
+++ b/tests/scitex_agent_container/runtimes/test__host_commands.py
@@ -12,10 +12,12 @@ host home via the shared ``env_save_restore`` fixture (no monkeypatch) so
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 from scitex_agent_container.runtimes._host_commands import (
     deploy_host_claude_commands,
+    snapshot_drift,
 )
 from scitex_agent_container.runtimes._to_home import materialize_to_home
 
@@ -114,3 +116,60 @@ class TestHostCommandPrecedenceViaMaterialize:
         # Assert — the per-agent command overwrites the host one.
         landed = agent_home / ".claude" / "commands" / "foo.md"
         assert landed.read_text() == "AGENT VERSION\n"
+
+
+class TestSnapshotDrift:
+    """Launch-time commands-snapshot drift check (card sac-launch-compares-
+the-copied-commands-snapshot-to-the-dotfiles-ref-and-logs-divergence-20260905).
+
+    The snapshot is the command file the agent will read (runtime home);
+    the source is the dotfiles / host original. Identical sha256 → no line.
+    """
+    def test_identical_pair_is_silent(self, tmp_path):
+        # Arrange — snapshot and source are byte-identical.
+        cmd = tmp_path / "commands"
+        cmd.mkdir()
+        snap = cmd / "constitution.md"
+        snap.write_text("rule one\nrule two\n")
+        src = tmp_path / "ref" / "constitution.md"
+        src.parent.mkdir()
+        src.write_text("rule one\nrule two\n")
+        # Act
+        lines = snapshot_drift([(snap, src)])
+        # Assert — identical files produce
+        assert lines == []
+    def test_differing_pair_names_both_hashes(self, tmp_path):
+        # Arrange — snapshot has 4 lines, source has 3.
+        cmd = tmp_path / "commands"
+        cmd.mkdir()
+        snap = cmd / "constitution.md"
+        snap.write_text("one\ntwo\nthree\nfour\n")
+        src = tmp_path / "ref" / "constitution.md"
+        src.parent.mkdir()
+        src.write_text("one\ntwo\nthree\n")
+        # Act
+        lines = snapshot_drift([(snap, src)])
+        # Assert — exactly one line, naming both hashes and both counts.
+        sh = hashlib.sha256(snap.read_bytes()).hexdigest()[:8]
+        rh = hashlib.sha256(src.read_bytes()).hexdigest()[:8]
+        expected = (
+            f"commands/constitution.md: snapshot {sh} (4 lines) != "
+            f"source {rh} (3 lines) — restart to pick up"
+        )
+        assert lines == [expected]
+    def test_missing_source_gets_one_line(self, tmp_path):
+        # Arrange — snapshot exists; the source path was never written.
+        cmd = tmp_path / "commands"
+        cmd.mkdir()
+        snap = cmd / "constitution.md"
+        snap.write_text("one\ntwo\n")
+        src = tmp_path / "ref" / "constitution.md"
+        # Act
+        lines = snapshot_drift([(snap, src)])
+        # Assert — one line naming the missing source.
+        sh = hashlib.sha256(snap.read_bytes()).hexdigest()[:8]
+        expected = (
+            f"commands/constitution.md: snapshot {sh} (2 lines) — "
+            "source missing — restart to pick up"
+        )
+        assert lines == [expected]


### PR DESCRIPTION
## What
The start log now names the commands snapshot that differs from its source
(the host / dotfiles ref).

After the to_home copy phase, each materialized .claude/commands/*.md is
hashed against its host (dotfiles) source of the same name, and one line
per divergent file is printed in the start log through the launcher's
existing logger channel; nothing is printed when there is no drift:

  commands/constitution.md: snapshot af83523b (449 lines)
    != source 879b6fff (452 lines) — restart to pick up

## Why
The agent reads the commands snapshot sac copies once at launch, never the
dotfiles ref: nothing refreshes it until a restart, and the daily
dotfiles-drift-check hashes the same inode twice (measured 2026-09-05:
runtime copy af83523b, 449 lines, vs ref 879b6fff, 452 lines — the three
missing lines were the hostname-naming rule). An agent can thus follow a
stale constitution all day and nobody sees the gap.

## Form
- snapshot_drift(pairs): pure pair comparator next to the copier
  (runtimes/_host_commands.py).
- _command_source_pairs(dest): builds the (snapshot, source) pairs;
  called once in deploy_to_home, right after the copy phase.
- No re-copy into a running session and no periodic check: a live rewrite
  under a session that already read the file is worse than a stale one —
  the honest fix is "restart to pick up", said out loud.
- Tests (test__host_commands.py): identical pair → silent; differing pair →
  exactly one line naming both hashes; missing source → one line saying
  so. AAA markers, one assertion per test, no mocks.

## Gates (local, from the worktree)
- pytest tests/scitex_agent_container/runtimes -q → 2228 passed, 28 skipped (exit 0)
- ruff, CI selection (F401,F811 on src/ tests/; T201,T203 on src/) → both exit 0
- scitex_dev ecosystem audit-all scitex-agent-container → exit 0 (0 unmasked errors)

Card: sac-launch-compares-the-copied-commands-snapshot-to-the-dotfiles-ref-
and-logs-divergence-20260905
