### PR TITLE
chore(hooks): the retired scitex_todo.hooks entry-point group leaves sac

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -530,45 +530,18 @@ scitex-agent-container = "scitex_agent_container._store_plugin:provide"
 # a2a port is unreachable inbound) still receives it. The consumer
 # filters for the card-event kinds and ignores everything else, incl.
 # sac's OWN liveness-tick anomaly events on the same bus. Bus-only
-# contract: no import of scitex_todo.
-# DECLARED IN BOTH GROUPS, and the duplication is the correct migration
-# state — not an oversight to tidy up later.
+# contract: no import of scitex_cards.
 #
-# MEASURED 2026-08-20 by scitex-cards: this consumer has NEVER been invoked in
-# production. The running notify daemon executes scitex-cards 0.42.0, whose
-# `_hooks/_plugins.py` reads `scitex_cards.hooks` and has ZERO references to
-# the retired group. sac was registered only under the retired name, so every
-# card event was dispatched to an EMPTY SET — succeeded, reported success,
-# called nobody. Corroborating symptoms, all explained by that one fact:
-#
-#     notifyd-liveness.json  last_delivery_at: null   never delivered, ever
-#     local inbox            150 rows, all unseen     enqueued, never pushed
-#     agents still get cards                          the PULL rail is separate
-#
-# Nothing anywhere reported a failure. That is the signature of this defect
-# class, and scitex-cards' own docstring recorded the identical state on
-# 2026-08-17 — the fix shipped in 0.48.0 and has never executed, because the
-# unit whose Description reads "supervised so a package upgrade actually
-# reaches it" points ExecStart at a hand-made venv that `pip install -U` never
-# touches.
-#
-# WHY BOTH RATHER THAN A MOVE. 0.42.0 (running now) reads only the new group,
-# so adding it revives delivery immediately. 0.48.0 reads both and dedupes, so
-# nothing double-fires. And leaving the retired entry in place preserves the
-# fleet's only registration under that name, which is what lets scitex-cards
-# verify the alias actually works when 0.48.0 finally runs — deleting it would
-# make "the alias works" indistinguishable from "nobody was left".
-#
-# THE NAME AND THE DOTTED PATH MUST STAY BYTE-IDENTICAL between the two
-# blocks. 0.48.0 dedupes on the tuple `(ep.name, ep.value)`:
-#
-#     seen  = {(ep.name, ep.value) for ep in current}
-#     extra = [ep for ep in retired if (ep.name, ep.value) not in seen]
-#
-# so renaming the entry or moving the callable on one side only turns the
-# alias meant to FIX delivery into a double-delivery bug. A migration is
-# exactly when tidying a name is tempting; do not, until the retired block
-# goes away entirely.
+# HISTORY. Until 2026-09-05 this consumer was ALSO registered under the retired
+# group name `scitex_todo.hooks`: scitex-cards 0.42.0 read only the new group
+# (so the new block revived delivery), and 0.46.0+ read both and deduped on
+# `(ep.name, ep.value)`, so the duplicate dispatched exactly once per event
+# while giving scitex-cards a live registration to verify the alias against.
+# scitex-cards confirmed on 2026-09-05 that the alias had been exercised on
+# every card event for three weeks and declared the retired group closed, so
+# the duplicate was removed. Do not re-add it: a second registration whose
+# name or dotted path drifts from this one turns the dedupe into a
+# double-delivery bug.
 #
 # C10 — sac's consumer on the shared card-event bus. When the board emits a
 # card-event (commented / created / reassigned / status_changed / completed /
@@ -581,13 +554,6 @@ scitex-agent-container = "scitex_agent_container._store_plugin:provide"
 # anomaly events on the same bus. Bus-only contract: no import of the board
 # package.
 [project.entry-points."scitex_cards.hooks"]
-scitex-agent-container = "scitex_agent_container._listen._card_event_delivery:deliver_card_event"
-
-# The retired spelling, kept deliberately. See the note above: it is the
-# fleet's only registration under this group and therefore the only way to
-# verify the 0.48.0 alias when it runs. Remove it only once that verification
-# has happened and scitex-cards says the group is closed.
-[project.entry-points."scitex_todo.hooks"]
 scitex-agent-container = "scitex_agent_container._listen._card_event_delivery:deliver_card_event"
 
 # Claude Code hook RULES sac declares about its own surfaces. sac owns the

--- a/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
@@ -196,7 +196,7 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
         # Liveness-tick reconciler (card sac-card-anchored-stop-reconciler):
         # deterministic alarm-engine producer — reads cards (truth) vs.
         # real agent activity and emits an anomaly on the
-        # ``scitex_todo.hooks`` bus when an OPEN, unblocked card's owner is
+        # ``scitex_cards.hooks`` bus when an OPEN, unblocked card's owner is
         # dead/idle past the stale threshold. Its FS/registry reads route
         # through ``_off_loop`` so it can never starve the bind. Honour
         # SAC_LIVENESS_TICK_DISABLED=1 to skip launching.
@@ -223,7 +223,7 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
         # Each tick does a ``git fetch`` + ``rev-list`` (OFF the event loop
         # via ``_off_loop`` so a wedged fetch can never starve the bind) and,
         # when the checkout is behind origin/develop, FAILS LOUD: a warning
-        # log + an anomaly on the ``scitex_todo.hooks`` bus. Sleeps before
+        # log + an anomaly on the ``scitex_cards.hooks`` bus. Sleeps before
         # the first tick. Honour SAC_DEPLOY_FRESHNESS_DISABLED=1 to skip.
         if os.environ.get(DEPLOY_FRESHNESS_ENV_DISABLED, "") != "1":
             df_task = asyncio.create_task(

--- a/src/scitex_agent_container/_listen/_card_event_delivery.py
+++ b/src/scitex_agent_container/_listen/_card_event_delivery.py
@@ -1,16 +1,16 @@
-"""C10 — sac's ``scitex_todo.hooks`` consumer: deliver card-events to agents.
+"""C10 — sac's ``scitex_cards.hooks`` consumer: deliver card-events to agents.
 
 The problem this closes
 =======================
 scitex-todo's board emits canonical card-events on the shared
-``scitex_todo.hooks`` entry-point bus (its C5, already deployed): kinds
+``scitex_cards.hooks`` entry-point bus (its C5, already deployed): kinds
 ``commented`` / ``created`` / ``reassigned`` / ``status_changed`` /
 ``completed`` (and C6 adds ``committed`` / ``pushed`` / ``merged``). Each
 event names the card + its owner / collaborators / subscribers.
 
 sac REGISTERS this module's :func:`deliver_card_event` as a consumer in
 that entry-point group (see this repo's ``pyproject.toml``
-``[project.entry-points."scitex_todo.hooks"]``). When scitex-todo emits a
+``[project.entry-points."scitex_cards.hooks"]``). When scitex-todo emits a
 card-event, this consumer is invoked IN THE EMITTING PROCESS (the board's
 process — the same host that runs ``sac listen``). It resolves the target
 agent(s) from the event and delivers the notification to each.
@@ -30,7 +30,7 @@ the daemon PUBLISHES down it, so a direct POST to the agent's own
 
 The bus is shared in BOTH directions
 =====================================
-sac ITSELF emits anomaly events on ``scitex_todo.hooks`` (the
+sac ITSELF emits anomaly events on ``scitex_cards.hooks`` (the
 liveness-tick producer in :mod:`._liveness_tick`). Those have a
 ``reason`` / ``severity`` shape, NOT one of the card-event kinds above.
 :func:`deliver_card_event` FILTERS for the card-event kinds and IGNORES
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 # The card-event kinds this consumer recognises. Anything else — most
 # importantly sac's OWN liveness-tick anomaly events on the same bus, plus
 # any future kind we don't yet handle — is ignored (no-op) so the two
-# flows sharing ``scitex_todo.hooks`` never cross-wire.
+# flows sharing ``scitex_cards.hooks`` never cross-wire.
 CARD_EVENT_KINDS = frozenset(
     {
         "commented",
@@ -269,10 +269,10 @@ def _post_notify(
 
 
 def deliver_card_event(event: Any) -> int:
-    """``scitex_todo.hooks`` consumer entry-point — deliver a card-event.
+    """``scitex_cards.hooks`` consumer entry-point — deliver a card-event.
 
     Registered via ``pyproject.toml``
-    ``[project.entry-points."scitex_todo.hooks"]``. Invoked by
+    ``[project.entry-points."scitex_cards.hooks"]``. Invoked by
     scitex-todo's board (and ignored-by-design when sac's own
     liveness-tick fires on the same bus). Contract:
 

--- a/src/scitex_agent_container/_listen/_deploy_freshness.py
+++ b/src/scitex_agent_container/_listen/_deploy_freshness.py
@@ -18,7 +18,7 @@ SEPARATION OF CONCERNS (same as the liveness-tick producer): **sac only
 DETECTS and EMITS.** sac does NOT pull, reset, or otherwise mutate the
 checkout — a deploy-freshness alarm is a report, not an action. We (1) log
 a LOUD warning naming how-many-behind + the newest undeployed commit
-subjects, and (2) emit an anomaly event on the SAME ``scitex_todo.hooks``
+subjects, and (2) emit an anomaly event on the SAME ``scitex_cards.hooks``
 entry-point bus the liveness-tick reconciler uses. scitex-todo's own
 consumer (registered separately, on their side) turns it into a card
 record + operator push. Nothing here writes ``tasks.yaml`` or touches git
@@ -76,7 +76,7 @@ MAX_SUBJECTS = 5
 # The entry-point bus sac emits an anomaly onto — the SAME group the
 # liveness-tick reconciler uses. scitex-todo registers its consumer here
 # (separately, on their side); until then the emit degrades to the loud log.
-HOOKS_ENTRY_POINT_GROUP = "scitex_todo.hooks"
+HOOKS_ENTRY_POINT_GROUP = "scitex_cards.hooks"
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +129,7 @@ def reconcile_deploy_freshness(
         production this is :func:`production_count_behind` bound to the
         resolved checkout; a broken git read returns ``(0, [])`` so a
         degraded read can NEVER raise a false alarm.
-      * ``emit(alarm)`` → deliver the alarm onto the ``scitex_todo.hooks``
+      * ``emit(alarm)`` → deliver the alarm onto the ``scitex_cards.hooks``
         bus. In production this is :func:`production_emit`.
       * ``log`` → the logger to scream on (defaults to the module logger).
 
@@ -256,12 +256,12 @@ def production_count_behind_or_zero() -> tuple[int, list[str]]:
 
 
 # ---------------------------------------------------------------------------
-# production emit — reuse the SAME scitex_todo.hooks bus as liveness-tick
+# production emit — reuse the SAME scitex_cards.hooks bus as liveness-tick
 # ---------------------------------------------------------------------------
 
 
 def production_emit(alarm: dict) -> int:
-    """Emit ``alarm`` onto the ``scitex_todo.hooks`` bus. Returns delivered count.
+    """Emit ``alarm`` onto the ``scitex_cards.hooks`` bus. Returns delivered count.
 
     Reuses the liveness-tick producer's graceful bus plumbing verbatim
     (``_load_hook_consumers`` + ``emit_anomaly``) rather than re-deriving
@@ -296,7 +296,7 @@ async def deploy_freshness_loop(
 
     Each tick runs one deploy-freshness reconcile pass and, when the
     checkout is behind ``origin/develop``, FAILS LOUD (a warning log +
-    an emit on ``scitex_todo.hooks``).
+    an emit on ``scitex_cards.hooks``).
 
     Two lessons baked in (both cost the fleet an incident already):
 

--- a/src/scitex_agent_container/_listen/_liveness_tick.py
+++ b/src/scitex_agent_container/_listen/_liveness_tick.py
@@ -9,7 +9,7 @@ a stuck/crashed agent can never sit silent.
 
 SEPARATION OF CONCERNS (locked with the scitex-todo team): **sac only
 DETECTS and EMITS.** sac does NOT write to the card store. We emit an
-anomaly event on the ``scitex_todo.hooks`` entry-point bus; scitex-todo's
+anomaly event on the ``scitex_cards.hooks`` entry-point bus; scitex-todo's
 own consumer (registered separately, on their side) turns it into a card
 record + operator push. Nothing here writes ``tasks.yaml``.
 
@@ -73,14 +73,14 @@ DEFAULT_RENOTIFY_S = 3600.0
 # its consumer here (separately, on their side); sac is the FIRST
 # producer — until a consumer is registered the emit degrades to a logged
 # line.
-HOOKS_ENTRY_POINT_GROUP = "scitex_todo.hooks"
+HOOKS_ENTRY_POINT_GROUP = "scitex_cards.hooks"
 
 
 # --- bus emit (degrade gracefully) ------------------------------------------
 
 
 def _load_hook_consumers() -> list[Callable[[dict], Any]]:
-    """Load every callable registered on the ``scitex_todo.hooks`` group.
+    """Load every callable registered on the ``scitex_cards.hooks`` group.
 
     Uses the stdlib selectable ``entry_points`` API. Fail-soft per entry:
     one un-loadable entry-point contributes nothing. Returns ``[]`` when
@@ -122,7 +122,7 @@ def emit_anomaly(event: dict, consumers: Iterable[Callable[[dict], Any]]) -> int
             delivered += 1
         except Exception as exc:  # stx-allow: fallback (a consumer failure must never crash the alarm loop)
             logger.warning(
-                "liveness_tick: scitex_todo.hooks consumer %r raised on emit "
+                "liveness_tick: scitex_cards.hooks consumer %r raised on emit "
                 "(%s); continuing — the alarm loop must stay up",
                 getattr(fn, "__name__", fn),
                 exc,
@@ -156,7 +156,7 @@ async def liveness_tick_reconciler_loop(
     Each tick: resolve ``tasks.yaml`` + owner liveness OFF the event loop
     (bind-safe), run the pure :func:`find_stuck_cards` rule, and emit one
     anomaly event per newly-stuck ``(agent, card_id)`` onto the
-    ``scitex_todo.hooks`` bus. DEDUP: at most one emit per ``(agent,
+    ``scitex_cards.hooks`` bus. DEDUP: at most one emit per ``(agent,
     card_id)`` per ``renotify_s`` cooldown (in-memory; the daemon is
     long-running), so a persistently-stuck card does NOT spam per tick.
 

--- a/src/scitex_agent_container/_listen/_liveness_tick_detect.py
+++ b/src/scitex_agent_container/_listen/_liveness_tick_detect.py
@@ -70,7 +70,7 @@ _SEVERITY_CRITICAL_MULT = 4.0
 class StuckCard:
     """A detected anomaly: an OPEN, unblocked, stale card whose owner is
     not progressing. :func:`find_stuck_cards` returns these; the loop
-    turns each into a ``scitex_todo.hooks`` bus event."""
+    turns each into a ``scitex_cards.hooks`` bus event."""
 
     agent: str
     card_id: str

--- a/src/scitex_agent_container/_listen/_notify.py
+++ b/src/scitex_agent_container/_listen/_notify.py
@@ -24,7 +24,7 @@ body is published into the named agent's inbox bus via the EXACT same
 subscribed (containerized) agent.
 
 The full event-driven rail (C10) is :mod:`._card_event_delivery`, which
-registers a ``scitex_todo.hooks`` consumer and calls the same
+registers a ``scitex_cards.hooks`` consumer and calls the same
 :func:`publish_to_agent` helper. This module owns the HTTP seam; that
 one owns the bus-consumer seam. Both deliver through ``publish_to_agent``
 so there is ONE router-publish code path.

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -375,7 +375,7 @@ def isolated_board(tmp_path: Path) -> Iterator[Path]:
       RECONCILES, so isolating only the YAML meant a five-card tmp doc
       deleted 2,772 real cards. See the inline note below.
 
-    * **the notification rail** — sac registers a ``scitex_todo.hooks``
+    * **the notification rail** — sac registers a ``scitex_cards.hooks``
       consumer (``_listen._card_event_delivery``), so every real
       ``reassign_task`` emits a ``reassigned`` event which that consumer
       turns into an HTTP POST to the LOCAL ``sac listen`` daemon on

--- a/tests/scitex_agent_container/_listen/test__card_event_delivery.py
+++ b/tests/scitex_agent_container/_listen/test__card_event_delivery.py
@@ -1,4 +1,4 @@
-"""Unit tests for the C10 ``scitex_todo.hooks`` consumer.
+"""Unit tests for the C10 ``scitex_cards.hooks`` consumer.
 
 Mirrors ``src/scitex_agent_container/_listen/_card_event_delivery.py``
 (PS-204 §2).

--- a/tests/scitex_agent_container/_listen/test__liveness_tick.py
+++ b/tests/scitex_agent_container/_listen/test__liveness_tick.py
@@ -109,13 +109,13 @@ class TestDefaults:
         # Assert
         assert observed == 3600.0
 
-    def test_entry_point_group_is_scitex_todo_hooks(self) -> None:
+    def test_entry_point_group_is_scitex_cards_hooks(self) -> None:
         # Arrange
         constant = HOOKS_ENTRY_POINT_GROUP
         # Act
         observed = constant
         # Assert
-        assert observed == "scitex_todo.hooks"
+        assert observed == "scitex_cards.hooks"
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

The retired `scitex_todo.hooks` entry-point group leaves sac entirely:

- `pyproject.toml`: the duplicate registration of `deliver_card_event` under `scitex_todo.hooks` is removed; the consumer stays registered under `scitex_cards.hooks`. The 38-line migration note becomes a short history paragraph.
- `_listen/_liveness_tick.py` and `_listen/_deploy_freshness.py`: `HOOKS_ENTRY_POINT_GROUP` moves from `"scitex_todo.hooks"` to `"scitex_cards.hooks"`. These are sac's OWN emitters (liveness-tick anomalies, deploy-freshness alarms) and they load their consumers with `entry_points(group=HOOKS_ENTRY_POINT_GROUP)`; sac's registration was the only one under the retired group, so removing the registration without moving the emitters would have had them dispatch to an empty set — the exact silent-success defect the old pyproject note documented.
- Docstrings and comments in `_card_event_delivery.py`, `_liveness_tick_detect.py`, `_notify.py`, `_listen_lifespan.py`, the tests and the fleet_root helper name the current group.

## Why now

scitex-cards said so, with evidence (DM 2026-09-05 21:09Z): their alias (0.46.0, 2026-08-17) reads both groups and dedupes on `(name, value)`, so sac's double registration has dispatched exactly once per event for three weeks; the "card-event hooks found in the retired entry-point group" warning on every write was that alias finding sac. They declared the retired group closed for scitex-cards; the alias itself retires after a fleet-wide entry-point sweep reads zero under `scitex_todo.hooks`, which this PR makes true for sac.

## Test plan

- `tests/scitex_agent_container/_listen/{test__liveness_tick,test__liveness_tick_detect,test__deploy_freshness,test__card_event_delivery,test__notify}.py` and `_lifecycle/test__listen_lifespan.py` against the worktree source (import path asserted).
- `test_entry_point_group_is_scitex_cards_hooks` pins the new constant.
- `git grep scitex_todo.hooks` on the branch: only the history paragraph in pyproject.toml.
- CI on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsMm3cJpEtocFt5mf1m9HL
