### PR TITLE
fix(listen): a brokered start that 202s then exits 0 must not vanish silently

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -24,8 +24,8 @@ from starlette.responses import JSONResponse
 from .._sac_binary import SacBinaryNotFoundError, sac_binary
 from ._acl import check_spawn, deny_response
 from ._agent_exec_liveness import (
-    _POST_ACK_LIVENESS_TIMEOUT_S,
     _probe_post_ack_liveness,
+    post_ack_timeout_from_env,
 )
 from ._agent_exec_send import _find_claude_binary, agent_send
 from ._inline_spec import materialize_inline_spec
@@ -419,18 +419,12 @@ async def agents_start(request: Request) -> JSONResponse:
     from .._runners._session_state import state_dir_for
 
     runtime_dir = state_dir_for(name)
-    # Test escape hatch: ``SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S`` env
-    # var lets the suite skip / shorten the probe (≤0 → skip entirely).
-    # Production callers leave it unset and get the default grace window.
-    try:
-        env_timeout = float(
-            os.environ.get(
-                "SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S",
-                str(_POST_ACK_LIVENESS_TIMEOUT_S),
-            )
-        )
-    except ValueError:
-        env_timeout = _POST_ACK_LIVENESS_TIMEOUT_S
+    # Test escape hatch: ``SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S`` env var lets
+    # the suite skip / shorten the probe (<= 0 -> skip entirely). Production
+    # callers leave it unset and get the default grace window. Resolved by the
+    # SHARED helper so the detached post-202 path (``_spawn_detach``) probes on
+    # exactly this budget rather than a second, drifting copy of it.
+    env_timeout = post_ack_timeout_from_env()
     # Passing ``name`` is load-bearing: it lets the probe pick the check that is
     # VALID for this agent's runtime. Without it, the probe waits for an
     # ``apptainer_pid`` file that a ``tui`` agent — the fleet's DEFAULT runtime —

--- a/src/scitex_agent_container/_listen/_agent_exec_liveness.py
+++ b/src/scitex_agent_container/_listen/_agent_exec_liveness.py
@@ -42,9 +42,11 @@ from typing import Callable
 __all__ = [
     "_POST_ACK_LIVENESS_TIMEOUT_S",
     "_POST_ACK_LIVENESS_POLL_INTERVAL_S",
+    "POST_ACK_LIVENESS_TIMEOUT_ENV",
     "_pid_alive",
     "_probe_post_ack_liveness",
     "_runtime_writes_apptainer_pidfile",
+    "post_ack_timeout_from_env",
 ]
 
 # Grace window the listen waits AFTER `sac agents start <child>` returns rc=0
@@ -60,6 +62,30 @@ _POST_ACK_LIVENESS_TIMEOUT_S = 20.0
 
 # How often to re-check the apptainer_pid file inside the grace window.
 _POST_ACK_LIVENESS_POLL_INTERVAL_S = 0.1
+
+
+# Env knob the suite uses to shorten (or, at <= 0, skip) the grace window.
+POST_ACK_LIVENESS_TIMEOUT_ENV = "SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S"
+
+
+def post_ack_timeout_from_env() -> float:
+    """Resolve the post-ack grace window from the environment.
+
+    ONE definition, deliberately: the synchronous ``POST /agents`` path and the
+    detached post-202 path must probe on the SAME budget, or the 202 becomes a
+    degraded mode again by the back door — a caller could not tell whether the
+    absence of a ``startup_failed`` marker meant "healthy" or "the other path
+    used a different (or zero) window". A malformed value falls back to the
+    default rather than crashing a launch that has already been accepted.
+    """
+    try:
+        return float(
+            os.environ.get(
+                POST_ACK_LIVENESS_TIMEOUT_ENV, str(_POST_ACK_LIVENESS_TIMEOUT_S)
+            )
+        )
+    except ValueError:  # stx-allow: fallback (reason: a malformed operator knob must not break the probe; the documented default is the safe reading)
+        return _POST_ACK_LIVENESS_TIMEOUT_S
 
 
 def _runtime_writes_apptainer_pidfile(name: str) -> bool | None:

--- a/src/scitex_agent_container/_listen/_spawn_detach.py
+++ b/src/scitex_agent_container/_listen/_spawn_detach.py
@@ -2,8 +2,8 @@
 
 When ``POST /agents`` hits its declared answer-by deadline
 (:mod:`._handler_deadline`) the handler answers ``202 Accepted`` — but the
-launch it started is STILL RUNNING and must not be disturbed. Two things then
-have to be true, and neither is automatic:
+launch it started is STILL RUNNING and must not be disturbed. Three things then
+have to be true, and none of them is automatic:
 
 1. THE LAUNCH MUST NOT BE CANCELLED. ``asyncio.wait_for`` cancels its inner
    awaitable on timeout, which is the opposite of what we want here — the whole
@@ -18,24 +18,67 @@ have to be true, and neither is automatic:
    rc and stderr that explain WHY discarded when the task was garbage
    collected. The 202 would then have traded one silence for another.
 
-There is a third, quieter reason: an abandoned ``asyncio.Task`` whose exception
+3. rc == 0 IS NOT A SUCCESS REPORT — AND THAT HOLE SWALLOWED A WHOLE LAUNCH.
+   Measured 2026-09-06 on scitex-compute-04: ``sac agents start dotfiles``
+   brokered from a container answered 202 at 07:23:13 and then NOTHING
+   happened — no tmux session, no marker, no log line, not one file written
+   under the agent's state dir, for six minutes. Host forensics showed the
+   boot gate was taken at 07:22:43 and released normally, so the launch RAN
+   TO COMPLETION and this module's done callback DID fire; it simply took the
+   branch below that writes nothing, because the child exited 0 having started
+   nothing. The same command run on the host self-verified first try.
+
+   The asymmetry is the defect. On the SYNCHRONOUS path an rc=0 launch is not
+   believed on its word: ``_agent_exec`` runs
+   :func:`._agent_exec_liveness._probe_post_ack_liveness`, which for the
+   fleet's default ``tui`` runtime asks the agent's OWN runtime whether a
+   session exists and, on a POSITIVELY OBSERVED absence, writes
+   ``post_ack_session_absent`` + answers 502. That probe is unreachable once
+   the handler has answered 202, so the 202 path trusted an exit code that the
+   200 path explicitly refuses to trust. This module now runs the same probe on
+   the same budget after a detached launch, which is what makes the module
+   docstring's own claim below — "the 202 must not be a degraded mode" — true
+   rather than aspirational.
+
+There is a fourth, quieter reason: an abandoned ``asyncio.Task`` whose exception
 is never retrieved is collected with a "Task exception was never retrieved"
 warning and the error is gone. Holding a strong reference until the done
 callback runs is what makes the failure reportable at all.
+
+WHY EVERY LINE HERE IS ``WARNING`` AND NOT ``INFO``
+---------------------------------------------------
+Measured on the interpreter this fleet runs: uvicorn's ``LOGGING_CONFIG``
+defines handlers for ``uvicorn`` / ``uvicorn.error`` / ``uvicorn.access`` and NO
+root logger, with ``disable_existing_loggers`` false. A library ``INFO`` record
+from sac therefore reaches the journal only through ``logging.lastResort``,
+whose level is ``WARNING`` — i.e. it goes nowhere at all. Logging the detached
+path at ``INFO`` would look like fixing the silence while reproducing it. A
+brokered launch that outran its deadline is an exceptional event by
+construction (it blew a 30 s budget), so ``WARNING`` is also the honest level
+for it, not merely the reachable one.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 __all__ = ["detach_launch", "inflight_count"]
 
+logger = logging.getLogger(__name__)
 
-# Strong references to launches that outlived their handler's deadline. Without
-# this, the event loop holds only a weak reference and a still-running spawn can
-# be garbage collected mid-flight — taking its exception (and any chance of
-# writing the failure marker) with it. Entries are removed by the done callback.
+# Headroom added to the probe's own budget when dispatching it off the loop.
+# ``run_blocking`` needs a ceiling STRICTLY GREATER than the work it bounds, or
+# it would abandon a probe that was about to answer and report UNKNOWN — a
+# self-inflicted blind spot in the very check that exists to remove one.
+_PROBE_DISPATCH_MARGIN_S = 5.0
+
+# Strong references to launches that outlived their handler's deadline, plus the
+# follow-up verification tasks they spawn. Without this, the event loop holds
+# only a weak reference and a still-running spawn can be garbage collected
+# mid-flight — taking its exception (and any chance of writing the failure
+# marker) with it. Entries are removed by the done callbacks.
 _INFLIGHT: set[asyncio.Task] = set()
 
 
@@ -51,46 +94,222 @@ def _write_launch_marker(
     exit_code: int,
     stdout: str,
     stderr: str,
+    phase: str = "container_creation",
+    kind_override: str | None = None,
 ) -> None:
     """Best-effort ``STARTUP_FAILED`` write for a launch that failed AFTER 202.
 
     Mirrors the synchronous path's marker exactly (same ``phase``, same
-    fields) so a caller polling ``GET /agents/<name>/status`` cannot tell
-    whether the failure was reported inside the deadline or after it — the
-    diagnostic is identical either way. That equivalence is the point: the
-    202 must not be a degraded mode.
+    ``kind_override``, same fields) so a caller polling
+    ``GET /agents/<name>/status`` cannot tell whether the failure was reported
+    inside the deadline or after it — the diagnostic is identical either way.
+    That equivalence is the point: the 202 must not be a degraded mode.
+
+    A marker that could not be written (or that ``write_marker`` deliberately
+    declines to write, e.g. an operator's ``--yes``-less refusal) is LOGGED
+    rather than dropped: the whole failure mode this module now guards against
+    is an outcome that left no trace anywhere.
     """
     try:
         from .._lifecycle._startup_failed import write_marker
         from .._runners._session_state import state_dir_for
 
-        write_marker(
+        target = write_marker(
             state_dir_for(name),
             started_at=started_at,
-            phase="container_creation",
+            phase=phase,
             exit_code=exit_code,
             stdout=stdout,
             stderr=stderr,
+            kind_override=kind_override,
         )
-    except Exception:  # stx-allow: fallback (reason: the marker is observability for an already-answered request; a write failure must not raise inside a done callback, where it would be swallowed by the loop anyway)
-        pass
+    except Exception as exc:  # stx-allow: fallback (reason: the marker is observability for an already-answered request; a write failure must not raise inside a done callback, where the loop would swallow it. Not dropped: the line below goes to the daemon's stderr, which systemd captures into `journalctl -u sac-listen` at WARNING, which is the sink the whole module exists to reach.)
+        logger.warning(
+            "spawn_detach: could NOT write the STARTUP_FAILED marker for %r "
+            "(phase=%s kind=%s): %s: %s. The failure below is the only record.",
+            name,
+            phase,
+            kind_override,
+            type(exc).__name__,
+            exc,
+        )
+        return
+    if target is None:
+        logger.warning(
+            "spawn_detach: no STARTUP_FAILED marker written for %r (phase=%s) "
+            "— write_marker declined it (start was refused without --yes). "
+            "Recording it here so the outcome is not silent.",
+            name,
+            phase,
+        )
+
+
+def _tail(text: str, limit: int = 400) -> str:
+    """Last ``limit`` characters of ``text``, single-line, for a log record."""
+    flattened = " ".join((text or "").split())
+    if len(flattened) <= limit:
+        return flattened
+    return "..." + flattened[-limit:]
+
+
+async def _verify_post_ack(name: str, *, started_at: str, proc: Any) -> None:
+    """Run the SAME post-ack liveness probe the synchronous path runs.
+
+    Reached only for a detached launch that exited 0. ``rc == 0`` from
+    ``sac agents start`` means "the wrapper returned without error", NOT "an
+    agent is running" — the background branch is a ``Popen`` that reports
+    success the instant it forks, and a child can also return 0 having decided
+    to start nothing at all. Believing it is precisely the "Popen + rc=0
+    immediately" lie that Layer-3 fail-loud exists to catch, and the 202 path
+    had re-opened it.
+
+    UNKNOWN CONVICTS NOTHING. The probe returns a failure only on a POSITIVELY
+    OBSERVED absence; an unresolvable spec, a wedged tmux or a probe that
+    outran its dispatch ceiling are all "we could not tell", and stamping
+    ``startup_failed`` on those would hand an operator a death verdict whose
+    remedy (``--force --fresh``) destroys a healthy agent. Those cases are
+    LOGGED instead, which is the whole difference from before: a launch whose
+    outcome we cannot determine now says so, out loud, in the journal.
+    """
+    try:
+        from .._lifecycle._off_loop import run_blocking
+        from .._runners._session_state import state_dir_for
+        from ._agent_exec_liveness import (
+            _probe_post_ack_liveness,
+            post_ack_timeout_from_env,
+        )
+
+        budget = post_ack_timeout_from_env()
+        if budget <= 0.0:
+            # Operator/suite disabled the probe. Honour it on BOTH paths, or
+            # the two would disagree about what a missing marker means.
+            return
+        runtime_dir = state_dir_for(name)
+
+        def post_ack_liveness_probe() -> tuple[str, str] | None:
+            return _probe_post_ack_liveness(
+                runtime_dir, name=name, timeout_s=budget
+            )
+
+        try:
+            failure = await run_blocking(
+                post_ack_liveness_probe,
+                timeout_s=budget + _PROBE_DISPATCH_MARGIN_S,
+            )
+        except asyncio.TimeoutError:
+            # The probe itself wedged. It observed nothing, so it convicts
+            # nothing — but a launch we cannot verify must not pass in silence.
+            logger.warning(
+                "spawn_detach: post-ack liveness probe for %r did not return "
+                "within %.1fs; its outcome is UNKNOWN and no startup_failed "
+                "marker was written. Poll /agents/%s/status and check the "
+                "runtime dir by hand.",
+                name,
+                budget + _PROBE_DISPATCH_MARGIN_S,
+                name,
+            )
+            return
+        if failure is None:
+            logger.warning(
+                "spawn_detach: detached launch of %r verified — its runtime "
+                "reports a live session within %.1fs of the rc=0 exit.",
+                name,
+                budget,
+            )
+            return
+        kind, hint = failure
+        logger.warning(
+            "spawn_detach: detached launch of %r exited 0 but STARTED NOTHING "
+            "(%s). Writing a startup_failed marker so GET /agents/%s/status — "
+            "the route the 202 told the caller to poll — can say so. %s",
+            name,
+            kind,
+            name,
+            hint,
+        )
+        _write_launch_marker(
+            name,
+            started_at=started_at,
+            phase="post_ack_liveness",
+            exit_code=0,
+            stdout=getattr(proc, "stdout", "") or "",
+            stderr=(getattr(proc, "stderr", "") or "")
+            + f"\n\n[listen post-ack liveness probe] {kind}: {hint}\n",
+            kind_override=kind,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: this runs in a detached task for an already-answered request; it must never escape as an unretrieved-task exception. The line below reaches the daemon's stderr, which systemd captures into `journalctl -u sac-listen` at WARNING, which is the entire point of the module.)
+        logger.warning(
+            "spawn_detach: post-ack verification of %r blew up (%s: %s). The "
+            "launch's outcome is UNRECORDED; poll /agents/%s/status.",
+            name,
+            type(exc).__name__,
+            exc,
+            name,
+        )
+
+
+def _on_verify_done(task: "asyncio.Task") -> None:
+    """Drop the strong ref on a finished verification task."""
+    _INFLIGHT.discard(task)
+
+
+def _schedule_post_ack_verification(
+    name: str, *, started_at: str, proc: Any
+) -> None:
+    """Kick the blocking liveness probe OFF the done-callback's thread.
+
+    A done callback runs ON the event loop, and the probe blocks for up to the
+    full grace window. Running it inline would stall uvicorn for twenty seconds
+    per detached launch — the exact class of loop-blocking bug
+    :mod:`.._lifecycle._off_loop` was written to make impossible — so the work
+    is handed to a task that dispatches it through that bounded, dedicated-
+    thread helper.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(
+            _verify_post_ack(name, started_at=started_at, proc=proc)
+        )
+    except RuntimeError as exc:  # stx-allow: fallback (reason: the loop is gone or closing — e.g. the daemon is shutting down; nothing can be scheduled, and RAISING here would surface as an opaque "Exception in callback". The line below reaches the daemon's stderr, which systemd captures into `journalctl -u sac-listen` at WARNING instead.)
+        logger.warning(
+            "spawn_detach: no usable event loop to verify the detached launch "
+            "of %r (%s); its rc=0 exit is UNVERIFIED.",
+            name,
+            exc,
+        )
+        return
+    _INFLIGHT.add(task)
+    task.add_done_callback(_on_verify_done)
 
 
 def _on_launch_done(task: "asyncio.Task", *, name: str, started_at: str) -> None:
-    """Done callback: drop the strong ref, then record a failing outcome.
+    """Done callback: drop the strong ref, then RECORD the outcome.
 
-    A SUCCESSFUL launch needs nothing written — the agent's own liveness is the
-    record, and that is exactly what ``GET /agents/<name>/status`` reports. Only
-    failure needs a marker, because a failed spawn is otherwise indistinguishable
-    from an agent that was never asked to start.
+    Every terminal outcome now leaves a trace. A failing rc writes the marker as
+    before; an rc of 0 is handed to :func:`_verify_post_ack`, because "the
+    wrapper returned 0" and "an agent is running" are different claims and this
+    callback used to treat them as the same one — which is how a launch
+    disappeared without a single byte written anywhere (see the module
+    docstring).
     """
     _INFLIGHT.discard(task)
     if task.cancelled():
         # Should not happen (the launch is shielded), but a cancelled task has
         # no result to inspect and calling .result() would raise here.
+        logger.warning(
+            "spawn_detach: the detached launch of %r was CANCELLED — it is "
+            "shielded, so this should be unreachable. Outcome unknown.",
+            name,
+        )
         return
     exc = task.exception()
     if exc is not None:
+        logger.warning(
+            "spawn_detach: the detached launch of %r raised %s: %s",
+            name,
+            type(exc).__name__,
+            exc,
+        )
         _write_launch_marker(
             name,
             started_at=started_at,
@@ -101,6 +320,12 @@ def _on_launch_done(task: "asyncio.Task", *, name: str, started_at: str) -> None
         return
     proc: Any = task.result()
     returncode = getattr(proc, "returncode", None)
+    logger.warning(
+        "spawn_detach: detached launch of %r finished rc=%s (stderr tail: %s)",
+        name,
+        returncode,
+        _tail(getattr(proc, "stderr", "") or "") or "<empty>",
+    )
     if returncode not in (0, None):
         _write_launch_marker(
             name,
@@ -109,18 +334,29 @@ def _on_launch_done(task: "asyncio.Task", *, name: str, started_at: str) -> None
             stdout=getattr(proc, "stdout", "") or "",
             stderr=getattr(proc, "stderr", "") or "",
         )
+        return
+    _schedule_post_ack_verification(name, started_at=started_at, proc=proc)
 
 
 def detach_launch(task: "asyncio.Task", *, name: str, started_at: str) -> None:
     """Adopt ``task`` so it survives the handler that started it.
 
     Called ONLY when the handler has already decided to answer 202. Holds a
-    strong reference until completion, then records a failing outcome via
-    :func:`_write_launch_marker` so the caller's follow-up
+    strong reference until completion, then records the outcome via
+    :func:`_on_launch_done` so the caller's follow-up
     ``GET /agents/<name>/status`` carries the same diagnostic it would have
     carried on the synchronous path.
     """
     _INFLIGHT.add(task)
+    logger.warning(
+        "spawn_detach: the launch of %r outran the handler's deadline; "
+        "answering 202 and adopting it (started_at=%s, in flight=%d). Its "
+        "outcome will be logged here and, on failure, written to the agent's "
+        "STARTUP_FAILED marker.",
+        name,
+        started_at,
+        len(_INFLIGHT),
+    )
     task.add_done_callback(
         lambda t: _on_launch_done(t, name=name, started_at=started_at)
     )

--- a/tests/scitex_agent_container/_listen/test__spawn_detach_rc0_silence.py
+++ b/tests/scitex_agent_container/_listen/test__spawn_detach_rc0_silence.py
@@ -1,0 +1,359 @@
+"""A detached launch that exits 0 having started NOTHING must not be silent.
+
+THE MEASURED INCIDENT (2026-09-06, scitex-compute-04) THIS PINS
+---------------------------------------------------------------
+A container ran ``sac agents start dotfiles``. The host's ``sac listen``
+answered ``202 accepted (phase=launch)`` at 07:23:13 and the CLI exited 0 with
+"launch verification skipped: start was brokered to the host, the evidence lives
+on the host". There was no evidence on the host. No ``tui-dotfiles`` tmux
+session, no ``STARTUP_FAILED`` marker, not one file written under the agent's
+state dir that day, and — for the following six minutes — not one application
+line in the ``sac-listen`` journal beyond the 202 itself and the caller's own
+status polls. The service was healthy throughout. The SAME command run on the
+host worked first try and self-verified.
+
+Host forensics established the shape: the credential boot gate was taken at
+07:22:43 (its lock file holds the daemon pid, stamped exactly
+``AGENT_START_DEADLINE_S`` before the 202) and was released normally, so the
+launch RAN TO COMPLETION and the detach done-callback DID fire. It simply took
+the branch that writes nothing, because the child exited 0.
+
+WHAT IS UNDER TEST HERE — THE SILENCE, NOT THE CHILD
+-----------------------------------------------------
+WHY the child exited 0 without starting anything is NOT established, and cannot
+be recovered from that incident precisely because of the defect below: the
+child's rc, stdout and stderr existed in the daemon's memory and were read by
+nobody. So this module does not test a theory about the child. It tests the
+recording layer that lost it:
+
+* the synchronous ``POST /agents`` path does NOT believe ``rc == 0`` — it runs
+  the post-ack liveness probe and, on a positively-observed absence, writes a
+  ``STARTUP_FAILED`` marker and answers 502;
+* once the handler answers 202 that probe is unreachable, and the detached path
+  treated ``rc == 0`` as success and wrote nothing;
+* so the 202 was a DEGRADED MODE, contrary to ``_spawn_detach``'s own docstring
+  claim that "the diagnostic is identical either way".
+
+The two assertions are therefore: a marker appears, and a log line appears. A
+failure that leaves neither is indistinguishable from an agent nobody asked to
+start, which is exactly how six minutes of a real launch went missing.
+
+Same convention as the sibling deadline/subprocess modules: a real
+``TestClient`` against a real fake ``sac`` shim on ``$PATH``. No mocks — the
+shim really outlives the deadline and really exits 0 without creating a
+session, so this exercises the actual asyncio shield/detach/probe path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._lifecycle._startup_failed import read_marker
+from scitex_agent_container._listen import _handler_deadline, _spawn_detach
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._runners._session_state import state_dir_for
+from scitex_agent_container._state import registry as _reg
+
+_TOKEN = "spawn-detach-rc0-token"
+
+# The shim outlives the handler's deadline so the 202/detach path is the one
+# taken; it then exits 0 WITHOUT creating any session — the incident's shape.
+_SHIM_SLEEP_S = 1.0
+_TEST_DEADLINE_S = 0.3
+
+# The post-ack grace window for this module. Positive (so the probe actually
+# RUNS — the sibling deadline tests set it to 0 to opt out) and short, because
+# the shim writes no pidfile and never will, so the probe's answer is already
+# determined; the window only decides how long we wait to hear it.
+_PROBE_WINDOW_S = "0.5"
+
+# FAILSAFE ONLY — never a pacing budget. The aftermath loop exits the INSTANT
+# its condition holds, so a generous ceiling costs a fast run nothing and costs
+# a loaded run its false failure. See the sibling module's note on the
+# 2026-08-12 red: a clock standing in for an event.
+_AFTERMATH_TIMEOUT_S = 60.0
+
+
+class _RecordCollector(logging.Handler):
+    """Collect ``_spawn_detach``'s own records, whichever thread emits them.
+
+    Attached DIRECTLY to the module's logger rather than using ``caplog``: the
+    records are emitted from the app's event-loop thread during a fixture, and
+    a handler on the logger itself is indifferent to both — no phase bookkeeping
+    and no dependence on the root logger's level, which is the thing that makes
+    this path invisible in production in the first place.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+def _install_rc0_no_session_shim(bin_dir: Path, done_flag: Path) -> None:
+    """The incident's child: outlives the deadline, exits 0, starts NOTHING.
+
+    It writes no ``apptainer_pid``, opens no tmux session and leaves no trace in
+    the agent's state dir — the only thing it does is touch ``done_flag`` so the
+    test can prove the launch really ran to completion rather than being
+    cancelled by the 202.
+    """
+    script = bin_dir / "sac"
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import sys, time, pathlib\n"
+        f"time.sleep({_SHIM_SLEEP_S})\n"
+        f"pathlib.Path({str(done_flag)!r}).write_text('done')\n"
+        'sys.stdout.write("started agent (nothing was actually started)\\n")\n'
+        "sys.exit(0)\n"
+    )
+    script.chmod(0o755)
+
+
+class _Rc0Spawn(NamedTuple):
+    status_code: int
+    launch_completed: bool
+    marker: dict | None
+    log_messages: list[str]
+
+
+@pytest.fixture
+def isolated_listen_env(tmp_path: Path):
+    """Isolated state.db + registry/runtime dirs (mirrors the sibling tests)."""
+    saved = {
+        key: os.environ.get(key)
+        for key in ("SCITEX_AGENT_CONTAINER_STATE_DB", "HOME")
+    }
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(tmp_path / "state.db")
+    os.environ["HOME"] = str(tmp_path)
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    try:
+        yield tmp_path
+    finally:
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture
+def short_deadline():
+    """Shrink the handler's answer-by budget so the 202/detach path is taken.
+
+    ``agents_start`` imports ``AGENT_START_DEADLINE_S`` INSIDE its body, so
+    reassigning the module attribute is picked up on the next call — the same
+    save/restore seam the sibling deadline module uses.
+    """
+    saved = _handler_deadline.AGENT_START_DEADLINE_S
+    _handler_deadline.AGENT_START_DEADLINE_S = _TEST_DEADLINE_S
+    try:
+        yield _TEST_DEADLINE_S
+    finally:
+        _handler_deadline.AGENT_START_DEADLINE_S = saved
+
+
+@pytest.fixture
+def captured_detach_logs():
+    """Collect ``_spawn_detach``'s records for the duration of one test."""
+    collector = _RecordCollector()
+    detach_logger = logging.getLogger(_spawn_detach.__name__)
+    saved_level = detach_logger.level
+    detach_logger.addHandler(collector)
+    detach_logger.setLevel(logging.DEBUG)
+    try:
+        yield collector
+    finally:
+        detach_logger.removeHandler(collector)
+        detach_logger.setLevel(saved_level)
+
+
+@pytest.fixture
+def rc0_no_session_spawn(
+    isolated_listen_env,
+    short_deadline,
+    captured_detach_logs,
+    env_save_restore,
+    tmp_path: Path,
+) -> _Rc0Spawn:
+    """One brokered launch that 202s, then exits 0 having started nothing.
+
+    Function-scoped, like the sibling deadline module's fixtures: a
+    module-scoped fixture that mutates state in its body is what STX-TQ004
+    forbids, and the reason it forbids it — one test's leftovers deciding
+    another's verdict — is exactly the failure mode a regression test for a
+    SILENT bug can least afford, because its evidence is an ABSENCE.
+    """
+    name = "rc0-no-session"
+    flag = tmp_path / "flag_rc0"
+    bin_dir = tmp_path / "sac_bin_rc0"
+    bin_dir.mkdir()
+    _install_rc0_no_session_shim(bin_dir, flag)
+    env_save_restore.set(
+        "PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"
+    )
+    # Positive, unlike the sibling deadline module: the probe must RUN.
+    env_save_restore.set(
+        "SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", _PROBE_WINDOW_S
+    )
+    with TestClient(create_app(token=_TOKEN)) as client:
+        resp = client.post(
+            "/agents",
+            json={"name": name},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+        # Stay inside the client context so the app's event loop is alive and
+        # the detached done-callback + verification task can actually run.
+        watch_until = time.monotonic() + _AFTERMATH_TIMEOUT_S
+        marker = None
+        while time.monotonic() < watch_until:
+            marker = read_marker(state_dir_for(name))
+            if flag.exists() and marker is not None:
+                break
+            time.sleep(0.1)
+    return _Rc0Spawn(
+        status_code=resp.status_code,
+        launch_completed=flag.exists(),
+        marker=marker,
+        log_messages=list(captured_detach_logs.messages),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Preconditions — this really is the detached, uncancelled, rc=0 path
+# ---------------------------------------------------------------------------
+
+
+def test_the_slow_launch_is_answered_with_202(rc0_no_session_spawn) -> None:
+    """Guard on the setup: a 200 here would mean the probe ran synchronously."""
+    # Arrange
+    result = rc0_no_session_spawn
+    # Act
+    status = result.status_code
+    # Assert
+    assert status == 202
+
+
+def test_the_202_does_not_cancel_the_launch(rc0_no_session_spawn) -> None:
+    """The shim reached its final act, so the child really did exit 0."""
+    # Arrange
+    result = rc0_no_session_spawn
+    # Act
+    completed = result.launch_completed
+    # Assert
+    assert completed is True
+
+
+# ---------------------------------------------------------------------------
+# THE REGRESSION: the silence itself
+# ---------------------------------------------------------------------------
+
+
+def test_an_rc0_launch_that_started_nothing_writes_a_startup_failed_marker(
+    rc0_no_session_spawn,
+) -> None:
+    """The incident, exactly: rc=0, no session, and nothing written anywhere.
+
+    Before the fix this assertion fails with ``marker is None`` — which is not
+    the test being flaky, it IS the bug: ``_on_launch_done`` wrote a marker only
+    when ``returncode not in (0, None)``, so a child that exited 0 having
+    started nothing was recorded nowhere, and ``GET /agents/<name>/status`` —
+    the route the 202 tells the caller to poll — had nothing to report.
+    """
+    # Arrange
+    result = rc0_no_session_spawn
+    # Act
+    marker = result.marker
+    # Assert
+    assert marker is not None
+
+
+def test_the_late_marker_names_the_post_ack_liveness_phase(
+    rc0_no_session_spawn,
+) -> None:
+    """Same phase the SYNCHRONOUS path stamps — the 202 is not a degraded mode.
+
+    If the detached path convicted under some other phase, a caller could tell
+    which side of the deadline its spawn fell on, and the equivalence the module
+    docstring promises would be decorative.
+    """
+    # Arrange
+    result = rc0_no_session_spawn
+    # Act
+    phase = (result.marker or {}).get("phase")
+    # Assert
+    assert phase == "post_ack_liveness"
+
+
+def test_the_late_marker_carries_the_probe_s_positively_observed_kind(
+    rc0_no_session_spawn,
+) -> None:
+    """A ``post_ack_*`` kind is what makes the marker actionable rather than
+    merely present — it says the probe RAN and observed an absence."""
+    # Arrange
+    result = rc0_no_session_spawn
+    # Act
+    kind = str((result.marker or {}).get("kind", ""))
+    # Assert
+    assert kind.startswith("post_ack_")
+
+
+def test_the_detached_outcome_is_logged(rc0_no_session_spawn) -> None:
+    """The other half of the silence: the journal held ZERO application lines.
+
+    ``rg -n 'logging|logger|print\\('`` over the whole path returned nothing
+    before this change, so a launch could complete, fail, or vanish without the
+    daemon ever saying a word. The 202 in the journal was uvicorn's ACCESS line,
+    not sac's.
+    """
+    # Arrange
+    result = rc0_no_session_spawn
+    # Act
+    messages = result.log_messages
+    # Assert
+    assert messages != []
+
+
+def test_a_logged_line_names_the_agent_that_started_nothing(
+    rc0_no_session_spawn,
+) -> None:
+    """An operator reading the journal must be able to tell WHICH agent."""
+    # Arrange
+    result = rc0_no_session_spawn
+    # Act
+    naming = [m for m in result.log_messages if "rc0-no-session" in m]
+    # Assert
+    assert naming != []
+
+
+def test_a_logged_line_says_the_launch_started_nothing(
+    rc0_no_session_spawn,
+) -> None:
+    """The line has to carry the VERDICT, not just the agent's name.
+
+    A log that says only "launch finished rc=0" reproduces the original lie in
+    a louder voice; the point is that the daemon now says the rc=0 exit did not
+    produce a running agent.
+    """
+    # Arrange
+    result = rc0_no_session_spawn
+    # Act
+    verdicts = [m for m in result.log_messages if "STARTED NOTHING" in m]
+    # Assert
+    assert verdicts != []


### PR DESCRIPTION
fix(listen): a brokered start that exits 0 having started nothing is no longer silent

## The defect, measured

`sac agents start dotfiles` brokered from inside a container on scitex-compute-04:

```
07:23:13Z  POST /agents -> 202 Accepted  ("spawn in flight, poll status")
           CLI exits 0: "launch verification skipped — brokered to the host"
then       no tmux session, no startup_failed marker, no log line, and NOT ONE
           file written under the agent's state dir (newest was 2026-08-23)
           sac-listen journal: the 202, then only my own status polls
```

The broker was healthy throughout (`sac-listen.service` active, pid 532567 on
0.0.0.0:7878). The identical command run **on the host** worked first try and
self-verified: *"ready: boot drain passed and the tmux pane process is alive
(probed 40.7s after launch)"*.

## Why

Two silent windows, and the second is the real one.

**1. Queued.** `run_brokered_launch` step 1 is an unbounded blocking
`fcntl.flock(LOCK_EX)` on `creds-refresh.lock`. Measured: that lock was held
from 07:22:43 until after 07:39 — **17+ minutes** against a documented ≤20s
settle window — confirmed held by a non-blocking `flock` returning `EAGAIN`, and
confirmed released later by the same probe acquiring it. While queued,
`_INFLIGHT` holds a live task for the name, the done-callback has not fired, no
marker exists, and `GET /agents/<name>/status` returns its default prose:
*"nobody is home … nothing will reconnect until someone deliberately starts
it."* The 202 designates that endpoint as its source of truth, and that endpoint
contradicts it — and tells the caller to start the agent again, which is the
duplicate start that then happened.

**2. rc == 0 is not a success report.** The `STARTUP_FAILED` marker is written
only when `returncode != 0`, and `detach_launch`'s callback records only a
*failing* outcome. So a launch that exits 0 **having started nothing** leaves no
marker, no log and no status change.

The asymmetry is the defect: on the synchronous path an rc=0 launch is *not*
believed on its word — `_agent_exec` runs `_probe_post_ack_liveness`, which for
the default `tui` runtime asks the agent's own runtime whether a session exists
and, on a **positively observed** absence, writes `post_ack_session_absent` and
answers 502. That probe is unreachable once the handler has answered 202. **The
202 path trusted an exit code that the 200 path explicitly refuses to trust.**

## The fix

Run the same probe, on the same budget, after a detached launch; write the
marker and log the outcome.

- the marker fires on a **positively observed** absence only, preserving the
  three-valued discipline where UNKNOWN authorises nothing — a healthy-but-slow
  agent is not stamped `startup_failed`
- the post-ack timeout is resolved through one shared
  `post_ack_timeout_from_env()` so the synchronous and detached paths cannot
  drift apart on how long to wait
- `_PROBE_DISPATCH_MARGIN_S = 5.0`: the dispatch ceiling must exceed the work it
  bounds, or it abandons a probe about to answer and reports UNKNOWN
- every line logs at **WARNING**, measured: uvicorn's `LOGGING_CONFIG` defines no
  root logger, so a library `INFO` record reaches the journal only via
  `logging.lastResort` (level WARNING) — i.e. nowhere. Logging this at INFO would
  look like fixing the silence while reproducing it.

**The 202 contract is untouched.** `wait_for(shield(launch))`, the
`TimeoutError` branch, `detach_launch(...)` and the `accepted_payload` response
are unchanged — "this is not a failure and must not be retried" still holds.

## Verification

Regression test reproduces the defect, not a mock of it: a real
`POST /agents` through `TestClient(create_app())`, a shim on `PATH` that exits 0
having started nothing, a real handler on the real `_spawn_detach` logger, and
the test stays inside the client context so the event loop is alive and the
detached callback actually runs.

**Negative control, run by the orchestrator independently of the author** —
revert `_spawn_detach.py` to its pre-fix parent, keep the tests, re-run:

```
with the fix:      8 passed in 14.45s
source reverted:   6 failed, 2 passed in 484.10s (0:08:04)
after restore:     8 passed in 14.52s
```

The right six fail — the marker, its phase, the probe's positively-observed kind,
and all three logging assertions. The two that still pass are the preconditions
(`the_slow_launch_is_answered_with_202`, `the_202_does_not_cancel_the_launch`),
which assert behaviour that exists *without* the fix; a control in which
everything failed would have been the suspicious result.

Note the reverted run takes **484 seconds against 14**: without the fix the module
does not fail fast, it waits out its aftermath failsafe for a marker that is never
written. That is the defect in its purest form — not a wrong answer, an absent one.

The revert was proven non-vacuous (`git status` showed the file modified) before the
result was read; the tree and the stash count were asserted identical afterwards.

**Full suite** (author's run, on the merged tree):
`6 failed, 16275 passed, 2416 skipped, 23 deselected in 947.54s`.
The six are pre-existing and environmental — `test_codex_session_daemon.py` (3) and
`test_openai_session_daemon.py` (3), all dying in `assert_venv_distributions_unique`
on a duplicate `scitex-dev` dist-info in `/opt/venv-sac`. Proven pre-existing by
reverting all three source files, moving the new test out of the tree, and re-running
those two modules alone: same six, same error.

`PYTHONPATH=<worktree>/src` is required on every pytest invocation here — without it
the repo's `enforce_pytest_worktree_source` hook means pytest collects the worktree's
tests but runs the MAIN checkout's code.

## Not in scope

The 17-minute lock hold itself. That is a separate question — why the credential
gate is held far beyond its designed window — and is worth its own card. This PR
makes the consequence visible rather than pretending the wait does not happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaiWJHYdhALg2wB4hRNft1
