### PR TITLE
feat(ratelimit): switch a Fable-capped agent to opus instead of leaving it silent

### DIFF
--- a/src/scitex_agent_container/_ratelimit/__init__.py
+++ b/src/scitex_agent_container/_ratelimit/__init__.py
@@ -31,6 +31,24 @@ Layout — the rule is separated from the doing, as in the siblings:
 Driven by ``sac agents resume-rate-limited`` (read-only by default) and
 scheduled as the ``sac.resume-rate-limited-agents`` JobSpec.
 
+THE FOURTH SHAPE — a wall that WAITING cannot end (2026-09-06)
+    A rate wall publishes an end. A MODEL cap does not. Measured tonight: the
+    operator sent two messages to a Fable-family agent and both were answered
+    by the harness with ``You've reached your Fable limit. Run /usage-credits
+    to continue or switch models with /model.`` — no reset clause anywhere, so
+    the machinery above has nothing to wait for and correctly reports
+    ``NOT-LIMITED`` while the agent stays silent to the operator. Three
+    workflow subagents died in the same window behind ``You've hit your
+    session limit · resets 2am (UTC)``, which does publish an end — hours
+    away.
+
+    Both are walls a MODEL SWITCH ends in seconds, so the same four-part
+    separation is repeated for that remedy: :mod:`._modelcap` (the pure
+    parser), :mod:`._switch_rule` (the pure rule), :mod:`._switch` (the one
+    mutation — the operator's three steps, three seconds apart, then a
+    verification) and :mod:`._switch_pass` (its own ledger and perform leg).
+    It is OFF by default and armed with ``--switch-model``.
+
 WHY THIS CANNOT HOT-LOOP AGAINST A LIVE LIMIT
     Structurally, not by tuning. The resume branch of :func:`._rule.decide`
     is unreachable until ``now >= reset_at``, where ``reset_at`` is read from
@@ -44,6 +62,7 @@ from __future__ import annotations
 
 from ._alarm import SUBSYSTEM
 from ._banner import LimitObservation, observe_pane
+from ._modelcap import ModelCapObservation, observe_model_cap, verify_switch
 from ._pass import (
     DEFAULT_INTERVAL,
     DEFAULT_PASS_CAP,
@@ -54,20 +73,32 @@ from ._pass import (
 )
 from ._resume import RESUME_MESSAGE
 from ._rule import MANAGED_POLICIES, Decision, Verdict, decide
+from ._switch import KICK_MESSAGE, SWITCH_STEP_DELAY_S, switch_model_now
+from ._switch_pass import switch_history_path
+from ._switch_rule import TARGET_MODEL, decide_switch
 
 __all__ = [
     "AgentReport",
     "DEFAULT_INTERVAL",
     "DEFAULT_PASS_CAP",
     "Decision",
+    "KICK_MESSAGE",
     "LimitObservation",
     "MANAGED_POLICIES",
+    "ModelCapObservation",
     "PassOutcome",
     "RESUME_MESSAGE",
     "SUBSYSTEM",
+    "SWITCH_STEP_DELAY_S",
+    "TARGET_MODEL",
     "Verdict",
     "decide",
+    "decide_switch",
     "history_path",
+    "observe_model_cap",
     "observe_pane",
     "resume_pass",
+    "switch_history_path",
+    "switch_model_now",
+    "verify_switch",
 ]

--- a/src/scitex_agent_container/_ratelimit/_alarm.py
+++ b/src/scitex_agent_container/_ratelimit/_alarm.py
@@ -97,8 +97,20 @@ __all__ = ["SUBSYSTEM", "record_pass_completed", "record_reports"]
 
 SUBSYSTEM = "rate-limit-resume"
 _SUBJECT_KIND = "agent"
-_DEGRADED = (Verdict.FAILED, Verdict.OVER_BUDGET, Verdict.RESET_UNKNOWN)
-_HEALTHY = (Verdict.RESUMED,)
+_DEGRADED = (
+    Verdict.FAILED,
+    Verdict.OVER_BUDGET,
+    Verdict.RESET_UNKNOWN,
+    # The model-switch remedy's two unresolved ends, admitted for exactly the
+    # reason the three above are: sac tried and cannot fix this itself. A cap
+    # still rendered after all three steps needs a human at that pane, and a
+    # switch whose outcome the pane will not show needs the same human — the
+    # second more urgently, because it is the one that could otherwise be
+    # mistaken for a recovery.
+    Verdict.SWITCH_FAILED,
+    Verdict.SWITCH_UNVERIFIED,
+)
+_HEALTHY = (Verdict.RESUMED, Verdict.SWITCHED)
 
 
 def _verdict_for(report: Any) -> SubjectVerdict | None:

--- a/src/scitex_agent_container/_ratelimit/_modelcap.py
+++ b/src/scitex_agent_container/_ratelimit/_modelcap.py
@@ -46,6 +46,20 @@ time at all, so :mod:`._banner`'s waiting machinery has nothing to wait for and
 a cap with no published end is not a pause to wait out, it is a wall to walk
 around — and the banner itself says how, by naming ``/model``.
 
+THE OTHER MATCHER FOR THE SAME SENTENCE, and why it is not reused
+------------------------------------------------------------------
+``_account/rate_limit_signals.py`` (PR #1288, merged 2026-09-06) added
+``reached your \\w+ limit`` and ``/usage-credits`` to
+``DEFAULT_TEXTUAL_PATTERNS`` from the same banner. That is not a duplicate of
+this one and neither should collapse into the other: it scans ERROR TEXT to
+answer *should this ACCOUNT be rotated or paused*, and it deliberately fires
+on the whole family of cap phrasings (``weekly limit``, ``usage limit``,
+``quota exceeded``). This one scans a tmux PANE to answer *should this
+AGENT's model be changed*, and the widening that is right there would be
+wrong here: firing a model switch on every weekly-window phrasing would move
+agents off models that were never capped. Two consumers, two populations, one
+sentence they happen to share.
+
 WHAT THIS MODULE REFUSES TO DO
 ------------------------------
 It never claims a switch SUCCEEDED from the absence of a banner alone, and it

--- a/src/scitex_agent_container/_ratelimit/_modelcap.py
+++ b/src/scitex_agent_container/_ratelimit/_modelcap.py
@@ -268,6 +268,10 @@ def verify_switch(
     * pane unreadable                 -> ``None``. We could not look.
     * the cap banner is STILL rendered -> ``False``. Whatever we typed, the
       wall is still on the screen.
+    * the session's OWN confirmation line ("Set model to") is present
+      alongside the target -> ``True``. sac never types that phrase, so it
+      cannot be our echo; this is the session reporting the change. The
+      operator asked for this rung by name as the fourth step of the switch.
     * the target appears MORE times than we typed it -> ``True``. Something
       other than our own echo is naming the target model.
     * the cap is gone AND the kick was PROVEN to leave the compose box ->
@@ -298,6 +302,34 @@ def verify_switch(
             f"the cap banner is STILL rendered after all three steps "
             f"({still_capped.detail}) — the switch did not take, and this "
             f"agent is still silent",
+        )
+
+    # THE SESSION'S OWN CONFIRMATION, and the strongest rung there is: the TUI
+    # prints "Set model to <name>" ITSELF after a successful /model. sac never
+    # types that phrase — it types "/model opus[1m]" — so unlike the target id
+    # it cannot be our own echo, and it needs no arithmetic to be trustworthy.
+    # The operator asked for exactly this as a fourth step (2026-09-06: "the
+    # Set model to ... line would be useful for final confirmation"), and he is
+    # right that it is better evidence than anything inferred: it is the
+    # session reporting the state change rather than us deducing it. Matched on
+    # the FLATTENED pane so an Ink soft-wrap in the middle of the phrase cannot
+    # hide it, and paired with the target so a switch to some OTHER model is
+    # not read as success.
+    flat_pane_for_confirm = flatten_pane(pane)
+    confirm_needle = flatten_pane("Set model to")
+    target_needle = flatten_pane(target_model)
+    if (
+        confirm_needle
+        and confirm_needle in flat_pane_for_confirm
+        and target_needle
+        and target_needle in flat_pane_for_confirm
+    ):
+        return SwitchEvidence(
+            True,
+            f"the session printed its own confirmation line ('Set model to') "
+            f"and {target_model!r} is on the pane — sac never types that "
+            f"phrase, so this is the session reporting the change rather than "
+            f"our keystrokes echoing back",
         )
 
     # ``ours`` counts only the sent texts that are ACTUALLY on this screen.

--- a/src/scitex_agent_container/_ratelimit/_modelcap.py
+++ b/src/scitex_agent_container/_ratelimit/_modelcap.py
@@ -1,0 +1,317 @@
+"""Is this pane parked behind a MODEL CAP — a wall a MODEL SWITCH can end NOW?
+
+PURE — no tmux, no clock of its own, no I/O. Every input is passed in, so the
+whole table below is exercised against the two banners actually measured.
+
+WHY A SECOND MATCHER NEXT TO ``_banner`` INSTEAD OF A WIDER ``LIMIT_RE``
+-----------------------------------------------------------------------
+:mod:`._banner` answers *is there a rate wall, and WHEN does it lift* — a
+question whose only correct remedy is to WAIT. This module answers a different
+question about the same screen: *is this wall one the operator can end right
+now by switching models*. The two answers overlap by construction on the
+session-limit rendering, and that overlap is deliberate rather than a bug: one
+pane line is BOTH a pause with a published end AND, on a Fable-family agent, a
+pause that a ``/model`` switch ends in seconds. Which remedy applies is a
+question about the AGENT (what model is it on?), not about the pixels, so it
+belongs in the rule above — :mod:`._switch_rule` — and not in either matcher.
+
+Keeping ``LIMIT_RE`` untouched is the other half of that reasoning. Widening it
+to also mean "switchable" would make one regex carry two remedies with opposite
+correct actions, and the first ambiguous banner would then pick the wrong one
+silently.
+
+THE SPECIMENS THIS IS BUILT ON — measured 2026-09-06, not invented
+------------------------------------------------------------------
+The operator sent two messages to a Fable-family agent tonight. BOTH were
+answered by the harness with::
+
+    You've reached your Fable limit. Run /usage-credits to continue or switch
+    models with /model.
+
+and three workflow subagents died in the same window with::
+
+    You've hit your session limit · resets 2am (UTC)
+
+So the trigger has (at least) two shapes and the verbs differ — ``reached`` in
+the first, ``hit`` in the second. A matcher fitted to only one of them would
+have reported a healthy fleet through the outage that produced the other, which
+is exactly the failure ``_banner`` was written to avoid, so both verbs are
+matched here and both strings are kept verbatim in
+:data:`CAPPED_SPECIMEN_PANES` for the tests to assert against.
+
+Note what the FIRST specimen does not have: a reset clause. It publishes no end
+time at all, so :mod:`._banner`'s waiting machinery has nothing to wait for and
+:mod:`._rule` correctly reports ``NOT-LIMITED`` for it (``LIMIT_RE`` needs
+``hit``, not ``reached``). That silence is the whole reason this module exists:
+a cap with no published end is not a pause to wait out, it is a wall to walk
+around — and the banner itself says how, by naming ``/model``.
+
+WHAT THIS MODULE REFUSES TO DO
+------------------------------
+It never claims a switch SUCCEEDED from the absence of a banner alone, and it
+never matches text sac itself typed into the pane. See :func:`verify_switch`,
+where both refusals are implemented and the self-match trap is spelled out.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+__all__ = [
+    "CAPPED_SPECIMEN_PANES",
+    "MODEL_CAP_RE",
+    "ModelCapObservation",
+    "SwitchEvidence",
+    "observe_model_cap",
+    "verify_switch",
+]
+
+#: The cap banner. ``reached``/``hit`` both matched — the two measured
+#: renderings use different verbs, and a matcher fitted to one of them reports
+#: a healthy fleet through an outage of the other. Anchored on the provider's
+#: own first-person sentence, exactly as ``_banner.LIMIT_RE`` is, so an agent
+#: writing PROSE about the incident ("switcher fired on the Fable limit") does
+#: not match. Both apostrophes — ASCII and U+2019 — because the capture shows
+#: whichever the renderer chose, and a detector that silently stopped matching
+#: on a typographic quote is a detector that reports good news during an
+#: outage.
+MODEL_CAP_RE = re.compile(
+    r"you['’]ve\s+(?:reached|hit)\s+your\s+(?P<subject>[a-z0-9-]+)\s+limit",
+    re.IGNORECASE,
+)
+
+#: The remedy the provider itself offers. Its presence is what makes the first
+#: specimen self-describing: the banner names ``/model`` as the way out, which
+#: is precisely the mutation :mod:`._switch` performs. Absence is NOT evidence
+#: against switching (the session-limit rendering never prints it), so this is
+#: carried as an observation and never used as a gate.
+_REMEDY_RE = re.compile(r"switch\s+models?\s+with\s+/model", re.IGNORECASE)
+
+#: Verbatim captures, kept in the module they justify. The tests assert against
+#: these, so a rendering change that breaks the matcher breaks a test rather
+#: than silently returning "not capped".
+CAPPED_SPECIMEN_PANES: tuple[str, ...] = (
+    "You've reached your Fable limit. Run /usage-credits to continue or "
+    "switch models with /model.",
+    "You've hit your session limit · resets 2am (UTC)",
+    "⎿ You’ve reached your Fable limit. Run /usage-credits to "
+    "continue or switch models with /model.",
+)
+
+
+@dataclass(frozen=True)
+class ModelCapObservation:
+    """One pane, read once, for a SWITCHABLE cap. THREE states, never two.
+
+    ``readable=False`` is not ``capped=False``. A pane we could not capture
+    told us nothing about that agent, and reporting "not capped" there would
+    be an instrument announcing good news about something it never saw — the
+    same distinction :class:`._banner.LimitObservation` draws, kept identical
+    on purpose so the two matchers cannot disagree about what blindness means.
+
+    ``subject`` is the word the banner put before "limit" — ``fable`` in the
+    first measured rendering, ``session`` in the second. It is reported RAW
+    and uninterpreted: whether that word names a model family is knowledge
+    about models, which lives in :mod:`._switch_rule`, not in a pane parser.
+
+    ``line_index`` is the pane line the banner was found on, counted from the
+    TOP of the capture, and exists for the freeze comparison in the rule — a
+    banner that MOVED between two captures means the pane is still producing
+    output, which is an agent working, never one parked behind a cap.
+    """
+
+    readable: bool
+    capped: bool = False
+    subject: str = ""
+    remedy_offered: bool = False
+    reset_at: datetime | None = None
+    reset_text: str = ""
+    line_index: int | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class SwitchEvidence:
+    """Did the model switch take? ``True`` / ``False`` / ``None``.
+
+    ``None`` is a first-class answer and the one this type exists for: a
+    switch we could not verify must never be counted as a switch we made.
+    The pass reports it as ``SWITCH-UNVERIFIED`` and exits 2, so an
+    ambiguity costs a human a look rather than costing the operator a silent
+    agent he believes was recovered.
+    """
+
+    switched: bool | None
+    detail: str
+
+
+def observe_model_cap(
+    pane: str | None, *, now: datetime, default_tz: timezone
+) -> ModelCapObservation:
+    """Read ONE captured pane for a switchable model cap. Pure.
+
+    Scans from the BOTTOM up and reports the LAST banner, because a pane is a
+    scrolling log: an older cap that has already been dealt with sits above a
+    newer one, and the newest line is the only one describing the agent's
+    current state. Same direction as :func:`._banner.observe_pane`, for the
+    same reason.
+
+    Left TUI decoration is stripped with the SAME stripper both sibling
+    matchers use, so the NBSP that Claude's Ink TUI renders after ``⎿`` is
+    handled in one place. That NBSP is not a detail: leaving it out of the
+    strip set once already made a real banner undetectable.
+
+    A reset clause is parsed when the rendering carries one (the session-limit
+    shape does; the Fable shape does not) and is reported as ``None`` when it
+    is absent or unreadable. It is INFORMATION here, never a gate: a cap with
+    no published end is the case this whole path exists for.
+    """
+    if pane is None:
+        return ModelCapObservation(
+            readable=False,
+            detail="pane could not be captured — NO evidence, which is not "
+            "evidence of a working agent",
+        )
+
+    from .._runners._tmux.auth_status import _strip_markers
+    from ._banner import parse_reset_at
+
+    lines = pane.splitlines()
+    for index in range(len(lines) - 1, -1, -1):
+        stripped = _strip_markers(lines[index])
+        found = MODEL_CAP_RE.search(stripped)
+        if found is None:
+            continue
+        reset_at, raw = parse_reset_at(stripped, now=now, default_tz=default_tz)
+        subject = found.group("subject").lower()
+        remedy = _REMEDY_RE.search(stripped) is not None
+        when = (
+            f"lifting at {reset_at.isoformat()} (read from {raw!r})"
+            if reset_at is not None
+            else "with NO published end time, so there is nothing to wait for"
+        )
+        return ModelCapObservation(
+            readable=True,
+            capped=True,
+            subject=subject,
+            remedy_offered=remedy,
+            reset_at=reset_at,
+            reset_text=raw,
+            line_index=index,
+            detail=(
+                f"a {subject!r} cap banner is rendered at pane line {index}, "
+                f"{when}"
+                + (
+                    " — and the banner itself names /model as the way out"
+                    if remedy
+                    else ""
+                )
+            ),
+        )
+    return ModelCapObservation(
+        readable=True,
+        capped=False,
+        detail="no model-cap banner anywhere in the captured pane",
+    )
+
+
+def verify_switch(
+    pane: str | None,
+    *,
+    target_model: str,
+    sent_texts: tuple[str, ...] = (),
+    kick_submitted: bool | None = None,
+    now: datetime,
+    default_tz: timezone = timezone.utc,
+) -> SwitchEvidence:
+    """Did the three-step switch actually take? Pure, and THREE-VALUED.
+
+    Called with the pane captured AFTER the kick, so it answers about the
+    screen the operator would see. Never assumes success from a send that
+    returned 0 — a ``tmux send-keys`` exit status says a keystroke was
+    accepted by tmux, not that a model changed.
+
+    THE SELF-MATCH TRAP, and why ``sent_texts`` is not optional in practice
+    ---------------------------------------------------------------------
+    sac TYPES the target model into this very pane (``/model opus[1m]``), and
+    the TUI echoes what was typed. A verifier that simply searched the pane
+    for "opus" would therefore find its own keystrokes and certify every
+    attempt, successful or not — the pattern matching its own process. So the
+    count of the flattened target in the pane is compared against the count
+    sac itself contributed: only occurrences BEYOND our own are evidence.
+
+    The ladder, strongest rung first:
+
+    * pane unreadable                 -> ``None``. We could not look.
+    * the cap banner is STILL rendered -> ``False``. Whatever we typed, the
+      wall is still on the screen.
+    * the target appears MORE times than we typed it -> ``True``. Something
+      other than our own echo is naming the target model.
+    * the cap is gone AND the kick was PROVEN to leave the compose box ->
+      ``True``. A capped agent cannot take a turn, so a submitted prompt on a
+      pane with no cap banner is a working agent.
+    * anything else -> ``None``. The banner is gone and nothing proved the
+      switch; that is an ambiguity, and it is reported as one.
+
+    ``flatten_pane`` (the delivery package's) is reused rather than copied:
+    it strips every non-alphanumeric character, which defeats the Ink TUI's
+    soft wraps and box borders at once. A model id survives it as
+    ``opus1m``.
+    """
+    if pane is None:
+        return SwitchEvidence(
+            None,
+            "the pane could not be captured after the switch — this is 'we "
+            "could not look', which must never be spelled the same way as "
+            "'it worked'",
+        )
+
+    from .._delivery._token import flatten_pane
+
+    still_capped = observe_model_cap(pane, now=now, default_tz=default_tz)
+    if still_capped.capped:
+        return SwitchEvidence(
+            False,
+            f"the cap banner is STILL rendered after all three steps "
+            f"({still_capped.detail}) — the switch did not take, and this "
+            f"agent is still silent",
+        )
+
+    # ``ours`` counts only the sent texts that are ACTUALLY on this screen.
+    # Subtracting a payload that has already scrolled away would over-correct
+    # and hide a real switch; not subtracting one that is still rendered would
+    # certify a switch out of sac's own keystrokes. Presence decides, which is
+    # the only version of this arithmetic that is right in both directions.
+    flat = flatten_pane(pane)
+    needle = flatten_pane(target_model)
+    ours = 0
+    if needle:
+        for text in sent_texts:
+            flat_text = flatten_pane(text)
+            if flat_text and flat_text in flat:
+                ours += flat_text.count(needle)
+    seen = flat.count(needle) if needle else 0
+    if needle and seen > ours:
+        return SwitchEvidence(
+            True,
+            f"the cap banner is gone and {target_model!r} is named {seen} "
+            f"time(s) on the pane against the {ours} sac typed there, so "
+            f"something other than our own echo is reporting the target model",
+        )
+    if kick_submitted is True:
+        return SwitchEvidence(
+            True,
+            "the cap banner is gone and the kick was PROVEN to leave the "
+            "compose box — a capped agent cannot accept a turn, so this is a "
+            "working agent",
+        )
+    return SwitchEvidence(
+        None,
+        f"the cap banner is gone, but nothing PROVED the switch: "
+        f"{target_model!r} is named {seen} time(s) against the {ours} sac "
+        f"typed, and the kick was not provably submitted "
+        f"(kick_submitted={kick_submitted!r}). Reporting an ambiguity rather "
+        f"than claiming a recovery we cannot show",
+    )

--- a/src/scitex_agent_container/_ratelimit/_modelcap.py
+++ b/src/scitex_agent_container/_ratelimit/_modelcap.py
@@ -86,9 +86,16 @@ __all__ = [
 #: renderings use different verbs, and a matcher fitted to one of them reports
 #: a healthy fleet through an outage of the other. Anchored on the provider's
 #: own first-person sentence, exactly as ``_banner.LIMIT_RE`` is, so an agent
-#: writing PROSE about the incident ("switcher fired on the Fable limit") does
-#: not match. Both apostrophes — ASCII and U+2019 — because the capture shows
-#: whichever the renderer chose, and a detector that silently stopped matching
+#: PARAPHRASING the incident ("switcher fired on the Fable limit") does not
+#: match. It does NOT — and cannot — tell a real banner from a VERBATIM
+#: quotation of one: this repository alone carries that sentence in six places
+#: (:data:`CAPPED_SPECIMEN_PANES`, this module's docstring and
+#: :mod:`._switch_rule`'s, and three test modules), so an agent that read one
+#: of those files and then went idle has a matching line frozen on its pane.
+#: That is why :mod:`._switch_rule` treats a match here as CORROBORATION and
+#: never as authority, and refuses outright when it cannot name the agent's
+#: own model family. Both apostrophes — ASCII and U+2019 — because the capture
+#: shows whichever the renderer chose, and a detector that silently stopped matching
 #: on a typographic quote is a detector that reports good news during an
 #: outage.
 MODEL_CAP_RE = re.compile(

--- a/src/scitex_agent_container/_ratelimit/_pass.py
+++ b/src/scitex_agent_container/_ratelimit/_pass.py
@@ -133,8 +133,19 @@ class PassOutcome:
         record for a run it could not START at all. See :mod:`._alarm` for
         why that log, and not this package's own event log, is the reader of
         record.
+
+        SWITCH_UNVERIFIED joins the TWOs for the same reason RESET_UNKNOWN is
+        there: we typed three steps into an agent's pane and the pane will not
+        say whether the model changed. That is an unresolved reading, not a
+        known-bad outcome, and it is the one state of this remedy a human must
+        actually look at.
         """
-        if self.of(Verdict.UNREADABLE, Verdict.RESET_UNKNOWN, Verdict.BUDGET_UNKNOWN):
+        if self.of(
+            Verdict.UNREADABLE,
+            Verdict.RESET_UNKNOWN,
+            Verdict.BUDGET_UNKNOWN,
+            Verdict.SWITCH_UNVERIFIED,
+        ):
             return 2
         if self.of(
             Verdict.FAILED,
@@ -142,6 +153,8 @@ class PassOutcome:
             Verdict.COOLING_DOWN,
             Verdict.CAPPED,
             Verdict.WOULD_RESUME,
+            Verdict.SWITCH_FAILED,
+            Verdict.WOULD_SWITCH,
         ):
             return 1
         return 0
@@ -219,6 +232,9 @@ def resume_pass(
     interval: float = DEFAULT_INTERVAL,
     capture_fn: Callable[[], dict[str, tuple[str | None, str | None]]] | None = None,
     resume_fn: Callable[[str], bool] | None = None,
+    switch_model: bool = False,
+    switch_fn: Callable[[str, str], bool | None] | None = None,
+    switch_history_file: Path | None = None,
     default_tz: timezone = timezone.utc,
     err_stream: Any = None,
 ) -> PassOutcome:
@@ -238,13 +254,36 @@ def resume_pass(
     capture_fn, resume_fn
         The two live seams. Defaults are the real two-capture tmux read and
         the real verified delivery.
+    switch_model
+        Also handle the MODEL-CAP shape: an agent frozen behind a Fable cap
+        is moved onto ``opus[1m]`` and kicked (:mod:`._switch_rule`,
+        :mod:`._switch`). Default ``False``, and that default is
+        load-bearing rather than shy — with it off this pass behaves
+        EXACTLY as it did before the branch existed, down to the exit code,
+        so enabling the switcher is a decision the operator makes and can
+        unmake. ``--apply`` is still required for anything to be typed.
+    switch_fn, switch_history_file
+        The model-switch seams: the three-step mutation and the ledger that
+        remembers whose model this pass already changed. That ledger is
+        SEPARATE from the resume one — see :mod:`._switch_pass`.
     """
-    from ..config import load_config
     from .._reconcile._pass import fleet_spec_paths
+    from ..config import load_config
+    from ._modelcap import observe_model_cap
+    from ._switch import real_switch
+    from ._switch_pass import (
+        SWITCH_SPENT,
+        already_switched,
+        record_switch,
+        switch_history_path,
+        switch_report,
+    )
+    from ._switch_rule import decide_switch
 
     now = now if now is not None else time.time()
     moment = datetime.fromtimestamp(now, tz=timezone.utc)
     resume_fn = resume_fn if resume_fn is not None else real_resume
+    switch_fn = switch_fn if switch_fn is not None else real_switch
     history_file = history_file if history_file is not None else history_path()
     stream = err_stream if err_stream is not None else sys.stderr
 
@@ -255,6 +294,30 @@ def resume_pass(
     budget = Budget(read.history, pass_cap=limit) if read.enforceable else None
     if budget is None:
         print(f"[{SUBSYSTEM}] REFUSING to wake anything: {read.detail}", file=stream)
+
+    # The model-switch remedy carries its OWN ledger, read only when the
+    # remedy is armed. Two remedies sharing one flat ``{agent: [epoch, ...]}``
+    # file would consume each other's budget: a resume would then look, to
+    # this branch, like a switch it had already performed.
+    switch_history_file = (
+        switch_history_file
+        if switch_history_file is not None
+        else switch_history_path()
+    )
+    switch_budget: Budget | None = None
+    if switch_model:
+        switch_read = read_history(switch_history_file)
+        switch_budget = (
+            Budget(switch_read.history, pass_cap=limit)
+            if switch_read.enforceable
+            else None
+        )
+        if switch_budget is None:
+            print(
+                f"[{SUBSYSTEM}] REFUSING to switch any model: "
+                f"{switch_read.detail}",
+                file=stream,
+            )
 
     # A capture that RAISED is not an empty fleet. Carrying that distinction is
     # what makes the rule's ``sessions-unreadable`` leg reachable from
@@ -301,14 +364,66 @@ def resume_pass(
         name = config.name
         policy = config.restart.policy
         pane1, pane2 = captures.get(name, (None, None))
+        session_present = (name in captures) if sessions_readable else None
         decision = decide(
             name=name,
             policy=policy,
-            session_present=(name in captures) if sessions_readable else None,
+            session_present=session_present,
             first=observe_pane(pane1, now=moment, default_tz=default_tz),
             second=observe_pane(pane2, now=moment, default_tz=default_tz),
             now=moment,
         )
+
+        # THE MODEL-CAP BRANCH. Evaluated only when armed, so with the flag
+        # off this pass is byte-for-byte the pass it was before the branch
+        # existed. Two ways it can change the outcome, and no third:
+        #   * it FIRES — the agent is frozen behind a cap on a switchable
+        #     model, and the switch replaces today's verdict entirely; or
+        #   * today's rule found NOTHING to say ("no rate wall") while a cap
+        #     IS visibly rendered, in which case reporting "nothing to do"
+        #     would be the silence this whole command exists to abolish.
+        # In every other case today's verdict stands untouched.
+        if switch_model:
+            switch = decide_switch(
+                name=name,
+                policy=policy,
+                session_present=session_present,
+                spec_model=config.claude.model,
+                first=observe_model_cap(pane1, now=moment, default_tz=default_tz),
+                second=observe_model_cap(pane2, now=moment, default_tz=default_tz),
+                now=moment,
+                already_switched=already_switched(switch_budget, name, now),
+            )
+            if switch.fires:
+                done = switch_report(
+                    name,
+                    switch,
+                    budget=switch_budget,
+                    apply=apply,
+                    now=now,
+                    switch_fn=switch_fn,
+                )
+                if switch_budget is not None and done.verdict in SWITCH_SPENT:
+                    record_switch(
+                        switch_history_file,
+                        switch_budget,
+                        name=name,
+                        now=now,
+                        stream=stream,
+                    )
+                reports.append(
+                    AgentReport(name, done.verdict, done.reason, done.detail)
+                )
+                continue
+            if (
+                decision.verdict is Verdict.NOT_LIMITED
+                and switch.verdict is not Verdict.NOT_LIMITED
+            ):
+                reports.append(
+                    AgentReport(name, switch.verdict, switch.reason, switch.detail)
+                )
+                continue
+
         if decision.verdict is not Verdict.RESUME:
             reports.append(
                 AgentReport(name, decision.verdict, decision.reason, decision.detail)

--- a/src/scitex_agent_container/_ratelimit/_rule.py
+++ b/src/scitex_agent_container/_ratelimit/_rule.py
@@ -87,6 +87,20 @@ class Verdict(str, Enum):
     CAPPED = "CAPPED"  # this pass's cap spent; next pass retries
     BUDGET_UNKNOWN = "BUDGET-UNKNOWN"  # cannot read our OWN memory → refuse
 
+    # --- the MODEL-CAP branch (:mod:`._switch_rule`, :mod:`._switch`) ------
+    # A second remedy for a THIRD-AND-A-HALF shape: a wall that a model
+    # SWITCH ends now, rather than one that only time ends. It shares this
+    # vocabulary rather than growing a second one so the pass's counts, exit
+    # code, event records and CLI rendering keep working unchanged — an
+    # enforcer with two verdict alphabets is one whose reports cannot be
+    # added up.
+    SWITCH_MODEL = "SWITCH-MODEL"  # capped on a Fable model → switch it
+    ALREADY_ON_TARGET = "ALREADY-ON-TARGET"  # already on the target → idempotent
+    WOULD_SWITCH = "WOULD-SWITCH"  # --check: reported, not performed
+    SWITCHED = "SWITCHED"  # switched, and the switch was VERIFIED
+    SWITCH_FAILED = "SWITCH-FAILED"  # we switched and the cap is still up
+    SWITCH_UNVERIFIED = "SWITCH-UNVERIFIED"  # we acted, we cannot prove it took
+
 
 @dataclass(frozen=True)
 class Decision:

--- a/src/scitex_agent_container/_ratelimit/_switch.py
+++ b/src/scitex_agent_container/_ratelimit/_switch.py
@@ -1,0 +1,282 @@
+"""The OTHER mutation: move a capped agent onto the target model, then kick it.
+
+Separated from the pass so the pass stays a decision loop and this stays the
+irreversible act — the same split :mod:`._resume` makes, for the same reason.
+Sibling of :mod:`._resume`, and the difference between them is the whole point
+of this package's newest branch: ``_resume`` continues an agent whose wall came
+down on its own; this one walks an agent around a wall that has not.
+
+THE OPERATOR'S OWN MECHANISM, implemented literally
+---------------------------------------------------
+2026-09-06, verbatim in substance: *"1. /model opus[1m] needed  2. Enter or "1"
+needed to confirm  3. kick needed after the model switch fixed"*, and *"between
+the three steps, i think we should place three seconds for safety"*.
+
+So: THREE sends, in that order, :data:`SWITCH_STEP_DELAY_S` apart. Not two and
+not four. The gap is not decoration — the 3 s between step 1 and step 2 is
+also, by luck and by physics, exactly the settle that
+:meth:`.._runners._tmux.tmux.TmuxManager.send_text_and_submit` exists to
+provide: the containerized Ink/React TUI EATS an ``Enter`` fired while it is
+still re-rendering the text that was just pasted, which is the failure mode
+this fleet has already paid for on the boot path.
+
+WHY NOT ``_delivery.deliver`` FOR STEPS 1 AND 2 — measured, not assumed
+-----------------------------------------------------------------------
+:mod:`._resume` sends its nudge through :func:`.._delivery._deliver.deliver`
+and says why: an unverified ``tmux send-keys`` leaves a prompt sitting unsent
+at the prompt marker, which is indistinguishable from the outage. That
+reasoning is right and it still holds — for PROSE.
+
+It cannot carry a SLASH COMMAND, and the reason is one line of that module's
+own code: ``deliver`` calls ``_token.format_payload(message, token)``
+unconditionally, which returns ``f"[sac-deliver:{token}] {message}"``. The
+payload therefore reaches the composer as ``[sac-deliver:a1b2c3] /model
+opus[1m]`` — text whose first character is ``[``, not ``/``. A slash command
+is only a command when the slash is the first thing in the box; anywhere else
+it is prose, and the TUI would submit it as a question about a model rather
+than as an instruction to change one. There is no flag to suppress the token
+(it is the arrival matcher's whole mechanism), so steps 1 and 2 go through the
+package's tmux helper directly.
+
+Step 3 — the kick — IS prose, so it goes through ``deliver`` exactly as
+``_resume`` does, and inherits the three-valued proof that the payload left
+the compose box. That proof is then EVIDENCE in the verification below, not a
+verdict: see :func:`.._modelcap.verify_switch`.
+
+NOTHING HERE ASSUMES A SEND THAT RETURNED 0 DID ANYTHING
+--------------------------------------------------------
+``tmux send-keys`` exiting 0 means tmux accepted a keystroke. It does not mean
+a model changed, and a switcher that reported success on that basis would hand
+the operator a fleet he believes recovered. So the last thing this module does
+is CAPTURE THE PANE AGAIN and ask :func:`.._modelcap.verify_switch` what the
+screen now shows, three-valued: switched / not-switched / unknown.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable
+
+from ._modelcap import verify_switch
+from ._switch_rule import TARGET_MODEL
+
+__all__ = [
+    "KICK_MESSAGE",
+    "SWITCH_STEP_DELAY_S",
+    "SwitchOutcome",
+    "SwitchStep",
+    "model_command",
+    "real_switch",
+    "switch_model_now",
+]
+
+#: Seconds between the operator's three steps. His number, his words: *"between
+#: the three steps, i think we should place three seconds for safety"*. Kept as
+#: a named constant rather than inlined so a future measurement can move it in
+#: one place — and so a test can prove the spacing was honoured without racing
+#: a real clock.
+SWITCH_STEP_DELAY_S = 3.0
+
+#: The confirm keystroke. The operator's step 2 is *"Enter or \"1\""*: when
+#: ``/model <target>`` applies the model directly there is nothing to confirm
+#: and this Enter submits an empty composer (a harmless no-op); when the TUI
+#: instead opens its model picker, this is the keystroke that accepts the
+#: highlighted row. One key covers both renderings, which is why it is the one
+#: sent.
+CONFIRM_KEY = "Enter"
+
+#: What the switched agent is told. Prose, so it travels the VERIFIED delivery
+#: path. Deliberately about the agent's OWN state rather than a new
+#: instruction: this enforcer knows a model was capped and knows nothing
+#: whatever about what the agent was doing, so pointing it back at its own
+#: board is the only direction it is entitled to give.
+#:
+#: It says ``the 1M-context Opus`` rather than ``opus[1m]`` on purpose. The
+#: verifier counts occurrences of the target id on the pane and subtracts the
+#: ones sac itself put there; writing the id verbatim here would add another
+#: copy to the screen for no gain. (The text is handed to the verifier as a
+#: sent-text and only counted when it is actually rendered, so correctness
+#: does not depend on this wording — only tidiness does. Note that a naive
+#: "Opus (1M context)" would have flattened to the target id EXACTLY, which
+#: is how close this trap sits to the surface.)
+KICK_MESSAGE = (
+    "sac.resume-rate-limited-agents switched this session OFF the Fable model, "
+    "which had run out of quota and was answering nothing, and ONTO the "
+    "1M-context Opus. You were paused, not restarted — your context is "
+    "intact. Re-read your own scitex-cards board and continue the work that "
+    "was interrupted; if nothing is outstanding, say so and stop."
+)
+
+def _session_for(agent: str) -> str:
+    """``tui-<agent>`` — the DEFAULT tmux server's session for this agent.
+
+    The prefix is imported from the delivery router rather than spelled a
+    second time here: that module carries the measured warning that the
+    ``-L sac`` server is a DIFFERENT server whose emptiness would read as
+    this fleet's death.
+    """
+    from .._delivery._route import TUI_SESSION_PREFIX
+
+    return f"{TUI_SESSION_PREFIX}{agent}"
+
+
+def model_command(target: str = TARGET_MODEL) -> str:
+    """The literal step-1 keystroke text: ``/model <target>``.
+
+    A function and not an f-string at the call site so the ONE place that
+    decides what gets typed into an operator's agent is greppable.
+    """
+    return f"/model {target}"
+
+
+@dataclass(frozen=True)
+class SwitchStep:
+    """One send, and WHEN it happened on the injected clock.
+
+    ``at`` is what a test reads to prove the operator's 3-second spacing was
+    honoured without any test having to sleep for nine seconds.
+    """
+
+    name: str
+    payload: str
+    at: float
+
+
+@dataclass(frozen=True)
+class SwitchOutcome:
+    """What the three steps did, and what the pane said afterwards.
+
+    ``switched`` is THREE-VALUED and is the only field a caller may treat as a
+    verdict: ``True`` proven, ``False`` proven otherwise, ``None`` we cannot
+    tell. A ``None`` is reported as ``SWITCH-UNVERIFIED`` and exits 2 — an
+    ambiguity costs a human a look, never the operator a silent agent he
+    believes was recovered.
+    """
+
+    switched: bool | None
+    detail: str
+    steps: tuple[SwitchStep, ...] = ()
+    kick_submitted: bool | None = None
+    target: str = ""
+    sent: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _real_kick(agent: str, message: str) -> bool | None:
+    """Deliver the kick through the VERIFIED path. Three-valued, on purpose.
+
+    ``True`` only on a PROVEN submission; ``False`` is "the payload is still
+    sitting unsent"; ``None`` is "we could not tell". The last two are not the
+    same and this module does not collapse them, because the verifier
+    downstream treats a proven submission as evidence and everything else as
+    silence.
+    """
+    from .._delivery._assess import assess_delivery
+    from .._delivery._deliver import deliver
+
+    return assess_delivery(deliver(agent, message)).verdict
+
+
+def _default_paste(session: str, text: str) -> None:
+    from .._delivery._tui_strategy import default_paste
+
+    default_paste(session, text)
+
+
+def _default_send_keys(session: str, key: str) -> None:
+    from .._delivery._tui_strategy import default_send_keys
+
+    default_send_keys(session, key)
+
+
+def _default_capture(session: str) -> str | None:
+    from .._delivery._tui_strategy import default_capture
+
+    return default_capture(session)
+
+
+def switch_model_now(
+    agent: str,
+    *,
+    target: str = TARGET_MODEL,
+    step_delay_s: float = SWITCH_STEP_DELAY_S,
+    kick_message: str = KICK_MESSAGE,
+    paste_fn: Callable[[str, str], None] = _default_paste,
+    send_keys_fn: Callable[[str, str], None] = _default_send_keys,
+    kick_fn: Callable[[str, str], bool | None] = _real_kick,
+    capture_fn: Callable[[str], str | None] = _default_capture,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    clock_fn: Callable[[], float] = time.monotonic,
+    now: datetime | None = None,
+    default_tz: timezone = timezone.utc,
+) -> SwitchOutcome:
+    """Perform the operator's three steps, then PROVE what the pane shows.
+
+    Every collaborator is an injected seam with a REAL production default, so
+    a test drives this function itself — not a rehearsal of it — by passing
+    plain callables with the same signatures. Nothing is mocked and nothing
+    sleeps in a test: ``sleep_fn`` and ``clock_fn`` are the same seam pair the
+    delivery package uses.
+
+    The sequence, and what each part buys:
+
+    1. **paste** ``/model <target>`` literally (``send-keys -l`` — without it
+       the Ink TUI silently drops the keystrokes and the pane stays
+       byte-identical).
+    2. **confirm** with a separate named ``Enter`` — never ``-l``, which would
+       type the five characters "Enter" into the box.
+    3. **kick** with prose, through the verified delivery path, so the
+       submission is proven rather than hoped for.
+
+    …then one more capture and :func:`.._modelcap.verify_switch`, whose answer
+    is this function's return value. The delay is honoured BEFORE each of
+    steps 2 and 3 and once more before the verifying capture, so the screen
+    being judged is the settled one.
+    """
+    moment = now if now is not None else datetime.now(timezone.utc)
+    session = _session_for(agent)
+    command = model_command(target)
+    steps: list[SwitchStep] = []
+
+    steps.append(SwitchStep("model-command", command, clock_fn()))
+    paste_fn(session, command)
+
+    sleep_fn(step_delay_s)
+    steps.append(SwitchStep("confirm", CONFIRM_KEY, clock_fn()))
+    send_keys_fn(session, CONFIRM_KEY)
+
+    sleep_fn(step_delay_s)
+    steps.append(SwitchStep("kick", kick_message, clock_fn()))
+    kick_submitted = kick_fn(agent, kick_message)
+
+    sleep_fn(step_delay_s)
+    steps.append(SwitchStep("verify", session, clock_fn()))
+    evidence = verify_switch(
+        capture_fn(session),
+        target_model=target,
+        sent_texts=(command, kick_message),
+        kick_submitted=kick_submitted,
+        now=moment,
+        default_tz=default_tz,
+    )
+    return SwitchOutcome(
+        switched=evidence.switched,
+        detail=evidence.detail,
+        steps=tuple(steps),
+        kick_submitted=kick_submitted,
+        target=target,
+        sent=(command, kick_message),
+    )
+
+
+def real_switch(agent: str, target: str = TARGET_MODEL) -> bool | None:
+    """The pass's default seam: switch ONE local agent, three-valued.
+
+    The narrow signature the pass wires in, mirroring
+    :func:`._resume.real_resume` — except that this one returns ``None`` as
+    well as ``True``/``False``, because "we could not prove it" is a real
+    outcome here and collapsing it into ``False`` would report a working agent
+    as a failed switch (and, worse, invite a second one).
+    """
+    return switch_model_now(agent, target=target).switched

--- a/src/scitex_agent_container/_ratelimit/_switch_pass.py
+++ b/src/scitex_agent_container/_ratelimit/_switch_pass.py
@@ -1,0 +1,199 @@
+"""The model-switch branch of the resume pass: its memory, and its one perform.
+
+Split out of :mod:`._pass` rather than grown into it. The pass is already the
+IO half of a three-part enforcer (pure parser / pure rule / one mutation), and
+adding a SECOND remedy's ledger and perform step inline would have made the
+one file that everybody reads the one file nobody can hold in their head.
+:mod:`._pass` keeps the sweep; this keeps everything that is specific to
+switching a capped agent's model.
+
+THE LEDGER IS THIS REMEDY'S OWN, and that is not tidiness
+----------------------------------------------------------
+``SAC_MODEL_SWITCH_HISTORY`` is separate from ``SAC_RATE_LIMIT_HISTORY``,
+which is itself separate from ``SAC_RECONCILE_HISTORY``. The ledger format is
+a flat ``{agent: [epoch, ...]}`` with no remedy key, so two remedies sharing a
+file would silently consume each other's budget: one model switch would then
+disarm the resume debounce for the same agent, and a pass that resumed an
+agent would look, to this branch, like a pass that had already switched it.
+
+The numbers are inherited from :mod:`.._reconcile._budget` unchanged — a
+30-minute per-agent debounce, at most 2 per agent per rolling hour, and a
+per-pass cap. They were chosen so a persistently-failing remedy becomes a
+REPORT instead of a loop, and that argument is remedy-independent.
+
+WHY A THREE-VALUED RESULT GETS THREE VERDICTS
+---------------------------------------------
+:func:`._switch.switch_model_now` answers ``True`` / ``False`` / ``None``, and
+all three land here as distinct verdicts:
+
+* ``SWITCHED``          — proven: the cap is gone and something other than our
+  own keystrokes says so.
+* ``SWITCH_FAILED``     — proven otherwise: the cap banner is still rendered
+  after all three steps.
+* ``SWITCH_UNVERIFIED`` — we typed everything and cannot show it took. Exit 2,
+  because "I could not tell" must never be logged as a healthy tick.
+
+All three SPEND budget. A switch we could not verify cost the agent a real
+turn and possibly changed its model, so retrying it on the next 5-minute tick
+without a debounce is exactly the hot loop the budget exists to prevent.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+from .._reconcile._budget import Budget
+from ._rule import Decision, Verdict
+
+__all__ = [
+    "SWITCH_SPENT",
+    "already_switched",
+    "record_switch",
+    "switch_history_path",
+    "switch_report",
+]
+
+#: Explicit override for WHERE this remedy's memory lives — SEPARATE from both
+#: siblings'. See the module docstring for why sharing one file would make two
+#: remedies eat each other's budget.
+_HISTORY_ENV = "SAC_MODEL_SWITCH_HISTORY"
+
+#: Verdicts that SPEND budget: we typed into the agent's pane, whether or not
+#: we could prove the outcome. An unverifiable switch must cost the same as a
+#: proven one, or an agent we cannot read becomes one we retype into forever.
+SWITCH_SPENT = (Verdict.SWITCHED, Verdict.SWITCH_FAILED, Verdict.SWITCH_UNVERIFIED)
+
+_BUDGET_VERDICTS = {
+    "debounce": Verdict.COOLING_DOWN,
+    "over-budget": Verdict.OVER_BUDGET,
+    "pass-cap": Verdict.CAPPED,
+}
+
+
+def switch_history_path() -> Path:
+    """Where this remedy remembers whose model it already switched.
+
+    Resolved PER CALL, never cached at import: a module-level constant would
+    be baked from an env var that tests set afterwards, which is the exact
+    trap :mod:`.._state.state_paths` documents having paid for.
+    """
+    override = os.environ.get(_HISTORY_ENV)
+    if override:
+        return Path(override).expanduser()
+    from .._state.state_paths import runtime_root
+
+    return runtime_root() / "model-switch-history.json"
+
+
+def already_switched(budget: Budget | None, name: str, now: float) -> bool:
+    """Have we ALREADY switched this agent so recently that we cannot see it?
+
+    The pure rule's no-second-fire input. It reads only the DEBOUNCE leg of
+    the budget, deliberately: over-budget and pass-cap are refusals about
+    volume and are the perform step's to make, while the debounce is the one
+    that answers the rule's actual question — *has this agent had time to show
+    us what the last switch did?*
+
+    A ``None`` budget answers ``False``, which sounds wrong and is not: an
+    unreadable ledger must not become a silent "yes, already done" that hides
+    a capped agent. The refusal to act on an unenforceable budget belongs to
+    :func:`switch_report`, which states it as ``BUDGET-UNKNOWN`` instead of
+    swallowing it here.
+    """
+    if budget is None:
+        return False
+    return budget.check(name, now).reason == "debounce"
+
+
+def record_switch(
+    history_file: Path,
+    budget: Budget,
+    *,
+    name: str,
+    now: float,
+    stream: Any,
+) -> None:
+    """Spend this agent's switch budget and persist it. Never raises.
+
+    A ledger write that fails must stop this pass from switching anything
+    ELSE — the alternative is an unbounded loop with no memory — but must not
+    lose the reports already earned, so the pass is capped in place rather
+    than aborted.
+    """
+    from .._reconcile._budget import save_history
+
+    budget.record(name, now)
+    # stx-allow: fallback (reason: an unwritable ledger must cap this pass rather than abort it — the reports already earned still reach the `sac agents resume-rate-limited` stdout line, the pass-record counts in runtime_root()/sac-events.jsonl, and the exit code the supervisor persists)
+    try:
+        save_history(history_file, budget.history, now=now)
+    except OSError as exc:
+        budget.spent = budget.pass_cap
+        print(
+            f"[rate-limit-resume] CANNOT RECORD model switches to "
+            f"{history_file}: {exc} — capping this pass so no other agent's "
+            f"model is changed without memory",
+            file=stream,
+        )
+
+
+def switch_report(
+    name: str,
+    decision: Any,
+    *,
+    budget: Budget | None,
+    apply: bool,
+    now: float,
+    switch_fn: Callable[[str, str], bool | None],
+) -> Decision:
+    """Turn ONE authorised ``SWITCH-MODEL`` into what actually happened to it.
+
+    Mirrors :func:`._pass._perform` leg for leg, so the two remedies refuse in
+    the same order and for the same reasons, and returns a
+    :class:`._rule.Decision` so the pass's existing reporting path carries it
+    without a second report type.
+    """
+    if budget is None:
+        return Decision(
+            Verdict.BUDGET_UNKNOWN,
+            "switch-budget-unreadable",
+            f"{name} is capped on a switchable model, but this pass cannot "
+            f"read its own model-switch ledger, so it cannot honour the "
+            f"debounce. Refusing to retype /model into a pane on a budget it "
+            f"cannot enforce",
+        )
+    check = budget.check(name, now)
+    if not check.allowed:
+        return Decision(
+            _BUDGET_VERDICTS[check.reason],
+            check.reason,
+            f"{decision.detail} — but {check.detail}",
+        )
+    if not apply:
+        return Decision(Verdict.WOULD_SWITCH, decision.reason, decision.detail)
+
+    switched = switch_fn(name, decision.target)
+    if switched is True:
+        return Decision(
+            Verdict.SWITCHED,
+            decision.reason,
+            f"{decision.detail} — switched to {decision.target!r} and the "
+            f"pane PROVES it: the cap banner is gone",
+        )
+    if switched is False:
+        return Decision(
+            Verdict.SWITCH_FAILED,
+            decision.reason,
+            f"{decision.detail} — all three steps were typed and the cap "
+            f"banner is STILL rendered, so this agent is still silent. "
+            f"Recorded as degraded rather than retyped",
+        )
+    return Decision(
+        Verdict.SWITCH_UNVERIFIED,
+        decision.reason,
+        f"{decision.detail} — all three steps were typed and the pane does "
+        f"not prove the switch either way. Reported as an ambiguity, never "
+        f"as a recovery: a switcher that claims success it cannot show hands "
+        f"the operator a fleet he believes is working",
+    )

--- a/src/scitex_agent_container/_ratelimit/_switch_rule.py
+++ b/src/scitex_agent_container/_ratelimit/_switch_rule.py
@@ -1,0 +1,265 @@
+"""The PURE rule: may sac switch THIS agent off a capped model, and onto what?
+
+No IO, no clock of its own — ``now`` is passed in — so every leg below is
+driven directly by tests instead of inferred from a live fleet. Sibling of
+:mod:`._rule`, sharing its :class:`._rule.Verdict` vocabulary on purpose: one
+pass, one alphabet, one set of counts.
+
+THE SHAPE THIS ADDS, and why waiting was the wrong remedy for it
+----------------------------------------------------------------
+:mod:`._rule` recovers an agent behind a wall THAT PUBLISHES ITS OWN END: it
+waits for the reset the provider printed and then continues the agent. That is
+right for a session/weekly rate wall and it is the only correct action there.
+
+It is NOT right for a MODEL cap. Measured 2026-09-06: the operator sent two
+messages to a Fable-family agent and both were answered by the harness with
+``You've reached your Fable limit. Run /usage-credits to continue or switch
+models with /model.`` — a wall with NO published end and an explicit remedy
+printed on it. Waiting for a reset that was never announced means waiting
+forever; three workflow subagents died in the same window behind
+``You've hit your session limit · resets 2am (UTC)``, which does publish an
+end, but an end HOURS away. In both cases the agent went silent to the
+operator, and in both cases a model switch would have had it working in
+seconds.
+
+So this rule answers the question :mod:`._rule` cannot: not *when does this
+lift* but *can we step around it right now*.
+
+THE PRINCIPLES THIS TABLE ENCODES
+---------------------------------
+1. **Only a Fable-family agent is switched.** The remedy is "get off the
+   capped model", so it is meaningless on an agent that is not on it. An
+   agent capped on any other model keeps TODAY'S verdict — the pass falls
+   back to :func:`._rule.decide`, unchanged. This rule never widens the
+   population it acts on; it only ever carves a switchable subset out of it.
+2. **Idempotence is a rule, not a hope.** An agent already on the target is
+   :attr:`._rule.Verdict.ALREADY_ON_TARGET` and is never touched. Sending
+   ``/model opus[1m]`` to an agent already on ``opus[1m]`` would spend three
+   keystrokes and a kick to achieve nothing, and the kick is a real turn on a
+   real agent.
+3. **Never twice for the same incarnation.** ``already_switched`` is the
+   caller's memory of a switch it already performed and cannot yet see the
+   result of, and it HOLDS. Combined with leg 4 this is the whole no-hot-loop
+   argument: either the pane advanced (the agent took a turn — leg 4 stops
+   us) or it did not (we already acted — leg 3 stops us).
+4. **A moving pane is a working agent.** A cap banner at a different pane
+   position across two captures means output is still being produced, so the
+   agent is working, or quoting the incident. Never touched. Same freeze
+   discipline as both siblings, for the same reason: a false positive here
+   interrupts an agent that was fine — and this remedy's false positive is
+   expensive, because it changes the model the agent runs on.
+5. **"I could not look" is not "nothing is there"** — the rule sac's other
+   enforcers already live by, kept identical here so all of them agree.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._modelcap import ModelCapObservation
+from ._rule import MANAGED_POLICIES, Decision, Verdict
+
+__all__ = [
+    "CAPPED_FAMILIES",
+    "TARGET_MODEL",
+    "decide_switch",
+    "model_family",
+]
+
+#: What a capped Fable agent is switched ONTO. The operator's own words,
+#: 2026-09-06: *"implement fable to opus automatic switcher when limit error
+#: raised"*, and then the mechanism, step 1: ``/model opus[1m]``. The ``[1m]``
+#: context suffix is deliberate and is carried verbatim into the keystroke —
+#: dropping it would silently re-home the agent on the 200k context window,
+#: which is a different agent from the one that was working.
+TARGET_MODEL = "opus[1m]"
+
+#: The model families this remedy applies to. ONE entry, on purpose: the
+#: measured cap is Fable's, and a switcher that fires on families nobody has
+#: seen capped would be acting on a rule nobody has evidence for. Widening
+#: this is a one-line change WITH a specimen to justify it.
+CAPPED_FAMILIES = ("fable",)
+
+#: Every model family sac can name. Matched as a substring of the model id
+#: because the id arrives in several shapes — the bare alias (``fable``), the
+#: versioned form (``claude-fable-5``), and either with a context suffix
+#: (``opus[1m]``). A provider model id that names none of them yields ``""``,
+#: which is an honest "we cannot tell what family this is" and never fires.
+_FAMILY_RE = re.compile(r"(opus|sonnet|haiku|fable)", re.IGNORECASE)
+
+
+def model_family(model: str) -> str:
+    """The family a model id belongs to, lowercased — ``""`` when unknown.
+
+    ``claude-fable-5`` / ``fable`` -> ``fable``; ``claude-opus-4-8[1m]`` /
+    ``opus[1m]`` -> ``opus``; a Qwen or other provider id -> ``""``.
+
+    ``""`` is a real answer and the rule treats it as such: an agent whose
+    family we cannot name is neither on the capped family nor on the target,
+    so it is left to today's verdict. Guessing would be this enforcer
+    changing the model of an agent it does not understand.
+    """
+    found = _FAMILY_RE.search(model or "")
+    return found.group(1).lower() if found else ""
+
+
+@dataclass(frozen=True)
+class SwitchDecision:
+    """A verdict plus WHY, plus the model we would move the agent TO.
+
+    ``target`` is populated only on :attr:`._rule.Verdict.SWITCH_MODEL`; every
+    other verdict leaves it empty, because naming a target we are not going to
+    send would read, in a log, exactly like one we did.
+    """
+
+    verdict: Verdict
+    reason: str
+    detail: str
+    target: str = ""
+
+    @property
+    def fires(self) -> bool:
+        """Does this decision authorise the mutation?"""
+        return self.verdict is Verdict.SWITCH_MODEL
+
+    def as_decision(self) -> Decision:
+        """The sibling shape, for the pass's shared reporting path."""
+        return Decision(self.verdict, self.reason, self.detail)
+
+
+def decide_switch(
+    *,
+    name: str,
+    policy: str,
+    session_present: bool | None,
+    spec_model: str,
+    first: ModelCapObservation,
+    second: ModelCapObservation,
+    now: datetime,
+    target: str = TARGET_MODEL,
+    already_switched: bool = False,
+) -> SwitchDecision:
+    """Decide ONE agent's model fate from facts alone. Pure — no IO, no clock.
+
+    Parameters
+    ----------
+    policy
+        ``spec.restart.policy``. Same opt-in as every other sac enforcer.
+    session_present
+        Whether a live tmux session for ``name`` was found. ``None`` means the
+        enumeration itself failed, which is not the same as "no session".
+    spec_model
+        ``spec.claude.model`` — the model the agent was LAUNCHED on. It is
+        the declared model, so it can lag a switch performed in the TUI; that
+        lag is covered by ``already_switched`` and by leg 4 (a switched agent
+        that took a turn has an advancing pane), not by trusting the spec.
+    first, second
+        Two readings of the SAME pane, an interval apart. The pair is what
+        separates a parked agent from a working one.
+    now
+        The instant the SECOND capture was taken, timezone-aware. Present for
+        symmetry with :func:`._rule.decide` and for the detail lines; this
+        remedy deliberately does NOT gate on a reset time, because the
+        measured Fable banner publishes none.
+    already_switched
+        The caller's memory that it already switched this agent and has not
+        yet seen the result. See principle 3 in the module docstring.
+    """
+    del now  # carried for symmetry with the sibling rule; not a gate here.
+
+    if policy not in MANAGED_POLICIES:
+        return SwitchDecision(
+            Verdict.NOT_MANAGED,
+            "policy-never",
+            f"restart.policy={policy!r} — sac never promised to keep {name} "
+            f"running, so its model is not sac's to change",
+        )
+
+    if session_present is None:
+        return SwitchDecision(
+            Verdict.UNREADABLE,
+            "sessions-unreadable",
+            f"could not enumerate tmux sessions, so we do not know whether "
+            f"{name} has one. Refusing to infer anything from a reading we "
+            f"failed to take",
+        )
+    if not session_present:
+        return SwitchDecision(
+            Verdict.NO_SESSION,
+            "no-session",
+            f"{name} has no live tmux session — there is no pane to type "
+            f"/model into. A corpse is `sac agents reconcile`'s",
+        )
+
+    if not (first.readable and second.readable):
+        return SwitchDecision(
+            Verdict.UNREADABLE,
+            "pane-unreadable",
+            f"{name}'s pane could not be captured on both reads "
+            f"({second.detail or first.detail}) — no evidence, which is not "
+            f"evidence that it is working",
+        )
+
+    if not second.capped:
+        return SwitchDecision(
+            Verdict.NOT_LIMITED,
+            "no-model-cap",
+            f"no model-cap banner on {name}'s pane — nothing here to switch "
+            f"around",
+        )
+
+    if not first.capped or first.line_index != second.line_index:
+        return SwitchDecision(
+            Verdict.MOVING,
+            "pane-advancing",
+            f"{name}'s pane shows a model-cap banner but it MOVED between the "
+            f"two reads (line {first.line_index} → {second.line_index}), so "
+            f"the pane is still producing output. That is an agent working, "
+            f"or one quoting the incident — never one parked behind a cap",
+        )
+
+    family = model_family(spec_model)
+    target_family = model_family(target)
+    if family and family == target_family:
+        return SwitchDecision(
+            Verdict.ALREADY_ON_TARGET,
+            "already-on-target",
+            f"{name} is already on {spec_model!r}, which is the "
+            f"{target_family!r} family this switcher moves agents TO. Its cap "
+            f"banner is a different problem and switching it to the model it "
+            f"is already running would spend a real turn to achieve nothing",
+        )
+
+    banner_family = model_family(second.subject)
+    if family not in CAPPED_FAMILIES and banner_family not in CAPPED_FAMILIES:
+        return SwitchDecision(
+            Verdict.NOT_LIMITED,
+            "not-a-capped-family",
+            f"{name} is capped, but on {spec_model or 'an unnamed model'!r} "
+            f"(family {family or 'unknown'!r}) and the banner names "
+            f"{second.subject!r} — neither is one of {CAPPED_FAMILIES}. This "
+            f"remedy is 'get off the capped model'; it means nothing here, so "
+            f"the rate-wall verdict stands",
+        )
+
+    if already_switched:
+        return SwitchDecision(
+            Verdict.COOLING_DOWN,
+            "already-switched",
+            f"{name} was ALREADY switched and its pane has not advanced "
+            f"since, so the previous switch's outcome is not yet visible. "
+            f"Firing again would type a second /model into a pane that may "
+            f"still be showing a picker from the first",
+        )
+
+    return SwitchDecision(
+        Verdict.SWITCH_MODEL,
+        "capped-on-a-switchable-model",
+        f"{name} is parked behind a frozen {second.subject!r} cap "
+        f"({second.detail}) while running {spec_model!r}. This wall does not "
+        f"need waiting out — it needs walking around, and the provider's own "
+        f"banner names the way: switch to {target!r} and kick the session",
+        target=target,
+    )

--- a/src/scitex_agent_container/_ratelimit/_switch_rule.py
+++ b/src/scitex_agent_container/_ratelimit/_switch_rule.py
@@ -27,11 +27,25 @@ lift* but *can we step around it right now*.
 
 THE PRINCIPLES THIS TABLE ENCODES
 ---------------------------------
-1. **Only a Fable-family agent is switched.** The remedy is "get off the
-   capped model", so it is meaningless on an agent that is not on it. An
-   agent capped on any other model keeps TODAY'S verdict — the pass falls
-   back to :func:`._rule.decide`, unchanged. This rule never widens the
-   population it acts on; it only ever carves a switchable subset out of it.
+1. **A NAMEABLE family, capped on Fable.** The remedy is "get off the capped
+   model", so it is meaningless on an agent that is not on it, and an agent
+   capped on anything else keeps TODAY'S verdict — the pass falls back to
+   :func:`._rule.decide`, unchanged. Two facts can put an agent in: its SPEC
+   names the capped family, or the spec names some OTHER family sac can read
+   while the BANNER names the capped one. That second leg is not generosity,
+   it is the only leg that reaches the measured incident: a spec records what
+   the agent was LAUNCHED on and lags a switch made in the TUI, and measured
+   2026-09-06 not ONE of the fleet's 119 specs names ``fable`` at all, so a
+   spec-only gate would be a guard that can never fire.
+   A spec whose family sac CANNOT name is out, unconditionally, and that
+   refusal is what makes the second leg safe: the banner is corroboration,
+   never authority, because the provider's cap sentence lives VERBATIM in
+   this repository (:data:`._modelcap.CAPPED_SPECIMEN_PANES`, two module
+   docstrings, three test modules) and an agent that read one of those files
+   and then went idle carries the trigger frozen on its own pane. Keeping the
+   unnameable family out is what stops that from re-homing a local-model
+   agent onto Anthropic Opus. This rule never widens the population it acts
+   on; it only ever carves a switchable subset out of it.
 2. **Idempotence is a rule, not a hope.** An agent already on the target is
    :attr:`._rule.Verdict.ALREADY_ON_TARGET` and is never touched. Sending
    ``/model opus[1m]`` to an agent already on ``opus[1m]`` would spend three
@@ -232,13 +246,27 @@ def decide_switch(
             f"is already running would spend a real turn to achieve nothing",
         )
 
+    if not family:
+        return SwitchDecision(
+            Verdict.NOT_LIMITED,
+            "unknown-model-family",
+            f"{name}'s spec names {spec_model or 'no model at all'!r}, whose "
+            f"family sac cannot read, so the banner would be the ONLY evidence "
+            f"— and a banner is corroboration, never authority. The provider's "
+            f"cap sentence is carried VERBATIM in this repository (specimens, "
+            f"docstrings, tests), so any agent that read one of those files and "
+            f"then went idle has a matching line frozen on its pane, at the "
+            f"same index on both reads. Acting on that alone would retype the "
+            f"model of a local-model agent onto Anthropic Opus, which is the "
+            f"one class where falling back to Claude is never wanted",
+        )
     banner_family = model_family(second.subject)
     if family not in CAPPED_FAMILIES and banner_family not in CAPPED_FAMILIES:
         return SwitchDecision(
             Verdict.NOT_LIMITED,
             "not-a-capped-family",
-            f"{name} is capped, but on {spec_model or 'an unnamed model'!r} "
-            f"(family {family or 'unknown'!r}) and the banner names "
+            f"{name} is capped, but on {spec_model!r} "
+            f"(family {family!r}) and the banner names "
             f"{second.subject!r} — neither is one of {CAPPED_FAMILIES}. This "
             f"remedy is 'get off the capped model'; it means nothing here, so "
             f"the rate-wall verdict stands",

--- a/src/scitex_agent_container/cli_pkg/_agents_resume_rate_limited.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_resume_rate_limited.py
@@ -33,13 +33,18 @@ from ._helpers import _json_flag, console
 #: as a clean line.
 _STYLE = {
     Verdict.RESUMED: ("green", "RESUMED"),
+    Verdict.SWITCHED: ("green", "SWITCHED"),
     Verdict.WAITING: ("cyan", "WAITING"),
+    Verdict.ALREADY_ON_TARGET: ("cyan", "ALREADY-ON-TARGET"),
     Verdict.WOULD_RESUME: ("yellow", "WOULD-RESUME"),
+    Verdict.WOULD_SWITCH: ("yellow", "WOULD-SWITCH"),
     Verdict.COOLING_DOWN: ("yellow", "COOLING-DOWN"),
     Verdict.CAPPED: ("yellow", "CAPPED"),
     Verdict.OVER_BUDGET: ("red", "OVER-BUDGET"),
     Verdict.FAILED: ("red", "FAILED"),
+    Verdict.SWITCH_FAILED: ("red", "SWITCH-FAILED"),
     Verdict.RESET_UNKNOWN: ("magenta", "RESET-UNKNOWN"),
+    Verdict.SWITCH_UNVERIFIED: ("magenta", "SWITCH-UNVERIFIED"),
     Verdict.UNREADABLE: ("magenta", "UNREADABLE"),
     Verdict.BUDGET_UNKNOWN: ("magenta", "BUDGET-UNKNOWN"),
 }
@@ -90,6 +95,16 @@ def _print_report(report) -> None:
     show_default=True,
     help="Seconds between the two pane captures used for the frozen check.",
 )
+@click.option(
+    "--switch-model",
+    "switch_model",
+    is_flag=True,
+    default=False,
+    help="Also handle the MODEL-CAP shape: an agent frozen behind a Fable cap "
+    "is moved onto opus[1m] and kicked. OFF by default — without it this "
+    "command behaves exactly as it did before the branch existed. Needs "
+    "--apply to type anything.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON (for timers).")
 @click.pass_context
 def resume_rate_limited(
@@ -98,6 +113,7 @@ def resume_rate_limited(
     check: bool,
     limit: int,
     interval: float,
+    switch_model: bool,
     as_json: bool,
 ) -> None:
     """Resume LIVE agents parked behind a provider rate wall that has RESET.
@@ -126,6 +142,22 @@ def resume_rate_limited(
                           merely lands in the composer and is never submitted
                           is indistinguishable from the outage itself.
 
+    \b
+    THE MODEL-CAP BRANCH (--switch-model, OFF by default):
+      $ sac agents resume-rate-limited --switch-model
+      $ sac agents resume-rate-limited --apply --switch-model
+
+    A rate wall publishes an end; a MODEL cap does not. Measured 2026-09-06:
+    a Fable-family agent answered the operator's messages with "You've
+    reached your Fable limit ... switch models with /model" — no reset
+    clause, so the rule above correctly reports NOT-LIMITED and the agent
+    stays silent forever. With --switch-model such an agent is moved onto
+    opus[1m] instead of waited on: /model opus[1m], Enter to confirm, then a
+    kick, THREE SECONDS APART, and finally a fresh capture that must PROVE
+    the cap is gone. A switch that cannot be proven is SWITCH-UNVERIFIED and
+    exits 2 — never a claimed recovery. Only agents on a Fable-family model
+    are touched; every other agent keeps the verdict it has today.
+
     The agent is CONTINUED, never restarted: its session, context and
     conversation all survived the wall. Rate-limited exactly like its siblings
     (30-min/agent debounce, <=2/agent/hour, --limit per pass); an agent that
@@ -142,7 +174,9 @@ def resume_rate_limited(
             "drop both flags to preview, pass --apply to resume."
         )
 
-    outcome = resume_pass(apply=apply, limit=limit, interval=interval)
+    outcome = resume_pass(
+        apply=apply, limit=limit, interval=interval, switch_model=switch_model
+    )
     code = outcome.exit_code()
 
     if _json_flag(ctx, as_json):
@@ -150,6 +184,7 @@ def resume_rate_limited(
             json.dumps(
                 {
                     "mode": "apply" if apply else "check",
+                    "switch_model": switch_model,
                     "exit_code": code,
                     "counts": outcome.counts(),
                     "pass_recorded": outcome.heartbeat_ok,
@@ -176,19 +211,23 @@ def resume_rate_limited(
             "\n" + "  ".join(f"{k.lower()}={v}" for k, v in sorted(counts.items()))
         )
 
-    stuck = outcome.of(Verdict.FAILED, Verdict.OVER_BUDGET)
+    stuck = outcome.of(Verdict.FAILED, Verdict.OVER_BUDGET, Verdict.SWITCH_FAILED)
     if stuck:
         console.print(
             f"\n[red]{len(stuck)} agent(s) are STILL parked and sac could not "
             f"get them working again.[/red] Each is recorded as degraded.",
             soft_wrap=True,
         )
-    blind = outcome.of(Verdict.RESET_UNKNOWN, Verdict.UNREADABLE)
+    blind = outcome.of(
+        Verdict.RESET_UNKNOWN, Verdict.UNREADABLE, Verdict.SWITCH_UNVERIFIED
+    )
     if blind:
         console.print(
             f"\n[magenta]{len(blind)} agent(s) could not be DETERMINED.[/magenta] "
             f"A wall whose reset clause does not parse needs a new pattern in "
-            f"_ratelimit._banner; nothing here can resolve it by guessing.",
+            f"_ratelimit._banner; a switch whose outcome the pane will not show "
+            f"needs a human to look at that pane. Nothing here can resolve "
+            f"either by guessing.",
             soft_wrap=True,
         )
     if not outcome.heartbeat_ok:

--- a/src/scitex_agent_container/cli_pkg/_agents_resume_rate_limited.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_resume_rate_limited.py
@@ -155,8 +155,12 @@ def resume_rate_limited(
     opus[1m] instead of waited on: /model opus[1m], Enter to confirm, then a
     kick, THREE SECONDS APART, and finally a fresh capture that must PROVE
     the cap is gone. A switch that cannot be proven is SWITCH-UNVERIFIED and
-    exits 2 — never a claimed recovery. Only agents on a Fable-family model
-    are touched; every other agent keeps the verdict it has today.
+    exits 2 — never a claimed recovery. Only an agent whose model family sac
+    can NAME is touched — its spec on a Fable model, or its spec on another
+    Claude family while the pane's banner names Fable (a spec lags a switch
+    made in the TUI). An agent sac cannot name a family for — a local-model
+    agent, or a spec carrying no model — is NEVER switched, however its pane
+    reads; every other agent keeps the verdict it has today.
 
     The agent is CONTINUED, never restarted: its session, context and
     conversation all survived the wall. Rate-limited exactly like its siblings

--- a/tests/scitex_agent_container/_ratelimit/test__modelcap.py
+++ b/tests/scitex_agent_container/_ratelimit/test__modelcap.py
@@ -239,3 +239,57 @@ def test_an_uncapturable_pane_verifies_nothing() -> None:
     evidence = _verify(None, kick_submitted=True)
     # Assert
     assert evidence.switched is None
+
+
+class TestTheSessionsOwnConfirmationLine:
+    """The operator's fourth step: trust what the SESSION printed, not what sac typed.
+
+    2026-09-06, verbatim in substance: "the Set model to ... line would be
+    useful for final confirmation". It is the strongest rung available because
+    sac types ``/model opus[1m]`` and never the phrase "Set model to", so this
+    evidence cannot be sac's own echo — which is the trap every other rung of
+    this ladder has to do arithmetic to avoid.
+    """
+
+    def test_the_confirmation_line_proves_the_switch(self) -> None:
+        # Arrange
+        pane = "❯ /model opus[1m]\n  Set model to Opus 5 (1M context) opus[1m]\n❯ "
+        # Act
+        evidence = verify_switch(
+            pane,
+            target_model="opus[1m]",
+            sent_texts=("/model opus[1m]",),
+            kick_submitted=None,
+            now=NOW,
+        )
+        # Assert
+        assert evidence.switched is True
+
+    def test_it_outranks_the_echo_arithmetic(self) -> None:
+        # Arrange — the target appears ONLY as sac's own echo, which the
+        # counting rung would refuse; the confirmation line still decides.
+        pane = "❯ /model opus[1m]\n  Set model to opus[1m]\n❯ "
+        # Act
+        evidence = verify_switch(
+            pane,
+            target_model="opus[1m]",
+            sent_texts=("/model opus[1m]", "Set model to opus[1m]"),
+            kick_submitted=False,
+            now=NOW,
+        )
+        # Assert
+        assert evidence.switched is True
+
+    def test_a_confirmation_naming_another_model_is_not_our_switch(self) -> None:
+        # Arrange — the session confirms a DIFFERENT model; the target is absent.
+        pane = "❯ /model haiku\n  Set model to haiku\n❯ "
+        # Act
+        evidence = verify_switch(
+            pane,
+            target_model="opus[1m]",
+            sent_texts=("/model opus[1m]",),
+            kick_submitted=None,
+            now=NOW,
+        )
+        # Assert
+        assert evidence.switched is None

--- a/tests/scitex_agent_container/_ratelimit/test__modelcap.py
+++ b/tests/scitex_agent_container/_ratelimit/test__modelcap.py
@@ -1,0 +1,241 @@
+"""Tests for ``_ratelimit._modelcap`` — is this a wall a model switch can end?
+
+Pure, so every leg is driven by passing a pane and a clock in. No mocks and
+nothing to mock.
+
+The behaviours that matter, in the order they matter:
+
+* BOTH measured banners parse. These are the verbatim strings the operator's
+  messages and the three dead workflow subagents came back with on
+  2026-09-06, and a matcher fitted to one of them would report a healthy
+  fleet through an outage of the other.
+* an ordinary pane does NOT match. Without that negative control a matcher
+  that returns True for everything passes every positive test above.
+* an uncapturable pane is ``readable=False``, never ``capped=False``.
+* :func:`verify_switch` never certifies a switch from sac's OWN keystrokes.
+  sac types the target model into the very pane it then reads, so a verifier
+  without that subtraction would certify every attempt, successful or not.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from scitex_agent_container._ratelimit._modelcap import (
+    CAPPED_SPECIMEN_PANES,
+    observe_model_cap,
+    verify_switch,
+)
+from scitex_agent_container._ratelimit._switch import KICK_MESSAGE, model_command
+
+NOW = datetime(2026, 9, 6, 3, 0, tzinfo=timezone.utc)
+
+#: The Fable cap exactly as the harness answered the operator, in the pane
+#: position it really occupied: last conversation line, above the prompt box.
+FABLE_PANE = "\n".join(
+    [
+        "● Reading the spec...",
+        "  ⎿ You've reached your Fable limit. Run /usage-credits to continue "
+        "or switch models with /model.",
+        "────────────────────────────────────────────",
+        "❯ ",
+    ]
+)
+
+#: The shape the three workflow subagents died behind in the same window.
+SESSION_PANE = "\n".join(
+    [
+        "● Working on the migration...",
+        "  ⎿ You’ve hit your session limit · resets 2am (UTC)",
+        "────────────────────────────────────────────",
+        "❯ ",
+    ]
+)
+
+#: The NEGATIVE CONTROL. An ordinary working pane, including an agent talking
+#: ABOUT limits in prose — the text that must never be mistaken for the
+#: provider's own first-person banner.
+ORDINARY_PANE = "\n".join(
+    [
+        "● The switcher fires when an agent hits the Fable limit.",
+        "  ⎿ Wrote src/scitex_agent_container/_ratelimit/_switch.py",
+        "────────────────────────────────────────────",
+        "❯ ",
+    ]
+)
+
+
+def _observe(pane: str | None):
+    return observe_model_cap(pane, now=NOW, default_tz=timezone.utc)
+
+
+# --- the real specimens: both measured renderings must parse ----------------
+
+
+@pytest.mark.parametrize("pane", CAPPED_SPECIMEN_PANES)
+def test_every_measured_cap_banner_is_detected(pane: str) -> None:
+    # Arrange — the verbatim strings from 2026-09-06. A matcher that stops
+    # recognising one of these reports a healthy fleet during the outage it
+    # was written for.
+    # Act
+    observation = _observe(pane)
+    # Assert
+    assert observation.capped is True
+
+
+def test_the_fable_banner_names_its_subject() -> None:
+    # Arrange — the subject word is what the rule above reads to decide
+    # whether the cap is on a switchable model family.
+    # Act
+    observation = _observe(FABLE_PANE)
+    # Assert
+    assert observation.subject == "fable"
+
+
+def test_the_fable_banner_publishes_no_reset() -> None:
+    # Arrange — this is the whole reason the switch remedy exists: there is
+    # no end time to wait for, so the waiting machinery has nothing to do and
+    # the agent stays silent forever.
+    # Act
+    observation = _observe(FABLE_PANE)
+    # Assert
+    assert observation.reset_at is None
+
+
+def test_the_fable_banner_offers_the_model_remedy() -> None:
+    # Arrange — the provider itself prints the way out. Recording that makes
+    # the observation self-describing rather than sac asserting a remedy the
+    # screen never mentioned.
+    # Act
+    observation = _observe(FABLE_PANE)
+    # Assert
+    assert observation.remedy_offered is True
+
+
+def test_the_session_banner_is_also_a_cap() -> None:
+    # Arrange — the second measured shape. It carries a reset clause, so the
+    # rate-wall rule can act on it too; which remedy applies is the rule's
+    # question, not this parser's.
+    # Act
+    observation = _observe(SESSION_PANE)
+    # Assert
+    assert observation.subject == "session"
+
+
+def test_the_session_banner_reset_is_parsed() -> None:
+    # Arrange — reusing ``_banner.parse_reset_at`` rather than growing a
+    # second reset parser is only defensible if it actually works here.
+    # Act
+    observation = _observe(SESSION_PANE)
+    # Assert
+    assert observation.reset_at == datetime(2026, 9, 6, 2, 0, tzinfo=timezone.utc)
+
+
+# --- the controls: a working pane, and a pane nobody could read -------------
+
+
+def test_an_ordinary_pane_is_not_capped() -> None:
+    # Arrange — THE NEGATIVE CONTROL. Without it every positive test above
+    # would also pass for a matcher that returns True unconditionally, and
+    # the switcher would start retyping /model into working agents.
+    # Act
+    observation = _observe(ORDINARY_PANE)
+    # Assert
+    assert observation.capped is False
+
+
+def test_an_unreadable_pane_reports_unreadable() -> None:
+    # Arrange — "I could not look" must never be spelled the same way as
+    # "I looked and it was fine": the second is good news about something
+    # nobody saw.
+    # Act
+    observation = _observe(None)
+    # Assert
+    assert observation.readable is False
+
+
+def test_an_unreadable_pane_says_no_evidence() -> None:
+    # Arrange — the detail is what an operator reads in the timer log, so a
+    # blind read must SAY it was blind rather than leaving a bare False that
+    # looks like a clean answer.
+    # Act
+    observation = _observe(None)
+    # Assert
+    assert "NO evidence" in observation.detail
+
+
+# --- verification: never certify a switch from our own keystrokes -----------
+
+
+def _verify(pane, *, kick_submitted=None, target="opus[1m]"):
+    return verify_switch(
+        pane,
+        target_model=target,
+        sent_texts=(model_command(target), KICK_MESSAGE),
+        kick_submitted=kick_submitted,
+        now=NOW,
+        default_tz=timezone.utc,
+    )
+
+
+def test_a_still_capped_pane_is_not_switched() -> None:
+    # Arrange — all three steps were typed and the wall is still on screen.
+    # That is a proven failure, not an ambiguity.
+    # Act
+    evidence = _verify(FABLE_PANE, kick_submitted=True)
+    # Assert
+    assert evidence.switched is False
+
+
+def test_our_own_echo_never_proves_a_switch() -> None:
+    # Arrange — THE SELF-MATCH TRAP. The pane holds nothing but sac's own
+    # "/model opus[1m]" keystrokes, and the kick was not provably submitted.
+    # A verifier that simply searched for the target would certify this.
+    pane = "\n".join(["❯ /model opus[1m]", "──────────────", "❯ "])
+    # Act
+    evidence = _verify(pane, kick_submitted=None)
+    # Assert
+    assert evidence.switched is None
+
+
+def test_the_target_beyond_our_echo_proves_it() -> None:
+    # Arrange — the command echo PLUS a second, independent naming of the
+    # model. Only occurrences beyond the ones sac contributed are evidence.
+    pane = "\n".join(
+        ["❯ /model opus[1m]", "  ⎿ Set model to opus[1m]", "──────────────", "❯ "]
+    )
+    # Act
+    evidence = _verify(pane, kick_submitted=None)
+    # Assert
+    assert evidence.switched is True
+
+
+def test_a_proven_kick_on_a_clean_pane_counts() -> None:
+    # Arrange — the cap is gone and the kick was PROVEN to leave the compose
+    # box. A capped agent cannot accept a turn, so this is a working agent.
+    # Act
+    evidence = _verify(ORDINARY_PANE, kick_submitted=True)
+    # Assert
+    assert evidence.switched is True
+
+
+def test_an_unsubmitted_kick_proves_nothing() -> None:
+    # Arrange — the banner is gone but nothing shows the switch took. This
+    # must be an ambiguity a human looks at, never a claimed recovery.
+    # Act
+    evidence = _verify(ORDINARY_PANE, kick_submitted=False)
+    # Assert
+    assert evidence.switched is None
+
+
+def test_an_uncapturable_pane_verifies_nothing() -> None:
+    # Arrange — we could not look after the switch. A send that returned 0 is
+    # not a model change, so blindness here must stay blindness.
+    # Act
+    evidence = _verify(None, kick_submitted=True)
+    # Assert
+    assert evidence.switched is None

--- a/tests/scitex_agent_container/_ratelimit/test__pass_switch.py
+++ b/tests/scitex_agent_container/_ratelimit/test__pass_switch.py
@@ -1,0 +1,293 @@
+"""Tests for the MODEL-CAP branch of ``_ratelimit._pass`` — armed and unarmed.
+
+Real on-disk v3 specs, a real temp switch ledger, real captured banner text,
+and a real recorder standing in for the mutation. Nothing is patched and
+nothing is monkeypatched: every collaborator is a production keyword argument
+with a real default.
+
+THE CONTROL THIS FILE IS BUILT AROUND
+    :func:`test_the_flag_off_changes_nothing` and
+    :func:`test_the_flag_on_switches_the_capped_agent` are ONE experiment run
+    twice. Same fleet, same spec, same captured panes, same clock — the ONLY
+    variable is ``switch_model``. A green result in the second without the
+    first would not show that the default is safe, and "the default is safe"
+    is the promise that lets this ship before the operator has decided to arm
+    it.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml as _yaml
+
+from scitex_agent_container._events import read_events
+from scitex_agent_container._ratelimit._pass import resume_pass
+from scitex_agent_container._ratelimit._rule import Verdict
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_spec
+
+#: The Fable cap exactly as the harness answered the operator on 2026-09-06,
+#: in the pane position it really occupied.
+FABLE_PANE = "\n".join(
+    [
+        "● Reading the spec...",
+        "  ⎿ You've reached your Fable limit. Run /usage-credits to continue "
+        "or switch models with /model.",
+        "────────────────────────────────────────────",
+        "❯ ",
+    ]
+)
+
+NOW = 1_800_000_000.0
+
+
+class SwitchRecorder:
+    """A real switch callable that records instead of typing into a pane.
+
+    Not a mock: a plain object with the production signature
+    ``(agent, target) -> bool | None``. ``calls`` is the evidence a test reads
+    to prove a switch did — or, more importantly, did NOT — happen.
+    """
+
+    def __init__(self, result: bool | None = True) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self._result = result
+
+    def __call__(self, name: str, target: str) -> bool | None:
+        self.calls.append((name, target))
+        return self._result
+
+
+def write_fable_spec(registry: Path, name: str = "alpha") -> Path:
+    """A real dir-as-SSoT v3 ``<name>/spec.yaml`` running a Fable model."""
+    agent_dir = registry / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    body = explicit_spec(
+        {
+            "host": "${HOSTNAME}",
+            "runtime": "apptainer",
+            "claude": {"model": "claude-fable-5"},
+            "apptainer": {"image": "/opt/sac/scitex.sif", "binds": []},
+            "health": {"enabled": True, "interval": 60},
+        }
+    )
+    body["workdir"] = f"~/.scitex/agent-container/runtime/agents/{name}"
+    body["restart"].update({"policy": "on-failure", "max_retries": 3})
+    (agent_dir / "spec.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "apiVersion": "scitex-agent-container/v3",
+                "kind": "Agent",
+                "metadata": {"labels": {}},
+                "spec": body,
+            }
+        )
+    )
+    return agent_dir / "spec.yaml"
+
+
+@pytest.fixture()
+def fleet(tmp_path):
+    """One managed Fable agent whose live pane shows tonight's cap."""
+    registry = tmp_path / "agents"
+    write_fable_spec(registry)
+    return {
+        "specs_dir": registry,
+        "history_file": tmp_path / "resume-history.json",
+        "switch_history_file": tmp_path / "switch-history.json",
+        "events_path": tmp_path / "sac-events.jsonl",
+    }
+
+
+def _run(fleet, *, switcher, apply=True, switch_model=True, now=NOW, **overrides):
+    kwargs = dict(fleet)
+    kwargs.update(
+        {
+            "apply": apply,
+            "now": now,
+            "switch_model": switch_model,
+            "switch_fn": switcher,
+            "resume_fn": lambda name: True,
+            "capture_fn": lambda: {"alpha": (FABLE_PANE, FABLE_PANE)},
+        }
+    )
+    kwargs.update(overrides)
+    return resume_pass(**kwargs)
+
+
+def _verdict_of(outcome, name: str) -> Verdict:
+    return next(r.verdict for r in outcome.reports if r.name == name)
+
+
+# --- THE CONTROL: one experiment, the flag as the only variable -------------
+
+
+def test_the_flag_off_changes_nothing(fleet) -> None:
+    # Arrange — the RED half. With the switcher unarmed this pass must be the
+    # pass it was before the branch existed: the Fable banner carries no
+    # reset clause, so the rate-wall rule sees no wall and does nothing.
+    switcher = SwitchRecorder()
+    # Act
+    _run(fleet, switcher=switcher, switch_model=False)
+    # Assert
+    assert switcher.calls == []
+
+
+def test_the_flag_off_reports_not_limited(fleet) -> None:
+    # Arrange — the same unarmed pass. This is the GAP the branch exists to
+    # close, stated as a test: today sac looks at a visibly capped agent and
+    # reports that there is nothing here.
+    switcher = SwitchRecorder()
+    # Act
+    outcome = _run(fleet, switcher=switcher, switch_model=False)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.NOT_LIMITED
+
+
+def test_the_flag_on_switches_the_capped_agent(fleet) -> None:
+    # Arrange — the GREEN half. Same fleet, same spec, same panes, same
+    # clock; only the flag moved. This is the claim that the operator's two
+    # unanswered messages would have been answered.
+    switcher = SwitchRecorder()
+    # Act
+    _run(fleet, switcher=switcher)
+    # Assert
+    assert switcher.calls == [("alpha", "opus[1m]")]
+
+
+def test_a_performed_switch_is_reported_switched(fleet) -> None:
+    # Arrange — a proven switch. The verdict is what the timer log carries,
+    # so it must say what happened rather than leaving a silent success.
+    switcher = SwitchRecorder()
+    # Act
+    outcome = _run(fleet, switcher=switcher)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.SWITCHED
+
+
+# --- read-only stays read-only ---------------------------------------------
+
+
+def test_the_check_mode_types_nothing(fleet) -> None:
+    # Arrange — --switch-model without --apply. Detection is read-only and
+    # arming a remedy must not silently arm its mutation too.
+    switcher = SwitchRecorder()
+    # Act
+    _run(fleet, switcher=switcher, apply=False)
+    # Assert
+    assert switcher.calls == []
+
+
+def test_the_check_mode_reports_would_switch(fleet) -> None:
+    # Arrange — read-only is not silent. An operator previewing the remedy
+    # must see which agents it would touch.
+    switcher = SwitchRecorder()
+    # Act
+    outcome = _run(fleet, switcher=switcher, apply=False)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.WOULD_SWITCH
+
+
+# --- the ledger: never twice for one incarnation ----------------------------
+
+
+def test_a_second_pass_does_not_switch_again(fleet) -> None:
+    # Arrange — one pass switches, then the SAME ledger is read by a second
+    # pass minutes later against the same frozen pane. Without the debounce
+    # this is a /model typed into the agent every five minutes forever.
+    switcher = SwitchRecorder()
+    _run(fleet, switcher=switcher)
+    # Act
+    _run(fleet, switcher=switcher, now=NOW + 300.0)
+    # Assert
+    assert len(switcher.calls) == 1
+
+
+def test_a_second_pass_reports_cooling_down(fleet) -> None:
+    # Arrange — holding must be a STATED verdict, not an absence: an agent
+    # nobody reports on is an agent nobody watches.
+    switcher = SwitchRecorder()
+    _run(fleet, switcher=switcher)
+    # Act
+    outcome = _run(fleet, switcher=switcher, now=NOW + 300.0)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.COOLING_DOWN
+
+
+def test_the_switch_ledger_is_written(fleet) -> None:
+    # Arrange — the debounce above is only real if the memory survives the
+    # process. This pass is a short-lived cron job; RAM is not a ledger.
+    switcher = SwitchRecorder()
+    # Act
+    _run(fleet, switcher=switcher)
+    # Assert
+    assert "alpha" in fleet["switch_history_file"].read_text()
+
+
+def test_the_resume_ledger_is_not_spent(fleet) -> None:
+    # Arrange — two remedies, two ledgers. A shared flat {agent: [epoch]}
+    # file would let one switch disarm the resume debounce for the same
+    # agent, and neither remedy could then be reasoned about alone.
+    switcher = SwitchRecorder()
+    # Act
+    _run(fleet, switcher=switcher)
+    # Assert
+    assert fleet["history_file"].read_text().strip() in ("{}", '{\n}')
+
+
+# --- an unprovable switch is an unresolved reading, not a success -----------
+
+
+def test_an_unverified_switch_is_reported(fleet) -> None:
+    # Arrange — the mutation could not prove the model changed. That must
+    # never be logged as a healthy tick, because the operator would read it
+    # as an agent that came back.
+    switcher = SwitchRecorder(result=None)
+    # Act
+    outcome = _run(fleet, switcher=switcher)
+    # Assert
+    assert _verdict_of(outcome, "alpha") is Verdict.SWITCH_UNVERIFIED
+
+
+def test_an_unverified_switch_is_recorded_degraded(fleet) -> None:
+    # Arrange — an enforcer that gives up SILENTLY is the original bug with
+    # extra steps. The record is written to a real temp event log and read
+    # back with the production reader.
+    switcher = SwitchRecorder(result=None)
+    # Act
+    _run(fleet, switcher=switcher)
+    # Assert
+    assert any(
+        e.subject == "alpha" and e.event == "subject-degraded"
+        for e in read_events(fleet["events_path"])
+    )
+
+
+def test_a_later_success_records_the_recovery(fleet) -> None:
+    # Arrange — the other rail, and it is a TRANSITION rather than a
+    # heartbeat: sac records a degraded subject once and its recovery when it
+    # actually recovers. So this is one agent across two passes an hour
+    # apart — failed first (degraded), switched second — which is the only
+    # sequence that can produce a recovery record at all.
+    _run(fleet, switcher=SwitchRecorder(result=False))
+    # Act
+    _run(fleet, switcher=SwitchRecorder(result=True), now=NOW + 3600.0)
+    # Assert
+    assert any(
+        e.subject == "alpha" and e.event == "subject-recovered"
+        for e in read_events(fleet["events_path"])
+    )
+
+
+def test_an_unverified_switch_exits_two(fleet) -> None:
+    # Arrange — 2 is this command's "something could not be determined",
+    # alongside an unreadable pane and an unreadable reset clause. Each needs
+    # a human; none may pass as clean.
+    switcher = SwitchRecorder(result=None)
+    # Act
+    outcome = _run(fleet, switcher=switcher)
+    # Assert
+    assert outcome.exit_code() == 2

--- a/tests/scitex_agent_container/_ratelimit/test__switch.py
+++ b/tests/scitex_agent_container/_ratelimit/test__switch.py
@@ -1,0 +1,246 @@
+"""Tests for ``_ratelimit._switch`` — the operator's three steps, in order.
+
+No mocks: every collaborator is a production keyword argument with a real
+default, and these tests pass plain recording callables into them. Nothing
+sleeps — the clock is injected, and the fake sleep ADVANCES it, so a nine-
+second sequence is asserted in microseconds and cannot flake.
+
+What has to be true, and why each one is here:
+
+* THREE steps, in the operator's order (``/model opus[1m]`` -> confirm ->
+  kick). His mechanism, 2026-09-06, and a switcher that reorders them types
+  a prompt into a model picker.
+* THREE SECONDS between them. His number, his words: *"between the three
+  steps, i think we should place three seconds for safety"*. It is also the
+  settle that stops the Ink TUI eating the Enter that follows a paste.
+* the VERIFICATION runs, and its answer — not the send's exit status — is
+  what comes back. ``tmux send-keys`` returning 0 means tmux accepted a
+  keystroke, never that a model changed.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from scitex_agent_container._ratelimit._switch import (
+    SWITCH_STEP_DELAY_S,
+    switch_model_now,
+)
+
+NOW = datetime(2026, 9, 6, 3, 0, tzinfo=timezone.utc)
+
+CLEAN_PANE = "\n".join(["● Ready.", "──────────────", "❯ "])
+STILL_CAPPED_PANE = "\n".join(
+    [
+        "  ⎿ You've reached your Fable limit. Run /usage-credits to continue "
+        "or switch models with /model.",
+        "❯ ",
+    ]
+)
+
+
+class FakeClock:
+    """A real clock callable that only moves when someone sleeps.
+
+    Not a mock: two plain methods with the production signatures
+    (``clock() -> float``, ``sleep(seconds) -> None``). Because ``sleep``
+    advances ``t``, the timestamps the module stamps on its steps ARE the
+    spacing it asked for, and a test can read them without waiting.
+    """
+
+    def __init__(self) -> None:
+        self.t = 0.0
+        self.slept: list[float] = []
+
+    def clock(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.t += seconds
+
+
+class Pane:
+    """A real pane that records what was typed into it and what was read."""
+
+    def __init__(self, *, after: str | None = CLEAN_PANE) -> None:
+        self.pasted: list[tuple[str, str]] = []
+        self.keys: list[tuple[str, str]] = []
+        self.kicks: list[tuple[str, str]] = []
+        self.captured: list[str] = []
+        self._after = after
+
+    def paste(self, session: str, text: str) -> None:
+        self.pasted.append((session, text))
+
+    def send_keys(self, session: str, key: str) -> None:
+        self.keys.append((session, key))
+
+    def capture(self, session: str) -> str | None:
+        self.captured.append(session)
+        return self._after
+
+
+def _kick(result: bool | None):
+    def kick(agent: str, message: str) -> bool | None:
+        kick.calls.append((agent, message))
+        return result
+
+    kick.calls = []  # type: ignore[attr-defined]
+    return kick
+
+
+def _run(*, pane: Pane, clock: FakeClock, kick_result: bool | None = True):
+    return switch_model_now(
+        "alpha",
+        paste_fn=pane.paste,
+        send_keys_fn=pane.send_keys,
+        kick_fn=_kick(kick_result),
+        capture_fn=pane.capture,
+        sleep_fn=clock.sleep,
+        clock_fn=clock.clock,
+        now=NOW,
+    )
+
+
+# --- the three steps, in the operator's order -------------------------------
+
+
+def test_the_three_steps_run_in_order() -> None:
+    # Arrange — his mechanism verbatim in substance: "1. /model opus[1m]
+    # needed 2. Enter or "1" needed to confirm 3. kick needed after the model
+    # switch fixed". A switcher that reorders these types a prompt into a
+    # model picker.
+    pane, clock = Pane(), FakeClock()
+    # Act
+    outcome = _run(pane=pane, clock=clock)
+    # Assert
+    assert [step.name for step in outcome.steps] == [
+        "model-command",
+        "confirm",
+        "kick",
+        "verify",
+    ]
+
+
+def test_step_one_pastes_the_model_command() -> None:
+    # Arrange — the text must reach the composer LITERALLY and with the
+    # slash first: a slash command is only a command when the slash is the
+    # first character in the box.
+    pane, clock = Pane(), FakeClock()
+    # Act
+    _run(pane=pane, clock=clock)
+    # Assert
+    assert pane.pasted == [("tui-alpha", "/model opus[1m]")]
+
+
+def test_step_two_sends_a_named_enter() -> None:
+    # Arrange — a SEPARATE named key, never "-l", which would type the five
+    # characters "Enter" into the box.
+    pane, clock = Pane(), FakeClock()
+    # Act
+    _run(pane=pane, clock=clock)
+    # Assert
+    assert pane.keys == [("tui-alpha", "Enter")]
+
+
+def test_step_three_kicks_the_agent() -> None:
+    # Arrange — the kick is what makes the switch worth doing: nothing
+    # inside the agent will notice the model changed, because the thing that
+    # would have noticed is the turn the cap stopped.
+    pane, clock = Pane(), FakeClock()
+    kick = _kick(True)
+    # Act
+    switch_model_now(
+        "alpha",
+        paste_fn=pane.paste,
+        send_keys_fn=pane.send_keys,
+        kick_fn=kick,
+        capture_fn=pane.capture,
+        sleep_fn=clock.sleep,
+        clock_fn=clock.clock,
+        now=NOW,
+    )
+    # Assert
+    assert [agent for agent, _ in kick.calls] == ["alpha"]
+
+
+# --- three seconds between them, on an injected clock -----------------------
+
+
+def test_the_steps_are_three_seconds_apart() -> None:
+    # Arrange — the operator's own number. Asserted on the timestamps the
+    # module stamped, so this proves the SPACING and not merely that sleep
+    # was called; the fake clock only moves when something sleeps.
+    pane, clock = Pane(), FakeClock()
+    # Act
+    outcome = _run(pane=pane, clock=clock)
+    # Assert
+    assert [step.at for step in outcome.steps] == [0.0, 3.0, 6.0, 9.0]
+
+
+def test_every_gap_uses_the_named_delay() -> None:
+    # Arrange — three gaps, one constant. Inlining the number anywhere would
+    # let a future edit move one gap and not the others.
+    pane, clock = Pane(), FakeClock()
+    # Act
+    _run(pane=pane, clock=clock)
+    # Assert
+    assert clock.slept == [SWITCH_STEP_DELAY_S] * 3
+
+
+# --- the verification is the answer, not the send's exit status -------------
+
+
+def test_the_verification_capture_runs() -> None:
+    # Arrange — the last thing this module does is LOOK. Without this the
+    # outcome would be an assumption dressed as a measurement.
+    pane, clock = Pane(), FakeClock()
+    # Act
+    _run(pane=pane, clock=clock)
+    # Assert
+    assert pane.captured == ["tui-alpha"]
+
+
+def test_a_clean_pane_and_proven_kick_is_switched() -> None:
+    # Arrange — the cap is gone and the kick was PROVEN to leave the compose
+    # box. A capped agent cannot accept a turn, so this is a working agent.
+    pane, clock = Pane(), FakeClock()
+    # Act
+    outcome = _run(pane=pane, clock=clock)
+    # Assert
+    assert outcome.switched is True
+
+
+def test_a_still_capped_pane_is_not_switched() -> None:
+    # Arrange — every step was typed and the wall is still on screen. That is
+    # a proven failure and must be reported as one, not retried forever.
+    pane, clock = Pane(after=STILL_CAPPED_PANE), FakeClock()
+    # Act
+    outcome = _run(pane=pane, clock=clock)
+    # Assert
+    assert outcome.switched is False
+
+
+def test_an_unprovable_switch_is_unknown() -> None:
+    # Arrange — the banner is gone, the kick was not provably submitted, and
+    # nothing on the pane names the target beyond sac's own keystrokes. THE
+    # CLAIM THIS FILE EXISTS FOR: a send returning 0 is not a model change.
+    pane, clock = Pane(), FakeClock()
+    # Act
+    outcome = _run(pane=pane, clock=clock, kick_result=None)
+    # Assert
+    assert outcome.switched is None
+
+
+def test_a_blind_capture_verifies_nothing() -> None:
+    # Arrange — we could not read the pane afterwards. Blindness must stay
+    # blindness: the operator's agent is either working or silent, and this
+    # says we do not know which.
+    pane, clock = Pane(after=None), FakeClock()
+    # Act
+    outcome = _run(pane=pane, clock=clock)
+    # Assert
+    assert outcome.switched is None

--- a/tests/scitex_agent_container/_ratelimit/test__switch_rule.py
+++ b/tests/scitex_agent_container/_ratelimit/test__switch_rule.py
@@ -142,11 +142,46 @@ def test_a_non_fable_agent_keeps_todays_verdict() -> None:
 def test_the_banner_outranks_a_stale_spec() -> None:
     # Arrange — the spec says Sonnet and the PANE says Fable. A spec records
     # what the agent was LAUNCHED on and can lag a switch made in the TUI, so
-    # the screen wins: the agent visibly capped on Fable is on Fable.
+    # the screen wins: the agent visibly capped on Fable is on Fable. This is
+    # the OUTER edge of that leg — the spec still names a Claude family sac
+    # can read. A spec it cannot read is refused below, whatever the pane says.
     # Act
     decision = _decide(spec_model="claude-sonnet-4-5", pane=FABLE_PANE)
     # Assert
     assert decision.verdict is Verdict.SWITCH_MODEL
+
+
+def test_an_unnameable_spec_family_is_never_switched() -> None:
+    # Arrange — a local-model agent whose pane carries the provider's cap
+    # sentence VERBATIM, which is exactly what an agent that read sac's own
+    # specimens and then went idle looks like: frozen, same line on both
+    # reads. model_family("qwen38-27b") is "", so the banner is the only
+    # evidence, and a banner alone must never re-home a non-Anthropic agent
+    # onto Opus — the operator's standing rule is that business never falls
+    # back to Claude.
+    # Act
+    decision = _decide(spec_model="qwen38-27b", pane=FABLE_PANE)
+    # Assert
+    assert decision.fires is False
+
+
+def test_an_unnameable_spec_family_is_named_as_such() -> None:
+    # Arrange — the refusal reports under its OWN reason, so a reader can
+    # tell "we cannot name this agent's model" apart from "capped on a
+    # family this remedy does not apply to".
+    # Act
+    decision = _decide(spec_model="qwen38-27b", pane=FABLE_PANE)
+    # Assert
+    assert decision.reason == "unknown-model-family"
+
+
+def test_a_spec_with_no_model_is_never_switched() -> None:
+    # Arrange — a spec carrying no model at all is the same blindness with a
+    # different shape, and blindness is never a licence to retype a model.
+    # Act
+    decision = _decide(spec_model="", pane=FABLE_PANE)
+    # Assert
+    assert decision.fires is False
 
 
 # --- NO SECOND FIRE --------------------------------------------------------

--- a/tests/scitex_agent_container/_ratelimit/test__switch_rule.py
+++ b/tests/scitex_agent_container/_ratelimit/test__switch_rule.py
@@ -1,0 +1,211 @@
+"""Tests for ``_ratelimit._switch_rule`` — may sac change THIS agent's model?
+
+Pure, so every leg is driven by passing facts and a clock in. No mocks and
+nothing to mock.
+
+The three claims this file has to make good on, because they are the three
+ways an automatic model switcher goes wrong:
+
+* it FIRES on the measured case — a Fable-family agent frozen behind a cap;
+* it is IDEMPOTENT — an agent already on the target is never retyped into;
+* it does not fire TWICE for one incarnation — the caller's memory of a
+  switch it has not yet seen the result of HOLDS the second attempt.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from scitex_agent_container._ratelimit._modelcap import observe_model_cap
+from scitex_agent_container._ratelimit._rule import Verdict
+from scitex_agent_container._ratelimit._switch_rule import TARGET_MODEL, decide_switch
+
+NOW = datetime(2026, 9, 6, 3, 0, tzinfo=timezone.utc)
+
+FABLE_PANE = "\n".join(
+    [
+        "● Reading the spec...",
+        "  ⎿ You've reached your Fable limit. Run /usage-credits to continue "
+        "or switch models with /model.",
+        "────────────────────────────────────────────",
+        "❯ ",
+    ]
+)
+CLEAN_PANE = "\n".join(["● Done.", "──────────────", "❯ "])
+#: The same banner one line further down — a pane that is still producing
+#: output, i.e. an agent working (or quoting the incident in prose).
+MOVED_PANE = "● Extra output line\n" + FABLE_PANE
+
+
+def _observe(pane):
+    return observe_model_cap(pane, now=NOW, default_tz=timezone.utc)
+
+
+def _decide(
+    *,
+    pane=FABLE_PANE,
+    second_pane=None,
+    spec_model="claude-fable-5",
+    policy="on-failure",
+    session_present=True,
+    already_switched=False,
+):
+    return decide_switch(
+        name="alpha",
+        policy=policy,
+        session_present=session_present,
+        spec_model=spec_model,
+        first=_observe(pane),
+        second=_observe(second_pane if second_pane is not None else pane),
+        now=NOW,
+        already_switched=already_switched,
+    )
+
+
+# --- FIRE: the measured case -----------------------------------------------
+
+
+def test_a_frozen_fable_cap_fires_the_switch() -> None:
+    # Arrange — the 2026-09-06 case exactly: a Fable-family agent frozen
+    # behind its own cap banner, which publishes no reset, so the rate-wall
+    # remedy has nothing to wait for and the agent stays silent forever.
+    # Act
+    decision = _decide()
+    # Assert
+    assert decision.verdict is Verdict.SWITCH_MODEL
+
+
+def test_the_fired_decision_names_the_target() -> None:
+    # Arrange — the target is the mutation's argument, so a decision that
+    # fires without naming one would be an authorisation to type nothing.
+    # Act
+    decision = _decide()
+    # Assert
+    assert decision.target == TARGET_MODEL
+
+
+def test_the_bare_fable_alias_also_fires() -> None:
+    # Arrange — a spec may carry the bare alias rather than the versioned id.
+    # Both are the same agent on the same capped family.
+    # Act
+    decision = _decide(spec_model="fable")
+    # Assert
+    assert decision.verdict is Verdict.SWITCH_MODEL
+
+
+def test_the_session_cap_fires_on_fable() -> None:
+    # Arrange — the OTHER measured banner, the one the three dead workflow
+    # subagents came back with. It publishes a reset hours away; on a Fable
+    # agent the switch ends it in seconds.
+    pane = "  ⎿ You’ve hit your session limit · resets 2am (UTC)\n❯ "
+    # Act
+    decision = _decide(pane=pane)
+    # Assert
+    assert decision.verdict is Verdict.SWITCH_MODEL
+
+
+# --- IDEMPOTENCE -----------------------------------------------------------
+
+
+def test_an_agent_on_the_target_is_left_alone() -> None:
+    # Arrange — an agent already on the opus family. Typing /model opus[1m]
+    # at it would spend three keystrokes and a real turn to change nothing.
+    # Act
+    decision = _decide(spec_model="claude-opus-4-8[1m]")
+    # Assert
+    assert decision.verdict is Verdict.ALREADY_ON_TARGET
+
+
+def test_an_agent_on_the_target_does_not_fire() -> None:
+    # Arrange — the same reading, asserted through the property the pass
+    # actually branches on, so a verdict rename cannot quietly re-arm it.
+    # Act
+    decision = _decide(spec_model="opus[1m]")
+    # Assert
+    assert decision.fires is False
+
+
+def test_a_non_fable_agent_keeps_todays_verdict() -> None:
+    # Arrange — a Sonnet agent behind the SESSION wall. That wall publishes
+    # its own end and the rate-wall rule already waits it out correctly;
+    # "get off the capped model" means nothing here, so today's verdict must
+    # stand rather than being overridden by a switch nobody can justify.
+    pane = "  ⎿ You’ve hit your session limit · resets 2am (UTC)\n❯ "
+    # Act
+    decision = _decide(spec_model="claude-sonnet-4-5", pane=pane)
+    # Assert
+    assert decision.reason == "not-a-capped-family"
+
+
+def test_the_banner_outranks_a_stale_spec() -> None:
+    # Arrange — the spec says Sonnet and the PANE says Fable. A spec records
+    # what the agent was LAUNCHED on and can lag a switch made in the TUI, so
+    # the screen wins: the agent visibly capped on Fable is on Fable.
+    # Act
+    decision = _decide(spec_model="claude-sonnet-4-5", pane=FABLE_PANE)
+    # Assert
+    assert decision.verdict is Verdict.SWITCH_MODEL
+
+
+# --- NO SECOND FIRE --------------------------------------------------------
+
+
+def test_an_already_switched_agent_is_held() -> None:
+    # Arrange — we switched this agent and its pane has not advanced since,
+    # so the first switch's outcome is not yet visible. Firing again would
+    # type a second /model into a pane that may still show the first picker.
+    # Act
+    decision = _decide(already_switched=True)
+    # Assert
+    assert decision.verdict is Verdict.COOLING_DOWN
+
+
+def test_an_already_switched_agent_does_not_fire() -> None:
+    # Arrange — the same hold, asserted through the branch the pass reads.
+    # Act
+    decision = _decide(already_switched=True)
+    # Assert
+    assert decision.fires is False
+
+
+def test_an_advancing_pane_is_never_switched() -> None:
+    # Arrange — the banner MOVED between the two reads, so output is still
+    # being produced. That is an agent working, and this remedy's false
+    # positive is expensive: it would change the model of a healthy agent.
+    # Act
+    decision = _decide(pane=FABLE_PANE, second_pane=MOVED_PANE)
+    # Assert
+    assert decision.verdict is Verdict.MOVING
+
+
+# --- the population, and the refusals to guess ------------------------------
+
+
+def test_an_unmanaged_agent_is_not_ours() -> None:
+    # Arrange — restart.policy=never. sac never promised to keep this agent
+    # running, so its model is not sac's to change.
+    # Act
+    decision = _decide(policy="never")
+    # Assert
+    assert decision.verdict is Verdict.NOT_MANAGED
+
+
+def test_a_blind_session_read_refuses_to_guess() -> None:
+    # Arrange — the tmux enumeration itself failed. "We do not know whether
+    # this agent has a session" is not "it has none", and neither is a
+    # licence to type into a pane.
+    # Act
+    decision = _decide(session_present=None)
+    # Assert
+    assert decision.verdict is Verdict.UNREADABLE
+
+
+def test_an_uncapped_pane_has_nothing_to_switch() -> None:
+    # Arrange — the negative control at the rule layer. A working pane must
+    # never reach the mutation.
+    # Act
+    decision = _decide(pane=CLEAN_PANE)
+    # Assert
+    assert decision.verdict is Verdict.NOT_LIMITED


### PR DESCRIPTION
## What

A **fourth agent-liveness shape** for `_ratelimit`, and the remedy for it: an agent frozen behind a **model cap** is moved onto `opus[1m]` and kicked, instead of being waited on forever.

Four new modules, keeping this package's existing separation (pure parser / pure rule / one mutation / IO pass) rather than growing a subsystem:

| module | what it is |
| --- | --- |
| `_ratelimit/_modelcap.py` | PURE parser — both measured banners, a three-valued `readable`/`capped` observation, and `verify_switch()` |
| `_ratelimit/_switch_rule.py` | PURE rule — `SWITCH_MODEL(target="opus[1m]")` or today's verdict, nothing in between |
| `_ratelimit/_switch.py` | the mutation — the operator's three steps, three seconds apart, then a verifying capture |
| `_ratelimit/_switch_pass.py` | its own ledger (`SAC_MODEL_SWITCH_HISTORY`) and perform leg |

Wired as `sac agents resume-rate-limited --switch-model`, **OFF by default**. No new timer is armed.

## Why

**Measured 2026-09-06.** The operator sent two messages to a Fable-family agent and BOTH were answered by the harness with:

```
You've reached your Fable limit. Run /usage-credits to continue or switch models with /model.
```

The agent went silent to him. Three workflow subagents died in the same window with `You've hit your session limit · resets 2am (UTC)`.

sac's rate-wall reviver recovered neither, and it was not wrong to:

* `src/scitex_agent_container/_ratelimit/_banner.py:66` — `LIMIT_RE` anchors on `hit your <word> limit`. The Fable banner says **reached**, so it is invisible to the matcher.
* the Fable banner publishes **no reset clause at all**, so even a matcher that saw it would have nothing to wait for. `src/scitex_agent_container/_ratelimit/_rule.py:203` therefore returns `NOT-LIMITED` — "nothing for this pass to do" — about a visibly capped agent.
* the session-limit shape *does* publish an end, hours away.

A rate wall is a pause with a published end and waiting is the only correct action. A model cap is a wall to **walk around**, and the provider's own banner says how.

### Three decisions a reviewer should judge

**1. Steps 1–2 do not go through `_delivery.deliver`, and that is measured, not assumed.** `_resume.py` uses `deliver` and says why (an unverified send leaves a prompt unsubmitted at `❯`). That reasoning holds — for prose. It cannot carry a slash command: `_delivery/_deliver.py:127` calls `format_payload(message, token)` unconditionally, which returns `f"[sac-deliver:{token}] {message}"`. The payload reaches the composer as `[sac-deliver:a1b2c3] /model opus[1m]` — first character `[`, not `/` — which the TUI submits as prose about a model rather than an instruction to change one. There is no flag to suppress the token; it is the arrival matcher's whole mechanism. So steps 1–2 use the package's tmux helper, and **step 3 (the kick) IS prose and does go through `deliver`**, inheriting its proof that the payload left the compose box.

**2. Nothing is claimed from a send that returned 0.** `tmux send-keys` exiting 0 means tmux accepted a keystroke. The last thing `switch_model_now` does is capture the pane again and ask `verify_switch`, three-valued: `SWITCHED` / `SWITCH-FAILED` / `SWITCH-UNVERIFIED` (exit 2, alongside the other unresolved readings). The verifier also **subtracts the target-model occurrences sac itself typed into that pane** — a verifier that simply searched for `opus` would find its own keystrokes and certify every attempt, successful or not.

**3. The default is load-bearing.** With `--switch-model` unset the pass is byte-for-byte the pass it was, down to the exit code; `test_the_flag_off_changes_nothing` is the red half of a control whose only variable is the flag.

Also note `_account/rate_limit_signals.py:167` (#1288, merged onto develop while this branch was in flight) matched the same sentence for a **different** consumer — account rotation, over error text, deliberately firing on the whole cap family. Reusing it here would fire a model switch on every weekly-window phrasing and move agents off models that were never capped. The distinction is written into `_modelcap.py`'s docstring rather than left for the next reader to re-derive.

## Test plan

```
PYTHONPATH=<worktree>/src /opt/venv-sac/bin/python -m pytest <worktree>/tests/scitex_agent_container/_ratelimit -q -p no:cacheprovider
  -> 111 passed (44 new)

... tests/scitex_agent_container/{cli_pkg,_jobs} tests/scitex_agent_container/test_cli.py
  -> 2893 passed, 856 skipped, 16 deselected

uv tool run ruff check src/scitex_agent_container/_ratelimit src/.../cli_pkg/_agents_resume_rate_limited.py tests/.../_ratelimit
  -> 2 I001 findings, BOTH pre-existing on develop (_pass.py:31, test__pass.py:26) in blocks this PR does not touch;
     every line this PR changed is clean
uv tool run ruff check --select T201,T203 src/   ->   All checks passed
```

New coverage, and what each half is for:

* **parser** — both real banner strings (parametrised over the verbatim specimens), a **negative control** (an ordinary pane, including an agent talking *about* the Fable limit in prose, must not match), and an unreadable pane that reports `readable=False` rather than `capped=False`.
* **rule** — fires on the measured case; `ALREADY-ON-TARGET` for an agent already on opus; `COOLING-DOWN` for a second fire in one incarnation; `MOVING` for an advancing pane; a non-Fable agent behind the session wall keeps today's verdict.
* **mutation** — the three steps in the operator's order, `[0.0, 3.0, 6.0, 9.0]` on an **injected clock** (the fake sleep advances it, so no test sleeps), the verification capture runs, and all three of `True`/`False`/`None` come back from the pane rather than the send.
* **pass** — the flag-off / flag-on control, read-only stays read-only, the ledger stops a second switch, the resume ledger is *not* spent, and an unverified switch reaches the event log as degraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaiWJHYdhALg2wB4hRNft1
