### PR TITLE
fix(state): port_store() reopens a cached claim-ledger handle whose connection is closed

### DIFF
--- a/src/scitex_agent_container/_state/port_allocator_store.py
+++ b/src/scitex_agent_container/_state/port_allocator_store.py
@@ -93,7 +93,6 @@ a forked child (the concurrency tests use ``multiprocessing``) never reuses
 from __future__ import annotations
 
 import logging
-
 import threading
 from typing import TYPE_CHECKING, Any
 

--- a/src/scitex_agent_container/_state/port_allocator_store.py
+++ b/src/scitex_agent_container/_state/port_allocator_store.py
@@ -92,6 +92,8 @@ a forked child (the concurrency tests use ``multiprocessing``) never reuses
 
 from __future__ import annotations
 
+import logging
+
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -102,6 +104,8 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 #: greppable across the migration and in operator muscle memory.
 #: ``scitex_dev.store`` renders it as four physical tables (``<name>_rows``,
 #: ``_oplog``, ``_identity``, ``_cursor``).
+logger = logging.getLogger(__name__)
+
 STORE_NAME = "a2a_ports"
 
 #: Recorded on every write as the acting component.
@@ -246,7 +250,21 @@ def port_store() -> "Store":
         if _STORE_CACHE is not None:
             cached_key, cached_pid, cached = _STORE_CACHE
             if cached_key == target and cached_pid == pid:
-                return cached
+                if not _handle_is_closed(cached):
+                    return cached
+                # The peer closed the connection under the cache (a pooler
+                # or server restart, an idle cut) and psycopg has already
+                # marked it closed. Every later call would raise
+                # "the connection is closed" forever — measured 2026-09-05:
+                # the tui-bridge-supervisor skipped every tick for two hours
+                # on two hosts (card sac-tui-bridge-supervisor-skips-every-
+                # tick-after-its-db-connection-closes-20260905). A closed
+                # handle is not a handle; reopen and say so once.
+                logger.warning(
+                    "port_store: the cached claim-ledger connection is "
+                    "closed (pid %d); reopening it",
+                    pid,
+                )
             # A fork inherited the parent's connection through the same fd:
             # closing it HERE would send a termination on the parent's
             # socket. Only the same process that opened a handle may close
@@ -257,6 +275,20 @@ def port_store() -> "Store":
         fresh = open_port_store()
         _STORE_CACHE = (target, pid, fresh)
         return fresh
+
+
+def _handle_is_closed(store: "Store") -> bool:
+    """True when the store's psycopg connection reports itself closed.
+
+    A LOCAL check, no round trip: psycopg sets ``connection.closed`` the
+    moment an operation finds the peer gone, and the message every later
+    call raises ("the connection is closed") is exactly this flag. A
+    handle with no such attribute (a dialect that is not psycopg) is
+    treated as open — this guard exists for the one failure that was
+    measured, not to second-guess every backend.
+    """
+    connection = getattr(store, "_connection", None)
+    return bool(getattr(connection, "closed", False))
 
 
 def _reset_store_cache() -> None:

--- a/tests/scitex_agent_container/_state/test_port_allocator_store_reopens_closed_handle.py
+++ b/tests/scitex_agent_container/_state/test_port_allocator_store_reopens_closed_handle.py
@@ -1,0 +1,44 @@
+"""``port_store()`` must not hand back a cached handle whose connection is closed.
+
+Measured 2026-09-05 on compute-03 and compute-04: the host tui-bridge-supervisor
+logged "could not evaluate the bridge ... the connection is closed" every 30 s
+for two hours, because its per-process cached claim-ledger handle had lost its
+connection once and the cache never noticed. The fix is a local check on the
+psycopg ``closed`` flag before the cached handle is returned.
+
+Real PostgreSQL through the shared ``pg_schema`` fixture (skips without one);
+the connection is closed for real, not faked.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._state import port_allocator as pa
+from scitex_agent_container._state import port_allocator_store as pas
+
+
+def test_port_store_reopens_after_its_connection_was_closed(pg_schema: str) -> None:
+    # Arrange: a cached handle whose connection the peer (here: we) closed.
+    pas._reset_store_cache()
+    first = pas.port_store()
+    first._connection.close()
+    assert pas._handle_is_closed(first)
+
+    # Act: the next caller asks the cache.
+    second = pas.port_store()
+
+    # Assert: a fresh, open handle — and the allocator works again on it.
+    assert second is not first
+    assert not pas._handle_is_closed(second)
+    assert pa.get_port("nobody-claimed-this") is None
+
+
+def test_port_store_keeps_an_open_cached_handle(pg_schema: str) -> None:
+    # Arrange
+    pas._reset_store_cache()
+    first = pas.port_store()
+
+    # Act
+    second = pas.port_store()
+
+    # Assert: the cache still saves the connect when nothing is wrong.
+    assert second is first

--- a/tests/scitex_agent_container/_state/test_port_allocator_store_reopens_closed_handle.py
+++ b/tests/scitex_agent_container/_state/test_port_allocator_store_reopens_closed_handle.py
@@ -12,33 +12,60 @@ the connection is closed for real, not faked.
 
 from __future__ import annotations
 
+import pytest
+
 from scitex_agent_container._state import port_allocator as pa
 from scitex_agent_container._state import port_allocator_store as pas
 
 
-def test_port_store_reopens_after_its_connection_was_closed(pg_schema: str) -> None:
-    # Arrange: a cached handle whose connection the peer (here: we) closed.
+@pytest.fixture
+def closed_first_handle(pg_schema: str) -> object:
+    """A cached handle whose connection the peer (here: we) closed for real."""
     pas._reset_store_cache()
     first = pas.port_store()
     first._connection.close()
-    assert pas._handle_is_closed(first)
+    return first
 
-    # Act: the next caller asks the cache.
+
+def test_closed_flag_is_seen_on_the_cached_handle(closed_first_handle: object) -> None:
+    # Arrange: fixture closed the connection.
+    # Act
+    closed = pas._handle_is_closed(closed_first_handle)
+    # Assert
+    assert closed
+
+
+def test_port_store_returns_a_different_handle_after_a_close(
+    closed_first_handle: object,
+) -> None:
+    # Arrange: fixture closed the connection.
+    # Act
     second = pas.port_store()
+    # Assert
+    assert second is not closed_first_handle
 
-    # Assert: a fresh, open handle — and the allocator works again on it.
-    assert second is not first
+
+def test_port_store_reopened_handle_is_open(closed_first_handle: object) -> None:
+    # Arrange: fixture closed the connection.
+    # Act
+    second = pas.port_store()
+    # Assert
     assert not pas._handle_is_closed(second)
-    assert pa.get_port("nobody-claimed-this") is None
+
+
+def test_allocator_works_again_after_the_reopen(closed_first_handle: object) -> None:
+    # Arrange: fixture closed the connection.
+    # Act
+    port = pa.get_port("nobody-claimed-this")
+    # Assert
+    assert port is None
 
 
 def test_port_store_keeps_an_open_cached_handle(pg_schema: str) -> None:
     # Arrange
     pas._reset_store_cache()
     first = pas.port_store()
-
     # Act
     second = pas.port_store()
-
     # Assert: the cache still saves the connect when nothing is wrong.
     assert second is first


### PR DESCRIPTION
The per-process cache in `port_allocator_store.port_store()` returned its handle without looking at it. When the peer closed the connection once (2026-09-05 15:30Z on compute-03 and compute-04), every later call raised `the connection is closed`, and the host **tui-bridge-supervisor** — whose per-agent fallback is "skip this tick" — skipped every tick for two hours while its process stayed up (journal: `could not evaluate the bridge for '<agent>' (skipped this tick): the connection is closed`, every 30 s, every agent). handyman-01's bridge kept running pre-#1308 code and refused every dispatch meanwhile.

Fix: check psycopg's local `closed` flag before returning the cached handle; reopen (one warning) when it is set. No round trip on the happy path, so the 10.7 ms connect the cache exists to save is still saved.

Test: real PostgreSQL via the shared `pg_schema` fixture — the cached handle's connection is closed for real, the next `port_store()` must return a fresh open handle and `get_port()` must work; a second test proves an open handle is still reused.

Deploy note (measured today): a pull of the bind-mounted checkout does NOT restart the listen daemon that runs the supervisor; after merge, `systemctl --user restart` the sac listen unit on each host (from a login shell, so the fleet secrets reach it).

Card: `sac-tui-bridge-supervisor-skips-every-tick-after-its-db-connection-closes-20260905`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsMm3cJpEtocFt5mf1m9HL