### PR TITLE
feat(engines): sac agents migrate-engines — write HARNESS x ENGINE into every spec

### DIFF
--- a/.scitex/agent-container/engines.yaml
+++ b/.scitex/agent-container/engines.yaml
@@ -1,0 +1,76 @@
+# THE FLEET ENGINE LIBRARY — the engines an agent can name, declared ONCE.
+#
+# WHERE THIS FILE BELONGS. Here, tracked, beside `agents/` — the same
+# `.scitex/agent-container/` layout `config/_engine_library.py` resolves, so
+# the reviewed copy and the deployed copy are the SAME shape and a diff
+# between them is readable. It is tracked because it is a fleet-wide
+# decision: `engine:` below repoints every agent that has not pinned itself,
+# and a decision that large does not belong in an untracked file on one host.
+#
+# HOW IT IS FOUND AT RUNTIME, stated rather than assumed
+# (`_engine_library.fleet_engines_path`, measured on this host 2026-09-06):
+#
+#     $SAC_ENGINES_FILE            unset  — ops/test override only, never a
+#                                           spec surface, and nothing in the
+#                                           sweep may depend on it
+#     $SCITEX_DIR                  unset  — so `state_paths.scitex_dir()`
+#                                           takes its DOCUMENTED default,
+#                                           ~/.scitex
+#     => ~/.scitex/agent-container/engines.yaml
+#
+# That path already holds `agents/`, `accounts/`, `containers/` and
+# `runtime/` on every fleet host, so the library lands beside the state it
+# describes. `$SCITEX_DIR` being unset is the default case, not a gap: the
+# resolver names `~/.scitex` explicitly and a relocated state root (Spartan
+# exports one) takes the library with it. This file is DEPLOYED to that path
+# like every other spec; the deployed copy is a synced copy and is never
+# hand-edited.
+#
+# A MISSING LIBRARY IS LEGAL AND SILENT — every spec then resolves exactly as
+# it did before. An unreadable or self-contradictory one is a LOAD ERROR
+# naming this path, never an empty default.
+
+apiVersion: scitex-agent-container/v3
+kind: EngineLibrary
+
+# THE FLEET DEFAULT is deliberately NOT set here. Uncommenting one line moves
+# every agent that pins nothing onto that engine, and picking which one is the
+# operator's call, not the migration's:
+#
+#   engine: qwen38-27b
+#
+# Note the precedence (`_engine_precedence`): a spec's own `engine:` pin, a
+# spec-local engines block, and a legacy `spec.claude` backend all sit ABOVE
+# this line, so writing it changes nothing for a spec that still states its
+# own backend. It becomes real one agent at a time, as the sweep clears each
+# legacy pin.
+
+engines:
+  # The fleet Qwen gateway, declared ONCE instead of copied into 119 specs —
+  # which is what `sac agents migrate-engines` used to do, and why this file
+  # exists. Selectable anywhere with `--engine qwen38-27b`; pinnable in one
+  # spec with `engine: qwen38-27b` at the top of its `spec:`.
+  qwen38-27b:
+    model: qwen38-27b
+
+    # NAMED, not addressed. `qwen-gateway` resolves through
+    # `config/_provider_registry` at START time, on whichever host the agent
+    # actually starts on, so the ADDRESS lives in `config/_qwen_gateway.py`
+    # and moving the gateway is an edit there rather than here. A host that
+    # reaches it by another route overrides $SAC_QWEN_GATEWAY_URL without
+    # anyone editing YAML.
+    provider: qwen-gateway
+
+    # Q4 (operator, 2026-09-03): Qwen runs at low effort permanently.
+    reasoning_effort: low
+
+    # The window the gateway actually serves (serve conf
+    # MAX_MODEL_LEN=1048576). Claude Code assumes 200k for a model it does
+    # not recognise and auto-compacts at that boundary; on `business`'s
+    # resumed 1M session the compaction request itself crashed the engine.
+    max_context_tokens: 1048576
+
+    # NO `harness:` LINE, deliberately. An entry that states one claims the
+    # HARNESS axis — the coupling the harness/engine split removes. Stating
+    # none means "no opinion", so the spec's own `harness:` wins and this ONE
+    # entry serves a Claude-Code agent and a Codex agent unchanged.

--- a/docs/harness-and-engine.md
+++ b/docs/harness-and-engine.md
@@ -60,10 +60,21 @@ proof the two axes are orthogonal:
 
 #### The fleet engine library — `$SCITEX_DIR/agent-container/engines.yaml`
 
-Source of truth: `~/.dotfiles/src/.scitex/agent-container/engines.yaml`, deployed
-like every other spec. `$SCITEX_DIR/agent-container/` is a **synced copy**, never
-hand-edited. `$SAC_ENGINES_FILE` overrides the path for one process (ops/test
-only — never a spec surface).
+Source of truth: [`.scitex/agent-container/engines.yaml`](../.scitex/agent-container/engines.yaml)
+**in this repo**, tracked beside the code that defines the provider names it
+uses — so the library and `config/_provider_registry` are reviewed in one diff
+instead of drifting across two repos. It is deployed to
+`$SCITEX_DIR/agent-container/engines.yaml`; that copy is a **synced copy**,
+never hand-edited.
+
+How that path is resolved, with nothing assumed (`fleet_engines_path`):
+`$SAC_ENGINES_FILE` wins if set — an ops/test override for ONE process, never a
+spec surface — otherwise `$SCITEX_DIR` (documented default `~/.scitex`) plus
+`agent-container/engines.yaml`. Both variables are unset on the fleet hosts, so
+the library lands at `~/.scitex/agent-container/engines.yaml`, beside the
+`agents/` directory it describes. That is the default case, not a gap: a host
+that relocates its state root (Spartan exports `$SCITEX_DIR`) takes the library
+with it.
 
 ```yaml
 apiVersion: scitex-agent-container/v3

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -243,34 +243,26 @@ declares `engines:`, at which point the legacy reading is deleted.
 **The sweep that gets there:** `sac agents migrate-engines`. Dry-run by
 DEFAULT — it writes nothing and prints a unified diff per spec — with
 `--apply` as the deliberate act and `--agent` / `--host` / `--limit` for
-batching. Each spec's CURRENT backend becomes its DEFAULT engine, restated
-verbatim, and a `qwen38-27b` alternate is added pointing at the fleet gateway
-by NAME (`provider: qwen-gateway`), so the address lives in
-[`config/_qwen_gateway.py`](../src/scitex_agent_container/config/_qwen_gateway.py)
-— overridable per host with `$SAC_QWEN_GATEWAY_URL` — instead of being copied
-into 119 files. `spec.claude.model` and `spec.claude.provider` are EMPTIED
-(present, stating nothing — the explicit-spec ruling keeps the keys) because
-the engines now carry them; `spec.harness` stays stated and agrees with the
-default engine. The edit is line surgery, not a YAML round-trip, so operator
-comments survive, and it re-parses its own output through `parse_engines`,
-`validate_engines` and `legacy_conflict_messages` before returning. The apply
-loads every spec before and after and restores every original unless the
-effective backend is unchanged.
+batching. Each spec's CURRENT backend becomes ONE named engine, restated
+verbatim; `spec.claude.model` and `spec.claude.provider` are EMPTIED (present,
+stating nothing — the explicit-spec ruling keeps the keys) while `spec.harness`
+stays stated and the entry inherits it. The edit is line surgery, so comments
+survive, and it re-parses its own output through `parse_engines`,
+`validate_engines` and `legacy_conflict_messages` first. The apply loads every
+spec before and after and restores every original unless the effective backend
+is unchanged. Precedence, the worked YAML cases and the harness × engine
+refusal table: [`harness-and-engine.md`](harness-and-engine.md).
 
-**KNOWN MISMATCH, stated rather than shipped silently.** The sweep as it stands
-today still writes the two entry fields the table above marks DEPRECATED —
-`default: true` on the chosen entry, and a per-entry `harness:` — and it copies
-a `qwen38-27b` entry into every spec rather than leaving that definition to the
-fleet engine library. All three still parse and still behave correctly, so
-nothing is broken; but a spec-local `default:` OUTRANKS the fleet library in
-precedence, so a sweep run before the adaptation lands would trade 119 legacy
-pins for 119 engines pins and leave a fleet-wide engine flip still a 119-file
-edit. Retargeting the sweep's write side onto the `spec.engine:` /
-fleet-library grammar is tracked as the follow-up to this merge; until it
-lands, read the sweep's output as "clears the legacy block", not as "adopts the
-new grammar". The precedence order, the three worked YAML cases and the
-harness × engine refusal table are in
-[`harness-and-engine.md`](harness-and-engine.md).
+**What it deliberately does NOT write:** no per-entry `harness:` (that claims
+the HARNESS axis); no `default: true` (a spec-local default OUTRANKS the fleet
+library — `engine: <key>` at the top of `spec:` is the one-line pin); and no
+copied `qwen38-27b`, which lives once in the tracked
+[fleet library](../.scitex/agent-container/engines.yaml), deployed to
+`$SCITEX_DIR/agent-container/engines.yaml` (`$SAC_ENGINES_FILE` unset,
+`$SCITEX_DIR` at its documented `~/.scitex` default) and reached with `--engine
+qwen38-27b`. Its ADDRESS stays in
+[`_qwen_gateway.py`](../src/scitex_agent_container/config/_qwen_gateway.py) as
+`provider: qwen-gateway`, overridable per host with `$SAC_QWEN_GATEWAY_URL`.
 
 **A version floor, enforced at plan time.** A sac older than 2026-09-03
 (commit `0d61e077`) does not ignore an unknown `engines:` key — it REJECTS the

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -249,6 +249,20 @@ comments survive, and it re-parses its own output through `parse_engines`,
 loads every spec before and after and restores every original unless the
 effective backend is unchanged.
 
+**Where it writes, and how a batch advances.** The root is `--root DIR`, else
+`$SCITEX_AGENT_CONTAINER_AGENTS_DIR`, else `$HOME/.scitex/agent-container/agents`
+— the LIVE copy, which is not a git checkout, and inside a container is not the
+host's `$HOME` either. Every report names the root it searched; pass `--root` to
+sweep the git-tracked tree instead. `--limit N` caps what is WRITTEN, not what is
+examined: already-migrated and refused specs do not consume the cap, so running
+the same command again takes the NEXT N and the specs past the cap are reported
+as `held_back` rather than dropped. `--host` reads each spec to decide, and one
+it cannot read is KEPT so it reaches the plan as `unreadable` — a filter that
+excluded it would be the flag that disables the guard blocking an unsafe apply.
+In `--json`, `migration_complete` is the answer to "is the sweep finished"; the
+exit code is not, because a run that wrote nothing because every spec was
+refused also exits 0.
+
 **Preflight, three-valued:** `sac agents migrate-engines --preflight` names
 what the gateway did rather than returning a boolean —
 `reachable-but-unauthorized` (a 401 proves something is listening and

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -249,10 +249,32 @@ comments survive, and it re-parses its own output through `parse_engines`,
 loads every spec before and after and restores every original unless the
 effective backend is unchanged.
 
+**A version floor, enforced at plan time.** A sac older than 2026-09-03
+(commit `0d61e077`) does not ignore an unknown `engines:` key — it REJECTS the
+spec. Measured by running that commit's PARENT validator over a real fleet
+spec: 0 errors without the block, exactly one with it
+(`Unknown spec field 'engines'`). So writing the block into a spec pinned on
+such a host stops that agent starting, at a validator on a machine nobody is
+watching. The sweep therefore REFUSES those specs by name BEFORE the write,
+against a recorded roster of measured hosts in
+[`_maintenance/_engines_floor.py`](../src/scitex_agent_container/_maintenance/_engines_floor.py)
+— measured by FIX PRESENCE (is `apply_default_engine` in that host's own
+`config/_engine_types.py`), not by a version string. It **fails closed**: a
+host absent from the roster is refused, never assumed capable, and so is a
+spec that names no host at all. `--host-supports-engines HOST` (repeatable)
+lifts the floor for a machine you have checked yourself, and the claim is
+recorded in `engine_floor_overrides` in `--json`. A floor refusal is a NAMED
+refusal like any other: it does not fail the exit code and does not make the
+plan unsafe to apply — it just means those specs are not written.
+
 **Where it writes, and how a batch advances.** The root is `--root DIR`, else
-`$SCITEX_AGENT_CONTAINER_AGENTS_DIR`, else `$HOME/.scitex/agent-container/agents`
-— the LIVE copy, which is not a git checkout, and inside a container is not the
-host's `$HOME` either. Every report names the root it searched; pass `--root` to
+`$SCITEX_AGENT_CONTAINER_AGENTS_DIR`, else EVERY user-scope root the rest of
+the CLI resolves (`sac agents find` / `sac agents start` share that resolver),
+de-duplicated by agent name with the earlier root winning. The old default
+read a different env var and landed on `$HOME/.scitex/agent-container/agents`,
+which inside a container is the container's own home — measured, one spec
+beside the fleet's 123, reported as a finished sweep. Every report names the
+roots it searched (`roots` in `--json`); pass `--root` to
 sweep the git-tracked tree instead. `--limit N` caps what is WRITTEN, not what is
 examined: already-migrated and refused specs do not consume the cap, so running
 the same command again takes the NEXT N and the specs past the cap are reported

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -232,6 +232,31 @@ and silently. Both blocks that AGREE are accepted; both that DISAGREE are a
 hard load error naming both values. The migration ends when every deployed spec
 declares `engines:`, at which point the legacy reading is deleted.
 
+**The sweep that gets there:** `sac agents migrate-engines`. Dry-run by
+DEFAULT — it writes nothing and prints a unified diff per spec — with
+`--apply` as the deliberate act and `--agent` / `--host` / `--limit` for
+batching. Each spec's CURRENT backend becomes its DEFAULT engine, restated
+verbatim, and a `qwen38-27b` alternate is added pointing at the fleet gateway
+by NAME (`provider: qwen-gateway`), so the address lives in
+[`config/_qwen_gateway.py`](../src/scitex_agent_container/config/_qwen_gateway.py)
+— overridable per host with `$SAC_QWEN_GATEWAY_URL` — instead of being copied
+into 119 files. `spec.claude.model` and `spec.claude.provider` are EMPTIED
+(present, stating nothing — the explicit-spec ruling keeps the keys) because
+the engines now carry them; `spec.harness` stays stated and agrees with the
+default engine. The edit is line surgery, not a YAML round-trip, so operator
+comments survive, and it re-parses its own output through `parse_engines`,
+`validate_engines` and `legacy_conflict_messages` before returning. The apply
+loads every spec before and after and restores every original unless the
+effective backend is unchanged.
+
+**Preflight, three-valued:** `sac agents migrate-engines --preflight` names
+what the gateway did rather than returning a boolean —
+`reachable-but-unauthorized` (a 401 proves something is listening and
+demanding a key), `connection-refused` (the one definite negative), or
+`name-does-not-resolve` (undetermined: `curl` prints `000` for a hostname
+typo and for a dead host alike). The spelling that resolves fleet-wide is
+`scitex-compute-04`; `compute-04` and `compute-04-lan` do not.
+
 ### `spec.claude` — SDK knobs
 
 | Field                       | Type                                  | Description                                                       |

--- a/src/scitex_agent_container/_maintenance/_engines_apply.py
+++ b/src/scitex_agent_container/_maintenance/_engines_apply.py
@@ -147,7 +147,7 @@ def _restore(targets, archive_dir: Path) -> "list[str]":
         except (
             OSError,
             shutil.Error,
-        ) as exc:  # stx-allow: fallback (reason: one spec that cannot be restored must not abandon the rest; it is named and reported)
+        ) as exc:  # stx-allow: fallback (reason: one spec that cannot be restored must not abandon the rest; it is named into the returned failures list, which becomes MigrationApply.errors and is reported on stdout by `sac agents migrate-engines`)
             failures.append(f"{outcome.agent}: could not be restored: {exc}")
     return failures
 

--- a/src/scitex_agent_container/_maintenance/_engines_apply.py
+++ b/src/scitex_agent_container/_maintenance/_engines_apply.py
@@ -40,6 +40,12 @@ class ApplyResult:
     """What the apply actually did."""
 
     written: "tuple[str, ...]" = ()
+    #: The same writes, as PATHS. ``written`` carries agent NAMES, which is
+    #: what a human reads — and a name cannot answer "which root did that
+    #: land in?". The default sweep searches several roots, one of which is
+    #: the container's own ``$HOME``, so an agent name is not enough to tell
+    #: a fleet spec from a stray one under a root nobody meant to write.
+    written_paths: "tuple[str, ...]" = ()
     archive_dir: "Path | None" = None
     applied: bool = False
     refused: str = ""
@@ -233,6 +239,7 @@ def apply_engines_migration(plan, archive_dir: Path) -> ApplyResult:
         )
     return ApplyResult(
         written=tuple(o.agent for o in targets),
+        written_paths=tuple(str(o.path) for o in targets),
         archive_dir=archive_dir,
         applied=True,
     )

--- a/src/scitex_agent_container/_maintenance/_engines_apply.py
+++ b/src/scitex_agent_container/_maintenance/_engines_apply.py
@@ -1,0 +1,238 @@
+"""Write the ``spec.engines`` sweep, and undo it unless nothing moved.
+
+Split out of :mod:`._engines_migration`, which now owns only the PLAN. The
+two halves answer different questions — "what would this do?" reads files,
+"do it" rewrites them and must be able to put every one back — and the
+apply half is where every failure mode with teeth lives:
+
+**THE GATE IS A MEASUREMENT, NOT AN ARGUMENT.** The edit restates the
+backend a spec already declares, so it cannot change what an agent starts
+on. That is the argument, and an argument has never stopped a bulk edit
+from being wrong. Every selected spec is loaded through the production
+loader BEFORE the write and again after, and unless the effective backend
+is identical for every one, every original is restored. A gate is only
+worth its exit code if it measures the fields the edit can actually move —
+see :func:`_backend_snapshot`, which was measuring four of six.
+
+**A WRITE EITHER LANDS OR DOES NOT.** ``Path.write_text`` truncates before
+it writes, so an interrupted write leaves half a spec. Every write here is
+a temp file plus ``os.replace``.
+
+**A FAILED BATCH IS ROLLED BACK, NOT ABANDONED.** Measured: one spec at
+mode 444 part-way through a batch raised out of the apply, through the
+Click callback, and exited 1 on a traceback — two specs rewritten, four
+untouched, the archive taken and never consulted, and no report of either.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["ApplyResult", "apply_engines_migration"]
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """What the apply actually did."""
+
+    written: "tuple[str, ...]" = ()
+    archive_dir: "Path | None" = None
+    applied: bool = False
+    refused: str = ""
+    rolled_back: str = ""
+    drift: "tuple[str, ...]" = ()
+    #: I/O failures — the write that could not happen, and any restore that
+    #: could not undo it. Separate from ``drift`` because "the backend moved"
+    #: and "the disk said no" need different responses from a human.
+    errors: "tuple[str, ...]" = ()
+
+
+def _backend_snapshot(path: Path):
+    """The effective backend this spec resolves to, through the real loader.
+
+    EVERY FIELD THE EDIT COULD MOVE, not only the ones it means to keep.
+    ``claude.model`` alone was measured and it is the ENGINE-RESOLVED value,
+    so it came back identical while the top-level ``config.model`` and the
+    container-injected ``SCITEX_AGENT_CONTAINER_MODEL`` — both derived from
+    the RAW ``spec.claude.model`` this edit empties — flipped to the
+    ``sonnet`` default on 117 of 119 specs. The gate certified zero drift
+    over a fleet-wide misreport. A gate that measures only what the author
+    expected to change is an argument wearing a measurement's clothes.
+    """
+    from ..config import load_config
+    from ..config._parsers import MODEL_ENV_KEY
+
+    config = load_config(path)
+    claude = getattr(config, "claude", None)
+    provider = getattr(claude, "provider", None)
+    endpoint = None
+    if provider is not None:
+        endpoint = (
+            str(getattr(provider, "base_url", "") or ""),
+            str(getattr(provider, "auth_token_env", "") or ""),
+        )
+    env = getattr(config, "env", None) or {}
+    return (
+        str(getattr(config, "harness", "") or ""),
+        str(getattr(claude, "model", "") or ""),
+        endpoint,
+        str(getattr(claude, "account", "") or ""),
+        str(getattr(config, "model", "") or ""),
+        str(env.get(MODEL_ENV_KEY, "")),
+    )
+
+
+def _snapshot_all(paths):
+    """``(snapshots, unmeasurable)`` — a spec that will not load is named."""
+    snapshots: dict[str, object] = {}
+    unmeasurable: list[str] = []
+    for path in paths:
+        try:
+            snapshots[str(path)] = _backend_snapshot(path)
+        except Exception as exc:  # stx-allow: fallback (reason: a spec the loader rejects is UNMEASURABLE, the honest third value; enumerating loader exception types would turn any new one into a crash mid-sweep)
+            unmeasurable.append(f"{path.parent.name}: {type(exc).__name__}: {exc}")
+    return snapshots, unmeasurable
+
+
+def _write_atomically(path: Path, text: str) -> None:
+    """Replace ``path``'s contents with ``text`` — all of it, or none of it.
+
+    ``Path.write_text`` TRUNCATES the target before it writes a byte, so an
+    ENOSPC or a disconnect part-way leaves HALF a spec on disk and nothing to
+    fall back on but the archive. A temp file beside the target plus
+    ``os.replace`` means the file is either the old bytes or the new ones.
+
+    ``newline=""`` for the reason ``_engines_migration.read_spec_text``
+    states: the editor already chose this file's line endings, and letting
+    the writer translate them again rewrites every line of a CRLF spec.
+    """
+    path = Path(path)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        shutil.copymode(path, tmp)
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _restore(targets, archive_dir: Path) -> "list[str]":
+    """Copy every original back. Returns the restores that FAILED, by name.
+
+    A rollback that raises part-way is the same failure one level up: the
+    remaining originals stay unrestored and the exception carries no list of
+    which ones. So every copy is attempted and the casualties are NAMED.
+    """
+    failures: list[str] = []
+    for outcome in targets:
+        try:
+            shutil.copy2(archive_dir / f"{outcome.agent}.spec.yaml", outcome.path)
+        except (
+            OSError,
+            shutil.Error,
+        ) as exc:  # stx-allow: fallback (reason: one spec that cannot be restored must not abandon the rest; it is named and reported)
+            failures.append(f"{outcome.agent}: could not be restored: {exc}")
+    return failures
+
+
+def _archive(targets, archive_dir: Path) -> str:
+    """Copy every original into ``archive_dir``. Returns "" or a refusal."""
+    try:
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        for outcome in targets:
+            shutil.copy2(outcome.path, archive_dir / f"{outcome.agent}.spec.yaml")
+    except (
+        OSError,
+        shutil.Error,
+    ) as exc:  # stx-allow: fallback (reason: no archive means no copy-back, so nothing may be written; refuse before the first byte)
+        return (
+            f"the originals could not be archived to {archive_dir}, so an undo "
+            f"would be a reconstruction rather than a copy-back. Nothing was "
+            f"written: {type(exc).__name__}: {exc}"
+        )
+    return ""
+
+
+def apply_engines_migration(plan, archive_dir: Path) -> ApplyResult:
+    """Archive, write, re-measure, and undo unless the backends are identical."""
+    targets = list(plan.migrated)
+    if not targets:
+        return ApplyResult(applied=True)
+    paths = [o.path for o in targets]
+
+    before, unmeasurable = _snapshot_all(paths)
+    if unmeasurable:
+        # Refuse BEFORE writing. The gate would catch this afterwards too, but
+        # writing N files to learn something knowable beforehand is a rollback
+        # waiting to be needed, not a safety property.
+        return ApplyResult(
+            refused=(
+                f"{len(unmeasurable)} spec(s) could not be loaded BEFORE the "
+                f"sweep, so no post-write comparison could prove them "
+                f"unchanged: " + "; ".join(unmeasurable)
+            )
+        )
+
+    archive_dir = Path(archive_dir)
+    refusal = _archive(targets, archive_dir)
+    if refusal:
+        return ApplyResult(refused=refusal, errors=(refusal,))
+
+    written: list = []
+    failure = ""
+    for outcome in targets:
+        try:
+            _write_atomically(outcome.path, outcome.new_text or "")
+        except (
+            OSError,
+            UnicodeError,
+        ) as exc:  # stx-allow: fallback (reason: a failed write must roll the batch back, not abort the process mid-sweep on a traceback)
+            failure = f"{outcome.agent}: {type(exc).__name__}: {exc}"
+            break
+        written.append(outcome)
+    if failure:
+        restore_failures = _restore(written, archive_dir)
+        return ApplyResult(
+            archive_dir=archive_dir,
+            rolled_back=(
+                f"the write failed part-way through the batch, so the "
+                f"{len(written)} spec(s) already written were restored from "
+                f"{archive_dir}"
+            ),
+            errors=(failure, *restore_failures),
+        )
+
+    after, still_unmeasurable = _snapshot_all(paths)
+    drift = [
+        f"{Path(key).parent.name}: {before[key]!r} -> {after[key]!r}"
+        for key in before
+        if key in after and after[key] != before[key]
+    ]
+    if still_unmeasurable or drift:
+        restore_failures = _restore(targets, archive_dir)
+        return ApplyResult(
+            archive_dir=archive_dir,
+            rolled_back=(
+                f"{len(drift)} spec(s) changed backend and "
+                f"{len(still_unmeasurable)} stopped loading; every original was "
+                f"restored from {archive_dir}"
+            ),
+            drift=tuple(drift + still_unmeasurable),
+            errors=tuple(restore_failures),
+        )
+    return ApplyResult(
+        written=tuple(o.agent for o in targets),
+        archive_dir=archive_dir,
+        applied=True,
+    )

--- a/src/scitex_agent_container/_maintenance/_engines_floor.py
+++ b/src/scitex_agent_container/_maintenance/_engines_floor.py
@@ -189,9 +189,14 @@ HOST_ALIASES: "dict[str, str]" = {
 }
 
 # Refusal reasons. CONSTANT strings, nothing interpolated, so a 119-spec sweep
-# groups by reason and prints one line per KIND — the same contract
+# groups by reason and prints one BLOCK per KIND — the same contract
 # ``_engines_line``'s REFUSED_* constants keep. The variable half (which host,
-# what was measured) travels in the detail.
+# what was measured) travels in the detail, and that detail is per-HOST rather
+# than per-spec, so the grouping key that makes this claim true is
+# ``(reason, detail)``: nine specs on one pre-engines host are ONE block naming
+# nine agents, not nine copies of a 400-character paragraph. The renderer did
+# the second for a while, and the property was true only of the --json payload;
+# ``_agents_migrate_engines_report._group_refusals`` is where it is kept now.
 REFUSED_HOST_PREDATES_ENGINES = (
     "the target host runs a sac that PREDATES spec.engines and would reject "
     "the block as an unknown spec field — the agent would stop starting"
@@ -268,13 +273,31 @@ class EngineFloor:
     are alias-resolved on the way in, so lifting ``scitex-laptop-01`` also
     lifts the 14 specs that spell the same machine ``ywata-note-win`` —
     otherwise the override would silently miss the specs it was typed for.
+
+    ``active`` is what :meth:`disabled` turns off, and it exists so that
+    "plan without the floor" has to be SAID. The planner used to take
+    ``floor=None`` and default to it, which meant the documented public
+    entry point planned a pre-engines-host spec as safe to write; a caller
+    that wants no floor now names one rather than omitting an argument.
     """
 
     allowed: "frozenset[str]" = field(default_factory=frozenset)
+    active: bool = True
 
     @classmethod
     def with_overrides(cls, hosts: "tuple[str, ...]" = ()) -> "EngineFloor":
         return cls(allowed=frozenset(canonical_host(h) for h in hosts if h))
+
+    @classmethod
+    def disabled(cls) -> "EngineFloor":
+        """A floor that judges nothing — the EXPLICIT no-floor plan.
+
+        For the unit tests of the other buckets, which are about selection,
+        batching and line endings rather than about host capability. It is a
+        value a caller has to construct, so no plan is ever floorless by
+        accident.
+        """
+        return cls(active=False)
 
     def _describe(self, host: str) -> str:
         """One host's recorded verdict, spelled out.
@@ -302,6 +325,8 @@ class EngineFloor:
         host is the one to report — it is the fact, and the unknown is the
         absence of one.
         """
+        if not self.active:
+            return _PASS
         if hosts is None:
             return FloorVerdict(True, REFUSED_HOST_UNREADABLE)
         if not hosts:

--- a/src/scitex_agent_container/_maintenance/_engines_floor.py
+++ b/src/scitex_agent_container/_maintenance/_engines_floor.py
@@ -1,0 +1,340 @@
+"""The VERSION FLOOR — will the host that parses this spec accept ``engines:``?
+
+THE HAZARD, MEASURED. A sac that predates engines support does not ignore an
+unknown ``engines:`` key: it REJECTS the whole spec. Reproduced 2026-09-06 by
+extracting the parent of the commit that added the feature and running THAT
+validator against a real fleet spec::
+
+    engines added by   0d61e077  2026-09-03
+    its parent         46a5d40a
+    parent has config/_engine_types.py?   NO
+    CONTROL: parent has config/_types.py?  YES  (so the extract is a real tree)
+
+    business/spec.yaml, engines block stripped   -> 0 errors
+    the SAME spec + an engines block             -> 1 error:
+        "Unknown spec field 'engines'. Use spec.extensions for custom data;
+         known keys: [a2a, access, apptainer, ...]"
+
+The control is the load-bearing half: the spec is otherwise clean under that
+old validator, so the ONE error the engines block introduces is the whole
+difference. Write that block into a spec whose target host runs a pre-engines
+sac and the spec stops loading — the agent stops starting, at a validator on a
+machine nobody is watching.
+
+WHY THE REFUSAL HAPPENS HERE AND NOT THERE. The constitution's rule is that a
+declaration which cannot be honoured must FAIL rather than evaporate. It would
+fail — remotely, silently, later. So the failure is pulled forward to PLAN
+time, where a human is reading the output.
+
+HOW THE FLOOR LEARNS. From this recorded roster, not from an ssh probe at plan
+time, and that is a deliberate trade:
+
+  * a probe of seven hosts costs seven ssh round trips on every dry run, and
+    the sweep's whole value is that a dry run is cheap enough to re-read;
+  * a host that does not answer produces UNKNOWN, which this module must
+    refuse anyway — so an unreachable host converts a fast refusal into a
+    slow one and changes no verdict;
+  * a probe answers "what is installed right now", which is not reviewable.
+    A recorded fact carries its date, its method and its control, lands in a
+    diff, and can be argued with.
+
+FAIL CLOSED, ALWAYS. A host with no record here is UNKNOWN and is REFUSED. It
+is never assumed capable — assuming capability is precisely the write that
+strands an agent. Absence from the table is a refusal, so extending the fleet
+cannot silently widen what the sweep will write.
+
+THE MEASUREMENT BEHIND THE TABLE (2026-09-06, from scitex-compute-04). Each
+host was asked, over ssh, whether ``config/_engine_types.py`` exists in every
+root that holds ``scitex_agent_container`` and whether it contains
+``apply_default_engine`` — FIX PRESENCE, not a version string, because a
+version string is a claim about a package's metadata and the metadata sits
+outside the bind mount the fleet actually imports from. Every probe carried a
+positive control (how many candidate roots it saw, how many held the package)
+so an empty answer could not be mistaken for a measurement.
+
+    scitex-compute-01   2 roots hold the package, both engines=True
+    scitex-compute-03   2 roots hold the package, both engines=True
+    scitex-compute-04   2 roots hold the package, both engines=True
+    scitex-laptop-01    3 roots hold the package; the editable ~/proj checkout
+                        is True. The third (~/.local site-packages) holds a
+                        scitex_agent_container DIRECTORY with neither
+                        _engine_types.py nor _types.py — a partial remnant,
+                        not a sac that could load a spec at all, so it is not
+                        evidence against the checkout that does.
+    spartan             3 roots hold the package, NONE has _engine_types.py
+                        (control: config/_types.py IS present in that same
+                         checkout, so the probe read a real tree)
+    scitex-compute-02   NOT MEASURABLE — see below
+
+``ywata-note-win`` IS ``scitex-laptop-01``. The 14 specs pinned on the retired
+name are NOT refused, and the reason is a measurement rather than a courtesy:
+asked over both ssh aliases, the machine answers ``hostname`` ->
+``ywata-note-win`` in both cases. It is one machine with two names, and that
+machine's sac parses engines. Refusing those 14 would be the floor firing on a
+NAMING question it was not built to answer — the rename is its own card — and
+a floor that refuses for the wrong reason is the reason people route around
+the tool. The alias is recorded as a measured fact, not as an assumption.
+
+``scitex-compute-02`` IS REFUSED, and this is the fail-closed rule doing its
+job on the only host where it bites. The probe ran (it answered ``hostname``)
+and found NO sac at all: nothing named ``sac`` on ``PATH``, no ``/opt/venv*``,
+no ``~/proj/scitex-agent-container``, and a bounded ``find / -maxdepth 8``
+matching no ``_engine_types.py`` under any ``scitex_agent_container`` path —
+with ``/etc/hostname`` returned by the same find as the positive control that
+it ran at all. "No install located" is NOT "an install that predates engines";
+it is not knowing which sac would parse the spec. So the 3 specs pinned there
+are refused by name, for a human to resolve, rather than written blind.
+
+LIFTING IT. ``--host-supports-engines HOST`` (repeatable) tells the sweep that
+a named host is capable. It is per-HOST on purpose: a blunt global bypass gets
+typed by habit, while naming the machine makes the claim explicit, reviewable
+in the shell history and recorded in the JSON payload. Naming every host that
+appears lifts the floor completely, so it is not a wall — it is a statement
+someone has to make.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "ENGINES_ADDED_COMMIT",
+    "ENGINES_ADDED_DATE",
+    "HOST_ALIASES",
+    "HOST_SUPPORT",
+    "REFUSED_HOST_NOT_MEASURED",
+    "REFUSED_HOST_PREDATES_ENGINES",
+    "REFUSED_HOST_UNDECLARED",
+    "REFUSED_HOST_UNREADABLE",
+    "SUPPORT_NO",
+    "SUPPORT_UNKNOWN",
+    "SUPPORT_YES",
+    "EngineFloor",
+    "FloorVerdict",
+    "HostRecord",
+    "canonical_host",
+    "host_support",
+]
+
+#: The commit that taught sac ``spec.engines``, and the day it landed. Any
+#: checkout older than this rejects the key outright.
+ENGINES_ADDED_COMMIT = "0d61e077"
+ENGINES_ADDED_DATE = "2026-09-03"
+
+SUPPORT_YES = "supports-engines"
+SUPPORT_NO = "predates-engines"
+#: Not in the table. Refused — never read as "probably fine".
+SUPPORT_UNKNOWN = "not-measured"
+
+
+@dataclass(frozen=True)
+class HostRecord:
+    """One MEASURED fact about one host, with the date and the method.
+
+    ``evidence`` is not decoration: it is what lets a reader decide whether
+    to trust the row without re-running the probe, and what makes a stale row
+    arguable rather than authoritative.
+    """
+
+    support: str
+    measured_on: str
+    evidence: str
+
+
+#: Measured by FIX PRESENCE — see the module docstring for the probe and its
+#: controls. A host that is missing from this table is refused.
+HOST_SUPPORT: "dict[str, HostRecord]" = {
+    "scitex-compute-01": HostRecord(
+        SUPPORT_YES,
+        "2026-09-06",
+        "2 roots hold scitex_agent_container; config/_engine_types.py present "
+        "with apply_default_engine in both",
+    ),
+    "scitex-compute-03": HostRecord(
+        SUPPORT_YES,
+        "2026-09-06",
+        "2 roots hold scitex_agent_container; config/_engine_types.py present "
+        "with apply_default_engine in both",
+    ),
+    "scitex-compute-04": HostRecord(
+        SUPPORT_YES,
+        "2026-09-06",
+        "2 roots hold scitex_agent_container; config/_engine_types.py present "
+        "with apply_default_engine in both",
+    ),
+    "scitex-laptop-01": HostRecord(
+        SUPPORT_YES,
+        "2026-09-06",
+        "3 roots hold scitex_agent_container; the editable ~/proj checkout has "
+        "config/_engine_types.py with apply_default_engine. The third root is "
+        "a partial remnant with neither _engine_types.py nor _types.py, so it "
+        "is not a sac that could load a spec at all",
+    ),
+    "spartan": HostRecord(
+        SUPPORT_NO,
+        "2026-09-06",
+        "3 roots hold scitex_agent_container and NONE has "
+        "config/_engine_types.py; control: config/_types.py IS present in the "
+        "editable checkout, so the probe read a real tree",
+    ),
+}
+
+#: One machine, two names. ``hostname`` answers ``ywata-note-win`` over BOTH
+#: ssh aliases (measured 2026-09-06), so the 14 specs pinned on the retired
+#: name run on the host recorded as ``scitex-laptop-01``. Renaming them is a
+#: separate card; this table only stops the floor from refusing them for a
+#: reason that is not about engines.
+HOST_ALIASES: "dict[str, str]" = {
+    "ywata-note-win": "scitex-laptop-01",
+}
+
+# Refusal reasons. CONSTANT strings, nothing interpolated, so a 119-spec sweep
+# groups by reason and prints one line per KIND — the same contract
+# ``_engines_line``'s REFUSED_* constants keep. The variable half (which host,
+# what was measured) travels in the detail.
+REFUSED_HOST_PREDATES_ENGINES = (
+    "the target host runs a sac that PREDATES spec.engines and would reject "
+    "the block as an unknown spec field — the agent would stop starting"
+)
+REFUSED_HOST_NOT_MEASURED = (
+    "no measured record of whether the target host can parse spec.engines; an "
+    "unmeasured host is REFUSED, never assumed capable"
+)
+REFUSED_HOST_UNDECLARED = (
+    "the spec names no host, so which sac would parse the block is unknown"
+)
+REFUSED_HOST_UNREADABLE = (
+    "the spec's host could not be read, so which sac would parse the block is "
+    "unknown"
+)
+
+_LIFT = (
+    "Pass --host-supports-engines {host} if you know better; the claim is "
+    "recorded in the JSON payload."
+)
+
+
+def canonical_host(host: str) -> str:
+    """Resolve a known alias to the name the roster records.
+
+    An unknown name is returned unchanged — it then misses the table and is
+    refused, which is the fail-closed answer for a host nobody measured.
+    """
+    name = str(host).strip()
+    return HOST_ALIASES.get(name, name)
+
+
+def host_support(host: str) -> "tuple[str, HostRecord | None]":
+    """``(state, record)`` for one host name, alias-resolved.
+
+    ``record`` is None exactly when the state is :data:`SUPPORT_UNKNOWN`,
+    because an unmeasured host has no measurement to carry.
+    """
+    record = HOST_SUPPORT.get(canonical_host(host))
+    if record is None:
+        return SUPPORT_UNKNOWN, None
+    return record.support, record
+
+
+@dataclass(frozen=True)
+class FloorVerdict:
+    """Does the floor stop this spec being written, and exactly why?
+
+    Deliberately not castable to a bool: ``blocks`` is the question, and
+    ``reason`` / ``detail`` are what a refusal has to carry to be actionable
+    — which spec, which host, and what was measured about it.
+    """
+
+    blocks: bool
+    reason: str = ""
+    detail: str = ""
+
+    def __post_init__(self) -> None:
+        if self.blocks and not self.reason:
+            raise ValueError(
+                "a blocking floor verdict must NAME its reason; a refusal "
+                "without one is indistinguishable from a silent skip"
+            )
+
+
+_PASS = FloorVerdict(False)
+
+
+@dataclass(frozen=True)
+class EngineFloor:
+    """The floor, plus the per-host claims an operator made to lift it.
+
+    ``allowed`` holds the hosts named with ``--host-supports-engines``. They
+    are alias-resolved on the way in, so lifting ``scitex-laptop-01`` also
+    lifts the 14 specs that spell the same machine ``ywata-note-win`` —
+    otherwise the override would silently miss the specs it was typed for.
+    """
+
+    allowed: "frozenset[str]" = field(default_factory=frozenset)
+
+    @classmethod
+    def with_overrides(cls, hosts: "tuple[str, ...]" = ()) -> "EngineFloor":
+        return cls(allowed=frozenset(canonical_host(h) for h in hosts if h))
+
+    def _describe(self, host: str) -> str:
+        """One host's recorded verdict, spelled out.
+
+        Only ever called for a host :meth:`verdict_for` has already found
+        NOT overridden, so there is no override branch here — a guard for a
+        case the caller cannot produce is noise a reader has to rule out.
+        """
+        state, record = host_support(host)
+        canonical = canonical_host(host)
+        named = host if canonical == host else f"{host} (= {canonical})"
+        if record is None:
+            return f"{named}: {SUPPORT_UNKNOWN} — absent from the measured roster"
+        return f"{named}: {state}, measured {record.measured_on} — {record.evidence}"
+
+    def verdict_for(self, hosts: "set[str] | None") -> FloorVerdict:
+        """Judge the hosts one spec places itself on.
+
+        ``None`` means the hosts could NOT BE READ and ``set()`` means the
+        spec names none. Both are refusals and they are kept apart, because
+        "I could not read it" and "it says nothing" want different fixes.
+
+        A DEFINITE negative outranks an unknown: when a spec names both a
+        host measured as pre-engines and one nobody measured, the pre-engines
+        host is the one to report — it is the fact, and the unknown is the
+        absence of one.
+        """
+        if hosts is None:
+            return FloorVerdict(True, REFUSED_HOST_UNREADABLE)
+        if not hosts:
+            return FloorVerdict(
+                True,
+                REFUSED_HOST_UNDECLARED,
+                "a spec with no host could start on any machine, including one "
+                "that would reject the block",
+            )
+        predates: list[str] = []
+        unmeasured: list[str] = []
+        for host in sorted(hosts):
+            if canonical_host(host) in self.allowed:
+                continue
+            state, _ = host_support(host)
+            if state == SUPPORT_NO:
+                predates.append(host)
+            elif state == SUPPORT_UNKNOWN:
+                unmeasured.append(host)
+        if predates:
+            return FloorVerdict(
+                True,
+                REFUSED_HOST_PREDATES_ENGINES,
+                "; ".join(self._describe(h) for h in predates)
+                + ". "
+                + _LIFT.format(host=predates[0]),
+            )
+        if unmeasured:
+            return FloorVerdict(
+                True,
+                REFUSED_HOST_NOT_MEASURED,
+                "; ".join(self._describe(h) for h in unmeasured)
+                + ". "
+                + _LIFT.format(host=unmeasured[0]),
+            )
+        return _PASS

--- a/src/scitex_agent_container/_maintenance/_engines_floor_audit.py
+++ b/src/scitex_agent_container/_maintenance/_engines_floor_audit.py
@@ -1,0 +1,166 @@
+"""The floor's EVIDENCE, rolled up per host for the report.
+
+Split out of :mod:`._engines_floor` on the module line budget, and it earns
+its own file anyway: that module answers "does this spec get written?", while
+this one answers "on what basis did the 100 that DID get written get written?".
+
+WHY THE APPROVING SIDE NEEDS EVIDENCE TOO. Every refusal already prints its
+measurement and its date. The approvals printed nothing, so a 100-spec sweep
+recorded which hosts it had REFUSED and said not one word about which it had
+judged CAPABLE, on what, or how old the measurement was.
+
+That asymmetry is exactly where this design fails OPEN.
+:data:`._engines_floor.HOST_SUPPORT` is a static table with no expiry, and the
+floor deliberately does not probe — so the one thing that can go wrong without
+anybody noticing is a row going STALE: a host rebuilt, rolled back, or
+reinstalled onto an older sac after its ``measured_on`` date. In that case the
+sweep writes those specs and the report is byte-for-byte indistinguishable
+from a correct run. No roster date, no per-host verdict, nothing to prompt a
+re-measure. This module puts the basis for the writes in the same artifact as
+the writes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ._engines_floor import SUPPORT_NO, EngineFloor, canonical_host, host_support
+
+__all__ = ["FloorAudit", "HostAudit", "floor_audit"]
+
+
+@dataclass(frozen=True)
+class HostAudit:
+    """One host the floor was consulted about, and the row it answered from.
+
+    ``measured_on`` and ``evidence`` are copied from the roster verbatim
+    rather than summarised: a reader deciding whether to trust an approval
+    needs the same material a refusal already gives them.
+    """
+
+    host: str
+    canonical: str
+    support: str
+    #: "" exactly when nobody measured this host — an unmeasured host has no
+    #: measurement to date.
+    measured_on: str
+    evidence: str
+    overridden: bool
+    #: How many of THIS run's specs place themselves on this host. ``0`` for
+    #: a host named by ``--host-supports-engines`` that no selected spec
+    #: mentions — a claim that did nothing still has to be visible.
+    specs: int
+
+    @property
+    def contradicts_a_measurement(self) -> bool:
+        """Is this override arguing with a MEASURED negative?
+
+        Categorically different from lifting an UNKNOWN: one says "nobody
+        looked, I did", the other says "the roster looked and I disagree".
+        Only the second can strand an agent on a validator by the module's
+        own evidence, so only the second earns the loud line.
+        """
+        return self.overridden and self.support == SUPPORT_NO
+
+    def as_dict(self) -> dict:
+        return {
+            "host": self.host,
+            "canonical": self.canonical,
+            "support": self.support,
+            "measured_on": self.measured_on,
+            "evidence": self.evidence,
+            "overridden": self.overridden,
+            "contradicts_a_measurement": self.contradicts_a_measurement,
+            "specs": self.specs,
+        }
+
+
+@dataclass(frozen=True)
+class FloorAudit:
+    """The BASIS for everything this run would write, per host."""
+
+    hosts: "tuple[HostAudit, ...]" = ()
+    specs_with_no_declared_host: int = 0
+    specs_with_an_unreadable_host: int = 0
+    active: bool = True
+
+    @property
+    def counts(self) -> "dict[str, int]":
+        """Specs per verdict — the count the approvals never carried.
+
+        A spec that names two hosts is counted under each of them, so these
+        need not sum to the number of specs. The question this answers is
+        "how much of this run rests on that row", not "how many specs are
+        there" — ``specs`` in the payload is the second question.
+        """
+        tally: dict[str, int] = {}
+        for row in self.hosts:
+            tally[row.support] = tally.get(row.support, 0) + row.specs
+        return dict(sorted(tally.items()))
+
+    @property
+    def measured_on(self) -> "tuple[str, ...]":
+        """Every distinct measurement date consulted, oldest first.
+
+        A run's whole roster is only as current as its oldest row, and that
+        date is what a reader needs in order to ask "is this still true?".
+        """
+        return tuple(sorted({r.measured_on for r in self.hosts if r.measured_on}))
+
+    def as_dict(self) -> dict:
+        return {
+            "active": self.active,
+            "measured_on": list(self.measured_on),
+            "hosts": [r.as_dict() for r in self.hosts],
+            "counts": self.counts,
+            "specs_with_no_declared_host": self.specs_with_no_declared_host,
+            "specs_with_an_unreadable_host": self.specs_with_an_unreadable_host,
+        }
+
+
+def floor_audit(floor: EngineFloor, spec_hosts) -> FloorAudit:
+    """Roll up every host consulted for this run, with its measured row.
+
+    ``spec_hosts`` is one entry per selected spec: the set of hosts that spec
+    places itself on, or ``None`` when they could not be read. Both of those
+    are counted rather than dropped, for the same reason the plan keeps
+    ``unreadable`` as its own bucket.
+    """
+    per_host: "dict[str, int]" = {}
+    no_host = 0
+    unreadable = 0
+    for hosts in spec_hosts:
+        if hosts is None:
+            unreadable += 1
+            continue
+        if not hosts:
+            no_host += 1
+            continue
+        for host in hosts:
+            per_host[host] = per_host.get(host, 0) + 1
+
+    rows = [_audit_row(floor, host, per_host[host]) for host in per_host]
+    named = {r.canonical for r in rows}
+    # An override naming a host no selected spec mentions matched nothing. It
+    # is still a claim someone made, so it is reported rather than dropped —
+    # a lift typed for a host that is not in this batch reads as effective.
+    rows += [_audit_row(floor, h, 0) for h in floor.allowed if h not in named]
+    return FloorAudit(
+        hosts=tuple(sorted(rows, key=lambda r: r.host)),
+        specs_with_no_declared_host=no_host,
+        specs_with_an_unreadable_host=unreadable,
+        active=floor.active,
+    )
+
+
+def _audit_row(floor: EngineFloor, host: str, specs: int) -> HostAudit:
+    state, record = host_support(host)
+    return HostAudit(
+        host=host,
+        canonical=canonical_host(host),
+        support=state,
+        measured_on=record.measured_on if record else "",
+        evidence=record.evidence if record else "",
+        overridden=canonical_host(host) in floor.allowed,
+        specs=specs,
+    )

--- a/src/scitex_agent_container/_maintenance/_engines_migration.py
+++ b/src/scitex_agent_container/_maintenance/_engines_migration.py
@@ -22,11 +22,24 @@ reported:
                         and named, because a batch that does not say what it
                         deferred reads exactly like a finished sweep.
 
-NO FILTER MAY SILENTLY DROP A SPEC. ``--host`` reads each spec to decide,
-and a spec it cannot read is KEPT rather than excluded — an unreadable spec
-that vanishes from the selection is the "118 done over a fleet of 119"
-failure, and it would make the batching flag the thing that disarms the
-guard against an unsafe apply.
+NO FILTER MAY SILENTLY DROP A SPEC, and nothing else may either. Which specs
+this run looks at — and everything it declined to look at, from a shadowed
+second copy to a ``--agent`` value that matched nothing — is
+:mod:`._engines_selection`'s job.
+
+WHAT NARROWS THE RUN NARROWS THE CLAIM. Whatever the selection left out is
+carried onto the plan and consumed by :attr:`EnginesPlan.outstanding`, so the
+one boolean a scheduled runner reads cannot disagree with the prose a human
+reads. That disagreement is the defect this module keeps re-learning: the
+templates and the ``--agent`` filter were both printed and both invisible to
+``migration_complete``.
+
+THE VERSION FLOOR IS NOT OPTIONAL HERE. :func:`plan_engines_migration` REQUIRES
+a ``floor``; it used to default to None, and the documented public planner then
+planned a spec pinned on a pre-engines host as migrated and ``safe_to_apply``.
+The guard belonged in the data path rather than in the one caller that
+remembered to pass it. ``EngineFloor.disabled()`` is how a caller says "no
+floor" out loud.
 
 The writing half — the archive, the atomic write, the measured gate and the
 rollback — lives in :mod:`._engines_apply`.
@@ -38,11 +51,17 @@ import difflib
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import yaml
-
 from ..config._engines_line import REFUSED_ALREADY_DECLARED, migrate_engines_block
 from ._engines_apply import ApplyResult, apply_engines_migration
-from ._engines_floor import EngineFloor
+from ._engines_floor import REFUSED_HOST_PREDATES_ENGINES, EngineFloor
+from ._engines_selection import (
+    ShadowedSpec,
+    SpecSelection,
+    read_spec_text,
+    select_spec_paths,
+    select_spec_paths_over_roots,
+    spec_hosts_from_text,
+)
 from ._roster_state import inspect_roster, inspect_roster_over_roots
 
 __all__ = [
@@ -53,7 +72,9 @@ __all__ = [
     "STATE_UNREADABLE",
     "ApplyResult",
     "EnginesPlan",
+    "ShadowedSpec",
     "SpecOutcome",
+    "SpecSelection",
     "apply_engines_migration",
     "plan_engines_migration",
     "read_spec_text",
@@ -84,6 +105,12 @@ class SpecOutcome:
     default_key: str = ""
     new_text: "str | None" = None
     diff: str = ""
+    #: Every host THIS spec's text places itself on, sorted. ``None`` means
+    #: they could not be read — kept apart from ``()`` ("it names none") for
+    #: the reason ``_engines_selection.spec_hosts`` states, and carried on the
+    #: outcome so the report can roll up the floor's basis without re-reading
+    #: the file and risking two answers about one spec.
+    hosts: "tuple[str, ...] | None" = None
 
     @property
     def will_write(self) -> bool:
@@ -101,6 +128,18 @@ class EnginesPlan:
     #: these, so an unmigrated template re-introduces the legacy shape on
     #: every agent created after the sweep.
     skipped_templates: "tuple[str, ...]" = field(default=())
+    #: Spec files a LATER root held for an agent an earlier root already
+    #: supplied. Exactly one copy is written; the other is a real file this
+    #: run never looked at, and no later run can reach it either.
+    shadowed: "tuple[ShadowedSpec, ...]" = field(default=())
+    #: The narrowing selectors this run was given, spelled as the flags that
+    #: produced them (``--agent business``). Non-empty means the census
+    #: describes a SUBSET of the roster, which is why it costs completeness.
+    selectors: "tuple[str, ...]" = field(default=())
+    #: ``--agent`` values that matched no spec under any root.
+    unmatched_agents: "tuple[str, ...]" = field(default=())
+    #: ``--host`` values no selected spec places itself on.
+    unmatched_hosts: "tuple[str, ...]" = field(default=())
 
     def _of(self, state: str) -> "tuple[SpecOutcome, ...]":
         return tuple(o for o in self.outcomes if o.state == state)
@@ -125,6 +164,57 @@ class EnginesPlan:
     def held_back(self) -> "tuple[SpecOutcome, ...]":
         return self._of(STATE_HELD_BACK)
 
+    def remaining(self, *, migrated_written: bool = False) -> "tuple[str, ...]":
+        """Everything a further run still has to do, each named in one line.
+
+        :attr:`is_complete` is exactly "this is empty", so the boolean the
+        machine reads and the prose the human reads cannot drift apart —
+        which they did: the skipped templates and the ``--agent`` filter were
+        both printed to a human and both invisible to the boolean.
+
+        ``migrated_written`` is the ONE difference between the question
+        before a write and the question after a successful one: a completed
+        apply retires the ``migrated`` bucket and nothing else. The caller
+        that answers the second question passes this flag rather than
+        re-listing the conditions, because re-listing them is how the two
+        answers drifted apart in the first place.
+        """
+        left: "list[str]" = []
+        if self.roster is not None and not self.roster.is_populated:
+            left.append(self.roster.describe())
+        if self.selectors:
+            left.append(
+                f"this run was NARROWED to {', '.join(self.selectors)} — the "
+                f"rest of the roster was never examined"
+            )
+        if self.skipped_templates:
+            left.append(
+                f"{len(self.skipped_templates)} template spec(s) not migrated "
+                f"({', '.join(self.skipped_templates)}) — `sac agents create` "
+                f"copies them, so every agent minted after this sweep "
+                f"re-introduces the legacy shape"
+            )
+        if self.shadowed:
+            left.append(
+                f"{len(self.shadowed)} spec file(s) shadowed by an earlier root "
+                f"({', '.join(s.agent for s in self.shadowed)}) — still on disk, "
+                f"still legacy, and no run of this sweep can reach them"
+            )
+        if self.migrated and not migrated_written:
+            left.append(f"{len(self.migrated)} spec(s) still to write")
+        if self.held_back:
+            left.append(f"{len(self.held_back)} spec(s) held back by --limit")
+        if self.refused:
+            left.append(f"{len(self.refused)} spec(s) REFUSED")
+        if self.unreadable:
+            left.append(f"{len(self.unreadable)} spec(s) unreadable")
+        return tuple(left)
+
+    @property
+    def outstanding(self) -> "tuple[str, ...]":
+        """:meth:`remaining` for the question BEFORE any write."""
+        return self.remaining()
+
     @property
     def is_complete(self) -> bool:
         """Is there NOTHING left for a further run of this sweep to do?
@@ -133,10 +223,16 @@ class EnginesPlan:
         is not ``exit 0`` and not ``applied``. A run that wrote nothing
         because everything was refused, or because ``--limit`` held the rest
         back, is a run that did its job and left the migration unfinished.
+
+        A NARROWED run is likewise not a finished migration, and that is the
+        exact shape this field exists to stop: ``-a business --apply`` over a
+        113-spec root printed "this is what a completed one looks like",
+        named the FULL root it had not covered, and reported
+        ``migration_complete: true``. The templates and a shadowed second copy
+        are the same failure in two other costumes — work left behind that the
+        prose already reported and the boolean did not.
         """
-        if self.roster is not None and not self.roster.is_populated:
-            return False
-        return not (self.migrated or self.held_back or self.refused or self.unreadable)
+        return not self.outstanding
 
     @property
     def safe_to_apply(self) -> bool:
@@ -168,152 +264,24 @@ class EnginesPlan:
             parts.append(f"{len(self.refused)} REFUSED ({names})")
         if self.unreadable:
             parts.append(f"{len(self.unreadable)} unreadable — do not apply")
+        if self.selectors:
+            parts.append(
+                f"NARROWED by {', '.join(self.selectors)} — not a census of "
+                f"the roster"
+            )
+        if self.shadowed:
+            parts.append(f"{len(self.shadowed)} shadowed by an earlier root")
         return "; ".join(parts)
 
 
-def read_spec_text(path: Path) -> str:
-    """A spec's text with its LINE ENDINGS INTACT.
-
-    ``Path.read_text`` opens in universal-newline mode, which silently turns
-    every ``\\r\\n`` into ``\\n`` before the caller sees a byte. A CRLF spec
-    read that way and written back is rewritten END TO END — the
-    unreviewable whole-file diff the operator asked this sweep to avoid —
-    and ``_yaml_line_edit.split_ending``'s CRLF handling becomes unreachable
-    because the ``\\r`` is already gone. ``newline=""`` is what makes that
-    machinery real rather than decorative.
-    """
-    with Path(path).open("r", encoding="utf-8", newline="") as handle:
-        return handle.read()
-
-
-def _spec_hosts_from_text(text: str) -> "set[str] | None":
-    """Every host the spec TEXT places itself on. ``None`` when unparsable.
-
-    Takes text rather than a path so the caller that has already read the
-    file judges the SAME bytes it will edit. Re-reading to answer a second
-    question is how one file yields two answers.
-    """
-    try:
-        doc = yaml.safe_load(text)
-    except yaml.YAMLError:  # stx-allow: fallback (reason: an unparsable spec must reach the PLAN as "host unknown", not vanish from the selection filter)
-        return None
-    spec = (doc or {}).get("spec") or {}
-    hosts = {str(spec.get("host"))} if spec.get("host") else set()
-    declared = spec.get("hosts")
-    if isinstance(declared, list):
-        hosts |= {str(h) for h in declared if h}
-    return hosts
-
-
-def _spec_hosts(path: Path) -> "set[str] | None":
-    """Every host a spec places itself on.
-
-    ``set()`` means the spec was read and places itself nowhere. ``None``
-    means it COULD NOT BE READ — a different answer, and the one the host
-    filter must not confuse with "no match": an unreadable spec that vanishes
-    from the selection is the "118 done over a fleet of 119" failure, and
-    ``--host`` would then be the flag that disables the guard blocking an
-    unsafe apply.
-    """
-    try:
-        text = read_spec_text(path)
-    except (
-        OSError,
-        UnicodeDecodeError,
-    ):  # stx-allow: fallback (reason: an unreadable spec must reach the PLAN as unreadable, not vanish from the selection filter)
-        return None
-    return _spec_hosts_from_text(text)
-
-
-def _on_a_wanted_host(path: Path, wanted: "set[str]") -> bool:
-    """Keep a spec the host filter cannot rule out, so the PLAN reports it."""
-    hosts = _spec_hosts(path)
-    if hosts is None:
-        return True
-    return bool(hosts & wanted)
-
-
-def select_spec_paths(
-    root: Path,
-    *,
-    hosts: "tuple[str, ...]" = (),
-    agents: "tuple[str, ...]" = (),
-    templates: bool = False,
-) -> "tuple[list[Path], list[str]]":
-    """Which specs THIS run touches, plus the template names it left out.
-
-    Batching is the operator's own condition for trusting a 119-file rewrite:
-    ``agents`` names an explicit set and ``hosts`` takes one machine at a
-    time. The order is sorted so a dry-run and the apply that follows it
-    agree on what they are looking at.
-
-    THE BATCH SIZE IS NOT HERE. ``--limit`` caps what gets WRITTEN, and
-    which specs those are is only knowable after planning — see
-    :func:`plan_engines_migration`. Capping the glob instead re-selected the
-    same first N on every run, so the second batch wrote nothing and
-    reported the sweep complete.
-    """
-    every = sorted(Path(root).glob("*/spec.yaml"))
-    skipped = [p.parent.name for p in every if p.parent.name.startswith("_")]
-    picked = [p for p in every if templates or not p.parent.name.startswith("_")]
-    if agents:
-        wanted = set(agents)
-        picked = [p for p in picked if p.parent.name in wanted]
-    if hosts:
-        wanted_hosts = set(hosts)
-        picked = [p for p in picked if _on_a_wanted_host(p, wanted_hosts)]
-    return picked, ([] if templates else skipped)
-
-
-def select_spec_paths_over_roots(
-    roots: "tuple[Path, ...]",
-    *,
-    hosts: "tuple[str, ...]" = (),
-    agents: "tuple[str, ...]" = (),
-    templates: bool = False,
-) -> "tuple[list[Path], list[str]]":
-    """:func:`select_spec_paths` over SEVERAL roots, de-duped by AGENT NAME.
-
-    The resolver that produces those roots says in its own docstring that
-    callers de-duplicate, and by NAME rather than by path is the only
-    de-duplication that means anything here: the same agent appears under two
-    roots as two different paths, and writing both would migrate one agent
-    twice — once into the copy that is actually loaded and once into a stale
-    one, which is how two answers about one agent get created.
-
-    EARLIER ROOTS WIN, in the order the resolver hands them over. That is a
-    conservative choice, not a claim to know which copy loads: on a genuine
-    name collision between a project-local registry and the fleet,
-    ``config._resolve.resolve_config`` REFUSES to pick and raises
-    ``AmbiguousRegistryScope``. A colliding name is therefore a pre-existing
-    fleet fault this sweep must not paper over — so it writes exactly one
-    file for that agent and the report names every root it searched.
-    """
-    picked: "list[Path]" = []
-    skipped: "list[str]" = []
-    seen: "set[str]" = set()
-    for root in roots:
-        paths, root_skipped = select_spec_paths(
-            root, hosts=hosts, agents=agents, templates=templates
-        )
-        for path in paths:
-            if path.parent.name in seen:
-                continue
-            seen.add(path.parent.name)
-            picked.append(path)
-        for name in root_skipped:
-            if name not in skipped:
-                skipped.append(name)
-    return picked, skipped
-
-
-def plan_spec(path: Path, *, floor: "EngineFloor | None" = None) -> SpecOutcome:
+def plan_spec(path: Path, *, floor: EngineFloor) -> SpecOutcome:
     """Plan ONE spec. Reads it; writes nothing.
 
-    ``floor`` is the VERSION FLOOR (:mod:`._engines_floor`). It is consulted
-    only where it can change the outcome — where a block WOULD be written,
-    and where one is already declared on a host that cannot parse it. A spec
-    the editor refuses for its own reason gets no block either way, so the
+    ``floor`` is the VERSION FLOOR (:mod:`._engines_floor`) and is REQUIRED —
+    pass ``EngineFloor.disabled()`` to plan without one. It is consulted only
+    where it can change the outcome: where a block WOULD be written, and
+    where one is already declared on a host that cannot parse it. A spec the
+    editor refuses for its own reason gets no block either way, so the
     editor's reason is the actionable one and is left in place.
     """
     agent = path.parent.name
@@ -325,8 +293,10 @@ def plan_spec(path: Path, *, floor: "EngineFloor | None" = None) -> SpecOutcome:
     ) as exc:  # stx-allow: fallback (reason: one unreadable spec must not abort a 119-spec sweep; it is recorded and makes the plan unsafe)
         return SpecOutcome(agent, path, STATE_UNREADABLE, detail=str(exc))
 
+    hosts = spec_hosts_from_text(before)
+    declared = None if hosts is None else tuple(sorted(hosts))
     edit = migrate_engines_block(before, path=str(path))
-    blocked = _floor_refusal(agent, path, before, edit, floor)
+    blocked = _floor_refusal(agent, path, hosts, edit, floor)
     if blocked is not None:
         return blocked
     if not edit.changed:
@@ -334,7 +304,12 @@ def plan_spec(path: Path, *, floor: "EngineFloor | None" = None) -> SpecOutcome:
             STATE_ALREADY if edit.reason == REFUSED_ALREADY_DECLARED else STATE_REFUSED
         )
         return SpecOutcome(
-            agent, path, state, reason=edit.reason or "", detail=edit.detail
+            agent,
+            path,
+            state,
+            reason=edit.reason or "",
+            detail=edit.detail,
+            hosts=declared,
         )
     diff = "".join(
         difflib.unified_diff(
@@ -352,13 +327,23 @@ def plan_spec(path: Path, *, floor: "EngineFloor | None" = None) -> SpecOutcome:
         default_key=edit.default_key,
         new_text=edit.text,
         diff=diff,
+        hosts=declared,
     )
 
 
-#: Appended when the floor blocks a spec that ALREADY declares engines. That
-#: is not a migration this sweep would make — it is a spec which cannot load
-#: on its own host TODAY, and reporting it as "already migrated" would file a
-#: live incident under the one bucket that means "finished".
+#: Appended when the floor blocks a spec that ALREADY declares engines ON A
+#: HOST MEASURED AS PRE-ENGINES. That is not a migration this sweep would make
+#: — it is a spec which cannot load on its own host TODAY, and reporting it as
+#: "already migrated" would file a live incident under the one bucket that
+#: means "finished".
+#:
+#: ONLY that branch. It used to be appended to every floor refusal of an
+#: already-declaring spec, so the not-measured and no-host refusals asserted as
+#: fact the very thing their own preceding sentence says nobody knows: "absent
+#: from the measured roster … This spec ALREADY declares spec.engines, so it
+#: does not load on that host today." Nobody measured that host; nothing had
+#: established any load failure on it. And under the no-host reason there is no
+#: "that host" to refer to at all.
 _ALREADY_ON_AN_INCAPABLE_HOST = (
     " This spec ALREADY declares spec.engines, so it does not load on that "
     "host today — nothing here writes it, and a human has to resolve it."
@@ -368,22 +353,27 @@ _ALREADY_ON_AN_INCAPABLE_HOST = (
 def _floor_refusal(
     agent: str,
     path: Path,
-    text: str,
+    hosts: "set[str] | None",
     edit,
-    floor: "EngineFloor | None",
+    floor: EngineFloor,
 ) -> "SpecOutcome | None":
     """The floor's refusal for this spec, or None to leave the outcome alone."""
-    if floor is None:
-        return None
     already = edit.reason == REFUSED_ALREADY_DECLARED
     if not edit.changed and not already:
         return None
-    verdict = floor.verdict_for(_spec_hosts_from_text(text))
+    verdict = floor.verdict_for(hosts)
     if not verdict.blocks:
         return None
-    detail = verdict.detail + (_ALREADY_ON_AN_INCAPABLE_HOST if already else "")
+    detail = verdict.detail
+    if already and verdict.reason == REFUSED_HOST_PREDATES_ENGINES:
+        detail += _ALREADY_ON_AN_INCAPABLE_HOST
     return SpecOutcome(
-        agent, path, STATE_REFUSED, reason=verdict.reason, detail=detail
+        agent,
+        path,
+        STATE_REFUSED,
+        reason=verdict.reason,
+        detail=detail,
+        hosts=None if hosts is None else tuple(sorted(hosts)),
     )
 
 
@@ -413,6 +403,7 @@ def _cap_batch(
                         reason="held back by --limit",
                         engine_keys=outcome.engine_keys,
                         default_key=outcome.default_key,
+                        hosts=outcome.hosts,
                     )
                 )
                 continue
@@ -424,11 +415,15 @@ def _cap_batch(
 def plan_engines_migration(
     spec_paths: "list[Path]",
     *,
+    floor: EngineFloor,
     root: "Path | None" = None,
     roots: "tuple[Path, ...] | None" = None,
     skipped_templates: "list[str]" = (),
+    shadowed: "tuple[ShadowedSpec, ...]" = (),
+    selectors: "tuple[str, ...]" = (),
+    unmatched_agents: "tuple[str, ...]" = (),
+    unmatched_hosts: "tuple[str, ...]" = (),
     limit: "int | None" = None,
-    floor: "EngineFloor | None" = None,
 ) -> EnginesPlan:
     """What the sweep WOULD do over ``spec_paths``. Reads only.
 
@@ -437,10 +432,22 @@ def plan_engines_migration(
     and a roster that named only the first of them would be a report about a
     directory the sweep did not confine itself to.
 
-    ``floor`` is the version floor. Passing None disables it entirely, which
-    is what the unit tests of the OTHER buckets want; the CLI always passes
-    one, so the fleet path is never floorless.
+    ``floor`` is the version floor and is REQUIRED. Omitting it used to
+    disable it, so the documented public entry point — called the documented
+    way, ``plan_engines_migration(paths, root=root)`` — planned a spec pinned
+    on a measured pre-engines host as ``migrated`` and ``safe_to_apply``. The
+    fleet path was guarded only because the single CLI call site remembered;
+    a second entry point inherited nothing and got no error to trip over.
+    Pass ``EngineFloor.disabled()`` to plan without a floor on purpose.
     """
+    if floor is None:
+        raise TypeError(
+            "plan_engines_migration requires a floor. Pass "
+            "EngineFloor.with_overrides(...) for a real sweep, or "
+            "EngineFloor.disabled() to plan WITHOUT the version floor. There "
+            "is no default because the default was 'no floor', and a floorless "
+            "plan reports a spec pinned on a pre-engines host as safe to write."
+        )
     if limit is not None and limit < 1:
         raise ValueError(
             f"limit must be a positive count of specs to write; got {limit!r}. "
@@ -457,4 +464,8 @@ def plan_engines_migration(
         outcomes=_cap_batch(tuple(plan_spec(p, floor=floor) for p in paths), limit),
         roster=roster,
         skipped_templates=tuple(skipped_templates),
+        shadowed=tuple(shadowed),
+        selectors=tuple(selectors),
+        unmatched_agents=tuple(unmatched_agents),
+        unmatched_hosts=tuple(unmatched_hosts),
     )

--- a/src/scitex_agent_container/_maintenance/_engines_migration.py
+++ b/src/scitex_agent_container/_maintenance/_engines_migration.py
@@ -42,7 +42,8 @@ import yaml
 
 from ..config._engines_line import REFUSED_ALREADY_DECLARED, migrate_engines_block
 from ._engines_apply import ApplyResult, apply_engines_migration
-from ._roster_state import inspect_roster
+from ._engines_floor import EngineFloor
+from ._roster_state import inspect_roster, inspect_roster_over_roots
 
 __all__ = [
     "STATE_ALREADY",
@@ -57,6 +58,7 @@ __all__ = [
     "plan_engines_migration",
     "read_spec_text",
     "select_spec_paths",
+    "select_spec_paths_over_roots",
 ]
 
 STATE_MIGRATED = "migrated"
@@ -184,6 +186,25 @@ def read_spec_text(path: Path) -> str:
         return handle.read()
 
 
+def _spec_hosts_from_text(text: str) -> "set[str] | None":
+    """Every host the spec TEXT places itself on. ``None`` when unparsable.
+
+    Takes text rather than a path so the caller that has already read the
+    file judges the SAME bytes it will edit. Re-reading to answer a second
+    question is how one file yields two answers.
+    """
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError:  # stx-allow: fallback (reason: an unparsable spec must reach the PLAN as "host unknown", not vanish from the selection filter)
+        return None
+    spec = (doc or {}).get("spec") or {}
+    hosts = {str(spec.get("host"))} if spec.get("host") else set()
+    declared = spec.get("hosts")
+    if isinstance(declared, list):
+        hosts |= {str(h) for h in declared if h}
+    return hosts
+
+
 def _spec_hosts(path: Path) -> "set[str] | None":
     """Every host a spec places itself on.
 
@@ -195,19 +216,13 @@ def _spec_hosts(path: Path) -> "set[str] | None":
     unsafe apply.
     """
     try:
-        doc = yaml.safe_load(read_spec_text(path))
+        text = read_spec_text(path)
     except (
         OSError,
         UnicodeDecodeError,
-        yaml.YAMLError,
     ):  # stx-allow: fallback (reason: an unreadable spec must reach the PLAN as unreadable, not vanish from the selection filter)
         return None
-    spec = (doc or {}).get("spec") or {}
-    hosts = {str(spec.get("host"))} if spec.get("host") else set()
-    declared = spec.get("hosts")
-    if isinstance(declared, list):
-        hosts |= {str(h) for h in declared if h}
-    return hosts
+    return _spec_hosts_from_text(text)
 
 
 def _on_a_wanted_host(path: Path, wanted: "set[str]") -> bool:
@@ -250,8 +265,57 @@ def select_spec_paths(
     return picked, ([] if templates else skipped)
 
 
-def plan_spec(path: Path) -> SpecOutcome:
-    """Plan ONE spec. Reads it; writes nothing."""
+def select_spec_paths_over_roots(
+    roots: "tuple[Path, ...]",
+    *,
+    hosts: "tuple[str, ...]" = (),
+    agents: "tuple[str, ...]" = (),
+    templates: bool = False,
+) -> "tuple[list[Path], list[str]]":
+    """:func:`select_spec_paths` over SEVERAL roots, de-duped by AGENT NAME.
+
+    The resolver that produces those roots says in its own docstring that
+    callers de-duplicate, and by NAME rather than by path is the only
+    de-duplication that means anything here: the same agent appears under two
+    roots as two different paths, and writing both would migrate one agent
+    twice — once into the copy that is actually loaded and once into a stale
+    one, which is how two answers about one agent get created.
+
+    EARLIER ROOTS WIN, in the order the resolver hands them over. That is a
+    conservative choice, not a claim to know which copy loads: on a genuine
+    name collision between a project-local registry and the fleet,
+    ``config._resolve.resolve_config`` REFUSES to pick and raises
+    ``AmbiguousRegistryScope``. A colliding name is therefore a pre-existing
+    fleet fault this sweep must not paper over — so it writes exactly one
+    file for that agent and the report names every root it searched.
+    """
+    picked: "list[Path]" = []
+    skipped: "list[str]" = []
+    seen: "set[str]" = set()
+    for root in roots:
+        paths, root_skipped = select_spec_paths(
+            root, hosts=hosts, agents=agents, templates=templates
+        )
+        for path in paths:
+            if path.parent.name in seen:
+                continue
+            seen.add(path.parent.name)
+            picked.append(path)
+        for name in root_skipped:
+            if name not in skipped:
+                skipped.append(name)
+    return picked, skipped
+
+
+def plan_spec(path: Path, *, floor: "EngineFloor | None" = None) -> SpecOutcome:
+    """Plan ONE spec. Reads it; writes nothing.
+
+    ``floor`` is the VERSION FLOOR (:mod:`._engines_floor`). It is consulted
+    only where it can change the outcome — where a block WOULD be written,
+    and where one is already declared on a host that cannot parse it. A spec
+    the editor refuses for its own reason gets no block either way, so the
+    editor's reason is the actionable one and is left in place.
+    """
     agent = path.parent.name
     try:
         before = read_spec_text(path)
@@ -262,6 +326,9 @@ def plan_spec(path: Path) -> SpecOutcome:
         return SpecOutcome(agent, path, STATE_UNREADABLE, detail=str(exc))
 
     edit = migrate_engines_block(before, path=str(path))
+    blocked = _floor_refusal(agent, path, before, edit, floor)
+    if blocked is not None:
+        return blocked
     if not edit.changed:
         state = (
             STATE_ALREADY if edit.reason == REFUSED_ALREADY_DECLARED else STATE_REFUSED
@@ -285,6 +352,38 @@ def plan_spec(path: Path) -> SpecOutcome:
         default_key=edit.default_key,
         new_text=edit.text,
         diff=diff,
+    )
+
+
+#: Appended when the floor blocks a spec that ALREADY declares engines. That
+#: is not a migration this sweep would make — it is a spec which cannot load
+#: on its own host TODAY, and reporting it as "already migrated" would file a
+#: live incident under the one bucket that means "finished".
+_ALREADY_ON_AN_INCAPABLE_HOST = (
+    " This spec ALREADY declares spec.engines, so it does not load on that "
+    "host today — nothing here writes it, and a human has to resolve it."
+)
+
+
+def _floor_refusal(
+    agent: str,
+    path: Path,
+    text: str,
+    edit,
+    floor: "EngineFloor | None",
+) -> "SpecOutcome | None":
+    """The floor's refusal for this spec, or None to leave the outcome alone."""
+    if floor is None:
+        return None
+    already = edit.reason == REFUSED_ALREADY_DECLARED
+    if not edit.changed and not already:
+        return None
+    verdict = floor.verdict_for(_spec_hosts_from_text(text))
+    if not verdict.blocks:
+        return None
+    detail = verdict.detail + (_ALREADY_ON_AN_INCAPABLE_HOST if already else "")
+    return SpecOutcome(
+        agent, path, STATE_REFUSED, reason=verdict.reason, detail=detail
     )
 
 
@@ -326,10 +425,22 @@ def plan_engines_migration(
     spec_paths: "list[Path]",
     *,
     root: "Path | None" = None,
+    roots: "tuple[Path, ...] | None" = None,
     skipped_templates: "list[str]" = (),
     limit: "int | None" = None,
+    floor: "EngineFloor | None" = None,
 ) -> EnginesPlan:
-    """What the sweep WOULD do over ``spec_paths``. Reads only."""
+    """What the sweep WOULD do over ``spec_paths``. Reads only.
+
+    ``roots`` is the several-roots form of ``root`` and takes precedence when
+    given: the default sweep searches every user-scope root rather than one,
+    and a roster that named only the first of them would be a report about a
+    directory the sweep did not confine itself to.
+
+    ``floor`` is the version floor. Passing None disables it entirely, which
+    is what the unit tests of the OTHER buckets want; the CLI always passes
+    one, so the fleet path is never floorless.
+    """
     if limit is not None and limit < 1:
         raise ValueError(
             f"limit must be a positive count of specs to write; got {limit!r}. "
@@ -337,8 +448,13 @@ def plan_engines_migration(
             "the LAST spec instead of taking the first one."
         )
     paths = list(spec_paths)
+    roster = (
+        inspect_roster_over_roots(roots, paths)
+        if roots is not None
+        else inspect_roster(root, paths)
+    )
     return EnginesPlan(
-        outcomes=_cap_batch(tuple(plan_spec(p) for p in paths), limit),
-        roster=inspect_roster(root, paths),
+        outcomes=_cap_batch(tuple(plan_spec(p, floor=floor) for p in paths), limit),
+        roster=roster,
         skipped_templates=tuple(skipped_templates),
     )

--- a/src/scitex_agent_container/_maintenance/_engines_migration.py
+++ b/src/scitex_agent_container/_maintenance/_engines_migration.py
@@ -1,4 +1,4 @@
-"""Plan and apply the ``spec.engines`` sweep — three outcomes, never two.
+"""Plan the ``spec.engines`` sweep — five outcomes, never two.
 
 The ``to_home_layers`` kit next door plans a ONE-LINE insert, so its
 :class:`.._layers_migration_model.MigrationPlan` calls any edit touching other
@@ -18,34 +18,35 @@ reported:
   ``unreadable``        the file could not be read at all. This never reached
                         the editor, so the plan does not describe the sweep;
                         it makes the plan unsafe.
+  ``held-back``         migratable, and past this run's ``--limit``. Counted
+                        and named, because a batch that does not say what it
+                        deferred reads exactly like a finished sweep.
 
-THE APPLY GATE IS A MEASUREMENT, NOT AN ARGUMENT. The edit restates the
-backend a spec already declares, so it cannot change what an agent starts on
-— that is the argument, and an argument has never stopped a bulk edit from
-being wrong. So the apply loads every selected spec through the production
-loader BEFORE writing, writes, loads them all again, and RESTORES EVERY
-ORIGINAL unless the effective backend (harness, model, provider endpoint,
-pinned account) is identical for every one. A spec it could not load on
-either side blocks the sweep instead of being skipped.
+NO FILTER MAY SILENTLY DROP A SPEC. ``--host`` reads each spec to decide,
+and a spec it cannot read is KEPT rather than excluded — an unreadable spec
+that vanishes from the selection is the "118 done over a fleet of 119"
+failure, and it would make the batching flag the thing that disarms the
+guard against an unsafe apply.
 
-Originals are archived before the first byte changes, so the rollback is a
-copy-back and not a reconstruction.
+The writing half — the archive, the atomic write, the measured gate and the
+rollback — lives in :mod:`._engines_apply`.
 """
 
 from __future__ import annotations
 
 import difflib
-import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
 
 from ..config._engines_line import REFUSED_ALREADY_DECLARED, migrate_engines_block
+from ._engines_apply import ApplyResult, apply_engines_migration
 from ._roster_state import inspect_roster
 
 __all__ = [
     "STATE_ALREADY",
+    "STATE_HELD_BACK",
     "STATE_MIGRATED",
     "STATE_REFUSED",
     "STATE_UNREADABLE",
@@ -54,6 +55,7 @@ __all__ = [
     "SpecOutcome",
     "apply_engines_migration",
     "plan_engines_migration",
+    "read_spec_text",
     "select_spec_paths",
 ]
 
@@ -61,6 +63,10 @@ STATE_MIGRATED = "migrated"
 STATE_ALREADY = "already-migrated"
 STATE_REFUSED = "refused"
 STATE_UNREADABLE = "unreadable"
+#: Migratable, but beyond this run's ``--limit``. A fifth bucket rather than
+#: a silent drop: a batch that does not say what it held back is a batch a
+#: scheduled runner mistakes for a finished sweep.
+STATE_HELD_BACK = "held-back"
 
 
 @dataclass(frozen=True)
@@ -114,6 +120,23 @@ class EnginesPlan:
         return self._of(STATE_UNREADABLE)
 
     @property
+    def held_back(self) -> "tuple[SpecOutcome, ...]":
+        return self._of(STATE_HELD_BACK)
+
+    @property
+    def is_complete(self) -> bool:
+        """Is there NOTHING left for a further run of this sweep to do?
+
+        The only question a scheduled runner actually wants answered, and it
+        is not ``exit 0`` and not ``applied``. A run that wrote nothing
+        because everything was refused, or because ``--limit`` held the rest
+        back, is a run that did its job and left the migration unfinished.
+        """
+        if self.roster is not None and not self.roster.is_populated:
+            return False
+        return not (self.migrated or self.held_back or self.refused or self.unreadable)
+
+    @property
     def safe_to_apply(self) -> bool:
         """Refusals do NOT make a plan unsafe. An unsearched roster does.
 
@@ -133,6 +156,11 @@ class EnginesPlan:
             f"{len(self.migrated)} would be migrated",
             f"{len(self.already)} already migrated",
         ]
+        if self.held_back:
+            parts.append(
+                f"{len(self.held_back)} held back by --limit — run again to "
+                f"take the next batch"
+            )
         if self.refused:
             names = ", ".join(sorted(o.agent for o in self.refused))
             parts.append(f"{len(self.refused)} REFUSED ({names})")
@@ -141,16 +169,39 @@ class EnginesPlan:
         return "; ".join(parts)
 
 
-def _spec_hosts(path: Path) -> "set[str]":
-    """Every host a spec places itself on. Empty when it says nothing."""
+def read_spec_text(path: Path) -> str:
+    """A spec's text with its LINE ENDINGS INTACT.
+
+    ``Path.read_text`` opens in universal-newline mode, which silently turns
+    every ``\\r\\n`` into ``\\n`` before the caller sees a byte. A CRLF spec
+    read that way and written back is rewritten END TO END — the
+    unreviewable whole-file diff the operator asked this sweep to avoid —
+    and ``_yaml_line_edit.split_ending``'s CRLF handling becomes unreachable
+    because the ``\\r`` is already gone. ``newline=""`` is what makes that
+    machinery real rather than decorative.
+    """
+    with Path(path).open("r", encoding="utf-8", newline="") as handle:
+        return handle.read()
+
+
+def _spec_hosts(path: Path) -> "set[str] | None":
+    """Every host a spec places itself on.
+
+    ``set()`` means the spec was read and places itself nowhere. ``None``
+    means it COULD NOT BE READ — a different answer, and the one the host
+    filter must not confuse with "no match": an unreadable spec that vanishes
+    from the selection is the "118 done over a fleet of 119" failure, and
+    ``--host`` would then be the flag that disables the guard blocking an
+    unsafe apply.
+    """
     try:
-        doc = yaml.safe_load(path.read_text())
+        doc = yaml.safe_load(read_spec_text(path))
     except (
         OSError,
         UnicodeDecodeError,
         yaml.YAMLError,
     ):  # stx-allow: fallback (reason: an unreadable spec must reach the PLAN as unreadable, not vanish from the selection filter)
-        return set()
+        return None
     spec = (doc or {}).get("spec") or {}
     hosts = {str(spec.get("host"))} if spec.get("host") else set()
     declared = spec.get("hosts")
@@ -159,21 +210,33 @@ def _spec_hosts(path: Path) -> "set[str]":
     return hosts
 
 
+def _on_a_wanted_host(path: Path, wanted: "set[str]") -> bool:
+    """Keep a spec the host filter cannot rule out, so the PLAN reports it."""
+    hosts = _spec_hosts(path)
+    if hosts is None:
+        return True
+    return bool(hosts & wanted)
+
+
 def select_spec_paths(
     root: Path,
     *,
     hosts: "tuple[str, ...]" = (),
     agents: "tuple[str, ...]" = (),
     templates: bool = False,
-    limit: "int | None" = None,
 ) -> "tuple[list[Path], list[str]]":
     """Which specs THIS run touches, plus the template names it left out.
 
     Batching is the operator's own condition for trusting a 119-file rewrite:
-    ``agents`` names an explicit set, ``hosts`` takes one machine at a time,
-    and ``limit`` caps the batch whatever the other two selected. The order is
-    sorted so a dry-run and the apply that follows it agree on which specs the
-    cap kept.
+    ``agents`` names an explicit set and ``hosts`` takes one machine at a
+    time. The order is sorted so a dry-run and the apply that follows it
+    agree on what they are looking at.
+
+    THE BATCH SIZE IS NOT HERE. ``--limit`` caps what gets WRITTEN, and
+    which specs those are is only knowable after planning — see
+    :func:`plan_engines_migration`. Capping the glob instead re-selected the
+    same first N on every run, so the second batch wrote nothing and
+    reported the sweep complete.
     """
     every = sorted(Path(root).glob("*/spec.yaml"))
     skipped = [p.parent.name for p in every if p.parent.name.startswith("_")]
@@ -183,9 +246,7 @@ def select_spec_paths(
         picked = [p for p in picked if p.parent.name in wanted]
     if hosts:
         wanted_hosts = set(hosts)
-        picked = [p for p in picked if _spec_hosts(p) & wanted_hosts]
-    if limit is not None:
-        picked = picked[:limit]
+        picked = [p for p in picked if _on_a_wanted_host(p, wanted_hosts)]
     return picked, ([] if templates else skipped)
 
 
@@ -193,7 +254,7 @@ def plan_spec(path: Path) -> SpecOutcome:
     """Plan ONE spec. Reads it; writes nothing."""
     agent = path.parent.name
     try:
-        before = path.read_text()
+        before = read_spec_text(path)
     except (
         OSError,
         UnicodeDecodeError,
@@ -227,113 +288,57 @@ def plan_spec(path: Path) -> SpecOutcome:
     )
 
 
+def _cap_batch(
+    outcomes: "tuple[SpecOutcome, ...]", limit: "int | None"
+) -> "tuple[SpecOutcome, ...]":
+    """Hold back every migratable outcome past the ``limit``-th one.
+
+    THE CAP IS ON WHAT IS WRITTEN, not on what is looked at, and that is the
+    whole difference between a batch flag that advances and one that cannot.
+    Already-migrated, refused and unreadable specs do not consume the budget:
+    they cost no write, and letting them consume it is how ``--limit 2``
+    stalls forever on two permanently-refused specs.
+    """
+    if limit is None:
+        return outcomes
+    budget = limit
+    capped: list[SpecOutcome] = []
+    for outcome in outcomes:
+        if outcome.state == STATE_MIGRATED:
+            if budget <= 0:
+                capped.append(
+                    SpecOutcome(
+                        outcome.agent,
+                        outcome.path,
+                        STATE_HELD_BACK,
+                        reason="held back by --limit",
+                        engine_keys=outcome.engine_keys,
+                        default_key=outcome.default_key,
+                    )
+                )
+                continue
+            budget -= 1
+        capped.append(outcome)
+    return tuple(capped)
+
+
 def plan_engines_migration(
     spec_paths: "list[Path]",
     *,
     root: "Path | None" = None,
     skipped_templates: "list[str]" = (),
+    limit: "int | None" = None,
 ) -> EnginesPlan:
     """What the sweep WOULD do over ``spec_paths``. Reads only."""
+    if limit is not None and limit < 1:
+        raise ValueError(
+            f"limit must be a positive count of specs to write; got {limit!r}. "
+            "A Python slice accepts a negative bound and would silently drop "
+            "the LAST spec instead of taking the first one."
+        )
     paths = list(spec_paths)
     return EnginesPlan(
-        outcomes=tuple(plan_spec(p) for p in paths),
+        outcomes=_cap_batch(tuple(plan_spec(p) for p in paths), limit),
         roster=inspect_roster(root, paths),
         skipped_templates=tuple(skipped_templates),
-    )
-
-
-@dataclass(frozen=True)
-class ApplyResult:
-    """What the apply actually did."""
-
-    written: "tuple[str, ...]" = ()
-    archive_dir: "Path | None" = None
-    applied: bool = False
-    refused: str = ""
-    rolled_back: str = ""
-    drift: "tuple[str, ...]" = ()
-
-
-def _backend_snapshot(path: Path):
-    """The effective backend this spec resolves to, through the real loader."""
-    from ..config import load_config
-
-    config = load_config(path)
-    claude = getattr(config, "claude", None)
-    provider = getattr(claude, "provider", None)
-    endpoint = None
-    if provider is not None:
-        endpoint = (
-            str(getattr(provider, "base_url", "") or ""),
-            str(getattr(provider, "auth_token_env", "") or ""),
-        )
-    return (
-        str(getattr(config, "harness", "") or ""),
-        str(getattr(claude, "model", "") or ""),
-        endpoint,
-        str(getattr(claude, "account", "") or ""),
-    )
-
-
-def _snapshot_all(paths):
-    """``(snapshots, unmeasurable)`` — a spec that will not load is named."""
-    snapshots: dict[str, object] = {}
-    unmeasurable: list[str] = []
-    for path in paths:
-        try:
-            snapshots[str(path)] = _backend_snapshot(path)
-        except Exception as exc:  # stx-allow: fallback (reason: a spec the loader rejects is UNMEASURABLE, the honest third value; enumerating loader exception types would turn any new one into a crash mid-sweep)
-            unmeasurable.append(f"{path.parent.name}: {type(exc).__name__}: {exc}")
-    return snapshots, unmeasurable
-
-
-def apply_engines_migration(plan: EnginesPlan, archive_dir: Path) -> ApplyResult:
-    """Archive, write, re-measure, and undo unless the backends are identical."""
-    targets = list(plan.migrated)
-    if not targets:
-        return ApplyResult(applied=True)
-    paths = [o.path for o in targets]
-
-    before, unmeasurable = _snapshot_all(paths)
-    if unmeasurable:
-        # Refuse BEFORE writing. The gate would catch this afterwards too, but
-        # writing N files to learn something knowable beforehand is a rollback
-        # waiting to be needed, not a safety property.
-        return ApplyResult(
-            refused=(
-                f"{len(unmeasurable)} spec(s) could not be loaded BEFORE the "
-                f"sweep, so no post-write comparison could prove them "
-                f"unchanged: " + "; ".join(unmeasurable)
-            )
-        )
-
-    archive_dir = Path(archive_dir)
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    for outcome in targets:
-        shutil.copy2(outcome.path, archive_dir / f"{outcome.agent}.spec.yaml")
-    for outcome in targets:
-        outcome.path.write_text(outcome.new_text or "")
-
-    after, still_unmeasurable = _snapshot_all(paths)
-    drift = [
-        f"{Path(key).parent.name}: {before[key]!r} -> {after[key]!r}"
-        for key in before
-        if key in after and after[key] != before[key]
-    ]
-    if still_unmeasurable or drift:
-        for outcome in targets:
-            shutil.copy2(archive_dir / f"{outcome.agent}.spec.yaml", outcome.path)
-        return ApplyResult(
-            archive_dir=archive_dir,
-            rolled_back=(
-                f"{len(drift)} spec(s) changed backend and "
-                f"{len(still_unmeasurable)} stopped loading; every original was "
-                f"restored from {archive_dir}"
-            ),
-            drift=tuple(drift + still_unmeasurable),
-        )
-    return ApplyResult(
-        written=tuple(o.agent for o in targets),
-        archive_dir=archive_dir,
-        applied=True,
     )

--- a/src/scitex_agent_container/_maintenance/_engines_migration.py
+++ b/src/scitex_agent_container/_maintenance/_engines_migration.py
@@ -1,0 +1,339 @@
+"""Plan and apply the ``spec.engines`` sweep — three outcomes, never two.
+
+The ``to_home_layers`` kit next door plans a ONE-LINE insert, so its
+:class:`.._layers_migration_model.MigrationPlan` calls any edit touching other
+than exactly one line MALFORMED. This sweep writes a block, so it needs its own
+plan rather than a loosened version of that one — loosening the check would
+disarm it for the migration it was written for.
+
+WHAT IT KEEPS APART. Every spec lands in exactly one bucket and each is
+reported:
+
+  ``migrated``          the edit is ready, with its diff.
+  ``already-migrated``  the spec declares ``spec.engines`` already. Finished,
+                        not refused: a second run over a swept fleet reports
+                        119 of these and writes nothing.
+  ``refused``           the editor looked and declined, NAMING why. Expected,
+                        counted, and NOT an error exit — a human resolves it.
+  ``unreadable``        the file could not be read at all. This never reached
+                        the editor, so the plan does not describe the sweep;
+                        it makes the plan unsafe.
+
+THE APPLY GATE IS A MEASUREMENT, NOT AN ARGUMENT. The edit restates the
+backend a spec already declares, so it cannot change what an agent starts on
+— that is the argument, and an argument has never stopped a bulk edit from
+being wrong. So the apply loads every selected spec through the production
+loader BEFORE writing, writes, loads them all again, and RESTORES EVERY
+ORIGINAL unless the effective backend (harness, model, provider endpoint,
+pinned account) is identical for every one. A spec it could not load on
+either side blocks the sweep instead of being skipped.
+
+Originals are archived before the first byte changes, so the rollback is a
+copy-back and not a reconstruction.
+"""
+
+from __future__ import annotations
+
+import difflib
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from ..config._engines_line import REFUSED_ALREADY_DECLARED, migrate_engines_block
+from ._roster_state import inspect_roster
+
+__all__ = [
+    "STATE_ALREADY",
+    "STATE_MIGRATED",
+    "STATE_REFUSED",
+    "STATE_UNREADABLE",
+    "ApplyResult",
+    "EnginesPlan",
+    "SpecOutcome",
+    "apply_engines_migration",
+    "plan_engines_migration",
+    "select_spec_paths",
+]
+
+STATE_MIGRATED = "migrated"
+STATE_ALREADY = "already-migrated"
+STATE_REFUSED = "refused"
+STATE_UNREADABLE = "unreadable"
+
+
+@dataclass(frozen=True)
+class SpecOutcome:
+    """What the sweep would do to ONE spec, and why."""
+
+    agent: str
+    path: Path
+    state: str
+    reason: str = ""
+    detail: str = ""
+    engine_keys: "tuple[str, ...]" = ()
+    default_key: str = ""
+    new_text: "str | None" = None
+    diff: str = ""
+
+    @property
+    def will_write(self) -> bool:
+        return self.state == STATE_MIGRATED and self.new_text is not None
+
+
+@dataclass(frozen=True)
+class EnginesPlan:
+    """What the sweep would do, in full, before it does any of it."""
+
+    outcomes: "tuple[SpecOutcome, ...]" = ()
+    roster: object = None
+    #: Template specs (``_``-prefixed dirs) deliberately left out of the
+    #: selection. Named rather than dropped: ``sac agents create`` copies
+    #: these, so an unmigrated template re-introduces the legacy shape on
+    #: every agent created after the sweep.
+    skipped_templates: "tuple[str, ...]" = field(default=())
+
+    def _of(self, state: str) -> "tuple[SpecOutcome, ...]":
+        return tuple(o for o in self.outcomes if o.state == state)
+
+    @property
+    def migrated(self) -> "tuple[SpecOutcome, ...]":
+        return self._of(STATE_MIGRATED)
+
+    @property
+    def already(self) -> "tuple[SpecOutcome, ...]":
+        return self._of(STATE_ALREADY)
+
+    @property
+    def refused(self) -> "tuple[SpecOutcome, ...]":
+        return self._of(STATE_REFUSED)
+
+    @property
+    def unreadable(self) -> "tuple[SpecOutcome, ...]":
+        return self._of(STATE_UNREADABLE)
+
+    @property
+    def safe_to_apply(self) -> bool:
+        """Refusals do NOT make a plan unsafe. An unsearched roster does.
+
+        A named refusal is a legitimate outcome a human resolves. A spec that
+        could not be read, or a roster that was never searched, both mean the
+        plan does not describe the sweep — see :mod:`._roster_state` for the
+        measured incident behind the second one.
+        """
+        if self.roster is not None and not self.roster.is_populated:
+            return False
+        return not self.unreadable
+
+    def summary(self) -> str:
+        if self.roster is not None and not self.roster.is_populated:
+            return self.roster.describe()
+        parts = [
+            f"{len(self.migrated)} would be migrated",
+            f"{len(self.already)} already migrated",
+        ]
+        if self.refused:
+            names = ", ".join(sorted(o.agent for o in self.refused))
+            parts.append(f"{len(self.refused)} REFUSED ({names})")
+        if self.unreadable:
+            parts.append(f"{len(self.unreadable)} unreadable — do not apply")
+        return "; ".join(parts)
+
+
+def _spec_hosts(path: Path) -> "set[str]":
+    """Every host a spec places itself on. Empty when it says nothing."""
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except (
+        OSError,
+        UnicodeDecodeError,
+        yaml.YAMLError,
+    ):  # stx-allow: fallback (reason: an unreadable spec must reach the PLAN as unreadable, not vanish from the selection filter)
+        return set()
+    spec = (doc or {}).get("spec") or {}
+    hosts = {str(spec.get("host"))} if spec.get("host") else set()
+    declared = spec.get("hosts")
+    if isinstance(declared, list):
+        hosts |= {str(h) for h in declared if h}
+    return hosts
+
+
+def select_spec_paths(
+    root: Path,
+    *,
+    hosts: "tuple[str, ...]" = (),
+    agents: "tuple[str, ...]" = (),
+    templates: bool = False,
+    limit: "int | None" = None,
+) -> "tuple[list[Path], list[str]]":
+    """Which specs THIS run touches, plus the template names it left out.
+
+    Batching is the operator's own condition for trusting a 119-file rewrite:
+    ``agents`` names an explicit set, ``hosts`` takes one machine at a time,
+    and ``limit`` caps the batch whatever the other two selected. The order is
+    sorted so a dry-run and the apply that follows it agree on which specs the
+    cap kept.
+    """
+    every = sorted(Path(root).glob("*/spec.yaml"))
+    skipped = [p.parent.name for p in every if p.parent.name.startswith("_")]
+    picked = [p for p in every if templates or not p.parent.name.startswith("_")]
+    if agents:
+        wanted = set(agents)
+        picked = [p for p in picked if p.parent.name in wanted]
+    if hosts:
+        wanted_hosts = set(hosts)
+        picked = [p for p in picked if _spec_hosts(p) & wanted_hosts]
+    if limit is not None:
+        picked = picked[:limit]
+    return picked, ([] if templates else skipped)
+
+
+def plan_spec(path: Path) -> SpecOutcome:
+    """Plan ONE spec. Reads it; writes nothing."""
+    agent = path.parent.name
+    try:
+        before = path.read_text()
+    except (
+        OSError,
+        UnicodeDecodeError,
+    ) as exc:  # stx-allow: fallback (reason: one unreadable spec must not abort a 119-spec sweep; it is recorded and makes the plan unsafe)
+        return SpecOutcome(agent, path, STATE_UNREADABLE, detail=str(exc))
+
+    edit = migrate_engines_block(before, path=str(path))
+    if not edit.changed:
+        state = (
+            STATE_ALREADY if edit.reason == REFUSED_ALREADY_DECLARED else STATE_REFUSED
+        )
+        return SpecOutcome(
+            agent, path, state, reason=edit.reason or "", detail=edit.detail
+        )
+    diff = "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            edit.text.splitlines(keepends=True),
+            fromfile=f"a/{agent}/spec.yaml",
+            tofile=f"b/{agent}/spec.yaml",
+        )
+    )
+    return SpecOutcome(
+        agent,
+        path,
+        STATE_MIGRATED,
+        engine_keys=edit.engine_keys,
+        default_key=edit.default_key,
+        new_text=edit.text,
+        diff=diff,
+    )
+
+
+def plan_engines_migration(
+    spec_paths: "list[Path]",
+    *,
+    root: "Path | None" = None,
+    skipped_templates: "list[str]" = (),
+) -> EnginesPlan:
+    """What the sweep WOULD do over ``spec_paths``. Reads only."""
+    paths = list(spec_paths)
+    return EnginesPlan(
+        outcomes=tuple(plan_spec(p) for p in paths),
+        roster=inspect_roster(root, paths),
+        skipped_templates=tuple(skipped_templates),
+    )
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """What the apply actually did."""
+
+    written: "tuple[str, ...]" = ()
+    archive_dir: "Path | None" = None
+    applied: bool = False
+    refused: str = ""
+    rolled_back: str = ""
+    drift: "tuple[str, ...]" = ()
+
+
+def _backend_snapshot(path: Path):
+    """The effective backend this spec resolves to, through the real loader."""
+    from ..config import load_config
+
+    config = load_config(path)
+    claude = getattr(config, "claude", None)
+    provider = getattr(claude, "provider", None)
+    endpoint = None
+    if provider is not None:
+        endpoint = (
+            str(getattr(provider, "base_url", "") or ""),
+            str(getattr(provider, "auth_token_env", "") or ""),
+        )
+    return (
+        str(getattr(config, "harness", "") or ""),
+        str(getattr(claude, "model", "") or ""),
+        endpoint,
+        str(getattr(claude, "account", "") or ""),
+    )
+
+
+def _snapshot_all(paths):
+    """``(snapshots, unmeasurable)`` — a spec that will not load is named."""
+    snapshots: dict[str, object] = {}
+    unmeasurable: list[str] = []
+    for path in paths:
+        try:
+            snapshots[str(path)] = _backend_snapshot(path)
+        except Exception as exc:  # stx-allow: fallback (reason: a spec the loader rejects is UNMEASURABLE, the honest third value; enumerating loader exception types would turn any new one into a crash mid-sweep)
+            unmeasurable.append(f"{path.parent.name}: {type(exc).__name__}: {exc}")
+    return snapshots, unmeasurable
+
+
+def apply_engines_migration(plan: EnginesPlan, archive_dir: Path) -> ApplyResult:
+    """Archive, write, re-measure, and undo unless the backends are identical."""
+    targets = list(plan.migrated)
+    if not targets:
+        return ApplyResult(applied=True)
+    paths = [o.path for o in targets]
+
+    before, unmeasurable = _snapshot_all(paths)
+    if unmeasurable:
+        # Refuse BEFORE writing. The gate would catch this afterwards too, but
+        # writing N files to learn something knowable beforehand is a rollback
+        # waiting to be needed, not a safety property.
+        return ApplyResult(
+            refused=(
+                f"{len(unmeasurable)} spec(s) could not be loaded BEFORE the "
+                f"sweep, so no post-write comparison could prove them "
+                f"unchanged: " + "; ".join(unmeasurable)
+            )
+        )
+
+    archive_dir = Path(archive_dir)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    for outcome in targets:
+        shutil.copy2(outcome.path, archive_dir / f"{outcome.agent}.spec.yaml")
+    for outcome in targets:
+        outcome.path.write_text(outcome.new_text or "")
+
+    after, still_unmeasurable = _snapshot_all(paths)
+    drift = [
+        f"{Path(key).parent.name}: {before[key]!r} -> {after[key]!r}"
+        for key in before
+        if key in after and after[key] != before[key]
+    ]
+    if still_unmeasurable or drift:
+        for outcome in targets:
+            shutil.copy2(archive_dir / f"{outcome.agent}.spec.yaml", outcome.path)
+        return ApplyResult(
+            archive_dir=archive_dir,
+            rolled_back=(
+                f"{len(drift)} spec(s) changed backend and "
+                f"{len(still_unmeasurable)} stopped loading; every original was "
+                f"restored from {archive_dir}"
+            ),
+            drift=tuple(drift + still_unmeasurable),
+        )
+    return ApplyResult(
+        written=tuple(o.agent for o in targets),
+        archive_dir=archive_dir,
+        applied=True,
+    )

--- a/src/scitex_agent_container/_maintenance/_engines_selection.py
+++ b/src/scitex_agent_container/_maintenance/_engines_selection.py
@@ -1,0 +1,265 @@
+"""WHICH specs the ``spec.engines`` sweep touches — and what it left out.
+
+Split from :mod:`._engines_migration`, which now owns only "what would this do
+to them". The two questions have different failure modes, and every failure
+mode on THIS side has the same shape: a spec.yaml that exists on disk and is
+absent from the count, with nothing in the report to say so. That is the
+"reports N done over a fleet of N+1" defect, and a selection is only safe if
+it NAMES everything it declined to look at.
+
+FOUR THINGS ARE NAMED RATHER THAN DROPPED, and :class:`SpecSelection` carries
+all four:
+
+  ``skipped_templates``   the ``_``-prefixed dirs ``sac agents create`` copies.
+  ``shadowed``            a second root's spec.yaml for a name an earlier root
+                          already supplied. Exactly one copy may be written —
+                          writing both migrates one agent twice, into the copy
+                          that loads and into a stale one — but the loser is a
+                          real file still carrying the legacy shape, and
+                          earlier-root-wins is DETERMINISTIC, so no later run
+                          can reach it. Measured before this existed: 4
+                          spec.yaml on disk across two roots, ``specs: 3``, and
+                          the fourth in no bucket and no payload field.
+  ``unmatched_agents``    a ``--agent`` value that matched nothing. Set
+                          membership discards a typo or a renamed agent in
+                          silence, so ``-a a -a b -a c`` with ``c`` renamed
+                          covers two of three on every run and exits 0.
+  ``unmatched_hosts``     the same for ``--host``.
+
+AN UNREADABLE SPEC IS KEPT, NEVER EXCLUDED. ``--host`` reads each spec to
+decide, and a spec it cannot read reaches the plan as ``unreadable`` — which
+makes the plan unsafe to apply. Excluding it would make the batching flag the
+thing that disarms the guard against an unsafe apply. For the same reason an
+unreadable spec SUPPRESSES the unmatched-host report: "no spec declares that
+host" is a claim, and a spec whose hosts could not be read is not evidence for
+it.
+
+WHICH COPY WINS, AND WHY THAT IS NOT A CLAIM. Earlier roots win, in the order
+the resolver hands them over. The sweep's caller
+(:func:`..cli_pkg._agents_migrate_engines.default_spec_roots`) is what makes
+that order agree with :func:`...config._resolve.resolve_config`'s own
+precedence; this module just does not reorder them. On a genuine collision
+that resolver REFUSES to pick and raises ``AmbiguousRegistryScope``, so a
+colliding name is a pre-existing fleet fault a human resolves — which is
+exactly why the loser is reported rather than dropped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+__all__ = [
+    "ShadowedSpec",
+    "SpecSelection",
+    "read_spec_text",
+    "select_spec_paths",
+    "select_spec_paths_over_roots",
+]
+
+
+def read_spec_text(path: Path) -> str:
+    """A spec's text with its LINE ENDINGS INTACT.
+
+    ``Path.read_text`` opens in universal-newline mode, which silently turns
+    every ``\\r\\n`` into ``\\n`` before the caller sees a byte. A CRLF spec
+    read that way and written back is rewritten END TO END — the
+    unreviewable whole-file diff the operator asked this sweep to avoid —
+    and ``_yaml_line_edit.split_ending``'s CRLF handling becomes unreachable
+    because the ``\\r`` is already gone. ``newline=""`` is what makes that
+    machinery real rather than decorative.
+    """
+    with Path(path).open("r", encoding="utf-8", newline="") as handle:
+        return handle.read()
+
+
+def spec_hosts_from_text(text: str) -> "set[str] | None":
+    """Every host the spec TEXT places itself on. ``None`` when unparsable.
+
+    Takes text rather than a path so the caller that has already read the
+    file judges the SAME bytes it will edit. Re-reading to answer a second
+    question is how one file yields two answers.
+    """
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError:  # stx-allow: fallback (reason: an unparsable spec must reach the PLAN as "host unknown", not vanish from the selection filter)
+        return None
+    spec = (doc or {}).get("spec") or {}
+    hosts = {str(spec.get("host"))} if spec.get("host") else set()
+    declared = spec.get("hosts")
+    if isinstance(declared, list):
+        hosts |= {str(h) for h in declared if h}
+    return hosts
+
+
+def spec_hosts(path: Path) -> "set[str] | None":
+    """Every host a spec places itself on.
+
+    ``set()`` means the spec was read and places itself nowhere. ``None``
+    means it COULD NOT BE READ — a different answer, and the one the host
+    filter must not confuse with "no match": an unreadable spec that vanishes
+    from the selection is the "118 done over a fleet of 119" failure, and
+    ``--host`` would then be the flag that disables the guard blocking an
+    unsafe apply.
+    """
+    try:
+        text = read_spec_text(path)
+    except (
+        OSError,
+        UnicodeDecodeError,
+    ):  # stx-allow: fallback (reason: an unreadable spec must reach the PLAN as unreadable, not vanish from the selection filter)
+        return None
+    return spec_hosts_from_text(text)
+
+
+@dataclass(frozen=True)
+class ShadowedSpec:
+    """A spec.yaml an earlier root's copy of the same AGENT NAME displaced.
+
+    Both paths are carried because the agent name alone does not let anyone
+    act on it: resolving the collision means looking at two files.
+    """
+
+    agent: str
+    kept: Path
+    dropped: Path
+
+
+@dataclass(frozen=True)
+class SpecSelection:
+    """What this run looks at, and everything it deliberately did not.
+
+    A plain list of paths cannot express the second half, which is why this
+    exists: the count must add up to the spec.yaml files on disk, or say
+    exactly where the difference went.
+    """
+
+    paths: "tuple[Path, ...]" = ()
+    skipped_templates: "tuple[str, ...]" = field(default=())
+    shadowed: "tuple[ShadowedSpec, ...]" = field(default=())
+    unmatched_agents: "tuple[str, ...]" = field(default=())
+    unmatched_hosts: "tuple[str, ...]" = field(default=())
+
+
+def _candidates(roots, *, templates: bool) -> "tuple[list[Path], list[str]]":
+    """Every spec.yaml under every root, sorted per root, plus the templates."""
+    picked: "list[Path]" = []
+    skipped: "list[str]" = []
+    for root in roots:
+        for path in sorted(Path(root).glob("*/spec.yaml")):
+            if path.parent.name.startswith("_") and not templates:
+                if path.parent.name not in skipped:
+                    skipped.append(path.parent.name)
+                continue
+            picked.append(path)
+    return picked, skipped
+
+
+def _by_host(
+    paths: "list[Path]", wanted: "set[str]"
+) -> "tuple[list[Path], set[str], bool]":
+    """Filter by host; report which wanted hosts matched, and any blind spot.
+
+    The third value is True when at least one candidate's hosts could not be
+    read. It suppresses the unmatched-host report, because "nothing declares
+    that host" is a claim and a spec nobody could read is not evidence for it.
+    """
+    kept: "list[Path]" = []
+    matched: "set[str]" = set()
+    blind = False
+    for path in paths:
+        declared = spec_hosts(path)
+        if declared is None:
+            blind = True
+            kept.append(path)
+            continue
+        hit = declared & wanted
+        if hit:
+            matched |= hit
+            kept.append(path)
+    return kept, matched, blind
+
+
+def select_spec_paths_over_roots(
+    roots: "tuple[Path, ...]",
+    *,
+    hosts: "tuple[str, ...]" = (),
+    agents: "tuple[str, ...]" = (),
+    templates: bool = False,
+) -> SpecSelection:
+    """The selection over SEVERAL roots, de-duped by AGENT NAME.
+
+    Batching is the operator's own condition for trusting a 119-file rewrite:
+    ``agents`` names an explicit set and ``hosts`` takes one machine at a
+    time. The order is sorted so a dry-run and the apply that follows it
+    agree on what they are looking at.
+
+    THE BATCH SIZE IS NOT HERE. ``--limit`` caps what gets WRITTEN, and which
+    specs those are is only knowable after planning — see
+    :func:`.._engines_migration.plan_engines_migration`. Capping the glob
+    instead re-selected the same first N on every run, so the second batch
+    wrote nothing and reported the sweep complete.
+
+    De-duplication is by NAME rather than by path, because the same agent
+    under two roots is two paths and writing both migrates one agent twice —
+    once into the copy that loads and once into a stale one. The loser is
+    returned in :attr:`SpecSelection.shadowed` rather than dropped.
+    """
+    candidates, skipped = _candidates(roots, templates=templates)
+
+    wanted_agents = {a for a in agents if a}
+    matched_agents: "set[str]" = set()
+    if wanted_agents:
+        matched_agents = {p.parent.name for p in candidates} & wanted_agents
+        candidates = [p for p in candidates if p.parent.name in wanted_agents]
+
+    wanted_hosts = {h for h in hosts if h}
+    matched_hosts: "set[str]" = set()
+    blind = False
+    if wanted_hosts:
+        candidates, matched_hosts, blind = _by_host(candidates, wanted_hosts)
+
+    picked: "list[Path]" = []
+    shadowed: "list[ShadowedSpec]" = []
+    first: "dict[str, Path]" = {}
+    for path in candidates:
+        name = path.parent.name
+        if name in first:
+            shadowed.append(ShadowedSpec(name, first[name], path))
+            continue
+        first[name] = path
+        picked.append(path)
+
+    return SpecSelection(
+        paths=tuple(picked),
+        skipped_templates=() if templates else tuple(skipped),
+        shadowed=tuple(shadowed),
+        unmatched_agents=tuple(sorted(wanted_agents - matched_agents)),
+        unmatched_hosts=(
+            () if blind else tuple(sorted(wanted_hosts - matched_hosts))
+        ),
+    )
+
+
+def select_spec_paths(
+    root: Path,
+    *,
+    hosts: "tuple[str, ...]" = (),
+    agents: "tuple[str, ...]" = (),
+    templates: bool = False,
+) -> "tuple[list[Path], list[str]]":
+    """One root's ``(paths, skipped template names)``.
+
+    The single-root shorthand, expressed through the several-roots form so
+    there is exactly one implementation of the filters. A caller that needs
+    the shadowed copies or the unmatched selectors calls
+    :func:`select_spec_paths_over_roots` and reads the full selection —
+    a single root cannot shadow anything, and this shape is what the
+    bucket-level unit tests want.
+    """
+    selection = select_spec_paths_over_roots(
+        (root,), hosts=hosts, agents=agents, templates=templates
+    )
+    return list(selection.paths), list(selection.skipped_templates)

--- a/src/scitex_agent_container/_maintenance/_roster_state.py
+++ b/src/scitex_agent_container/_maintenance/_roster_state.py
@@ -64,6 +64,11 @@ class RosterState:
     root: Path
     state: str
     n_specs: int = 0
+    #: Every root searched, when the sweep searched more than one. ``root``
+    #: stays the representative (first) one rather than being widened into a
+    #: joined string, because a caller that treats it as a path must keep
+    #: getting a path.
+    roots: "tuple[Path, ...]" = ()
 
     def __post_init__(self) -> None:
         if self.state not in ROSTER_STATES:
@@ -76,6 +81,18 @@ class RosterState:
         """True only when a count of zero may be reported as a fact."""
         return self.state == "populated"
 
+    @property
+    def where(self) -> str:
+        """Every root searched, named. Never just the first of several.
+
+        A report that names one root out of three is the same class of defect
+        as one that names none: the reader cannot tell which directories the
+        count is a fact about.
+        """
+        if self.roots:
+            return ", ".join(str(r) for r in self.roots)
+        return str(self.root)
+
     def describe(self) -> str:
         """One line naming the state AND the root, because the root is the bug.
 
@@ -84,15 +101,16 @@ class RosterState:
         and a total discovery failure.
         """
         if self.state == "absent":
+            plural = "directories do" if self.roots else "directory does"
             return (
-                f"no spec roster at {self.root} — the directory does not exist, "
+                f"no spec roster at {self.where} — the {plural} not exist, "
                 f"so nothing was searched. This is NOT an empty fleet. Set "
                 f"SCITEX_AGENT_CONTAINER_AGENTS_DIR to the registry you mean "
                 f"(inside a container $HOME is not the host's)."
             )
         if self.state == "empty":
-            return f"{self.root} exists but holds no specs — the registry is empty"
-        return f"{self.n_specs} spec(s) under {self.root}"
+            return f"{self.where} exists but holds no specs — the registry is empty"
+        return f"{self.n_specs} spec(s) under {self.where}"
 
 
 def inspect_roster(root: "Path | None", spec_paths) -> RosterState:
@@ -121,4 +139,38 @@ def inspect_roster(root: "Path | None", spec_paths) -> RosterState:
     return RosterState(root=Path(root), state="populated", n_specs=len(paths))
 
 
-__all__ = ["ROSTER_STATES", "RosterState", "inspect_roster"]
+def inspect_roster_over_roots(roots, spec_paths) -> RosterState:
+    """Classify a roster gathered from SEVERAL roots at once.
+
+    The three states keep their meanings, widened by exactly one word:
+    ``absent`` is now "NONE of the roots is a directory" — the same "I looked
+    nowhere" that must never be reported as an empty fleet. A run where one
+    root of three exists but holds nothing DID look somewhere, so it is
+    ``empty``, which is a reportable fact rather than a discovery failure.
+
+    Only the directories that EXIST are carried into ``roots`` for the
+    report: naming a root that is not there alongside two that are invites
+    the reader to conclude the count came from all three.
+    """
+    every = [Path(r) for r in roots]
+    if not every:
+        return inspect_roster(None, spec_paths)
+    paths = list(spec_paths)
+    present = tuple(r for r in every if r.is_dir())
+    if not present:
+        return RosterState(
+            root=every[0], state="absent", n_specs=0, roots=tuple(every)
+        )
+    if not paths:
+        return RosterState(root=present[0], state="empty", n_specs=0, roots=present)
+    return RosterState(
+        root=present[0], state="populated", n_specs=len(paths), roots=present
+    )
+
+
+__all__ = [
+    "ROSTER_STATES",
+    "RosterState",
+    "inspect_roster",
+    "inspect_roster_over_roots",
+]

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
@@ -15,20 +15,33 @@ answer that and they are the command's shape:
 
   * **Dry-run is the DEFAULT.** ``--apply`` is the deliberate act, and the
     dry-run prints a real unified diff per spec rather than a count to trust.
-  * **Batches.** ``--agent`` names an explicit set, ``--host`` takes one
-    machine at a time, ``--limit`` caps whatever those selected. Nobody has
-    to rewrite 119 files to rewrite one.
+  * **Batches that ADVANCE.** ``--agent`` names an explicit set, ``--host``
+    takes one machine at a time, and ``--limit N`` caps what gets WRITTEN —
+    not what gets examined — so running the same command again takes the
+    NEXT N. Capping the selection instead re-picked the same first N
+    forever: batch two wrote nothing and announced a completed sweep.
   * **A measured gate on the apply.** Every selected spec is loaded through
     the production loader before the write and again after; unless the
     effective backend is identical for every one, every original is restored
-    from the archive taken first.
+    from the archive taken first. Every write is a temp file plus
+    ``os.replace``, and a failure part-way rolls the batch back instead of
+    aborting the process on a traceback over a half-migrated fleet.
 
 An unmigratable spec is REFUSED BY NAME with its reason, never skipped —
-skipping is how a sweep reports 118 done over a fleet of 119.
+skipping is how a sweep reports 118 done over a fleet of 119. No filter may
+make one vanish either: ``--host`` KEEPS a spec it could not read, so it
+reaches the plan as unreadable rather than out of the count.
+
+**Where it writes.** ``--root``, else ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR``,
+else ``$HOME/.scitex/agent-container/agents`` — the LIVE copy, which is not a
+git checkout and, inside a container, is not the host's ``$HOME``. Every
+report names the root it searched.
 
 **Exit codes.** ``0`` the plan is sound (a named refusal is NOT a failure),
 ``1`` a spec is unreadable or no roster was searched, ``2`` the apply was
-refused or rolled back.
+refused or rolled back. ``exit 0`` does NOT mean the migration is finished —
+a run whose every spec was refused also exits 0. ``migration_complete`` in
+``--json`` is the field that answers that question.
 
 ``--preflight`` probes the gateway the migration points at and reports a
 NAMED state rather than a boolean, because the two failure shapes look
@@ -42,31 +55,28 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+from pathlib import Path as _Path
 
 import click
-from rich.markup import escape
 
 from .._maintenance._engines_migration import (
     apply_engines_migration,
     plan_engines_migration,
     select_spec_paths,
 )
+from ._agents_migrate_engines_report import (
+    plan_payload,
+    preflight_payload,
+    render_apply,
+    render_diffs,
+    render_plan,
+    render_preflight,
+)
 from ._helpers import _json_flag, console
 
 _EXIT_OK = 0
 _EXIT_PLAN_UNSOUND = 1
 _EXIT_APPLY_REFUSED = 2
-
-
-def _lit(text: str) -> str:
-    """Escape before printing through rich.
-
-    Not habit — MEASURED on the sibling sweep: a value rendering as
-    ``[user-shared]`` is parsed by rich as a style tag and SWALLOWED, so a
-    report printed a correct histogram with every row blank. Engine keys and
-    model ids here include ``opus[1m]``, which is exactly that shape.
-    """
-    return escape(str(text))
 
 
 def _archive_dir():
@@ -76,149 +86,18 @@ def _archive_dir():
     return runtime_base_dir() / "engines-migration" / stamp
 
 
-def _preflight_payload() -> dict:
-    """Probe the gateway the migration writes into every spec."""
-    from ..config._engine_reach import reach_verdict
-    from ..config._qwen_gateway import QWEN_GATEWAY_PROVIDER, qwen_gateway_url
+def _complete_after_apply(plan, result) -> bool:
+    """Is the migration finished, given what this apply actually did?
 
-    url = qwen_gateway_url()
-    verdict = reach_verdict(url)
-    return {
-        "provider": QWEN_GATEWAY_PROVIDER,
-        "url": url,
-        "state": verdict.state,
-        "detail": verdict.detail,
-        "http_status": verdict.http_status,
-        "proves_listening": verdict.proves_listening,
-        "proves_absent": verdict.proves_absent,
-        "undetermined": verdict.undetermined,
-    }
-
-
-def _render_preflight(payload: dict) -> None:
-    colour = "green" if payload["proves_listening"] else "red"
-    if payload["undetermined"]:
-        colour = "yellow"
-    console.print(
-        f"[bold]gateway preflight[/bold] {_lit(payload['url'])} "
-        f"([{colour}]{_lit(payload['state'])}[/{colour}])\n"
-        f"  {_lit(payload['detail'])}",
-        soft_wrap=True,
-    )
-    if payload["undetermined"]:
-        console.print(
-            "  [dim]UNDETERMINED is not a negative. Nothing here says the "
-            "gateway is down.[/dim]",
-            soft_wrap=True,
-        )
-
-
-def _plan_payload(plan, root) -> dict:
-    return {
-        "root": str(root),
-        "roster": plan.roster.state if plan.roster else None,
-        "specs": len(plan.outcomes),
-        "would_migrate": len(plan.migrated),
-        "already_migrated": [o.agent for o in plan.already],
-        "refused": [
-            {"agent": o.agent, "reason": o.reason, "detail": o.detail}
-            for o in plan.refused
-        ],
-        "unreadable": [{"agent": o.agent, "detail": o.detail} for o in plan.unreadable],
-        "skipped_templates": list(plan.skipped_templates),
-        "engine_sets": _engine_histogram(plan),
-        "safe_to_apply": plan.safe_to_apply,
-        "summary": plan.summary(),
-    }
-
-
-def _engine_histogram(plan) -> "dict[str, int]":
-    hist: dict[str, int] = {}
-    for outcome in plan.migrated:
-        key = ", ".join(outcome.engine_keys)
-        hist[key] = hist.get(key, 0) + 1
-    return dict(sorted(hist.items(), key=lambda kv: (-kv[1], kv[0])))
-
-
-def _render_plan(plan, payload: dict, *, diff: bool) -> None:
+    Distinct from ``plan.is_complete``, which is the question BEFORE the
+    write: a successful apply retires the ``migrated`` bucket, and what is
+    left is whatever no further write of this batch can clear.
+    """
+    if not result.applied:
+        return False
     if plan.roster is not None and not plan.roster.is_populated:
-        console.print(f"[red]NO ROSTER SEARCHED[/red] — {_lit(plan.roster.describe())}")
-        return
-    console.print(
-        f"[bold]{payload['specs']} spec(s)[/bold] under {_lit(payload['root'])} — "
-        f"{payload['would_migrate']} would gain a spec.engines block\n"
-    )
-    for keys, count in payload["engine_sets"].items():
-        console.print(f"  [green]{count:4d}[/green]  engines: {_lit(keys)}")
-    if payload["already_migrated"]:
-        console.print(
-            f"\n[dim]{len(payload['already_migrated'])} spec(s) already declare "
-            f"spec.engines — nothing to do for those.[/dim]"
-        )
-    for entry in payload["refused"]:
-        console.print(
-            f"\n[yellow]REFUSED[/yellow] {_lit(entry['agent'])}: "
-            f"{_lit(entry['reason'])}",
-            soft_wrap=True,
-        )
-        if entry["detail"]:
-            console.print(f"    [dim]{_lit(entry['detail'])}[/dim]", soft_wrap=True)
-    for entry in payload["unreadable"]:
-        console.print(
-            f"\n[red]UNREADABLE[/red] {_lit(entry['agent'])}: {_lit(entry['detail'])}",
-            soft_wrap=True,
-        )
-    if payload["skipped_templates"]:
-        # Named, never silent: `sac agents create` copies these, so a template
-        # left behind re-introduces the legacy shape on every agent made after
-        # the sweep — the migration would then never finish.
-        console.print(
-            f"\n[yellow]NOT SEARCHED[/yellow] "
-            f"{len(payload['skipped_templates'])} template spec(s) "
-            f"({_lit(', '.join(payload['skipped_templates']))}). "
-            f"`sac agents create` copies them, so an unmigrated template "
-            f"re-introduces the legacy shape on every new agent. Pass "
-            f"--templates to include them.",
-            soft_wrap=True,
-        )
-    if diff:
-        for outcome in plan.migrated:
-            console.print(f"\n[bold]{_lit(outcome.agent)}[/bold]")
-            console.print(_lit(outcome.diff), soft_wrap=True, highlight=False)
-    console.print(f"\n[bold]{_lit(payload['summary'])}[/bold]")
-
-
-def _render_apply(result, payload: dict) -> None:
-    if result.applied and not result.written:
-        # Names the population it is making this claim about. The unqualified
-        # form of this sentence was printed by a sibling sweep that had
-        # discovered ZERO specs; an assertion that a migration is FINISHED is
-        # the last place to omit what it counted.
-        console.print(
-            f"[green]Nothing to write[/green] — all "
-            f"{payload['specs']} spec(s) under {_lit(payload['root'])} already "
-            f"declare spec.engines. The sweep is idempotent; this is what a "
-            f"completed one looks like."
-        )
-        return
-    if result.applied:
-        console.print(
-            f"[green]APPLIED[/green] {len(result.written)} spec(s) written and "
-            f"verified — every one still resolves the SAME backend.\n"
-            f"  [dim]originals archived at {_lit(result.archive_dir)}[/dim]"
-        )
-        return
-    if result.rolled_back:
-        console.print(
-            f"[red]ROLLED BACK[/red] — {_lit(result.rolled_back)}", soft_wrap=True
-        )
-        for entry in result.drift:
-            console.print(f"    [magenta]{_lit(entry)}[/magenta]", soft_wrap=True)
-        return
-    console.print(
-        f"[red]REFUSED[/red] — nothing was written.\n  {_lit(result.refused)}",
-        soft_wrap=True,
-    )
+        return False
+    return not (plan.held_back or plan.refused or plan.unreadable)
 
 
 @click.command(name="migrate-engines")
@@ -256,7 +135,22 @@ def _render_apply(result, payload: dict) -> None:
     type=int,
     default=None,
     metavar="N",
-    help="Cap the batch at N specs, after --agent/--host have selected.",
+    help=(
+        "Write at most N specs this run. Already-migrated and refused specs "
+        "do not consume the cap, so repeating the command ADVANCES."
+    ),
+)
+@click.option(
+    "--root",
+    "root_opt",
+    type=click.Path(file_okay=False, path_type=_Path),
+    default=None,
+    metavar="DIR",
+    help=(
+        "The agents/ directory to sweep. Defaults to "
+        "$SCITEX_AGENT_CONTAINER_AGENTS_DIR, else $HOME/.scitex/agent-container"
+        "/agents — which inside a container is NOT the host's."
+    ),
 )
 @click.option(
     "--templates",
@@ -284,6 +178,7 @@ def migrate_engines(
     agents: "tuple[str, ...]",
     hosts: "tuple[str, ...]",
     limit: "int | None",
+    root_opt: "_Path | None",
     templates: bool,
     diff: bool,
     preflight: bool,
@@ -303,47 +198,67 @@ def migrate_engines(
       $ sac agents migrate-engines
       $ sac agents migrate-engines --no-diff --json
     \b
-    In batches:
+    In batches (`--limit` advances: run it again for the next N):
       $ sac agents migrate-engines -a business -a handyman-02
       $ sac agents migrate-engines --host scitex-compute-04 --limit 5 --apply
+    \b
+    Somewhere other than the live copy:
+      $ sac agents migrate-engines --root ~/.dotfiles/src/.scitex/agent-container/agents
     \b
     Gateway reachability, three-valued:
       $ sac agents migrate-engines --preflight --no-diff
 
+    WHERE IT WRITES. `--root`, else $SCITEX_AGENT_CONTAINER_AGENTS_DIR, else
+    $HOME/.scitex/agent-container/agents — the LIVE copy, which is not a git
+    checkout and, inside a container, is not the host's $HOME either. Every
+    report names the root it searched; pass `--root` to sweep the tracked
+    tree instead.
+
     Exits 0 when the plan is sound (a named REFUSAL is not a failure), 1 when a
     spec is unreadable or no roster was searched, 2 when the apply was refused
-    or rolled back.
+    or rolled back. `migration_complete` in --json is the answer to "is the
+    sweep finished" — the exit code is not.
     """
     if apply and dry_run:
         raise click.UsageError(
             "--apply and --dry-run are contradictory. Dry-run is the DEFAULT: "
             "drop both flags to preview, pass --apply to write."
         )
+    if limit is not None and limit < 1:
+        # A bare slice accepted this: `--limit -1` silently dropped the LAST
+        # spec and reported success, so a typo turned "one spec" into "all
+        # but one".
+        raise click.UsageError(
+            f"--limit must be a positive number of specs to write; got {limit}."
+        )
 
     from .._maintenance._layers_migration_plan import fleet_agents_dir
 
-    root = fleet_agents_dir()
+    root = _Path(root_opt) if root_opt is not None else fleet_agents_dir()
     paths, skipped = select_spec_paths(
-        root, hosts=hosts, agents=agents, templates=templates, limit=limit
+        root, hosts=hosts, agents=agents, templates=templates
     )
-    plan = plan_engines_migration(paths, root=root, skipped_templates=skipped)
-    payload = _plan_payload(plan, root)
+    plan = plan_engines_migration(
+        paths, root=root, skipped_templates=skipped, limit=limit
+    )
+    payload = plan_payload(plan, root)
     payload["mode"] = "apply" if apply else "dry-run"
-    payload["preflight"] = _preflight_payload() if preflight else None
+    payload["preflight"] = preflight_payload() if preflight else None
+
+    if diff:
+        payload["diffs"] = {o.agent: o.diff for o in plan.migrated}
 
     if not apply:
         code = _EXIT_OK if plan.safe_to_apply else _EXIT_PLAN_UNSOUND
         payload["exit_code"] = code
-        if diff:
-            payload["diffs"] = {o.agent: o.diff for o in plan.migrated}
         if _json_flag(ctx, as_json):
             click.echo(json.dumps(payload, indent=2))
             raise SystemExit(code)
         console.print("[bold]sac agents migrate-engines[/bold]  dry-run (read-only)\n")
         if payload["preflight"]:
-            _render_preflight(payload["preflight"])
+            render_preflight(payload["preflight"])
             console.print("")
-        _render_plan(plan, payload, diff=diff)
+        render_plan(plan, payload, diff=diff)
         if plan.migrated:
             console.print(
                 "\nNothing was written — this is a dry-run. To act:\n"
@@ -358,7 +273,7 @@ def migrate_engines(
             click.echo(json.dumps(payload, indent=2))
             raise SystemExit(_EXIT_PLAN_UNSOUND)
         console.print("[bold]sac agents migrate-engines[/bold]  apply\n")
-        _render_plan(plan, payload, diff=False)
+        render_plan(plan, payload, diff=diff)
         console.print(
             "\n[red]REFUSED[/red] — nothing was written. A plan that cannot "
             "describe every spec does not describe the sweep."
@@ -375,6 +290,8 @@ def migrate_engines(
             "apply_refused": result.refused,
             "rolled_back": result.rolled_back,
             "drift": list(result.drift),
+            "errors": list(result.errors),
+            "migration_complete": _complete_after_apply(plan, result),
             "exit_code": code,
         }
     )
@@ -382,7 +299,13 @@ def migrate_engines(
         click.echo(json.dumps(payload, indent=2))
         raise SystemExit(code)
     console.print("[bold]sac agents migrate-engines[/bold]  apply\n")
-    _render_apply(result, payload)
+    if diff:
+        # `--diff` is on by DEFAULT and its help calls it "the whole point".
+        # It used to be accepted and dropped on this path, so an operator who
+        # believed they were reviewing what was written saw nothing at all.
+        render_diffs(plan)
+        console.print("")
+    render_apply(result, payload)
     raise SystemExit(code)
 
 

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
@@ -1,0 +1,394 @@
+"""``sac agents migrate-engines`` — give every spec a HARNESS x ENGINE block.
+
+The operator's direction (Telegram, 2026-09-05/06): rewrite every agent spec
+so HARNESS and ENGINE are separate axes, so any agent can be started on the
+Qwen engine instead of Claude, and so Qwen can eventually become the DEFAULT.
+The axis already exists in code — ``--engine`` at start, ``spec.engines`` in
+the loader; what was missing is the sweep that gives all 119 specs the block.
+1 of them has it today.
+
+And the condition attached to it, verbatim:「一気に書き換えるコマンドめちゃ
+くちゃ怖いので、ちゃんと git で管理してくださいね。大体置換のコードって
+いつも失敗するんですよね。」— a command that rewrites everything at once is
+frightening, keep it in git, bulk-replacement code always fails. Three things
+answer that and they are the command's shape:
+
+  * **Dry-run is the DEFAULT.** ``--apply`` is the deliberate act, and the
+    dry-run prints a real unified diff per spec rather than a count to trust.
+  * **Batches.** ``--agent`` names an explicit set, ``--host`` takes one
+    machine at a time, ``--limit`` caps whatever those selected. Nobody has
+    to rewrite 119 files to rewrite one.
+  * **A measured gate on the apply.** Every selected spec is loaded through
+    the production loader before the write and again after; unless the
+    effective backend is identical for every one, every original is restored
+    from the archive taken first.
+
+An unmigratable spec is REFUSED BY NAME with its reason, never skipped —
+skipping is how a sweep reports 118 done over a fleet of 119.
+
+**Exit codes.** ``0`` the plan is sound (a named refusal is NOT a failure),
+``1`` a spec is unreadable or no roster was searched, ``2`` the apply was
+refused or rolled back.
+
+``--preflight`` probes the gateway the migration points at and reports a
+NAMED state rather than a boolean, because the two failure shapes look
+identical through curl: ``scitex-compute-04:18772`` answers 401 (reachable
+and auth-gating) while ``compute-04:18772`` answers ``000`` — which reads as
+"the gateway is down" and means "the hostname does not resolve". See
+:mod:`...config._engine_reach`.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+
+import click
+from rich.markup import escape
+
+from .._maintenance._engines_migration import (
+    apply_engines_migration,
+    plan_engines_migration,
+    select_spec_paths,
+)
+from ._helpers import _json_flag, console
+
+_EXIT_OK = 0
+_EXIT_PLAN_UNSOUND = 1
+_EXIT_APPLY_REFUSED = 2
+
+
+def _lit(text: str) -> str:
+    """Escape before printing through rich.
+
+    Not habit — MEASURED on the sibling sweep: a value rendering as
+    ``[user-shared]`` is parsed by rich as a style tag and SWALLOWED, so a
+    report printed a correct histogram with every row blank. Engine keys and
+    model ids here include ``opus[1m]``, which is exactly that shape.
+    """
+    return escape(str(text))
+
+
+def _archive_dir():
+    from .._runtime_paths import runtime_base_dir
+
+    stamp = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return runtime_base_dir() / "engines-migration" / stamp
+
+
+def _preflight_payload() -> dict:
+    """Probe the gateway the migration writes into every spec."""
+    from ..config._engine_reach import reach_verdict
+    from ..config._qwen_gateway import QWEN_GATEWAY_PROVIDER, qwen_gateway_url
+
+    url = qwen_gateway_url()
+    verdict = reach_verdict(url)
+    return {
+        "provider": QWEN_GATEWAY_PROVIDER,
+        "url": url,
+        "state": verdict.state,
+        "detail": verdict.detail,
+        "http_status": verdict.http_status,
+        "proves_listening": verdict.proves_listening,
+        "proves_absent": verdict.proves_absent,
+        "undetermined": verdict.undetermined,
+    }
+
+
+def _render_preflight(payload: dict) -> None:
+    colour = "green" if payload["proves_listening"] else "red"
+    if payload["undetermined"]:
+        colour = "yellow"
+    console.print(
+        f"[bold]gateway preflight[/bold] {_lit(payload['url'])} "
+        f"([{colour}]{_lit(payload['state'])}[/{colour}])\n"
+        f"  {_lit(payload['detail'])}",
+        soft_wrap=True,
+    )
+    if payload["undetermined"]:
+        console.print(
+            "  [dim]UNDETERMINED is not a negative. Nothing here says the "
+            "gateway is down.[/dim]",
+            soft_wrap=True,
+        )
+
+
+def _plan_payload(plan, root) -> dict:
+    return {
+        "root": str(root),
+        "roster": plan.roster.state if plan.roster else None,
+        "specs": len(plan.outcomes),
+        "would_migrate": len(plan.migrated),
+        "already_migrated": [o.agent for o in plan.already],
+        "refused": [
+            {"agent": o.agent, "reason": o.reason, "detail": o.detail}
+            for o in plan.refused
+        ],
+        "unreadable": [{"agent": o.agent, "detail": o.detail} for o in plan.unreadable],
+        "skipped_templates": list(plan.skipped_templates),
+        "engine_sets": _engine_histogram(plan),
+        "safe_to_apply": plan.safe_to_apply,
+        "summary": plan.summary(),
+    }
+
+
+def _engine_histogram(plan) -> "dict[str, int]":
+    hist: dict[str, int] = {}
+    for outcome in plan.migrated:
+        key = ", ".join(outcome.engine_keys)
+        hist[key] = hist.get(key, 0) + 1
+    return dict(sorted(hist.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def _render_plan(plan, payload: dict, *, diff: bool) -> None:
+    if plan.roster is not None and not plan.roster.is_populated:
+        console.print(f"[red]NO ROSTER SEARCHED[/red] — {_lit(plan.roster.describe())}")
+        return
+    console.print(
+        f"[bold]{payload['specs']} spec(s)[/bold] under {_lit(payload['root'])} — "
+        f"{payload['would_migrate']} would gain a spec.engines block\n"
+    )
+    for keys, count in payload["engine_sets"].items():
+        console.print(f"  [green]{count:4d}[/green]  engines: {_lit(keys)}")
+    if payload["already_migrated"]:
+        console.print(
+            f"\n[dim]{len(payload['already_migrated'])} spec(s) already declare "
+            f"spec.engines — nothing to do for those.[/dim]"
+        )
+    for entry in payload["refused"]:
+        console.print(
+            f"\n[yellow]REFUSED[/yellow] {_lit(entry['agent'])}: "
+            f"{_lit(entry['reason'])}",
+            soft_wrap=True,
+        )
+        if entry["detail"]:
+            console.print(f"    [dim]{_lit(entry['detail'])}[/dim]", soft_wrap=True)
+    for entry in payload["unreadable"]:
+        console.print(
+            f"\n[red]UNREADABLE[/red] {_lit(entry['agent'])}: {_lit(entry['detail'])}",
+            soft_wrap=True,
+        )
+    if payload["skipped_templates"]:
+        # Named, never silent: `sac agents create` copies these, so a template
+        # left behind re-introduces the legacy shape on every agent made after
+        # the sweep — the migration would then never finish.
+        console.print(
+            f"\n[yellow]NOT SEARCHED[/yellow] "
+            f"{len(payload['skipped_templates'])} template spec(s) "
+            f"({_lit(', '.join(payload['skipped_templates']))}). "
+            f"`sac agents create` copies them, so an unmigrated template "
+            f"re-introduces the legacy shape on every new agent. Pass "
+            f"--templates to include them.",
+            soft_wrap=True,
+        )
+    if diff:
+        for outcome in plan.migrated:
+            console.print(f"\n[bold]{_lit(outcome.agent)}[/bold]")
+            console.print(_lit(outcome.diff), soft_wrap=True, highlight=False)
+    console.print(f"\n[bold]{_lit(payload['summary'])}[/bold]")
+
+
+def _render_apply(result, payload: dict) -> None:
+    if result.applied and not result.written:
+        # Names the population it is making this claim about. The unqualified
+        # form of this sentence was printed by a sibling sweep that had
+        # discovered ZERO specs; an assertion that a migration is FINISHED is
+        # the last place to omit what it counted.
+        console.print(
+            f"[green]Nothing to write[/green] — all "
+            f"{payload['specs']} spec(s) under {_lit(payload['root'])} already "
+            f"declare spec.engines. The sweep is idempotent; this is what a "
+            f"completed one looks like."
+        )
+        return
+    if result.applied:
+        console.print(
+            f"[green]APPLIED[/green] {len(result.written)} spec(s) written and "
+            f"verified — every one still resolves the SAME backend.\n"
+            f"  [dim]originals archived at {_lit(result.archive_dir)}[/dim]"
+        )
+        return
+    if result.rolled_back:
+        console.print(
+            f"[red]ROLLED BACK[/red] — {_lit(result.rolled_back)}", soft_wrap=True
+        )
+        for entry in result.drift:
+            console.print(f"    [magenta]{_lit(entry)}[/magenta]", soft_wrap=True)
+        return
+    console.print(
+        f"[red]REFUSED[/red] — nothing was written.\n  {_lit(result.refused)}",
+        soft_wrap=True,
+    )
+
+
+@click.command(name="migrate-engines")
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="ACTUALLY write the engines blocks. Without this, nothing is written.",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Report only, write nothing. This is already the DEFAULT.",
+)
+@click.option(
+    "-a",
+    "--agent",
+    "agents",
+    multiple=True,
+    metavar="NAME",
+    help="Restrict to these agents. Repeatable. The smallest batch.",
+)
+@click.option(
+    "--host",
+    "hosts",
+    multiple=True,
+    metavar="HOST",
+    help="Restrict to specs placed on this host. Repeatable.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=None,
+    metavar="N",
+    help="Cap the batch at N specs, after --agent/--host have selected.",
+)
+@click.option(
+    "--templates",
+    is_flag=True,
+    default=False,
+    help="Also migrate the _-prefixed template specs that `agents create` copies.",
+)
+@click.option(
+    "--diff/--no-diff",
+    default=True,
+    help="Print a unified diff per spec. On by default; the whole point.",
+)
+@click.option(
+    "--preflight",
+    is_flag=True,
+    default=False,
+    help="Probe the Qwen gateway and report a NAMED state (401 means reachable).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def migrate_engines(
+    ctx: click.Context,
+    apply: bool,
+    dry_run: bool,
+    agents: "tuple[str, ...]",
+    hosts: "tuple[str, ...]",
+    limit: "int | None",
+    templates: bool,
+    diff: bool,
+    preflight: bool,
+    as_json: bool,
+) -> None:
+    """Declare HARNESS x ENGINE in every spec. Dry-run by default.
+
+    Each spec's CURRENT backend becomes the DEFAULT engine, restated verbatim,
+    and a `qwen38-27b` entry is added pointing at the fleet gateway by NAME —
+    the address stays in config/_provider_registry, not in 119 files.
+    `spec.claude.model` and `spec.claude.provider` are emptied because the
+    engines now carry them; `spec.harness` stays and agrees with the default
+    engine. Comments are preserved, and the edit verifies that itself.
+
+    \b
+    Preview (read-only — the DEFAULT):
+      $ sac agents migrate-engines
+      $ sac agents migrate-engines --no-diff --json
+    \b
+    In batches:
+      $ sac agents migrate-engines -a business -a handyman-02
+      $ sac agents migrate-engines --host scitex-compute-04 --limit 5 --apply
+    \b
+    Gateway reachability, three-valued:
+      $ sac agents migrate-engines --preflight --no-diff
+
+    Exits 0 when the plan is sound (a named REFUSAL is not a failure), 1 when a
+    spec is unreadable or no roster was searched, 2 when the apply was refused
+    or rolled back.
+    """
+    if apply and dry_run:
+        raise click.UsageError(
+            "--apply and --dry-run are contradictory. Dry-run is the DEFAULT: "
+            "drop both flags to preview, pass --apply to write."
+        )
+
+    from .._maintenance._layers_migration_plan import fleet_agents_dir
+
+    root = fleet_agents_dir()
+    paths, skipped = select_spec_paths(
+        root, hosts=hosts, agents=agents, templates=templates, limit=limit
+    )
+    plan = plan_engines_migration(paths, root=root, skipped_templates=skipped)
+    payload = _plan_payload(plan, root)
+    payload["mode"] = "apply" if apply else "dry-run"
+    payload["preflight"] = _preflight_payload() if preflight else None
+
+    if not apply:
+        code = _EXIT_OK if plan.safe_to_apply else _EXIT_PLAN_UNSOUND
+        payload["exit_code"] = code
+        if diff:
+            payload["diffs"] = {o.agent: o.diff for o in plan.migrated}
+        if _json_flag(ctx, as_json):
+            click.echo(json.dumps(payload, indent=2))
+            raise SystemExit(code)
+        console.print("[bold]sac agents migrate-engines[/bold]  dry-run (read-only)\n")
+        if payload["preflight"]:
+            _render_preflight(payload["preflight"])
+            console.print("")
+        _render_plan(plan, payload, diff=diff)
+        if plan.migrated:
+            console.print(
+                "\nNothing was written — this is a dry-run. To act:\n"
+                "    sac agents migrate-engines --apply"
+            )
+        raise SystemExit(code)
+
+    if not plan.safe_to_apply:
+        payload["exit_code"] = _EXIT_PLAN_UNSOUND
+        payload["apply_refused"] = f"plan is not safe to apply: {plan.summary()}"
+        if _json_flag(ctx, as_json):
+            click.echo(json.dumps(payload, indent=2))
+            raise SystemExit(_EXIT_PLAN_UNSOUND)
+        console.print("[bold]sac agents migrate-engines[/bold]  apply\n")
+        _render_plan(plan, payload, diff=False)
+        console.print(
+            "\n[red]REFUSED[/red] — nothing was written. A plan that cannot "
+            "describe every spec does not describe the sweep."
+        )
+        raise SystemExit(_EXIT_PLAN_UNSOUND)
+
+    result = apply_engines_migration(plan, _archive_dir())
+    code = _EXIT_OK if result.applied else _EXIT_APPLY_REFUSED
+    payload.update(
+        {
+            "written": list(result.written),
+            "archive_dir": str(result.archive_dir) if result.archive_dir else None,
+            "applied": result.applied,
+            "apply_refused": result.refused,
+            "rolled_back": result.rolled_back,
+            "drift": list(result.drift),
+            "exit_code": code,
+        }
+    )
+    if _json_flag(ctx, as_json):
+        click.echo(json.dumps(payload, indent=2))
+        raise SystemExit(code)
+    console.print("[bold]sac agents migrate-engines[/bold]  apply\n")
+    _render_apply(result, payload)
+    raise SystemExit(code)
+
+
+def register(agent_group) -> None:
+    """Attach ``migrate-engines`` to the parent ``agents`` Click group."""
+    agent_group.add_command(migrate_engines)
+
+
+__all__ = ["migrate_engines", "register"]

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
@@ -348,12 +348,14 @@ def migrate_engines(
 ) -> None:
     """Declare HARNESS x ENGINE in every spec. Dry-run by default.
 
-    Each spec's CURRENT backend becomes the DEFAULT engine, restated verbatim,
-    and a `qwen38-27b` entry is added pointing at the fleet gateway by NAME —
-    the address stays in config/_provider_registry, not in 119 files.
-    `spec.claude.model` and `spec.claude.provider` are emptied because the
-    engines now carry them; `spec.harness` stays and agrees with the default
-    engine. Comments are preserved, and the edit verifies that itself.
+    Each spec's CURRENT backend becomes ONE named engine, restated verbatim —
+    no `harness:` and no `default:` inside the entry, both deprecated by the
+    split. Alternates are NOT copied in: they live once in the fleet engine
+    library ($SCITEX_DIR/agent-container/engines.yaml) and stay reachable with
+    `--engine <key>`. `spec.claude.model` and `spec.claude.provider` are
+    emptied because the engine now carries them; `spec.harness` stays stated
+    and the entry inherits it. Comments are preserved, and the edit verifies
+    that itself.
 
     \b
     Preview (read-only — the DEFAULT):

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
@@ -41,16 +41,22 @@ and the fail-closed rule (an unmeasured host is refused, never assumed
 capable). ``--host-supports-engines HOST`` lifts it for a named machine.
 
 **Where it writes.** ``--root``, else ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR``,
-else EVERY user-scope root the rest of the CLI resolves, de-duplicated by
-agent name. The old default read a different env var and landed on the
-container's own ``$HOME`` — one spec next to the fleet's 123, reported as a
-finished sweep. Every report names the roots it searched.
+else every user-scope root the rest of the CLI resolves EXCEPT the
+project-local one, de-duplicated by agent name. The old default read a
+different env var and landed on the container's own ``$HOME`` — one spec next
+to the fleet's 123, reported as a finished sweep. Every report names the roots
+it searched, the roots it resolved and did not search, and the PATH of every
+spec it would write.
 
 **Exit codes.** ``0`` the plan is sound (a named refusal is NOT a failure),
 ``1`` a spec is unreadable or no roster was searched, ``2`` the apply was
 refused or rolled back. ``exit 0`` does NOT mean the migration is finished —
 a run whose every spec was refused also exits 0. ``migration_complete`` in
-``--json`` is the field that answers that question.
+``--json`` is the field that answers that question, and it is FALSE for any
+run that did not cover the whole roster: a ``--agent``/``--host`` filter, a
+``--limit`` batch, an unmigrated template, or a spec.yaml shadowed by an
+earlier root. The selectors themselves are echoed into the payload, so a
+filtered census can never be mistaken for a full one.
 
 ``--preflight`` probes the gateway the migration points at and reports a
 NAMED state rather than a boolean, because the two failure shapes look
@@ -76,13 +82,12 @@ from .._maintenance._engines_migration import (
     plan_engines_migration,
     select_spec_paths_over_roots,
 )
+from ._agents_migrate_engines_preflight import preflight_payload, render_preflight
 from ._agents_migrate_engines_report import (
     plan_payload,
-    preflight_payload,
     render_apply,
     render_diffs,
     render_plan,
-    render_preflight,
 )
 from ._helpers import _json_flag, console
 
@@ -94,26 +99,72 @@ _EXIT_APPLY_REFUSED = 2
 _AGENTS_DIR_ENV = "SCITEX_AGENT_CONTAINER_AGENTS_DIR"
 
 
+def _project_local_roots() -> "tuple[_Path, ...]":
+    """The registry found by WALKING UP FROM CWD, which is why it is excluded.
+
+    ``config._resolve`` prepends "the first ``.scitex/agent-container/agents``
+    found by walking upward from cwd" to the search path. That is right for
+    ``sac agents start`` — a repo's checked-in fixtures should win for a name
+    typed inside that repo — and wrong for a bulk rewrite, in two ways
+    measured 2026-09-06 with ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR`` unset::
+
+        cwd = <the sac repo, i.e. this agent's own workdir>
+            3 roots, 119 specs   (includes the repo's own sdk-test + self)
+        cwd = /uvwork/tmp   or   /home/agent
+            2 roots, 117 specs
+
+    First, the sweep's scope — and with ``--apply``, its WRITE SET — changed
+    with the working directory. Second, ``git ls-files`` confirms
+    ``.scitex/agent-container/agents/{sdk-test,self}/spec.yaml`` are TRACKED
+    repo test fixtures: from the normal invocation, ``--apply`` would rewrite
+    them. Both escaped today only by accident of unrelated guards, and
+    ``--host-supports-engines local`` — a plausible developer flag — put the
+    tracked fixture straight back into the write set.
+
+    So the default sweep does not include it. ``SAC_AGENT_SCOPE=project`` is
+    the one exception: there the operator asked for project scope by name,
+    and honouring an explicit request is not the same as inheriting a cwd.
+    ``--root`` still sweeps whatever directory is named.
+    """
+    # Private siblings on purpose: this is a statement about THAT resolver's
+    # project-local rule, so it has to consult that resolver rather than
+    # re-deriving the walk-up and drifting from it.
+    from ..config._resolve import _project_local_dirs, _read_scope
+
+    if _read_scope() == "project":
+        return ()
+    return tuple(_Path(d) for d in _project_local_dirs())
+
+
 def default_spec_roots() -> "tuple[_Path, ...]":
     """Where to sweep when neither ``--root`` nor the env var says.
 
-    EVERY user-scope root, not one. Measured inside this container on
-    2026-09-06, with ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR`` unset and
+    Every user-scope root except the cwd-derived project-local one (see
+    :func:`_project_local_roots`), in the order
+    ``config._resolve.resolve_config`` itself resolves them: the home primary,
+    then ``$SCITEX_AGENT_CONTAINER_YAML_DIRS``. Measured inside this container
+    on 2026-09-06, with ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR`` unset and
     ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` set by the runtime to the
     operator's tree::
 
         fleet_agents_dir() -> /home/agent/.scitex/…/agents            1 spec
-        user_scope_roots() -> /home/agent/.scitex/…/agents            1 spec
-                              …/.worktrees/…/.scitex/…/agents         2 specs
-                              /home/ywatanabe/.scitex/…/agents      123 specs
+        this function     -> /home/agent/.scitex/…/agents            1 spec
+                             /home/ywatanabe/.scitex/…/agents      123 specs
 
     ``fleet_agents_dir`` reads a DIFFERENT variable, which the runtime does
     not set, and lands on the container's own ``$HOME`` — a root holding one
     spec, next to the fleet's 123. A sweep defaulting there does not refuse:
     it reports one spec and exits 0, which is the shape of a finished
-    migration. ``user_scope_roots`` is the resolver ``sac agents find`` and
-    ``sac agents start`` already use, so the sweep sees the agents the rest
-    of the CLI sees.
+    migration.
+
+    THE ORDER IS THE LOADER'S. ``user_scope_roots`` returns ``[primary,
+    *project_local, *operator_env_dirs]`` while ``resolve_config`` resolves
+    ``project_local -> primary -> operator_env_dirs``: on a name collision the
+    sweep would have migrated the copy the loader does not load, and the
+    report could not have said which. Dropping project-local removes that
+    disagreement rather than papering over it — what is left, primary before
+    the operator dirs, is the loader's own order. A collision between the two
+    that remain is reported as ``shadowed`` either way.
 
     ``fleet_agents_dir`` is deliberately NOT fixed here — four other callers
     share it and that consolidation is its own card.
@@ -125,7 +176,53 @@ def default_spec_roots() -> "tuple[_Path, ...]":
         return (_Path(override).expanduser(),)
     from ._helpers._agent_list_roots import user_scope_roots
 
-    return tuple(_Path(r) for r in user_scope_roots())
+    excluded = set(_project_local_roots())
+    return tuple(_Path(r) for r in user_scope_roots() if _Path(r) not in excluded)
+
+
+def excluded_spec_roots() -> "tuple[_Path, ...]":
+    """Roots this run RESOLVED and deliberately did not sweep.
+
+    Reported for the same reason ``roots_absent`` is: a root that was resolved
+    and then left out has to be visible, or the count reads as covering it.
+    """
+    import os
+
+    if (os.environ.get(_AGENTS_DIR_ENV) or "").strip():
+        return ()
+    from ._helpers._agent_list_roots import user_scope_roots
+
+    resolved = {_Path(r) for r in user_scope_roots()}
+    return tuple(r for r in _project_local_roots() if r in resolved)
+
+
+def _selectors(agents: "tuple[str, ...]", hosts: "tuple[str, ...]") -> "tuple[str, ...]":
+    """The narrowing flags this run was given, spelled back as flags.
+
+    A filtered run is a census of a SUBSET, and nothing recorded that: the
+    payload carried no field naming the filter, so ``-a business --apply``
+    over a 113-spec root reported ``specs: 1``, ``migration_complete: true``
+    and printed "this is what a completed one looks like" while naming the
+    full root it had not covered.
+    """
+    return tuple(
+        [f"--agent {a}" for a in agents if a] + [f"--host {h}" for h in hosts if h]
+    )
+
+
+def _show_preflight(payload: dict) -> None:
+    """Print the gateway verdict on EVERY path that paid for the probe.
+
+    ``--preflight`` is computed before the apply/dry-run branch, so the probe
+    is a real network round trip on every path — and it was rendered only in
+    the dry-run branch. ``--preflight --apply``, the natural "check the
+    gateway, then write" invocation, therefore printed no red, no yellow and
+    no green line at all. Exactly the defect this module's docstring records
+    having fixed for ``--diff``.
+    """
+    if payload.get("preflight"):
+        render_preflight(payload["preflight"])
+        console.print("")
 
 
 def _archive_dir():
@@ -141,12 +238,16 @@ def _complete_after_apply(plan, result) -> bool:
     Distinct from ``plan.is_complete``, which is the question BEFORE the
     write: a successful apply retires the ``migrated`` bucket, and what is
     left is whatever no further write of this batch can clear.
+
+    Everything else :attr:`EnginesPlan.outstanding` names still counts. The
+    two claims are the same claim minus one bucket, so this asks the plan
+    rather than re-listing the conditions — re-listing them is how the
+    ``--agent`` filter and the skipped templates came to be invisible here
+    while the dry-run reported them.
     """
     if not result.applied:
         return False
-    if plan.roster is not None and not plan.roster.is_populated:
-        return False
-    return not (plan.held_back or plan.refused or plan.unreadable)
+    return not plan.remaining(migrated_written=True)
 
 
 @click.command(name="migrate-engines")
@@ -301,15 +402,25 @@ def migrate_engines(
             f"--limit must be a positive number of specs to write; got {limit}."
         )
 
-    roots = (_Path(root_opt),) if root_opt is not None else default_spec_roots()
+    explicit_root = root_opt is not None
+    roots = (_Path(root_opt),) if explicit_root else default_spec_roots()
+    excluded = () if explicit_root else excluded_spec_roots()
     floor = EngineFloor.with_overrides(floor_overrides)
-    paths, skipped = select_spec_paths_over_roots(
+    selection = select_spec_paths_over_roots(
         roots, hosts=hosts, agents=agents, templates=templates
     )
     plan = plan_engines_migration(
-        paths, roots=roots, skipped_templates=skipped, limit=limit, floor=floor
+        list(selection.paths),
+        roots=roots,
+        skipped_templates=list(selection.skipped_templates),
+        shadowed=selection.shadowed,
+        selectors=_selectors(agents, hosts),
+        unmatched_agents=selection.unmatched_agents,
+        unmatched_hosts=selection.unmatched_hosts,
+        limit=limit,
+        floor=floor,
     )
-    payload = plan_payload(plan, roots)
+    payload = plan_payload(plan, roots, floor=floor, excluded_roots=excluded)
     payload["engine_floor_overrides"] = sorted(set(floor.allowed))
     payload["mode"] = "apply" if apply else "dry-run"
     payload["preflight"] = preflight_payload() if preflight else None
@@ -324,9 +435,7 @@ def migrate_engines(
             click.echo(json.dumps(payload, indent=2))
             raise SystemExit(code)
         console.print("[bold]sac agents migrate-engines[/bold]  dry-run (read-only)\n")
-        if payload["preflight"]:
-            render_preflight(payload["preflight"])
-            console.print("")
+        _show_preflight(payload)
         render_plan(plan, payload, diff=diff)
         if plan.migrated:
             console.print(
@@ -342,6 +451,7 @@ def migrate_engines(
             click.echo(json.dumps(payload, indent=2))
             raise SystemExit(_EXIT_PLAN_UNSOUND)
         console.print("[bold]sac agents migrate-engines[/bold]  apply\n")
+        _show_preflight(payload)
         render_plan(plan, payload, diff=diff)
         console.print(
             "\n[red]REFUSED[/red] — nothing was written. A plan that cannot "
@@ -354,6 +464,7 @@ def migrate_engines(
     payload.update(
         {
             "written": list(result.written),
+            "written_paths": list(result.written_paths),
             "archive_dir": str(result.archive_dir) if result.archive_dir else None,
             "applied": result.applied,
             "apply_refused": result.refused,
@@ -361,6 +472,10 @@ def migrate_engines(
             "drift": list(result.drift),
             "errors": list(result.errors),
             "migration_complete": _complete_after_apply(plan, result),
+            # Re-derived AFTER the write, from the same source as the boolean
+            # above: a successful apply retires the `still to write` line and
+            # nothing else, and the prose must not keep claiming it.
+            "outstanding": list(plan.remaining(migrated_written=result.applied)),
             "exit_code": code,
         }
     )
@@ -368,6 +483,7 @@ def migrate_engines(
         click.echo(json.dumps(payload, indent=2))
         raise SystemExit(code)
     console.print("[bold]sac agents migrate-engines[/bold]  apply\n")
+    _show_preflight(payload)
     if diff:
         # `--diff` is on by DEFAULT and its help calls it "the whole point".
         # It used to be accepted and dropped on this path, so an operator who

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines.py
@@ -32,10 +32,19 @@ skipping is how a sweep reports 118 done over a fleet of 119. No filter may
 make one vanish either: ``--host`` KEEPS a spec it could not read, so it
 reaches the plan as unreadable rather than out of the count.
 
+**A VERSION FLOOR, ENFORCED AT PLAN TIME.** A sac that predates engines
+support REJECTS an unknown ``engines:`` key rather than ignoring it, so
+writing the block into a spec pinned on such a host stops that agent
+starting. The floor refuses those specs by name BEFORE the write — see
+:mod:`..._maintenance._engines_floor` for the measurement, the fleet roster
+and the fail-closed rule (an unmeasured host is refused, never assumed
+capable). ``--host-supports-engines HOST`` lifts it for a named machine.
+
 **Where it writes.** ``--root``, else ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR``,
-else ``$HOME/.scitex/agent-container/agents`` — the LIVE copy, which is not a
-git checkout and, inside a container, is not the host's ``$HOME``. Every
-report names the root it searched.
+else EVERY user-scope root the rest of the CLI resolves, de-duplicated by
+agent name. The old default read a different env var and landed on the
+container's own ``$HOME`` — one spec next to the fleet's 123, reported as a
+finished sweep. Every report names the roots it searched.
 
 **Exit codes.** ``0`` the plan is sound (a named refusal is NOT a failure),
 ``1`` a spec is unreadable or no roster was searched, ``2`` the apply was
@@ -47,8 +56,10 @@ a run whose every spec was refused also exits 0. ``migration_complete`` in
 NAMED state rather than a boolean, because the two failure shapes look
 identical through curl: ``scitex-compute-04:18772`` answers 401 (reachable
 and auth-gating) while ``compute-04:18772`` answers ``000`` — which reads as
-"the gateway is down" and means "the hostname does not resolve". See
-:mod:`...config._engine_reach`.
+"the gateway is down" and means "the hostname does not resolve". It dials
+``/v1/models`` rather than the base, which answers 404: a 401 there proves
+the inference API is present AND gating, while the base's 404 proves only
+that some process holds the port. See :mod:`...config._engine_reach`.
 """
 
 from __future__ import annotations
@@ -59,10 +70,11 @@ from pathlib import Path as _Path
 
 import click
 
+from .._maintenance._engines_floor import EngineFloor
 from .._maintenance._engines_migration import (
     apply_engines_migration,
     plan_engines_migration,
-    select_spec_paths,
+    select_spec_paths_over_roots,
 )
 from ._agents_migrate_engines_report import (
     plan_payload,
@@ -77,6 +89,43 @@ from ._helpers import _json_flag, console
 _EXIT_OK = 0
 _EXIT_PLAN_UNSOUND = 1
 _EXIT_APPLY_REFUSED = 2
+
+#: The one env var the RUNTIME actually exports for this purpose.
+_AGENTS_DIR_ENV = "SCITEX_AGENT_CONTAINER_AGENTS_DIR"
+
+
+def default_spec_roots() -> "tuple[_Path, ...]":
+    """Where to sweep when neither ``--root`` nor the env var says.
+
+    EVERY user-scope root, not one. Measured inside this container on
+    2026-09-06, with ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR`` unset and
+    ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` set by the runtime to the
+    operator's tree::
+
+        fleet_agents_dir() -> /home/agent/.scitex/…/agents            1 spec
+        user_scope_roots() -> /home/agent/.scitex/…/agents            1 spec
+                              …/.worktrees/…/.scitex/…/agents         2 specs
+                              /home/ywatanabe/.scitex/…/agents      123 specs
+
+    ``fleet_agents_dir`` reads a DIFFERENT variable, which the runtime does
+    not set, and lands on the container's own ``$HOME`` — a root holding one
+    spec, next to the fleet's 123. A sweep defaulting there does not refuse:
+    it reports one spec and exits 0, which is the shape of a finished
+    migration. ``user_scope_roots`` is the resolver ``sac agents find`` and
+    ``sac agents start`` already use, so the sweep sees the agents the rest
+    of the CLI sees.
+
+    ``fleet_agents_dir`` is deliberately NOT fixed here — four other callers
+    share it and that consolidation is its own card.
+    """
+    import os
+
+    override = (os.environ.get(_AGENTS_DIR_ENV) or "").strip()
+    if override:
+        return (_Path(override).expanduser(),)
+    from ._helpers._agent_list_roots import user_scope_roots
+
+    return tuple(_Path(r) for r in user_scope_roots())
 
 
 def _archive_dir():
@@ -148,8 +197,19 @@ def _complete_after_apply(plan, result) -> bool:
     metavar="DIR",
     help=(
         "The agents/ directory to sweep. Defaults to "
-        "$SCITEX_AGENT_CONTAINER_AGENTS_DIR, else $HOME/.scitex/agent-container"
-        "/agents — which inside a container is NOT the host's."
+        "$SCITEX_AGENT_CONTAINER_AGENTS_DIR, else EVERY user-scope root the "
+        "rest of the CLI resolves, de-duplicated by agent name."
+    ),
+)
+@click.option(
+    "--host-supports-engines",
+    "floor_overrides",
+    multiple=True,
+    metavar="HOST",
+    help=(
+        "Assert that HOST runs a sac new enough to parse spec.engines, "
+        "lifting the version floor for the specs pinned there. Repeatable. "
+        "Per-host on purpose: the claim is explicit and lands in --json."
     ),
 )
 @click.option(
@@ -179,6 +239,7 @@ def migrate_engines(
     hosts: "tuple[str, ...]",
     limit: "int | None",
     root_opt: "_Path | None",
+    floor_overrides: "tuple[str, ...]",
     templates: bool,
     diff: bool,
     preflight: bool,
@@ -205,14 +266,22 @@ def migrate_engines(
     Somewhere other than the live copy:
       $ sac agents migrate-engines --root ~/.dotfiles/src/.scitex/agent-container/agents
     \b
-    Gateway reachability, three-valued:
+    Gateway reachability, named states (it dials /v1/models, not the base):
       $ sac agents migrate-engines --preflight --no-diff
+    \b
+    Lifting the version floor for a host you have checked yourself:
+      $ sac agents migrate-engines --host-supports-engines scitex-compute-02
 
     WHERE IT WRITES. `--root`, else $SCITEX_AGENT_CONTAINER_AGENTS_DIR, else
-    $HOME/.scitex/agent-container/agents — the LIVE copy, which is not a git
-    checkout and, inside a container, is not the host's $HOME either. Every
-    report names the root it searched; pass `--root` to sweep the tracked
-    tree instead.
+    EVERY user-scope root the rest of the CLI resolves, de-duplicated by agent
+    name. Every report names the roots it searched; pass `--root` to sweep the
+    tracked tree instead.
+
+    THE VERSION FLOOR. A sac older than 2026-09-03 rejects `engines:` as an
+    unknown spec field, so a spec written for such a host stops loading and
+    the agent stops starting. Specs pinned on a host measured as pre-engines,
+    or on one nobody measured, are REFUSED by name before anything is written
+    — fail closed. `--host-supports-engines HOST` lifts it per machine.
 
     Exits 0 when the plan is sound (a named REFUSAL is not a failure), 1 when a
     spec is unreadable or no roster was searched, 2 when the apply was refused
@@ -232,16 +301,16 @@ def migrate_engines(
             f"--limit must be a positive number of specs to write; got {limit}."
         )
 
-    from .._maintenance._layers_migration_plan import fleet_agents_dir
-
-    root = _Path(root_opt) if root_opt is not None else fleet_agents_dir()
-    paths, skipped = select_spec_paths(
-        root, hosts=hosts, agents=agents, templates=templates
+    roots = (_Path(root_opt),) if root_opt is not None else default_spec_roots()
+    floor = EngineFloor.with_overrides(floor_overrides)
+    paths, skipped = select_spec_paths_over_roots(
+        roots, hosts=hosts, agents=agents, templates=templates
     )
     plan = plan_engines_migration(
-        paths, root=root, skipped_templates=skipped, limit=limit
+        paths, roots=roots, skipped_templates=skipped, limit=limit, floor=floor
     )
-    payload = plan_payload(plan, root)
+    payload = plan_payload(plan, roots)
+    payload["engine_floor_overrides"] = sorted(set(floor.allowed))
     payload["mode"] = "apply" if apply else "dry-run"
     payload["preflight"] = preflight_payload() if preflight else None
 

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines_preflight.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines_preflight.py
@@ -1,0 +1,81 @@
+"""``--preflight`` — is the gateway the migration points at actually there?
+
+Split from :mod:`._agents_migrate_engines_report` on the module line budget,
+and it is a different question anyway: that module reports the CENSUS (which
+specs, which roots, what would be written), this one reports one HTTP round
+trip to the address the sweep writes into every spec.
+
+THE PROBE IS THREE-VALUED BECAUSE THE FAILURES LOOK ALIKE. Through curl,
+``scitex-compute-04:18772`` answers 401 (reachable and auth-gating) while
+``compute-04:18772`` answers ``000`` — which reads as "the gateway is down"
+and means "the hostname does not resolve". And it dials ``/v1/models`` rather
+than the base, which answers 404: a 401 there proves the inference API is
+present AND gating, while the base's 404 proves only that some process holds
+the port. See :mod:`...config._engine_reach`.
+"""
+
+from __future__ import annotations
+
+from ._agents_migrate_engines_report import _lit
+from ._helpers import console
+
+__all__ = ["preflight_payload", "render_preflight"]
+
+
+def preflight_payload() -> dict:
+    """Probe the gateway the migration writes into every spec.
+
+    ``/v1/models``, NOT the base. The base answers 404 — measured — and a
+    preflight that dials it reports "something is listening" from a path the
+    gateway does not serve. Both addresses are in the payload so a reader can
+    see which one was dialled rather than inferring it.
+    """
+    from ..config._engine_reach import reach_verdict
+    from ..config._qwen_gateway import (
+        QWEN_GATEWAY_PROBE_PATH,
+        QWEN_GATEWAY_PROVIDER,
+        qwen_gateway_probe_url,
+        qwen_gateway_url,
+    )
+
+    url = qwen_gateway_probe_url()
+    verdict = reach_verdict(url)
+    return {
+        "provider": QWEN_GATEWAY_PROVIDER,
+        "url": url,
+        "base_url": qwen_gateway_url(),
+        "probe_path": QWEN_GATEWAY_PROBE_PATH,
+        "state": verdict.state,
+        "detail": verdict.detail,
+        "http_status": verdict.http_status,
+        "proves_listening": verdict.proves_listening,
+        # The load-bearing one: is the INFERENCE API served at that address?
+        # ``proves_listening`` is true of a 404 too, and a 404 is what the
+        # base returns, so a report keying on it goes green on no evidence.
+        "serves_endpoint": verdict.serves_endpoint,
+        "proves_absent": verdict.proves_absent,
+        "undetermined": verdict.undetermined,
+    }
+
+
+def render_preflight(payload: dict) -> None:
+    if payload["serves_endpoint"]:
+        colour = "green"
+    elif payload["proves_absent"]:
+        colour = "red"
+    else:
+        # Undetermined AND listening-wrong-path land here. Neither is a
+        # negative and neither is evidence the API is there.
+        colour = "yellow"
+    console.print(
+        f"[bold]gateway preflight[/bold] {_lit(payload['url'])} "
+        f"([{colour}]{_lit(payload['state'])}[/{colour}])\n"
+        f"  {_lit(payload['detail'])}",
+        soft_wrap=True,
+    )
+    if payload["undetermined"]:
+        console.print(
+            "  [dim]UNDETERMINED is not a negative. Nothing here says the "
+            "gateway is down.[/dim]",
+            soft_wrap=True,
+        )

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines_report.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines_report.py
@@ -44,27 +44,49 @@ def _lit(text: str) -> str:
 
 
 def preflight_payload() -> dict:
-    """Probe the gateway the migration writes into every spec."""
-    from ..config._engine_reach import reach_verdict
-    from ..config._qwen_gateway import QWEN_GATEWAY_PROVIDER, qwen_gateway_url
+    """Probe the gateway the migration writes into every spec.
 
-    url = qwen_gateway_url()
+    ``/v1/models``, NOT the base. The base answers 404 — measured — and a
+    preflight that dials it reports "something is listening" from a path the
+    gateway does not serve. Both addresses are in the payload so a reader can
+    see which one was dialled rather than inferring it.
+    """
+    from ..config._engine_reach import reach_verdict
+    from ..config._qwen_gateway import (
+        QWEN_GATEWAY_PROBE_PATH,
+        QWEN_GATEWAY_PROVIDER,
+        qwen_gateway_probe_url,
+        qwen_gateway_url,
+    )
+
+    url = qwen_gateway_probe_url()
     verdict = reach_verdict(url)
     return {
         "provider": QWEN_GATEWAY_PROVIDER,
         "url": url,
+        "base_url": qwen_gateway_url(),
+        "probe_path": QWEN_GATEWAY_PROBE_PATH,
         "state": verdict.state,
         "detail": verdict.detail,
         "http_status": verdict.http_status,
         "proves_listening": verdict.proves_listening,
+        # The load-bearing one: is the INFERENCE API served at that address?
+        # ``proves_listening`` is true of a 404 too, and a 404 is what the
+        # base returns, so a report keying on it goes green on no evidence.
+        "serves_endpoint": verdict.serves_endpoint,
         "proves_absent": verdict.proves_absent,
         "undetermined": verdict.undetermined,
     }
 
 
 def render_preflight(payload: dict) -> None:
-    colour = "green" if payload["proves_listening"] else "red"
-    if payload["undetermined"]:
+    if payload["serves_endpoint"]:
+        colour = "green"
+    elif payload["proves_absent"]:
+        colour = "red"
+    else:
+        # Undetermined AND listening-wrong-path land here. Neither is a
+        # negative and neither is evidence the API is there.
         colour = "yellow"
     console.print(
         f"[bold]gateway preflight[/bold] {_lit(payload['url'])} "
@@ -81,8 +103,26 @@ def render_preflight(payload: dict) -> None:
 
 
 def plan_payload(plan, root) -> dict:
+    """``root`` is one root or several — the report names every one of them.
+
+    The default sweep searches EVERY user-scope root, so a payload carrying
+    the first of them would be a claim about a directory the sweep did not
+    confine itself to. ``roots`` is every root RESOLVED, in order;
+    ``roots_absent`` is the subset that is not a directory, named rather than
+    quietly dropped — an operator whose tree was resolved and found missing
+    has to be able to see that, and it is the same distinction
+    :mod:`..._maintenance._roster_state` draws between "empty" and "absent".
+    ``root`` stays the human line and names them all.
+    """
+    from pathlib import Path
+
+    given = list(root) if isinstance(root, (list, tuple)) else [root]
+    roots = [str(r) for r in given]
+    absent = [str(r) for r in given if not Path(r).is_dir()]
     return {
-        "root": str(root),
+        "root": ", ".join(roots),
+        "roots": roots,
+        "roots_absent": absent,
         "roster": plan.roster.state if plan.roster else None,
         "specs": len(plan.outcomes),
         "would_migrate": len(plan.migrated),
@@ -124,6 +164,16 @@ def render_plan(plan, payload: dict, *, diff: bool) -> None:
     )
     for keys, count in payload["engine_sets"].items():
         console.print(f"  [green]{count:4d}[/green]  engines: {_lit(keys)}")
+    if payload.get("roots_absent"):
+        # A resolved root that is not there was NOT searched. Dropping it from
+        # the report would let an operator whose tree is missing read the
+        # count as covering it.
+        console.print(
+            f"[yellow]NOT SEARCHED[/yellow] "
+            f"{len(payload['roots_absent'])} resolved root(s) do not exist "
+            f"({_lit(', '.join(payload['roots_absent']))}).\n",
+            soft_wrap=True,
+        )
     if payload["already_migrated"]:
         console.print(
             f"\n[dim]{len(payload['already_migrated'])} spec(s) already declare "

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines_report.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines_report.py
@@ -1,0 +1,247 @@
+"""What ``sac agents migrate-engines`` PRINTS, and the payload behind it.
+
+Split out of the command module, which had outgrown its line budget. The
+command decides and writes; this decides what a human and a scheduled runner
+are told, and those are the two places this sweep has been wrong in ways no
+exit code showed:
+
+* an apply that wrote nothing printed "this is what a completed one looks
+  like" over a fleet where every spec had been REFUSED, and counted the
+  SELECTED specs as proof. ``migration_complete`` is now the claim, and it
+  is about the migration rather than about this invocation;
+* the human path carried the refusals only in ``--json``, so the readable
+  output was clean over a fleet it could not migrate;
+* the success line never named the root it had written into — and the
+  default root is the untracked live copy, which inside a container is not
+  even the host's.
+"""
+
+from __future__ import annotations
+
+from rich.markup import escape
+
+from ._helpers import console
+
+__all__ = [
+    "plan_payload",
+    "render_diffs",
+    "preflight_payload",
+    "render_apply",
+    "render_plan",
+    "render_preflight",
+]
+
+
+def _lit(text: str) -> str:
+    """Escape before printing through rich.
+
+    Not habit — MEASURED on the sibling sweep: a value rendering as
+    ``[user-shared]`` is parsed by rich as a style tag and SWALLOWED, so a
+    report printed a correct histogram with every row blank. Engine keys and
+    model ids here include ``opus[1m]``, which is exactly that shape.
+    """
+    return escape(str(text))
+
+
+def preflight_payload() -> dict:
+    """Probe the gateway the migration writes into every spec."""
+    from ..config._engine_reach import reach_verdict
+    from ..config._qwen_gateway import QWEN_GATEWAY_PROVIDER, qwen_gateway_url
+
+    url = qwen_gateway_url()
+    verdict = reach_verdict(url)
+    return {
+        "provider": QWEN_GATEWAY_PROVIDER,
+        "url": url,
+        "state": verdict.state,
+        "detail": verdict.detail,
+        "http_status": verdict.http_status,
+        "proves_listening": verdict.proves_listening,
+        "proves_absent": verdict.proves_absent,
+        "undetermined": verdict.undetermined,
+    }
+
+
+def render_preflight(payload: dict) -> None:
+    colour = "green" if payload["proves_listening"] else "red"
+    if payload["undetermined"]:
+        colour = "yellow"
+    console.print(
+        f"[bold]gateway preflight[/bold] {_lit(payload['url'])} "
+        f"([{colour}]{_lit(payload['state'])}[/{colour}])\n"
+        f"  {_lit(payload['detail'])}",
+        soft_wrap=True,
+    )
+    if payload["undetermined"]:
+        console.print(
+            "  [dim]UNDETERMINED is not a negative. Nothing here says the "
+            "gateway is down.[/dim]",
+            soft_wrap=True,
+        )
+
+
+def plan_payload(plan, root) -> dict:
+    return {
+        "root": str(root),
+        "roster": plan.roster.state if plan.roster else None,
+        "specs": len(plan.outcomes),
+        "would_migrate": len(plan.migrated),
+        "already_migrated": [o.agent for o in plan.already],
+        # Migratable, and past --limit. Named so a batch is never mistaken
+        # for a completed sweep — see ``migration_complete`` below.
+        "held_back": [o.agent for o in plan.held_back],
+        "refused": [
+            {"agent": o.agent, "reason": o.reason, "detail": o.detail}
+            for o in plan.refused
+        ],
+        "unreadable": [{"agent": o.agent, "detail": o.detail} for o in plan.unreadable],
+        "skipped_templates": list(plan.skipped_templates),
+        "engine_sets": _engine_histogram(plan),
+        "safe_to_apply": plan.safe_to_apply,
+        # THE QUESTION A SCHEDULED RUNNER IS ACTUALLY ASKING, and neither
+        # ``exit_code`` nor ``applied`` answers it: both are 0/true for a run
+        # that wrote nothing because every spec was refused or held back.
+        "migration_complete": plan.is_complete,
+        "summary": plan.summary(),
+    }
+
+
+def _engine_histogram(plan) -> "dict[str, int]":
+    hist: dict[str, int] = {}
+    for outcome in plan.migrated:
+        key = ", ".join(outcome.engine_keys)
+        hist[key] = hist.get(key, 0) + 1
+    return dict(sorted(hist.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def render_plan(plan, payload: dict, *, diff: bool) -> None:
+    if plan.roster is not None and not plan.roster.is_populated:
+        console.print(f"[red]NO ROSTER SEARCHED[/red] — {_lit(plan.roster.describe())}")
+        return
+    console.print(
+        f"[bold]{payload['specs']} spec(s)[/bold] under {_lit(payload['root'])} — "
+        f"{payload['would_migrate']} would gain a spec.engines block\n"
+    )
+    for keys, count in payload["engine_sets"].items():
+        console.print(f"  [green]{count:4d}[/green]  engines: {_lit(keys)}")
+    if payload["already_migrated"]:
+        console.print(
+            f"\n[dim]{len(payload['already_migrated'])} spec(s) already declare "
+            f"spec.engines — nothing to do for those.[/dim]"
+        )
+    for entry in payload["refused"]:
+        console.print(
+            f"\n[yellow]REFUSED[/yellow] {_lit(entry['agent'])}: "
+            f"{_lit(entry['reason'])}",
+            soft_wrap=True,
+        )
+        if entry["detail"]:
+            console.print(f"    [dim]{_lit(entry['detail'])}[/dim]", soft_wrap=True)
+    for entry in payload["unreadable"]:
+        console.print(
+            f"\n[red]UNREADABLE[/red] {_lit(entry['agent'])}: {_lit(entry['detail'])}",
+            soft_wrap=True,
+        )
+    if payload["held_back"]:
+        console.print(
+            f"\n[cyan]HELD BACK[/cyan] {len(payload['held_back'])} spec(s) past "
+            f"--limit ({_lit(', '.join(payload['held_back']))}). Run the same "
+            f"command again to take the next batch.",
+            soft_wrap=True,
+        )
+    if payload["skipped_templates"]:
+        # Named, never silent: `sac agents create` copies these, so a template
+        # left behind re-introduces the legacy shape on every agent made after
+        # the sweep — the migration would then never finish.
+        console.print(
+            f"\n[yellow]NOT SEARCHED[/yellow] "
+            f"{len(payload['skipped_templates'])} template spec(s) "
+            f"({_lit(', '.join(payload['skipped_templates']))}). "
+            f"`sac agents create` copies them, so an unmigrated template "
+            f"re-introduces the legacy shape on every new agent. Pass "
+            f"--templates to include them.",
+            soft_wrap=True,
+        )
+    if diff:
+        for outcome in plan.migrated:
+            console.print(f"\n[bold]{_lit(outcome.agent)}[/bold]")
+            console.print(_lit(outcome.diff), soft_wrap=True, highlight=False)
+    console.print(f"\n[bold]{_lit(payload['summary'])}[/bold]")
+
+
+def _render_unfinished(payload: dict) -> None:
+    """Name everything a further run still has to do. Never a bare count."""
+    for entry in payload["refused"]:
+        console.print(
+            f"  [yellow]REFUSED[/yellow] {_lit(entry['agent'])}: "
+            f"{_lit(entry['reason'])}",
+            soft_wrap=True,
+        )
+    if payload["held_back"]:
+        console.print(
+            f"  [cyan]HELD BACK[/cyan] {len(payload['held_back'])} past --limit "
+            f"({_lit(', '.join(payload['held_back']))})",
+            soft_wrap=True,
+        )
+
+
+def render_apply(result, payload: dict) -> None:
+    if result.applied and not result.written:
+        # THE CLAIM IS ABOUT THE MIGRATION, so it is made only when the
+        # migration is finished. "Nothing was written" is true of a completed
+        # sweep AND of a run whose every spec was refused, and of a --limit
+        # batch that already took its N — and the earlier form of this
+        # sentence counted the SELECTED specs, so it called both of those
+        # completed. A scheduled runner reading exit 0 believed it.
+        if not payload["migration_complete"]:
+            console.print(
+                f"[yellow]Nothing was written[/yellow] — "
+                f"{len(payload['already_migrated'])} of {payload['specs']} "
+                f"spec(s) under {_lit(payload['root'])} declare spec.engines. "
+                f"The sweep is NOT complete:",
+                soft_wrap=True,
+            )
+            _render_unfinished(payload)
+            return
+        console.print(
+            f"[green]Nothing to write[/green] — all "
+            f"{payload['specs']} spec(s) under {_lit(payload['root'])} already "
+            f"declare spec.engines. The sweep is idempotent; this is what a "
+            f"completed one looks like."
+        )
+        return
+    if result.applied:
+        console.print(
+            f"[green]APPLIED[/green] {len(result.written)} spec(s) written and "
+            f"verified under {_lit(payload['root'])} — every one still resolves "
+            f"the SAME backend.\n"
+            f"  [dim]originals archived at {_lit(result.archive_dir)}[/dim]"
+        )
+        if not payload["migration_complete"]:
+            console.print("\n[bold]Still outstanding[/bold] — run again:")
+            _render_unfinished(payload)
+        return
+    if result.rolled_back:
+        console.print(
+            f"[red]ROLLED BACK[/red] — {_lit(result.rolled_back)}", soft_wrap=True
+        )
+        for entry in (*result.drift, *result.errors):
+            console.print(f"    [magenta]{_lit(entry)}[/magenta]", soft_wrap=True)
+        return
+    console.print(
+        f"[red]REFUSED[/red] — nothing was written.\n  {_lit(result.refused)}",
+        soft_wrap=True,
+    )
+
+
+def render_diffs(plan) -> None:
+    """One unified diff per spec about to be written.
+
+    Used by BOTH the dry-run and the apply. ``--diff`` is on by default and
+    its own help calls it "the whole point"; the apply path used to accept
+    the flag and print nothing, so an operator who believed they were
+    reviewing the rewrite saw a one-line summary and no diff at all.
+    """
+    for outcome in plan.migrated:
+        console.print(f"\n[bold]{_lit(outcome.agent)}[/bold]")
+        console.print(_lit(outcome.diff), soft_wrap=True, highlight=False)

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_engines_report.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_engines_report.py
@@ -14,6 +14,29 @@ exit code showed:
 * the success line never named the root it had written into — and the
   default root is the untracked live copy, which inside a container is not
   even the host's.
+
+THE SAME SHAPE, THREE MORE TIMES, and all three are about the ``--json``
+payload carrying a fact the readable output did not:
+
+* a ``--agent``/``--host`` filter narrowed the census and left no trace of
+  itself anywhere, so the completion sentence above came back — this time
+  over a run that had covered 1 of 113 specs and NAMED the full root;
+* ``--host-supports-engines`` lifted the floor for a host the roster records
+  as a MEASURED negative and printed nothing at all: ``grep -i spartan`` over
+  the whole terminal output matched zero lines while nine specs moved from
+  REFUSED into the migratable count. An override of a MEASURED NO is
+  categorically different from an override of an UNKNOWN, and it has to
+  restate the measurement it contradicts;
+* the floor's evidence reached the report only on the REFUSING side, so 100
+  approvals said nothing about which hosts were judged capable, on what, or
+  how old the measurement is.
+
+AND ONE ABOUT VOLUME. The floor's refusal detail is per-HOST and ~400
+characters, and ``render_plan`` printed it once per SPEC: twelve refusals
+rendered as twelve blocks, nine of them the byte-identical spartan paragraph.
+:func:`_group_refusals` is what makes the "one block per KIND" contract that
+``_engines_floor``'s own comment claims actually true of the human output and
+not only of the payload.
 """
 
 from __future__ import annotations
@@ -24,11 +47,10 @@ from ._helpers import console
 
 __all__ = [
     "plan_payload",
-    "render_diffs",
-    "preflight_payload",
     "render_apply",
+    "render_diffs",
+    "render_floor",
     "render_plan",
-    "render_preflight",
 ]
 
 
@@ -43,89 +65,47 @@ def _lit(text: str) -> str:
     return escape(str(text))
 
 
-def preflight_payload() -> dict:
-    """Probe the gateway the migration writes into every spec.
-
-    ``/v1/models``, NOT the base. The base answers 404 — measured — and a
-    preflight that dials it reports "something is listening" from a path the
-    gateway does not serve. Both addresses are in the payload so a reader can
-    see which one was dialled rather than inferring it.
-    """
-    from ..config._engine_reach import reach_verdict
-    from ..config._qwen_gateway import (
-        QWEN_GATEWAY_PROBE_PATH,
-        QWEN_GATEWAY_PROVIDER,
-        qwen_gateway_probe_url,
-        qwen_gateway_url,
-    )
-
-    url = qwen_gateway_probe_url()
-    verdict = reach_verdict(url)
-    return {
-        "provider": QWEN_GATEWAY_PROVIDER,
-        "url": url,
-        "base_url": qwen_gateway_url(),
-        "probe_path": QWEN_GATEWAY_PROBE_PATH,
-        "state": verdict.state,
-        "detail": verdict.detail,
-        "http_status": verdict.http_status,
-        "proves_listening": verdict.proves_listening,
-        # The load-bearing one: is the INFERENCE API served at that address?
-        # ``proves_listening`` is true of a 404 too, and a 404 is what the
-        # base returns, so a report keying on it goes green on no evidence.
-        "serves_endpoint": verdict.serves_endpoint,
-        "proves_absent": verdict.proves_absent,
-        "undetermined": verdict.undetermined,
-    }
-
-
-def render_preflight(payload: dict) -> None:
-    if payload["serves_endpoint"]:
-        colour = "green"
-    elif payload["proves_absent"]:
-        colour = "red"
-    else:
-        # Undetermined AND listening-wrong-path land here. Neither is a
-        # negative and neither is evidence the API is there.
-        colour = "yellow"
-    console.print(
-        f"[bold]gateway preflight[/bold] {_lit(payload['url'])} "
-        f"([{colour}]{_lit(payload['state'])}[/{colour}])\n"
-        f"  {_lit(payload['detail'])}",
-        soft_wrap=True,
-    )
-    if payload["undetermined"]:
-        console.print(
-            "  [dim]UNDETERMINED is not a negative. Nothing here says the "
-            "gateway is down.[/dim]",
-            soft_wrap=True,
-        )
-
-
-def plan_payload(plan, root) -> dict:
+def plan_payload(plan, root, *, floor=None, excluded_roots=()) -> dict:
     """``root`` is one root or several — the report names every one of them.
 
     The default sweep searches EVERY user-scope root, so a payload carrying
     the first of them would be a claim about a directory the sweep did not
     confine itself to. ``roots`` is every root RESOLVED, in order;
-    ``roots_absent`` is the subset that is not a directory, named rather than
-    quietly dropped — an operator whose tree was resolved and found missing
-    has to be able to see that, and it is the same distinction
+    ``roots_absent`` is the subset that is not a directory and
+    ``roots_excluded`` the subset deliberately not swept — both named rather
+    than quietly dropped, because an operator whose tree was resolved and then
+    left out has to be able to see that. It is the same distinction
     :mod:`..._maintenance._roster_state` draws between "empty" and "absent".
     ``root`` stays the human line and names them all.
+
+    ``floor`` supplies the ``engine_floor`` block: which hosts were consulted,
+    the measured row each was judged by, and how many specs each covers.
+    Passing None omits it — the CLI always passes one.
     """
     from pathlib import Path
 
     given = list(root) if isinstance(root, (list, tuple)) else [root]
     roots = [str(r) for r in given]
     absent = [str(r) for r in given if not Path(r).is_dir()]
-    return {
+    payload = {
         "root": ", ".join(roots),
         "roots": roots,
         "roots_absent": absent,
+        "roots_excluded": [str(r) for r in excluded_roots],
         "roster": plan.roster.state if plan.roster else None,
         "specs": len(plan.outcomes),
+        # The narrowing flags, echoed. A filtered run is a census of a SUBSET
+        # and nothing said so, so `migration_complete` went true over 1 of 113.
+        "selectors": list(plan.selectors),
+        "filtered": bool(plan.selectors),
+        # A selector that matched nothing: a typo or a renamed agent used to
+        # drop out of every batch in silence, exit 0, forever.
+        "unmatched_agents": list(plan.unmatched_agents),
+        "unmatched_hosts": list(plan.unmatched_hosts),
         "would_migrate": len(plan.migrated),
+        # PATHS, not just the count: `written` carries agent names, and a name
+        # cannot say which root a write landed in.
+        "would_migrate_paths": [str(o.path) for o in plan.migrated],
         "already_migrated": [o.agent for o in plan.already],
         # Migratable, and past --limit. Named so a batch is never mistaken
         # for a completed sweep — see ``migration_complete`` below.
@@ -136,14 +116,124 @@ def plan_payload(plan, root) -> dict:
         ],
         "unreadable": [{"agent": o.agent, "detail": o.detail} for o in plan.unreadable],
         "skipped_templates": list(plan.skipped_templates),
+        # A spec.yaml an earlier root's copy displaced. It is on disk, it is
+        # legacy, and earlier-root-wins is deterministic, so no later run
+        # reaches it: the count must say where the difference went.
+        "shadowed": [
+            {"agent": s.agent, "kept": str(s.kept), "shadowed": str(s.dropped)}
+            for s in plan.shadowed
+        ],
         "engine_sets": _engine_histogram(plan),
         "safe_to_apply": plan.safe_to_apply,
         # THE QUESTION A SCHEDULED RUNNER IS ACTUALLY ASKING, and neither
         # ``exit_code`` nor ``applied`` answers it: both are 0/true for a run
         # that wrote nothing because every spec was refused or held back.
         "migration_complete": plan.is_complete,
+        # The same answer in prose, from the same source, so the two cannot
+        # disagree about WHY the migration is unfinished.
+        "outstanding": list(plan.outstanding),
         "summary": plan.summary(),
     }
+    if floor is not None:
+        from .._maintenance._engines_floor_audit import floor_audit
+
+        payload["engine_floor"] = floor_audit(
+            floor, [o.hosts if o.hosts is None else set(o.hosts) for o in plan.outcomes]
+        ).as_dict()
+    return payload
+
+
+def render_floor(audit: "dict | None") -> None:
+    """The BASIS for every write this run would make, and every lift of it.
+
+    Two things were invisible in the readable output, and both of them are
+    about the floor being trusted rather than read:
+
+    * the approvals carried no evidence. ``HOST_SUPPORT`` is a static table
+      with no expiry and nothing probes, so a row that goes stale — a host
+      rebuilt or rolled back onto an older sac after its ``measured_on`` date
+      — makes a wrong run byte-for-byte identical to a right one. Printing
+      the rows consulted, with their dates, is what makes it arguable;
+    * ``--host-supports-engines`` printed NOTHING. Measured: the run went
+      from "100 would be migrated; 12 REFUSED" to "109 would be migrated; 3
+      REFUSED" and ``grep -in 'spartan|override|lift'`` over the full output
+      matched zero lines. The nine specs simply appeared in the migratable
+      count with the reader never seeing the fact being overridden.
+    """
+    if not audit or not audit.get("active"):
+        return
+    dates = ", ".join(audit["measured_on"]) or "no measured rows"
+    console.print(
+        f"[bold]version floor[/bold] {len(audit['hosts'])} host(s) consulted, "
+        f"roster measured {_lit(dates)}",
+        soft_wrap=True,
+    )
+    width = max((len(r["host"]) for r in audit["hosts"]), default=0)
+    for row in audit["hosts"]:
+        colour = "green" if row["support"] == "supports-engines" else "yellow"
+        when = (
+            f"measured {row['measured_on']}"
+            if row["measured_on"]
+            else "absent from the roster"
+        )
+        # The alias is a MEASURED fact, not a courtesy: ywata-note-win answers
+        # `hostname` on both ssh names, so 14 specs spelling it the retired way
+        # are judged by the scitex-laptop-01 row and the reader must see that.
+        alias = (
+            f"  (= {_lit(row['canonical'])})"
+            if row["canonical"] != row["host"]
+            else ""
+        )
+        console.print(
+            f"  [{colour}]{row['specs']:4d}[/{colour}]  "
+            f"{_lit(row['host'].ljust(width))}  {_lit(row['support'].ljust(16))}  "
+            f"{_lit(when)}{alias}{'  LIFTED' if row['overridden'] else ''}",
+            soft_wrap=True,
+        )
+    if audit["specs_with_an_unreadable_host"]:
+        console.print(
+            f"  [red]{audit['specs_with_an_unreadable_host']:4d}[/red]  "
+            f"(host unreadable)",
+            soft_wrap=True,
+        )
+    if audit["specs_with_no_declared_host"]:
+        console.print(
+            f"  [yellow]{audit['specs_with_no_declared_host']:4d}[/yellow]  "
+            f"(spec names no host)",
+            soft_wrap=True,
+        )
+    _render_overrides(audit)
+
+
+def _render_overrides(audit: dict) -> None:
+    """Say what each ``--host-supports-engines`` claim actually overrode.
+
+    A lift of an UNKNOWN says "nobody looked, I did". A lift of a MEASURED
+    negative says "the roster looked and I disagree" — and by the roster's own
+    evidence those specs then fail their host's validator and stop those
+    agents starting. Two different claims; only one of them can strand an
+    agent, so only one gets the red block restating the measurement.
+    """
+    for row in (r for r in audit["hosts"] if r["overridden"]):
+        if row["contradicts_a_measurement"]:
+            console.print(
+                f"\n[red]FLOOR LIFTED[/red] --host-supports-engines "
+                f"{_lit(row['host'])} CONTRADICTS a measurement: "
+                f"{_lit(row['host'])} is recorded {_lit(row['support'])}, "
+                f"measured {_lit(row['measured_on'])} — {_lit(row['evidence'])}. "
+                f"{row['specs']} spec(s) pinned there will be written and, by "
+                f"that measurement, then fail their host's validator and stop "
+                f"those agents starting.",
+                soft_wrap=True,
+            )
+            continue
+        console.print(
+            f"\n[yellow]FLOOR LIFTED[/yellow] --host-supports-engines "
+            f"{_lit(row['host'])}: nobody measured that host, so nothing here "
+            f"contradicts it — {row['specs']} spec(s) will be written on your "
+            f"claim.",
+            soft_wrap=True,
+        )
 
 
 def _engine_histogram(plan) -> "dict[str, int]":
@@ -152,6 +242,55 @@ def _engine_histogram(plan) -> "dict[str, int]":
         key = ", ".join(outcome.engine_keys)
         hist[key] = hist.get(key, 0) + 1
     return dict(sorted(hist.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def _group_refusals(entries) -> "list[tuple[str, str, list[str]]]":
+    """``(reason, detail, agents)`` — one entry per KIND, not per spec.
+
+    The refusal CONSTANTS are constant precisely so a 119-spec sweep can do
+    this, and the floor's detail is per-HOST, so ``(reason, detail)`` is the
+    key that makes the contract true. Rendering per-spec instead printed the
+    identical ~400-character spartan paragraph nine times inside twelve
+    refusal blocks, and would have printed it sixty times for a whole-host
+    refusal on ``scitex-laptop-01`` — burying the review an operator does
+    before a 100-file apply under copies of two paragraphs.
+    """
+    grouped: "dict[tuple[str, str], list[str]]" = {}
+    for entry in entries:
+        grouped.setdefault((entry["reason"], entry["detail"]), []).append(
+            entry["agent"]
+        )
+    return [(reason, detail, agents) for (reason, detail), agents in grouped.items()]
+
+
+def _render_selection_gaps(payload: dict) -> None:
+    """Everything the SELECTION left out, named. Never a silent narrowing."""
+    if payload.get("selectors"):
+        console.print(
+            f"\n[cyan]FILTERED[/cyan] this run was narrowed to "
+            f"{_lit(', '.join(payload['selectors']))} — it is a census of a "
+            f"SUBSET, not of the roster, so it can never report the migration "
+            f"as complete.",
+            soft_wrap=True,
+        )
+    for kind, key in (("--agent", "unmatched_agents"), ("--host", "unmatched_hosts")):
+        if payload.get(key):
+            console.print(
+                f"\n[yellow]MATCHED NOTHING[/yellow] {kind} "
+                f"{_lit(', '.join(payload[key]))} selected no spec. A typo or a "
+                f"renamed agent drops out of every batch in silence otherwise.",
+                soft_wrap=True,
+            )
+    for entry in payload.get("shadowed", ()):
+        console.print(
+            f"\n[yellow]SHADOWED[/yellow] {_lit(entry['agent'])}: "
+            f"{_lit(entry['shadowed'])} was NOT examined — an earlier root "
+            f"supplied {_lit(entry['kept'])} for the same agent name. Earlier "
+            f"roots win deterministically, so no later run reaches it either; "
+            f"the loader raises AmbiguousRegistryScope on this collision and a "
+            f"human has to resolve it.",
+            soft_wrap=True,
+        )
 
 
 def render_plan(plan, payload: dict, *, diff: bool) -> None:
@@ -174,19 +313,32 @@ def render_plan(plan, payload: dict, *, diff: bool) -> None:
             f"({_lit(', '.join(payload['roots_absent']))}).\n",
             soft_wrap=True,
         )
+    if payload.get("roots_excluded"):
+        console.print(
+            f"[yellow]NOT SEARCHED[/yellow] "
+            f"{len(payload['roots_excluded'])} project-local root(s) found by "
+            f"walking up from the working directory "
+            f"({_lit(', '.join(payload['roots_excluded']))}). A repo's own "
+            f"checked-in fixtures are not the fleet, and a sweep whose scope "
+            f"changed with the cwd could rewrite them. Pass --root to sweep "
+            f"one deliberately.\n",
+            soft_wrap=True,
+        )
+    render_floor(payload.get("engine_floor"))
+    _render_selection_gaps(payload)
     if payload["already_migrated"]:
         console.print(
             f"\n[dim]{len(payload['already_migrated'])} spec(s) already declare "
             f"spec.engines — nothing to do for those.[/dim]"
         )
-    for entry in payload["refused"]:
+    for reason, detail, agents in _group_refusals(payload["refused"]):
         console.print(
-            f"\n[yellow]REFUSED[/yellow] {_lit(entry['agent'])}: "
-            f"{_lit(entry['reason'])}",
+            f"\n[yellow]REFUSED[/yellow] {len(agents)} spec(s): {_lit(reason)}\n"
+            f"    {_lit(', '.join(sorted(agents)))}",
             soft_wrap=True,
         )
-        if entry["detail"]:
-            console.print(f"    [dim]{_lit(entry['detail'])}[/dim]", soft_wrap=True)
+        if detail:
+            console.print(f"    [dim]{_lit(detail)}[/dim]", soft_wrap=True)
     for entry in payload["unreadable"]:
         console.print(
             f"\n[red]UNREADABLE[/red] {_lit(entry['agent'])}: {_lit(entry['detail'])}",
@@ -213,18 +365,25 @@ def render_plan(plan, payload: dict, *, diff: bool) -> None:
             soft_wrap=True,
         )
     if diff:
-        for outcome in plan.migrated:
-            console.print(f"\n[bold]{_lit(outcome.agent)}[/bold]")
-            console.print(_lit(outcome.diff), soft_wrap=True, highlight=False)
+        render_diffs(plan)
     console.print(f"\n[bold]{_lit(payload['summary'])}[/bold]")
 
 
 def _render_unfinished(payload: dict) -> None:
-    """Name everything a further run still has to do. Never a bare count."""
-    for entry in payload["refused"]:
+    """Name everything a further run still has to do. Never a bare count.
+
+    Sourced from ``plan.outstanding``, which is the SAME list
+    ``migration_complete`` is the emptiness of — so the sentence a human reads
+    and the boolean a scheduled runner reads cannot say different things.
+    Re-deriving it here is how the ``--agent`` filter and the skipped
+    templates came to be reported in one and absent from the other.
+    """
+    for line in payload.get("outstanding", ()):
+        console.print(f"  [yellow]•[/yellow] {_lit(line)}", soft_wrap=True)
+    for reason, _detail, agents in _group_refusals(payload["refused"]):
         console.print(
-            f"  [yellow]REFUSED[/yellow] {_lit(entry['agent'])}: "
-            f"{_lit(entry['reason'])}",
+            f"  [yellow]REFUSED[/yellow] {_lit(', '.join(sorted(agents)))}: "
+            f"{_lit(reason)}",
             soft_wrap=True,
         )
     if payload["held_back"]:

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -80,6 +80,7 @@ class _AgentsGroup(HelpRecursiveGroup):
                 "refresh-acl",
                 "declare-a2a-host",
                 "migrate-layers",
+                "migrate-engines",
                 "scratch-migrate",
             ],
         ),
@@ -291,6 +292,18 @@ agent_group.add_command(_refresh_acl_impl)
 from ._agents_migrate_layers import register as _register_migrate_layers  # noqa: E402
 
 _register_migrate_layers(agent_group)
+
+# `migrate-engines` — the roll-over `config._engine_types` names but does not
+# ship: give every spec a `spec.engines` block so HARNESS and ENGINE are
+# separate axes and any agent can start on the Qwen gateway instead of Claude.
+# 1 of 119 specs declares the block today. Same shape as `migrate-layers`
+# (dry-run by default, `--apply` is the act, `--json` for machines) plus the
+# two things a 119-file rewrite needs and a one-line insert did not: a unified
+# diff per spec, and batching by --agent / --host / --limit. Agent-spec-scoped,
+# so it lives here rather than under a new top-level noun.
+from ._agents_migrate_engines import register as _register_migrate_engines  # noqa: E402
+
+_register_migrate_engines(agent_group)
 
 # `scratch-migrate` — ADR-0024: move each STOPPED agent's overlay-upper
 # ``/uvwork`` (11.7 GB for sac alone on the root LV, measured 2026-09-03)

--- a/src/scitex_agent_container/config/_engine_library.py
+++ b/src/scitex_agent_container/config/_engine_library.py
@@ -50,10 +50,22 @@ which the spec validator surfaces as a load error naming this path.
 WHERE IT LIVES, AND WHERE IT IS EDITED. Resolved through
 ``_state.state_paths`` exactly like ``agents/`` is (so ``$SCITEX_DIR``
 is honoured and a relocated state root takes its library with it). The
-SOURCE OF TRUTH is ``~/.dotfiles/src/.scitex/agent-container/engines.yaml``
-and it is deployed from there — ``$SCITEX_DIR/agent-container`` is a
-synced copy, never hand-edited, the same standing rule agent specs
-follow.
+SOURCE OF TRUTH is ``.scitex/agent-container/engines.yaml`` IN THIS
+REPO, tracked beside :mod:`._provider_registry`, which defines the
+provider names the library's entries use — one diff reviews both, where
+a copy in another repo would let the two drift. It is deployed from
+there; ``$SCITEX_DIR/agent-container`` is a synced copy, never
+hand-edited, the same standing rule agent specs follow.
+
+NOTHING SILENTLY DEPENDS ON AN UNSET VARIABLE. Measured on the fleet
+hosts 2026-09-06: ``$SAC_ENGINES_FILE`` and ``$SCITEX_DIR`` are both
+unset, so :func:`fleet_engines_path` takes ``scitex_dir()``'s DOCUMENTED
+``~/.scitex`` default and lands on ``~/.scitex/agent-container/
+engines.yaml`` — the directory that already holds ``agents/``,
+``accounts/``, ``containers/`` and ``runtime/``. Unset is the ordinary
+case here, not a hole: the default is written down in
+``_state.state_paths``, and a host that exports ``$SCITEX_DIR``
+(Spartan) moves the library with the rest of its state.
 
 ``$SAC_ENGINES_FILE`` overrides the path for one process. It is an
 OPS/TEST surface, not a spec surface: a spec must not be able to point

--- a/src/scitex_agent_container/config/_engine_reach.py
+++ b/src/scitex_agent_container/config/_engine_reach.py
@@ -277,7 +277,7 @@ def reach_verdict(url: str, *, timeout_s: float = REACH_TIMEOUT_S) -> ReachVerdi
         return _classify_url_error(url, exc.reason, host, port)
     except (TimeoutError, socket.timeout) as exc:
         return _verdict(url, REACH_TIMED_OUT, host=host, port=port, extra=str(exc))
-    except OSError as exc:  # stx-allow: fallback (reason: an unreachable endpoint is an ANSWER; a socket fault must be reported as undetermined, never raised into a caller that asked a yes/no question)
+    except OSError as exc:  # stx-allow: fallback (reason: an unreachable endpoint is an ANSWER; a socket fault becomes a REACH_TRANSPORT_ERROR verdict carrying str(exc), reported on stdout by `sac agents migrate-engines --preflight` (render_preflight), never raised into a caller that asked a yes/no question)
         return _verdict(
             url, REACH_TRANSPORT_ERROR, host=host, port=port, extra=str(exc)
         )

--- a/src/scitex_agent_container/config/_engine_reach.py
+++ b/src/scitex_agent_container/config/_engine_reach.py
@@ -1,0 +1,231 @@
+"""Is the engine endpoint THERE? — a named state, never a boolean.
+
+MEASURED BY scitex-hub, 2026-09-05, against the one Qwen gateway:
+
+    scitex-compute-04:18772   ->  HTTP 401   listening and auth-gating
+    compute-04:18772          ->  000        the NAME does not resolve
+    compute-04-lan:18772      ->  000        the NAME does not resolve
+
+Two facts live in that table and a boolean carries neither of them.
+
+**401 is the CORRECT answer for a healthy gateway.** It proves something is
+listening on that port and demanding a key. A check that treats a non-2xx
+response as failure reports the working gateway as broken.
+
+**000 is not a verdict.** curl prints it for an unresolvable hostname exactly
+as it prints it for a dead host, so "the Qwen gateway is down" and "you spelled
+the host wrong" arrive as the same three characters. Anyone following the
+fleet's ``-lan`` naming convention gets ``000`` from a gateway that is up.
+Collapsing those into one boolean is how a correct migration gets abandoned on
+a false negative — so this module refuses to.
+
+THE STATES, and the three the measurement above forced apart:
+
+  ``reachable-but-unauthorized``  the endpoint answered 401/403. Something IS
+                                  listening and IS demanding a key. REACHABLE.
+  ``listening``                   the endpoint answered anything else. Also
+                                  reachable; kept apart from the 401 case only
+                                  so a report can say which one it saw.
+  ``connection-refused``          the name resolved, the port answered, and it
+                                  said closed. A DEFINITE negative.
+  ``name-does-not-resolve``       DNS gave nothing. This says NOTHING about the
+                                  gateway. Undetermined.
+  ``timed-out``                   no answer inside the bounded timeout. Also
+                                  undetermined — a slow path is not a dead one.
+  ``no-host-in-url``              the URL carries no host to dial at all.
+
+DNS IS CHECKED FIRST AND SEPARATELY, before any connect. Folded into the
+connect, a resolution failure surfaces as one more socket error among many and
+lands in the same bucket as a timeout — which is the bucket that reads as
+"down". :func:`._engine_honour.probe_verdict` does exactly that fold (every
+non-refusal ``OSError`` becomes ``could-not-tell``); it is correct for its job,
+which is deciding whether to refuse a START, and it deliberately never refuses
+on a name it could not resolve. This module answers the operator's different
+question — WHICH of those things happened — and is the one a preflight prints.
+
+No key is ever sent, so a 401 is the expected outcome and not a failure to
+authenticate: this asks whether the door exists, not whether we may enter.
+"""
+
+from __future__ import annotations
+
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+__all__ = [
+    "REACH_LISTENING",
+    "REACH_NAME_UNRESOLVED",
+    "REACH_NO_HOST",
+    "REACH_REFUSED",
+    "REACH_STATES",
+    "REACH_TIMED_OUT",
+    "REACH_TRANSPORT_ERROR",
+    "REACH_UNAUTHORIZED",
+    "ReachVerdict",
+    "reach_verdict",
+]
+
+REACH_LISTENING = "listening"
+REACH_UNAUTHORIZED = "reachable-but-unauthorized"
+REACH_REFUSED = "connection-refused"
+REACH_NAME_UNRESOLVED = "name-does-not-resolve"
+REACH_TIMED_OUT = "timed-out"
+REACH_NO_HOST = "no-host-in-url"
+REACH_TRANSPORT_ERROR = "transport-error"
+
+#: Every state this module can return. A caller switching on the state is
+#: expected to handle all of them; there is no residual "other".
+REACH_STATES = (
+    REACH_LISTENING,
+    REACH_UNAUTHORIZED,
+    REACH_REFUSED,
+    REACH_NAME_UNRESOLVED,
+    REACH_TIMED_OUT,
+    REACH_NO_HOST,
+    REACH_TRANSPORT_ERROR,
+)
+
+#: Bounded, and short. This is a preflight a human reads, not a health check.
+REACH_TIMEOUT_S = 3.0
+
+_SENTENCES = {
+    REACH_LISTENING: ("the endpoint answered — something is listening at this address"),
+    REACH_UNAUTHORIZED: (
+        "reachable but unauthorized (401) — this is the CORRECT answer for a "
+        "live gateway: something is listening and demanding a key"
+    ),
+    REACH_REFUSED: (
+        "connection refused — the name resolved and the host actively said the "
+        "port is closed. This is a definite negative"
+    ),
+    REACH_NAME_UNRESOLVED: (
+        "the NAME does not resolve — this is NOT evidence the gateway is down, "
+        "it is evidence the hostname is wrong. curl reports 000 here, the same "
+        "000 it reports for a dead host"
+    ),
+    REACH_TIMED_OUT: (
+        "timed out — undetermined. A slow or filtered path is not a dead one"
+    ),
+    REACH_NO_HOST: (
+        "the URL carries no host to dial, so reachability could not be asked"
+    ),
+    REACH_TRANSPORT_ERROR: (
+        "the transport failed before any answer — undetermined, not a negative"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ReachVerdict:
+    """What the endpoint did, named. Deliberately not castable to a bool."""
+
+    url: str
+    state: str
+    detail: str
+    host: str = ""
+    port: int = 0
+    http_status: "int | None" = None
+
+    def __post_init__(self) -> None:
+        if self.state not in REACH_STATES:
+            raise ValueError(
+                f"unknown reachability state {self.state!r}; "
+                f"expected one of {REACH_STATES}"
+            )
+
+    @property
+    def proves_listening(self) -> bool:
+        """Something IS there. A 401 counts — that is the whole point."""
+        return self.state in (REACH_LISTENING, REACH_UNAUTHORIZED)
+
+    @property
+    def proves_absent(self) -> bool:
+        """Something is definitely NOT there. Only a refusal earns this."""
+        return self.state == REACH_REFUSED
+
+    @property
+    def undetermined(self) -> bool:
+        """Neither of the above. An unresolvable NAME lands here, not in absent."""
+        return not self.proves_listening and not self.proves_absent
+
+    def describe(self) -> str:
+        where = f"{self.host}:{self.port}" if self.host else self.url
+        return f"{where} -> {self.state}: {self.detail}"
+
+
+def _verdict(url, state, *, host="", port=0, status=None, extra="") -> ReachVerdict:
+    detail = _SENTENCES[state]
+    if extra:
+        detail = f"{detail} ({extra})"
+    return ReachVerdict(
+        url=url, state=state, detail=detail, host=host, port=port, http_status=status
+    )
+
+
+def reach_verdict(url: str, *, timeout_s: float = REACH_TIMEOUT_S) -> ReachVerdict:
+    """Probe ``url`` and name what happened. One DNS lookup, one HTTP request.
+
+    Never raises for a network condition — an unreachable endpoint is an
+    ANSWER here, not an error. The only exception it can propagate is a
+    programming fault such as a non-string ``url``.
+    """
+    parsed = urlparse(str(url))
+    host = parsed.hostname
+    if not host:
+        return _verdict(url, REACH_NO_HOST)
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+
+    # DNS FIRST, on its own. Folding it into the connect is what makes an
+    # unresolvable name indistinguishable from a dead host.
+    try:
+        socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        return _verdict(
+            url, REACH_NAME_UNRESOLVED, host=host, port=port, extra=str(exc)
+        )
+
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
+            return _verdict(
+                url,
+                REACH_LISTENING,
+                host=host,
+                port=port,
+                status=getattr(response, "status", None),
+            )
+    except urllib.error.HTTPError as exc:
+        # An HTTP status IS an answer, so every one of these is REACHABLE.
+        state = REACH_UNAUTHORIZED if exc.code in (401, 403) else REACH_LISTENING
+        return _verdict(
+            url, state, host=host, port=port, status=exc.code, extra=f"HTTP {exc.code}"
+        )
+    except urllib.error.URLError as exc:
+        return _classify_url_error(url, exc.reason, host, port)
+    except (TimeoutError, socket.timeout) as exc:
+        return _verdict(url, REACH_TIMED_OUT, host=host, port=port, extra=str(exc))
+    except OSError as exc:  # stx-allow: fallback (reason: an unreachable endpoint is an ANSWER; a socket fault must be reported as undetermined, never raised into a caller that asked a yes/no question)
+        return _verdict(
+            url, REACH_TRANSPORT_ERROR, host=host, port=port, extra=str(exc)
+        )
+
+
+def _classify_url_error(url, reason, host, port) -> ReachVerdict:
+    """Name the cause urllib wrapped, rather than reporting the wrapper.
+
+    ``URLError`` carries the real socket error in ``.reason``; reporting the
+    wrapper is what produces "URLError: <urlopen error ...>" in a preflight
+    that was asked which of three specific things happened.
+    """
+    if isinstance(reason, ConnectionRefusedError):
+        return _verdict(url, REACH_REFUSED, host=host, port=port, extra=str(reason))
+    if isinstance(reason, socket.gaierror):
+        return _verdict(
+            url, REACH_NAME_UNRESOLVED, host=host, port=port, extra=str(reason)
+        )
+    if isinstance(reason, (TimeoutError, socket.timeout)):
+        return _verdict(url, REACH_TIMED_OUT, host=host, port=port, extra=str(reason))
+    return _verdict(url, REACH_TRANSPORT_ERROR, host=host, port=port, extra=str(reason))

--- a/src/scitex_agent_container/config/_engine_reach.py
+++ b/src/scitex_agent_container/config/_engine_reach.py
@@ -19,13 +19,39 @@ fleet's ``-lan`` naming convention gets ``000`` from a gateway that is up.
 Collapsing those into one boolean is how a correct migration gets abandoned on
 a false negative — so this module refuses to.
 
-THE STATES, and the three the measurement above forced apart:
+**A 404 IS NOT AN ANSWER ABOUT THE ENDPOINT.** Measured from
+scitex-compute-04, 2026-09-06, against the same gateway::
+
+    /                       404   listening, but this path does not exist
+    /v1/models              401   REACHABLE + AUTH-GATED — the informative one
+    /v1/chat/completions    401   same
+    /health                 200   a real health endpoint exists
+    /healthz                404   does not exist
+    /v1                     307   redirect
+    CONTROL http://scitex-compute-99:18772/v1/models -> 000 (name unresolvable)
+
+Folding that 404 into ``listening`` made the gateway BASE — which is what a
+preflight naturally probes — report a green "something is listening" from a
+path the gateway does not serve. It says a process holds the port; it says
+nothing about whether the inference API is there. So it gets its own state,
+and callers that need the API to exist ask :attr:`ReachVerdict.serves_endpoint`
+rather than :attr:`ReachVerdict.proves_listening`.
+
+``/health`` is deliberately NOT the probe: a 200 there proves the process is
+up and says nothing about whether ``/v1`` is served or auth is wired — a gate
+that cannot fail. ``/v1/models`` is the one whose 401 proves both.
+
+THE STATES, and the four the measurements above forced apart:
 
   ``reachable-but-unauthorized``  the endpoint answered 401/403. Something IS
-                                  listening and IS demanding a key. REACHABLE.
-  ``listening``                   the endpoint answered anything else. Also
-                                  reachable; kept apart from the 401 case only
-                                  so a report can say which one it saw.
+                                  listening and IS demanding a key. REACHABLE,
+                                  and the probed path IS served.
+  ``listening``                   the endpoint answered some other status. Also
+                                  reachable and served; kept apart from the 401
+                                  case only so a report can say which it saw.
+  ``listening-wrong-path``        HTTP 404. Something holds the port and it does
+                                  NOT serve this path. Reachable at the address,
+                                  but no evidence about the API.
   ``connection-refused``          the name resolved, the port answered, and it
                                   said closed. A DEFINITE negative.
   ``name-does-not-resolve``       DNS gave nothing. This says NOTHING about the
@@ -64,12 +90,15 @@ __all__ = [
     "REACH_TIMED_OUT",
     "REACH_TRANSPORT_ERROR",
     "REACH_UNAUTHORIZED",
+    "REACH_WRONG_PATH",
     "ReachVerdict",
     "reach_verdict",
 ]
 
 REACH_LISTENING = "listening"
 REACH_UNAUTHORIZED = "reachable-but-unauthorized"
+#: HTTP 404 — something holds the port, this path is not served.
+REACH_WRONG_PATH = "listening-wrong-path"
 REACH_REFUSED = "connection-refused"
 REACH_NAME_UNRESOLVED = "name-does-not-resolve"
 REACH_TIMED_OUT = "timed-out"
@@ -81,6 +110,7 @@ REACH_TRANSPORT_ERROR = "transport-error"
 REACH_STATES = (
     REACH_LISTENING,
     REACH_UNAUTHORIZED,
+    REACH_WRONG_PATH,
     REACH_REFUSED,
     REACH_NAME_UNRESOLVED,
     REACH_TIMED_OUT,
@@ -96,6 +126,12 @@ _SENTENCES = {
     REACH_UNAUTHORIZED: (
         "reachable but unauthorized (401) — this is the CORRECT answer for a "
         "live gateway: something is listening and demanding a key"
+    ),
+    REACH_WRONG_PATH: (
+        "listening, but this PATH is not served (404) — a process holds the "
+        "port, and that says nothing about whether the inference API is "
+        "there. The gateway BASE answers exactly this; the path that answers "
+        "informatively is /v1/models"
     ),
     REACH_REFUSED: (
         "connection refused — the name resolved and the host actively said the "
@@ -138,7 +174,22 @@ class ReachVerdict:
 
     @property
     def proves_listening(self) -> bool:
-        """Something IS there. A 401 counts — that is the whole point."""
+        """Something IS at this ADDRESS. A 401 counts — that is the whole point.
+
+        A 404 counts too: a process answered HTTP, so the port is held. It is
+        the weaker fact, and :attr:`serves_endpoint` is the one to ask when
+        the question is whether the API is there.
+        """
+        return self.state in (REACH_LISTENING, REACH_UNAUTHORIZED, REACH_WRONG_PATH)
+
+    @property
+    def serves_endpoint(self) -> bool:
+        """The PROBED PATH is served. Gated counts; missing does not.
+
+        401/403 is a served path refusing an unauthenticated caller, which is
+        exactly what an engine entry needs to see. 404 is the path not being
+        there, and no amount of listening makes that evidence about the API.
+        """
         return self.state in (REACH_LISTENING, REACH_UNAUTHORIZED)
 
     @property
@@ -154,6 +205,20 @@ class ReachVerdict:
     def describe(self) -> str:
         where = f"{self.host}:{self.port}" if self.host else self.url
         return f"{where} -> {self.state}: {self.detail}"
+
+
+def _http_state(code: int) -> str:
+    """Which state an HTTP status earns. Three outcomes, not two.
+
+    401/403 is the informative success — a served, gated path. 404 is the
+    address answering while the path is absent. Everything else is a served
+    path answering something.
+    """
+    if code in (401, 403):
+        return REACH_UNAUTHORIZED
+    if code == 404:
+        return REACH_WRONG_PATH
+    return REACH_LISTENING
 
 
 def _verdict(url, state, *, host="", port=0, status=None, extra="") -> ReachVerdict:
@@ -198,10 +263,15 @@ def reach_verdict(url: str, *, timeout_s: float = REACH_TIMEOUT_S) -> ReachVerdi
                 status=getattr(response, "status", None),
             )
     except urllib.error.HTTPError as exc:
-        # An HTTP status IS an answer, so every one of these is REACHABLE.
-        state = REACH_UNAUTHORIZED if exc.code in (401, 403) else REACH_LISTENING
+        # An HTTP status IS an answer, so every one of these is REACHABLE at
+        # the ADDRESS. Only 404 fails to say the PATH is served.
         return _verdict(
-            url, state, host=host, port=port, status=exc.code, extra=f"HTTP {exc.code}"
+            url,
+            _http_state(exc.code),
+            host=host,
+            port=port,
+            status=exc.code,
+            extra=f"HTTP {exc.code}",
         )
     except urllib.error.URLError as exc:
         return _classify_url_error(url, exc.reason, host, port)

--- a/src/scitex_agent_container/config/_engine_types.py
+++ b/src/scitex_agent_container/config/_engine_types.py
@@ -341,11 +341,27 @@ def apply_engine(config: Any, engine: EngineSpec) -> None:
     ``env`` merges ON TOP of ``spec.apptainer.env`` — a per-engine env
     entry is a deliberate override for THIS backend, so it wins over the
     agent-wide value it was written to displace.
+
+    THE TOP-LEVEL MODEL SURFACE FOLLOWS TOO, and it is not decoration.
+    ``_loaders`` derives ``AgentConfig.model`` and the injected
+    ``SCITEX_AGENT_CONTAINER_MODEL`` from the RAW ``spec.claude.model``,
+    which a spec declaring ``engines:`` deliberately leaves empty — so
+    without this the whole fleet reported the ``sonnet`` default while
+    running something else. Measured over the 119-spec corpus: 117 specs
+    flipped to ``'sonnet'`` / ``'Claude Sonnet'`` on migration while
+    ``claude.model`` stayed correct. ``sac agents list`` reads
+    ``config.model`` (``_lifecycle._status``), the tmux runner builds
+    ``--model`` from it, and ``sac whoami`` prints the env — three
+    surfaces lying about one backend.
     """
+    from ._parsers import MODEL_ENV_KEY, resolve_model_surface
+
     config.engine_key = engine.key
     config.harness = engine.harness
     config.reasoning_effort = engine.reasoning_effort
     config.max_context_tokens = engine.max_context_tokens
+    resolved_model, display_model = resolve_model_surface(engine.model)
+    config.model = resolved_model
     claude = getattr(config, "claude", None)
     if claude is not None:
         claude.model = engine.model
@@ -361,10 +377,16 @@ def apply_engine(config: Any, engine: EngineSpec) -> None:
         # the account, because OAuth is then the only auth it has.
         if engine.provider is not None:
             claude.account = ""
+    merged = dict(getattr(config, "env", {}) or {})
+    # An EXPLICIT ``spec.apptainer.env`` entry still wins, exactly as it does
+    # over the loader's auto-derived value: this refreshes the DERIVED half,
+    # it does not overrule an author who wrote the key themselves.
+    declared_env = getattr(getattr(config, "apptainer", None), "env", None) or {}
+    if MODEL_ENV_KEY not in declared_env:
+        merged[MODEL_ENV_KEY] = display_model
     if engine.env:
-        merged = dict(getattr(config, "env", {}) or {})
         merged.update(engine.env)
-        config.env = merged
+    config.env = merged
 
 
 def apply_default_engine(

--- a/src/scitex_agent_container/config/_engines_derive.py
+++ b/src/scitex_agent_container/config/_engines_derive.py
@@ -4,22 +4,36 @@ Pure. No YAML parsing, no line numbers, no I/O — it takes the backend a spec
 already declares, as primitives, and returns the entries plus the exact lines
 to write. :mod:`._engines_line` owns the text surgery that puts them in a file.
 
-THE DERIVATION, and what each half is allowed to invent (nothing):
+ONE ENTRY, AND IT INVENTS NOTHING. A swept spec gets exactly one engine: its
+own backend, restated. The ``model`` is the spec's own ``spec.claude.model``
+text copied verbatim and the ``provider`` is ``spec.claude.provider`` copied
+verbatim, so a spec whose provider points at a local endpoint keeps pointing
+there. ``provider: anthropic`` is written ONLY when the spec declared no
+provider at all — that is the registry's own sentinel for "the default
+Anthropic OAuth backend", it is what the spec already resolves to, and
+writing it is how the entry avoids the other failure: an unstated provider
+that silently defaults to a vendor.
 
-* **The DEFAULT entry is the spec's own backend, restated.** Its ``harness``
-  is what :func:`._harness_types.resolve_spec_harness` already resolves, its
-  ``model`` is the spec's own ``spec.claude.model`` text copied verbatim, and
-  its ``provider`` is ``spec.claude.provider`` copied verbatim. A spec whose
-  provider points at a local endpoint keeps pointing there. ``provider:
-  anthropic`` is written ONLY when the spec declared no provider at all —
-  that is the registry's own sentinel for "the default Anthropic OAuth
-  backend", it is what the spec already resolves to, and writing it is how
-  the entry avoids the other failure: an unstated provider that silently
-  defaults to a vendor.
+NO SECOND ENTRY IS COPIED IN. The sweep used to append a whole ``qwen38-27b``
+entry to every spec it touched. That definition now lives ONCE in the fleet
+engine library (:mod:`._engine_library`), where ``--engine qwen38-27b``
+reaches it through the merged namespace and where one ``engine:`` line moves
+the fleet. 119 identical copies of a row is the shape a library exists to
+delete, and a copy also stops being the definition the moment the library's
+row changes.
 
-* **The ALTERNATE entry is the fleet Qwen gateway**, named by
-  :data:`._qwen_gateway.QWEN_GATEWAY_PROVIDER` rather than by address, so the
-  address stays in one module instead of in 119 spec files.
+TWO FIELDS THIS DELIBERATELY DOES NOT WRITE, both deprecated by the
+harness/engine split (see :data:`._engine_types.ENGINE_ENTRY_KEYS`):
+
+* **``harness:``** — an entry that states one claims the HARNESS axis, which
+  is the coupling the split removes. The spec's own ``spec.harness`` line is
+  left stated and untouched, so the harness still resolves exactly as before;
+  the entry simply states no opinion about it.
+* **``default: true``** — a spec-local ``default:`` OUTRANKS the fleet
+  library in :mod:`._engine_precedence`, so writing it on every swept spec
+  would trade 119 legacy pins for 119 engine pins and leave a fleet-wide flip
+  still a 119-file edit. A block with exactly ONE entry needs no marker:
+  precedence step 3 starts on it because it cannot be ambiguous.
 
 THE ENTRY KEY. ``claude`` when the backend is the plain Anthropic OAuth path
 AND the harness is the Anthropic one — the name the operator's own
@@ -27,12 +41,12 @@ already-migrated ``business`` spec uses — and a slug of the model otherwise,
 because "claude" is a false name for an entry holding Qwen, a vendor name is
 a claim about scope, and a Codex session is not the vendor that name states.
 
-WHEN THE TWO COLLIDE. A spec that ALREADY runs ``qwen38-27b`` derives the
-alternate's own key, and one mapping cannot hold two entries under one key.
-Such a spec gets a single-engine block naming the backend it already has, and
-the migration reports it as its own outcome rather than pretending it wrote
-two. Repointing that spec's inline loopback URL at the fleet gateway would be
-a behaviour change dressed as a migration, so it is not done here.
+A KEY THE FLEET LIBRARY ALSO USES IS NOT A COLLISION. A spec already running
+``qwen38-27b`` derives that key for its own entry, and
+:func:`._engine_library.resolve_engine_namespace` gives the SPEC-LOCAL entry
+precedence — which is the right answer: the 8 handymen reach the gateway over
+a loopback forward, and repointing them at the fleet address would be a
+behaviour change dressed as a migration.
 """
 
 from __future__ import annotations
@@ -41,14 +55,6 @@ import re
 from dataclasses import dataclass
 
 from ._harness_types import DEFAULT_AGENT_HARNESS
-from ._qwen_gateway import (
-    QWEN_ENGINE_HARNESS,
-    QWEN_ENGINE_KEY,
-    QWEN_ENGINE_MAX_CONTEXT_TOKENS,
-    QWEN_ENGINE_MODEL,
-    QWEN_ENGINE_REASONING_EFFORT,
-    QWEN_GATEWAY_PROVIDER,
-)
 
 __all__ = [
     "CLAUDE_ENGINE_KEY",
@@ -117,10 +123,21 @@ def engine_key_for(
 
 @dataclass(frozen=True)
 class EngineEntry:
-    """ONE rendered engine entry. ``provider_lines`` holds the nested form."""
+    """ONE rendered engine entry. ``provider_lines`` holds the nested form.
+
+    THE FIELDS ARE EXACTLY WHAT A MIGRATION CAN DERIVE, and no more. There is
+    no ``harness`` and no ``is_default``, because both are deprecated inside
+    an entry and a renderer that could HOLD them would be a renderer that
+    could WRITE them (see the module docstring). There is no
+    ``reasoning_effort`` and no ``max_context_tokens`` either, for a quieter
+    reason: the legacy single-backend surface has no such fields, so a
+    restatement of it cannot honestly carry them. They were here only to
+    render the copied ``qwen38-27b`` entry, and that entry now lives in the
+    fleet engine library — which declares them in YAML, where the operator
+    can change them without a release.
+    """
 
     key: str
-    harness: str
     model: str
     #: The scalar written after ``provider:``. None when the provider is a
     #: nested block, in which case ``provider_lines`` carries its children
@@ -129,21 +146,6 @@ class EngineEntry:
     #: as a nested mapping rather than being flattened into siblings.
     provider_scalar: "str | None" = None
     provider_lines: "tuple[str, ...]" = ()
-    reasoning_effort: str = ""
-    max_context_tokens: "int | None" = None
-    is_default: bool = False
-
-
-def qwen_entry() -> EngineEntry:
-    """The fleet-gateway alternate, identical in every migrated spec."""
-    return EngineEntry(
-        key=QWEN_ENGINE_KEY,
-        harness=QWEN_ENGINE_HARNESS,
-        model=QWEN_ENGINE_MODEL,
-        provider_scalar=QWEN_GATEWAY_PROVIDER,
-        reasoning_effort=QWEN_ENGINE_REASONING_EFFORT,
-        max_context_tokens=QWEN_ENGINE_MAX_CONTEXT_TOKENS,
-    )
 
 
 def derive_entries(
@@ -160,6 +162,16 @@ def derive_entries(
     ``(entries, "")``. ``provider_scalar`` / ``provider_lines`` are the
     VERBATIM text the caller lifted out of the spec, so the restated backend
     is byte-for-byte the one that was already there.
+
+    EXACTLY ONE ENTRY today — the spec's own backend. The plural shape is not
+    hedging: ``engines:`` is a MAPPING, the renderer below writes N of them,
+    and every alternate a spec could name now comes from the fleet engine
+    library rather than from a copy this function makes.
+
+    ``harness`` is an INPUT and not an output. It decides the entry's KEY
+    (``claude`` is only right on the Anthropic path) and whether stating the
+    ``anthropic`` provider sentinel would be a true claim; the entry itself
+    stays silent about the harness axis.
     """
     key = engine_key_for(model, provider_declared, harness)
     if not key:
@@ -183,18 +195,14 @@ def derive_entries(
         # exactly what the spec said: nothing.
         scalar = ANTHROPIC_PROVIDER
 
-    default = EngineEntry(
-        key=key,
-        harness=harness,
-        model=model,
-        provider_scalar=scalar,
-        provider_lines=tuple(provider_lines),
-        is_default=True,
-    )
-    if key == QWEN_ENGINE_KEY:
-        # This spec already IS the Qwen engine. See the module docstring.
-        return (default,), ""
-    return (default, qwen_entry()), ""
+    return (
+        EngineEntry(
+            key=key,
+            model=model,
+            provider_scalar=scalar,
+            provider_lines=tuple(provider_lines),
+        ),
+    ), ""
 
 
 def render_engines_block(
@@ -220,7 +228,6 @@ def render_engines_block(
     out.append(f"{indent}engines:")
     for entry in entries:
         out.append(f"{key_indent}{entry.key}:")
-        out.append(f"{field_indent}harness: {entry.harness}")
         out.append(f"{field_indent}model: {entry.model}")
         if entry.provider_lines:
             out.append(f"{field_indent}provider:")
@@ -233,10 +240,4 @@ def render_engines_block(
             )
         elif entry.provider_scalar is not None:
             out.append(f"{field_indent}provider: {entry.provider_scalar}")
-        if entry.reasoning_effort:
-            out.append(f"{field_indent}reasoning_effort: {entry.reasoning_effort}")
-        if entry.max_context_tokens:
-            out.append(f"{field_indent}max_context_tokens: {entry.max_context_tokens}")
-        if entry.is_default:
-            out.append(f"{field_indent}default: true")
     return out

--- a/src/scitex_agent_container/config/_engines_derive.py
+++ b/src/scitex_agent_container/config/_engines_derive.py
@@ -1,0 +1,205 @@
+"""What a migrated ``spec.engines`` block SAYS, and how it is rendered.
+
+Pure. No YAML parsing, no line numbers, no I/O — it takes the backend a spec
+already declares, as primitives, and returns the entries plus the exact lines
+to write. :mod:`._engines_line` owns the text surgery that puts them in a file.
+
+THE DERIVATION, and what each half is allowed to invent (nothing):
+
+* **The DEFAULT entry is the spec's own backend, restated.** Its ``harness``
+  is what :func:`._harness_types.resolve_spec_harness` already resolves, its
+  ``model`` is the spec's own ``spec.claude.model`` text copied verbatim, and
+  its ``provider`` is ``spec.claude.provider`` copied verbatim. A spec whose
+  provider points at a local endpoint keeps pointing there. ``provider:
+  anthropic`` is written ONLY when the spec declared no provider at all —
+  that is the registry's own sentinel for "the default Anthropic OAuth
+  backend", it is what the spec already resolves to, and writing it is how
+  the entry avoids the other failure: an unstated provider that silently
+  defaults to a vendor.
+
+* **The ALTERNATE entry is the fleet Qwen gateway**, named by
+  :data:`._qwen_gateway.QWEN_GATEWAY_PROVIDER` rather than by address, so the
+  address stays in one module instead of in 119 spec files.
+
+THE ENTRY KEY. ``claude`` when the backend is the plain Anthropic OAuth path
+— the name the operator's own already-migrated ``business`` spec uses — and
+a slug of the model otherwise, because "claude" is a false name for an entry
+holding Qwen and a vendor name is a claim about scope.
+
+WHEN THE TWO COLLIDE. A spec that ALREADY runs ``qwen38-27b`` derives the
+alternate's own key, and one mapping cannot hold two entries under one key.
+Such a spec gets a single-engine block naming the backend it already has, and
+the migration reports it as its own outcome rather than pretending it wrote
+two. Repointing that spec's inline loopback URL at the fleet gateway would be
+a behaviour change dressed as a migration, so it is not done here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from ._qwen_gateway import (
+    QWEN_ENGINE_HARNESS,
+    QWEN_ENGINE_KEY,
+    QWEN_ENGINE_MAX_CONTEXT_TOKENS,
+    QWEN_ENGINE_MODEL,
+    QWEN_ENGINE_REASONING_EFFORT,
+    QWEN_GATEWAY_PROVIDER,
+)
+
+__all__ = [
+    "CLAUDE_ENGINE_KEY",
+    "EngineEntry",
+    "derive_entries",
+    "engine_key_for",
+    "render_engines_block",
+    "slug_engine_key",
+]
+
+#: The name the Anthropic OAuth entry gets, matching the fleet's one
+#: hand-migrated spec.
+CLAUDE_ENGINE_KEY = "claude"
+
+#: The registry sentinel meaning "the default Anthropic OAuth backend,
+#: stated".
+ANTHROPIC_PROVIDER = "anthropic"
+
+_ILLEGAL = re.compile(r"[^A-Za-z0-9._-]+")
+_RUNS = re.compile(r"-{2,}")
+
+
+def slug_engine_key(model: str) -> str:
+    """A model id turned into something typable after ``--engine``.
+
+    ``_engine_validation`` requires an engine key to start alphanumeric and to
+    hold only ``[A-Za-z0-9._-]`` thereafter, because it is typed on a command
+    line. ``opus[1m]`` is a legal model and an illegal key; this is the one
+    place that gap is bridged. Returns ``""`` when nothing survives, which the
+    caller treats as a refusal rather than inventing a name.
+    """
+    slug = _RUNS.sub("-", _ILLEGAL.sub("-", str(model).strip().lower()))
+    slug = slug.strip("-._")
+    while slug and not slug[0].isalnum():
+        slug = slug[1:]
+    return slug
+
+
+def engine_key_for(model: str, provider_declared: object) -> str:
+    """The key the DEFAULT entry gets. ``""`` when the model yields no slug."""
+    if provider_declared is None:
+        return CLAUDE_ENGINE_KEY
+    if (
+        isinstance(provider_declared, str)
+        and provider_declared.strip().lower() == ANTHROPIC_PROVIDER
+    ):
+        return CLAUDE_ENGINE_KEY
+    return slug_engine_key(model)
+
+
+@dataclass(frozen=True)
+class EngineEntry:
+    """ONE rendered engine entry. ``provider_lines`` holds the nested form."""
+
+    key: str
+    harness: str
+    model: str
+    #: The scalar written after ``provider:``. None when the provider is a
+    #: nested block, in which case ``provider_lines`` carries its children
+    #: with their original indentation already stripped.
+    provider_scalar: "str | None" = None
+    provider_lines: "tuple[str, ...]" = ()
+    reasoning_effort: str = ""
+    max_context_tokens: "int | None" = None
+    is_default: bool = False
+
+
+def qwen_entry() -> EngineEntry:
+    """The fleet-gateway alternate, identical in every migrated spec."""
+    return EngineEntry(
+        key=QWEN_ENGINE_KEY,
+        harness=QWEN_ENGINE_HARNESS,
+        model=QWEN_ENGINE_MODEL,
+        provider_scalar=QWEN_GATEWAY_PROVIDER,
+        reasoning_effort=QWEN_ENGINE_REASONING_EFFORT,
+        max_context_tokens=QWEN_ENGINE_MAX_CONTEXT_TOKENS,
+    )
+
+
+def derive_entries(
+    *,
+    harness: str,
+    model: str,
+    provider_declared: object,
+    provider_scalar: "str | None",
+    provider_lines: "tuple[str, ...]" = (),
+) -> "tuple[tuple[EngineEntry, ...], str]":
+    """The entries for one spec, in write order, plus a refusal reason.
+
+    Returns ``((), reason)`` when the spec cannot be given a key; otherwise
+    ``(entries, "")``. ``provider_scalar`` / ``provider_lines`` are the
+    VERBATIM text the caller lifted out of the spec, so the restated backend
+    is byte-for-byte the one that was already there.
+    """
+    key = engine_key_for(model, provider_declared)
+    if not key:
+        return (), "the model yields no usable engine key"
+
+    scalar = provider_scalar
+    if provider_declared is None and not provider_lines:
+        # Stated explicitly rather than left empty: an omitted provider reads
+        # as "no opinion", and an entry with no opinion about its backend is
+        # the ambiguity this axis exists to remove.
+        scalar = ANTHROPIC_PROVIDER
+
+    default = EngineEntry(
+        key=key,
+        harness=harness,
+        model=model,
+        provider_scalar=scalar,
+        provider_lines=tuple(provider_lines),
+        is_default=True,
+    )
+    if key == QWEN_ENGINE_KEY:
+        # This spec already IS the Qwen engine. See the module docstring.
+        return (default,), ""
+    return (default, qwen_entry()), ""
+
+
+def render_engines_block(
+    entries: "tuple[EngineEntry, ...]",
+    *,
+    indent: str,
+    step: int,
+    header: "tuple[str, ...]" = (),
+) -> "list[str]":
+    """The block's line BODIES (no line endings), ready to splice into a file.
+
+    ``indent`` is the indentation of the sibling keys the block joins (that of
+    ``spec.claude``); ``step`` is the file's own nesting increment, taken from
+    the file rather than assumed, so an oddly-indented spec stays consistent
+    with itself.
+    """
+    pad = " " * max(step, 1)
+    key_indent = indent + pad
+    field_indent = key_indent + pad
+    child_indent = field_indent + pad
+
+    out: list[str] = [f"{indent}# {line}".rstrip() for line in header]
+    out.append(f"{indent}engines:")
+    for entry in entries:
+        out.append(f"{key_indent}{entry.key}:")
+        out.append(f"{field_indent}harness: {entry.harness}")
+        out.append(f"{field_indent}model: {entry.model}")
+        if entry.provider_lines:
+            out.append(f"{field_indent}provider:")
+            out.extend(f"{child_indent}{line}" for line in entry.provider_lines)
+        elif entry.provider_scalar is not None:
+            out.append(f"{field_indent}provider: {entry.provider_scalar}")
+        if entry.reasoning_effort:
+            out.append(f"{field_indent}reasoning_effort: {entry.reasoning_effort}")
+        if entry.max_context_tokens:
+            out.append(f"{field_indent}max_context_tokens: {entry.max_context_tokens}")
+        if entry.is_default:
+            out.append(f"{field_indent}default: true")
+    return out

--- a/src/scitex_agent_container/config/_engines_derive.py
+++ b/src/scitex_agent_container/config/_engines_derive.py
@@ -22,9 +22,10 @@ THE DERIVATION, and what each half is allowed to invent (nothing):
   address stays in one module instead of in 119 spec files.
 
 THE ENTRY KEY. ``claude`` when the backend is the plain Anthropic OAuth path
-— the name the operator's own already-migrated ``business`` spec uses — and
-a slug of the model otherwise, because "claude" is a false name for an entry
-holding Qwen and a vendor name is a claim about scope.
+AND the harness is the Anthropic one — the name the operator's own
+already-migrated ``business`` spec uses — and a slug of the model otherwise,
+because "claude" is a false name for an entry holding Qwen, a vendor name is
+a claim about scope, and a Codex session is not the vendor that name states.
 
 WHEN THE TWO COLLIDE. A spec that ALREADY runs ``qwen38-27b`` derives the
 alternate's own key, and one mapping cannot hold two entries under one key.
@@ -39,6 +40,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from ._harness_types import DEFAULT_AGENT_HARNESS
 from ._qwen_gateway import (
     QWEN_ENGINE_HARNESS,
     QWEN_ENGINE_KEY,
@@ -85,14 +87,30 @@ def slug_engine_key(model: str) -> str:
     return slug
 
 
-def engine_key_for(model: str, provider_declared: object) -> str:
-    """The key the DEFAULT entry gets. ``""`` when the model yields no slug."""
+def _is_anthropic_oauth(provider_declared: object) -> bool:
+    """Does this declared provider mean "the plain Anthropic OAuth path"?"""
     if provider_declared is None:
-        return CLAUDE_ENGINE_KEY
-    if (
+        return True
+    return (
         isinstance(provider_declared, str)
         and provider_declared.strip().lower() == ANTHROPIC_PROVIDER
-    ):
+    )
+
+
+def engine_key_for(
+    model: str,
+    provider_declared: object,
+    harness: str = DEFAULT_AGENT_HARNESS,
+) -> str:
+    """The key the DEFAULT entry gets. ``""`` when the model yields no slug.
+
+    HARNESS IS PART OF THE QUESTION. ``claude`` is the right name only for
+    the Anthropic OAuth path; on a ``harness: codex`` spec it is a vendor
+    name attached to something that is not that vendor, which is exactly the
+    claim-about-scope failure this axis exists to remove. Such a spec gets a
+    slug of its model, like every other non-Anthropic backend.
+    """
+    if harness == DEFAULT_AGENT_HARNESS and _is_anthropic_oauth(provider_declared):
         return CLAUDE_ENGINE_KEY
     return slug_engine_key(model)
 
@@ -106,7 +124,9 @@ class EngineEntry:
     model: str
     #: The scalar written after ``provider:``. None when the provider is a
     #: nested block, in which case ``provider_lines`` carries its children
-    #: with their original indentation already stripped.
+    #: with the block's own first-child indent removed and everything
+    #: DEEPER than that kept — a nested mapping under the provider survives
+    #: as a nested mapping rather than being flattened into siblings.
     provider_scalar: "str | None" = None
     provider_lines: "tuple[str, ...]" = ()
     reasoning_effort: str = ""
@@ -141,15 +161,26 @@ def derive_entries(
     VERBATIM text the caller lifted out of the spec, so the restated backend
     is byte-for-byte the one that was already there.
     """
-    key = engine_key_for(model, provider_declared)
+    key = engine_key_for(model, provider_declared, harness)
     if not key:
         return (), "the model yields no usable engine key"
 
     scalar = provider_scalar
-    if provider_declared is None and not provider_lines:
+    if (
+        provider_declared is None
+        and not provider_lines
+        and harness == DEFAULT_AGENT_HARNESS
+    ):
         # Stated explicitly rather than left empty: an omitted provider reads
         # as "no opinion", and an entry with no opinion about its backend is
         # the ambiguity this axis exists to remove.
+        #
+        # ONLY ON THE ANTHROPIC HARNESS. ``anthropic`` is this registry's
+        # sentinel for the Anthropic OAuth backend; writing it under a
+        # ``harness: codex`` entry states the WRONG vendor, which is worse
+        # than stating none — and the entry then reads as a claim nobody
+        # made. A non-Anthropic harness with no declared provider keeps
+        # exactly what the spec said: nothing.
         scalar = ANTHROPIC_PROVIDER
 
     default = EngineEntry(
@@ -193,7 +224,13 @@ def render_engines_block(
         out.append(f"{field_indent}model: {entry.model}")
         if entry.provider_lines:
             out.append(f"{field_indent}provider:")
-            out.extend(f"{child_indent}{line}" for line in entry.provider_lines)
+            # ``rstrip`` so a blank line copied out of the original block
+            # comes back blank rather than as an indent-only line, and each
+            # child keeps whatever extra indentation it carried RELATIVE to
+            # the block's first child — that relative depth is the nesting.
+            out.extend(
+                f"{child_indent}{line}".rstrip() for line in entry.provider_lines
+            )
         elif entry.provider_scalar is not None:
             out.append(f"{field_indent}provider: {entry.provider_scalar}")
         if entry.reasoning_effort:

--- a/src/scitex_agent_container/config/_engines_line.py
+++ b/src/scitex_agent_container/config/_engines_line.py
@@ -1,0 +1,436 @@
+"""Give ONE spec an ``engines:`` block, as a TEXT edit that keeps its comments.
+
+Operator, Telegram 2026-09-05:「一気に書き換えるコマンドめちゃくちゃ怖いので、
+ちゃんと git で管理してくださいね。大体置換のコードっていつも失敗するんですよね。」
+— a command that rewrites everything at once is frightening, keep it in git,
+bulk-replacement code always fails. Two properties answer that, and both are
+in this module rather than in the CLI that calls it.
+
+**COMMENTS SURVIVE.** 29 of the 119 fleet specs carry ``#`` comments;
+``handyman-08`` alone carries 168. They are operator rulings and measured
+numbers — the only record of WHY a value is what it is. A
+``yaml.safe_load`` + ``yaml.dump`` round-trip destroys every one, so there is
+none: the edit is line surgery through :mod:`._yaml_line_edit`, the same
+convention ``_a2a_host_line`` and ``_to_home_layers_line`` follow, and every
+line the migration does not deliberately rewrite comes out byte-identical.
+:func:`_verify` re-counts the comments afterwards and refuses the edit if one
+went missing, so the property is checked per spec rather than argued once.
+
+**THE EDIT CHECKS ITSELF.** Before returning, the new text is re-parsed and
+put through the production readers: :func:`parse_engines`,
+:func:`default_engine`, :func:`validate_engines` (which includes
+``legacy_conflict_messages``), and a before/after ``validate_raw`` comparison.
+The default engine's effective backend triple must equal the triple the spec
+resolved BEFORE the edit. An edit that fails any of those is a REFUSAL naming
+what failed — never a written file.
+
+WHAT IS REWRITTEN, and why only these two lines. The engines block supersedes
+the legacy single-backend reading of ``spec.claude.model`` and
+``spec.claude.provider``, so both are EMPTIED — the explicit-spec ruling
+(2026-07-21) requires the keys to stay written, so "removed" means "present
+and stating nothing", exactly as the operator's own migrated ``business``
+spec spells it. Leaving a value in either one builds a wall: the day
+``default: true`` moves to the Qwen entry, a stated legacy model becomes a
+hard load error from ``legacy_conflict_messages``.
+
+``spec.harness`` is NOT emptied. It is the one legacy field the engine entry
+restates verbatim, so the two AGREE — the case ``_engine_types`` blesses
+explicitly ("BOTH, agreeing → accepted, silently") — and it stays readable by
+every reader that asks a raw spec what harness it declares.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+import yaml
+
+from ._engine_types import (
+    ENGINES_KEY,
+    EngineError,
+    default_engine,
+    parse_engines,
+    select_engine,
+)
+from ._engine_validation import validate_engines
+from ._engines_derive import derive_entries, render_engines_block
+from ._harness_types import LEGACY_HARNESS_KEY, resolve_spec_harness
+from ._provider_parse import provider_identity
+from ._qwen_gateway import QWEN_ENGINE_KEY, QWEN_GATEWAY_URL_ENV
+from ._yaml_line_edit import (
+    find_block,
+    find_key,
+    is_skippable,
+    last_content_line,
+    parse_key_line,
+    split_ending,
+)
+
+__all__ = [
+    "EnginesEdit",
+    "REFUSED_ALREADY_DECLARED",
+    "REFUSED_EMPTY_CLAUDE",
+    "REFUSED_EMPTY_MODEL",
+    "REFUSED_INLINE_CLAUDE",
+    "REFUSED_LEGACY_HARNESS_ALIAS",
+    "REFUSED_NO_CLAUDE_BLOCK",
+    "REFUSED_NO_MODEL",
+    "REFUSED_NO_SPEC_BLOCK",
+    "REFUSED_PROVIDER_COMMENT",
+    "REFUSED_PROXY",
+    "REFUSED_TRAILING_COMMENT",
+    "REFUSED_UNNAMEABLE",
+    "REFUSED_UNPARSABLE",
+    "REFUSED_VERIFY_FAILED",
+    "migrate_engines_block",
+]
+
+# Refusal reasons. CONSTANT strings with nothing interpolated, so a 119-spec
+# sweep can group by reason and print one line per KIND of refusal instead of
+# one per spec. The variable half travels in ``EnginesEdit.detail``.
+REFUSED_ALREADY_DECLARED = "already declares spec.engines"
+REFUSED_UNPARSABLE = "the spec is not parsable YAML"
+REFUSED_NO_SPEC_BLOCK = "no spec: mapping to migrate"
+REFUSED_PROXY = "kind: AgentProxy — spec.engines is forbidden on a proxy"
+REFUSED_LEGACY_HARNESS_ALIAS = (
+    "declares the deprecated spec.provider harness alias; rename it to "
+    "spec.harness before migrating"
+)
+REFUSED_NO_CLAUDE_BLOCK = "no spec.claude block to derive the backend from"
+REFUSED_INLINE_CLAUDE = "spec.claude has an inline value, not a block"
+REFUSED_EMPTY_CLAUDE = "spec.claude has no child keys"
+REFUSED_NO_MODEL = "spec.claude has no model: line"
+REFUSED_EMPTY_MODEL = (
+    "spec.claude.model states no model, so there is no backend to name as "
+    "the default engine"
+)
+REFUSED_TRAILING_COMMENT = (
+    "spec.claude.model carries a trailing comment the edit would destroy"
+)
+REFUSED_PROVIDER_COMMENT = (
+    "spec.claude.provider carries a comment the edit would destroy"
+)
+REFUSED_UNNAMEABLE = "the model yields no usable engine key"
+REFUSED_VERIFY_FAILED = "the migrated text failed its own verification"
+
+_MODEL_MARK = "# explicit-empty (2026-07-21 rule): the engines carry the models"
+_PROVIDER_MARK = "# explicit-empty (2026-07-21 rule): the engines carry the providers"
+
+_HEADER_PAIR = (
+    "spec.engines (written by `sac agents migrate-engines`). HARNESS and ENGINE",
+    "are separate axes. The DEFAULT entry below is this spec's own backend,",
+    f"restated verbatim; `{QWEN_ENGINE_KEY}` is the fleet-gateway alternate, picked",
+    f"at start with `--engine {QWEN_ENGINE_KEY}`. The gateway ADDRESS is NOT written",
+    "here: the provider NAME resolves through config/_provider_registry, and is",
+    f"overridable per host with ${QWEN_GATEWAY_URL_ENV}.",
+)
+_HEADER_SOLO = (
+    "spec.engines (written by `sac agents migrate-engines`). HARNESS and ENGINE",
+    "are separate axes. This spec ALREADY runs the gateway model, so its own",
+    "backend is the engine, restated verbatim — no second entry could carry the",
+    "same key, and repointing this one at another endpoint would be a behaviour",
+    "change rather than a migration.",
+)
+
+
+@dataclass(frozen=True)
+class EnginesEdit:
+    """The outcome of one spec's edit — the ``LineEdit`` shape, plus provenance.
+
+    ``text`` / ``changed`` / ``reason`` are the contract
+    ``_maintenance._spec_sweep_plan`` consumes. ``reason`` is None exactly
+    when ``changed`` is True. ``detail`` carries the per-spec half of a
+    refusal that ``reason`` deliberately does not, so refusals stay groupable
+    while nothing is lost.
+    """
+
+    text: str
+    changed: bool
+    reason: "str | None" = None
+    detail: str = ""
+    engine_keys: "tuple[str, ...]" = ()
+    default_key: str = ""
+
+
+def _refuse(text: str, reason: str, detail: str = "") -> EnginesEdit:
+    return EnginesEdit(text, False, reason, detail)
+
+
+def _split_value_comment(value: str) -> "tuple[str, str]":
+    """Split a key line's value into ``(value, trailing comment)``.
+
+    Quote-aware, because a ``#`` inside a quoted scalar is data. Anything this
+    cannot read confidently is returned as a comment, which makes the caller
+    REFUSE rather than silently discard text.
+    """
+    value = value.strip()
+    if not value or value.startswith("#"):
+        return "", value
+    if value[0] in ("'", '"'):
+        quote = value[0]
+        i = 1
+        while i < len(value):
+            char = value[i]
+            if char == "\\" and quote == '"':
+                i += 2
+                continue
+            if char == quote:
+                if quote == "'" and value[i + 1 : i + 2] == "'":
+                    i += 2
+                    continue
+                i += 1
+                break
+            i += 1
+        return value[:i], value[i:].strip()
+    cut = value.find(" #")
+    if cut == -1:
+        return value, ""
+    return value[:cut].rstrip(), value[cut:].strip()
+
+
+def _dominant_ending(lines: "list[str]") -> str:
+    for raw in lines:
+        ending = split_ending(raw)[1]
+        if ending:
+            return ending
+    return "\n"
+
+
+def _insertion_point(bodies: "list[str]", key_line: int, floor: int) -> int:
+    """Where the block goes: above the comment run that introduces ``key_line``.
+
+    Inserting directly above the key would wedge the new block between a
+    comment and the key it explains. Walking back over the contiguous blank
+    and comment run keeps every comment attached to what it describes, and
+    lands the block after the previous sibling — the placement the operator's
+    own migrated spec uses.
+    """
+    index = key_line
+    while index - 1 >= floor and is_skippable(bodies[index - 1]):
+        index -= 1
+    return index
+
+
+def _provider_text(bodies, claude_doc):
+    """Lift ``spec.claude.provider`` verbatim: ``(scalar, lines, span, reason)``.
+
+    ``span`` is the half-open line range the legacy value occupies, or None
+    when there is nothing to empty. ``reason`` is non-empty on a refusal.
+    """
+    declared = claude_doc.get("provider")
+    block = find_block(bodies, ("spec", "claude", "provider"))
+    if block is None:
+        return None, (), None, ""
+    if block.inline_value is not None:
+        value, comment = _split_value_comment(block.inline_value)
+        if comment:
+            return None, (), None, REFUSED_PROVIDER_COMMENT
+        if declared is None:
+            return None, (), None, ""
+        span = (block.key_line, block.key_line + 1)
+        return value, (), span, ""
+    end = last_content_line(bodies, block.start, block.stop)
+    if end is None or not isinstance(declared, dict):
+        return None, (), None, ""
+    children: list[str] = []
+    for i in range(block.start, end + 1):
+        body = bodies[i]
+        if not body.strip():
+            continue
+        if body.strip().startswith("#"):
+            return None, (), None, REFUSED_PROVIDER_COMMENT
+        children.append(body.strip())
+    return None, tuple(children), (block.key_line, end + 1), ""
+
+
+def migrate_engines_block(text: str, *, path: str = "<spec>") -> EnginesEdit:
+    """Add ``spec.engines`` to one spec's TEXT. Returns the edit or a refusal.
+
+    When ``changed`` is False the text comes back BYTE-IDENTICAL and
+    ``reason`` names which case applies. Idempotent: a spec that already
+    declares the block is refused as ``already declares spec.engines``, so a
+    second run over a migrated fleet writes nothing.
+    """
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return _refuse(text, REFUSED_UNPARSABLE, str(exc))
+    if not isinstance(doc, dict) or not isinstance(doc.get("spec"), dict):
+        return _refuse(text, REFUSED_NO_SPEC_BLOCK)
+    spec, kind = doc["spec"], str(doc.get("kind") or "Agent")
+    if kind == "AgentProxy":
+        return _refuse(text, REFUSED_PROXY)
+    if ENGINES_KEY in spec:
+        return _refuse(text, REFUSED_ALREADY_DECLARED)
+    if LEGACY_HARNESS_KEY in spec:
+        return _refuse(text, REFUSED_LEGACY_HARNESS_ALIAS)
+    claude_doc = spec.get("claude")
+    if not isinstance(claude_doc, dict):
+        return _refuse(text, REFUSED_NO_CLAUDE_BLOCK)
+
+    lines = text.splitlines(keepends=True)
+    bodies = [split_ending(raw)[0] for raw in lines]
+    spec_block = find_block(bodies, ("spec",))
+    claude = find_block(bodies, ("spec", "claude"))
+    if spec_block is None or claude is None:
+        return _refuse(text, REFUSED_NO_CLAUDE_BLOCK)
+    if claude.inline_value is not None:
+        return _refuse(text, REFUSED_INLINE_CLAUDE)
+    if claude.child_indent is None:
+        return _refuse(text, REFUSED_EMPTY_CLAUDE)
+
+    model_line = find_key(
+        bodies, claude.start, claude.stop, claude.child_indent, "model"
+    )
+    if model_line is None:
+        return _refuse(text, REFUSED_NO_MODEL)
+    parsed_model = parse_key_line(bodies[model_line])
+    model_text, model_comment = _split_value_comment(
+        parsed_model.value if parsed_model else ""
+    )
+    if model_comment:
+        return _refuse(text, REFUSED_TRAILING_COMMENT)
+    if not str(claude_doc.get("model") or "").strip():
+        return _refuse(text, REFUSED_EMPTY_MODEL)
+
+    scalar, child_lines, provider_span, reason = _provider_text(bodies, claude_doc)
+    if reason:
+        return _refuse(text, reason)
+
+    entries, why = derive_entries(
+        harness=resolve_spec_harness(spec),
+        model=model_text,
+        provider_declared=claude_doc.get("provider"),
+        provider_scalar=scalar,
+        provider_lines=child_lines,
+    )
+    if why:
+        return _refuse(text, REFUSED_UNNAMEABLE, why)
+
+    step = len(claude.child_indent) - len(claude.indent)
+    header = _HEADER_PAIR if len(entries) > 1 else _HEADER_SOLO
+    block = render_engines_block(
+        entries, indent=claude.indent, step=step, header=header
+    )
+    ending = _dominant_ending(lines)
+
+    new_lines = list(lines)
+    edits = [
+        (
+            model_line,
+            model_line + 1,
+            f"{claude.child_indent}model: ''   {_MODEL_MARK}{ending}",
+        )
+    ]
+    if provider_span is not None:
+        edits.append(
+            (
+                provider_span[0],
+                provider_span[1],
+                f"{claude.child_indent}provider: null   {_PROVIDER_MARK}{ending}",
+            )
+        )
+    # Highest index FIRST. `provider:` sits after `model:` in most specs and
+    # before it in some, and its block is several lines long — applying them
+    # in file order would have the first edit silently shift the second one's
+    # span onto whatever line happened to move into it.
+    for start, stop, replacement in sorted(edits, key=lambda edit: -edit[0]):
+        new_lines[start:stop] = [replacement]
+    at = _insertion_point(bodies, claude.key_line, spec_block.key_line + 1)
+    if at > 0 and bodies[at - 1].strip():
+        # One blank line so the block reads as its own section rather than as
+        # a continuation of whatever key happens to precede it.
+        block = [""] + block
+    new_lines[at:at] = [f"{line}{ending}" for line in block]
+    new_text = "".join(new_lines)
+
+    problem = _verify(text, new_text, doc, kind, entries, path)
+    if problem:
+        return _refuse(text, REFUSED_VERIFY_FAILED, problem)
+    return EnginesEdit(
+        new_text,
+        True,
+        engine_keys=tuple(entry.key for entry in entries),
+        default_key=entries[0].key,
+    )
+
+
+def _comment_counts(text: str) -> Counter:
+    return Counter(
+        line.strip() for line in text.splitlines() if line.strip().startswith("#")
+    )
+
+
+def _verify(before, after, old_doc, kind, entries, path) -> str:
+    """Everything that must hold. Returns "" when it all does.
+
+    Each check answers a way this edit could be wrong that reading the diff
+    would not reveal: the block might not parse, it might parse into an
+    engine set the loader rejects, it might change what the agent starts on,
+    or it might have eaten a comment.
+    """
+    try:
+        new_doc = yaml.safe_load(after)
+    except yaml.YAMLError as exc:
+        return f"the migrated text does not parse as YAML: {exc}"
+    if not isinstance(new_doc, dict) or not isinstance(new_doc.get("spec"), dict):
+        return "the migrated text has no spec: mapping"
+    new_spec = new_doc["spec"]
+
+    engines = parse_engines(new_spec)
+    expected = [entry.key for entry in entries]
+    if list(engines) != expected:
+        return f"parse_engines returned {list(engines)}, expected {expected}"
+    errors = validate_engines(new_spec, kind)
+    if errors:
+        return "validate_engines rejected the block: " + "; ".join(errors)
+    try:
+        chosen = default_engine(engines)
+    except EngineError as exc:
+        return f"default_engine refused the block: {exc}"
+    if chosen is None or chosen.key != expected[0]:
+        return f"the default engine is {chosen and chosen.key!r}, not {expected[0]!r}"
+    if QWEN_ENGINE_KEY in expected:
+        picked = select_engine(engines, QWEN_ENGINE_KEY)
+        if picked is None or picked.key != QWEN_ENGINE_KEY:
+            return f"select_engine could not pick {QWEN_ENGINE_KEY!r}"
+        if picked.provider is None or not picked.provider.base_url:
+            return f"the {QWEN_ENGINE_KEY!r} entry resolves to no endpoint"
+
+    drift = _backend_drift(old_doc["spec"], chosen)
+    if drift:
+        return drift
+
+    lost = _comment_counts(before) - _comment_counts(after)
+    if lost:
+        return "comment line(s) lost: " + "; ".join(sorted(lost))
+
+    from ._validation import validate_raw
+
+    added = set(validate_raw(new_doc, path)) - set(validate_raw(old_doc, path))
+    if added:
+        return "the edit introduced validation error(s): " + "; ".join(sorted(added))
+    return ""
+
+
+def _backend_drift(old_spec, engine) -> str:
+    """Does the default engine start the SAME backend the spec started before?
+
+    The one property that makes this migration safe to run over 119 files: it
+    changes what a spec SAYS, never what an agent RUNS. Compared through the
+    production readers, and the provider through ``provider_identity`` so a
+    registry name and the dict it stands for are correctly equal.
+    """
+    old_harness = resolve_spec_harness(old_spec)
+    if engine.harness != old_harness:
+        return f"harness would change: {old_harness!r} -> {engine.harness!r}"
+    old_claude = old_spec.get("claude") or {}
+    old_model = str(old_claude.get("model") or "").strip()
+    if engine.model != old_model:
+        return f"model would change: {old_model!r} -> {engine.model!r}"
+    old_provider = provider_identity(old_claude.get("provider"))
+    new_provider = provider_identity(engine.provider_declared)
+    if old_provider != new_provider:
+        return f"provider would change: {old_provider!r} -> {new_provider!r}"
+    return ""

--- a/src/scitex_agent_container/config/_engines_line.py
+++ b/src/scitex_agent_container/config/_engines_line.py
@@ -29,14 +29,23 @@ the legacy single-backend reading of ``spec.claude.model`` and
 ``spec.claude.provider``, so both are EMPTIED — the explicit-spec ruling
 (2026-07-21) requires the keys to stay written, so "removed" means "present
 and stating nothing", exactly as the operator's own migrated ``business``
-spec spells it. Leaving a value in either one builds a wall: the day
-``default: true`` moves to the Qwen entry, a stated legacy model becomes a
+spec spells it. Leaving a value in either one builds a wall: the day the spec
+pins another engine with ``spec.engine:``, a stated legacy model becomes a
 hard load error from ``legacy_conflict_messages``.
 
-``spec.harness`` is NOT emptied. It is the one legacy field the engine entry
-restates verbatim, so the two AGREE — the case ``_engine_types`` blesses
-explicitly ("BOTH, agreeing → accepted, silently") — and it stays readable by
-every reader that asks a raw spec what harness it declares.
+``spec.harness`` is NOT emptied, and the engine entry does NOT restate it.
+The harness is the OTHER axis: the entry states no opinion about it (a
+``harness:`` inside an entry is deprecated — ``_engine_types``), the spec's
+own line keeps stating it, and ``legacy_conflict_messages`` skips the field
+precisely because a harness-silent engine INHERITS rather than disagrees. So
+the raw-spec readers keep their answer and the two axes stay uncoupled.
+
+ONE ENTRY, NOT TWO, AND NO ``default:``. The block this writes names the
+spec's own backend and nothing else; every alternate — ``qwen38-27b``
+included — comes from the fleet engine library, resolvable with ``--engine``
+through the merged namespace. A single entry needs no ``default: true``
+marker, and writing one would OUTRANK the fleet library in the precedence,
+turning 119 legacy pins into 119 engine pins. See ``_engines_derive``.
 """
 
 from __future__ import annotations
@@ -47,17 +56,16 @@ from dataclasses import dataclass
 import yaml
 
 from ._engine_types import (
+    ENGINE_PIN_KEY,
     ENGINES_KEY,
     EngineError,
     default_engine,
     parse_engines,
-    select_engine,
 )
 from ._engine_validation import validate_engines
 from ._engines_derive import derive_entries, render_engines_block
 from ._harness_types import LEGACY_HARNESS_KEY, resolve_spec_harness
 from ._provider_parse import provider_identity
-from ._qwen_gateway import QWEN_ENGINE_KEY, QWEN_GATEWAY_URL_ENV
 from ._yaml_line_edit import (
     find_block,
     find_key,
@@ -123,20 +131,17 @@ REFUSED_VERIFY_FAILED = "the migrated text failed its own verification"
 _MODEL_MARK = "# explicit-empty (2026-07-21 rule): the engines carry the models"
 _PROVIDER_MARK = "# explicit-empty (2026-07-21 rule): the engines carry the providers"
 
-_HEADER_PAIR = (
+_HEADER = (
     "spec.engines (written by `sac agents migrate-engines`). HARNESS and ENGINE",
-    "are separate axes. The DEFAULT entry below is this spec's own backend,",
-    f"restated verbatim; `{QWEN_ENGINE_KEY}` is the fleet-gateway alternate, picked",
-    f"at start with `--engine {QWEN_ENGINE_KEY}`. The gateway ADDRESS is NOT written",
-    "here: the provider NAME resolves through config/_provider_registry, and is",
-    f"overridable per host with ${QWEN_GATEWAY_URL_ENV}.",
-)
-_HEADER_SOLO = (
-    "spec.engines (written by `sac agents migrate-engines`). HARNESS and ENGINE",
-    "are separate axes. This spec ALREADY runs the gateway model, so its own",
-    "backend is the engine, restated verbatim — no second entry could carry the",
-    "same key, and repointing this one at another endpoint would be a behaviour",
-    "change rather than a migration.",
+    "are separate axes: the entry below is this spec's own BACKEND, restated",
+    "verbatim, and it states no `harness:` on purpose — `spec.harness` still",
+    "owns that axis and the entry inherits whatever it says.",
+    "",
+    "Other engines are NOT copied in here. They live once in the fleet engine",
+    "library ($SCITEX_DIR/agent-container/engines.yaml) and are selectable at",
+    "start with `--engine <key>`. To PIN this agent to one of them, add",
+    f"`{ENGINE_PIN_KEY}: <key>` at the top of spec: — one line, and it outranks",
+    "the fleet default without touching anything below.",
 )
 
 
@@ -343,9 +348,8 @@ def migrate_engines_block(text: str, *, path: str = "<spec>") -> EnginesEdit:
         return _refuse(text, REFUSED_UNNAMEABLE, why)
 
     step = len(claude.child_indent) - len(claude.indent)
-    header = _HEADER_PAIR if len(entries) > 1 else _HEADER_SOLO
     block = render_engines_block(
-        entries, indent=claude.indent, step=step, header=header
+        entries, indent=claude.indent, step=step, header=_HEADER
     )
     ending = _dominant_ending(lines)
 
@@ -437,12 +441,24 @@ def _verify(before, after, old_doc, kind, entries, path) -> str:
         return f"default_engine refused the block: {exc}"
     if chosen is None or chosen.key != expected[0]:
         return f"the default engine is {chosen and chosen.key!r}, not {expected[0]!r}"
-    if QWEN_ENGINE_KEY in expected:
-        picked = select_engine(engines, QWEN_ENGINE_KEY)
-        if picked is None or picked.key != QWEN_ENGINE_KEY:
-            return f"select_engine could not pick {QWEN_ENGINE_KEY!r}"
-        if picked.provider is None or not picked.provider.base_url:
-            return f"the {QWEN_ENGINE_KEY!r} entry resolves to no endpoint"
+    if chosen.harness is not None:
+        # The single-entry shape states no harness. A stated one here would
+        # mean the renderer had claimed the harness axis for the engine —
+        # the coupling the split removes — and would silently overwrite a
+        # `harness: codex` spec through ``apply_engine``.
+        return (
+            f"the {chosen.key!r} entry states harness={chosen.harness!r}; a "
+            "migrated entry must state none and inherit spec.harness"
+        )
+    if chosen.is_default:
+        # A spec-local `default:` OUTRANKS the fleet library, so writing one
+        # here would trade a legacy pin for an engine pin rather than clear
+        # it. Caught on the emitted TEXT, not argued in the renderer.
+        return (
+            f"the {chosen.key!r} entry is marked `default: true`; a "
+            "single-entry block must state no default so the fleet engine "
+            f"library stays reachable through `{ENGINE_PIN_KEY}:`"
+        )
 
     drift = _backend_drift(old_doc["spec"], chosen)
     if drift:
@@ -467,9 +483,18 @@ def _backend_drift(old_spec, engine) -> str:
     changes what a spec SAYS, never what an agent RUNS. Compared through the
     production readers, and the provider through ``provider_identity`` so a
     registry name and the dict it stands for are correctly equal.
+
+    THE HARNESS FIELD IS NULLABLE NOW, and ``None`` is not drift. An engine
+    that states no harness states NO OPINION and inherits ``spec.harness``,
+    which this edit leaves stated and untouched — so the effective harness is
+    the one the spec already resolved. Comparing ``None`` against that value
+    would report drift on every single spec the sweep touches, which is what
+    a check written against the pre-split dataclass (where ``harness``
+    defaulted to ``"anthropic"``) would now do. A STATED harness is still
+    compared: an entry that claims the axis must at least claim it correctly.
     """
     old_harness = resolve_spec_harness(old_spec)
-    if engine.harness != old_harness:
+    if engine.harness is not None and engine.harness != old_harness:
         return f"harness would change: {old_harness!r} -> {engine.harness!r}"
     old_claude = old_spec.get("claude") or {}
     old_model = str(old_claude.get("model") or "").strip()

--- a/src/scitex_agent_container/config/_engines_line.py
+++ b/src/scitex_agent_container/config/_engines_line.py
@@ -78,11 +78,13 @@ __all__ = [
     "REFUSED_NO_MODEL",
     "REFUSED_NO_SPEC_BLOCK",
     "REFUSED_PROVIDER_COMMENT",
+    "REFUSED_PROVIDER_SHAPE",
     "REFUSED_PROXY",
     "REFUSED_TRAILING_COMMENT",
     "REFUSED_UNNAMEABLE",
     "REFUSED_UNPARSABLE",
     "REFUSED_VERIFY_FAILED",
+    "lost_comment_lines",
     "migrate_engines_block",
 ]
 
@@ -110,6 +112,10 @@ REFUSED_TRAILING_COMMENT = (
 )
 REFUSED_PROVIDER_COMMENT = (
     "spec.claude.provider carries a comment the edit would destroy"
+)
+REFUSED_PROVIDER_SHAPE = (
+    "spec.claude.provider has a child line indented less than its first "
+    "child, a shape this edit will not re-indent blind"
 )
 REFUSED_UNNAMEABLE = "the model yields no usable engine key"
 REFUSED_VERIFY_FAILED = "the migrated text failed its own verification"
@@ -205,10 +211,22 @@ def _insertion_point(bodies: "list[str]", key_line: int, floor: int) -> int:
     and comment run keeps every comment attached to what it describes, and
     lands the block after the previous sibling — the placement the operator's
     own migrated spec uses.
+
+    A COMMENT GLUED TO THE PREVIOUS CONTENT LINE IS NOT AN INTRODUCTION. It
+    is that block's own trailing note (``# ^ the overlay above is per-agent
+    ...``), and hoisting it above 20 lines of engines block makes it a note
+    about the wrong key. Nothing downstream would catch that: ``_verify``
+    compares MULTISETS of comment text, so a comment that MOVED is invisible
+    to it — only a DELETED one is caught. The blank line is the tell: a
+    comment separated from what precedes it introduces what follows, and a
+    comment touching it belongs to it.
     """
     index = key_line
     while index - 1 >= floor and is_skippable(bodies[index - 1]):
         index -= 1
+    if index > floor and not is_skippable(bodies[index - 1]):
+        while index < key_line and bodies[index].strip().startswith("#"):
+            index += 1
     return index
 
 
@@ -234,13 +252,29 @@ def _provider_text(bodies, claude_doc):
     if end is None or not isinstance(declared, dict):
         return None, (), None, ""
     children: list[str] = []
+    base: "str | None" = None
     for i in range(block.start, end + 1):
         body = bodies[i]
-        if not body.strip():
-            continue
         if body.strip().startswith("#"):
             return None, (), None, REFUSED_PROVIDER_COMMENT
-        children.append(body.strip())
+        if not body.strip():
+            # A blank line INSIDE the block, kept so the restated block is
+            # what "verbatim" claims. ``last_content_line`` already excluded
+            # the trailing run, so this is only ever an interior one.
+            children.append("")
+            continue
+        indent = body[: len(body) - len(body.lstrip(" \t"))]
+        if base is None:
+            base = indent
+        if not indent.startswith(base):
+            return None, (), None, REFUSED_PROVIDER_SHAPE
+        # RELATIVE to the block's first child, not stripped bare. Stripping
+        # every child FLATTENED a nested mapping — `extra_headers:` with two
+        # keys under it came out as three siblings, one of them null — while
+        # the original block was deleted and `_backend_drift` (which compares
+        # only base_url and auth_token_env through ``provider_identity``)
+        # reported no change.
+        children.append(body[len(base) :])
     return None, tuple(children), (block.key_line, end + 1), ""
 
 
@@ -362,6 +396,18 @@ def _comment_counts(text: str) -> Counter:
     )
 
 
+def lost_comment_lines(before: str, after: str) -> "list[str]":
+    """Comment lines present in ``before`` and missing from ``after``.
+
+    Public so the guard is testable as a unit. It compares MULTISETS of
+    comment TEXT, which catches a deleted comment and — deliberately — not a
+    moved one: keeping a comment attached to the key it describes is
+    :func:`_insertion_point`'s job, and a check that cannot tell the two
+    apart would report a false loss on every legitimate reflow.
+    """
+    return sorted(_comment_counts(before) - _comment_counts(after))
+
+
 def _verify(before, after, old_doc, kind, entries, path) -> str:
     """Everything that must hold. Returns "" when it all does.
 
@@ -402,9 +448,9 @@ def _verify(before, after, old_doc, kind, entries, path) -> str:
     if drift:
         return drift
 
-    lost = _comment_counts(before) - _comment_counts(after)
+    lost = lost_comment_lines(before, after)
     if lost:
-        return "comment line(s) lost: " + "; ".join(sorted(lost))
+        return "comment line(s) lost: " + "; ".join(lost)
 
     from ._validation import validate_raw
 

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -14,7 +14,7 @@ from ._host import (
     substitute_hostnames,
 )
 from ._parsers import (
-    MODEL_DISPLAY_NAMES,
+    MODEL_ENV_KEY,
     interpolate_mcp_servers,
     parse_a2a,
     parse_apptainer,
@@ -33,6 +33,7 @@ from ._parsers import (
     parse_skills,
     parse_startup_commands,
     parse_watchdog,
+    resolve_model_surface,
 )
 from ._types import AgentConfig, HostsSpec
 
@@ -311,9 +312,13 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
             "SCITEX_AGENT_CONTAINER_ROLE"
         ) or labels.get("role")
         claude_spec.session = default_session_for_role(_role)
-    model = claude_spec.model or "sonnet"
-    display_model = MODEL_DISPLAY_NAMES.get(model, model)
-    auto_env["SCITEX_AGENT_CONTAINER_MODEL"] = display_model
+    # The LEGACY reading of the model. A spec declaring ``spec.engines``
+    # states nothing here on purpose (the engines carry the models), so this
+    # pair is provisional: ``apply_default_engine`` below folds the default
+    # engine's model over both halves. Computing it here anyway keeps a spec
+    # with no engines block on exactly the path it has always had.
+    model, display_model = resolve_model_surface(claude_spec.model)
+    auto_env[MODEL_ENV_KEY] = display_model
 
     # CLAUDE_AGENT_ACCOUNT — operator #16 self-awareness requirement.
     # Propagate the per-agent account dir-name (e.g. "alpha-example-com")

--- a/src/scitex_agent_container/config/_parsers/__init__.py
+++ b/src/scitex_agent_container/config/_parsers/__init__.py
@@ -17,11 +17,14 @@ from ._container import parse_container
 from ._extensions import parse_extensions
 from ._health import parse_health
 from ._helpers import (
+    DEFAULT_MODEL,
     HOOK_KEYS,
     MODEL_DISPLAY_NAMES,
+    MODEL_ENV_KEY,
     _parse_command_list,
     get_nested,
     interpolate_metadata,
+    resolve_model_surface,
 )
 from ._hooks import parse_hooks
 from ._hosts import _VALID_SCHEDULING_MODES, parse_hosts_spec, parse_scheduling
@@ -34,8 +37,10 @@ from ._startup import parse_startup_commands
 from ._watchdog import parse_watchdog
 
 __all__ = [
+    "DEFAULT_MODEL",
     "HOOK_KEYS",
     "MODEL_DISPLAY_NAMES",
+    "MODEL_ENV_KEY",
     "get_nested",
     "interpolate_mcp_servers",
     "interpolate_metadata",
@@ -57,4 +62,5 @@ __all__ = [
     "parse_skills",
     "parse_startup_commands",
     "parse_watchdog",
+    "resolve_model_surface",
 ]

--- a/src/scitex_agent_container/config/_parsers/_helpers.py
+++ b/src/scitex_agent_container/config/_parsers/_helpers.py
@@ -39,6 +39,29 @@ MODEL_DISPLAY_NAMES: dict[str, str] = {
     "haiku": "Claude Haiku",
 }
 
+#: What ``model`` resolves to when nothing states one. Named rather than
+#: repeated: it is applied in TWO places now — the legacy read in
+#: ``_loaders`` and the engine fold in ``_engine_types.apply_engine`` — and
+#: two spellings of a default is how they drift apart.
+DEFAULT_MODEL = "sonnet"
+
+#: The auto-derived env var carrying the DISPLAY form of the resolved model
+#: into the container. Injected into every agent (``SAC_SPEC_ENV_KEYS``) and
+#: printed by ``sac whoami``.
+MODEL_ENV_KEY = "SCITEX_AGENT_CONTAINER_MODEL"
+
+
+def resolve_model_surface(model: "str | None") -> "tuple[str, str]":
+    """``(model, display)`` — the pair every read surface shows.
+
+    One function because the two halves must never disagree: ``sac agents
+    list`` prints the first and the container receives the second, and a
+    model resolved twice by two rules is a fleet reporting one thing and
+    running another.
+    """
+    resolved = str(model or "").strip() or DEFAULT_MODEL
+    return resolved, MODEL_DISPLAY_NAMES.get(resolved, resolved)
+
 
 def get_nested(data: dict, key: str, default: Any = None) -> Any:
     """Traverse a dot-separated key path in a nested dict."""

--- a/src/scitex_agent_container/config/_provider_registry.py
+++ b/src/scitex_agent_container/config/_provider_registry.py
@@ -26,9 +26,25 @@ as no provider at all.
 Aliases (e.g. ``"xiaomi"`` → same metadata as ``"mimo"``) are
 intentional duplicates rather than indirection: the registry stays a
 flat read so no caller has to chase aliases.
+
+ONE ENTRY IS RESOLVED, NOT READ — see :data:`_DYNAMIC_PROVIDERS`. The
+fleet Qwen gateway moves with the host that serves it, so its address is
+owned by :mod:`._qwen_gateway` and overridable from the environment. Its
+row in :data:`PROVIDERS` below is the DEFAULT, kept there so
+:func:`list_providers` names it and the shape of the table stays uniform;
+every read must go through :func:`resolve_provider`, which applies the
+override. Reading :data:`PROVIDERS` directly would silently ignore a
+per-host override — no caller in this package does.
 """
 
 from __future__ import annotations
+
+from ._qwen_gateway import (
+    DEFAULT_QWEN_GATEWAY_TOKEN_ENV,
+    DEFAULT_QWEN_GATEWAY_URL,
+    QWEN_GATEWAY_PROVIDER,
+    qwen_gateway_provider_entry,
+)
 
 PROVIDERS: dict[str, dict[str, str | None]] = {
     "anthropic": {
@@ -55,7 +71,26 @@ PROVIDERS: dict[str, dict[str, str | None]] = {
         "base_url": "https://token-plan-sgp.xiaomimimo.com/anthropic",
         "auth_token_env": "XIAOMI_API_KEY",
     },
+    # The fleet Qwen gateway. THE DEFAULT ONLY — resolved through
+    # _DYNAMIC_PROVIDERS below so $SAC_QWEN_GATEWAY_URL wins on a host that
+    # reaches it another way. Written into every migrated spec as the bare
+    # name `qwen-gateway`, so the address is in this file and not in 119
+    # spec.yaml files.
+    QWEN_GATEWAY_PROVIDER: {
+        "base_url": DEFAULT_QWEN_GATEWAY_URL,
+        "auth_token_env": DEFAULT_QWEN_GATEWAY_TOKEN_ENV,
+    },
 }
+
+#: Providers whose metadata is HOST-DEPENDENT and therefore computed on each
+#: read instead of frozen in :data:`PROVIDERS`. Keyed by provider name, valued
+#: by a zero-argument callable returning the same two-field dict.
+#:
+#: A frozen constant cannot honour an environment variable exported after
+#: import, and sac is imported long before a launch resolves a provider. One
+#: member today; the mechanism is general so a second movable backend does not
+#: become a second special case in :func:`resolve_provider`.
+_DYNAMIC_PROVIDERS = {QWEN_GATEWAY_PROVIDER: qwen_gateway_provider_entry}
 
 
 def resolve_provider(name: str) -> dict[str, str | None] | None:
@@ -68,11 +103,18 @@ def resolve_provider(name: str) -> dict[str, str | None] | None:
 
     The returned dict is a copy — callers may mutate it without
     disturbing the registry.
+
+    A name in :data:`_DYNAMIC_PROVIDERS` is RESOLVED here rather than read
+    from :data:`PROVIDERS`, so a per-host override is honoured by every
+    caller (the parser, the validator, the honourability verdict and the
+    launch argv all arrive through this one function).
     """
-    entry = PROVIDERS.get(name)
-    if entry is None:
+    if name not in PROVIDERS:
         return None
-    return dict(entry)
+    dynamic = _DYNAMIC_PROVIDERS.get(name)
+    if dynamic is not None:
+        return dict(dynamic())
+    return dict(PROVIDERS[name])
 
 
 def list_providers() -> list[str]:

--- a/src/scitex_agent_container/config/_qwen_gateway.py
+++ b/src/scitex_agent_container/config/_qwen_gateway.py
@@ -55,9 +55,11 @@ __all__ = [
     "QWEN_ENGINE_REASONING_EFFORT",
     "QWEN_GATEWAY_HOST",
     "QWEN_GATEWAY_PORT",
+    "QWEN_GATEWAY_PROBE_PATH",
     "QWEN_GATEWAY_PROVIDER",
     "QWEN_GATEWAY_TOKEN_ENV_ENV",
     "QWEN_GATEWAY_URL_ENV",
+    "qwen_gateway_probe_url",
     "qwen_gateway_provider_entry",
     "qwen_gateway_token_env",
     "qwen_gateway_url",
@@ -127,6 +129,36 @@ def qwen_gateway_url() -> str:
     return (os.environ.get(QWEN_GATEWAY_URL_ENV) or "").strip() or (
         DEFAULT_QWEN_GATEWAY_URL
     )
+
+
+#: The path a PREFLIGHT asks for, and it is not the base. Measured from
+#: scitex-compute-04 on 2026-09-06 against this very gateway:
+#:
+#:     /                     404   listening, but this path does not exist
+#:     /v1/models            401   REACHABLE + AUTH-GATED — the informative one
+#:     /v1/chat/completions   401   same
+#:     /health               200   a real health endpoint exists
+#:     /healthz              404   does not exist
+#:     /v1                   307   redirect
+#:     CONTROL scitex-compute-99:18772/v1/models -> 000 (name unresolvable)
+#:
+#: A 401 HERE proves the inference API is present AND gating, which is exactly
+#: what an engine entry needs. ``/health`` is deliberately not it: a 200 there
+#: proves the process is up and says nothing about whether ``/v1`` is served
+#: or auth is wired — a gate that cannot fail.
+QWEN_GATEWAY_PROBE_PATH = "/v1/models"
+
+
+def qwen_gateway_probe_url() -> str:
+    """The address a reachability probe should actually dial.
+
+    The base URL answers 404, which :mod:`._engine_reach` now names
+    ``listening-wrong-path`` rather than passing off as a healthy gateway.
+    Joined by hand rather than with ``urljoin`` so a base carrying a path
+    prefix (a reverse proxy mounting the gateway under ``/qwen``) keeps it —
+    ``urljoin`` would discard the prefix and probe the wrong place.
+    """
+    return f"{qwen_gateway_url().rstrip('/')}{QWEN_GATEWAY_PROBE_PATH}"
 
 
 def qwen_gateway_token_env() -> str:

--- a/src/scitex_agent_container/config/_qwen_gateway.py
+++ b/src/scitex_agent_container/config/_qwen_gateway.py
@@ -1,0 +1,150 @@
+"""The fleet Qwen gateway — ONE address, written once, overridable per host.
+
+WHY THIS MODULE EXISTS. Measured over the 119 tracked specs on 2026-09-06,
+the same gateway is spelled two incompatible ways and copy-pasted eleven
+times: ``http://127.0.0.1:18772`` in the eight handyman specs (they run on
+the machine that serves it) and ``http://100.64.0.1:18772`` in ``business``
+(it runs on scitex-compute-01, where a loopback URL points at nothing —
+its own comment says so). One of those two is wrong on any given host, and
+which one is wrong depends on where the agent starts. ``handyman-08`` also
+names a different ``auth_token_env`` than its seven siblings, which is what
+copy-paste drift looks like when it is silent.
+
+``sac agents migrate-engines`` adds a Qwen engine to every fleet spec. If it
+wrote the address, the fleet would hold 119 copies of a value that moves,
+and a gateway move would then be a 119-file edit. So the migration writes a
+provider NAME — :data:`QWEN_GATEWAY_PROVIDER` — which resolves through
+``_provider_registry.resolve_provider`` at start time, on whichever host the
+agent actually starts on. The address lives here and nowhere else.
+
+THE SPELLING IS LOAD-BEARING. Measured by scitex-hub on 2026-09-05:
+
+    scitex-compute-04:18772   HTTP 401   listening and auth-gating = REACHABLE
+    compute-04:18772          000        the NAME does not resolve
+    compute-04-lan:18772      000        the NAME does not resolve
+
+``scitex-compute-04`` is the spelling that resolves from every host on the
+fleet; the shorter forms and the ``-lan`` convention do not. curl reports
+``000`` for an unresolvable name, which reads as "the gateway is down" while
+meaning "the hostname is wrong" — see :mod:`._engine_reach`, which refuses to
+collapse those two into one answer.
+
+OVERRIDING IT. :data:`QWEN_GATEWAY_URL_ENV` and
+:data:`QWEN_GATEWAY_TOKEN_ENV_ENV` override the address and the key's env-var
+NAME for one host or one process, so a peer that reaches the gateway by a
+different route does not need its specs rewritten. They are read at RESOLVE
+time, not at import time: a module-level constant frozen at import would make
+an export set after ``import scitex_agent_container`` silently ineffective.
+
+The value of the API key is never held here — only the NAME of the host env
+var that holds it, which is the same rule ``ProviderSpec.auth_token_env``
+already follows.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = [
+    "DEFAULT_QWEN_GATEWAY_TOKEN_ENV",
+    "DEFAULT_QWEN_GATEWAY_URL",
+    "QWEN_ENGINE_HARNESS",
+    "QWEN_ENGINE_KEY",
+    "QWEN_ENGINE_MAX_CONTEXT_TOKENS",
+    "QWEN_ENGINE_MODEL",
+    "QWEN_ENGINE_REASONING_EFFORT",
+    "QWEN_GATEWAY_HOST",
+    "QWEN_GATEWAY_PORT",
+    "QWEN_GATEWAY_PROVIDER",
+    "QWEN_GATEWAY_TOKEN_ENV_ENV",
+    "QWEN_GATEWAY_URL_ENV",
+    "qwen_gateway_provider_entry",
+    "qwen_gateway_token_env",
+    "qwen_gateway_url",
+]
+
+#: The registered provider name a migrated spec writes instead of an address.
+QWEN_GATEWAY_PROVIDER = "qwen-gateway"
+
+#: The hostname that RESOLVES from every fleet host. Not an alias — see the
+#: module docstring for the measurement that rules out the short forms.
+QWEN_GATEWAY_HOST = "scitex-compute-04"
+
+#: The Anthropic-Messages port the gateway serves. Distinct from the per-agent
+#: vLLM replica ports (18773-18775, OpenAI transport), which are a different
+#: axis and are NOT touched by the engines migration.
+QWEN_GATEWAY_PORT = 18772
+
+#: Where the gateway is, absent an override.
+DEFAULT_QWEN_GATEWAY_URL = f"http://{QWEN_GATEWAY_HOST}:{QWEN_GATEWAY_PORT}"
+
+#: The NAME of the host env var holding the gateway key — never the key.
+DEFAULT_QWEN_GATEWAY_TOKEN_ENV = "SCITEX_GENAI_GATEWAY_API_KEY"
+
+#: Per-host override for the address. Read at resolve time.
+QWEN_GATEWAY_URL_ENV = "SAC_QWEN_GATEWAY_URL"
+
+#: Per-host override for the env-var NAME the key is read from. This is one
+#: level of indirection deeper than it looks: the value of THIS variable is
+#: itself a variable name, which is how ``handyman-08``'s divergent
+#: ``SAC_LOCAL_GPTOSS_KEY`` can be honoured on one host without editing specs.
+QWEN_GATEWAY_TOKEN_ENV_ENV = "SAC_QWEN_GATEWAY_TOKEN_ENV"
+
+#: The engine key the migration writes, and the model it names. They are the
+#: same string on purpose: the operator's already-migrated ``business`` spec
+#: names its Qwen engine after the model, and one spelling is easier to type
+#: after ``--engine`` than two.
+QWEN_ENGINE_KEY = "qwen38-27b"
+QWEN_ENGINE_MODEL = "qwen38-27b"
+
+#: The gateway speaks the Anthropic Messages transport, so Claude Code stays
+#: the harness. HARNESS and ENGINE are separate axes and this is the whole
+#: point of the split: swapping the engine does not swap the harness.
+QWEN_ENGINE_HARNESS = "anthropic"
+
+#: Q4 (operator, 2026-09-03): Qwen is expected to run at low effort
+#: permanently.
+QWEN_ENGINE_REASONING_EFFORT = "low"
+
+#: The window the gateway actually serves (serve conf MAX_MODEL_LEN=1048576).
+#: Claude Code assumes 200k for a model it does not recognise and auto-compacts
+#: at that boundary; on ``business``'s resumed 1M session the compaction
+#: request itself crashed the engine. sac renders this as
+#: ``SAC_ENGINE_MAX_CONTEXT_TOKENS`` and, on the anthropic harness, as
+#: ``CLAUDE_CODE_MAX_CONTEXT_TOKENS`` — the knob the harness names in its own
+#: error text (``runtimes._apptainer_provider.engine_env_flags``).
+QWEN_ENGINE_MAX_CONTEXT_TOKENS = 1048576
+
+
+def qwen_gateway_url() -> str:
+    """The gateway address for THIS host, honouring the env override.
+
+    An override that is set but blank is treated as unset rather than as "the
+    empty URL": an exported-but-empty variable is how a shell says nothing,
+    and resolving it to an unusable address would turn a typo in a profile
+    into a fleet-wide refusal.
+    """
+    return (os.environ.get(QWEN_GATEWAY_URL_ENV) or "").strip() or (
+        DEFAULT_QWEN_GATEWAY_URL
+    )
+
+
+def qwen_gateway_token_env() -> str:
+    """The NAME of the env var holding the gateway key, honouring the override."""
+    return (os.environ.get(QWEN_GATEWAY_TOKEN_ENV_ENV) or "").strip() or (
+        DEFAULT_QWEN_GATEWAY_TOKEN_ENV
+    )
+
+
+def qwen_gateway_provider_entry() -> "dict[str, str | None]":
+    """The registry entry for :data:`QWEN_GATEWAY_PROVIDER`, resolved now.
+
+    Same two-field shape every other ``PROVIDERS`` entry has, so a spec
+    writing ``provider: qwen-gateway`` is byte-equivalent to one that
+    copy-pasted this dict inline — which is exactly the equivalence the
+    provider registry was created for (operator directive 2026-05-28).
+    """
+    return {
+        "base_url": qwen_gateway_url(),
+        "auth_token_env": qwen_gateway_token_env(),
+    }

--- a/src/scitex_agent_container/config/_qwen_gateway.py
+++ b/src/scitex_agent_container/config/_qwen_gateway.py
@@ -10,12 +10,23 @@ which one is wrong depends on where the agent starts. ``handyman-08`` also
 names a different ``auth_token_env`` than its seven siblings, which is what
 copy-paste drift looks like when it is silent.
 
-``sac agents migrate-engines`` adds a Qwen engine to every fleet spec. If it
-wrote the address, the fleet would hold 119 copies of a value that moves,
-and a gateway move would then be a 119-file edit. So the migration writes a
-provider NAME — :data:`QWEN_GATEWAY_PROVIDER` — which resolves through
-``_provider_registry.resolve_provider`` at start time, on whichever host the
-agent actually starts on. The address lives here and nowhere else.
+THE FLEET ENGINE LIBRARY declares the Qwen engine ONCE
+(``$SCITEX_DIR/agent-container/engines.yaml``, :mod:`._engine_library`) and
+names its backend by provider NAME — :data:`QWEN_GATEWAY_PROVIDER` — which
+resolves through ``_provider_registry.resolve_provider`` at start time, on
+whichever host the agent actually starts on. The address lives here and
+nowhere else, so a gateway move is an edit to THIS file rather than to 119
+spec files.
+
+WHAT THIS MODULE NO LONGER OWNS. It used to carry the ENGINE half too
+(``QWEN_ENGINE_KEY`` / ``_MODEL`` / ``_HARNESS`` / ``_REASONING_EFFORT`` /
+``_MAX_CONTEXT_TOKENS``), because ``sac agents migrate-engines`` copied a
+whole ``qwen38-27b`` entry into every spec it swept. That entry is data, and
+data belongs in the engine library where one line moves the whole fleet — a
+Python constant naming a model, an effort and a context window was a second
+place to say what a YAML row already says. The engine definition moved
+there; the ADDRESS stayed here, because an address that must resolve
+differently per host is code, not data.
 
 THE SPELLING IS LOAD-BEARING. Measured by scitex-hub on 2026-09-05:
 
@@ -48,11 +59,6 @@ import os
 __all__ = [
     "DEFAULT_QWEN_GATEWAY_TOKEN_ENV",
     "DEFAULT_QWEN_GATEWAY_URL",
-    "QWEN_ENGINE_HARNESS",
-    "QWEN_ENGINE_KEY",
-    "QWEN_ENGINE_MAX_CONTEXT_TOKENS",
-    "QWEN_ENGINE_MODEL",
-    "QWEN_ENGINE_REASONING_EFFORT",
     "QWEN_GATEWAY_HOST",
     "QWEN_GATEWAY_PORT",
     "QWEN_GATEWAY_PROBE_PATH",
@@ -91,31 +97,6 @@ QWEN_GATEWAY_URL_ENV = "SAC_QWEN_GATEWAY_URL"
 #: itself a variable name, which is how ``handyman-08``'s divergent
 #: ``SAC_LOCAL_GPTOSS_KEY`` can be honoured on one host without editing specs.
 QWEN_GATEWAY_TOKEN_ENV_ENV = "SAC_QWEN_GATEWAY_TOKEN_ENV"
-
-#: The engine key the migration writes, and the model it names. They are the
-#: same string on purpose: the operator's already-migrated ``business`` spec
-#: names its Qwen engine after the model, and one spelling is easier to type
-#: after ``--engine`` than two.
-QWEN_ENGINE_KEY = "qwen38-27b"
-QWEN_ENGINE_MODEL = "qwen38-27b"
-
-#: The gateway speaks the Anthropic Messages transport, so Claude Code stays
-#: the harness. HARNESS and ENGINE are separate axes and this is the whole
-#: point of the split: swapping the engine does not swap the harness.
-QWEN_ENGINE_HARNESS = "anthropic"
-
-#: Q4 (operator, 2026-09-03): Qwen is expected to run at low effort
-#: permanently.
-QWEN_ENGINE_REASONING_EFFORT = "low"
-
-#: The window the gateway actually serves (serve conf MAX_MODEL_LEN=1048576).
-#: Claude Code assumes 200k for a model it does not recognise and auto-compacts
-#: at that boundary; on ``business``'s resumed 1M session the compaction
-#: request itself crashed the engine. sac renders this as
-#: ``SAC_ENGINE_MAX_CONTEXT_TOKENS`` and, on the anthropic harness, as
-#: ``CLAUDE_CODE_MAX_CONTEXT_TOKENS`` — the knob the harness names in its own
-#: error text (``runtimes._apptainer_provider.engine_env_flags``).
-QWEN_ENGINE_MAX_CONTEXT_TOKENS = 1048576
 
 
 def qwen_gateway_url() -> str:

--- a/src/scitex_agent_container/config/_yaml_line_edit.py
+++ b/src/scitex_agent_container/config/_yaml_line_edit.py
@@ -60,10 +60,53 @@ def _indent_of(body: str) -> str:
     return body[: len(body) - len(body.lstrip(" \t"))]
 
 
-def _is_skippable(body: str) -> bool:
-    """True for blank and comment-only lines — they carry no structure."""
+def is_skippable(body: str) -> bool:
+    """True for blank and comment-only lines — they carry no structure.
+
+    Public because two things outside this module need the SAME answer: an
+    editor walking back over the comment block that belongs to the key it is
+    inserting above, and one locating where a block's real content ends. A
+    second spelling of "is this line structure?" is exactly the drift this
+    module was created to prevent.
+    """
     stripped = body.strip()
     return not stripped or stripped.startswith("#")
+
+
+@dataclass(frozen=True)
+class KeyLine:
+    """A parsed ``<indent><key>: <value>`` line. ``value`` is "" for a block."""
+
+    indent: str
+    key: str
+    value: str
+
+
+def parse_key_line(body: str) -> "KeyLine | None":
+    """Split one line into indent / key / value, or None if it is not a key.
+
+    The same strict :data:`_KEY_RE` :func:`find_key` matches on, exposed so a
+    caller reading a VALUE (rather than locating a key) does not reach for a
+    regex of its own and quietly accept a shape this module refuses.
+    """
+    m = _KEY_RE.match(body)
+    if m is None:
+        return None
+    return KeyLine(m.group("indent"), m.group("key"), m.group("value") or "")
+
+
+def last_content_line(bodies: "list[str]", start: int, stop: int) -> "int | None":
+    """Index of the last line carrying structure in ``[start, stop)``.
+
+    A block's ``stop`` is the next SIBLING key, so the lines between a block's
+    final child and its ``stop`` are the blank and comment lines that visually
+    introduce that sibling. Replacing through ``stop`` would eat them; this is
+    where a replacement must end instead.
+    """
+    for i in range(stop - 1, start - 1, -1):
+        if not is_skippable(bodies[i]):
+            return i
+    return None
 
 
 @dataclass(frozen=True)
@@ -95,7 +138,7 @@ def _block_extent(bodies: "list[str]", key_line: int, indent: str) -> int:
     """
     for i in range(key_line + 1, len(bodies)):
         body = bodies[i]
-        if _is_skippable(body):
+        if is_skippable(body):
             continue
         if len(_indent_of(body)) <= len(indent):
             return i
@@ -107,7 +150,7 @@ def _first_child_indent(
 ) -> "str | None":
     for i in range(start, stop):
         body = bodies[i]
-        if _is_skippable(body):
+        if is_skippable(body):
             continue
         child = _indent_of(body)
         return child if len(child) > len(indent) else None
@@ -124,7 +167,7 @@ def find_key(
     """
     for i in range(start, stop):
         body = bodies[i]
-        if _is_skippable(body):
+        if is_skippable(body):
             continue
         m = _KEY_RE.match(body)
         if m is None or m.group("indent") != indent or m.group("key") != key:
@@ -203,8 +246,12 @@ def insert_after(
 
 __all__ = [
     "Block",
+    "KeyLine",
     "find_block",
     "find_key",
     "insert_after",
+    "is_skippable",
+    "last_content_line",
+    "parse_key_line",
     "split_ending",
 ]

--- a/tests/scitex_agent_container/_maintenance/test__engines_apply.py
+++ b/tests/scitex_agent_container/_maintenance/test__engines_apply.py
@@ -27,6 +27,7 @@ from scitex_agent_container._maintenance._engines_apply import (
     _backend_snapshot,
     apply_engines_migration,
 )
+from scitex_agent_container._maintenance._engines_floor import EngineFloor
 from scitex_agent_container._maintenance._engines_migration import (
     STATE_MIGRATED,
     EnginesPlan,
@@ -82,7 +83,13 @@ def fleet(tmp_path: Path):
 
 
 def _plan(fleet: Path, **kwargs) -> EnginesPlan:
+    # These tests are about the WRITE — the archive, the atomic replace, the
+    # measured gate and the rollback — not about host capability, so the floor
+    # is disabled EXPLICITLY. It is a required argument: omitting it used to
+    # disable it silently, which is how the public planner came to report a
+    # pre-engines-host spec as safe to write.
     paths, skipped = select_spec_paths(fleet)
+    kwargs.setdefault("floor", EngineFloor.disabled())
     return plan_engines_migration(
         paths, root=fleet, skipped_templates=skipped, **kwargs
     )

--- a/tests/scitex_agent_container/_maintenance/test__engines_apply.py
+++ b/tests/scitex_agent_container/_maintenance/test__engines_apply.py
@@ -1,0 +1,397 @@
+"""The WRITING half of the ``spec.engines`` sweep — and its undo.
+
+Mutation testing over the previous suite found that every SAFETY mechanism
+here survived: deleting the before/after measurement, making the rollback
+unreachable, and dropping the pre-write "could not be loaded" refusal each
+left 94 tests green. Those mechanisms are the reason a 119-file rewrite was
+considered safe to run, so they are what this module exercises.
+
+No mocks and no sabotage of production code. Where a test needs a write that
+must be rolled back, it hands ``apply_engines_migration`` a REAL plan whose
+``new_text`` is a real spec declaring a different backend — which is exactly
+what a bulk-replacement bug would produce, and the failure the gate exists
+to catch.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._maintenance._engines_apply import (
+    _backend_snapshot,
+    apply_engines_migration,
+)
+from scitex_agent_container._maintenance._engines_migration import (
+    STATE_MIGRATED,
+    EnginesPlan,
+    SpecOutcome,
+    plan_engines_migration,
+    select_spec_paths,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+_SETTINGS = '{"hooks": {}}'
+
+
+def _write_settings(to_home: Path) -> None:
+    claude = to_home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / "settings.json").write_text(_SETTINGS)
+
+
+def _write_spec(root: Path, name: str, *, model="opus[1m]", **overrides) -> Path:
+    agent_dir = root / name
+    agent_dir.mkdir(parents=True)
+    _write_settings(agent_dir / "to_home")
+    spec = {"to_home": "./to_home", "claude": {"model": model}}
+    spec.update(overrides)
+    path = agent_dir / "spec.yaml"
+    path.write_text(yaml.safe_dump(explicit_doc(spec), sort_keys=False))
+    return path
+
+
+@pytest.fixture
+def fleet(tmp_path: Path):
+    """A tmp fleet with every root pinned inside tmp_path."""
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    _write_settings(agents / "_shared" / "to_home")
+    user_shared = tmp_path / "user-baseline" / "to_home"
+    _write_settings(user_shared)
+    keys = {
+        "SCITEX_AGENT_CONTAINER_AGENTS_DIR": str(agents),
+        "SAC_USER_TO_HOME_BASELINE": str(user_shared),
+        "SAC_SPEC_CACHE_DISABLE": "1",
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    os.environ.update(keys)
+    try:
+        yield agents
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _plan(fleet: Path, **kwargs) -> EnginesPlan:
+    paths, skipped = select_spec_paths(fleet)
+    return plan_engines_migration(
+        paths, root=fleet, skipped_templates=skipped, **kwargs
+    )
+
+
+def _drifting_plan(fleet: Path, path: Path) -> EnginesPlan:
+    """A REAL plan whose written text declares a DIFFERENT model.
+
+    Not a mock and not a patched renderer: a spec body a broken bulk edit
+    would plausibly emit. The gate's whole claim is that it catches this.
+    """
+    new_text = path.read_text().replace("model: opus[1m]", "model: haiku")
+    return EnginesPlan(
+        outcomes=(
+            SpecOutcome(
+                path.parent.name, path, STATE_MIGRATED, new_text=new_text
+            ),
+        ),
+        roster=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The gate, and the rollback behind it
+# ---------------------------------------------------------------------------
+
+
+def test_a_backend_change_is_not_applied(fleet: Path, tmp_path: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    plan = _drifting_plan(fleet, spec)
+    # Act
+    result = apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert result.applied is False
+
+
+def test_a_backend_change_is_named_as_drift(fleet: Path, tmp_path: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    plan = _drifting_plan(fleet, spec)
+    # Act
+    result = apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert any("alpha" in entry for entry in result.drift)
+
+
+def test_a_backend_change_restores_the_original_bytes(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange — the rollback must be a copy-back, not a reconstruction.
+    spec = _write_spec(fleet, "alpha")
+    original = spec.read_bytes()
+    plan = _drifting_plan(fleet, spec)
+    # Act
+    apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert spec.read_bytes() == original
+
+
+def test_a_rolled_back_apply_says_where_the_archive_is(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    plan = _drifting_plan(fleet, spec)
+    # Act
+    result = apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert str(result.archive_dir) in result.rolled_back
+
+
+def test_the_snapshot_measures_the_top_level_model(fleet: Path) -> None:
+    # Arrange — measuring only `claude.model` (the ENGINE-RESOLVED field) is
+    # what let 117 specs flip their reported model under a zero-drift
+    # certificate.
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    snapshot = _backend_snapshot(spec)
+    # Assert
+    assert "opus[1m]" in snapshot
+
+
+def test_the_snapshot_measures_the_injected_model_env(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    snapshot = _backend_snapshot(spec)
+    # Assert
+    assert "Claude Opus (1M)" in snapshot
+
+
+def test_the_gate_passes_on_the_real_migration(fleet: Path, tmp_path: Path) -> None:
+    # Arrange — the positive control: the gate must still let the real edit
+    # through, or the tests above would pass with the gate stuck shut.
+    _write_spec(fleet, "alpha")
+    plan = _plan(fleet)
+    # Act
+    result = apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert result.written == ("alpha",)
+
+
+def test_the_real_migration_leaves_the_backend_identical(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange — measured through the production loader, both sides.
+    spec = _write_spec(fleet, "alpha")
+    before = _backend_snapshot(spec)
+    # Act
+    apply_engines_migration(_plan(fleet), tmp_path / "archive")
+    # Assert
+    assert _backend_snapshot(spec) == before
+
+
+# ---------------------------------------------------------------------------
+# A spec that will not load is refused BEFORE the first byte
+# ---------------------------------------------------------------------------
+
+
+def _unloadable_plan(fleet: Path, path: Path) -> EnginesPlan:
+    """A spec the editor migrates and the LOADER rejects (real, not forced).
+
+    ``to_home_layers`` as a mapping is a declaration the loader raises on,
+    while ``validate_raw`` reports nothing new for it, so the edit itself
+    verifies clean. That asymmetry is exactly the case the pre-write refusal
+    exists for.
+    """
+    doc = yaml.safe_load(path.read_text())
+    doc["spec"]["to_home_layers"] = {"unusable": True}
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return _plan(fleet)
+
+
+def test_an_unloadable_spec_refuses_the_apply(fleet: Path, tmp_path: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    plan = _unloadable_plan(fleet, spec)
+    # Act
+    result = apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert result.refused
+
+
+def test_an_unloadable_spec_is_named_in_the_refusal(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    plan = _unloadable_plan(fleet, spec)
+    # Act
+    result = apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert "alpha" in result.refused
+
+
+def test_an_unloadable_spec_is_not_written_at_all(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange — the mtime, not the bytes: a rollback restores the bytes, so
+    # only the mtime distinguishes "refused before writing" from "written
+    # and undone".
+    spec = _write_spec(fleet, "alpha")
+    plan = _unloadable_plan(fleet, spec)
+    mtime = spec.stat().st_mtime_ns
+    # Act
+    apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert spec.stat().st_mtime_ns == mtime
+
+
+# ---------------------------------------------------------------------------
+# A failed write rolls the batch back instead of aborting the process
+# ---------------------------------------------------------------------------
+
+
+def _readonly_dir_fleet(fleet: Path) -> "tuple[Path, Path, Path]":
+    """Three specs where the LAST one's directory refuses a new file."""
+    first = _write_spec(fleet, "a1")
+    second = _write_spec(fleet, "a2")
+    third = _write_spec(fleet, "a3")
+    third.parent.chmod(0o555)
+    return first, second, third
+
+
+def test_a_failed_write_does_not_raise_out_of_the_apply(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange — measured: this raised through the Click callback and exited 1
+    # on a traceback, leaving two specs rewritten and four legacy.
+    _readonly_dir_fleet(fleet)
+    plan = _plan(fleet)
+    # Act
+    try:
+        result = apply_engines_migration(plan, tmp_path / "archive")
+    finally:
+        (fleet / "a3").chmod(0o755)
+    # Assert
+    assert result.applied is False
+
+
+def test_a_failed_write_restores_the_specs_already_written(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    first, _, _ = _readonly_dir_fleet(fleet)
+    original = first.read_bytes()
+    plan = _plan(fleet)
+    # Act
+    try:
+        apply_engines_migration(plan, tmp_path / "archive")
+    finally:
+        (fleet / "a3").chmod(0o755)
+    # Assert
+    assert first.read_bytes() == original
+
+
+def test_a_failed_write_leaves_no_half_migrated_fleet(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    _readonly_dir_fleet(fleet)
+    plan = _plan(fleet)
+    # Act
+    try:
+        apply_engines_migration(plan, tmp_path / "archive")
+    finally:
+        (fleet / "a3").chmod(0o755)
+    # Assert
+    assert not [
+        p
+        for p in sorted(fleet.glob("*/spec.yaml"))
+        if "engines" in yaml.safe_load(p.read_text())["spec"]
+    ]
+
+
+def test_a_failed_write_names_the_spec_that_failed(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    _readonly_dir_fleet(fleet)
+    plan = _plan(fleet)
+    # Act
+    try:
+        result = apply_engines_migration(plan, tmp_path / "archive")
+    finally:
+        (fleet / "a3").chmod(0o755)
+    # Assert
+    assert any("a3" in entry for entry in result.errors)
+
+
+def test_a_failed_write_says_where_the_archive_is(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange — the archive was taken and never mentioned, so the operator
+    # was not told where the undo lived.
+    _readonly_dir_fleet(fleet)
+    plan = _plan(fleet)
+    # Act
+    try:
+        result = apply_engines_migration(plan, tmp_path / "archive")
+    finally:
+        (fleet / "a3").chmod(0o755)
+    # Assert
+    assert str(tmp_path / "archive") in result.rolled_back
+
+
+def test_an_unarchivable_batch_writes_nothing(fleet: Path, tmp_path: Path) -> None:
+    # Arrange — no archive means no copy-back, so no write may happen.
+    spec = _write_spec(fleet, "alpha")
+    original = spec.read_bytes()
+    plan = _plan(fleet)
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    blocked.chmod(0o555)
+    # Act
+    try:
+        apply_engines_migration(plan, blocked / "archive")
+    finally:
+        blocked.chmod(0o755)
+    # Assert
+    assert spec.read_bytes() == original
+
+
+def test_an_unarchivable_batch_is_refused_by_name(
+    fleet: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    plan = _plan(fleet)
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    blocked.chmod(0o555)
+    # Act
+    try:
+        result = apply_engines_migration(plan, blocked / "archive")
+    finally:
+        blocked.chmod(0o755)
+    # Assert
+    assert "could not be archived" in result.refused
+
+
+def test_the_write_preserves_the_specs_file_mode(fleet: Path, tmp_path: Path) -> None:
+    # Arrange — an atomic replace brings its own temp file's mode with it
+    # unless the original's is copied across.
+    spec = _write_spec(fleet, "alpha")
+    spec.chmod(0o640)
+    plan = _plan(fleet)
+    # Act
+    apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert spec.stat().st_mode & 0o777 == 0o640

--- a/tests/scitex_agent_container/_maintenance/test__engines_floor.py
+++ b/tests/scitex_agent_container/_maintenance/test__engines_floor.py
@@ -357,14 +357,42 @@ def test_an_override_typed_as_an_alias_is_recorded_canonically() -> None:
     assert floor.allowed == frozenset({"scitex-laptop-01"})
 
 
-def test_a_plan_without_a_floor_does_not_refuse(root: Path) -> None:
-    # Arrange — floor=None is the seam the other buckets' tests plan through.
+def test_an_explicitly_disabled_floor_does_not_refuse(root: Path) -> None:
+    # Arrange — EngineFloor.disabled() is the seam the other buckets' tests
+    # plan through, and it has to be SAID: see the two tests below for why
+    # omitting the argument is no longer the way to say it.
     _write_spec(root, "grounded", host=PREDATES)
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root)
+    plan = plan_engines_migration(paths, root=root, floor=EngineFloor.disabled())
     # Assert
     assert _outcome(plan, "grounded").state == STATE_MIGRATED
+
+
+def test_planning_without_naming_a_floor_is_a_type_error(root: Path) -> None:
+    # Arrange — the documented public planner, called the documented way,
+    # planned a spec pinned on a measured pre-engines host as migrated and
+    # safe_to_apply. The guard lived in the one caller that remembered to
+    # pass a floor; a second entry point would inherit nothing.
+    _write_spec(root, "grounded", host=PREDATES)
+    paths, _ = select_spec_paths(root)
+    # Act
+    act = lambda: plan_engines_migration(paths, root=root)  # noqa: E731
+    # Assert
+    with pytest.raises(TypeError):
+        act()
+
+
+def test_passing_none_as_the_floor_is_refused_by_name(root: Path) -> None:
+    # Arrange — None used to MEAN "no floor", so it must not keep meaning it
+    # silently now that the argument is required.
+    _write_spec(root, "grounded", host=PREDATES)
+    paths, _ = select_spec_paths(root)
+    # Act
+    act = lambda: plan_engines_migration(paths, root=root, floor=None)  # noqa: E731
+    # Assert
+    with pytest.raises(TypeError, match="EngineFloor.disabled"):
+        act()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_maintenance/test__engines_floor.py
+++ b/tests/scitex_agent_container/_maintenance/test__engines_floor.py
@@ -1,0 +1,468 @@
+"""The VERSION FLOOR — the sweep must not strand an agent on an old sac.
+
+Real spec files under ``tmp_path``, planned and applied by the real
+functions. No mocks: the fact under test is that a write DOES NOT HAPPEN, and
+a mocked writer would only report what the test author believed.
+
+WHY THIS MODULE EXISTS. Reproduced 2026-09-06 by extracting the parent of the
+commit that added engines support (``0d61e077``, 2026-09-03) and running THAT
+validator over a real fleet spec::
+
+    business/spec.yaml, engines block stripped   -> 0 errors
+    the SAME spec + an engines block             -> 1 error:
+        "Unknown spec field 'engines'. …"
+
+The zero-error control is the load-bearing half: the block is the whole
+difference. Nine of the 119 tracked specs are pinned on hosts that measure as
+pre-engines or unmeasured, so an unguarded sweep would make nine specs
+unloadable on machines nobody is watching.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._maintenance._engines_apply import (
+    apply_engines_migration,
+)
+from scitex_agent_container._maintenance._engines_floor import (
+    HOST_ALIASES,
+    REFUSED_HOST_NOT_MEASURED,
+    REFUSED_HOST_PREDATES_ENGINES,
+    REFUSED_HOST_UNDECLARED,
+    REFUSED_HOST_UNREADABLE,
+    SUPPORT_NO,
+    SUPPORT_UNKNOWN,
+    SUPPORT_YES,
+    EngineFloor,
+    FloorVerdict,
+    host_support,
+)
+from scitex_agent_container._maintenance._engines_migration import (
+    STATE_ALREADY,
+    STATE_MIGRATED,
+    STATE_REFUSED,
+    plan_engines_migration,
+    select_spec_paths,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+#: Measured pre-engines (3 roots hold the package, none has _engine_types.py).
+PREDATES = "spartan"
+#: Measured capable.
+CAPABLE = "scitex-compute-04"
+#: Reachable, but no sac install located — UNKNOWN, therefore refused.
+UNMEASURED = "scitex-compute-02"
+#: The retired name of the machine recorded as scitex-laptop-01.
+RETIRED_ALIAS = "ywata-note-win"
+
+
+def _write_spec(root: Path, name: str, *, host: str, **overrides) -> Path:
+    agent_dir = root / name
+    agent_dir.mkdir(parents=True)
+    spec = {"to_home": "./to_home", "claude": {"model": "opus[1m]"}, "host": host}
+    spec.update(overrides)
+    path = agent_dir / "spec.yaml"
+    path.write_text(yaml.safe_dump(explicit_doc(spec), sort_keys=False))
+    return path
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    return agents
+
+
+def _plan(root: Path, *, overrides: "tuple[str, ...]" = ()):
+    paths, _ = select_spec_paths(root)
+    return plan_engines_migration(
+        paths, root=root, floor=EngineFloor.with_overrides(overrides)
+    )
+
+
+def _outcome(plan, agent: str):
+    return next(o for o in plan.outcomes if o.agent == agent)
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# The roster itself — measured facts, fail closed
+# ---------------------------------------------------------------------------
+
+
+def test_a_measured_capable_host_reports_supports_engines() -> None:
+    # Arrange
+    host = CAPABLE
+    # Act
+    state, _ = host_support(host)
+    # Assert
+    assert state == SUPPORT_YES
+
+
+def test_the_host_measured_without_engine_types_reports_predates() -> None:
+    # Arrange
+    host = PREDATES
+    # Act
+    state, _ = host_support(host)
+    # Assert
+    assert state == SUPPORT_NO
+
+
+def test_a_host_absent_from_the_roster_is_not_measured() -> None:
+    # Arrange — fail closed: absence is never read as "probably fine".
+    host = "scitex-compute-99"
+    # Act
+    state, _ = host_support(host)
+    # Assert
+    assert state == SUPPORT_UNKNOWN
+
+
+def test_a_measured_host_carries_the_evidence_it_was_measured_by() -> None:
+    # Arrange — a row a reader cannot check is a row they must take on trust.
+    host = PREDATES
+    # Act
+    _, record = host_support(host)
+    # Assert
+    assert "_engine_types.py" in record.evidence
+
+
+def test_the_retired_alias_resolves_to_the_machine_it_names() -> None:
+    # Arrange — `hostname` answers ywata-note-win over BOTH ssh aliases.
+    alias = RETIRED_ALIAS
+    # Act
+    state, _ = host_support(alias)
+    # Assert
+    assert state == SUPPORT_YES
+
+
+def test_the_alias_table_names_the_canonical_host() -> None:
+    # Arrange
+    alias = RETIRED_ALIAS
+    # Act
+    canonical = HOST_ALIASES[alias]
+    # Assert
+    assert canonical == "scitex-laptop-01"
+
+
+def test_a_blocking_verdict_cannot_be_built_without_a_reason() -> None:
+    # Arrange — a refusal with no reason is a silent skip wearing a flag.
+    construct = FloorVerdict
+    # Act
+    blocking_with_no_reason = dict(blocks=True)
+    # Assert
+    with pytest.raises(ValueError):
+        construct(**blocking_with_no_reason)
+
+
+# ---------------------------------------------------------------------------
+# The refusal, at PLAN time, in the bucket that already exists
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_on_a_pre_engines_host_is_refused(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "grounded").state == STATE_REFUSED
+
+
+def test_a_spec_on_a_pre_engines_host_is_not_planned_for_migration(
+    root: Path,
+) -> None:
+    # Arrange
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert plan.migrated == ()
+
+
+def test_the_refusal_names_the_pre_engines_reason(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "grounded").reason == REFUSED_HOST_PREDATES_ENGINES
+
+
+def test_the_refusal_names_the_host_in_its_detail(root: Path) -> None:
+    # Arrange — "which spec, which host, why" is what makes it actionable.
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert PREDATES in _outcome(plan, "grounded").detail
+
+
+def test_the_refusal_names_the_flag_that_lifts_it(root: Path) -> None:
+    # Arrange — a floor with no visible exit is a reason to bypass the tool.
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert "--host-supports-engines" in _outcome(plan, "grounded").detail
+
+
+def test_a_floor_refusal_lands_in_the_existing_refused_bucket(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert [o.agent for o in plan.refused] == ["grounded"]
+
+
+def test_a_floor_refusal_leaves_the_plan_safe_to_apply(root: Path) -> None:
+    # Arrange — a NAMED refusal is a legitimate outcome, not an unsound plan.
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert plan.safe_to_apply is True
+
+
+def test_a_floor_refusal_leaves_the_migration_incomplete(root: Path) -> None:
+    # Arrange — nine refused specs are nine specs a human still has to answer.
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert plan.is_complete is False
+
+
+# ---------------------------------------------------------------------------
+# Fail closed — the unknown host is the one the assumption strands
+# ---------------------------------------------------------------------------
+
+
+def test_an_unmeasured_host_is_refused_not_assumed_capable(root: Path) -> None:
+    # Arrange — compute-02 answered `hostname` and held no sac we could find.
+    _write_spec(root, "unknown-ground", host=UNMEASURED)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "unknown-ground").state == STATE_REFUSED
+
+
+def test_the_unmeasured_refusal_is_a_distinct_reason(root: Path) -> None:
+    # Arrange — "predates" is a fact; "not measured" is the absence of one.
+    _write_spec(root, "unknown-ground", host=UNMEASURED)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "unknown-ground").reason == REFUSED_HOST_NOT_MEASURED
+
+
+def test_a_never_seen_host_is_refused(root: Path) -> None:
+    # Arrange — extending the fleet must not silently widen what gets written.
+    _write_spec(root, "newcomer", host="scitex-compute-77")
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "newcomer").state == STATE_REFUSED
+
+
+def test_a_spec_naming_no_host_is_refused(root: Path) -> None:
+    # Arrange — it could start anywhere, including on a machine that refuses.
+    agent_dir = root / "homeless"
+    agent_dir.mkdir()
+    doc = explicit_doc({"to_home": "./to_home", "claude": {"model": "opus[1m]"}})
+    doc["spec"].pop("host", None)
+    (agent_dir / "spec.yaml").write_text(yaml.safe_dump(doc, sort_keys=False))
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "homeless").reason == REFUSED_HOST_UNDECLARED
+
+
+def test_a_definite_negative_outranks_an_unknown() -> None:
+    # Arrange — a fact beats the absence of one in the reported reason.
+    floor = EngineFloor()
+    # Act
+    verdict = floor.verdict_for({PREDATES, UNMEASURED})
+    # Assert
+    assert verdict.reason == REFUSED_HOST_PREDATES_ENGINES
+
+
+def test_the_unreadable_host_refusal_names_its_own_reason() -> None:
+    # Arrange — None means "could not read", which is not "says nothing".
+    floor = EngineFloor()
+    # Act
+    verdict = floor.verdict_for(None)
+    # Assert
+    assert verdict.reason == REFUSED_HOST_UNREADABLE
+
+
+# ---------------------------------------------------------------------------
+# A capable host is untouched, and the override lifts the floor
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_on_a_capable_host_still_migrates(root: Path) -> None:
+    # Arrange — the floor must not be a wall in front of the 110 good specs.
+    _write_spec(root, "fine", host=CAPABLE)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "fine").state == STATE_MIGRATED
+
+
+def test_the_retired_alias_is_not_refused(root: Path) -> None:
+    # Arrange — 14 specs spell scitex-laptop-01 by its retired name.
+    _write_spec(root, "old-name", host=RETIRED_ALIAS)
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "old-name").state == STATE_MIGRATED
+
+
+def test_the_override_lifts_the_floor_for_the_named_host(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root, overrides=(PREDATES,))
+    # Assert
+    assert _outcome(plan, "grounded").state == STATE_MIGRATED
+
+
+def test_the_override_for_one_host_does_not_lift_another(root: Path) -> None:
+    # Arrange — the claim is about the machine named, and only that one.
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    plan = _plan(root, overrides=(UNMEASURED,))
+    # Assert
+    assert _outcome(plan, "grounded").state == STATE_REFUSED
+
+
+def test_an_override_typed_as_an_alias_is_recorded_canonically() -> None:
+    # Arrange — otherwise an override typed one way silently misses the specs
+    # that spell the same machine the other way, in either direction.
+    overrides = (RETIRED_ALIAS,)
+    # Act
+    floor = EngineFloor.with_overrides(overrides)
+    # Assert
+    assert floor.allowed == frozenset({"scitex-laptop-01"})
+
+
+def test_a_plan_without_a_floor_does_not_refuse(root: Path) -> None:
+    # Arrange — floor=None is the seam the other buckets' tests plan through.
+    _write_spec(root, "grounded", host=PREDATES)
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root)
+    # Assert
+    assert _outcome(plan, "grounded").state == STATE_MIGRATED
+
+
+# ---------------------------------------------------------------------------
+# Already-declared on an incapable host is a LIVE incident, not "finished"
+# ---------------------------------------------------------------------------
+
+
+def test_an_already_declared_spec_on_a_pre_engines_host_is_refused(
+    root: Path,
+) -> None:
+    # Arrange — that spec does not load on that host TODAY. Filing it under
+    # "already migrated" files a live incident under the bucket meaning done.
+    _write_spec(
+        root,
+        "already-grounded",
+        host=PREDATES,
+        engines={"default": "claude", "claude": {"harness": "anthropic"}},
+    )
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "already-grounded").state == STATE_REFUSED
+
+
+def test_the_already_declared_refusal_says_it_does_not_load_today(
+    root: Path,
+) -> None:
+    # Arrange
+    _write_spec(
+        root,
+        "already-grounded",
+        host=PREDATES,
+        engines={"default": "claude", "claude": {"harness": "anthropic"}},
+    )
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert "does not load on that host today" in _outcome(
+        plan, "already-grounded"
+    ).detail
+
+
+def test_an_already_declared_spec_on_a_capable_host_stays_already(
+    root: Path,
+) -> None:
+    # Arrange — the floor must not turn a finished spec into a refusal.
+    _write_spec(
+        root,
+        "done",
+        host=CAPABLE,
+        engines={"default": "claude", "claude": {"harness": "anthropic"}},
+    )
+    # Act
+    plan = _plan(root)
+    # Assert
+    assert _outcome(plan, "done").state == STATE_ALREADY
+
+
+# ---------------------------------------------------------------------------
+# THE POINT: the apply writes nothing into the floored spec
+# ---------------------------------------------------------------------------
+
+
+def test_the_apply_leaves_a_floored_spec_byte_identical(
+    root: Path, tmp_path: Path
+) -> None:
+    # Arrange — the whole hazard in one assertion.
+    path = _write_spec(root, "grounded", host=PREDATES)
+    before = _digest(path)
+    plan = _plan(root)
+    # Act
+    apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert _digest(path) == before
+
+
+def test_the_apply_still_writes_the_capable_hosts_spec(
+    root: Path, tmp_path: Path
+) -> None:
+    # Arrange — a floor that stops the whole batch would be its own outage.
+    _write_spec(root, "grounded", host=PREDATES)
+    fine = _write_spec(root, "fine", host=CAPABLE)
+    before = _digest(fine)
+    plan = _plan(root)
+    # Act
+    apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert _digest(fine) != before
+
+
+def test_the_floored_spec_never_reaches_the_written_list(
+    root: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    _write_spec(root, "grounded", host=PREDATES)
+    _write_spec(root, "fine", host=CAPABLE)
+    plan = _plan(root)
+    # Act
+    result = apply_engines_migration(plan, tmp_path / "archive")
+    # Assert
+    assert list(result.written) == ["fine"]

--- a/tests/scitex_agent_container/_maintenance/test__engines_floor_audit.py
+++ b/tests/scitex_agent_container/_maintenance/test__engines_floor_audit.py
@@ -1,0 +1,314 @@
+"""The floor has to carry its EVIDENCE on the approving side too.
+
+Real spec files under ``tmp_path``, planned by the real functions. Two facts
+live here and they are opposite halves of the same asymmetry:
+
+**THE APPROVALS SAID NOTHING.** Every refusal prints its measurement and its
+date; the 100 writes printed neither. ``HOST_SUPPORT`` is a static table with
+no expiry and the design deliberately does not probe, so the one way it fails
+OPEN is a row going stale — a host rebuilt, rolled back, or reinstalled onto
+an older sac after ``measured_on``. In that case the sweep writes those specs
+and the report is byte-for-byte indistinguishable from a correct run.
+
+**THE REFUSALS SAID TOO MUCH.** The "already declares engines, so it does not
+load on that host today" sentence was appended to EVERY floor refusal of an
+already-declaring spec, including the two whose own preceding sentence says
+nobody knows anything about that host:
+
+    scitex-compute-77: not-measured — absent from the measured roster. […]
+    This spec ALREADY declares spec.engines, so it does not load on that host
+    today […]
+
+Nobody measured that host; nothing established any load failure on it. Under
+the no-host reason there is no "that host" to refer to at all. Only
+``REFUSED_HOST_PREDATES_ENGINES`` measured a rejection, so only it earns the
+sentence.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._maintenance._engines_floor import (
+    SUPPORT_NO,
+    SUPPORT_UNKNOWN,
+    SUPPORT_YES,
+    EngineFloor,
+)
+from scitex_agent_container._maintenance._engines_floor_audit import floor_audit
+from scitex_agent_container._maintenance._engines_migration import (
+    plan_engines_migration,
+    select_spec_paths,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+CAPABLE = "scitex-compute-04"
+PREDATES = "spartan"
+UNMEASURED = "scitex-compute-02"
+NEVER_SEEN = "scitex-compute-77"
+
+#: The sentence that asserts a load failure. Only the measured-negative
+#: refusal is entitled to it.
+_ASSERTS_A_LOAD_FAILURE = "does not load on that host today"
+
+
+def _write_spec(root: Path, name: str, *, host: "str | None" = CAPABLE) -> Path:
+    agent_dir = root / name
+    agent_dir.mkdir(parents=True)
+    spec = {"to_home": "./to_home", "claude": {"model": "opus[1m]"}}
+    if host is not None:
+        spec["host"] = host
+    doc = explicit_doc(spec)
+    if host is None:
+        doc["spec"].pop("host", None)
+    path = agent_dir / "spec.yaml"
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return path
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    return agents
+
+
+def _already_declaring(root: Path, name: str, *, host: "str | None") -> Path:
+    """A spec that ALREADY carries an engines block, on ``host``.
+
+    Written by the real editor with the floor explicitly disabled, so the
+    block is exactly what the sweep would have produced.
+    """
+    path = _write_spec(root, name, host=host)
+    plan = plan_engines_migration([path], floor=EngineFloor.disabled())
+    path.write_text(plan.migrated[0].new_text)
+    return path
+
+
+def _detail(root: Path, agent: str) -> str:
+    paths, _ = select_spec_paths(root)
+    plan = plan_engines_migration(paths, root=root, floor=EngineFloor())
+    return next(o for o in plan.outcomes if o.agent == agent).detail
+
+
+def _audit(root: Path, *, overrides: "tuple[str, ...]" = ()):
+    floor = EngineFloor.with_overrides(overrides)
+    paths, _ = select_spec_paths(root)
+    plan = plan_engines_migration(paths, root=root, floor=floor)
+    return floor_audit(
+        floor, [o.hosts if o.hosts is None else set(o.hosts) for o in plan.outcomes]
+    )
+
+
+def _row(audit, host: str):
+    return next(r for r in audit.hosts if r.host == host)
+
+
+# ---------------------------------------------------------------------------
+# The refusal must not assert what its own reason says nobody knows
+# ---------------------------------------------------------------------------
+
+
+def test_a_never_measured_host_refusal_asserts_no_load_failure(root: Path) -> None:
+    # Arrange — "absent from the measured roster" and "it does not load there
+    # today" cannot both be true of one host in one paragraph.
+    _already_declaring(root, "newcomer", host=NEVER_SEEN)
+    # Act
+    detail = _detail(root, "newcomer")
+    # Assert
+    assert _ASSERTS_A_LOAD_FAILURE not in detail
+
+
+def test_an_unmeasured_host_refusal_asserts_no_load_failure(root: Path) -> None:
+    # Arrange — compute-02 answered `hostname` and held no sac we could find;
+    # that is not knowing, not a measured rejection.
+    _already_declaring(root, "unknown-ground", host=UNMEASURED)
+    # Act
+    detail = _detail(root, "unknown-ground")
+    # Assert
+    assert _ASSERTS_A_LOAD_FAILURE not in detail
+
+
+def test_a_host_less_refusal_asserts_no_load_failure(root: Path) -> None:
+    # Arrange — there is no "that host" for the sentence to refer to, and the
+    # preceding reason does not even end in a full stop, so the two ran on
+    # into "…would reject the block This spec ALREADY declares…".
+    _already_declaring(root, "homeless", host=None)
+    # Act
+    detail = _detail(root, "homeless")
+    # Assert
+    assert _ASSERTS_A_LOAD_FAILURE not in detail
+
+
+def test_a_measured_pre_engines_refusal_still_asserts_the_load_failure(
+    root: Path,
+) -> None:
+    # Arrange — the positive control, and the whole point of the sentence: on
+    # THIS host a rejection was measured, so the spec really does not load
+    # today and filing it under "already migrated" would file a live incident.
+    _already_declaring(root, "grounded", host=PREDATES)
+    # Act
+    detail = _detail(root, "grounded")
+    # Assert
+    assert _ASSERTS_A_LOAD_FAILURE in detail
+
+
+# ---------------------------------------------------------------------------
+# The approving side carries its evidence
+# ---------------------------------------------------------------------------
+
+
+def test_the_audit_names_the_host_the_writes_were_judged_by(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "alpha", host=CAPABLE)
+    # Act
+    audit = _audit(root)
+    # Assert
+    assert [r.host for r in audit.hosts] == [CAPABLE]
+
+
+def test_an_approving_row_carries_its_measurement_date(root: Path) -> None:
+    # Arrange — a static table with no expiry fails open by going stale, and
+    # the date is what lets a reader ask whether it is still true.
+    _write_spec(root, "alpha", host=CAPABLE)
+    # Act
+    audit = _audit(root)
+    # Assert
+    assert _row(audit, CAPABLE).measured_on == "2026-09-06"
+
+
+def test_an_approving_row_carries_the_evidence_behind_it(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "alpha", host=CAPABLE)
+    # Act
+    audit = _audit(root)
+    # Assert
+    assert "config/_engine_types.py" in _row(audit, CAPABLE).evidence
+
+
+def test_the_audit_counts_the_specs_each_verdict_covers(root: Path) -> None:
+    # Arrange — two approved, one refused: the count is per VERDICT, which is
+    # what "how much of this run rests on that row" means.
+    _write_spec(root, "alpha", host=CAPABLE)
+    _write_spec(root, "beta", host=CAPABLE)
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    audit = _audit(root)
+    # Assert
+    assert audit.counts == {SUPPORT_NO: 1, SUPPORT_YES: 2}
+
+
+def test_the_audit_reports_the_oldest_roster_date_consulted(root: Path) -> None:
+    # Arrange — a run's roster is only as current as its oldest row.
+    _write_spec(root, "alpha", host=CAPABLE)
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    audit = _audit(root)
+    # Assert
+    assert audit.measured_on == ("2026-09-06",)
+
+
+def test_a_spec_naming_no_host_is_counted_apart(root: Path) -> None:
+    # Arrange — "it says nothing" is not a host row.
+    _write_spec(root, "homeless", host=None)
+    # Act
+    audit = _audit(root)
+    # Assert
+    assert audit.specs_with_no_declared_host == 1
+
+
+def test_a_spec_whose_hosts_could_not_be_read_is_counted_apart(root: Path) -> None:
+    # Arrange — "I could not read it" and "it says nothing" want different
+    # fixes, so the audit keeps them apart exactly as the floor does.
+    broken = _write_spec(root, "broken", host=CAPABLE)
+    broken.chmod(0o000)
+    # Act
+    try:
+        audit = _audit(root)
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert audit.specs_with_an_unreadable_host == 1
+
+
+# ---------------------------------------------------------------------------
+# An override of a MEASURED NO is not an override of an unknown
+# ---------------------------------------------------------------------------
+
+
+def test_an_override_of_a_measured_negative_is_flagged_as_contradicting(
+    root: Path,
+) -> None:
+    # Arrange — the roster records spartan as predates-engines with a positive
+    # control. Lifting it writes blocks that, by that same measurement, then
+    # fail the host's validator and stop those agents starting.
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    audit = _audit(root, overrides=(PREDATES,))
+    # Assert
+    assert _row(audit, PREDATES).contradicts_a_measurement is True
+
+
+def test_an_override_of_an_unknown_is_not_flagged_as_contradicting(
+    root: Path,
+) -> None:
+    # Arrange — nobody measured compute-02, so there is no measurement to
+    # contradict. Categorically a different claim, and it must not be
+    # reported as the loud one.
+    _write_spec(root, "unknown-ground", host=UNMEASURED)
+    # Act
+    audit = _audit(root, overrides=(UNMEASURED,))
+    # Assert
+    assert _row(audit, UNMEASURED).contradicts_a_measurement is False
+
+
+def test_the_overridden_row_still_carries_the_measurement_it_lifts(
+    root: Path,
+) -> None:
+    # Arrange — an override has to RESTATE what it is arguing with, or the
+    # reader never sees the fact being overridden.
+    _write_spec(root, "grounded", host=PREDATES)
+    # Act
+    audit = _audit(root, overrides=(PREDATES,))
+    # Assert
+    assert "NONE has" in _row(audit, PREDATES).evidence
+
+
+def test_an_override_naming_a_host_no_spec_mentions_is_still_reported(
+    root: Path,
+) -> None:
+    # Arrange — a lift typed for a host that is not in this batch did nothing,
+    # and reads as though it did.
+    _write_spec(root, "alpha", host=CAPABLE)
+    # Act
+    audit = _audit(root, overrides=(PREDATES,))
+    # Assert
+    assert _row(audit, PREDATES).specs == 0
+
+
+def test_a_disabled_floor_reports_itself_as_inactive(root: Path) -> None:
+    # Arrange — the report must not present a floor's basis for a run that
+    # had no floor.
+    _write_spec(root, "alpha", host=CAPABLE)
+    # Act
+    audit = floor_audit(EngineFloor.disabled(), [{CAPABLE}])
+    # Assert
+    assert audit.active is False
+
+
+def test_an_unmeasured_row_carries_no_invented_date(root: Path) -> None:
+    # Arrange — an unmeasured host has no measurement to date, and a blank is
+    # the honest value.
+    _write_spec(root, "newcomer", host=NEVER_SEEN)
+    # Act
+    audit = _audit(root)
+    # Assert
+    assert (_row(audit, NEVER_SEEN).support, _row(audit, NEVER_SEEN).measured_on) == (
+        SUPPORT_UNKNOWN,
+        "",
+    )

--- a/tests/scitex_agent_container/_maintenance/test__engines_migration.py
+++ b/tests/scitex_agent_container/_maintenance/test__engines_migration.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from scitex_agent_container._maintenance._engines_floor import EngineFloor
 from scitex_agent_container._maintenance._engines_migration import (
     STATE_HELD_BACK,
     STATE_MIGRATED,
@@ -26,6 +27,11 @@ from scitex_agent_container._maintenance._engines_migration import (
     select_spec_paths,
 )
 from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+#: These tests are about SELECTION, BATCHING and LINE ENDINGS, not about
+#: host capability. `floor` is a required argument now — omitting it used to
+#: disable the floor silently — so saying "no floor" is a value, not a gap.
+_NO_FLOOR = EngineFloor.disabled()
 
 
 def _write_spec(root: Path, name: str, *, model="opus[1m]", **overrides) -> Path:
@@ -96,7 +102,7 @@ def test_an_unopenable_spec_reaches_the_plan_as_unreadable(root: Path) -> None:
     # Act
     try:
         paths, _ = select_spec_paths(root, hosts=("scitex-compute-04",))
-        plan = plan_engines_migration(paths, root=root)
+        plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR)
     finally:
         broken.chmod(0o644)
     # Assert
@@ -110,7 +116,7 @@ def test_an_unreadable_spec_makes_the_plan_unsafe(root: Path) -> None:
     # Act
     try:
         paths, _ = select_spec_paths(root, hosts=("scitex-compute-04",))
-        plan = plan_engines_migration(paths, root=root)
+        plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR)
     finally:
         broken.chmod(0o644)
     # Assert
@@ -139,7 +145,7 @@ def test_the_limit_caps_the_migratable_specs(root: Path) -> None:
         _write_spec(root, name)
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root, limit=2)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=2)
     # Assert
     assert [o.agent for o in plan.migrated] == ["b1", "b2"]
 
@@ -150,7 +156,7 @@ def test_the_specs_past_the_limit_are_held_back_not_dropped(root: Path) -> None:
         _write_spec(root, name)
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root, limit=2)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=2)
     # Assert
     assert [o.agent for o in plan.held_back] == ["b3"]
 
@@ -162,7 +168,7 @@ def test_a_refused_spec_does_not_consume_the_limit(root: Path) -> None:
     _write_spec(root, "b2")
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root, limit=1)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=1)
     # Assert
     assert _states(plan) == {"b1": STATE_REFUSED, "b2": STATE_MIGRATED}
 
@@ -172,10 +178,10 @@ def test_an_already_migrated_spec_does_not_consume_the_limit(root: Path) -> None
     first = _write_spec(root, "b1")
     _write_spec(root, "b2")
     paths, _ = select_spec_paths(root)
-    plan = plan_engines_migration(paths, root=root, limit=1)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=1)
     first.write_text(plan.migrated[0].new_text)
     # Act
-    again = plan_engines_migration(paths, root=root, limit=1)
+    again = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=1)
     # Assert
     assert [o.agent for o in again.migrated] == ["b2"]
 
@@ -186,7 +192,7 @@ def test_a_held_back_spec_is_never_written(root: Path) -> None:
         _write_spec(root, name)
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root, limit=1)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=1)
     # Assert
     assert [o.will_write for o in plan.held_back] == [False]
 
@@ -197,7 +203,7 @@ def test_a_held_back_spec_keeps_the_plan_from_claiming_completion(root: Path) ->
         _write_spec(root, name)
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root, limit=1)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=1)
     # Assert
     assert plan.is_complete is False
 
@@ -207,7 +213,7 @@ def test_a_refusal_keeps_the_plan_from_claiming_completion(root: Path) -> None:
     _write_spec(root, "b1", model="")
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR)
     # Assert
     assert plan.is_complete is False
 
@@ -216,9 +222,9 @@ def test_a_fully_migrated_fleet_is_reported_complete(root: Path) -> None:
     # Arrange — the positive control for the claim above.
     spec = _write_spec(root, "b1")
     paths, _ = select_spec_paths(root)
-    spec.write_text(plan_engines_migration(paths, root=root).migrated[0].new_text)
+    spec.write_text(plan_engines_migration(paths, root=root, floor=_NO_FLOOR).migrated[0].new_text)
     # Act
-    plan = plan_engines_migration(paths, root=root)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR)
     # Assert
     assert plan.is_complete is True
 
@@ -228,7 +234,7 @@ def test_a_zero_limit_is_refused(root: Path) -> None:
     _write_spec(root, "b1")
     paths, _ = select_spec_paths(root)
     # Act — a slice would have accepted it and planned nothing.
-    act = lambda: plan_engines_migration(paths, root=root, limit=0)  # noqa: E731
+    act = lambda: plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=0)  # noqa: E731
     # Assert
     with pytest.raises(ValueError):
         act()
@@ -240,7 +246,7 @@ def test_a_negative_limit_is_refused(root: Path) -> None:
         _write_spec(root, name)
     paths, _ = select_spec_paths(root)
     # Act
-    act = lambda: plan_engines_migration(paths, root=root, limit=-1)  # noqa: E731
+    act = lambda: plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=-1)  # noqa: E731
     # Assert
     with pytest.raises(ValueError):
         act()
@@ -252,7 +258,7 @@ def test_the_summary_names_what_the_limit_held_back(root: Path) -> None:
         _write_spec(root, name)
     paths, _ = select_spec_paths(root)
     # Act
-    summary = plan_engines_migration(paths, root=root, limit=1).summary()
+    summary = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=1).summary()
     # Assert
     assert "held back by --limit" in summary
 
@@ -263,7 +269,7 @@ def test_a_held_back_outcome_is_its_own_state(root: Path) -> None:
         _write_spec(root, name)
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root, limit=1)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR, limit=1)
     # Assert
     assert _states(plan) == {"b1": STATE_MIGRATED, "b2": STATE_HELD_BACK}
 
@@ -291,7 +297,7 @@ def test_a_crlf_spec_is_planned_with_crlf_endings(root: Path) -> None:
     spec.write_bytes(spec.read_text().replace("\n", "\r\n").encode())
     paths, _ = select_spec_paths(root)
     # Act
-    plan = plan_engines_migration(paths, root=root)
+    plan = plan_engines_migration(paths, root=root, floor=_NO_FLOOR)
     # Assert
     assert "\r\n" in plan.migrated[0].new_text
 
@@ -302,6 +308,6 @@ def test_a_crlf_spec_gains_no_bare_line_feed(root: Path) -> None:
     spec.write_bytes(spec.read_text().replace("\n", "\r\n").encode())
     paths, _ = select_spec_paths(root)
     # Act
-    new_text = plan_engines_migration(paths, root=root).migrated[0].new_text
+    new_text = plan_engines_migration(paths, root=root, floor=_NO_FLOOR).migrated[0].new_text
     # Assert
     assert new_text.count("\n") == new_text.count("\r\n")

--- a/tests/scitex_agent_container/_maintenance/test__engines_migration.py
+++ b/tests/scitex_agent_container/_maintenance/test__engines_migration.py
@@ -1,0 +1,307 @@
+"""The PLAN half of the ``spec.engines`` sweep — selection and bucketing.
+
+Real spec files under ``tmp_path``, planned by the real functions. There was
+no test module for this file at all, which is how ``--host`` came to drop the
+specs it could not read and ``--limit`` came to re-select the same first N on
+every run: both are selection behaviour, and selection was only ever exercised
+through the CLI's happy path.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._maintenance._engines_migration import (
+    STATE_HELD_BACK,
+    STATE_MIGRATED,
+    STATE_REFUSED,
+    STATE_UNREADABLE,
+    plan_engines_migration,
+    read_spec_text,
+    select_spec_paths,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+
+def _write_spec(root: Path, name: str, *, model="opus[1m]", **overrides) -> Path:
+    agent_dir = root / name
+    agent_dir.mkdir(parents=True)
+    spec = {"to_home": "./to_home", "claude": {"model": model}}
+    spec.update(overrides)
+    path = agent_dir / "spec.yaml"
+    path.write_text(yaml.safe_dump(explicit_doc(spec), sort_keys=False))
+    return path
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    return agents
+
+
+def _states(plan) -> "dict[str, str]":
+    return {o.agent: o.state for o in plan.outcomes}
+
+
+# ---------------------------------------------------------------------------
+# --host must not make a spec vanish
+# ---------------------------------------------------------------------------
+
+
+def test_the_host_filter_selects_the_named_hosts_specs(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "here", host="scitex-compute-04")
+    _write_spec(root, "there", host="scitex-compute-01")
+    # Act
+    paths, _ = select_spec_paths(root, hosts=("scitex-compute-04",))
+    # Assert
+    assert [p.parent.name for p in paths] == ["here"]
+
+
+def test_the_host_filter_keeps_an_unparsable_spec(root: Path) -> None:
+    # Arrange — it cannot be ruled out, so it must reach the plan by name.
+    _write_spec(root, "here", host="scitex-compute-04")
+    broken = _write_spec(root, "broken", host="scitex-compute-04")
+    broken.write_text(broken.read_text() + "  bad: [unclosed\n")
+    # Act
+    paths, _ = select_spec_paths(root, hosts=("scitex-compute-04",))
+    # Assert
+    assert "broken" in [p.parent.name for p in paths]
+
+
+def test_the_host_filter_keeps_a_spec_it_cannot_open(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "here", host="scitex-compute-04")
+    broken = _write_spec(root, "broken", host="scitex-compute-04")
+    broken.chmod(0o000)
+    # Act
+    try:
+        paths, _ = select_spec_paths(root, hosts=("scitex-compute-04",))
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert "broken" in [p.parent.name for p in paths]
+
+
+def test_an_unopenable_spec_reaches_the_plan_as_unreadable(root: Path) -> None:
+    # Arrange
+    broken = _write_spec(root, "broken", host="scitex-compute-04")
+    broken.chmod(0o000)
+    # Act
+    try:
+        paths, _ = select_spec_paths(root, hosts=("scitex-compute-04",))
+        plan = plan_engines_migration(paths, root=root)
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert _states(plan) == {"broken": STATE_UNREADABLE}
+
+
+def test_an_unreadable_spec_makes_the_plan_unsafe(root: Path) -> None:
+    # Arrange — this is the guard --host used to disable.
+    broken = _write_spec(root, "broken", host="scitex-compute-04")
+    broken.chmod(0o000)
+    # Act
+    try:
+        paths, _ = select_spec_paths(root, hosts=("scitex-compute-04",))
+        plan = plan_engines_migration(paths, root=root)
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert plan.safe_to_apply is False
+
+
+def test_a_spec_placed_on_another_host_is_still_excluded(root: Path) -> None:
+    # Arrange — the filter must still filter; keeping the unreadable ones is
+    # not "keep everything".
+    _write_spec(root, "here", host="scitex-compute-04")
+    _write_spec(root, "there", host="scitex-compute-01")
+    # Act
+    paths, _ = select_spec_paths(root, hosts=("scitex-compute-01",))
+    # Assert
+    assert [p.parent.name for p in paths] == ["there"]
+
+
+# ---------------------------------------------------------------------------
+# --limit caps what is WRITTEN, so a batch can advance
+# ---------------------------------------------------------------------------
+
+
+def test_the_limit_caps_the_migratable_specs(root: Path) -> None:
+    # Arrange
+    for name in ("b1", "b2", "b3"):
+        _write_spec(root, name)
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root, limit=2)
+    # Assert
+    assert [o.agent for o in plan.migrated] == ["b1", "b2"]
+
+
+def test_the_specs_past_the_limit_are_held_back_not_dropped(root: Path) -> None:
+    # Arrange
+    for name in ("b1", "b2", "b3"):
+        _write_spec(root, name)
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root, limit=2)
+    # Assert
+    assert [o.agent for o in plan.held_back] == ["b3"]
+
+
+def test_a_refused_spec_does_not_consume_the_limit(root: Path) -> None:
+    # Arrange — a permanently-refused spec that ate the budget would stall
+    # `--limit 1` on it forever.
+    _write_spec(root, "b1", model="")
+    _write_spec(root, "b2")
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root, limit=1)
+    # Assert
+    assert _states(plan) == {"b1": STATE_REFUSED, "b2": STATE_MIGRATED}
+
+
+def test_an_already_migrated_spec_does_not_consume_the_limit(root: Path) -> None:
+    # Arrange — the second batch must reach the specs the first one left.
+    first = _write_spec(root, "b1")
+    _write_spec(root, "b2")
+    paths, _ = select_spec_paths(root)
+    plan = plan_engines_migration(paths, root=root, limit=1)
+    first.write_text(plan.migrated[0].new_text)
+    # Act
+    again = plan_engines_migration(paths, root=root, limit=1)
+    # Assert
+    assert [o.agent for o in again.migrated] == ["b2"]
+
+
+def test_a_held_back_spec_is_never_written(root: Path) -> None:
+    # Arrange
+    for name in ("b1", "b2"):
+        _write_spec(root, name)
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root, limit=1)
+    # Assert
+    assert [o.will_write for o in plan.held_back] == [False]
+
+
+def test_a_held_back_spec_keeps_the_plan_from_claiming_completion(root: Path) -> None:
+    # Arrange
+    for name in ("b1", "b2"):
+        _write_spec(root, name)
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root, limit=1)
+    # Assert
+    assert plan.is_complete is False
+
+
+def test_a_refusal_keeps_the_plan_from_claiming_completion(root: Path) -> None:
+    # Arrange — a refusal is not a failure, and it is not a finished sweep.
+    _write_spec(root, "b1", model="")
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root)
+    # Assert
+    assert plan.is_complete is False
+
+
+def test_a_fully_migrated_fleet_is_reported_complete(root: Path) -> None:
+    # Arrange — the positive control for the claim above.
+    spec = _write_spec(root, "b1")
+    paths, _ = select_spec_paths(root)
+    spec.write_text(plan_engines_migration(paths, root=root).migrated[0].new_text)
+    # Act
+    plan = plan_engines_migration(paths, root=root)
+    # Assert
+    assert plan.is_complete is True
+
+
+def test_a_zero_limit_is_refused(root: Path) -> None:
+    # Arrange
+    _write_spec(root, "b1")
+    paths, _ = select_spec_paths(root)
+    # Act — a slice would have accepted it and planned nothing.
+    act = lambda: plan_engines_migration(paths, root=root, limit=0)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        act()
+
+
+def test_a_negative_limit_is_refused(root: Path) -> None:
+    # Arrange — `picked[:-1]` silently dropped the LAST spec instead.
+    for name in ("b1", "b2", "b3"):
+        _write_spec(root, name)
+    paths, _ = select_spec_paths(root)
+    # Act
+    act = lambda: plan_engines_migration(paths, root=root, limit=-1)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        act()
+
+
+def test_the_summary_names_what_the_limit_held_back(root: Path) -> None:
+    # Arrange
+    for name in ("b1", "b2"):
+        _write_spec(root, name)
+    paths, _ = select_spec_paths(root)
+    # Act
+    summary = plan_engines_migration(paths, root=root, limit=1).summary()
+    # Assert
+    assert "held back by --limit" in summary
+
+
+def test_a_held_back_outcome_is_its_own_state(root: Path) -> None:
+    # Arrange
+    for name in ("b1", "b2"):
+        _write_spec(root, name)
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root, limit=1)
+    # Assert
+    assert _states(plan) == {"b1": STATE_MIGRATED, "b2": STATE_HELD_BACK}
+
+
+# ---------------------------------------------------------------------------
+# Reading a spec must not silently rewrite it
+# ---------------------------------------------------------------------------
+
+
+def test_read_spec_text_keeps_crlf_endings(tmp_path: Path) -> None:
+    # Arrange — Path.read_text translates them away, which makes
+    # `_yaml_line_edit.split_ending`'s CRLF handling unreachable and rewrites
+    # every line of the file.
+    path = tmp_path / "spec.yaml"
+    path.write_bytes(b"spec:\r\n  claude:\r\n")
+    # Act
+    text = read_spec_text(path)
+    # Assert
+    assert text == "spec:\r\n  claude:\r\n"
+
+
+def test_a_crlf_spec_is_planned_with_crlf_endings(root: Path) -> None:
+    # Arrange
+    spec = _write_spec(root, "alpha")
+    spec.write_bytes(spec.read_text().replace("\n", "\r\n").encode())
+    paths, _ = select_spec_paths(root)
+    # Act
+    plan = plan_engines_migration(paths, root=root)
+    # Assert
+    assert "\r\n" in plan.migrated[0].new_text
+
+
+def test_a_crlf_spec_gains_no_bare_line_feed(root: Path) -> None:
+    # Arrange
+    spec = _write_spec(root, "alpha")
+    spec.write_bytes(spec.read_text().replace("\n", "\r\n").encode())
+    paths, _ = select_spec_paths(root)
+    # Act
+    new_text = plan_engines_migration(paths, root=root).migrated[0].new_text
+    # Assert
+    assert new_text.count("\n") == new_text.count("\r\n")

--- a/tests/scitex_agent_container/_maintenance/test__engines_selection.py
+++ b/tests/scitex_agent_container/_maintenance/test__engines_selection.py
@@ -1,0 +1,338 @@
+"""The SELECTION must add up to the spec.yaml files on disk.
+
+Real spec files under ``tmp_path``, selected and planned by the real
+functions. No mocks: every fact here is about a file the sweep did NOT look
+at, and a mocked selector would report only what the test author believed.
+
+THE FOUR WAYS A SPEC USED TO LEAVE THE COUNT UNNAMED:
+
+1. **A shadowed copy.** Two roots hold a spec.yaml for the same agent name;
+   the de-duplication keeps one and dropped the other into no bucket and no
+   payload field. Measured: 4 spec.yaml on disk, ``specs: 3``. Earlier-root-
+   wins is deterministic, so no later run reaches it either — and the apply
+   still reported ``migration_complete``.
+2. **An unmigrated template.** ``sac agents create`` copies those, so a sweep
+   that leaves one behind re-introduces the legacy shape on every agent minted
+   afterwards. The prose said so; the one boolean built for a machine reader
+   did not.
+3. **A ``--agent`` value that matched nothing.** Set membership discards a
+   typo or a renamed agent in silence.
+4. **A ``--host`` value that matched nothing.** Same.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._maintenance._engines_floor import EngineFloor
+from scitex_agent_container._maintenance._engines_migration import (
+    plan_engines_migration,
+    select_spec_paths,
+    select_spec_paths_over_roots,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+#: Measured engines-capable, so the version floor is not what these tests are
+#: about — the selection is.
+CAPABLE = "scitex-compute-04"
+_NO_FLOOR = EngineFloor.disabled()
+
+
+def _write_spec(root: Path, name: str, *, host: str = CAPABLE) -> Path:
+    agent_dir = root / name
+    agent_dir.mkdir(parents=True)
+    doc = explicit_doc(
+        {"to_home": "./to_home", "claude": {"model": "opus[1m]"}, "host": host}
+    )
+    path = agent_dir / "spec.yaml"
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return path
+
+
+def _migrate_in_place(paths) -> None:
+    """Write the migrated text back, so those specs read as already-migrated."""
+    plan = plan_engines_migration(list(paths), floor=_NO_FLOOR)
+    for outcome in plan.migrated:
+        outcome.path.write_text(outcome.new_text)
+
+
+def _declares_engines(path: Path) -> bool:
+    return "engines" in yaml.safe_load(path.read_text())["spec"]
+
+
+@pytest.fixture
+def two_roots(tmp_path: Path):
+    first = tmp_path / "rootA"
+    second = tmp_path / "rootB"
+    first.mkdir()
+    second.mkdir()
+    return first, second
+
+
+# ---------------------------------------------------------------------------
+# 1. A shadowed copy is a real file, and it is named
+# ---------------------------------------------------------------------------
+
+
+def test_the_shadowed_copy_is_named_with_its_path(two_roots) -> None:
+    # Arrange — the loser of the de-duplication used to appear nowhere.
+    first, second = two_roots
+    _write_spec(first, "dup")
+    dropped = _write_spec(second, "dup")
+    # Act
+    selection = select_spec_paths_over_roots((first, second))
+    # Assert
+    assert [s.dropped for s in selection.shadowed] == [dropped]
+
+
+def test_the_shadowed_entry_names_the_copy_that_was_kept(two_roots) -> None:
+    # Arrange — resolving the collision means looking at BOTH files.
+    first, second = two_roots
+    kept = _write_spec(first, "dup")
+    _write_spec(second, "dup")
+    # Act
+    selection = select_spec_paths_over_roots((first, second))
+    # Assert
+    assert selection.shadowed[0].kept == kept
+
+
+def test_the_selection_accounts_for_every_spec_on_disk(two_roots) -> None:
+    # Arrange — the measured shape: 4 spec.yaml, and the plan said 3.
+    first, second = two_roots
+    for root, names in ((first, ("dup", "onlyA")), (second, ("dup", "onlyB"))):
+        for name in names:
+            _write_spec(root, name)
+    # Act
+    selection = select_spec_paths_over_roots((first, second))
+    # Assert
+    assert len(selection.paths) + len(selection.shadowed) == 4
+
+
+def test_a_shadowed_copy_keeps_the_plan_from_claiming_completion(
+    two_roots,
+) -> None:
+    # Arrange — every SELECTED spec is already migrated, and rootB still holds
+    # a legacy spec.yaml no run of this sweep can ever reach.
+    first, second = two_roots
+    _write_spec(first, "dup")
+    _write_spec(second, "dup")
+    selection = select_spec_paths_over_roots((first, second))
+    _migrate_in_place(selection.paths)
+    # Act
+    plan = plan_engines_migration(
+        list(selection.paths),
+        roots=(first, second),
+        shadowed=selection.shadowed,
+        floor=_NO_FLOOR,
+    )
+    # Assert
+    assert plan.is_complete is False
+
+
+def test_the_shadowed_copy_really_is_still_legacy(two_roots) -> None:
+    # Arrange — the positive control for the claim above: the file the sweep
+    # skipped is a real spec that really does still carry the old shape.
+    first, second = two_roots
+    _write_spec(first, "dup")
+    dropped = _write_spec(second, "dup")
+    selection = select_spec_paths_over_roots((first, second))
+    # Act
+    _migrate_in_place(selection.paths)
+    # Assert
+    assert _declares_engines(dropped) is False
+
+
+def test_the_kept_copy_really_was_migrated(two_roots) -> None:
+    # Arrange — the other half of the control: exactly one of the two moved.
+    first, second = two_roots
+    kept = _write_spec(first, "dup")
+    _write_spec(second, "dup")
+    selection = select_spec_paths_over_roots((first, second))
+    # Act
+    _migrate_in_place(selection.paths)
+    # Assert
+    assert _declares_engines(kept) is True
+
+
+def test_one_root_alone_shadows_nothing(two_roots) -> None:
+    # Arrange — the control: de-duplication must not invent a collision.
+    first, _ = two_roots
+    _write_spec(first, "alpha")
+    _write_spec(first, "beta")
+    # Act
+    selection = select_spec_paths_over_roots((first,))
+    # Assert
+    assert selection.shadowed == ()
+
+
+# ---------------------------------------------------------------------------
+# 2. A skipped template is work left behind
+# ---------------------------------------------------------------------------
+
+
+def test_a_skipped_template_keeps_the_plan_from_claiming_completion(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the real agent is migrated; the template `agents create`
+    # copies is not, so every agent minted afterwards is legacy again.
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "real-agent")
+    _write_spec(root, "_template_generalist")
+    selection = select_spec_paths_over_roots((root,))
+    _migrate_in_place(selection.paths)
+    # Act
+    plan = plan_engines_migration(
+        list(selection.paths),
+        roots=(root,),
+        skipped_templates=list(selection.skipped_templates),
+        floor=_NO_FLOOR,
+    )
+    # Assert
+    assert plan.is_complete is False
+
+
+def test_the_skipped_template_really_is_still_legacy(tmp_path: Path) -> None:
+    # Arrange — the positive control for the claim above.
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "real-agent")
+    template = _write_spec(root, "_template_generalist")
+    selection = select_spec_paths_over_roots((root,))
+    # Act
+    _migrate_in_place(selection.paths)
+    # Assert
+    assert _declares_engines(template) is False
+
+
+def test_including_the_templates_lets_the_plan_claim_completion(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the positive control: --templates leaves nothing behind, so
+    # the claim must still be makeable.
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "real-agent")
+    _write_spec(root, "_template_generalist")
+    selection = select_spec_paths_over_roots((root,), templates=True)
+    _migrate_in_place(selection.paths)
+    # Act
+    plan = plan_engines_migration(
+        list(selection.paths),
+        roots=(root,),
+        skipped_templates=list(selection.skipped_templates),
+        floor=_NO_FLOOR,
+    )
+    # Assert
+    assert plan.is_complete is True
+
+
+# ---------------------------------------------------------------------------
+# 3 & 4. A selector that matched nothing
+# ---------------------------------------------------------------------------
+
+
+def test_an_agent_selector_matching_nothing_is_named(tmp_path: Path) -> None:
+    # Arrange — a scripted `-a a -a b -a c` loop where `c` was renamed covers
+    # two of three on every run and never says which one it could not find.
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "business")
+    # Act
+    selection = select_spec_paths_over_roots(
+        (root,), agents=("business", "NOSUCH-AGENT-TYPO")
+    )
+    # Assert
+    assert selection.unmatched_agents == ("NOSUCH-AGENT-TYPO",)
+
+
+def test_an_agent_selector_that_matched_is_not_named(tmp_path: Path) -> None:
+    # Arrange — the control: a selector that worked must not be reported.
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "business")
+    # Act
+    selection = select_spec_paths_over_roots((root,), agents=("business",))
+    # Assert
+    assert selection.unmatched_agents == ()
+
+
+def test_a_partial_agent_miss_still_selects_the_ones_that_matched(
+    tmp_path: Path,
+) -> None:
+    # Arrange — reporting the miss must not cost the hits.
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "business")
+    # Act
+    selection = select_spec_paths_over_roots(
+        (root,), agents=("business", "NOSUCH-AGENT-TYPO")
+    )
+    # Assert
+    assert [p.parent.name for p in selection.paths] == ["business"]
+
+
+def test_a_host_selector_matching_nothing_is_named(tmp_path: Path) -> None:
+    # Arrange
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "here", host="scitex-compute-01")
+    # Act
+    selection = select_spec_paths_over_roots(
+        (root,), hosts=("scitex-compute-01", "NOSUCHHOST")
+    )
+    # Assert
+    assert selection.unmatched_hosts == ("NOSUCHHOST",)
+
+
+def test_a_host_selector_that_matched_is_not_named(tmp_path: Path) -> None:
+    # Arrange — the control.
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "here", host="scitex-compute-01")
+    # Act
+    selection = select_spec_paths_over_roots((root,), hosts=("scitex-compute-01",))
+    # Assert
+    assert selection.unmatched_hosts == ()
+
+
+def test_an_unreadable_spec_suppresses_the_unmatched_host_claim(
+    tmp_path: Path,
+) -> None:
+    # Arrange — "no spec declares that host" is a CLAIM, and a spec whose
+    # hosts could not be read is not evidence for it. The unreadable spec is
+    # reported in its own bucket instead.
+    root = tmp_path / "agents"
+    root.mkdir()
+    broken = _write_spec(root, "broken", host="scitex-compute-01")
+    broken.chmod(0o000)
+    # Act
+    try:
+        selection = select_spec_paths_over_roots((root,), hosts=("NOSUCHHOST",))
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert selection.unmatched_hosts == ()
+
+
+def test_the_single_root_helper_still_returns_paths_and_templates(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the bucket-level unit tests unpack a 2-tuple from this, and a
+    # single root cannot shadow anything, so the shorthand keeps its shape.
+    root = tmp_path / "agents"
+    root.mkdir()
+    _write_spec(root, "alpha")
+    _write_spec(root, "_template_handyman")
+    # Act
+    paths, skipped = select_spec_paths(root)
+    # Assert
+    assert ([p.parent.name for p in paths], skipped) == (
+        ["alpha"],
+        ["_template_handyman"],
+    )

--- a/tests/scitex_agent_container/_maintenance/test__roster_state.py
+++ b/tests/scitex_agent_container/_maintenance/test__roster_state.py
@@ -20,6 +20,7 @@ from scitex_agent_container._maintenance._layers_migration_model import (
 from scitex_agent_container._maintenance._roster_state import (
     RosterState,
     inspect_roster,
+    inspect_roster_over_roots,
 )
 
 
@@ -229,3 +230,81 @@ class TestPlanSafety:
         summary = plan.summary()
         # Assert
         assert str(missing) in summary
+
+
+class TestSeveralRootsAtOnce:
+    """The engines sweep searches EVERY user-scope root, not one.
+
+    The three states keep their meanings, widened by one word: ``absent``
+    becomes "NONE of them is a directory". A run where one root of two exists
+    but holds nothing DID look somewhere, so it is ``empty`` — a reportable
+    fact rather than a discovery failure.
+    """
+
+    def test_no_root_existing_is_absent(self, tmp_path):
+        # Arrange
+        roots = [tmp_path / "nowhere", tmp_path / "also-nowhere"]
+        # Act
+        roster = inspect_roster_over_roots(roots, [])
+        # Assert
+        assert roster.state == "absent"
+
+    def test_one_root_existing_and_empty_is_empty_not_absent(
+        self, tmp_path, root
+    ):
+        # Arrange — it DID look somewhere; "nothing here" is a fact.
+        roots = [tmp_path / "nowhere", root]
+        # Act
+        roster = inspect_roster_over_roots(roots, [])
+        # Assert
+        assert roster.state == "empty"
+
+    def test_specs_found_across_roots_is_populated(self, tmp_path, root):
+        # Arrange
+        roots = [root, tmp_path / "nowhere"]
+        # Act
+        roster = inspect_roster_over_roots(roots, [root / "a" / "spec.yaml"])
+        # Assert
+        assert roster.state == "populated"
+
+    def test_the_populated_description_names_every_searched_root(
+        self, tmp_path, root
+    ):
+        # Arrange — a count naming one root of two is as unreadable as one
+        # naming none.
+        second = tmp_path / "second"
+        second.mkdir()
+        roster = inspect_roster_over_roots([root, second], [root / "a" / "spec.yaml"])
+        # Act
+        described = roster.describe()
+        # Assert
+        assert str(root) in described and str(second) in described
+
+    def test_an_absent_root_is_not_named_among_the_searched(self, tmp_path, root):
+        # Arrange — naming a root that is not there beside one that is invites
+        # the reader to conclude the count came from both.
+        roster = inspect_roster_over_roots(
+            [root, tmp_path / "nowhere"], [root / "a" / "spec.yaml"]
+        )
+        # Act
+        described = roster.describe()
+        # Assert
+        assert str(tmp_path / "nowhere") not in described
+
+    def test_no_roots_at_all_falls_back_to_the_explicit_paths_shape(self):
+        # Arrange — an empty root list claims no directory, so nothing may be
+        # called absent.
+        roots = []
+        # Act
+        roster = inspect_roster_over_roots(roots, [])
+        # Assert
+        assert roster.state == "empty"
+
+    def test_the_representative_root_stays_a_path(self, tmp_path, root):
+        # Arrange — widening ``root`` into a joined string would be a type lie
+        # for every caller that treats it as a path.
+        roots = [root, tmp_path / "nowhere"]
+        # Act
+        roster = inspect_roster_over_roots(roots, [root / "a" / "spec.yaml"])
+        # Assert
+        assert roster.root == root

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines.py
@@ -1,0 +1,419 @@
+"""``sac agents migrate-engines`` — the CLI surface of the spec.engines sweep.
+
+Real ``CliRunner`` against the real click command, over a real tmp fleet of
+real spec files. Every root is pinned inside ``tmp_path`` through the
+documented env seams, so no test can read or rewrite the operator's live specs.
+
+What only the CLI owns, and what these pin:
+
+* **dry-run is the DEFAULT** — asserted on the file BYTES and on the file's
+  MTIME, because "wrote the same content back" is still a write;
+* batching, which is the operator's own condition for trusting a 119-file
+  rewrite: ``--agent``, ``--host``, ``--limit``;
+* that a refusal is NAMED and does NOT fail the exit code, while an
+  unreadable spec does; and
+* that the apply is behaviour-preserving in the only way that counts —
+  measured, by re-loading every written spec and comparing the backend.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._agents_migrate_engines import migrate_engines
+from scitex_agent_container.config._qwen_gateway import QWEN_ENGINE_KEY
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+_SETTINGS = {"hooks": {"PreToolUse": [{"hooks": [{"command": "guard.sh"}]}]}}
+
+
+def _write_settings(to_home: Path) -> None:
+    claude = to_home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / "settings.json").write_text(json.dumps(_SETTINGS))
+
+
+def _write_spec(agents_dir: Path, name: str, *, model="opus[1m]", **overrides) -> Path:
+    agent_dir = agents_dir / name
+    agent_dir.mkdir(parents=True)
+    _write_settings(agent_dir / "to_home")
+    spec = {"to_home": "./to_home", "claude": {"model": model}}
+    spec.update(overrides)
+    doc = explicit_doc(spec)
+    path = agent_dir / "spec.yaml"
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return path
+
+
+@pytest.fixture
+def fleet(tmp_path: Path):
+    """A tmp fleet with every root pinned inside tmp_path."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    _write_settings(agents_dir / "_shared" / "to_home")
+    user_shared = tmp_path / "user-baseline" / "to_home"
+    _write_settings(user_shared)
+
+    keys = {
+        "SCITEX_AGENT_CONTAINER_AGENTS_DIR": str(agents_dir),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": str(tmp_path / "runtime"),
+        "SAC_USER_TO_HOME_BASELINE": str(user_shared),
+        "SAC_SPEC_CACHE_DISABLE": "1",
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    os.environ.update(keys)
+    try:
+        yield agents_dir
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _run(*args) -> "object":
+    """Assert on ``result.stdout``, never ``result.output``.
+
+    ``Result.output`` is stdout and stderr COMBINED; the scheduled form of
+    this command is ``--json`` piped to a parser, where they were never
+    merged. A single log line on stderr would otherwise make ``json.loads``
+    fail on a command that behaved perfectly.
+    """
+    return CliRunner().invoke(migrate_engines, list(args), catch_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run is the DEFAULT
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_invocation_writes_nothing(fleet: Path) -> None:
+    # Arrange — the single most important property of this verb.
+    spec = _write_spec(fleet, "alpha")
+    before = spec.read_text()
+    # Act
+    _run("--no-diff")
+    # Assert
+    assert spec.read_text() == before
+
+
+def test_the_default_invocation_does_not_touch_the_mtime(fleet: Path) -> None:
+    # Arrange — writing identical bytes back is still a write.
+    spec = _write_spec(fleet, "alpha")
+    before = spec.stat().st_mtime_ns
+    # Act
+    _run("--no-diff")
+    # Assert
+    assert spec.stat().st_mtime_ns == before
+
+
+def test_the_default_invocation_reports_dry_run_mode(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--no-diff", "--json")
+    # Assert
+    assert json.loads(result.stdout)["mode"] == "dry-run"
+
+
+def test_the_dry_run_counts_what_it_would_migrate(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "beta")
+    # Act
+    result = _run("--no-diff", "--json")
+    # Assert
+    assert json.loads(result.stdout)["would_migrate"] == 2
+
+
+def test_the_dry_run_carries_a_unified_diff_per_spec(fleet: Path) -> None:
+    # Arrange — a reviewable diff is the operator's stated condition.
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--json").stdout)
+    # Assert
+    assert payload["diffs"]["alpha"].startswith("--- a/alpha/spec.yaml")
+
+
+def test_the_dry_run_diff_shows_the_engines_block(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--json").stdout)
+    # Assert
+    assert "+  engines:" in payload["diffs"]["alpha"]
+
+
+def test_the_dry_run_exits_zero_on_a_sound_plan(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--no-diff", "--json")
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_apply_and_dry_run_together_is_a_usage_error(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    result = CliRunner().invoke(migrate_engines, ["--apply", "--dry-run"])
+    # Assert
+    assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Batching — nobody has to rewrite 119 files to rewrite one
+# ---------------------------------------------------------------------------
+
+
+def test_a_batch_by_agent_selects_only_that_agent(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "beta")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "-a", "alpha").stdout)
+    # Assert
+    assert payload["specs"] == 1
+
+
+def test_a_batch_by_host_selects_only_that_hosts_specs(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha", host="scitex-compute-01")
+    _write_spec(fleet, "beta", host="scitex-compute-04")
+    # Act
+    payload = json.loads(
+        _run("--no-diff", "--json", "--host", "scitex-compute-04").stdout
+    )
+    # Assert
+    assert payload["would_migrate"] == 1
+
+
+def test_limit_caps_the_batch(fleet: Path) -> None:
+    # Arrange
+    for name in ("alpha", "beta", "gamma"):
+        _write_spec(fleet, name)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "--limit", "2").stdout)
+    # Assert
+    assert payload["specs"] == 2
+
+
+def test_template_specs_are_named_as_not_searched(fleet: Path) -> None:
+    # Arrange — `agents create` copies these; leaving them silently behind
+    # re-introduces the legacy shape on every new agent.
+    _write_spec(fleet, "_template_handyman")
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["skipped_templates"] == ["_template_handyman"]
+
+
+def test_templates_flag_includes_them(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "_template_handyman")
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "--templates").stdout)
+    # Assert
+    assert payload["specs"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Refusals are named, and are not failures
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_with_no_model_is_named_in_the_refusals(fleet: Path) -> None:
+    # Arrange — the explicit-spec default is model: '' , so this is real.
+    _write_spec(fleet, "alpha", model="")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["refused"][0]["agent"] == "alpha"
+
+
+def test_a_refusal_carries_its_reason(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha", model="")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert "no model" in payload["refused"][0]["reason"]
+
+
+def test_a_refusal_does_not_fail_the_exit_code(fleet: Path) -> None:
+    # Arrange — a named refusal is an outcome a human resolves.
+    _write_spec(fleet, "alpha", model="")
+    # Act
+    result = _run("--no-diff", "--json")
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_a_refused_spec_is_not_counted_as_migrated(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha", model="")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["would_migrate"] == 0
+
+
+def test_an_empty_roster_is_reported_as_unsearched(tmp_path: Path) -> None:
+    # Arrange — a root that does not exist is NOT a fleet with nothing to do.
+    keys = {
+        "SCITEX_AGENT_CONTAINER_AGENTS_DIR": str(tmp_path / "nowhere"),
+        "SAC_SPEC_CACHE_DISABLE": "1",
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    os.environ.update(keys)
+    # Act
+    try:
+        payload = json.loads(_run("--no-diff", "--json").stdout)
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    # Assert
+    assert payload["roster"] == "absent"
+
+
+# ---------------------------------------------------------------------------
+# The apply, and the measurement that gates it
+# ---------------------------------------------------------------------------
+
+
+def test_apply_writes_the_engines_block(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    assert "engines" in yaml.safe_load(spec.read_text())["spec"]
+
+
+def test_apply_writes_both_engines(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    assert list(yaml.safe_load(spec.read_text())["spec"]["engines"]) == [
+        "claude",
+        QWEN_ENGINE_KEY,
+    ]
+
+
+def test_apply_reports_what_it_wrote(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert payload["written"] == ["alpha"]
+
+
+def test_apply_archives_the_originals_first(fleet: Path) -> None:
+    # Arrange — a rollback must be a copy-back, not a reconstruction.
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert (Path(payload["archive_dir"]) / "alpha.spec.yaml").is_file()
+
+
+def test_the_applied_spec_still_starts_on_the_same_model(fleet: Path) -> None:
+    # Arrange — measured through the production loader, not argued.
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    from scitex_agent_container.config import load_config
+
+    assert load_config(spec).claude.model == "opus[1m]"
+
+
+def test_the_applied_spec_selects_its_default_engine(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    from scitex_agent_container.config import load_config
+
+    assert load_config(spec).engine_key == "claude"
+
+
+def test_a_second_apply_writes_nothing_more(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    _run("--apply", "--no-diff", "--json")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert payload["written"] == []
+
+
+def test_a_second_run_reports_the_spec_as_already_migrated(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    _run("--apply", "--no-diff", "--json")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["already_migrated"] == ["alpha"]
+
+
+def test_apply_exits_zero_when_the_gate_passes(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--apply", "--no-diff", "--json")
+    # Assert
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# The gateway preflight, three-valued
+# ---------------------------------------------------------------------------
+
+
+def test_the_preflight_reports_a_named_state_not_a_boolean(fleet: Path) -> None:
+    # Arrange — the address may or may not be reachable from the test host;
+    # what is asserted is that the answer is a NAME either way.
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "--preflight").stdout)
+    # Assert
+    assert isinstance(payload["preflight"]["state"], str)
+
+
+def test_the_preflight_states_which_gateway_it_asked(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "--preflight").stdout)
+    # Assert
+    assert payload["preflight"]["url"].startswith("http")
+
+
+def test_without_the_flag_no_preflight_is_run(fleet: Path) -> None:
+    # Arrange — a sweep must not dial the network unless asked.
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["preflight"] is None

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines.py
@@ -41,11 +41,18 @@ def _write_settings(to_home: Path) -> None:
     (claude / "settings.json").write_text(json.dumps(_SETTINGS))
 
 
+#: A host the version floor records as engines-capable. Fixtures name one
+#: because the floor is fail-closed: ``explicit_doc``'s ``${HOSTNAME}``
+#: placeholder names no machine anyone measured, so a spec carrying it is
+#: REFUSED — correctly, since which sac would parse it is unknowable.
+CAPABLE_HOST = "scitex-compute-04"
+
+
 def _write_spec(agents_dir: Path, name: str, *, model="opus[1m]", **overrides) -> Path:
     agent_dir = agents_dir / name
     agent_dir.mkdir(parents=True)
     _write_settings(agent_dir / "to_home")
-    spec = {"to_home": "./to_home", "claude": {"model": model}}
+    spec = {"to_home": "./to_home", "claude": {"model": model}, "host": CAPABLE_HOST}
     spec.update(overrides)
     doc = explicit_doc(spec)
     path = agent_dir / "spec.yaml"

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines.py
@@ -199,13 +199,23 @@ def test_a_batch_by_host_selects_only_that_hosts_specs(fleet: Path) -> None:
 
 
 def test_limit_caps_the_batch(fleet: Path) -> None:
-    # Arrange
+    # Arrange — the cap is on what gets WRITTEN, not on what is looked at.
     for name in ("alpha", "beta", "gamma"):
         _write_spec(fleet, name)
     # Act
     payload = json.loads(_run("--no-diff", "--json", "--limit", "2").stdout)
     # Assert
-    assert payload["specs"] == 2
+    assert payload["would_migrate"] == 2
+
+
+def test_limit_still_examines_every_selected_spec(fleet: Path) -> None:
+    # Arrange — capping the GLOB is what made a second batch impossible.
+    for name in ("alpha", "beta", "gamma"):
+        _write_spec(fleet, name)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "--limit", "2").stdout)
+    # Assert
+    assert payload["specs"] == 3
 
 
 def test_template_specs_are_named_as_not_searched(fleet: Path) -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines.py
@@ -29,7 +29,6 @@ import yaml
 from click.testing import CliRunner
 
 from scitex_agent_container.cli_pkg._agents_migrate_engines import migrate_engines
-from scitex_agent_container.config._qwen_gateway import QWEN_ENGINE_KEY
 from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
 
 _SETTINGS = {"hooks": {"PreToolUse": [{"hooks": [{"command": "guard.sh"}]}]}}
@@ -322,16 +321,15 @@ def test_apply_writes_the_engines_block(fleet: Path) -> None:
     assert "engines" in yaml.safe_load(spec.read_text())["spec"]
 
 
-def test_apply_writes_both_engines(fleet: Path) -> None:
-    # Arrange
+def test_apply_writes_exactly_the_specs_own_backend(fleet: Path) -> None:
+    # Arrange — and nothing else. The sweep used to copy a `qwen38-27b`
+    # entry into every spec; that definition lives once in the fleet engine
+    # library now, reachable with `--engine` without being duplicated here.
     spec = _write_spec(fleet, "alpha")
     # Act
     _run("--apply", "--no-diff", "--json")
     # Assert
-    assert list(yaml.safe_load(spec.read_text())["spec"]["engines"]) == [
-        "claude",
-        QWEN_ENGINE_KEY,
-    ]
+    assert list(yaml.safe_load(spec.read_text())["spec"]["engines"]) == ["claude"]
 
 
 def test_apply_reports_what_it_wrote(fleet: Path) -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_batching.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_batching.py
@@ -1,0 +1,354 @@
+"""``migrate-engines`` batching, filtering, and what the report CLAIMS.
+
+Split from ``test__agents_migrate_engines`` on the module line budget. Same
+real ``CliRunner``, same real tmp fleet, every root pinned inside
+``tmp_path``. What lives here is the half of the surface a review measured
+as wrong rather than missing:
+
+* ``--limit`` capped the specs EXAMINED, so batch two re-selected the same
+  first N and wrote nothing while printing a completion message;
+* ``--host`` silently DROPPED the specs it could not read — the batching
+  flag disabling the guard that blocks an unsafe apply;
+* the apply asserted the migration was COMPLETE whenever it wrote nothing,
+  counting refused and held-back specs as done;
+* the root was undocumented, unsettable and never printed, and the default
+  is the untracked live copy;
+* ``--diff`` was accepted and dropped on the apply path.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._agents_migrate_engines import migrate_engines
+from tests.scitex_agent_container.cli_pkg.test__agents_migrate_engines import (
+    _run,
+    _write_settings,
+    _write_spec,
+    fleet,
+)
+
+__all__ = ["fleet"]
+
+
+# ---------------------------------------------------------------------------
+# --limit is a BATCH, which means it has to advance
+# ---------------------------------------------------------------------------
+
+
+def _engine_count(fleet: Path) -> int:
+    return sum(
+        1
+        for spec in sorted(fleet.glob("*/spec.yaml"))
+        if "engines" in (yaml.safe_load(spec.read_text())["spec"])
+    )
+
+
+def test_a_second_limited_batch_writes_the_next_specs(fleet: Path) -> None:
+    # Arrange — the operator's stated condition for trusting a 119-file
+    # rewrite is "apply in small batches". Slicing the sorted glob re-selected
+    # the same first N forever, so batch two wrote nothing.
+    for name in ("b1", "b2", "b3", "b4"):
+        _write_spec(fleet, name)
+    _run("--apply", "--no-diff", "--json", "--limit", "2")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json", "--limit", "2").stdout)
+    # Assert
+    assert payload["written"] == ["b3", "b4"]
+
+
+def test_repeated_limited_batches_finish_the_fleet(fleet: Path) -> None:
+    # Arrange
+    for name in ("b1", "b2", "b3", "b4"):
+        _write_spec(fleet, name)
+    # Act
+    for _ in range(2):
+        _run("--apply", "--no-diff", "--json", "--limit", "2")
+    # Assert
+    assert _engine_count(fleet) == 4
+
+
+def test_the_specs_past_the_limit_are_named_as_held_back(fleet: Path) -> None:
+    # Arrange — deferred, not dropped: a batch that says nothing about what
+    # it left reads exactly like a finished sweep.
+    for name in ("b1", "b2", "b3"):
+        _write_spec(fleet, name)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "--limit", "1").stdout)
+    # Assert
+    assert payload["held_back"] == ["b2", "b3"]
+
+
+def test_a_limited_run_does_not_claim_the_migration_is_complete(fleet: Path) -> None:
+    # Arrange
+    for name in ("b1", "b2"):
+        _write_spec(fleet, name)
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json", "--limit", "1").stdout)
+    # Assert
+    assert payload["migration_complete"] is False
+
+
+def test_a_negative_limit_is_a_usage_error(fleet: Path) -> None:
+    # Arrange — `picked[:-1]` accepted this and silently dropped the LAST
+    # spec, so a typo turned "one spec" into "all but one".
+    for name in ("b1", "b2", "b3"):
+        _write_spec(fleet, name)
+    # Act
+    result = CliRunner().invoke(migrate_engines, ["--no-diff", "--json", "--limit", "-1"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_a_negative_limit_writes_nothing(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "b1")
+    before = spec.read_text()
+    # Act
+    CliRunner().invoke(migrate_engines, ["--apply", "--no-diff", "--limit", "-1"])
+    # Assert
+    assert spec.read_text() == before
+
+
+# ---------------------------------------------------------------------------
+# No filter may make a spec vanish
+# ---------------------------------------------------------------------------
+
+
+def test_the_host_filter_keeps_a_spec_it_could_not_read(fleet: Path) -> None:
+    # Arrange — --host reads each spec to decide. A spec it cannot read must
+    # reach the PLAN as unreadable; excluding it makes the batching flag the
+    # thing that disables the guard against an unsafe apply.
+    _write_spec(fleet, "good", host="scitex-compute-04")
+    broken = _write_spec(fleet, "broken", host="scitex-compute-04")
+    broken.chmod(0o000)
+    try:
+        # Act
+        payload = json.loads(
+            _run("--no-diff", "--json", "--host", "scitex-compute-04").stdout
+        )
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert [o["agent"] for o in payload["unreadable"]] == ["broken"]
+
+
+def test_the_host_filter_keeps_a_spec_that_does_not_parse(fleet: Path) -> None:
+    # Arrange — it declares its host in the readable prefix and still does
+    # not parse, so the filter cannot rule it out either way.
+    _write_spec(fleet, "good", host="scitex-compute-04")
+    broken = _write_spec(fleet, "broken", host="scitex-compute-04")
+    broken.write_text(broken.read_text() + "  bad: [unclosed\n")
+    # Act
+    payload = json.loads(
+        _run("--no-diff", "--json", "--host", "scitex-compute-04").stdout
+    )
+    # Assert
+    assert [o["agent"] for o in payload["refused"]] == ["broken"]
+
+
+def test_an_unreadable_spec_under_a_host_filter_still_blocks_the_apply(
+    fleet: Path,
+) -> None:
+    # Arrange
+    _write_spec(fleet, "good", host="scitex-compute-04")
+    broken = _write_spec(fleet, "broken", host="scitex-compute-04")
+    broken.chmod(0o000)
+    try:
+        # Act
+        result = _run("--apply", "--no-diff", "--json", "--host", "scitex-compute-04")
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_an_unreadable_spec_blocks_the_apply_from_writing(fleet: Path) -> None:
+    # Arrange — `safe_to_apply` exists for this; nothing asserted it.
+    good = _write_spec(fleet, "good")
+    broken = _write_spec(fleet, "broken")
+    broken.chmod(0o000)
+    try:
+        # Act
+        _run("--apply", "--no-diff", "--json")
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert "engines" not in yaml.safe_load(good.read_text())["spec"]
+
+
+def test_an_absent_roster_refuses_the_apply(tmp_path: Path) -> None:
+    # Arrange — "0 specs" is equally true of a finished sweep and of a total
+    # discovery failure. Only one of them licenses an apply.
+    keys = {
+        "SCITEX_AGENT_CONTAINER_AGENTS_DIR": str(tmp_path / "nowhere"),
+        "SAC_SPEC_CACHE_DISABLE": "1",
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    os.environ.update(keys)
+    # Act
+    try:
+        result = _run("--apply", "--no-diff", "--json")
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    # Assert
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Where it writes, and saying so
+# ---------------------------------------------------------------------------
+
+
+def test_an_explicit_root_is_swept_instead_of_the_default(tmp_path: Path) -> None:
+    # Arrange — the default is the untracked LIVE copy, and inside a
+    # container it is not even the host's. Without --root the git-tracked
+    # tree was reachable only through an undocumented env var.
+    elsewhere = tmp_path / "tracked" / "agents"
+    elsewhere.mkdir(parents=True)
+    _write_settings(elsewhere / "_shared" / "to_home")
+    _write_spec(elsewhere, "alpha")
+    saved = os.environ.get("SAC_SPEC_CACHE_DISABLE")
+    os.environ["SAC_SPEC_CACHE_DISABLE"] = "1"
+    # Act
+    try:
+        payload = json.loads(
+            _run("--no-diff", "--json", "--root", str(elsewhere)).stdout
+        )
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_SPEC_CACHE_DISABLE", None)
+        else:
+            os.environ["SAC_SPEC_CACHE_DISABLE"] = saved
+    # Assert
+    assert payload["root"] == str(elsewhere)
+
+
+def test_the_apply_names_the_root_it_wrote_into(fleet: Path) -> None:
+    # Arrange — the success line never said where it had written.
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--apply", "--no-diff")
+    # Assert — console width wraps the path, so compare without the wrap.
+    assert str(fleet) in result.stdout.replace("\n", "")
+
+
+# ---------------------------------------------------------------------------
+# The apply says what it actually did
+# ---------------------------------------------------------------------------
+
+
+def test_a_run_that_refused_everything_is_not_called_complete(fleet: Path) -> None:
+    # Arrange — two specs neither of which can be migrated. "Nothing to
+    # write" was printed as "this is what a completed one looks like".
+    _write_spec(fleet, "alpha", model="")
+    _write_spec(fleet, "beta", model="")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert payload["migration_complete"] is False
+
+
+def test_a_run_that_refused_everything_does_not_print_the_completion_line(
+    fleet: Path,
+) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha", model="")
+    # Act
+    result = _run("--apply", "--no-diff")
+    # Assert
+    assert "completed one looks like" not in result.stdout
+
+
+def test_the_apply_names_its_refusals_without_json(fleet: Path) -> None:
+    # Arrange — only --json carried them, so the human path reported a clean
+    # run over a fleet it could not migrate.
+    _write_spec(fleet, "alpha", model="")
+    # Act
+    result = _run("--apply", "--no-diff")
+    # Assert
+    assert "alpha" in result.stdout
+
+
+def test_a_finished_sweep_is_reported_as_complete(fleet: Path) -> None:
+    # Arrange — the positive half: the claim must still be makeable.
+    _write_spec(fleet, "alpha")
+    _run("--apply", "--no-diff", "--json")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert payload["migration_complete"] is True
+
+
+def test_apply_prints_the_diff_it_is_writing(fleet: Path) -> None:
+    # Arrange — --diff is ON by default and its help calls it "the whole
+    # point"; the apply path accepted it and printed nothing.
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--apply")
+    # Assert
+    assert "+  engines:" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# What the gate measures
+# ---------------------------------------------------------------------------
+
+
+def test_the_applied_spec_still_reports_the_same_top_level_model(fleet: Path) -> None:
+    # Arrange — `spec.claude.model` is emptied by the migration, and the
+    # loader derived AgentConfig.model from that raw field. 117 of 119 specs
+    # flipped to the 'sonnet' default while the gate reported zero drift.
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    from scitex_agent_container.config import load_config
+
+    assert load_config(spec).model == "opus[1m]"
+
+
+def test_the_applied_spec_still_injects_the_same_model_env(fleet: Path) -> None:
+    # Arrange — SCITEX_AGENT_CONTAINER_MODEL is injected into every container
+    # and is what `sac whoami` prints.
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    from scitex_agent_container.config import load_config
+
+    assert load_config(spec).env["SCITEX_AGENT_CONTAINER_MODEL"] == "Claude Opus (1M)"
+
+
+def test_a_crlf_spec_keeps_its_line_endings(fleet: Path) -> None:
+    # Arrange — Path.read_text does universal-newline translation, so a CRLF
+    # spec was rewritten end to end: every line changed, which is exactly the
+    # unreviewable whole-file diff this sweep exists to avoid.
+    spec = _write_spec(fleet, "alpha")
+    spec.write_bytes(spec.read_text().replace("\n", "\r\n").encode())
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    assert b"\r\n" in spec.read_bytes()
+
+
+def test_a_crlf_spec_gains_no_bare_line_feed(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    spec.write_bytes(spec.read_text().replace("\n", "\r\n").encode())
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    body = spec.read_bytes()
+    assert body.count(b"\n") == body.count(b"\r\n")

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_gaps.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_gaps.py
@@ -1,0 +1,465 @@
+"""The three gaps ``sac agents migrate-engines`` shipped with, at CLI level.
+
+Real ``CliRunner`` against the real command, real spec files under
+``tmp_path``, a real HTTP server on a real loopback port. No mocks: two of the
+three facts here are about something NOT happening (a write that must not
+occur, a root that must not be the only one searched), and a mock would report
+only what the test author believed.
+
+THE THREE:
+
+1. **The version floor.** A sac predating 2026-09-03 rejects ``engines:`` as
+   an unknown spec field, so the block strands an agent on such a host. The
+   sweep refuses those specs by name, before the write, and an UNMEASURED host
+   is refused too — fail closed.
+2. **The preflight probed the wrong path.** The gateway base answers 404 while
+   ``/v1/models`` answers 401; a probe of the base reports "listening" from a
+   path the gateway does not serve.
+3. **The roster default.** With neither ``--root`` nor the env var set, the
+   sweep fell through to a resolver reading a DIFFERENT env var, landing on
+   the container's own ``$HOME`` — one spec beside the fleet's 123, reported
+   as a finished sweep.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._maintenance._engines_floor import (
+    REFUSED_HOST_NOT_MEASURED,
+    REFUSED_HOST_PREDATES_ENGINES,
+)
+from scitex_agent_container.cli_pkg._agents_migrate_engines import (
+    default_spec_roots,
+)
+from scitex_agent_container.cli_pkg._agents_migrate_engines_report import (
+    preflight_payload,
+)
+from scitex_agent_container.config._engine_reach import (
+    REACH_UNAUTHORIZED,
+    REACH_WRONG_PATH,
+)
+from scitex_agent_container.config._qwen_gateway import (
+    QWEN_GATEWAY_URL_ENV,
+    qwen_gateway_probe_url,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+from tests.scitex_agent_container.cli_pkg.test__agents_migrate_engines import (
+    CAPABLE_HOST,
+    _run,
+    _write_settings,
+    _write_spec,
+    fleet,
+)
+
+__all__ = ["fleet"]
+
+PREDATES = "spartan"
+UNMEASURED = "scitex-compute-02"
+
+
+# ---------------------------------------------------------------------------
+# 1. THE VERSION FLOOR
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_on_a_pre_engines_host_is_refused_by_the_cli(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert [e["agent"] for e in payload["refused"]] == ["grounded"]
+
+
+def test_the_cli_refusal_carries_the_pre_engines_reason(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["refused"][0]["reason"] == REFUSED_HOST_PREDATES_ENGINES
+
+
+def test_a_floored_spec_is_not_counted_as_migratable(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "grounded", host=PREDATES)
+    _write_spec(fleet, "fine", host=CAPABLE_HOST)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["would_migrate"] == 1
+
+
+def test_a_floor_refusal_does_not_fail_the_exit_code(fleet: Path) -> None:
+    # Arrange — a NAMED refusal is a legitimate outcome a human resolves.
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["exit_code"] == 0
+
+
+def test_a_floor_refusal_keeps_the_plan_safe_to_apply(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["safe_to_apply"] is True
+
+
+def test_an_unmeasured_host_is_refused_by_the_cli(fleet: Path) -> None:
+    # Arrange — compute-02 answered `hostname` and held no sac we could find.
+    _write_spec(fleet, "unknown-ground", host=UNMEASURED)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["refused"][0]["reason"] == REFUSED_HOST_NOT_MEASURED
+
+
+def test_apply_leaves_the_floored_spec_byte_identical(fleet: Path) -> None:
+    # Arrange — the hazard itself: an agent stranded on a validator nobody
+    # is watching.
+    path = _write_spec(fleet, "grounded", host=PREDATES)
+    before = path.read_bytes()
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    assert path.read_bytes() == before
+
+
+def test_apply_still_writes_a_spec_on_a_capable_host(fleet: Path) -> None:
+    # Arrange — a floor that stopped the whole batch would be its own outage.
+    _write_spec(fleet, "grounded", host=PREDATES)
+    _write_spec(fleet, "fine", host=CAPABLE_HOST)
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert payload["written"] == ["fine"]
+
+
+def test_the_override_flag_lifts_the_floor(fleet: Path) -> None:
+    # Arrange — a floor with no exit becomes a reason to bypass the tool.
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    payload = json.loads(
+        _run("--no-diff", "--json", "--host-supports-engines", PREDATES).stdout
+    )
+    # Assert
+    assert payload["would_migrate"] == 1
+
+
+def test_the_override_is_recorded_in_the_payload(fleet: Path) -> None:
+    # Arrange — the claim someone made has to be readable after the fact.
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    payload = json.loads(
+        _run("--no-diff", "--json", "--host-supports-engines", PREDATES).stdout
+    )
+    # Assert
+    assert payload["engine_floor_overrides"] == [PREDATES]
+
+
+def test_a_placeholder_host_is_refused(fleet: Path) -> None:
+    # Arrange — ${HOSTNAME} names no machine anyone measured, so which sac
+    # would parse the block is unknowable. Fail closed.
+    agent_dir = fleet / "anywhere"
+    agent_dir.mkdir()
+    _write_settings(agent_dir / "to_home")
+    doc = explicit_doc(
+        {"to_home": "./to_home", "claude": {"model": "opus[1m]"}, "host": "${HOSTNAME}"}
+    )
+    (agent_dir / "spec.yaml").write_text(yaml.safe_dump(doc, sort_keys=False))
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["refused"][0]["reason"] == REFUSED_HOST_NOT_MEASURED
+
+
+# ---------------------------------------------------------------------------
+# 2. THE PREFLIGHT PROBES /v1/models, NOT THE BASE
+# ---------------------------------------------------------------------------
+
+
+class _LikeTheGateway(BaseHTTPRequestHandler):
+    """The measured gateway shape: 404 at the base, 401 at /v1/models."""
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's own name
+        self.send_response(401 if self.path.startswith("/v1/models") else 404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *args) -> None:
+        """Silence the default stderr access log; it is not the fact under test."""
+
+
+@pytest.fixture
+def gateway_like_server():
+    """A real server answering exactly as scitex-compute-04:18772 measured."""
+    server = HTTPServer(("127.0.0.1", 0), _LikeTheGateway)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_port}"
+    saved = os.environ.get(QWEN_GATEWAY_URL_ENV)
+    os.environ[QWEN_GATEWAY_URL_ENV] = base
+    try:
+        yield base
+    finally:
+        if saved is None:
+            os.environ.pop(QWEN_GATEWAY_URL_ENV, None)
+        else:
+            os.environ[QWEN_GATEWAY_URL_ENV] = saved
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_the_probe_url_appends_the_models_path(gateway_like_server) -> None:
+    # Arrange
+    base = gateway_like_server
+    # Act
+    url = qwen_gateway_probe_url()
+    # Assert
+    assert url == f"{base}/v1/models"
+
+
+def test_the_preflight_dials_the_models_path(gateway_like_server) -> None:
+    # Arrange
+    base = gateway_like_server
+    # Act
+    payload = preflight_payload()
+    # Assert
+    assert payload["url"] == f"{base}/v1/models"
+
+
+def test_the_preflight_reads_the_gateway_as_auth_gated(gateway_like_server) -> None:
+    # Arrange — probing the BASE returned 404 here, which read as "listening".
+    _ = gateway_like_server
+    # Act
+    payload = preflight_payload()
+    # Assert
+    assert payload["state"] == REACH_UNAUTHORIZED
+
+
+def test_the_preflight_reports_the_endpoint_as_served(gateway_like_server) -> None:
+    # Arrange
+    _ = gateway_like_server
+    # Act
+    payload = preflight_payload()
+    # Assert
+    assert payload["serves_endpoint"] is True
+
+
+def test_the_preflight_still_names_the_base_it_derived_from(
+    gateway_like_server,
+) -> None:
+    # Arrange — a reader must see WHICH address was dialled, not infer it.
+    base = gateway_like_server
+    # Act
+    payload = preflight_payload()
+    # Assert
+    assert payload["base_url"] == base
+
+
+def test_probing_the_base_would_have_reported_the_wrong_path(
+    gateway_like_server,
+) -> None:
+    # Arrange — the defect, pinned: the OLD probe target on the SAME server.
+    from scitex_agent_container.config._engine_reach import reach_verdict
+
+    base = gateway_like_server
+    # Act
+    verdict = reach_verdict(base)
+    # Assert
+    assert verdict.state == REACH_WRONG_PATH
+
+
+def test_the_cli_preflight_carries_the_probed_path(
+    fleet: Path, gateway_like_server
+) -> None:
+    # Arrange
+    _write_spec(fleet, "one", host=CAPABLE_HOST)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "--preflight").stdout)
+    # Assert
+    assert payload["preflight"]["probe_path"] == "/v1/models"
+
+
+# ---------------------------------------------------------------------------
+# 3. THE ROSTER DEFAULT — every user-scope root, de-duplicated by agent name
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _env(**pairs):
+    """Set real env vars for the block, restore exactly what was there.
+
+    A ``yield``-based fixture over ``os.environ`` rather than
+    ``monkeypatch``: the production resolver reads the real environment, so
+    the test sets the real environment. ``None`` removes a variable.
+    """
+    saved = {key: os.environ.get(key) for key in pairs}
+    for key, value in pairs.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = str(value)
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture
+def two_roots(tmp_path: Path):
+    """Two real user-scope roots, both pinned inside ``tmp_path``.
+
+    ``$SCITEX_DIR`` moves the primary root and
+    ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` adds the second — the same two
+    seams the runtime uses. ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR`` is
+    explicitly UNSET, because that is the state the defect lives in.
+
+    The cwd moves into ``tmp_path`` for the same reason: the resolver walks
+    upward looking for a project-local registry, and this repo has one — a
+    test run from the checkout would otherwise sweep the repo's own fixtures.
+    """
+    primary = tmp_path / "home-scitex" / "agent-container" / "agents"
+    extra = tmp_path / "operator" / "agents"
+    primary.mkdir(parents=True)
+    extra.mkdir(parents=True)
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        with _env(
+            SCITEX_AGENT_CONTAINER_AGENTS_DIR=None,
+            SCITEX_DIR=tmp_path / "home-scitex",
+            SCITEX_AGENT_CONTAINER_YAML_DIRS=extra,
+            SAC_AGENT_SCOPE="user",
+            SCITEX_AGENT_CONTAINER_RUNTIME_DIR=tmp_path / "runtime",
+            SAC_SPEC_CACHE_DISABLE="1",
+        ):
+            yield primary, extra
+    finally:
+        os.chdir(cwd)
+
+
+def test_the_default_roots_include_every_user_scope_root(two_roots) -> None:
+    # Arrange — the old default resolved ONE root, and the wrong one.
+    primary, extra = two_roots
+    # Act
+    roots = default_spec_roots()
+    # Assert
+    assert {primary, extra} <= set(roots)
+
+
+def test_the_agents_dir_env_var_still_wins(two_roots, tmp_path: Path) -> None:
+    # Arrange — the documented override keeps its precedence.
+    named = tmp_path / "named" / "agents"
+    named.mkdir(parents=True)
+    # Act
+    with _env(SCITEX_AGENT_CONTAINER_AGENTS_DIR=named):
+        roots = default_spec_roots()
+    # Assert
+    assert roots == (named,)
+
+
+def _plant(root: Path, name: str, *, host: str = CAPABLE_HOST) -> Path:
+    agent_dir = root / name
+    agent_dir.mkdir(parents=True)
+    _write_settings(agent_dir / "to_home")
+    doc = explicit_doc(
+        {"to_home": "./to_home", "claude": {"model": "opus[1m]"}, "host": host}
+    )
+    path = agent_dir / "spec.yaml"
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return path
+
+
+def test_the_sweep_sees_agents_from_every_root(two_roots) -> None:
+    # Arrange — the measured shape: one spec in the container's own root,
+    # the fleet's specs in the operator's.
+    primary, extra = two_roots
+    _plant(primary, "lonely")
+    _plant(extra, "fleet-one")
+    _plant(extra, "fleet-two")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["specs"] == 3
+
+
+def test_the_report_names_every_root_it_searched(two_roots) -> None:
+    # Arrange — a count with no root is equally true of a finished migration
+    # and of a total discovery failure.
+    primary, extra = two_roots
+    _plant(primary, "lonely")
+    _plant(extra, "fleet-one")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["roots"] == [str(primary), str(extra)]
+
+
+def test_an_agent_present_in_two_roots_is_planned_once(two_roots) -> None:
+    # Arrange — the same NAME under two roots is two paths; writing both
+    # migrates one agent twice and creates two answers about it.
+    primary, extra = two_roots
+    _plant(primary, "twin")
+    _plant(extra, "twin")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["specs"] == 1
+
+
+def test_the_de_duplication_keeps_the_earlier_root(two_roots) -> None:
+    # Arrange
+    primary, extra = two_roots
+    kept = _plant(primary, "twin")
+    dropped = _plant(extra, "twin")
+    before = dropped.read_bytes()
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    assert (kept.read_bytes() != before) and (dropped.read_bytes() == before)
+
+
+def test_a_resolved_root_that_does_not_exist_is_named_absent(
+    two_roots, tmp_path: Path
+) -> None:
+    # Arrange — an operator whose tree was resolved and found MISSING must be
+    # able to see that; silently dropping it lets the count read as covering
+    # it. This is the same absent-vs-empty split _roster_state draws.
+    _, extra = two_roots
+    _plant(extra, "fleet-one")
+    absent = tmp_path / "nowhere"
+    # Act
+    with _env(SCITEX_AGENT_CONTAINER_YAML_DIRS=f"{extra}:{absent}"):
+        payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["roots_absent"] == [str(absent)]
+
+
+def test_a_root_that_exists_is_not_named_absent(two_roots) -> None:
+    # Arrange — the control for the assertion above.
+    _, extra = two_roots
+    _plant(extra, "fleet-one")
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert payload["roots_absent"] == []

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_gaps.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_gaps.py
@@ -42,7 +42,7 @@ from scitex_agent_container._maintenance._engines_floor import (
 from scitex_agent_container.cli_pkg._agents_migrate_engines import (
     default_spec_roots,
 )
-from scitex_agent_container.cli_pkg._agents_migrate_engines_report import (
+from scitex_agent_container.cli_pkg._agents_migrate_engines_preflight import (
     preflight_payload,
 )
 from scitex_agent_container.config._engine_reach import (

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_honesty.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_honesty.py
@@ -1,0 +1,391 @@
+"""What the READABLE output says, and what a filtered run may claim.
+
+Real ``CliRunner`` against the real command, real spec files under
+``tmp_path``. Every fact here was measured on the live corpus and every one of
+them is the same class of defect: the ``--json`` payload knew something the
+human output did not, or the human output knew something the one boolean built
+for a machine reader did not.
+
+FOUR MEASURED SHAPES:
+
+1. **A filter narrowed the census with no record of it.**
+   ``migrate-engines --root <113 specs> -a business --apply`` printed, verbatim:
+   "Nothing to write — all 1 spec(s) under <root> already declare spec.engines.
+   The sweep is idempotent; this is what a completed one looks like." — the
+   exact sentence the report module's own docstring identifies as the historic
+   bug, over a root holding 100 unmigrated specs, while NAMING that root. The
+   ``--json`` form reported ``specs: 1``, ``migration_complete: true`` and
+   carried no key naming the ``-a`` filter.
+2. **``--host-supports-engines`` lifted a MEASURED negative in silence.**
+   The run went from "100 would be migrated; 12 REFUSED" to "109 would be
+   migrated; 3 REFUSED" and ``grep -in 'spartan|override|lift'`` over the
+   whole terminal output matched ZERO lines.
+3. **One refusal paragraph, printed once per SPEC.** Twelve refusals rendered
+   as twelve blocks, nine carrying the byte-identical ~400-character spartan
+   paragraph. A whole-host refusal on ``scitex-laptop-01`` (60 specs) would
+   have printed it sixty times.
+4. **``--preflight`` was dropped on the ``--apply`` human path.** The probe
+   still ran — a real network round trip — and no verdict was printed at all.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from tests.scitex_agent_container.cli_pkg.test__agents_migrate_engines import (
+    CAPABLE_HOST,
+    _run,
+    _write_spec,
+    fleet,
+)
+
+__all__ = ["fleet"]
+
+PREDATES = "spartan"
+UNMEASURED = "scitex-compute-02"
+
+#: A distinctive, unbroken slice of the spartan roster row. The renderer
+#: prints refusal details with ``soft_wrap=True``, so it is never re-wrapped.
+_SPARTAN_EVIDENCE = "3 roots hold scitex_agent_container and NONE has"
+
+
+def _flat(result) -> str:
+    """Terminal output with the console's line breaks removed."""
+    return result.stdout.replace("\n", "")
+
+
+# ---------------------------------------------------------------------------
+# 1. A filtered run is a census of a SUBSET
+# ---------------------------------------------------------------------------
+
+
+def test_a_filtered_run_records_the_selector_in_the_payload(fleet: Path) -> None:
+    # Arrange — no key anywhere named the -a filter, so a scheduled runner
+    # could not tell a full census from a one-agent one.
+    for name in ("alpha", "beta", "gamma"):
+        _write_spec(fleet, name)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "-a", "alpha").stdout)
+    # Assert
+    assert payload["selectors"] == ["--agent alpha"]
+
+
+def test_a_filtered_run_is_marked_as_filtered(fleet: Path) -> None:
+    # Arrange
+    for name in ("alpha", "beta"):
+        _write_spec(fleet, name)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json", "--host", CAPABLE_HOST).stdout)
+    # Assert
+    assert payload["filtered"] is True
+
+
+def test_a_filtered_apply_does_not_claim_the_migration_is_complete(
+    fleet: Path,
+) -> None:
+    # Arrange — one agent named, two others left untouched under the same root.
+    for name in ("alpha", "beta", "gamma"):
+        _write_spec(fleet, name)
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json", "-a", "alpha").stdout)
+    # Assert
+    assert payload["migration_complete"] is False
+
+
+def test_a_filtered_apply_does_not_print_the_completion_sentence(
+    fleet: Path,
+) -> None:
+    # Arrange — the measured shape: the one selected spec is ALREADY migrated,
+    # so the apply writes nothing and reaches the "nothing to write" branch.
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "beta")
+    _run("--apply", "--no-diff", "--json", "-a", "alpha")
+    # Act
+    result = _run("--apply", "--no-diff", "-a", "alpha")
+    # Assert
+    assert "completed one looks like" not in result.stdout
+
+
+def test_a_filtered_apply_names_the_filter_in_the_readable_output(
+    fleet: Path,
+) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "beta")
+    _run("--apply", "--no-diff", "--json", "-a", "alpha")
+    # Act
+    result = _run("--apply", "--no-diff", "-a", "alpha")
+    # Assert
+    assert "--agent alpha" in _flat(result)
+
+
+def test_an_unfiltered_finished_sweep_is_still_reported_complete(
+    fleet: Path,
+) -> None:
+    # Arrange — the positive control: the claim must still be makeable.
+    _write_spec(fleet, "alpha")
+    _run("--apply", "--no-diff", "--json")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert payload["migration_complete"] is True
+
+
+def test_a_selector_that_matched_nothing_is_named_in_the_payload(
+    fleet: Path,
+) -> None:
+    # Arrange — measured: `-a business -a scitex-orochi -a NOSUCH-AGENT-TYPO`
+    # reported specs:2, exit 0, and no field anywhere naming the typo.
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(
+        _run("--no-diff", "--json", "-a", "alpha", "-a", "NOSUCH-AGENT-TYPO").stdout
+    )
+    # Assert
+    assert payload["unmatched_agents"] == ["NOSUCH-AGENT-TYPO"]
+
+
+def test_a_selector_that_matched_nothing_is_named_in_the_readable_output(
+    fleet: Path,
+) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--no-diff", "-a", "alpha", "-a", "NOSUCH-AGENT-TYPO")
+    # Assert
+    assert "NOSUCH-AGENT-TYPO" in _flat(result)
+
+
+# ---------------------------------------------------------------------------
+# 2. An override of a measured NO restates what it contradicts
+# ---------------------------------------------------------------------------
+
+
+def test_lifting_the_floor_names_the_host_in_the_readable_output(
+    fleet: Path,
+) -> None:
+    # Arrange — nine specs moved from REFUSED into the migratable count and
+    # the word "spartan" appeared nowhere in the output.
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    result = _run("--no-diff", "--host-supports-engines", PREDATES)
+    # Assert
+    assert PREDATES in _flat(result)
+
+
+def test_lifting_a_measured_negative_says_it_contradicts_a_measurement(
+    fleet: Path,
+) -> None:
+    # Arrange
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    result = _run("--no-diff", "--host-supports-engines", PREDATES)
+    # Assert
+    assert "CONTRADICTS" in _flat(result)
+
+
+def test_lifting_a_measured_negative_restates_the_measurement(
+    fleet: Path,
+) -> None:
+    # Arrange — an override that does not show the evidence it is overriding
+    # is indistinguishable from one that had nothing to override.
+    _write_spec(fleet, "grounded", host=PREDATES)
+    # Act
+    result = _run("--no-diff", "--host-supports-engines", PREDATES)
+    # Assert
+    assert _SPARTAN_EVIDENCE in _flat(result)
+
+
+def test_lifting_an_unmeasured_host_does_not_claim_a_contradiction(
+    fleet: Path,
+) -> None:
+    # Arrange — nobody measured compute-02, so there is nothing to contradict.
+    # Reporting it the loud way would teach the reader to ignore the loud way.
+    _write_spec(fleet, "unknown-ground", host=UNMEASURED)
+    # Act
+    result = _run("--no-diff", "--host-supports-engines", UNMEASURED)
+    # Assert
+    assert "CONTRADICTS" not in _flat(result)
+
+
+def test_lifting_an_unmeasured_host_still_says_the_floor_was_lifted(
+    fleet: Path,
+) -> None:
+    # Arrange — the control for the assertion above: quieter, not silent.
+    _write_spec(fleet, "unknown-ground", host=UNMEASURED)
+    # Act
+    result = _run("--no-diff", "--host-supports-engines", UNMEASURED)
+    # Assert
+    assert "FLOOR LIFTED" in _flat(result)
+
+
+def test_the_approving_side_names_the_host_it_judged_capable(fleet: Path) -> None:
+    # Arrange — 100 writes and not a word about which hosts were judged
+    # capable, on what, or how old the measurement was.
+    _write_spec(fleet, "alpha", host=CAPABLE_HOST)
+    # Act
+    result = _run("--no-diff")
+    # Assert
+    assert "version floor" in _flat(result)
+
+
+def test_the_approving_side_prints_the_roster_date(fleet: Path) -> None:
+    # Arrange — HOST_SUPPORT has no expiry and nothing probes, so a stale row
+    # makes a wrong run look exactly like a right one.
+    _write_spec(fleet, "alpha", host=CAPABLE_HOST)
+    # Act
+    result = _run("--no-diff")
+    # Assert
+    assert "roster measured 2026-09-06" in _flat(result)
+
+
+def test_the_payload_carries_the_floor_rows_the_writes_rest_on(
+    fleet: Path,
+) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha", host=CAPABLE_HOST)
+    # Act
+    payload = json.loads(_run("--no-diff", "--json").stdout)
+    # Assert
+    assert [r["host"] for r in payload["engine_floor"]["hosts"]] == [CAPABLE_HOST]
+
+
+# ---------------------------------------------------------------------------
+# 3. One block per KIND, not one per spec
+# ---------------------------------------------------------------------------
+
+
+def test_a_whole_host_refusal_prints_its_evidence_once(fleet: Path) -> None:
+    # Arrange — three specs, one host, one measurement. The paragraph is
+    # per-HOST; printing it per-SPEC buried the review under copies.
+    for name in ("g1", "g2", "g3"):
+        _write_spec(fleet, name, host=PREDATES)
+    # Act
+    result = _run("--no-diff")
+    # Assert
+    assert _flat(result).count(_SPARTAN_EVIDENCE) == 1
+
+
+def test_the_grouped_refusal_still_names_every_agent(fleet: Path) -> None:
+    # Arrange — grouping must not cost the names; a refusal that does not say
+    # WHICH spec is a refusal nobody can act on.
+    for name in ("g1", "g2", "g3"):
+        _write_spec(fleet, name, host=PREDATES)
+    # Act
+    flat = _flat(_run("--no-diff"))
+    # Assert
+    assert all(name in flat for name in ("g1", "g2", "g3"))
+
+
+def test_two_different_refusal_kinds_stay_two_blocks(fleet: Path) -> None:
+    # Arrange — the control: grouping by (reason, detail) must not collapse
+    # a pre-engines host and an unmeasured one into one claim.
+    _write_spec(fleet, "g1", host=PREDATES)
+    _write_spec(fleet, "u1", host=UNMEASURED)
+    # Act
+    flat = _flat(_run("--no-diff"))
+    # Assert
+    assert (_SPARTAN_EVIDENCE in flat) and ("absent from the measured roster" in flat)
+
+
+# ---------------------------------------------------------------------------
+# 4. --preflight is rendered wherever it was paid for
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_prints_its_verdict_on_the_apply_path(fleet: Path) -> None:
+    # Arrange — `--preflight --apply` is the natural "check the gateway, then
+    # write" invocation. The probe ran and printed no line at all.
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--apply", "--no-diff", "--preflight")
+    # Assert
+    assert "gateway preflight" in _flat(result)
+
+
+def test_preflight_prints_its_verdict_on_the_dry_run_path(fleet: Path) -> None:
+    # Arrange — the control: the path that always worked still works.
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--no-diff", "--preflight")
+    # Assert
+    assert "gateway preflight" in _flat(result)
+
+
+def test_preflight_prints_its_verdict_when_the_apply_is_refused(
+    fleet: Path,
+) -> None:
+    # Arrange — an unreadable spec makes the plan unsafe, and that branch
+    # printed no preflight either.
+    _write_spec(fleet, "alpha")
+    broken = _write_spec(fleet, "broken")
+    broken.chmod(0o000)
+    # Act
+    try:
+        result = _run("--apply", "--no-diff", "--preflight")
+    finally:
+        broken.chmod(0o644)
+    # Assert
+    assert "gateway preflight" in _flat(result)
+
+
+def test_without_the_flag_the_apply_path_prints_no_preflight(fleet: Path) -> None:
+    # Arrange — the control: a sweep must not dial the network unasked.
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--apply", "--no-diff")
+    # Assert
+    assert "gateway preflight" not in _flat(result)
+
+
+# ---------------------------------------------------------------------------
+# The templates a completed sweep leaves behind
+# ---------------------------------------------------------------------------
+
+
+def test_an_apply_that_skips_a_template_is_not_complete(fleet: Path) -> None:
+    # Arrange — `sac agents create` copies the template, so every agent minted
+    # after this "finished" sweep re-introduces the legacy shape.
+    _write_spec(fleet, "real-agent")
+    _write_spec(fleet, "_template_generalist")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert payload["migration_complete"] is False
+
+
+def test_the_skipped_template_really_kept_the_legacy_shape(fleet: Path) -> None:
+    # Arrange — the positive control for the claim above.
+    _write_spec(fleet, "real-agent")
+    template = _write_spec(fleet, "_template_generalist")
+    # Act
+    _run("--apply", "--no-diff", "--json")
+    # Assert
+    assert "engines" not in yaml.safe_load(template.read_text())["spec"]
+
+
+def test_migrating_the_templates_too_reports_the_sweep_complete(
+    fleet: Path,
+) -> None:
+    # Arrange — the positive control: --templates leaves nothing behind.
+    _write_spec(fleet, "real-agent")
+    _write_spec(fleet, "_template_generalist")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json", "--templates").stdout)
+    # Assert
+    assert payload["migration_complete"] is True
+
+
+def test_the_apply_reports_the_paths_it_wrote(fleet: Path) -> None:
+    # Arrange — `written` carries agent NAMES, and a name cannot say which
+    # root the write landed in. The default sweep searches several.
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--apply", "--no-diff", "--json").stdout)
+    # Assert
+    assert payload["written_paths"] == [str(spec)]

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_roots.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_engines_roots.py
@@ -1,0 +1,232 @@
+"""The sweep's scope must not depend on the working directory.
+
+Real roots under ``tmp_path``, resolved by the real resolver through the real
+env seams. No mocks: the fact under test is which directories a 100-file
+rewrite would WRITE INTO, and a mocked resolver would report only what the
+test author believed.
+
+**MEASURED, 2026-09-06, with ``$SCITEX_AGENT_CONTAINER_AGENTS_DIR`` unset.**
+``default_spec_roots`` resolved through ``user_scope_roots``, whose first
+entry is "the first ``.scitex/agent-container/agents`` found by walking upward
+from cwd"::
+
+    cwd = the sac repo (this agent's own workdir)
+        3 roots, 119 specs   — includes the repo's own sdk-test and self
+    cwd = /uvwork/tmp   or   /home/agent
+        2 roots, 117 specs
+
+Two defects in one number. The sweep's scope — and with ``--apply``, its write
+set — changed with the working directory. And ``git ls-files`` confirms
+``.scitex/agent-container/agents/{sdk-test,self}/spec.yaml`` are TRACKED repo
+fixtures: from the normal invocation, ``--apply`` would rewrite them. Both
+escaped only by accident of unrelated guards, and
+``--host-supports-engines local`` — a plausible developer flag — put the
+tracked fixture straight back into the write set.
+
+**AND THE ORDER DISAGREED WITH THE LOADER.** ``user_scope_roots`` returns
+``[primary, *project_local, *operator_env_dirs]`` while ``config/_resolve``
+resolves ``project_local -> primary -> operator_env_dirs``. On a name
+collision the sweep would migrate the copy the loader does not load, and
+nothing in the report could say which. Dropping the cwd-derived root removes
+the disagreement rather than papering over it: what remains — primary, then
+the operator dirs — is the loader's own order.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg._agents_migrate_engines import (
+    default_spec_roots,
+    excluded_spec_roots,
+)
+
+
+@contextmanager
+def _env(**pairs):
+    """Set real env vars for the block, restore exactly what was there.
+
+    The production resolver reads the real environment, so the test sets the
+    real environment. ``None`` removes a variable.
+    """
+    saved = {key: os.environ.get(key) for key in pairs}
+    for key, value in pairs.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = str(value)
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@contextmanager
+def _cwd(where: Path):
+    was = os.getcwd()
+    os.chdir(where)
+    try:
+        yield
+    finally:
+        os.chdir(was)
+
+
+@pytest.fixture
+def repo_with_a_project_registry(tmp_path: Path):
+    """A git repo carrying its own ``.scitex/agent-container/agents``.
+
+    The shape the sac checkout itself has: a project-local registry holding
+    checked-in test fixtures, discovered by walking upward from cwd. ``.git``
+    only has to EXIST for both project-scope resolvers, which is what makes
+    this a faithful fixture rather than an approximation.
+    """
+    repo = tmp_path / "repo"
+    project_agents = repo / ".scitex" / "agent-container" / "agents"
+    project_agents.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    primary = tmp_path / "home-scitex" / "agent-container" / "agents"
+    primary.mkdir(parents=True)
+    operator = tmp_path / "operator" / "agents"
+    operator.mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    with _env(
+        SCITEX_AGENT_CONTAINER_AGENTS_DIR=None,
+        SCITEX_DIR=tmp_path / "home-scitex",
+        SCITEX_AGENT_CONTAINER_YAML_DIRS=operator,
+        SAC_AGENT_SCOPE=None,
+        SAC_SPEC_CACHE_DISABLE="1",
+    ):
+        yield repo, project_agents, primary, operator, elsewhere
+
+
+def test_the_project_local_registry_is_not_swept(
+    repo_with_a_project_registry,
+) -> None:
+    # Arrange — the repo's checked-in fixtures are not the fleet, and
+    # `--apply` from the repo would have rewritten tracked files.
+    repo, project_agents, _primary, _operator, _elsewhere = repo_with_a_project_registry
+    # Act
+    with _cwd(repo):
+        roots = default_spec_roots()
+    # Assert
+    assert project_agents not in roots
+
+
+def test_the_fleet_roots_are_still_swept_from_inside_the_repo(
+    repo_with_a_project_registry,
+) -> None:
+    # Arrange — the control: excluding one root must not cost the others.
+    repo, _project, primary, operator, _elsewhere = repo_with_a_project_registry
+    # Act
+    with _cwd(repo):
+        roots = default_spec_roots()
+    # Assert
+    assert roots == (primary, operator)
+
+
+def test_the_scope_does_not_change_with_the_working_directory(
+    repo_with_a_project_registry,
+) -> None:
+    # Arrange — measured: 119 specs from the repo, 117 from anywhere else.
+    repo, _project, _primary, _operator, elsewhere = repo_with_a_project_registry
+    # Act
+    with _cwd(repo):
+        from_repo = default_spec_roots()
+    with _cwd(elsewhere):
+        from_elsewhere = default_spec_roots()
+    # Assert
+    assert from_repo == from_elsewhere
+
+
+def test_the_order_matches_the_loaders_own_precedence(
+    repo_with_a_project_registry,
+) -> None:
+    # Arrange — resolve_config resolves primary before the operator dirs, and
+    # the sweep's earlier-root-wins must agree or it writes the copy the
+    # loader does not load.
+    repo, _project, primary, operator, _elsewhere = repo_with_a_project_registry
+    # Act
+    with _cwd(repo):
+        roots = default_spec_roots()
+    # Assert
+    assert list(roots).index(primary) < list(roots).index(operator)
+
+
+def test_the_excluded_root_is_named_rather_than_dropped(
+    repo_with_a_project_registry,
+) -> None:
+    # Arrange — a root that was resolved and then left out has to be visible,
+    # exactly as `roots_absent` is: otherwise the count reads as covering it.
+    repo, project_agents, _primary, _operator, _elsewhere = repo_with_a_project_registry
+    # Act
+    with _cwd(repo):
+        excluded = excluded_spec_roots()
+    # Assert
+    assert excluded == (project_agents,)
+
+
+def test_nothing_is_reported_excluded_outside_a_project(
+    repo_with_a_project_registry,
+) -> None:
+    # Arrange — the control: no project-local registry, nothing to report.
+    _repo, _project, _primary, _operator, elsewhere = repo_with_a_project_registry
+    # Act
+    with _cwd(elsewhere):
+        excluded = excluded_spec_roots()
+    # Assert
+    assert excluded == ()
+
+
+def test_an_explicit_project_scope_is_still_honoured(
+    repo_with_a_project_registry,
+) -> None:
+    # Arrange — `SAC_AGENT_SCOPE=project` is an operator asking for project
+    # scope BY NAME. Inheriting a cwd is the accident; an explicit request is
+    # not, and refusing it would make the flag a lie.
+    repo, project_agents, _primary, _operator, _elsewhere = repo_with_a_project_registry
+    # Act
+    with _cwd(repo), _env(SAC_AGENT_SCOPE="project"):
+        roots = default_spec_roots()
+    # Assert
+    assert project_agents in roots
+
+
+def test_the_agents_dir_env_var_still_wins_over_everything(
+    repo_with_a_project_registry, tmp_path: Path
+) -> None:
+    # Arrange — the documented override keeps its precedence, and excluding a
+    # root must not disturb it.
+    repo, _project, _primary, _operator, _elsewhere = repo_with_a_project_registry
+    named = tmp_path / "named" / "agents"
+    named.mkdir(parents=True)
+    # Act
+    with _cwd(repo), _env(SCITEX_AGENT_CONTAINER_AGENTS_DIR=named):
+        roots = default_spec_roots()
+    # Assert
+    assert roots == (named,)
+
+
+def test_an_explicit_agents_dir_reports_no_excluded_root(
+    repo_with_a_project_registry, tmp_path: Path
+) -> None:
+    # Arrange — the env var replaces the whole resolution, so nothing was
+    # resolved-and-left-out to report.
+    repo, _project, _primary, _operator, _elsewhere = repo_with_a_project_registry
+    named = tmp_path / "named" / "agents"
+    named.mkdir(parents=True)
+    # Act
+    with _cwd(repo), _env(SCITEX_AGENT_CONTAINER_AGENTS_DIR=named):
+        excluded = excluded_spec_roots()
+    # Assert
+    assert excluded == ()

--- a/tests/scitex_agent_container/config/test__engine_library_fleet_file.py
+++ b/tests/scitex_agent_container/config/test__engine_library_fleet_file.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""THE TRACKED FLEET ENGINE LIBRARY, read through the production reader.
+
+``.scitex/agent-container/engines.yaml`` is the file `sac agents
+migrate-engines` stopped copying into 119 specs: the ``qwen38-27b`` engine is
+declared THERE, once. A tracked YAML blob nothing loads is a blob that rots,
+so every assertion below goes through :func:`load_fleet_library` — the same
+call the loader makes — against the real file on disk.
+
+WHY A SEPARATE MODULE from ``test__engine_library``: that one is at the .py
+line cap, and its subject is the library MECHANISM (three YAML cases, the
+one-line switch, the refusals) written against fixtures in ``tmp_path``. This
+one's subject is the one library THIS REPO SHIPS.
+
+NO MOCKS, NO ``monkeypatch``: the path override is set and restored by a real
+fixture, and the file under test is the tracked file itself.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config._engine_library import (
+    FLEET_ENGINES_ENV,
+    FLEET_ENGINES_FILENAME,
+    fleet_engines_path,
+    load_fleet_library,
+)
+from scitex_agent_container.config._qwen_gateway import (
+    QWEN_GATEWAY_HOST,
+    QWEN_GATEWAY_PROVIDER,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+#: The tracked library, at the path the module docstring commits to.
+TRACKED_LIBRARY = (
+    _REPO_ROOT / ".scitex" / "agent-container" / FLEET_ENGINES_FILENAME
+)
+
+#: The gateway engine's key. A LITERAL, because the point of this file is
+#: that the key is DATA now — deriving it from the code under test would make
+#: the assertion true by construction.
+FLEET_QWEN_KEY = "qwen38-27b"
+
+
+@pytest.fixture
+def env_override():
+    """Set ``$SAC_ENGINES_FILE`` for one test and restore it afterwards."""
+    previous = os.environ.get(FLEET_ENGINES_ENV)
+
+    def _set(value: "str | None") -> None:
+        if value is None:
+            os.environ.pop(FLEET_ENGINES_ENV, None)
+        else:
+            os.environ[FLEET_ENGINES_ENV] = value
+
+    yield _set
+    _set(previous)
+
+
+@pytest.fixture
+def library(env_override):
+    """The tracked file, loaded through the production reader."""
+    env_override(str(TRACKED_LIBRARY))
+    return load_fleet_library()
+
+
+# ---------------------------------------------------------------------------
+# The file exists where the docs say, and parses through the real reader
+# ---------------------------------------------------------------------------
+
+
+def test_the_tracked_library_is_where_the_docs_say_it_is() -> None:
+    # Arrange — docs/harness-and-engine.md links this exact path.
+    path = TRACKED_LIBRARY
+    # Act
+    found = path.is_file()
+    # Assert
+    assert found, f"the tracked fleet engine library is missing at {path}"
+
+
+def test_the_tracked_library_parses_without_errors(library) -> None:
+    # Arrange — a malformed library is a LOAD error for every spec that
+    # depends on it, so this file is checked rather than trusted.
+    # Act
+    errors = library.errors
+    # Assert
+    assert errors == ()
+
+
+def test_the_tracked_library_declares_the_gateway_engine(library) -> None:
+    # Arrange — the entry the sweep used to copy into every spec.
+    # Act
+    keys = sorted(library.engines)
+    # Assert
+    assert keys == [FLEET_QWEN_KEY]
+
+
+# ---------------------------------------------------------------------------
+# What the entry says — and the two things it deliberately does not
+# ---------------------------------------------------------------------------
+
+
+def test_the_gateway_engine_names_its_provider_rather_than_an_address(
+    library,
+) -> None:
+    # Arrange — one address, in one module, not copied into YAML.
+    # Act
+    engine = library.engines[FLEET_QWEN_KEY]
+    # Assert
+    assert engine.provider_declared == QWEN_GATEWAY_PROVIDER
+
+
+def test_the_gateway_engine_still_resolves_to_an_endpoint(library) -> None:
+    # Arrange — naming it by reference must not mean naming nothing.
+    # Act
+    engine = library.engines[FLEET_QWEN_KEY]
+    # Assert
+    assert engine.provider is not None and engine.provider.base_url
+
+
+def test_the_gateway_address_is_not_written_into_the_library() -> None:
+    # Arrange — the positive control for the test above: the endpoint
+    # resolves, and the hostname is nowhere in the file.
+    text = TRACKED_LIBRARY.read_text(encoding="utf-8")
+    # Act
+    written = QWEN_GATEWAY_HOST in text
+    # Assert
+    assert written is False
+
+
+def test_the_gateway_engine_states_no_harness(library) -> None:
+    # Arrange — stating one would claim the HARNESS axis, and this ONE entry
+    # has to serve a Claude-Code agent and a Codex agent unchanged.
+    # Act
+    engine = library.engines[FLEET_QWEN_KEY]
+    # Assert
+    assert engine.harness is None
+
+
+def test_the_gateway_engine_runs_at_low_reasoning_effort(library) -> None:
+    # Arrange — Q4 (operator, 2026-09-03): permanently low.
+    # Act
+    engine = library.engines[FLEET_QWEN_KEY]
+    # Assert
+    assert engine.reasoning_effort == "low"
+
+
+def test_the_gateway_engine_carries_the_measured_context_window(library) -> None:
+    # Arrange — the gateway's serve conf MAX_MODEL_LEN. Claude Code assumes
+    # 200k for a model it does not recognise and compacts at that boundary.
+    # Act
+    engine = library.engines[FLEET_QWEN_KEY]
+    # Assert
+    assert engine.max_context_tokens == 1048576
+
+
+def test_the_tracked_library_declares_no_fleet_default(library) -> None:
+    # Arrange — writing `engine:` here repoints every unpinned agent, which
+    # is the operator's one-line decision and not the migration's to make.
+    # Act
+    default_key = library.default_key
+    # Assert
+    assert default_key == ""
+
+
+# ---------------------------------------------------------------------------
+# How it is FOUND — stated, not assumed
+# ---------------------------------------------------------------------------
+
+
+def test_the_override_env_var_decides_the_path_when_set(env_override) -> None:
+    # Arrange — the ops/test seam, and the one this module's fixture uses.
+    env_override(str(TRACKED_LIBRARY))
+    # Act
+    resolved = fleet_engines_path()
+    # Assert
+    assert resolved == TRACKED_LIBRARY
+
+
+def test_with_no_override_the_path_sits_beside_the_agents_dir(
+    env_override,
+) -> None:
+    # Arrange — the fleet case: $SAC_ENGINES_FILE unset, so the library is
+    # resolved from the state root and lands next to `agents/`. Asserted
+    # against the SSOT resolver rather than a hard-coded ~/.scitex, so a host
+    # exporting $SCITEX_DIR is answered correctly too.
+    from scitex_agent_container._state.state_paths import agent_container_root
+
+    env_override(None)
+    # Act
+    resolved = fleet_engines_path()
+    # Assert
+    assert resolved == agent_container_root() / FLEET_ENGINES_FILENAME

--- a/tests/scitex_agent_container/config/test__engine_reach.py
+++ b/tests/scitex_agent_container/config/test__engine_reach.py
@@ -30,6 +30,7 @@ from scitex_agent_container.config._engine_reach import (
     REACH_NO_HOST,
     REACH_REFUSED,
     REACH_UNAUTHORIZED,
+    REACH_WRONG_PATH,
     ReachVerdict,
     reach_verdict,
 )
@@ -234,3 +235,144 @@ def test_an_unknown_state_cannot_be_constructed() -> None:
     # Assert
     with pytest.raises(ValueError):
         construct(url="http://x", state=bogus, detail="")
+
+
+# ---------------------------------------------------------------------------
+# A 404 is listening at the ADDRESS and says nothing about the PATH
+#
+# Measured from scitex-compute-04, 2026-09-06, against the fleet gateway:
+#     /            404   listening, but this path does not exist
+#     /v1/models   401   REACHABLE + AUTH-GATED — the informative answer
+#     /health      200   a real health endpoint — a gate that cannot fail
+# Folding the first into ``listening`` made a preflight of the gateway BASE
+# report green from a path the gateway does not serve.
+# ---------------------------------------------------------------------------
+
+
+class _NotFound(BaseHTTPRequestHandler):
+    """A process holding the port that does not serve the path asked for."""
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's own name
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *args) -> None:
+        """Silence the default stderr access log; it is not the fact under test."""
+
+
+class _Open(BaseHTTPRequestHandler):
+    """A gateway serving the path with no key demanded — 200, and reachable."""
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's own name
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *args) -> None:
+        """Silence the default stderr access log; it is not the fact under test."""
+
+
+def _serving(handler):
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1/models"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def missing_path_url():
+    """A real HTTP server on a real port that answers 404 to everything."""
+    yield from _serving(_NotFound)
+
+
+@pytest.fixture
+def open_url():
+    """A real HTTP server on a real port that answers 200 to everything."""
+    yield from _serving(_Open)
+
+
+def test_a_404_is_named_listening_wrong_path(missing_path_url) -> None:
+    # Arrange
+    url = missing_path_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.state == REACH_WRONG_PATH
+
+
+def test_a_404_does_not_prove_the_endpoint_is_served(missing_path_url) -> None:
+    # Arrange — the whole defect: the gateway base answers exactly this.
+    url = missing_path_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.serves_endpoint is False
+
+
+def test_a_404_still_proves_something_holds_the_address(missing_path_url) -> None:
+    # Arrange — a process DID answer, which is the weaker but true fact.
+    url = missing_path_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.proves_listening is True
+
+
+def test_a_404_is_not_read_as_an_absent_endpoint(missing_path_url) -> None:
+    # Arrange
+    url = missing_path_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.proves_absent is False
+
+
+def test_a_404_and_a_401_are_different_states(missing_path_url, gated_url) -> None:
+    # Arrange — one says the API is there and gating; the other says nothing.
+    served = reach_verdict(gated_url)
+    # Act
+    missing = reach_verdict(missing_path_url)
+    # Assert
+    assert served.state != missing.state
+
+
+def test_the_404_sentence_points_at_the_path_to_probe(missing_path_url) -> None:
+    # Arrange — a reader skims the sentence, not the enum member.
+    url = missing_path_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert "/v1/models" in verdict.detail
+
+
+def test_a_401_proves_the_probed_path_is_served(gated_url) -> None:
+    # Arrange — gated IS served; that is what an engine entry needs to see.
+    url = gated_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.serves_endpoint is True
+
+
+def test_a_200_proves_the_probed_path_is_served(open_url) -> None:
+    # Arrange — an ungated /v1/models is reachable too.
+    url = open_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.serves_endpoint is True
+
+
+def test_a_closed_port_does_not_prove_the_probed_path_is_served(closed_url) -> None:
+    # Arrange
+    url = closed_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.serves_endpoint is False

--- a/tests/scitex_agent_container/config/test__engine_reach.py
+++ b/tests/scitex_agent_container/config/test__engine_reach.py
@@ -1,0 +1,231 @@
+"""``reach_verdict`` — the three shapes of "not 200" that are NOT one shape.
+
+Real sockets, real DNS, a real HTTP server on a real loopback port. No mocks:
+the whole value of this module is that it reports what the NETWORK actually
+did, and a mock would only report what the test author believed it does.
+
+The measurement it encodes (scitex-hub, 2026-09-05):
+
+    scitex-compute-04:18772   HTTP 401   listening and auth-gating = REACHABLE
+    compute-04:18772          000        the NAME does not resolve
+    compute-04-lan:18772      000        the NAME does not resolve
+
+``.invalid`` is reserved by RFC 2606 precisely so a test may rely on it not
+resolving; the random-looking label guards against a wildcard resolver that
+answers for everything under a real suffix.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from scitex_agent_container.config._engine_reach import (
+    REACH_NAME_UNRESOLVED,
+    REACH_NO_HOST,
+    REACH_REFUSED,
+    REACH_UNAUTHORIZED,
+    ReachVerdict,
+    reach_verdict,
+)
+
+UNRESOLVABLE = "http://gateway-6f3a9c2e4b71.invalid:18772"
+
+
+class _Gated(BaseHTTPRequestHandler):
+    """A gateway that is UP and demanding a key — the 401 the fleet measures."""
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's own name
+        self.send_response(401)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *args) -> None:
+        """Silence the default stderr access log; it is not the fact under test."""
+
+
+@pytest.fixture
+def gated_url():
+    """A real HTTP server on a real port that answers 401 to everything."""
+    server = HTTPServer(("127.0.0.1", 0), _Gated)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def closed_url():
+    """A loopback port nothing is listening on — bound, read, then released."""
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return f"http://127.0.0.1:{port}"
+
+
+# ---------------------------------------------------------------------------
+# 401 is the CORRECT answer for a live gateway
+# ---------------------------------------------------------------------------
+
+
+def test_a_401_is_named_reachable_but_unauthorized(gated_url) -> None:
+    # Arrange
+    url = gated_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.state == REACH_UNAUTHORIZED
+
+
+def test_a_401_proves_the_endpoint_is_listening(gated_url) -> None:
+    # Arrange — a check that treats non-2xx as failure calls this gateway dead.
+    url = gated_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.proves_listening is True
+
+
+def test_a_401_is_not_read_as_an_absent_endpoint(gated_url) -> None:
+    # Arrange
+    url = gated_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.proves_absent is False
+
+
+def test_a_401_records_the_status_it_saw(gated_url) -> None:
+    # Arrange
+    url = gated_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.http_status == 401
+
+
+def test_the_401_sentence_says_reachable_in_those_words(gated_url) -> None:
+    # Arrange — a reader skims the sentence, not the enum member.
+    url = gated_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert "reachable but unauthorized" in verdict.detail
+
+
+# ---------------------------------------------------------------------------
+# An unresolvable NAME is not a dead gateway
+# ---------------------------------------------------------------------------
+
+
+def test_an_unresolvable_name_is_named_as_such() -> None:
+    # Arrange
+    url = UNRESOLVABLE
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.state == REACH_NAME_UNRESOLVED
+
+
+def test_an_unresolvable_name_is_not_evidence_the_gateway_is_down() -> None:
+    # Arrange — curl prints 000 here AND for a dead host; this is the split.
+    url = UNRESOLVABLE
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.proves_absent is False
+
+
+def test_an_unresolvable_name_is_undetermined() -> None:
+    # Arrange
+    url = UNRESOLVABLE
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.undetermined is True
+
+
+def test_the_unresolvable_sentence_says_the_name_does_not_resolve() -> None:
+    # Arrange
+    url = UNRESOLVABLE
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert "the NAME does not resolve" in verdict.detail
+
+
+# ---------------------------------------------------------------------------
+# A refusal is the one definite negative
+# ---------------------------------------------------------------------------
+
+
+def test_a_closed_port_is_named_connection_refused(closed_url) -> None:
+    # Arrange
+    url = closed_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.state == REACH_REFUSED
+
+
+def test_a_closed_port_proves_the_endpoint_is_absent(closed_url) -> None:
+    # Arrange
+    url = closed_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.proves_absent is True
+
+
+def test_a_closed_port_does_not_prove_listening(closed_url) -> None:
+    # Arrange
+    url = closed_url
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.proves_listening is False
+
+
+def test_a_refusal_and_an_unresolvable_name_are_different_states(
+    closed_url,
+) -> None:
+    # Arrange — the whole point of the module in one assertion.
+    refused = reach_verdict(closed_url)
+    # Act
+    unresolved = reach_verdict(UNRESOLVABLE)
+    # Assert
+    assert refused.state != unresolved.state
+
+
+# ---------------------------------------------------------------------------
+# Degenerate input, and the closed enum
+# ---------------------------------------------------------------------------
+
+
+def test_a_url_with_no_host_is_named_rather_than_dialled() -> None:
+    # Arrange
+    url = "not-a-url"
+    # Act
+    verdict = reach_verdict(url)
+    # Assert
+    assert verdict.state == REACH_NO_HOST
+
+
+def test_an_unknown_state_cannot_be_constructed() -> None:
+    # Arrange
+    bogus = "probably-down"
+    # Act
+    construct = ReachVerdict
+    # Assert
+    with pytest.raises(ValueError):
+        construct(url="http://x", state=bogus, detail="")

--- a/tests/scitex_agent_container/config/test__engine_reach.py
+++ b/tests/scitex_agent_container/config/test__engine_reach.py
@@ -65,12 +65,17 @@ def gated_url():
 
 @pytest.fixture
 def closed_url():
-    """A loopback port nothing is listening on — bound, read, then released."""
-    probe = socket.socket()
-    probe.bind(("127.0.0.1", 0))
-    port = probe.getsockname()[1]
-    probe.close()
-    return f"http://127.0.0.1:{port}"
+    """A loopback port nothing is listening on — bound, read, then released.
+
+    The bind is inside a ``with`` so the socket is released even if
+    ``getsockname`` raises, and the fixture ``yield``s rather than returns:
+    a fixture that acquires an external resource and hands it back with
+    ``return`` has no teardown edge at all (STX-TQ005).
+    """
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    yield f"http://127.0.0.1:{port}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/config/test__engine_types.py
+++ b/tests/scitex_agent_container/config/test__engine_types.py
@@ -479,3 +479,90 @@ def test_selecting_the_oauth_engine_keeps_the_account(tmp_path):
     apply_engine(config, select_engine(config.engines, "claude"))
     # Assert
     assert config.claude.account == "acct-a"
+
+
+# ---------------------------------------------------------------------------
+# The engine fold reaches the TOP-LEVEL model surface too
+# ---------------------------------------------------------------------------
+
+# The shape the migration writes, and the one the operator's hand-migrated
+# `business` spec already had: the engines carry the model and
+# `spec.claude.model` states nothing. `_loaders` derives AgentConfig.model
+# and the injected SCITEX_AGENT_CONTAINER_MODEL from that RAW field, so
+# without the fold both fall to the "sonnet" default while the agent runs
+# something else. Measured over the 119-spec corpus: 117 flipped.
+_MIGRATED = {
+    "claude": {"model": "", "provider": None},
+    "engines": {"claude": {"harness": "anthropic", "model": "opus[1m]", "default": True}},
+}
+
+
+def test_the_default_engines_model_becomes_the_top_level_model(tmp_path):
+    # Arrange — `sac agents list` and the tmux runner both read this field.
+    path = _write(tmp_path, "eng-model-surface", _MIGRATED)
+    # Act
+    config = load_config(path)
+    # Assert
+    assert config.model == "opus[1m]"
+
+
+def test_the_default_engines_model_becomes_the_injected_model_env(tmp_path):
+    # Arrange — injected into every container; `sac whoami` prints it.
+    path = _write(tmp_path, "eng-model-env", _MIGRATED)
+    # Act
+    config = load_config(path)
+    # Assert
+    assert config.env["SCITEX_AGENT_CONTAINER_MODEL"] == "Claude Opus (1M)"
+
+
+def test_a_selected_engines_model_becomes_the_top_level_model(tmp_path):
+    # Arrange — the same must hold for `--engine <key>` at start, not only
+    # for the load-time default fold.
+    path = _write(tmp_path, "eng-model-selected", {"engines": _two_engines()})
+    config = load_config(path)
+    # Act
+    apply_engine(config, select_engine(config.engines, "qwen38-27b"))
+    # Assert
+    assert config.model == "qwen38-27b"
+
+
+def test_a_selected_engines_model_becomes_the_injected_model_env(tmp_path):
+    # Arrange
+    path = _write(tmp_path, "eng-env-selected", {"engines": _two_engines()})
+    config = load_config(path)
+    # Act
+    apply_engine(config, select_engine(config.engines, "qwen38-27b"))
+    # Assert
+    assert config.env["SCITEX_AGENT_CONTAINER_MODEL"] == "qwen38-27b"
+
+
+def test_an_engine_stating_no_model_falls_back_to_the_documented_default(tmp_path):
+    # Arrange — the positive control for the fold's own default: "" means
+    # "use the runtime default", which is the same `sonnet` the legacy read
+    # applies, not an empty model string.
+    path = _write(
+        tmp_path,
+        "eng-model-unstated",
+        {"claude": {"model": ""}, "engines": {"solo": {"harness": "anthropic"}}},
+    )
+    # Act
+    config = load_config(path)
+    # Assert
+    assert config.model == "sonnet"
+
+
+def test_an_explicit_env_declaration_still_wins_over_the_fold(tmp_path):
+    # Arrange — the loader's rule is that user values override auto-derived
+    # ones, and refreshing the DERIVED half must not overrule an author.
+    path = _write(
+        tmp_path,
+        "eng-model-env-declared",
+        deep_merge(
+            _MIGRATED,
+            {"apptainer": {"env": {"SCITEX_AGENT_CONTAINER_MODEL": "hand-written"}}},
+        ),
+    )
+    # Act
+    config = load_config(path)
+    # Assert
+    assert config.env["SCITEX_AGENT_CONTAINER_MODEL"] == "hand-written"

--- a/tests/scitex_agent_container/config/test__engines_line.py
+++ b/tests/scitex_agent_container/config/test__engines_line.py
@@ -17,21 +17,20 @@ from __future__ import annotations
 
 import yaml
 
-from scitex_agent_container.config._engine_types import (
-    default_engine,
-    parse_engines,
-    select_engine,
-)
+from scitex_agent_container.config._engine_types import default_engine, parse_engines
 from scitex_agent_container.config._engine_validation import validate_engines
 from scitex_agent_container.config._engines_line import (
     REFUSED_ALREADY_DECLARED,
     migrate_engines_block,
 )
-from scitex_agent_container.config._qwen_gateway import (
-    QWEN_ENGINE_KEY,
-    QWEN_GATEWAY_HOST,
-    QWEN_GATEWAY_PROVIDER,
-)
+from scitex_agent_container.config._harness_types import resolve_spec_harness
+from scitex_agent_container.config._qwen_gateway import QWEN_GATEWAY_HOST
+
+#: The fleet engine library's own key for the gateway engine. Spelled as a
+#: LITERAL here on purpose: the sweep no longer imports it from anywhere, and
+#: a test that re-derived it from the code under test could not notice the
+#: sweep starting to write a copy of that entry again.
+FLEET_QWEN_KEY = "qwen38-27b"
 
 # The 107-spec majority shape: Claude model, no provider override. The two
 # comments are load-bearing for these tests — one introduces a key INSIDE the
@@ -94,6 +93,11 @@ def _engines_of(text: str) -> dict:
     return parse_engines(_spec_of(text))
 
 
+def _raw_entry(text: str, key: str) -> dict:
+    """ONE engine entry as WRITTEN — the raw mapping, before any folding."""
+    return _spec_of(text)["engines"][key]
+
+
 def _comments(text: str) -> "set[str]":
     return {line.strip() for line in text.splitlines() if line.strip().startswith("#")}
 
@@ -103,13 +107,15 @@ def _comments(text: str) -> "set[str]":
 # ---------------------------------------------------------------------------
 
 
-def test_a_claude_backed_spec_gains_both_a_claude_and_a_qwen_engine() -> None:
-    # Arrange
+def test_a_claude_backed_spec_gains_exactly_one_engine() -> None:
+    # Arrange — its OWN backend. The sweep used to append a second, copied
+    # `qwen38-27b` entry to every spec it touched; that definition lives once
+    # in the fleet engine library now.
     text = CLAUDE_SPEC
     # Act
     edit = migrate_engines_block(text)
     # Assert
-    assert edit.engine_keys == ("claude", QWEN_ENGINE_KEY)
+    assert edit.engine_keys == ("claude",)
 
 
 def test_the_default_engine_restates_the_specs_own_model() -> None:
@@ -121,13 +127,25 @@ def test_the_default_engine_restates_the_specs_own_model() -> None:
     assert engines["claude"].model == "opus[1m]"
 
 
-def test_the_default_engine_restates_the_specs_own_harness() -> None:
-    # Arrange
+def test_the_entry_states_no_harness_of_its_own() -> None:
+    # Arrange — an entry that states one claims the HARNESS axis, which is
+    # the coupling the split removes. None means "inherit spec.harness".
     edit = migrate_engines_block(CLAUDE_SPEC)
     # Act
     engines = _engines_of(edit.text)
     # Assert
-    assert engines["claude"].harness == "anthropic"
+    assert engines["claude"].harness is None
+
+
+def test_no_harness_key_is_written_into_the_entry_at_all() -> None:
+    # Arrange — the raw mapping, not the folded EngineSpec: the parser turns
+    # an ABSENT `harness` and a written `harness: null` into the same None,
+    # so only the raw keys can tell "states nothing" from "states null".
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    entry = _raw_entry(edit.text, "claude")
+    # Assert
+    assert "harness" not in entry
 
 
 def test_a_spec_with_no_provider_states_anthropic_rather_than_nothing() -> None:
@@ -140,13 +158,24 @@ def test_a_spec_with_no_provider_states_anthropic_rather_than_nothing() -> None:
     assert engines["claude"].provider_declared == "anthropic"
 
 
-def test_the_claude_entry_is_marked_default() -> None:
-    # Arrange
+def test_the_claude_entry_is_the_one_the_spec_starts_on() -> None:
+    # Arrange — by being the block's ONLY entry, not by carrying a marker.
     edit = migrate_engines_block(CLAUDE_SPEC)
     # Act
     chosen = default_engine(_engines_of(edit.text))
     # Assert
     assert chosen.key == "claude"
+
+
+def test_no_default_key_is_written_into_the_entry() -> None:
+    # Arrange — a spec-local `default:` OUTRANKS the fleet engine library, so
+    # writing one on every swept spec would trade 119 legacy pins for 119
+    # engine pins and leave a fleet-wide flip still a 119-file edit.
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    entry = _raw_entry(edit.text, "claude")
+    # Assert
+    assert "default" not in entry
 
 
 def test_a_local_provider_dict_is_restated_verbatim() -> None:
@@ -176,15 +205,16 @@ def test_a_local_provider_spec_is_keyed_by_its_model_not_by_claude() -> None:
     assert edit.default_key == "qwen36-35b-a3b"
 
 
-def test_a_codex_harness_is_restated_on_the_default_engine() -> None:
-    # Arrange — an engine entry omitting harness defaults to anthropic and
-    # would then hard-error as a legacy conflict against `harness: codex`.
+def test_a_codex_spec_keeps_resolving_to_the_codex_harness() -> None:
+    # Arrange — the entry states no harness, so the axis has to survive on
+    # `spec.harness` alone. Measured through the production resolver, which
+    # is what the runtime reads.
     text = CLAUDE_SPEC.replace("harness: anthropic", "harness: codex")
     edit = migrate_engines_block(text)
     # Act
-    engines = _engines_of(edit.text)
+    harness = resolve_spec_harness(_spec_of(edit.text))
     # Assert
-    assert engines[edit.default_key].harness == "codex"
+    assert harness == "codex"
 
 
 def test_a_codex_harness_spec_is_not_keyed_by_a_vendor_name() -> None:
@@ -209,27 +239,32 @@ def test_a_codex_harness_spec_does_not_claim_the_anthropic_provider() -> None:
     assert engines[edit.default_key].provider_declared is None
 
 
-def test_a_spec_already_running_the_gateway_model_gets_one_engine() -> None:
-    # Arrange — the 8 handymen. Two entries cannot share the alternate's key.
-    text = LOCAL_SPEC.replace("qwen36-35b-a3b", QWEN_ENGINE_KEY)
-    # Act
+def test_a_spec_already_running_the_gateway_model_keeps_its_own_entry() -> None:
+    # Arrange — the 8 handymen reach the gateway over a loopback forward.
+    # Their key collides with the fleet library's, and spec-local wins:
+    # repointing them at the fleet address would be a behaviour change.
+    text = LOCAL_SPEC.replace("qwen36-35b-a3b", FLEET_QWEN_KEY)
     edit = migrate_engines_block(text)
-    # Assert
-    assert edit.engine_keys == (QWEN_ENGINE_KEY,)
-
-
-# ---------------------------------------------------------------------------
-# The gateway address lives in ONE place
-# ---------------------------------------------------------------------------
-
-
-def test_the_qwen_entry_names_the_gateway_by_provider_name() -> None:
-    # Arrange
-    edit = migrate_engines_block(CLAUDE_SPEC)
     # Act
     engines = _engines_of(edit.text)
     # Assert
-    assert engines[QWEN_ENGINE_KEY].provider_declared == QWEN_GATEWAY_PROVIDER
+    assert engines[FLEET_QWEN_KEY].provider.base_url == "http://127.0.0.1:4000"
+
+
+# ---------------------------------------------------------------------------
+# The alternates are NOT copied in — they live in the fleet engine library
+# ---------------------------------------------------------------------------
+
+
+def test_no_fleet_gateway_entry_is_copied_into_the_spec() -> None:
+    # Arrange — 119 identical copies of one row is the shape a library
+    # exists to delete, and a copy stops being the definition the moment
+    # the library's row changes.
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    spec = _spec_of(edit.text)
+    # Assert
+    assert FLEET_QWEN_KEY not in spec["engines"]
 
 
 def test_the_gateway_address_is_not_written_into_the_spec() -> None:
@@ -241,13 +276,14 @@ def test_the_gateway_address_is_not_written_into_the_spec() -> None:
     assert QWEN_GATEWAY_HOST not in edit.text
 
 
-def test_the_qwen_entry_still_resolves_to_an_endpoint() -> None:
-    # Arrange — naming it by reference must not mean naming nothing.
+def test_the_block_names_the_fleet_library_as_where_the_others_live() -> None:
+    # Arrange — a reader who finds ONE engine here must be told where the
+    # rest are, or the block reads as "this agent has no alternatives".
     edit = migrate_engines_block(CLAUDE_SPEC)
     # Act
-    engines = _engines_of(edit.text)
+    text = edit.text
     # Assert
-    assert engines[QWEN_ENGINE_KEY].provider.base_url
+    assert "engines.yaml" in text
 
 
 # ---------------------------------------------------------------------------
@@ -374,31 +410,16 @@ def test_validate_engines_accepts_the_emitted_block() -> None:
     assert errors == []
 
 
-def test_select_engine_can_pick_the_qwen_entry() -> None:
-    # Arrange
-    engines = _engines_of(migrate_engines_block(CLAUDE_SPEC).text)
+def test_the_emitted_block_survives_the_legacy_reconciliation() -> None:
+    # Arrange — `spec.harness` stays stated beside a harness-SILENT entry.
+    # Before the split that pair was a hard load error (the entry's
+    # manufactured "anthropic" versus the spec's own value).
+    text = CLAUDE_SPEC.replace("harness: anthropic", "harness: codex")
+    edit = migrate_engines_block(text)
     # Act
-    picked = select_engine(engines, QWEN_ENGINE_KEY)
+    errors = validate_engines(_spec_of(edit.text))
     # Assert
-    assert picked.model == QWEN_ENGINE_KEY
-
-
-def test_the_qwen_entry_carries_the_measured_context_window() -> None:
-    # Arrange
-    edit = migrate_engines_block(CLAUDE_SPEC)
-    # Act
-    engines = _engines_of(edit.text)
-    # Assert
-    assert engines[QWEN_ENGINE_KEY].max_context_tokens == 1048576
-
-
-def test_the_qwen_entry_runs_at_low_reasoning_effort() -> None:
-    # Arrange
-    edit = migrate_engines_block(CLAUDE_SPEC)
-    # Act
-    engines = _engines_of(edit.text)
-    # Assert
-    assert engines[QWEN_ENGINE_KEY].reasoning_effort == "low"
+    assert errors == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/config/test__engines_line.py
+++ b/tests/scitex_agent_container/config/test__engines_line.py
@@ -25,10 +25,6 @@ from scitex_agent_container.config._engine_types import (
 from scitex_agent_container.config._engine_validation import validate_engines
 from scitex_agent_container.config._engines_line import (
     REFUSED_ALREADY_DECLARED,
-    REFUSED_EMPTY_MODEL,
-    REFUSED_LEGACY_HARNESS_ALIAS,
-    REFUSED_NO_MODEL,
-    REFUSED_PROXY,
     migrate_engines_block,
 )
 from scitex_agent_container.config._qwen_gateway import (
@@ -184,10 +180,33 @@ def test_a_codex_harness_is_restated_on_the_default_engine() -> None:
     # Arrange — an engine entry omitting harness defaults to anthropic and
     # would then hard-error as a legacy conflict against `harness: codex`.
     text = CLAUDE_SPEC.replace("harness: anthropic", "harness: codex")
+    edit = migrate_engines_block(text)
     # Act
-    engines = _engines_of(migrate_engines_block(text).text)
+    engines = _engines_of(edit.text)
     # Assert
-    assert engines["claude"].harness == "codex"
+    assert engines[edit.default_key].harness == "codex"
+
+
+def test_a_codex_harness_spec_is_not_keyed_by_a_vendor_name() -> None:
+    # Arrange — `claude` on a Codex engine is a vendor claim about something
+    # that is not that vendor: the naming failure this axis exists to remove.
+    text = CLAUDE_SPEC.replace("harness: anthropic", "harness: codex")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.default_key == "opus-1m"
+
+
+def test_a_codex_harness_spec_does_not_claim_the_anthropic_provider() -> None:
+    # Arrange — the `anthropic` sentinel is the registry's name for the
+    # Anthropic OAuth backend. Stating it under a Codex entry names the
+    # WRONG vendor, which is worse than stating none.
+    text = CLAUDE_SPEC.replace("harness: anthropic", "harness: codex")
+    edit = migrate_engines_block(text)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines[edit.default_key].provider_declared is None
 
 
 def test_a_spec_already_running_the_gateway_model_gets_one_engine() -> None:
@@ -412,80 +431,3 @@ def test_the_second_run_returns_the_text_byte_identical() -> None:
     twice = migrate_engines_block(once.text)
     # Assert
     assert twice.text == once.text
-
-
-# ---------------------------------------------------------------------------
-# Refusals — named and loud, never a silent skip
-# ---------------------------------------------------------------------------
-
-
-def test_a_spec_stating_no_model_is_refused() -> None:
-    # Arrange — 1 of 119 today, and the shape every fixture default has.
-    text = CLAUDE_SPEC.replace("model: opus[1m]", "model: ''")
-    # Act
-    edit = migrate_engines_block(text)
-    # Assert
-    assert edit.reason == REFUSED_EMPTY_MODEL
-
-
-def test_a_spec_stating_no_model_comes_back_byte_identical() -> None:
-    # Arrange
-    text = CLAUDE_SPEC.replace("model: opus[1m]", "model: ''")
-    # Act
-    edit = migrate_engines_block(text)
-    # Assert
-    assert edit.text == text
-
-
-def test_a_spec_with_no_model_line_at_all_is_refused() -> None:
-    # Arrange
-    text = CLAUDE_SPEC.replace("    model: opus[1m]\n", "")
-    # Act
-    edit = migrate_engines_block(text)
-    # Assert
-    assert edit.reason == REFUSED_NO_MODEL
-
-
-def test_the_deprecated_harness_alias_is_refused_rather_than_guessed() -> None:
-    # Arrange — spec.provider is the retired spelling of spec.harness.
-    text = CLAUDE_SPEC.replace("  harness: anthropic", "  provider: anthropic")
-    # Act
-    edit = migrate_engines_block(text)
-    # Assert
-    assert edit.reason == REFUSED_LEGACY_HARNESS_ALIAS
-
-
-def test_a_proxy_spec_is_refused_because_engines_are_forbidden_there() -> None:
-    # Arrange
-    text = CLAUDE_SPEC.replace("kind: Agent", "kind: AgentProxy")
-    # Act
-    edit = migrate_engines_block(text)
-    # Assert
-    assert edit.reason == REFUSED_PROXY
-
-
-def test_an_unparsable_spec_is_refused_and_not_raised() -> None:
-    # Arrange
-    text = "spec:\n  claude:\n   - [unbalanced\n"
-    # Act
-    edit = migrate_engines_block(text)
-    # Assert
-    assert edit.changed is False
-
-
-def test_a_refusal_always_carries_a_reason() -> None:
-    # Arrange — reason is None exactly when changed is True.
-    text = "not a spec at all\n"
-    # Act
-    edit = migrate_engines_block(text)
-    # Assert
-    assert edit.reason
-
-
-def test_a_successful_edit_carries_no_reason() -> None:
-    # Arrange
-    text = CLAUDE_SPEC
-    # Act
-    edit = migrate_engines_block(text)
-    # Assert
-    assert edit.reason is None

--- a/tests/scitex_agent_container/config/test__engines_line.py
+++ b/tests/scitex_agent_container/config/test__engines_line.py
@@ -1,0 +1,491 @@
+"""``migrate_engines_block`` — the pure spec-text edit behind the sweep.
+
+Pure string in, value out. No mocks, no monkeypatch, no tmp files: the whole
+unit is a function from spec TEXT to spec TEXT, and every fixture below is a
+real v3 spec body written the way the fleet writes them — comments included,
+because the comments are the thing most at risk.
+
+Each shape here was taken from the census of the 119 tracked specs
+(2026-09-06): 107 Claude-backed with a null provider, 11 with an inline
+provider dict pointing at a local endpoint, 1 already carrying an engines
+block, 1 on the codex harness, and the ``model: ''`` shape.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from scitex_agent_container.config._engine_types import (
+    default_engine,
+    parse_engines,
+    select_engine,
+)
+from scitex_agent_container.config._engine_validation import validate_engines
+from scitex_agent_container.config._engines_line import (
+    REFUSED_ALREADY_DECLARED,
+    REFUSED_EMPTY_MODEL,
+    REFUSED_LEGACY_HARNESS_ALIAS,
+    REFUSED_NO_MODEL,
+    REFUSED_PROXY,
+    migrate_engines_block,
+)
+from scitex_agent_container.config._qwen_gateway import (
+    QWEN_ENGINE_KEY,
+    QWEN_GATEWAY_HOST,
+    QWEN_GATEWAY_PROVIDER,
+)
+
+# The 107-spec majority shape: Claude model, no provider override. The two
+# comments are load-bearing for these tests — one introduces a key INSIDE the
+# claude block, one introduces the claude block ITSELF, and an insertion that
+# lands between a comment and the key it explains breaks the second.
+CLAUDE_SPEC = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  name: alpha
+spec:
+  host: scitex-compute-01
+  runtime: tui
+  harness: anthropic
+  apptainer:
+    image: base.sif
+    writable: false
+
+  # PINNED 2026-08-14. Was '' (empty), which let the pool below resolve to
+  # an account that then failed every turn with "Login expired".
+  claude:
+    # MUST match a model_name the router knows EXPLICITLY.
+    model: opus[1m]
+    session: null
+    provider: null
+    account: ''
+"""
+
+_PINNED = "  # PINNED 2026-08-14. Was '' (empty), which let the pool below resolve to"
+
+# The 10-spec local shape: an inline provider dict at a loopback address, with
+# an operator comment above it that must not move.
+LOCAL_SPEC = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  name: capsule
+spec:
+  host: scitex-compute-04
+  runtime: claude-agent-sdk
+  harness: anthropic
+  claude:
+    model: qwen36-35b-a3b
+    session: fresh
+    # 2026-08-22: the forward must be repointed when the node changes.
+    provider:
+      base_url: http://127.0.0.1:4000
+      auth_token_env: CLEW_VLLM_TOKEN
+    account: ''
+"""
+
+_FORWARD = "# 2026-08-22: the forward must be repointed when the node changes."
+
+
+def _spec_of(text: str) -> dict:
+    return yaml.safe_load(text)["spec"]
+
+
+def _engines_of(text: str) -> dict:
+    return parse_engines(_spec_of(text))
+
+
+def _comments(text: str) -> "set[str]":
+    return {line.strip() for line in text.splitlines() if line.strip().startswith("#")}
+
+
+# ---------------------------------------------------------------------------
+# Derivation — one test per shape found in the corpus
+# ---------------------------------------------------------------------------
+
+
+def test_a_claude_backed_spec_gains_both_a_claude_and_a_qwen_engine() -> None:
+    # Arrange
+    text = CLAUDE_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.engine_keys == ("claude", QWEN_ENGINE_KEY)
+
+
+def test_the_default_engine_restates_the_specs_own_model() -> None:
+    # Arrange
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines["claude"].model == "opus[1m]"
+
+
+def test_the_default_engine_restates_the_specs_own_harness() -> None:
+    # Arrange
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines["claude"].harness == "anthropic"
+
+
+def test_a_spec_with_no_provider_states_anthropic_rather_than_nothing() -> None:
+    # Arrange — an unstated provider silently defaults to a vendor; the
+    # registry's own sentinel says the same thing out loud.
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines["claude"].provider_declared == "anthropic"
+
+
+def test_the_claude_entry_is_marked_default() -> None:
+    # Arrange
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    chosen = default_engine(_engines_of(edit.text))
+    # Assert
+    assert chosen.key == "claude"
+
+
+def test_a_local_provider_dict_is_restated_verbatim() -> None:
+    # Arrange — repointing a spec's endpoint would be a behaviour change.
+    edit = migrate_engines_block(LOCAL_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines["qwen36-35b-a3b"].provider.base_url == "http://127.0.0.1:4000"
+
+
+def test_a_local_provider_specs_token_env_is_restated_verbatim() -> None:
+    # Arrange
+    edit = migrate_engines_block(LOCAL_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines["qwen36-35b-a3b"].provider.auth_token_env == "CLEW_VLLM_TOKEN"
+
+
+def test_a_local_provider_spec_is_keyed_by_its_model_not_by_claude() -> None:
+    # Arrange
+    text = LOCAL_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert — "claude" would be a false name for an entry holding Qwen.
+    assert edit.default_key == "qwen36-35b-a3b"
+
+
+def test_a_codex_harness_is_restated_on_the_default_engine() -> None:
+    # Arrange — an engine entry omitting harness defaults to anthropic and
+    # would then hard-error as a legacy conflict against `harness: codex`.
+    text = CLAUDE_SPEC.replace("harness: anthropic", "harness: codex")
+    # Act
+    engines = _engines_of(migrate_engines_block(text).text)
+    # Assert
+    assert engines["claude"].harness == "codex"
+
+
+def test_a_spec_already_running_the_gateway_model_gets_one_engine() -> None:
+    # Arrange — the 8 handymen. Two entries cannot share the alternate's key.
+    text = LOCAL_SPEC.replace("qwen36-35b-a3b", QWEN_ENGINE_KEY)
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.engine_keys == (QWEN_ENGINE_KEY,)
+
+
+# ---------------------------------------------------------------------------
+# The gateway address lives in ONE place
+# ---------------------------------------------------------------------------
+
+
+def test_the_qwen_entry_names_the_gateway_by_provider_name() -> None:
+    # Arrange
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines[QWEN_ENGINE_KEY].provider_declared == QWEN_GATEWAY_PROVIDER
+
+
+def test_the_gateway_address_is_not_written_into_the_spec() -> None:
+    # Arrange — the whole point: one address, not 119 copies of it.
+    text = CLAUDE_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert QWEN_GATEWAY_HOST not in edit.text
+
+
+def test_the_qwen_entry_still_resolves_to_an_endpoint() -> None:
+    # Arrange — naming it by reference must not mean naming nothing.
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines[QWEN_ENGINE_KEY].provider.base_url
+
+
+# ---------------------------------------------------------------------------
+# Comments survive — the operator's rulings are the only record of WHY
+# ---------------------------------------------------------------------------
+
+
+def test_an_operator_comment_survives_the_edit() -> None:
+    # Arrange — a yaml.safe_load + dump round-trip destroys this line.
+    text = CLAUDE_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert _PINNED in edit.text
+
+
+def test_every_comment_in_the_original_survives_the_edit() -> None:
+    # Arrange
+    text = CLAUDE_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert _comments(text) <= _comments(edit.text)
+
+
+def test_a_comment_introducing_the_claude_block_still_precedes_it() -> None:
+    # Arrange — the block must not wedge itself between a comment and its key.
+    lines = migrate_engines_block(CLAUDE_SPEC).text.splitlines()
+    # Act
+    gap = lines.index("  claude:") - lines.index(_PINNED)
+    # Assert
+    assert gap == 2
+
+
+def test_a_comment_inside_the_claude_block_survives_the_emptied_model() -> None:
+    # Arrange
+    text = CLAUDE_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert "    # MUST match a model_name the router knows EXPLICITLY." in edit.text
+
+
+def test_the_comment_above_a_replaced_provider_block_survives() -> None:
+    # Arrange — emptying the provider deletes LINES, the riskiest edit here.
+    text = LOCAL_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert _FORWARD in edit.text
+
+
+def test_every_comment_survives_a_provider_block_replacement() -> None:
+    # Arrange
+    text = LOCAL_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert _comments(text) <= _comments(edit.text)
+
+
+# ---------------------------------------------------------------------------
+# The legacy fields the engines block supersedes
+# ---------------------------------------------------------------------------
+
+
+def test_the_legacy_model_is_emptied() -> None:
+    # Arrange
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    spec = _spec_of(edit.text)
+    # Assert
+    assert spec["claude"]["model"] == ""
+
+
+def test_the_legacy_model_key_is_still_present() -> None:
+    # Arrange — the explicit-spec ruling requires the key to stay written.
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    spec = _spec_of(edit.text)
+    # Assert
+    assert "model" in spec["claude"]
+
+
+def test_a_stated_legacy_provider_is_emptied() -> None:
+    # Arrange
+    edit = migrate_engines_block(LOCAL_SPEC)
+    # Act
+    spec = _spec_of(edit.text)
+    # Assert
+    assert spec["claude"]["provider"] is None
+
+
+def test_the_legacy_provider_key_is_still_present() -> None:
+    # Arrange
+    edit = migrate_engines_block(LOCAL_SPEC)
+    # Act
+    spec = _spec_of(edit.text)
+    # Assert
+    assert "provider" in spec["claude"]
+
+
+def test_the_legacy_harness_is_left_stated() -> None:
+    # Arrange — it AGREES with the default engine, which is the case the
+    # engine axis blesses; emptying it would blind every raw-spec reader.
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    spec = _spec_of(edit.text)
+    # Assert
+    assert spec["harness"] == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# The emitted block goes through the production readers
+# ---------------------------------------------------------------------------
+
+
+def test_validate_engines_accepts_the_emitted_block() -> None:
+    # Arrange
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    errors = validate_engines(_spec_of(edit.text))
+    # Assert
+    assert errors == []
+
+
+def test_select_engine_can_pick_the_qwen_entry() -> None:
+    # Arrange
+    engines = _engines_of(migrate_engines_block(CLAUDE_SPEC).text)
+    # Act
+    picked = select_engine(engines, QWEN_ENGINE_KEY)
+    # Assert
+    assert picked.model == QWEN_ENGINE_KEY
+
+
+def test_the_qwen_entry_carries_the_measured_context_window() -> None:
+    # Arrange
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines[QWEN_ENGINE_KEY].max_context_tokens == 1048576
+
+
+def test_the_qwen_entry_runs_at_low_reasoning_effort() -> None:
+    # Arrange
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines[QWEN_ENGINE_KEY].reasoning_effort == "low"
+
+
+# ---------------------------------------------------------------------------
+# Idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_running_it_twice_produces_no_second_change() -> None:
+    # Arrange
+    once = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    twice = migrate_engines_block(once.text)
+    # Assert
+    assert twice.changed is False
+
+
+def test_the_second_run_names_the_spec_as_already_declaring_engines() -> None:
+    # Arrange
+    once = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    twice = migrate_engines_block(once.text)
+    # Assert
+    assert twice.reason == REFUSED_ALREADY_DECLARED
+
+
+def test_the_second_run_returns_the_text_byte_identical() -> None:
+    # Arrange
+    once = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    twice = migrate_engines_block(once.text)
+    # Assert
+    assert twice.text == once.text
+
+
+# ---------------------------------------------------------------------------
+# Refusals — named and loud, never a silent skip
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_stating_no_model_is_refused() -> None:
+    # Arrange — 1 of 119 today, and the shape every fixture default has.
+    text = CLAUDE_SPEC.replace("model: opus[1m]", "model: ''")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_EMPTY_MODEL
+
+
+def test_a_spec_stating_no_model_comes_back_byte_identical() -> None:
+    # Arrange
+    text = CLAUDE_SPEC.replace("model: opus[1m]", "model: ''")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.text == text
+
+
+def test_a_spec_with_no_model_line_at_all_is_refused() -> None:
+    # Arrange
+    text = CLAUDE_SPEC.replace("    model: opus[1m]\n", "")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_NO_MODEL
+
+
+def test_the_deprecated_harness_alias_is_refused_rather_than_guessed() -> None:
+    # Arrange — spec.provider is the retired spelling of spec.harness.
+    text = CLAUDE_SPEC.replace("  harness: anthropic", "  provider: anthropic")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_LEGACY_HARNESS_ALIAS
+
+
+def test_a_proxy_spec_is_refused_because_engines_are_forbidden_there() -> None:
+    # Arrange
+    text = CLAUDE_SPEC.replace("kind: Agent", "kind: AgentProxy")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_PROXY
+
+
+def test_an_unparsable_spec_is_refused_and_not_raised() -> None:
+    # Arrange
+    text = "spec:\n  claude:\n   - [unbalanced\n"
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.changed is False
+
+
+def test_a_refusal_always_carries_a_reason() -> None:
+    # Arrange — reason is None exactly when changed is True.
+    text = "not a spec at all\n"
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason
+
+
+def test_a_successful_edit_carries_no_reason() -> None:
+    # Arrange
+    text = CLAUDE_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason is None

--- a/tests/scitex_agent_container/config/test__engines_line_verify.py
+++ b/tests/scitex_agent_container/config/test__engines_line_verify.py
@@ -18,6 +18,8 @@ STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import yaml
 
 from scitex_agent_container.config._engine_types import parse_engines
@@ -301,15 +303,29 @@ def test_backend_drift_reports_a_changed_model() -> None:
     assert "model would change" in drift
 
 
-def test_backend_drift_reports_a_changed_harness() -> None:
-    # Arrange
+def test_backend_drift_reports_a_harness_an_entry_states_differently() -> None:
+    # Arrange — the sweep no longer writes `harness:` into an entry, but the
+    # predicate stays total: an entry that DOES claim the axis must at least
+    # claim it correctly. `replace` builds a real EngineSpec, not a mock.
     engine = _engines_of(migrate_engines_block(CLAUDE_SPEC).text)["claude"]
-    old_spec = _spec_of(CLAUDE_SPEC)
-    old_spec["harness"] = "codex"
+    stating_codex = replace(engine, harness="codex")
     # Act
-    drift = _backend_drift(old_spec, engine)
+    drift = _backend_drift(_spec_of(CLAUDE_SPEC), stating_codex)
     # Assert
     assert "harness would change" in drift
+
+
+def test_a_harness_silent_entry_inherits_rather_than_drifting() -> None:
+    # Arrange — a codex spec whose entry deliberately states no harness. A
+    # comparison written against the pre-split dataclass (where `harness`
+    # defaulted to "anthropic") reported drift on EVERY spec the sweep
+    # touched, which is a check that always fires — i.e. no check at all.
+    text = CLAUDE_SPEC.replace("harness: anthropic", "harness: codex")
+    engine = _engines_of(migrate_engines_block(text).text)["opus-1m"]
+    # Act
+    drift = _backend_drift(_spec_of(text), engine)
+    # Assert
+    assert drift == ""
 
 
 def test_backend_drift_reports_a_changed_provider() -> None:

--- a/tests/scitex_agent_container/config/test__engines_line_verify.py
+++ b/tests/scitex_agent_container/config/test__engines_line_verify.py
@@ -1,0 +1,335 @@
+"""The provider block's SHAPE, and the self-check that gates the edit.
+
+Split from ``test__engines_line`` on the module line budget. Same unit, same
+no-mocks rule; these are the cases where the edit must either preserve
+something exactly or REFUSE, and mutation testing found every one of the
+gating mechanisms untested:
+
+* the provider block is copied VERBATIM, which has to be true of nesting and
+  of blank lines, not only of the two keys anyone has written so far;
+* a comment glued to the previous block is that block's trailing note, and
+  the comment-count guard cannot see one that MOVED;
+* ``REFUSED_VERIFY_FAILED`` was produced by no test, so ``_verify`` could be
+  deleted outright with the suite still green; likewise ``_backend_drift``
+  replaced by ``return ""`` and the comment-loss detector by ``return []``.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from scitex_agent_container.config._engine_types import parse_engines
+from scitex_agent_container.config._engines_line import (
+    REFUSED_EMPTY_MODEL,
+    REFUSED_LEGACY_HARNESS_ALIAS,
+    REFUSED_NO_MODEL,
+    REFUSED_PROXY,
+    REFUSED_VERIFY_FAILED,
+    _backend_drift,
+    lost_comment_lines,
+    migrate_engines_block,
+)
+from tests.scitex_agent_container.config.test__engines_line import (
+    _PINNED,
+    CLAUDE_SPEC,
+    LOCAL_SPEC,
+)
+
+
+def _spec_of(text: str) -> dict:
+    return yaml.safe_load(text)["spec"]
+
+
+def _engines_of(text: str) -> dict:
+    return parse_engines(_spec_of(text))
+
+
+# ---------------------------------------------------------------------------
+# Refusals — named and loud, never a silent skip
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_stating_no_model_is_refused() -> None:
+    # Arrange — 1 of 119 today, and the shape every fixture default has.
+    text = CLAUDE_SPEC.replace("model: opus[1m]", "model: ''")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_EMPTY_MODEL
+
+
+def test_a_spec_stating_no_model_comes_back_byte_identical() -> None:
+    # Arrange
+    text = CLAUDE_SPEC.replace("model: opus[1m]", "model: ''")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.text == text
+
+
+def test_a_spec_with_no_model_line_at_all_is_refused() -> None:
+    # Arrange
+    text = CLAUDE_SPEC.replace("    model: opus[1m]\n", "")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_NO_MODEL
+
+
+def test_the_deprecated_harness_alias_is_refused_rather_than_guessed() -> None:
+    # Arrange — spec.provider is the retired spelling of spec.harness.
+    text = CLAUDE_SPEC.replace("  harness: anthropic", "  provider: anthropic")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_LEGACY_HARNESS_ALIAS
+
+
+def test_a_proxy_spec_is_refused_because_engines_are_forbidden_there() -> None:
+    # Arrange
+    text = CLAUDE_SPEC.replace("kind: Agent", "kind: AgentProxy")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_PROXY
+
+
+def test_an_unparsable_spec_is_refused_and_not_raised() -> None:
+    # Arrange
+    text = "spec:\n  claude:\n   - [unbalanced\n"
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.changed is False
+
+
+def test_a_refusal_always_carries_a_reason() -> None:
+    # Arrange — reason is None exactly when changed is True.
+    text = "not a spec at all\n"
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason
+
+
+def test_a_successful_edit_carries_no_reason() -> None:
+    # Arrange
+    text = CLAUDE_SPEC
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason is None
+
+
+# ---------------------------------------------------------------------------
+# The provider block is restated VERBATIM — including its shape
+# ---------------------------------------------------------------------------
+
+# A provider carrying a nested mapping. No spec in the 2026-09-06 corpus has
+# one (surveyed: 11 dict providers, all flat 2-key), so this is the shape the
+# edit must not silently destroy rather than one it meets today.
+NESTED_PROVIDER_SPEC = LOCAL_SPEC.replace(
+    "      base_url: http://127.0.0.1:4000\n",
+    "      base_url: http://127.0.0.1:4000\n"
+    "      extra_headers:\n"
+    "        X-Route: spartan\n"
+    "        X-Tier: gold\n",
+)
+
+BLANK_IN_PROVIDER_SPEC = LOCAL_SPEC.replace(
+    "      base_url: http://127.0.0.1:4000\n",
+    "      base_url: http://127.0.0.1:4000\n\n",
+)
+
+# A comment GLUED to the block above it — its trailing note, not an
+# introduction to `claude:`. Hoisting it below a 20-line engines block makes
+# it a note about the wrong key, and `_comment_counts` compares multisets so
+# a comment that MOVED is invisible to it.
+TRAILING_COMMENT_SPEC = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  name: alpha
+spec:
+  host: scitex-compute-01
+  runtime: tui
+  harness: anthropic
+  apptainer:
+    image: base.sif
+    writable: false
+  # ^ the overlay above is per-agent; never share one (2026-05 ruling)
+  claude:
+    model: opus[1m]
+    session: null
+    provider: null
+    account: ''
+"""
+
+
+def test_a_nested_provider_mapping_is_not_flattened() -> None:
+    # Arrange — stripping every child re-emitted them at ONE indent, so
+    # `extra_headers` became null and its two keys became its siblings.
+    edit = migrate_engines_block(NESTED_PROVIDER_SPEC)
+    # Act
+    engines = yaml.safe_load(edit.text)["spec"]["engines"]
+    # Assert
+    assert engines["qwen36-35b-a3b"]["provider"]["extra_headers"] == {
+        "X-Route": "spartan",
+        "X-Tier": "gold",
+    }
+
+
+def test_a_nested_provider_keeps_its_endpoint() -> None:
+    # Arrange
+    edit = migrate_engines_block(NESTED_PROVIDER_SPEC)
+    # Act
+    engines = _engines_of(edit.text)
+    # Assert
+    assert engines["qwen36-35b-a3b"].provider.base_url == "http://127.0.0.1:4000"
+
+
+def test_a_blank_line_inside_the_provider_block_survives() -> None:
+    # Arrange — "restated verbatim" has to be true of the whitespace too.
+    edit = migrate_engines_block(BLANK_IN_PROVIDER_SPEC)
+    # Act
+    text = edit.text
+    # Assert
+    assert (
+        "        base_url: http://127.0.0.1:4000\n\n        auth_token_env:" in text
+    )
+
+
+def test_a_trailing_comment_is_not_reparented_under_the_engines_block() -> None:
+    # Arrange
+    edit = migrate_engines_block(TRAILING_COMMENT_SPEC)
+    # Act
+    text = edit.text
+    # Assert — it still sits directly under the block it annotates.
+    assert (
+        "    writable: false\n  # ^ the overlay above is per-agent" in text
+    )
+
+
+def test_a_comment_introducing_the_claude_block_still_stays_with_it() -> None:
+    # Arrange — the other half of the same rule: a comment SEPARATED from
+    # what precedes it introduces what follows, and must not be left behind.
+    edit = migrate_engines_block(CLAUDE_SPEC)
+    # Act
+    text = edit.text
+    # Assert
+    assert (
+        f'{_PINNED}\n  # an account that then failed every turn with "Login '
+        f'expired".\n  claude:' in text
+    )
+
+
+# ---------------------------------------------------------------------------
+# The self-check — the mechanisms that decide whether the edit is written
+# ---------------------------------------------------------------------------
+
+
+def test_an_unregistered_provider_name_is_refused_by_the_verification() -> None:
+    # Arrange — REFUSED_VERIFY_FAILED was produced by no test at all, so
+    # `_verify` could be deleted outright with the suite still green.
+    text = CLAUDE_SPEC.replace("provider: null", "provider: ''")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.reason == REFUSED_VERIFY_FAILED
+
+
+def test_a_verification_refusal_writes_nothing() -> None:
+    # Arrange
+    text = CLAUDE_SPEC.replace("provider: null", "provider: ''")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.text == text
+
+
+def test_a_verification_refusal_names_what_failed() -> None:
+    # Arrange
+    text = CLAUDE_SPEC.replace("provider: null", "provider: ''")
+    # Act
+    edit = migrate_engines_block(text)
+    # Assert
+    assert edit.detail
+
+
+def test_lost_comment_lines_reports_a_deleted_comment() -> None:
+    # Arrange — the guard that makes "comments survive" a per-spec check
+    # rather than an argument made once in a docstring.
+    before = "# PINNED 2026-08-14\nmodel: opus\n"
+    after = "model: opus\n"
+    # Act
+    lost = lost_comment_lines(before, after)
+    # Assert
+    assert lost == ["# PINNED 2026-08-14"]
+
+
+def test_lost_comment_lines_reports_nothing_when_all_survive() -> None:
+    # Arrange
+    before = "# PINNED\nmodel: opus\n"
+    after = "engines:\n# PINNED\nmodel: ''\n"
+    # Act
+    lost = lost_comment_lines(before, after)
+    # Assert
+    assert lost == []
+
+
+def test_lost_comment_lines_counts_duplicates() -> None:
+    # Arrange — a multiset, so losing one of two identical comments counts.
+    before = "# note\n# note\n"
+    after = "# note\n"
+    # Act
+    lost = lost_comment_lines(before, after)
+    # Assert
+    assert lost == ["# note"]
+
+
+def test_backend_drift_reports_a_changed_model() -> None:
+    # Arrange — the one property that makes the sweep safe over 119 files,
+    # and it survived being replaced by `return ""`.
+    engine = _engines_of(migrate_engines_block(CLAUDE_SPEC).text)["claude"]
+    old_spec = _spec_of(CLAUDE_SPEC)
+    old_spec["claude"]["model"] = "haiku"
+    # Act
+    drift = _backend_drift(old_spec, engine)
+    # Assert
+    assert "model would change" in drift
+
+
+def test_backend_drift_reports_a_changed_harness() -> None:
+    # Arrange
+    engine = _engines_of(migrate_engines_block(CLAUDE_SPEC).text)["claude"]
+    old_spec = _spec_of(CLAUDE_SPEC)
+    old_spec["harness"] = "codex"
+    # Act
+    drift = _backend_drift(old_spec, engine)
+    # Assert
+    assert "harness would change" in drift
+
+
+def test_backend_drift_reports_a_changed_provider() -> None:
+    # Arrange
+    engine = _engines_of(migrate_engines_block(CLAUDE_SPEC).text)["claude"]
+    old_spec = _spec_of(CLAUDE_SPEC)
+    old_spec["claude"]["provider"] = {
+        "base_url": "http://127.0.0.1:9",
+        "auth_token_env": "TOKEN",
+    }
+    # Act
+    drift = _backend_drift(old_spec, engine)
+    # Assert
+    assert "provider would change" in drift
+
+
+def test_backend_drift_is_silent_when_the_backend_is_restated() -> None:
+    # Arrange — the positive control: a check that always fires is no check.
+    engine = _engines_of(migrate_engines_block(CLAUDE_SPEC).text)["claude"]
+    # Act
+    drift = _backend_drift(_spec_of(CLAUDE_SPEC), engine)
+    # Assert
+    assert drift == ""

--- a/tests/scitex_agent_container/config/test__qwen_gateway.py
+++ b/tests/scitex_agent_container/config/test__qwen_gateway.py
@@ -1,0 +1,140 @@
+"""The fleet Qwen gateway address — one home, resolved not frozen.
+
+The migration writes ``provider: qwen-gateway`` into every spec instead of an
+address, so these pin the two properties that makes that safe: the name is
+REGISTERED (an unregistered one refuses at start), and the address is resolved
+through :func:`resolve_provider` at call time so a per-host override works.
+
+No mocks. The environment is a real seam, saved and restored around each test
+so no other test — or the operator's shell — is disturbed.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from scitex_agent_container.config._provider_registry import (
+    list_providers,
+    resolve_provider,
+)
+from scitex_agent_container.config._qwen_gateway import (
+    DEFAULT_QWEN_GATEWAY_TOKEN_ENV,
+    DEFAULT_QWEN_GATEWAY_URL,
+    QWEN_GATEWAY_HOST,
+    QWEN_GATEWAY_PROVIDER,
+    QWEN_GATEWAY_TOKEN_ENV_ENV,
+    QWEN_GATEWAY_URL_ENV,
+    qwen_gateway_token_env,
+    qwen_gateway_url,
+)
+
+
+@pytest.fixture
+def clean_env():
+    """Both override variables removed, and restored afterwards."""
+    keys = (QWEN_GATEWAY_URL_ENV, QWEN_GATEWAY_TOKEN_ENV_ENV)
+    saved = {k: os.environ.get(k) for k in keys}
+    for key in keys:
+        os.environ.pop(key, None)
+    try:
+        yield os.environ
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def test_the_gateway_is_a_registered_provider_name() -> None:
+    # Arrange
+    names = list_providers()
+    # Act
+    registered = QWEN_GATEWAY_PROVIDER in names
+    # Assert
+    assert registered is True
+
+
+def test_the_default_address_uses_the_spelling_that_resolves(clean_env) -> None:
+    # Arrange — compute-04 and compute-04-lan both answer 000; this one 401.
+    expected = QWEN_GATEWAY_HOST
+    # Act
+    url = qwen_gateway_url()
+    # Assert
+    assert expected in url
+
+
+def test_the_default_address_is_the_measured_one(clean_env) -> None:
+    # Arrange
+    expected = DEFAULT_QWEN_GATEWAY_URL
+    # Act
+    url = qwen_gateway_url()
+    # Assert
+    assert url == expected
+
+
+def test_resolve_provider_returns_the_gateway_address(clean_env) -> None:
+    # Arrange
+    expected = DEFAULT_QWEN_GATEWAY_URL
+    # Act
+    entry = resolve_provider(QWEN_GATEWAY_PROVIDER)
+    # Assert
+    assert entry["base_url"] == expected
+
+
+def test_resolve_provider_names_the_key_env_var_not_the_key(clean_env) -> None:
+    # Arrange
+    expected = DEFAULT_QWEN_GATEWAY_TOKEN_ENV
+    # Act
+    entry = resolve_provider(QWEN_GATEWAY_PROVIDER)
+    # Assert
+    assert entry["auth_token_env"] == expected
+
+
+def test_a_host_override_wins_over_the_default(clean_env) -> None:
+    # Arrange
+    clean_env[QWEN_GATEWAY_URL_ENV] = "http://100.64.0.1:18772"
+    # Act
+    url = qwen_gateway_url()
+    # Assert
+    assert url == "http://100.64.0.1:18772"
+
+
+def test_the_override_reaches_resolve_provider(clean_env) -> None:
+    # Arrange — a frozen module constant would ignore an export made later.
+    clean_env[QWEN_GATEWAY_URL_ENV] = "http://100.64.0.1:18772"
+    # Act
+    entry = resolve_provider(QWEN_GATEWAY_PROVIDER)
+    # Assert
+    assert entry["base_url"] == "http://100.64.0.1:18772"
+
+
+def test_a_blank_override_is_treated_as_unset(clean_env) -> None:
+    # Arrange — an exported-but-empty variable is how a shell says nothing.
+    clean_env[QWEN_GATEWAY_URL_ENV] = "   "
+    # Act
+    url = qwen_gateway_url()
+    # Assert
+    assert url == DEFAULT_QWEN_GATEWAY_URL
+
+
+def test_the_token_env_name_is_overridable_too(clean_env) -> None:
+    # Arrange — handyman-08 names a different variable than its siblings.
+    clean_env[QWEN_GATEWAY_TOKEN_ENV_ENV] = "SAC_LOCAL_GPTOSS_KEY"
+    # Act
+    name = qwen_gateway_token_env()
+    # Assert
+    assert name == "SAC_LOCAL_GPTOSS_KEY"
+
+
+def test_an_unregistered_provider_still_resolves_to_nothing() -> None:
+    # Arrange — the dynamic entry must not make every name resolvable.
+    unknown = "no-such-gateway"
+    # Act
+    entry = resolve_provider(unknown)
+    # Assert
+    assert entry is None

--- a/tests/scitex_agent_container/config/test__qwen_gateway.py
+++ b/tests/scitex_agent_container/config/test__qwen_gateway.py
@@ -25,9 +25,11 @@ from scitex_agent_container.config._qwen_gateway import (
     DEFAULT_QWEN_GATEWAY_TOKEN_ENV,
     DEFAULT_QWEN_GATEWAY_URL,
     QWEN_GATEWAY_HOST,
+    QWEN_GATEWAY_PROBE_PATH,
     QWEN_GATEWAY_PROVIDER,
     QWEN_GATEWAY_TOKEN_ENV_ENV,
     QWEN_GATEWAY_URL_ENV,
+    qwen_gateway_probe_url,
     qwen_gateway_token_env,
     qwen_gateway_url,
 )
@@ -138,3 +140,56 @@ def test_an_unregistered_provider_still_resolves_to_nothing() -> None:
     entry = resolve_provider(unknown)
     # Assert
     assert entry is None
+
+
+# ---------------------------------------------------------------------------
+# The PROBE address is not the base — measured 2026-09-06:
+#     /            404   listening, but this path does not exist
+#     /v1/models   401   REACHABLE + AUTH-GATED
+# ---------------------------------------------------------------------------
+
+
+def test_the_probe_path_is_the_models_endpoint() -> None:
+    # Arrange — not /health: a 200 there is a gate that cannot fail.
+    path = QWEN_GATEWAY_PROBE_PATH
+    # Act
+    chosen = path
+    # Assert
+    assert chosen == "/v1/models"
+
+
+def test_the_probe_url_is_the_default_base_plus_the_path(clean_env) -> None:
+    # Arrange
+    _ = clean_env
+    # Act
+    url = qwen_gateway_probe_url()
+    # Assert
+    assert url == f"{DEFAULT_QWEN_GATEWAY_URL}/v1/models"
+
+
+def test_the_probe_url_honours_the_address_override(clean_env) -> None:
+    # Arrange — a peer reaching the gateway by another route probes THAT one.
+    clean_env[QWEN_GATEWAY_URL_ENV] = "http://100.64.0.1:18772"
+    # Act
+    url = qwen_gateway_probe_url()
+    # Assert
+    assert url == "http://100.64.0.1:18772/v1/models"
+
+
+def test_a_trailing_slash_does_not_double_up(clean_env) -> None:
+    # Arrange — a shell export with a trailing slash is ordinary.
+    clean_env[QWEN_GATEWAY_URL_ENV] = "http://100.64.0.1:18772/"
+    # Act
+    url = qwen_gateway_probe_url()
+    # Assert
+    assert url == "http://100.64.0.1:18772/v1/models"
+
+
+def test_a_base_carrying_a_path_prefix_keeps_it(clean_env) -> None:
+    # Arrange — a reverse proxy mounting the gateway under a prefix. urljoin
+    # would DISCARD the prefix and probe the wrong place.
+    clean_env[QWEN_GATEWAY_URL_ENV] = "http://proxy.example:8443/qwen"
+    # Act
+    url = qwen_gateway_probe_url()
+    # Assert
+    assert url == "http://proxy.example:8443/qwen/v1/models"

--- a/tests/scitex_agent_container/config/test__yaml_line_edit.py
+++ b/tests/scitex_agent_container/config/test__yaml_line_edit.py
@@ -15,6 +15,9 @@ from scitex_agent_container.config._yaml_line_edit import (
     find_block,
     find_key,
     insert_after,
+    is_skippable,
+    last_content_line,
+    parse_key_line,
     split_ending,
 )
 
@@ -148,3 +151,139 @@ def test_an_unterminated_anchor_gains_a_terminator() -> None:
     insert_after(lines, 2, "    ", "host", "127.0.0.1")
     # Assert
     assert "".join(lines).endswith("    port: auto\n    host: 127.0.0.1\n")
+
+
+# ---------------------------------------------------------------------------
+# parse_key_line — the ONE regex a value-reader is allowed to use
+# ---------------------------------------------------------------------------
+
+
+def test_parse_key_line_returns_the_value() -> None:
+    # Arrange
+    body = "    model: opus[1m]"
+    # Act
+    parsed = parse_key_line(body)
+    # Assert
+    assert parsed.value == "opus[1m]"
+
+
+def test_parse_key_line_returns_the_key() -> None:
+    # Arrange
+    body = "    model: opus[1m]"
+    # Act
+    parsed = parse_key_line(body)
+    # Assert
+    assert parsed.key == "model"
+
+
+def test_parse_key_line_returns_the_indent() -> None:
+    # Arrange
+    body = "    model: opus[1m]"
+    # Act
+    parsed = parse_key_line(body)
+    # Assert
+    assert parsed.indent == "    "
+
+
+def test_parse_key_line_reports_a_block_key_as_an_empty_value() -> None:
+    # Arrange — "" is what tells a caller this key opens a block.
+    body = "  claude:"
+    # Act
+    parsed = parse_key_line(body)
+    # Assert
+    assert parsed.value == ""
+
+
+def test_parse_key_line_refuses_a_sequence_item() -> None:
+    # Arrange — an unfamiliar shape must become a refusal, not a guess.
+    body = "  - command: run"
+    # Act
+    parsed = parse_key_line(body)
+    # Assert
+    assert parsed is None
+
+
+def test_parse_key_line_refuses_a_comment() -> None:
+    # Arrange
+    body = "  # model: opus[1m]"
+    # Act
+    parsed = parse_key_line(body)
+    # Assert
+    assert parsed is None
+
+
+# ---------------------------------------------------------------------------
+# last_content_line — where a multi-line replacement must STOP
+# ---------------------------------------------------------------------------
+
+_BLOCK = """\
+spec:
+  provider:
+    base_url: http://127.0.0.1:4000
+    auth_token_env: TOKEN
+
+  # the account below is pinned deliberately
+  account: ''
+"""
+
+
+def test_last_content_line_finds_the_final_child() -> None:
+    # Arrange — the block's `stop` is the next SIBLING key, so replacing
+    # through it would eat the blank and comment introducing that sibling.
+    bodies = _bodies(_BLOCK)
+    block = find_block(bodies, ("spec", "provider"))
+    # Act
+    end = last_content_line(bodies, block.start, block.stop)
+    # Assert
+    assert bodies[end] == "    auth_token_env: TOKEN"
+
+
+def test_last_content_line_stops_before_the_next_keys_comment() -> None:
+    # Arrange — this is the riskiest span computation in the engines edit.
+    bodies = _bodies(_BLOCK)
+    block = find_block(bodies, ("spec", "provider"))
+    # Act
+    end = last_content_line(bodies, block.start, block.stop)
+    # Assert
+    assert "# the account below" not in "".join(bodies[block.start : end + 1])
+
+
+def test_last_content_line_is_none_when_the_range_is_all_skippable() -> None:
+    # Arrange
+    bodies = ["", "  # nothing but a note", "   "]
+    # Act
+    end = last_content_line(bodies, 0, 3)
+    # Assert
+    assert end is None
+
+
+# ---------------------------------------------------------------------------
+# is_skippable — "does this line carry structure?", asked once
+# ---------------------------------------------------------------------------
+
+
+def test_a_blank_line_is_skippable() -> None:
+    # Arrange
+    body = "   "
+    # Act
+    answer = is_skippable(body)
+    # Assert
+    assert answer is True
+
+
+def test_a_comment_line_is_skippable() -> None:
+    # Arrange
+    body = "  # PINNED 2026-08-14"
+    # Act
+    answer = is_skippable(body)
+    # Assert
+    assert answer is True
+
+
+def test_a_key_line_is_not_skippable() -> None:
+    # Arrange
+    body = "  claude:"
+    # Act
+    answer = is_skippable(body)
+    # Assert
+    assert answer is False


### PR DESCRIPTION
feat(engines): sac agents migrate-engines — write HARNESS x ENGINE into every spec

Closes the gap between #1314's harness/engine grammar and the 119 specs still
carrying the legacy single-backend block.

## What it does

`sac agents migrate-engines` sweeps a spec roster and writes an `engines:` block
per spec. Dry-run is the DEFAULT; `--apply` is required to write anything.

- `-a/--agent NAME` restricts to named agents — the smallest reviewable batch
- `--host HOST` restricts by placement
- `--limit N` caps writes per run; already-migrated and refused specs do NOT
  consume the cap, so repeating the command advances rather than stalling
- `--diff` (on by default) prints a unified diff per spec
- `--preflight` probes the Qwen gateway and reports a NAMED state
- `--json` for machine consumption; `migration_complete` is the "is it finished"
  answer, not the exit code

## A REVIEWER MUST READ THIS BEFORE THE DOC DIFF

**This branch edits lines #1314 itself just added, and that is deliberate — not an
accidental revert.** #1314 appended DEPRECATED `harness` and `default` rows BESIDE
the pre-existing rows in the entry-field table, so after the merge the table listed
each key twice with contradictory text. The merge collapses each to one row, taking
develop's deprecation as the headline and folding the older factual constraints in.
The commit message says so explicitly; it is repeated here because a reviewer
scanning the diff will otherwise see develop's new lines being modified.

## Safety, and why the refusals are the interesting part

**Version floor.** A pre-#1314 sac REJECTS an `engines:` block outright — measured
by extracting the parent of the split commit and running its validator over a real
spec: 0 errors with the block stripped, 1 error with it (`Unknown spec field
'engines'`). The zero-error control is what makes that conclusive. So the sweep
REFUSES specs pinned to hosts whose sac cannot parse what it would write, and it
FAILS CLOSED: a host absent from the measured roster is UNKNOWN and therefore
refused, as is a spec naming no host, an unreadable host, and `${HOSTNAME}`.
`--host-supports-engines HOST` lifts it per-host, on purpose — a blunt global bypass
gets typed by habit.

**Fleet census, read-only, proven:** 113 specs (119 minus 6 templates) — 100 would
migrate, 1 already migrated, 12 refused (9 × spartan predates engines, 3 ×
compute-02 has no located install). Nothing was written: SHA-256 over every file's
bytes plus the path list is identical before and after
(`files=243 sha256=3f8c07f1…c89b26a5`).

**One judgement worth overruling if you disagree:** compute-02's 3 specs are refused
on "no sac install located", not on a measured old version. If sac reaches that host
some other way, the honest fix is to measure it and add a roster row — not to pass
`--host-supports-engines scitex-compute-02`, which asserts a capability nobody
checked.

## Verification

Each fix proven load-bearing by reverting it and watching the suite go red:

| reverted | result |
|---|---|
| floor not consulted | 22 failed |
| preflight dials the base path | 3 failed |
| 404 folded back into "listening" | 4 failed |
| default root → `fleet_agents_dir()` | 4 failed |
| by-name de-duplication removed | 2 failed |

The de-dup needed its own revert: the "one root" revert leaves nothing to
de-duplicate, so those two tests were not red under it.

Suite on the merged tree: `6 failed, 16617 passed, 2416 skipped`. One failure was a
pre-existing guard (`test_no_new_unnamed_delivery_claim`), proven pre-existing by
byte-identity to the branch tip and fixed in its own commit; the rest are
environmental.

**VANTAGE CAVEAT — do not read the green as proof.** 2416 skipped, overwhelmingly
PostgreSQL-backed tests refusing this host's read-only replica. Confirm on CI
against the MERGE commit `ce4ee4b6`, not the branch tip — they differ precisely in
`_engine_types.py`.

## Follow-ups, named rather than implied

- the fleet `engines.yaml` resolution: develop reads `$SAC_ENGINES_FILE` else
  `$SCITEX_DIR/agent-container/engines.yaml`, and BOTH are unset on compute-04
- version-floor re-measurement against develop's tree rather than the merge-base
- the floor currently certifies `engines:` tolerance only; if a follow-up teaches the
  sweep to write an `engine:` pin, the predicate must widen to cover that key too

## Post-#1314 adaptation (the second half of this branch)

`origin/develop`'s harness/engine split is merged in (`ce4ee4b6`), and the sweep's
WRITE side was then retargeted to its grammar (`9379b095`). Before that commit the
sweep emitted the pre-split shape; the merge commit's docs said so explicitly, in a
paragraph this commit DELETES because it is no longer true.

What the emitted block looks like now, measured from a dry run over the five app
specs rather than read off the code:

```yaml
  engines:
    claude:
      model: opus[1m]
      provider: anthropic
```

Counted in that output: `default: true` **0**, per-entry `harness:` **0**,
`reasoning_effort` **0**, copied qwen entry **0** — and, as the control that makes
those zeros mean something, `engines:` blocks written **5**. A sweep that emitted
nothing would also score zero on the first four.

`qwen38-27b` now lives ONCE in a tracked fleet engine library instead of being copied
into 119 specs. `EngineEntry` lost `harness`, `is_default`, `reasoning_effort` and
`max_context_tokens`: with the qwen entry gone nothing populates them, and a renderer
that can hold a field is a renderer that can write it.

## The SSoT question this PR does not answer

The library is placed at `.scitex/agent-container/engines.yaml` **in this repo**, and
two docstrings that had named `~/.dotfiles/src/.scitex/...` as the source of truth
were corrected to match. That is a real change of claimed SSoT, and the standing rule
is that agent specs live in dotfiles with `~/.scitex` as a synced copy.

**If dotfiles should remain the SSoT for the library too, this placement needs
reversing before anything deploys.** Flagging rather than deciding — two claimed
sources of truth is exactly the drift the library exists to remove.

## Ordering constraint for whoever deploys this

`engine: <key>` naming a key no library declares RAISES `UnknownEngineError`
(`config/_engine_types.py:313,321`, `config/_engine_precedence.py:102`) — it does not
fall back. Measured on compute-04: `~/.scitex/agent-container/engines.yaml` is absent
and both `$SAC_ENGINES_FILE` and `$SCITEX_DIR` are unset. So the library must land at
the resolved path BEFORE any spec pins a key from it. Pinning first fails those
agents at load.

A missing library is otherwise legal and silent: every spec resolves exactly as it
did before.

## Base note

This branch predates `d842ce9b` (the brokered-start fix, merged to develop after this
work began). No conflict is expected — that change is confined to `_listen/` and this
one to `config/`, `_maintenance/` and `cli_pkg/` — but the base has moved and CI will
judge the merge commit, not the branch tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaiWJHYdhALg2wB4hRNft1
