### PR TITLE
fix(identity): stop writing the retired board id and read the canonical one first

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py
@@ -237,12 +237,21 @@ def _stamp_owner(worktree_path: str) -> None:
     ``<checkout>/.git`` for a primary checkout) is OUTSIDE the working
     tree, so git never stages it.
 
-    Owner id = ``$SCITEX_TODO_AGENT_ID`` (the agent's board identity,
-    which equals its ``config.name``). Best-effort: a failure here must
-    NEVER break worktree creation, whose SDK contract is to echo the
-    path. An empty/unset agent id is left UNSTAMPED.
+    Owner id = ``$SCITEX_CARDS_AGENT_ID`` (the agent's board identity,
+    which equals its ``config.name``), falling back to the RETIRED
+    ``$SCITEX_TODO_AGENT_ID`` only for a container still launched from an
+    old-name spec. Canonical FIRST: reading the retired name alone left the
+    stamp unwritten in every container that carries only the current one.
+    Best-effort: a failure here must NEVER break worktree creation, whose
+    SDK contract is to echo the path. An empty/unset agent id is left
+    UNSTAMPED.
     """
-    owner = os.environ.get("SCITEX_TODO_AGENT_ID", "").strip()
+    owner = (
+        os.environ.get("SCITEX_CARDS_AGENT_ID", "").strip()
+        # Retired predecessor — kept ONLY so a container still launched from
+        # an old-name spec keeps stamping. Drop with the shim.
+        or os.environ.get("SCITEX_TODO_AGENT_ID", "").strip()
+    )
     if not owner:
         return
     try:

--- a/src/scitex_agent_container/_lifecycle/_twin.py
+++ b/src/scitex_agent_container/_lifecycle/_twin.py
@@ -24,12 +24,12 @@ Two halves live here:
   own env — a strict no-op for every non-twin start.
 
 IDENTITY SPLIT — safety-critical:
-  * author = the TWIN — ``SCITEX_TODO_AGENT_ID = <twin>`` in its env block,
-    so scitex-todo writes attribute to the twin (the operator's ask).
-  * owner = the PARENT — but scitex-todo has NO env knob for the default
+  * author = the TWIN — ``SCITEX_CARDS_AGENT_ID = <twin>`` in its env block,
+    so scitex-cards writes attribute to the twin (the operator's ask).
+  * owner = the PARENT — but scitex-cards has NO env knob for the default
     card owner (``add_task`` fails loud without an explicit ``assignee``;
-    ``SCITEX_TODO_AGENT_ID`` feeds ONLY the author path — verified against
-    scitex_todo._store). So owner=parent CANNOT be enforced from env; it is
+    ``SCITEX_CARDS_AGENT_ID`` feeds ONLY the author path — verified against
+    the card store). So owner=parent CANNOT be enforced from env; it is
     a HARD CONVENTION — the twin passes ``assignee=<parent>`` (==
     ``$SAC_TWIN_PARENT``, injected here) on EVERY card write. WHY: an
     ephemeral twin that owns cards then exits orphans them (the drift
@@ -49,8 +49,17 @@ logger = logging.getLogger(__name__)
 # AND is the value the twin passes as ``assignee=`` to keep card ownership
 # with the parent.
 TWIN_PARENT_ENV = "SAC_TWIN_PARENT"
-# scitex-todo author-identity var — set to the TWIN so writes attribute to it.
-TODO_AGENT_ENV = "SCITEX_TODO_AGENT_ID"
+# scitex-cards author-identity var — set to the TWIN so writes attribute to it.
+# CANONICAL name only: the retired ``SCITEX_TODO_AGENT_ID`` must never be
+# written into a spec sac generates (a spec that declares it is what keeps the
+# legacy alias alive).
+CARDS_AGENT_ENV = "SCITEX_CARDS_AGENT_ID"
+# Retired predecessor of :data:`CARDS_AGENT_ENV`. DROPPED from an inherited
+# twin env for the same reason ``SAC_NAME`` is: the parent's copy carries the
+# PARENT's name, so leaving it would hand any consumer still reading the old
+# name the wrong author — and would re-create a legacy-declaring spec on every
+# twin spawn, which is what keeps the alias alive.
+RETIRED_AGENT_ENV = "SCITEX_TODO_AGENT_ID"
 # sac self-name var — owned by ``listen_env_flags`` (injected from config.name),
 # so we must not let an inherited spec.env copy shadow it with the parent's.
 SELF_NAME_ENV = "SAC_NAME"
@@ -165,10 +174,11 @@ def derive_twin_spec(
         + copies that transcript at FIRST start (:func:`seed_twin_from_parent`),
         so it inherits the freshest context; on later restarts ``continue``
         resumes the twin's OWN diverged session (not a re-fork of the parent).
-      * ``spec.env`` — ``SCITEX_TODO_AGENT_ID = <twin>`` (author = twin),
+      * ``spec.env`` — ``SCITEX_CARDS_AGENT_ID = <twin>`` (author = twin),
         ``SAC_TWIN_PARENT = <parent>`` (owner-convention value + twin
         trigger); any inherited ``SAC_NAME`` is dropped (``listen_env_flags``
-        injects it from the twin's own name).
+        injects it from the twin's own name), as is any inherited
+        ``SCITEX_TODO_AGENT_ID`` (retired, and carrying the PARENT's name).
       * ``spec.restart.policy`` — ``always`` when ``persist`` else ``never``
         (ephemeral default: a stopped twin does not come back).
       * ``spec.a2a.port = "auto"`` — a fresh sidecar port, never the
@@ -214,9 +224,10 @@ def derive_twin_spec(
 
     env = spec.setdefault("env", {})
     if isinstance(env, dict):
-        env[TODO_AGENT_ENV] = twin_name
+        env[CARDS_AGENT_ENV] = twin_name
         env[TWIN_PARENT_ENV] = parent_name
         env.pop(SELF_NAME_ENV, None)
+        env.pop(RETIRED_AGENT_ENV, None)
 
     restart = spec.setdefault("restart", {})
     if isinstance(restart, dict):
@@ -229,7 +240,7 @@ def derive_twin_spec(
     # Reuse the PARENT's to_home tree (skills / hooks / .mcp.json) verbatim
     # via its absolute host path, so the twin has the SAME capabilities and
     # MCP wiring as the parent. Per-agent identity in those files is
-    # runtime-only (``${SCITEX_TODO_AGENT_ID}`` etc.) and expands from the
+    # runtime-only (``${SCITEX_CARDS_AGENT_ID}`` etc.) and expands from the
     # twin's OWN container env at boot, so sharing the tree is correct — the
     # author still resolves to the twin. Left unset (parent default) when the
     # caller could not resolve the parent's to_home dir.

--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -19,12 +19,17 @@ subcommands were removed in that restructure (``validate``,
 ``inspect``, ``check-priority``, ``take-snapshot``, ``attach``,
 ``logs``) are gone here too — except ``logs``, whose replacement
 ``tail`` is wired under the kept public name ``agent_logs``.
+
+``agent_twin`` lives in :mod:`._agent_twin` (it builds a spec and brokers a
+spawn rather than shelling a ``sac agents`` verb) and is re-exported here, so
+this module stays the single registration + ``__all__`` surface.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from ._agent_twin import agent_twin
 from ._helpers import invoke_cli_json, invoke_cli_text
 
 
@@ -214,58 +219,6 @@ def agent_spawn(
             "body": exc.body,
         }
     return {"status": "ok", "result": result}
-
-
-def agent_twin(
-    parent: str,
-    name: str | None = None,
-    task: str | None = None,
-    persist: bool = False,
-    role: str | None = None,
-    caller: str | None = None,
-) -> dict[str, Any]:
-    """Spawn a context-inheriting TWIN of a running agent (e.g. your own).
-
-    A TWIN forks PARENT's live session — inherits its transcript at birth
-    then diverges; PARENT is never touched. Same host-broker path as
-    ``agent_spawn``; repo/workdir/image/binds/model inherited verbatim; own
-    name + fresh a2a port + ``session: continue``; host seeds the twin's
-    session from the parent's transcript at first boot. (Use one to inherit context
-    without sharing future context, split parallel work, or run heavy work
-    off your main loop; a plain Task subagent is cheaper otherwise.)
-
-    IDENTITY CONTRACT (safety-critical; the twin's boot-kick repeats it):
-    AUTHOR = twin (``SCITEX_TODO_AGENT_ID`` = twin — its scitex-todo writes
-    attribute to it). OWNER = parent, but scitex-todo cannot default the card
-    owner from env, so the twin MUST pass ``assignee=<parent>`` (==
-    ``$SAC_TWIN_PARENT``) on every card write — a hard rule, not an env
-    guarantee; an ephemeral twin that owns cards then exits orphans them.
-
-    ``name`` defaults to ``<parent>-twin`` (bumped if taken); ``persist``
-    makes it long-lived (default ephemeral); ``task``/``role``/``caller``
-    optional. Returns ``{"status":"ok","twin":..,"result":{..}}`` else
-    ``{"status":"error","reason":..}``.
-    """
-    from ..._lifecycle._spawn_client import SpawnRequestError, request_spawn
-    from ..._lifecycle._twin import TwinSeedError, prepare_twin_spawn
-
-    try:
-        twin_name, doc = prepare_twin_spawn(
-            parent, twin_name=name, task=task, persist=persist, role=role
-        )
-    except TwinSeedError as exc:
-        return {"status": "error", "reason": str(exc)}
-
-    try:
-        result = request_spawn(twin_name, spec=doc, caller=caller, assume_yes=True)
-    except SpawnRequestError as exc:
-        return {
-            "status": "error",
-            "reason": str(exc),
-            "http_status": exc.status,
-            "body": exc.body,
-        }
-    return {"status": "ok", "twin": twin_name, "parent": parent, "result": result}
 
 
 def agent_stop(name: str) -> dict[str, Any]:

--- a/src/scitex_agent_container/_mcp/_tools/_agent_twin.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent_twin.py
@@ -1,0 +1,71 @@
+"""``agent_twin`` — the context-inheriting fork tool (Python API + MCP).
+
+Extracted from :mod:`._agent`, which holds the thin ``invoke_cli_*``
+wrappers over ``sac agents <verb>``. ``agent_twin`` is the one tool in that
+group that does real work of its own: it BUILDS a twin spec through
+:func:`scitex_agent_container._lifecycle._twin.prepare_twin_spawn` and
+brokers it to the host listen daemon through
+:func:`scitex_agent_container._lifecycle._spawn_client.request_spawn`.
+
+``_agent`` re-exports the name, so ``_mcp._tools._agent.agent_twin`` and the
+``register_agent_tools`` registration loop keep working unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def agent_twin(
+    parent: str,
+    name: str | None = None,
+    task: str | None = None,
+    persist: bool = False,
+    role: str | None = None,
+    caller: str | None = None,
+) -> dict[str, Any]:
+    """Spawn a context-inheriting TWIN of a running agent (e.g. your own).
+
+    A TWIN forks PARENT's live session — inherits its transcript at birth
+    then diverges; PARENT is never touched. Same host-broker path as
+    ``agent_spawn``; repo/workdir/image/binds/model inherited verbatim; own
+    name + fresh a2a port + ``session: continue``; host seeds the twin's
+    session from the parent's transcript at first boot. (Use one to inherit context
+    without sharing future context, split parallel work, or run heavy work
+    off your main loop; a plain Task subagent is cheaper otherwise.)
+
+    IDENTITY CONTRACT (safety-critical; the twin's boot-kick repeats it):
+    AUTHOR = twin (``SCITEX_CARDS_AGENT_ID`` = twin — its scitex-cards writes
+    attribute to it). OWNER = parent, but scitex-cards cannot default the card
+    owner from env, so the twin MUST pass ``assignee=<parent>`` (==
+    ``$SAC_TWIN_PARENT``) on every card write — a hard rule, not an env
+    guarantee; an ephemeral twin that owns cards then exits orphans them.
+
+    ``name`` defaults to ``<parent>-twin`` (bumped if taken); ``persist``
+    makes it long-lived (default ephemeral); ``task``/``role``/``caller``
+    optional. Returns ``{"status":"ok","twin":..,"result":{..}}`` else
+    ``{"status":"error","reason":..}``.
+    """
+    from ..._lifecycle._spawn_client import SpawnRequestError, request_spawn
+    from ..._lifecycle._twin import TwinSeedError, prepare_twin_spawn
+
+    try:
+        twin_name, doc = prepare_twin_spawn(
+            parent, twin_name=name, task=task, persist=persist, role=role
+        )
+    except TwinSeedError as exc:
+        return {"status": "error", "reason": str(exc)}
+
+    try:
+        result = request_spawn(twin_name, spec=doc, caller=caller, assume_yes=True)
+    except SpawnRequestError as exc:
+        return {
+            "status": "error",
+            "reason": str(exc),
+            "http_status": exc.status,
+            "body": exc.body,
+        }
+    return {"status": "ok", "twin": twin_name, "parent": parent, "result": result}
+
+
+__all__ = ["agent_twin"]

--- a/src/scitex_agent_container/cli_pkg/_create_templates.py
+++ b/src/scitex_agent_container/cli_pkg/_create_templates.py
@@ -176,7 +176,7 @@ _FULL_TEMPLATE = """\
 #   * relaxed + directory overlay persistent per-agent $HOME / installs
 #   * full host reach at the canonical path (so ~/proj/... paths match)
 #   * fleet push channels         server:sac + server:scitex-todo + telegrammer
-#   * SCITEX_TODO_AGENT_ID        todo-store writes attribute to THIS agent
+#   * SCITEX_CARDS_AGENT_ID       card-store writes attribute to THIS agent
 #   * editable install of the agent's own repo (live dev loop)
 #   * a generic "Start or continue." kick + metadata.labels + opus model
 # EVERY field is written explicitly (red-start ruling 2026-07-21); the
@@ -249,12 +249,14 @@ spec:
     binds:
       - {home}:{home}:rw
 
-    # Per-agent env. SCITEX_TODO_AGENT_ID makes scitex-todo writes
-    # attribute to THIS agent. (sac AUTO-injects
-    # SCITEX_AGENT_CONTAINER_STATE_DB + binds the per-agent state dir, so
-    # the state DB needs no manual entry here.)
+    # Per-agent env. SCITEX_CARDS_AGENT_ID makes scitex-cards writes
+    # attribute to THIS agent; it is the CANONICAL board-identity name (its
+    # predecessor SCITEX_TODO_AGENT_ID is retired and must not be emitted
+    # into a new spec). (sac AUTO-injects SCITEX_AGENT_CONTAINER_STATE_DB +
+    # binds the per-agent state dir, so the state DB needs no manual entry
+    # here.)
     env:
-      SCITEX_TODO_AGENT_ID: {name}
+      SCITEX_CARDS_AGENT_ID: {name}
 
     # Relaxed mode skips sac's curated isolation prepend, so re-declare the
     # user namespace, filesystem isolation, and the canonical container HOME

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_row.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_row.py
@@ -28,6 +28,18 @@ _MOVEMENT_DEFAULTS: dict = {
     "heartbeat_at": "",
 }
 
+# Board identity, CANONICAL FIRST; the retired predecessor is a fallback only.
+_BOARD_ID_ENVS = ("SCITEX_CARDS_AGENT_ID", "SCITEX_TODO_AGENT_ID")
+
+
+def _board_identity() -> str:
+    """This process's board identity, or ``""`` when neither var is set."""
+    for var in _BOARD_ID_ENVS:
+        value = os.environ.get(var, "")
+        if value:
+            return value
+    return ""
+
 
 def _movement_fields(name: str) -> dict:
     """Return the three movement keys for ``name`` (always all-present).
@@ -131,10 +143,16 @@ def build_agent_row(
     # into something the OUTPUT ITSELF reveals, which is the only version of
     # that rule that survives being forgotten.
     #
-    # Identity comes from SCITEX_TODO_AGENT_ID, the same variable every agent
+    # Identity comes from SCITEX_CARDS_AGENT_ID, the same variable every agent
     # already stamps its card writes with — deliberately NOT the hostname or
     # the spec, because those answer a different question. When it is unset
     # (a human at a shell), no row is marked and nothing changes.
-    if name and name == os.environ.get("SCITEX_TODO_AGENT_ID", ""):
+    #
+    # CANONICAL FIRST. This read used to name only the RETIRED
+    # SCITEX_TODO_AGENT_ID, so the self row was never marked in a container
+    # launched from a current spec — the exact case the marker exists for.
+    # The retired name stays as a fallback for containers still running an
+    # old-name spec, and goes away with the legacy shim.
+    if name and name == _board_identity():
         row["is_self"] = True
     return row

--- a/src/scitex_agent_container/cli_pkg/_whoami.py
+++ b/src/scitex_agent_container/cli_pkg/_whoami.py
@@ -15,7 +15,9 @@ Environment facts surveyed (injection sites, for the record):
 * ``SAC_NAME`` — agent self-name (``runtimes/_apptainer_listen_env.py``);
   ``SCITEX_AGENT_CONTAINER_AGENT`` / ``CLAUDE_AGENT_ID`` — the same name
   via the spec auto-env (``config/_loaders.py``).
-* ``SCITEX_TODO_AGENT_ID`` — board identity (authored in ``spec.env``).
+* ``SCITEX_CARDS_AGENT_ID`` — board identity (authored in ``spec.env``);
+  its retired predecessor ``SCITEX_TODO_AGENT_ID`` is read only as a
+  fallback, for a container still launched from an old-name spec.
 * ``SCITEX_AGENT_CONTAINER_MODEL`` — display model (spec auto-env).
 * ``SAC_LISTEN_BASE_URL`` / ``SAC_LISTEN_BEARER`` — host control-plane
   URL + bearer (``_apptainer_listen_env.py``). The bearer's VALUE is
@@ -218,6 +220,22 @@ def _role_from_spec(raw: dict) -> dict:
 # collection
 # ---------------------------------------------------------------------------
 
+# Board identity, CANONICAL FIRST. ``SCITEX_TODO_AGENT_ID`` is the retired
+# predecessor: reading only it printed ``board-id: None`` in every container
+# launched from a current spec (measured 2026-09-06: 22 of 26 agent
+# processes). It stays as a fallback so a container still running an
+# old-name spec keeps answering, and goes away with the legacy shim.
+_BOARD_ID_ENVS = ("SCITEX_CARDS_AGENT_ID", "SCITEX_TODO_AGENT_ID")
+
+
+def _board_identity() -> tuple[str | None, str]:
+    """Return ``(board id or None, the env var it was read from)``."""
+    for var in _BOARD_ID_ENVS:
+        value = os.environ.get(var)
+        if value:
+            return value, var
+    return None, _BOARD_ID_ENVS[0]
+
 
 def collect_whoami() -> dict:
     """Gather every fact into the ``--json`` shape (None = unknown)."""
@@ -238,7 +256,7 @@ def collect_whoami() -> dict:
     a2a_raw = spec.get("a2a") if isinstance(spec.get("a2a"), dict) else {}
     a2a_port = a2a_raw.get("port", "auto") if raw is not None else None
 
-    board_id = os.environ.get("SCITEX_TODO_AGENT_ID") or None
+    board_id, board_id_env = _board_identity()
     listen_url = _env_pair("LISTEN_BASE_URL")
 
     role = _role_from_spec(raw) if raw else {}
@@ -253,6 +271,7 @@ def collect_whoami() -> dict:
         "identity": {
             "agent": name,
             "board_id": board_id,
+            "board_id_env": board_id_env,
             "hostname": socket.gethostname(),
             "canonical_host": canonical,
         },
@@ -314,7 +333,7 @@ def render_whoami_text(facts: dict) -> str:
 
     lines: list[str] = ["IDENTITY"]
     lines.append(_kv("agent:", identity["agent"], "SAC_NAME"))
-    lines.append(_kv("board-id:", identity["board_id"], "SCITEX_TODO_AGENT_ID"))
+    lines.append(_kv("board-id:", identity["board_id"], identity["board_id_env"]))
     lines.append(_kv("hostname:", identity["hostname"]))
     lines.append(_kv("host:", identity["canonical_host"], "canonical"))
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_twin.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_twin.py
@@ -170,7 +170,7 @@ def twin(
     session) and then diverges. PARENT is never touched. Repo / workdir /
     image / binds / model are inherited verbatim; the twin gets its own
     name, a fresh a2a port, ``session: continue`` (seeded from the parent at
-    first boot), and the identity-split env (``SCITEX_TODO_AGENT_ID`` = twin,
+    first boot), and the identity-split env (``SCITEX_CARDS_AGENT_ID`` = twin,
     ``SAC_TWIN_PARENT`` = parent).
 
     \b

--- a/src/scitex_agent_container/runtimes/_envrc.py
+++ b/src/scitex_agent_container/runtimes/_envrc.py
@@ -206,11 +206,11 @@ def _folded_env(loaded: dict[str, str], baseline: dict[str, str]) -> dict[str, s
       so a stale ``SCITEX_TODO_AGENT`` that once landed in ``dest/.env`` cannot
       SELF-PERPETUATE: the fold sources ``dest/.env`` as its base, so any such
       orphan var (set by no cascade ``.envrc``) re-enters the diff and is
-      re-baked every deploy — and scitex-todo's MCP now HARD-REJECTS any call
+      re-baked every deploy — and the card MCP now HARD-REJECTS any call
       when ``SCITEX_TODO_AGENT`` is present (INCIDENT 2026-07-05/06 write-
       outage). The current ``_ID`` identity vars are deliberately NOT dropped:
       the ``.env`` is the container ``--env-file`` and the materialized
-      ``.mcp.json`` expands ``${SCITEX_TODO_AGENT_ID}`` from it.
+      ``.mcp.json`` expands ``${SCITEX_CARDS_AGENT_ID}`` from it.
     """
     return {
         key: val

--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -62,20 +62,22 @@ START_MARKER_PREFIX = "<!-- Start of scitex-agent-container generated section"
 # ``${RUNTIME:VAR}`` for their identity vars — that migration + removal is a
 # separate follow-up PR.
 # Legacy pre-0.7.30 identity ALIASES — deprecated names that a downstream
-# consumer now HARD-REJECTS if present. scitex-todo's MCP server refuses any
-# call when ``SCITEX_TODO_AGENT`` is set ("was renamed to
-# ``SCITEX_TODO_AGENT_ID``; unset the old var"), so a stale copy of one of
-# these baked into a materialized/folded ``.env`` is not merely redundant like
-# the current ``_ID`` names — it is FATAL to the consumer (live write-outage,
-# INCIDENT 2026-07-05/06). Kept as its OWN named subset (unioned into
-# :data:`_RUNTIME_ONLY_VARS` below, so the name list is defined ONCE) precisely
-# so the ``.env``-fold guard in :mod:`_envrc` can drop ONLY these legacy
-# aliases while the CURRENT identity vars (``SCITEX_TODO_AGENT_ID`` / ``CCT_*``
-# / ``SAC_NAME``) legitimately REMAIN in the ``--env-file`` the container needs
-# at runtime (the materialized ``.mcp.json`` expands ``${SCITEX_TODO_AGENT_ID}``
-# from that container env). Dropping the current vars from the fold too would
-# strip the agent's live identity — a second outage — so the fold must NOT use
-# the broad :func:`_is_runtime_only_var`.
+# consumer now HARD-REJECTS if present. The card MCP server refuses any call
+# when ``SCITEX_TODO_AGENT`` is set (its message, verbatim at the time: "was
+# renamed to ``SCITEX_TODO_AGENT_ID``; unset the old var" — that successor has
+# since itself been retired in favour of ``SCITEX_CARDS_AGENT_ID``), so a
+# stale copy of one of these baked into a materialized/folded ``.env`` is not
+# merely redundant like the current ``_ID`` names — it is FATAL to the
+# consumer (live write-outage, INCIDENT 2026-07-05/06). Kept as its OWN named
+# subset (unioned into :data:`_RUNTIME_ONLY_VARS` below, so the name list is
+# defined ONCE) precisely so the ``.env``-fold guard in :mod:`_envrc` can drop
+# ONLY these legacy aliases while the CURRENT identity vars
+# (``SCITEX_CARDS_AGENT_ID`` / ``CCT_*`` / ``SAC_NAME``) legitimately REMAIN in
+# the ``--env-file`` the container needs at runtime (the materialized
+# ``.mcp.json`` expands ``${SCITEX_CARDS_AGENT_ID}`` from that container env).
+# Dropping the current vars from the fold too would strip the agent's live
+# identity — a second outage — so the fold must NOT use the broad
+# :func:`_is_runtime_only_var`.
 _LEGACY_IDENTITY_VARS = frozenset(
     {
         "SCITEX_TODO_AGENT",
@@ -176,8 +178,16 @@ _RUNTIME_ONLY_VARS = (
             # incident this whole mechanism exists to prevent, re-entered
             # through the migration meant to close it.
             "SCITEX_CARDS_AGENT_ID",
-            # scitex-todo >= 0.7.30 names
+            # RETIRED board identity — kept here ON PURPOSE. sac no longer
+            # WRITES it (specs, twins and `agents create` emit the canonical
+            # name only), but the host baseline ``.mcp.json`` copies still
+            # reference ``${SCITEX_TODO_AGENT_ID}``; dropping the entry before
+            # that baseline is DELIVERED would let deploy-time interpolation
+            # bake the deploying process's identity into every materialized
+            # file — the 2026-07-02 incident described just above. Remove it
+            # with the legacy shim, not before.
             "SCITEX_TODO_AGENT_ID",
+            # scitex-todo >= 0.7.30 name
             "SCITEX_TODO_TASKS_YAML_SHARED",
             "SAC_NAME",
             "CLAUDE_AGENT_ID",

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/conftest.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/conftest.py
@@ -57,7 +57,7 @@ def _run_hook(
     returncode / stdout / stderr without retrying or coupling.
 
     ``env`` (when given) fully REPLACES the subprocess environment —
-    the owner-stamp tests use it to pin ``SCITEX_TODO_AGENT_ID`` (or to
+    the owner-stamp tests use it to pin ``SCITEX_CARDS_AGENT_ID`` (or to
     prove its absence) deterministically, independent of the runner's
     ambient value. When ``None`` the child inherits the parent env.
     """

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_create.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_create.py
@@ -25,6 +25,16 @@ from .conftest import (
     _run_hook,
 )
 
+# Both board-identity variables the hook reads. The runner's own container
+# exports the canonical one, so an owner-stamp test that only strips the
+# retired name would inherit a live identity and stamp when it must not.
+_AGENT_ID_ENVS = ("SCITEX_CARDS_AGENT_ID", "SCITEX_TODO_AGENT_ID")
+
+
+def _env_without_agent_ids() -> dict:
+    """A copy of the ambient env with EVERY board-identity var removed."""
+    return {k: v for k, v in os.environ.items() if k not in _AGENT_ID_ENVS}
+
 # ---------------------------------------------------------------------------
 # Relocation invariant — target lands under .worktrees/, NOT .claude/worktrees
 # ---------------------------------------------------------------------------
@@ -260,10 +270,10 @@ class TestWorktreeCreateBaseResolution:
 
 class TestWorktreeCreateOwnerStamp:
     def test_owner_stamp_written_to_private_gitdir(self, ephemeral_repo: Path) -> None:
-        # Arrange — SCITEX_TODO_AGENT_ID identifies the owning agent; the
+        # Arrange — SCITEX_CARDS_AGENT_ID identifies the owning agent; the
         # hook must stamp it into the worktree's PRIVATE gitdir.
         payload = _create_payload("stamp-probe", ephemeral_repo)
-        env = {**os.environ, "SCITEX_TODO_AGENT_ID": "stampy-agent"}
+        env = {**_env_without_agent_ids(), "SCITEX_CARDS_AGENT_ID": "stampy-agent"}
         # Act
         result = _run_hook(CREATE_SCRIPT, payload, env=env)
         target = Path(result.stdout.strip())
@@ -277,18 +287,49 @@ class TestWorktreeCreateOwnerStamp:
         # Arrange — the marker MUST live outside the working tree so the
         # rescue's ``git add -A`` can never stage it.
         payload = _create_payload("stamp-outside-probe", ephemeral_repo)
-        env = {**os.environ, "SCITEX_TODO_AGENT_ID": "stampy-agent"}
+        env = {**_env_without_agent_ids(), "SCITEX_CARDS_AGENT_ID": "stampy-agent"}
         # Act
         result = _run_hook(CREATE_SCRIPT, payload, env=env)
         target = Path(result.stdout.strip())
         # Assert — no sac-owner file in the worktree's working directory.
         assert not (target / "sac-owner").exists()
 
+    def test_owner_stamp_falls_back_to_the_retired_agent_id(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange — a container still launched from an old-name spec carries
+        # ONLY the retired variable; it must keep stamping.
+        payload = _create_payload("stamp-legacy-probe", ephemeral_repo)
+        env = {**_env_without_agent_ids(), "SCITEX_TODO_AGENT_ID": "legacy-agent"}
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload, env=env)
+        target = Path(result.stdout.strip())
+        git_dir = _git(target, "rev-parse", "--absolute-git-dir")
+        # Assert
+        assert (Path(git_dir) / "sac-owner").read_text().strip() == "legacy-agent"
+
+    def test_owner_stamp_prefers_the_canonical_agent_id(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange — both set (a spec mid-migration): the CANONICAL name wins.
+        payload = _create_payload("stamp-both-probe", ephemeral_repo)
+        env = {
+            **_env_without_agent_ids(),
+            "SCITEX_CARDS_AGENT_ID": "canonical-agent",
+            "SCITEX_TODO_AGENT_ID": "legacy-agent",
+        }
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload, env=env)
+        target = Path(result.stdout.strip())
+        git_dir = _git(target, "rev-parse", "--absolute-git-dir")
+        # Assert
+        assert (Path(git_dir) / "sac-owner").read_text().strip() == "canonical-agent"
+
     def test_no_owner_stamp_when_agent_id_unset(self, ephemeral_repo: Path) -> None:
         # Arrange — an unset agent id leaves the worktree UNSTAMPED (the
         # rescue then default-denies it) rather than stamping an empty id.
         payload = _create_payload("no-stamp-probe", ephemeral_repo)
-        env = {k: v for k, v in os.environ.items() if k != "SCITEX_TODO_AGENT_ID"}
+        env = _env_without_agent_ids()
         # Act
         result = _run_hook(CREATE_SCRIPT, payload, env=env)
         target = Path(result.stdout.strip())

--- a/tests/scitex_agent_container/_lifecycle/test__twin.py
+++ b/tests/scitex_agent_container/_lifecycle/test__twin.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container._lifecycle._twin import (
+    CARDS_AGENT_ENV,
+    RETIRED_AGENT_ENV,
     TWIN_PARENT_ENV,
     TwinSeedError,
     build_twin_boot_kick,
@@ -56,7 +58,7 @@ def _parent_doc() -> dict:
                 "channels": ["server:sac", "server:claude-code-telegrammer"],
             },
             "env": {
-                "SCITEX_TODO_AGENT_ID": "parent",
+                "SCITEX_CARDS_AGENT_ID": "parent",
                 "SAC_NAME": "parent",
                 "FOO": "bar",
             },
@@ -99,13 +101,33 @@ def test_resolve_twin_name_honours_explicit_request():
 # ─── derive_twin_spec: identity split (safety-critical) ───────────────────
 
 
-def test_derive_sets_todo_author_to_twin():
+def test_derive_sets_cards_author_to_twin():
     # Arrange
     doc = _parent_doc()
     # Act
     out = derive_twin_spec(doc, twin_name="parent-twin", parent_name="parent", persist=False)
+    # Assert — the CANONICAL board-identity key, never the retired one.
+    assert out["spec"]["env"][CARDS_AGENT_ENV] == "parent-twin"
+
+
+def test_derive_never_writes_the_retired_author_key():
+    # Arrange
+    doc = _parent_doc()
+    # Act
+    out = derive_twin_spec(doc, twin_name="parent-twin", parent_name="parent", persist=False)
+    # Assert — a generated spec must not re-declare the retired name.
+    assert RETIRED_AGENT_ENV not in out["spec"]["env"]
+
+
+def test_derive_drops_an_inherited_retired_author_key():
+    # Arrange — a parent still launched from an old-name spec. Left in place
+    # the key would carry the PARENT's name into the twin.
+    doc = _parent_doc()
+    doc["spec"]["env"][RETIRED_AGENT_ENV] = "parent"
+    # Act
+    out = derive_twin_spec(doc, twin_name="parent-twin", parent_name="parent", persist=False)
     # Assert
-    assert out["spec"]["env"]["SCITEX_TODO_AGENT_ID"] == "parent-twin"
+    assert RETIRED_AGENT_ENV not in out["spec"]["env"]
 
 
 def test_derive_sets_twin_parent_env_to_parent():
@@ -246,7 +268,7 @@ def test_derive_does_not_mutate_parent_doc():
     # Act
     derive_twin_spec(doc, twin_name="parent-twin", parent_name="parent", persist=False)
     # Assert
-    assert doc["spec"]["env"]["SCITEX_TODO_AGENT_ID"] == "parent"
+    assert doc["spec"]["env"][CARDS_AGENT_ENV] == "parent"
 
 
 # ─── build_twin_boot_kick ─────────────────────────────────────────────────

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_row_is_self.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_row_is_self.py
@@ -22,13 +22,18 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterator
+from contextlib import contextmanager
 
 import pytest
 
 from scitex_agent_container.cli_pkg._helpers._agent_list_row import build_agent_row
 
-_VAR = "SCITEX_TODO_AGENT_ID"
+# The CANONICAL board identity, read first, and its RETIRED predecessor, read
+# only as a fallback for a container still launched from an old-name spec.
+_VAR = "SCITEX_CARDS_AGENT_ID"
+_RETIRED_VAR = "SCITEX_TODO_AGENT_ID"
 _ME = "scitex-agent-container"
+_SOMEONE_ELSE = "handyman-01"
 
 _ROW_KWARGS = dict(
     status_val="running",
@@ -47,30 +52,56 @@ _ROW_KWARGS = dict(
 )
 
 
-@pytest.fixture
-def identified_as_me() -> Iterator[None]:
-    """Set the real agent-identity variable, restore whatever was there."""
-    previous = os.environ.get(_VAR)
-    os.environ[_VAR] = _ME
+@contextmanager
+def _identity_env(**values: str | None) -> Iterator[None]:
+    """Pin BOTH identity vars for real, restore whatever was there.
+
+    Every var not named in ``values`` is REMOVED, so a test never inherits
+    the runner's own live identity through the variable it is not pinning.
+    """
+    previous = {var: os.environ.get(var) for var in (_VAR, _RETIRED_VAR)}
+    for var in previous:
+        value = values.get(var)
+        if value is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = value
     try:
         yield
     finally:
-        if previous is None:
-            os.environ.pop(_VAR, None)
-        else:
-            os.environ[_VAR] = previous
+        for var, value in previous.items():
+            if value is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = value
+
+
+@pytest.fixture
+def identified_as_me() -> Iterator[None]:
+    """Canonical variable only — how a current spec identifies its agent."""
+    with _identity_env(**{_VAR: _ME}):
+        yield
+
+
+@pytest.fixture
+def identified_by_the_retired_var() -> Iterator[None]:
+    """Retired variable only — a container still on an old-name spec."""
+    with _identity_env(**{_RETIRED_VAR: _ME}):
+        yield
+
+
+@pytest.fixture
+def identified_by_both() -> Iterator[None]:
+    """Both set, DISAGREEING — a spec caught mid-migration."""
+    with _identity_env(**{_VAR: _ME, _RETIRED_VAR: _SOMEONE_ELSE}):
+        yield
 
 
 @pytest.fixture
 def identified_as_nobody() -> Iterator[None]:
     """Remove the identity entirely — a human at a shell, not an agent."""
-    previous = os.environ.get(_VAR)
-    os.environ.pop(_VAR, None)
-    try:
+    with _identity_env():
         yield
-    finally:
-        if previous is not None:
-            os.environ[_VAR] = previous
 
 
 def test_marks_the_caller(identified_as_me: None) -> None:
@@ -82,10 +113,42 @@ def test_marks_the_caller(identified_as_me: None) -> None:
     assert row["is_self"] is True
 
 
+def test_marks_the_caller_from_the_retired_var(
+    identified_by_the_retired_var: None,
+) -> None:
+    # Arrange — a container still launched from an old-name spec carries only
+    # the retired variable; the control must not vanish for it.
+    name = _ME
+    # Act
+    row = build_agent_row(name=name, **_ROW_KWARGS)
+    # Assert
+    assert row["is_self"] is True
+
+
+def test_canonical_var_wins_over_the_retired_one(identified_by_both: None) -> None:
+    # Arrange — both set and disagreeing: the CANONICAL name is the identity,
+    # so the row it names is the caller's.
+    name = _ME
+    # Act
+    row = build_agent_row(name=name, **_ROW_KWARGS)
+    # Assert
+    assert row["is_self"] is True
+
+
+def test_retired_var_does_not_mark_a_peer_row(identified_by_both: None) -> None:
+    # Arrange — the stale value must not mark a SECOND row as the caller; two
+    # self rows would destroy the control the marker exists to provide.
+    name = _SOMEONE_ELSE
+    # Act
+    row = build_agent_row(name=name, **_ROW_KWARGS)
+    # Assert
+    assert "is_self" not in row
+
+
 def test_omits_for_peers(identified_as_me: None) -> None:
     # Arrange — a peer's row must NOT claim to be the caller, or the control is
     # worse than useless: it would validate the listing against the wrong agent.
-    name = "handyman-01"
+    name = _SOMEONE_ELSE
     # Act
     row = build_agent_row(name=name, **_ROW_KWARGS)
     # Assert

--- a/tests/scitex_agent_container/cli_pkg/test__create.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create.py
@@ -67,7 +67,7 @@ def test_create_full_template_passes_v3_validator(tmp_path: Path) -> None:
 # sac-agents-new-template-stale; operator 2026-06-25 "very general, just
 # developer like existing ones"). It must render a READY dev agent, not the
 # stale generic skeleton (runtime apptainer, model sonnet, binds [],
-# placeholder prompt, NO overlay / SCITEX_TODO_AGENT_ID / channels /
+# placeholder prompt, NO overlay / SCITEX_CARDS_AGENT_ID / channels /
 # editable-install / dev labels). These tests pin every load-bearing field
 # the card flagged as missing — they FAIL against the old template.
 # ---------------------------------------------------------------------------
@@ -108,13 +108,24 @@ def test_full_template_declares_directory_overlay(tmp_path: Path) -> None:
     assert overlay.endswith("/overlays/proj-x/")
 
 
-def test_full_template_wires_scitex_todo_agent_id(tmp_path: Path) -> None:
+def test_full_template_wires_scitex_cards_agent_id(tmp_path: Path) -> None:
     # Arrange
     doc = _render_full(tmp_path)
     # Act
     env = doc["spec"]["apptainer"]["env"]
-    # Assert — todo-store writes attribute to THIS agent (MISSING before).
-    assert env["SCITEX_TODO_AGENT_ID"] == "proj-x"
+    # Assert — card-store writes attribute to THIS agent, under the CANONICAL
+    # board-identity key.
+    assert env["SCITEX_CARDS_AGENT_ID"] == "proj-x"
+
+
+def test_full_template_never_emits_the_retired_agent_id(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    env = doc["spec"]["apptainer"]["env"]
+    # Assert — a spec that declares the retired name is what keeps the legacy
+    # alias alive; `sac agents create` must not generate one.
+    assert "SCITEX_TODO_AGENT_ID" not in env
 
 
 def test_full_template_lists_the_three_fleet_channels(tmp_path: Path) -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__whoami.py
+++ b/tests/scitex_agent_container/cli_pkg/test__whoami.py
@@ -66,6 +66,10 @@ def _blank_env(tmp_path: Path, **overrides) -> dict:
         "CLAUDE_AGENT_ROLE": None,
         "SAC_ROLE": None,
         "SCITEX_AGENT_CONTAINER_ROLE": None,
+        # BOTH board-identity vars: whoami reads the canonical one first and
+        # the retired one as a fallback, so leaving either set would leak the
+        # runner's own live identity into a "hermetic" case.
+        "SCITEX_CARDS_AGENT_ID": None,
         "SCITEX_TODO_AGENT_ID": None,
         "SAC_MODEL": None,
         "SCITEX_AGENT_CONTAINER_MODEL": None,
@@ -195,11 +199,51 @@ def test_whoami_reports_agent_name_from_env(tmp_path):
 
 def test_whoami_reports_board_id_from_env(tmp_path):
     # Arrange
-    env = _blank_env(tmp_path, SCITEX_TODO_AGENT_ID="board-id-77")
+    env = _blank_env(tmp_path, SCITEX_CARDS_AGENT_ID="board-id-77")
     # Act
     result = _invoke(env)
     # Assert
     assert "board-id-77" in _line(result.output, "board-id:")
+
+
+def test_whoami_names_the_canonical_board_id_var(tmp_path):
+    # Arrange
+    env = _blank_env(tmp_path, SCITEX_CARDS_AGENT_ID="board-id-77")
+    # Act
+    result = _invoke(env)
+    # Assert — the hint names the var the value actually came from.
+    assert "SCITEX_CARDS_AGENT_ID" in _line(result.output, "board-id:")
+
+
+def test_whoami_falls_back_to_the_retired_board_id_var(tmp_path):
+    # Arrange — a container still launched from an old-name spec.
+    env = _blank_env(tmp_path, SCITEX_TODO_AGENT_ID="board-id-legacy")
+    # Act
+    result = _invoke(env)
+    # Assert
+    assert "board-id-legacy" in _line(result.output, "board-id:")
+
+
+def test_whoami_prefers_the_canonical_board_id_var(tmp_path):
+    # Arrange — both set and disagreeing (a spec mid-migration).
+    env = _blank_env(
+        tmp_path,
+        SCITEX_CARDS_AGENT_ID="board-id-canonical",
+        SCITEX_TODO_AGENT_ID="board-id-legacy",
+    )
+    # Act
+    result = _invoke(env)
+    # Assert
+    assert "board-id-canonical" in _line(result.output, "board-id:")
+
+
+def test_whoami_reports_no_board_id_when_neither_var_is_set(tmp_path):
+    # Arrange — a human at a shell; an honest placeholder, never a guess.
+    env = _blank_env(tmp_path)
+    # Act
+    facts = json.loads(_invoke(env, "--json").output)
+    # Assert
+    assert facts["identity"]["board_id"] is None
 
 
 def test_whoami_reports_listen_url_from_env(tmp_path):
@@ -445,7 +489,7 @@ def test_whoami_howto_points_at_bundled_skills(tmp_path):
 
 def test_whoami_howto_scope_uses_board_id(tmp_path):
     # Arrange
-    env = _blank_env(tmp_path, SCITEX_TODO_AGENT_ID="board-id-42")
+    env = _blank_env(tmp_path, SCITEX_CARDS_AGENT_ID="board-id-42")
     # Act
     result = _invoke(env)
     # Assert


### PR DESCRIPTION
## What

The SAC half of the `SCITEX_TODO_AGENT_ID` retirement — steps 2a (stop WRITING
the retired board identity) and 2b (READ the canonical name first). Step 2c (the
`_board_identity_env.py` shim retirement) is deliberately NOT in this PR: its
preconditions are not met yet.

**Writers — now emit `SCITEX_CARDS_AGENT_ID` only**

- `src/scitex_agent_container/cli_pkg/_create_templates.py:257` rendered
  `SCITEX_TODO_AGENT_ID: {name}` into the `full` template's
  `spec.apptainer.env`, so every `sac agents create` produced a spec declaring
  the retired name (the 8 `handyman-c03-*` specs are this template's output —
  their header comment is this template's `:179`). Comments at `:179` / `:252`
  updated with it.
- `src/scitex_agent_container/_lifecycle/_twin.py:53,217` wrote the retired key
  into every derived twin spec. The constant is now `CARDS_AGENT_ENV`, and
  `derive_twin_spec` additionally **drops an inherited** `SCITEX_TODO_AGENT_ID`
  (new `RETIRED_AGENT_ENV`) for the same reason it already drops `SAC_NAME`:
  the inherited copy carries the **parent's** name, so a consumer still reading
  the old variable resolved the twin's author to its parent.
- Docstrings that taught the retired name to agents:
  `_lifecycle/_twin.py:27,31,168,232`, `cli_pkg/lifecycle/_twin.py:173`, and the
  `agent_twin` MCP tool description (`_mcp/_tools/_agent.py:238`).

**Readers — canonical first, retired name as fallback**

Measured on 2026-09-06: 22 of 26 live agent processes carry only the canonical
variable, so each of these was permanently unsatisfied.

- `_baseline_assets/claude_worktree_hooks/worktree_create.py:245` resolved
  `owner=''` and left every worktree **UNSTAMPED** — which the pre-stop rescue
  reads as "not mine" (docstring `:240` updated with it).
- `cli_pkg/_whoami.py:241` printed `board-id: None`. It now resolves through
  `_board_identity()` and reports which variable answered
  (`identity.board_id_env`, also used as the text hint) instead of hardcoding
  the retired name as the label at `:317`. Module docstring `:18` updated.
- `cli_pkg/_helpers/_agent_list_row.py:138` never marked the self row — the one
  vantage control `sac agents list` offers. Precedence is first-non-empty, so
  a stale retired value can never mark a **second** row as the caller.

**Kept on purpose (not a miss)**

- `_lifecycle/_rename_spec.py:70` and `cli_pkg/lifecycle/_rename.py:41` still
  match BOTH names: a rename must still find old-name specs.
- `runtimes/_to_home_text.py`'s `_RUNTIME_ONLY_VARS` still lists
  `SCITEX_TODO_AGENT_ID`. Dropping it before the fixed baseline `.mcp.json` is
  *delivered* to the hosts would let deploy-time interpolation bake the
  deploying process's identity into every materialized file — the 2026-07-02
  wrong-identity incident that guard exists to prevent. Only the stale comments
  around it (`:67-75`) and in `runtimes/_envrc.py:213` are corrected, and the
  entry now carries the reason it is retained.
- `runtimes/_board_identity_env.py` (the asymmetric alias bridge) is untouched.

## Why

`runtimes/_board_identity_env.py:30-42` gates the shim's removal on "no spec
still declares the retired name". Three generators kept re-creating such specs,
so that condition could never become true by attrition. Meanwhile the three
readers above named only the retired variable, so the features they implement
(worktree ownership, `sac whoami`, the self-row control) were dead in every
container launched from a current spec.

Note the `agent_twin` MCP tool moved to a new module
`src/scitex_agent_container/_mcp/_tools/_agent_twin.py`, re-exported from
`_agent` (registration loop and `__all__` unchanged): `_agent.py` was 513 lines
— one over the per-file cap — so its docstring could not be corrected in place.
It is the one tool there that builds a spec and brokers a spawn rather than
shelling a `sac agents` verb, which makes it the natural extraction.

## Test plan

Absolute-path pytest under `/opt/venv-sac`, `PYTHONPATH=<worktree>/src`:

- **GREEN**, the touched modules' own suites: `test__create.py`,
  `_lifecycle/test__twin.py`, `_mcp/_tools/`, `_baseline_assets/claude_worktree_hooks/`,
  `test__whoami.py`, `_helpers/test__agent_list_row_is_self.py`,
  `runtimes/test__to_home_text.py`, `runtimes/test__envrc.py` —
  **337 passed, 0 skipped**.
- **GREEN**, re-run on the merge of this branch with `origin/develop`
  (`fd9ccb3e`), same set plus the three rename suites that must keep matching
  BOTH names — **364 passed, 156 skipped**. Every skip is the known
  PostgreSQL-fixture skip in the rename suites ("loopback is a read-only
  replica of the fleet cluster; there is no writable database on this host"),
  i.e. this vantage covers no PG path — none of it is in a module this PR
  changes, and none of it is a skip this PR introduced.
- **RED control** — the same suites with only the four changed source files
  reverted to their pre-change content: **11 failed, 103 passed**. The failures
  are exactly the new/updated assertions (canonical key in the template,
  no retired key in the template, owner stamp from the canonical var,
  canonical-wins for the stamp, whoami board-id + its var hint + precedence +
  howto scope, self-row marking + precedence + no second self row), so these
  tests genuinely gate the behaviour rather than passing either way.
- Updated tests now cover **canonical-first AND the fallback** for every reader:
  whoami (`falls_back_to_the_retired_board_id_var` / `prefers_the_canonical…`),
  the self row (`marks_the_caller_from_the_retired_var` /
  `canonical_var_wins_over_the_retired_one` /
  `retired_var_does_not_mark_a_peer_row`), and the worktree stamp
  (`falls_back_to_the_retired_agent_id` / `prefers_the_canonical_agent_id`).
  Two test env helpers had to be widened first — `_blank_env` in
  `test__whoami.py` and the owner-stamp env in `test_worktree_create.py`
  stripped only the retired variable, so with canonical-first they would have
  inherited the **runner's own live identity** and passed vacuously.
- `ruff check` on the 16 changed files: one `I001` in
  `tests/…/_lifecycle/test__twin.py` — **pre-existing** (the HEAD copy of that
  file reports the identical error, and the `explicitize_yaml`-before-`import os`
  order is a 20-file convention in this suite), and outside CI's selection.
  CI's actual gate, `ruff check --select F401,F811 … src/ tests/`, passes clean.

Not done here, by design: step 2c, and the dotfiles half (the 8 `handyman-c03`
specs + the stale host `.mcp.json` baseline) which is a separate repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaiWJHYdhALg2wB4hRNft1
