### PR TITLE
fix(ci): cannot-read-protection must refuse, not report CLEAN

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_ci_blocked.py
+++ b/src/scitex_agent_container/cli_pkg/_ci_blocked.py
@@ -161,6 +161,37 @@ class PRGate:
         }
 
 
+def _protection_payload_is_error(payload: dict) -> bool:
+    """True when GitHub answered with an ERROR OBJECT, not a protection body.
+
+    ``gh api`` prints a 404/403 body to STDOUT and exits non-zero, and
+    :func:`run_gh` deliberately returns stdout whenever it is non-empty (so
+    that ``gh pr checks`` can fail loudly and still hand back its JSON). The
+    consequence for THIS call is that an unreadable branch never raises: the
+    error body parses as valid JSON, carries no ``contexts``/``checks``, and
+    an unguarded reader turns it into an empty required-list — i.e. "clean".
+    """
+    if not isinstance(payload, dict):
+        return False
+    if "contexts" in payload or "checks" in payload:
+        return False
+    return "message" in payload
+
+
+def _branch_is_simply_unprotected(payload: dict) -> bool:
+    """True for the ONE error that is a real answer: no protection exists.
+
+    An unprotected branch requires nothing, so an empty list is the correct
+    verdict and no silent block is possible. GitHub says this with 404 and a
+    ``Branch not protected`` message. Every OTHER error — 403 (no rights to
+    read protection), a renamed branch, a network failure — means we could not
+    look, which is not the same fact and must never render as clean.
+    """
+    msg = str(payload.get("message") or "").lower()
+    status = str(payload.get("status") or "")
+    return status in ("", "404") and "not protected" in msg
+
+
 def required_contexts(
     branch: str, *, run_gh: GhRunner = run_gh, repo: Optional[str] = None
 ) -> list[str]:
@@ -169,21 +200,43 @@ def required_contexts(
     This is the half of the comparison that cannot be derived from the PR: it
     says what SHOULD report. An unprotected branch requires nothing, which is a
     real answer (no possible silent block), not an error.
+
+    COULD-NOT-READ IS NOT THE SAME ANSWER AS NOTHING-IS-REQUIRED, and this
+    function used to return ``[]`` for both. That is the whole bug: with an
+    empty required-list no context can be ``NEVER_STARTED``, so
+    :attr:`PRGate.silently_blocked` is False and the PR reads as CLEAN --
+    exactly the claim the old comment here said must never be made.
+
+    It also defeated a CORRECT guard one layer up: ``sac ci blocked`` already
+    catches :class:`CIWhyError` with "UNKNOWN is not green: never degrade into
+    'nothing blocked'". Swallowing the error here meant that guard could not
+    fire for this path -- a gate made unreachable by a well-meant except.
+    So this function now RAISES, and lets the existing guard do its job.
+
+    (Reported by scitex-ui, 2026-09-06, from the third of three
+    generalisations they drew after getting their own merge gate wrong four
+    times: separate CANNOT-TELL from NOT-GREEN in the output.)
     """
     owner_repo = repo if repo else "{owner}/{repo}"
     path = f"repos/{owner_repo}/branches/{branch}/protection/required_status_checks"
-    try:
-        raw = run_gh(["api", path])
-    except CIWhyError:
-        # No protection, or no admin rights to read it. Either way this tool
-        # cannot judge the branch — and must not claim it is clean.
-        return []
+    raw = run_gh(["api", path])
     try:
         payload = json.loads(raw or "{}")
     except ValueError as exc:
         raise CIWhyError(
             f"could not parse branch-protection JSON for {branch}"
         ) from exc
+
+    if _protection_payload_is_error(payload):
+        if _branch_is_simply_unprotected(payload):
+            return []
+        raise CIWhyError(
+            f"could not read branch protection for {branch}: "
+            f"{payload.get('message')!r}. This is NOT a verdict -- the branch "
+            f"may still have required checks that never started. Check `gh "
+            f"auth status` and that the token can read branch protection on "
+            f"this repo."
+        )
 
     names: list[str] = []
     for c in payload.get("contexts") or []:

--- a/tests/scitex_agent_container/cli_pkg/test__ci_blocked.py
+++ b/tests/scitex_agent_container/cli_pkg/test__ci_blocked.py
@@ -19,6 +19,7 @@ use) stands in for the network. AAA, one assertion per test.
 from __future__ import annotations
 
 import json
+from functools import partial
 
 import pytest
 
@@ -314,11 +315,11 @@ def test_unreadable_protection_raises_rather_than_reading_clean():
     gh = _gh([_pr([])], protection_body=UNREADABLE_BODY)
 
     # Act
-    with pytest.raises(CIWhyError) as excinfo:
-        audit_blocked(run_gh=gh)
+    audit = partial(audit_blocked, run_gh=gh)
 
     # Assert
-    assert "could not read branch protection" in str(excinfo.value)
+    with pytest.raises(CIWhyError, match="could not read branch protection"):
+        audit()
 
 
 def test_a_hard_protection_failure_propagates_rather_than_reading_clean():
@@ -330,11 +331,11 @@ def test_a_hard_protection_failure_propagates_rather_than_reading_clean():
     gh = _gh([_pr([])], protection_raises=True)
 
     # Act
-    with pytest.raises(CIWhyError) as excinfo:
-        audit_blocked(run_gh=gh)
+    audit = partial(audit_blocked, run_gh=gh)
 
     # Assert
-    assert excinfo.value is not None
+    with pytest.raises(CIWhyError):
+        audit()
 
 
 def test_base_filter_selects_only_matching_prs():

--- a/tests/scitex_agent_container/cli_pkg/test__ci_blocked.py
+++ b/tests/scitex_agent_container/cli_pkg/test__ci_blocked.py
@@ -62,8 +62,15 @@ def _pr(
     }
 
 
-def _gh(prs, contexts=REQUIRED, protection_raises=False):
-    """A gh seam answering both `pr list` and the branch-protection API."""
+def _gh(prs, contexts=REQUIRED, protection_raises=False, protection_body=None):
+    """A gh seam answering both `pr list` and the branch-protection API.
+
+    ``protection_body`` models the case that actually happens in production and
+    that ``protection_raises`` does NOT: ``gh api`` prints a 404/403 error body
+    to STDOUT and exits non-zero, and ``run_gh`` returns stdout whenever it is
+    non-empty. So an unreadable branch arrives here as parseable JSON, not as
+    an exception.
+    """
 
     def _router(argv: list[str]) -> str:
         if argv and argv[0] == "pr":
@@ -71,6 +78,8 @@ def _gh(prs, contexts=REQUIRED, protection_raises=False):
         if argv and argv[0] == "api":
             if protection_raises:
                 raise CIWhyError("404 Not Found")
+            if protection_body is not None:
+                return json.dumps(protection_body)
             return json.dumps({"strict": False, "contexts": contexts})
         raise AssertionError(f"unexpected gh call: {argv}")
 
@@ -279,15 +288,47 @@ def test_required_contexts_also_reads_the_newer_checks_form():
     assert names == ["c1"]
 
 
+UNPROTECTED_BODY = {"message": "Branch not protected", "status": "404"}
+UNREADABLE_BODY = {"message": "Resource not accessible by integration", "status": "403"}
+
+
 def test_an_unprotected_base_requires_nothing_and_is_not_flagged():
-    # Arrange — no protection to read: no required name can be missing.
-    gh = _gh([_pr([])], protection_raises=True)
+    # Arrange — GitHub's real "no protection" answer: a 404 BODY on stdout.
+    gh = _gh([_pr([])], protection_body=UNPROTECTED_BODY)
 
     # Act
     gates = audit_blocked(run_gh=gh)
 
     # Assert
     assert gates[0].silently_blocked is False
+
+
+def test_unreadable_protection_raises_rather_than_reading_clean():
+    """THE BUG. A 403 body parsed as data yielded [] -> nothing required ->
+    nothing can be NEVER_STARTED -> `silently_blocked` False -> CLEAN.
+
+    Not-permitted-to-look is not the same fact as nothing-is-required, and only
+    one of them is a verdict.
+    """
+    # Arrange
+    gh = _gh([_pr([])], protection_body=UNREADABLE_BODY)
+
+    # Act / Assert
+    with pytest.raises(CIWhyError, match="could not read branch protection"):
+        audit_blocked(run_gh=gh)
+
+
+def test_a_hard_protection_failure_propagates_rather_than_reading_clean():
+    """The sibling route to the same wrong verdict: `run_gh` raising was
+    swallowed here, which also defeated the CORRECT guard in `sac ci blocked`
+    ("UNKNOWN is not green"). That guard could not fire for this path.
+    """
+    # Arrange
+    gh = _gh([_pr([])], protection_raises=True)
+
+    # Act / Assert
+    with pytest.raises(CIWhyError):
+        audit_blocked(run_gh=gh)
 
 
 def test_base_filter_selects_only_matching_prs():

--- a/tests/scitex_agent_container/cli_pkg/test__ci_blocked.py
+++ b/tests/scitex_agent_container/cli_pkg/test__ci_blocked.py
@@ -313,9 +313,12 @@ def test_unreadable_protection_raises_rather_than_reading_clean():
     # Arrange
     gh = _gh([_pr([])], protection_body=UNREADABLE_BODY)
 
-    # Act / Assert
-    with pytest.raises(CIWhyError, match="could not read branch protection"):
+    # Act
+    with pytest.raises(CIWhyError) as excinfo:
         audit_blocked(run_gh=gh)
+
+    # Assert
+    assert "could not read branch protection" in str(excinfo.value)
 
 
 def test_a_hard_protection_failure_propagates_rather_than_reading_clean():
@@ -326,9 +329,12 @@ def test_a_hard_protection_failure_propagates_rather_than_reading_clean():
     # Arrange
     gh = _gh([_pr([])], protection_raises=True)
 
-    # Act / Assert
-    with pytest.raises(CIWhyError):
+    # Act
+    with pytest.raises(CIWhyError) as excinfo:
         audit_blocked(run_gh=gh)
+
+    # Assert
+    assert excinfo.value is not None
 
 
 def test_base_filter_selects_only_matching_prs():


### PR DESCRIPTION
## The bug

`sac ci blocked` judges a PR against the **required-context names** from branch
protection. When that protection read failed, `required_contexts()` returned
`[]` — and with an empty required-list no context can be `NEVER_STARTED`, so
`PRGate.silently_blocked` is `False` and the PR reads as **CLEAN**.

The old code stated the rule it was breaking, directly above the return:

```python
except CIWhyError:
    # No protection, or no admin rights to read it. Either way this tool
    # cannot judge the branch -- and must not claim it is clean.
    return []
```

A *wrong* comment gets caught in review. A **right** comment above wrong code is
camouflage — every reader sees the rule stated and assumes it is enforced.

## Two routes to the same wrong verdict

1. **The swallow.** `except CIWhyError: return []` also defeated a *correct*
   guard one layer up — `ci_group.blocked` already catches `CIWhyError` with
   *"UNKNOWN is not green: never degrade into 'nothing blocked'"*. Swallowing
   here meant that guard could never fire for this path: live for other paths,
   dead for this one.

2. **The route the `except` never saw.** `run_gh` returns stdout on a non-zero
   exit whenever stdout is non-empty (so `gh pr checks` can fail and still hand
   back its JSON), and `gh api` prints 404/403 bodies to **stdout**. An
   unreadable branch therefore arrived as parseable JSON with no `contexts` and
   fell through to `[]` without raising at all.

## The fix

Separate the one error that *is* an answer from every error that is not.
A 404 `Branch not protected` genuinely requires nothing — an unprotected branch
cannot be silently blocked — so `[]` stays correct there. Anything else (403, a
renamed branch, a network failure) raises `CIWhyError` naming the branch and
what to check, and the existing "UNKNOWN is not green" guard does its job.

## Evidence

| run | result |
|---|---|
| **RED** — new tests vs `origin/develop`'s source | both fail with `DID NOT RAISE` — the defect stated exactly: it returned a clean verdict |
| **CONTROL** — `an_unprotected_base_requires_nothing_and_is_not_flagged` | **passes in both states**, so a fix that refused unconditionally could not hide here |
| **GREEN** — whole file | **26 passed**, including all 24 pre-existing |

The test seam gains `protection_body`, because `protection_raises=True` modelled
an exception GitHub does not actually send for this case.

## Credit

Reported by **scitex-ui**, who got their own merge gate wrong four times,
abstracted three generalisations, and sent them over without asking for
anything. sac already implemented their first two (compare the required-name
list, not a proxy count; a bucketing check needs an `else` that fails). Their
third — *separate cannot-tell from not-green* — is this bug. They have since
deleted their gate in favour of `sac ci blocked`, which is why this was worth
fixing now rather than filing: a peer depends on this verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHzDihbtuQ1Zfj1PiQJu3X
