### PR TITLE
feat(health): report which engine an agent is ACTUALLY running on

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_health_engine.py
+++ b/src/scitex_agent_container/cli_pkg/_health_engine.py
@@ -1,0 +1,237 @@
+"""Resolved-engine observation for ``sac agents health``.
+
+Published NEXT TO ``healthy`` (never folded into the exit code), same as
+:mod:`._health_liveness` and :mod:`._health_overlay_masking`.
+
+WHY THIS EXISTS. Until now nothing reported which backend an agent is
+actually running on. ``check`` validates apptainer, binds and host and
+prints "Ready to deploy"; ``status`` reports ports, session and inbox.
+Neither says "engine". On 2026-09-06 that blind spot let ``business``
+run 27 hours on Claude while its own spec carried an operator ruling
+saying Qwen ONLY, and the only way to establish that was reading
+``/proc/<pid>/environ`` on the host.
+
+THE RUNNING ENGINE IS READ FROM THE RUNNING PROCESS, NOT THE SPEC.
+That is the entire point. A status that re-derived the engine from the
+spec would agree with the spec by construction and could never report
+the disagreement this module exists to surface.
+
+NOT from the tui-env snapshot, which was the obvious-looking source and
+is the WRONG one: ``env >`` runs in the outer shell BEFORE
+``exec apptainer --env SAC_ENGINE=<key>`` injects the engine, so the
+snapshot never contains it. Measured on ``business`` 2026-09-06 — a
+23 KB snapshot with zero ``SAC_ENGINE`` lines. The agent's own process
+environment is where the value actually lives, and reading the process
+is also what makes this an observation of REALITY rather than of
+configuration.
+
+Processes are matched on ``CLAUDE_AGENT_ID``, not on a pid from the
+registry and not on a process name: one host runs several agents whose
+processes are all called ``claude``, and the registry pid is known to be
+shared. ``CLAUDE_AGENT_ID`` is carried in the same environment block as
+``SAC_ENGINE``, so the match and the reading cannot drift apart.
+
+THREE-VALUED, and ``unknown`` is not ``match``. A missing or unreadable
+snapshot means we could not tell, which authorises nothing; folding it
+into "match" would reproduce the failure in a new place.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+__all__ = ["engine_payload", "print_engine"]
+
+VERDICT_MATCH = "match"
+VERDICT_MISMATCH = "mismatch"
+VERDICT_UNKNOWN = "unknown"
+
+REASON_NO_RUNNING_PROCESS = "no-running-process-carries-an-engine"
+REASON_ENGINES_DISAGREE = "live-processes-disagree-on-the-engine"
+REASON_ENVIRONS_UNREADABLE = "process-environments-not-readable-by-this-user"
+AGENT_ID_ENV = "CLAUDE_AGENT_ID"
+REASON_SPEC_DECLARES_NO_ENGINE = "spec-declares-no-engine"
+REASON_READ_ERROR = "process-environment-unreadable"
+
+_VERDICT_COLOUR = {
+    VERDICT_MATCH: "green",
+    VERDICT_MISMATCH: "red",
+    VERDICT_UNKNOWN: "yellow",
+}
+
+
+def _read_running_engine(
+    name: str, *, proc_root: Any = None
+) -> tuple[str | None, str | None, str | None]:
+    """``(engine, observed_at, reason)`` from ``name``'s RUNNING process.
+
+    ``engine`` is ``None`` whenever we could not read one, and ``reason``
+    then says which of the ways it failed. Never guesses.
+    """
+    import datetime
+    from pathlib import Path
+
+    from ..runtimes._apptainer_provider import ENGINE_KEY_ENV
+
+    root = Path(proc_root) if proc_root is not None else Path("/proc")
+    agent_prefix = f"{AGENT_ID_ENV}="
+    engine_prefix = f"{ENGINE_KEY_ENV}="
+
+    engines: set[str] = set()
+    earliest: float | None = None
+    # Counted, never swallowed. A process whose environ we may not read is
+    # NOT evidence of absence, and reporting it as "nothing is running" is
+    # the same conflation this whole module exists to end — measured
+    # 2026-09-06, where a host-side run reported no engine for five agents
+    # that were all running, because the caller was not their owner.
+    unreadable = 0
+    try:
+        entries = sorted(root.iterdir())
+    except OSError as exc:
+        return None, None, f"{REASON_READ_ERROR} ({type(exc).__name__}: {exc})"
+
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            block = (entry / "environ").read_bytes().decode("utf-8", errors="replace")
+        except PermissionError:
+            unreadable += 1
+            continue
+        except OSError:
+            # A process that exited between listing and reading is not an
+            # error: it simply is not one of ours to report on.
+            continue
+        variables = block.split("\0")
+        if f"{agent_prefix}{name}" not in variables:
+            continue
+        for variable in variables:
+            if variable.startswith(engine_prefix):
+                engines.add(variable[len(engine_prefix) :].strip())
+        try:
+            started = (entry / "environ").stat().st_mtime
+        except OSError:
+            started = None
+        if started is not None and (earliest is None or started < earliest):
+            earliest = started
+
+    observed_at = (
+        datetime.datetime.fromtimestamp(earliest, tz=datetime.timezone.utc).isoformat()
+        if earliest is not None
+        else None
+    )
+    if not engines:
+        if unreadable:
+            return (
+                None,
+                observed_at,
+                f"{REASON_ENVIRONS_UNREADABLE}: {unreadable} unreadable",
+            )
+        return None, observed_at, REASON_NO_RUNNING_PROCESS
+    if len(engines) > 1:
+        # Two live processes of one agent disagreeing about the backend is
+        # a real condition, and averaging it away would hide it.
+        return (
+            None,
+            observed_at,
+            f"{REASON_ENGINES_DISAGREE}: {sorted(engines)}",
+        )
+    return engines.pop(), observed_at, None
+
+
+def _declared_engine(config: Any) -> str | None:
+    """The engine key the SPEC selects, or ``None`` if it declares none.
+
+    Reads ``AgentConfig`` the way the rest of the package does — an
+    explicit ``engine_key`` pin first, then the default among
+    ``config.engines`` (already the fleet library UNION the spec's own
+    block by the time load_config is done). The plain-mapping branch
+    below keeps a raw spec dict usable by callers and tests.
+    """
+    from ..config._engine_types import parse_engines, resolve_default
+
+    pinned = str(getattr(config, "engine_key", "") or "").strip()
+    if pinned:
+        return pinned
+
+    engines = getattr(config, "engines", None)
+    if isinstance(engines, Mapping) and engines:
+        return getattr(resolve_default(engines), "key", None)
+
+    if isinstance(config, Mapping):
+        parsed = parse_engines(config)
+        if parsed:
+            return getattr(resolve_default(parsed), "key", None)
+    return None
+
+
+def engine_payload(
+    name: str,
+    config: Any,
+    *,
+    launch_engine_reader: Callable[[str], tuple[str | None, str | None, str | None]]
+    | None = None,
+) -> dict:
+    """JSON-ready engine verdict; any gather failure degrades to UNKNOWN.
+
+    ``launch_engine_reader`` is the test seam, matching the injected-reader
+    idiom used elsewhere in this package.
+    """
+    reader = launch_engine_reader or _read_running_engine
+    try:
+        running, observed_at, reason = reader(name)
+    except Exception as exc:  # stx-allow: fallback (reason: an unreadable process environment is UNKNOWN with its reason — never a fabricated MATCH, and never a crashed health command)
+        running, observed_at, reason = (
+            None,
+            None,
+            f"{REASON_READ_ERROR} ({type(exc).__name__}: {exc})",
+        )
+
+    try:
+        declared = _declared_engine(config)
+    except Exception as exc:  # stx-allow: fallback (reason: same rule — a spec we cannot parse is UNKNOWN, not a match)
+        declared = None
+        reason = reason or f"{REASON_READ_ERROR} ({type(exc).__name__}: {exc})"
+
+    if running is None:
+        verdict = VERDICT_UNKNOWN
+    elif declared is None:
+        verdict, reason = VERDICT_UNKNOWN, reason or REASON_SPEC_DECLARES_NO_ENGINE
+    elif declared == running:
+        verdict = VERDICT_MATCH
+    else:
+        verdict = VERDICT_MISMATCH
+
+    return {
+        "agent": name,
+        "declared": declared,
+        "running": running,
+        "verdict": verdict,
+        "reason": reason,
+        "observed_at": observed_at,
+    }
+
+
+def print_engine(console: Any, payload: dict) -> None:
+    """One verdict line; on MISMATCH, name both engines and the fix."""
+    verdict = str(payload.get("verdict", VERDICT_UNKNOWN))
+    colour = _VERDICT_COLOUR.get(verdict, "yellow")
+    declared = payload.get("declared") or "?"
+    running = payload.get("running") or "?"
+    if verdict == VERDICT_MATCH:
+        console.print(f"[{colour}]engine: {running} (matches spec)[/{colour}]")
+        return
+    if verdict == VERDICT_MISMATCH:
+        console.print(
+            f"[{colour}]engine: MISMATCH — spec selects {declared!r}, "
+            f"the running process was launched on {running!r}[/{colour}]"
+        )
+        console.print(
+            "[dim]  Fix: restart the agent so the declared engine is applied; "
+            "a start that silently ran a different backend than the one "
+            "declared is worse than a start that did not happen.[/dim]"
+        )
+        return
+    console.print(
+        f"[{colour}]engine: unknown — {payload.get('reason') or '?'}[/{colour}]"
+    )

--- a/src/scitex_agent_container/cli_pkg/_health_engine.py
+++ b/src/scitex_agent_container/cli_pkg/_health_engine.py
@@ -3,55 +3,64 @@
 Published NEXT TO ``healthy`` (never folded into the exit code), same as
 :mod:`._health_liveness` and :mod:`._health_overlay_masking`.
 
-WHY THIS EXISTS. Until now nothing reported which backend an agent is
-actually running on. ``check`` validates apptainer, binds and host and
-prints "Ready to deploy"; ``status`` reports ports, session and inbox.
-Neither says "engine". On 2026-09-06 that blind spot let ``business``
-run 27 hours on Claude while its own spec carried an operator ruling
-saying Qwen ONLY, and the only way to establish that was reading
-``/proc/<pid>/environ`` on the host.
+WHY THIS EXISTS. Nothing reported which backend an agent actually runs
+on. ``check`` validates apptainer, binds and host and prints "Ready to
+deploy"; ``status`` reports ports, session and inbox. Neither says
+"engine". On 2026-09-05 ``business`` was restarted with an explicit
+``--engine claude`` while its own spec declares ``qwen38-27b`` with
+``default: true`` and carries an operator ruling saying Qwen ONLY. It
+ran 27 hours that way and the only way to establish it was reading
+``/proc/<pid>/environ`` by hand.
 
-THE RUNNING ENGINE IS READ FROM THE RUNNING PROCESS, NOT THE SPEC.
-That is the entire point. A status that re-derived the engine from the
-spec would agree with the spec by construction and could never report
-the disagreement this module exists to surface.
+TWO RULES THIS MODULE IS BUILT AROUND.
 
-NOT from the tui-env snapshot, which was the obvious-looking source and
-is the WRONG one: ``env >`` runs in the outer shell BEFORE
-``exec apptainer --env SAC_ENGINE=<key>`` injects the engine, so the
-snapshot never contains it. Measured on ``business`` 2026-09-06 — a
-23 KB snapshot with zero ``SAC_ENGINE`` lines. The agent's own process
-environment is where the value actually lives, and reading the process
-is also what makes this an observation of REALITY rather than of
-configuration.
+1. ``declared`` HAS EXACTLY ONE SOURCE: ``AgentConfig.engine_key``,
+   which the loader writes from the same ``resolve_default_for_spec``
+   the START path uses. It is NEVER re-derived from ``config.engines``
+   -- that mapping is the MERGED namespace (fleet library UNION
+   spec-local), and handing it to ``resolve_default`` without
+   ``local_keys`` tells the resolver every FLEET engine was written by
+   THIS spec. Measured 2026-09-06: with a one-entry library, a spec
+   declaring no engines at all reported ``declared`` = that library's
+   lone key and ``verdict=mismatch``. 129 of 130 deployed specs declare
+   no engine, so that path manufactures 129 false alarms; with a
+   two-entry library it raises instead and degrades every one of them
+   to UNKNOWN blaming the process environment.
 
-Processes are matched on ``CLAUDE_AGENT_ID``, not on a pid from the
-registry and not on a process name: one host runs several agents whose
-processes are all called ``claude``, and the registry pid is known to be
-shared. ``CLAUDE_AGENT_ID`` is carried in the same environment block as
-``SAC_ENGINE``, so the match and the reading cannot drift apart.
-
-THREE-VALUED, and ``unknown`` is not ``match``. A missing or unreadable
-snapshot means we could not tell, which authorises nothing; folding it
-into "match" would reproduce the failure in a new place.
+2. ABSENCE IS ONLY CLAIMABLE FROM A VANTAGE THAT COULD HAVE SEEN IT.
+   The reader walks ``/proc``, and a process whose ``environ`` we may
+   not read, or a whole namespace we are not in, is NOT evidence that
+   nothing is running. Measured the same day: from inside a container
+   (18 pids visible) the reader returned a DEFINITE
+   "no-running-process-carries-an-engine" for ``business`` while 13 of
+   its processes were running on the host; and on that host as uid 1000,
+   235 of 283 environs were unreadable. So the census travels with every
+   answer -- scanned, matched, unreadable, vantage -- and a bare
+   "nothing found" is reported as *cannot tell*, never as *not there*.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Callable, Mapping
 
-__all__ = ["engine_payload", "print_engine"]
+__all__ = ["EngineScan", "engine_payload", "print_engine"]
 
 VERDICT_MATCH = "match"
 VERDICT_MISMATCH = "mismatch"
 VERDICT_UNKNOWN = "unknown"
 
 REASON_NO_RUNNING_PROCESS = "no-running-process-carries-an-engine"
-REASON_ENGINES_DISAGREE = "live-processes-disagree-on-the-engine"
 REASON_ENVIRONS_UNREADABLE = "process-environments-not-readable-by-this-user"
-AGENT_ID_ENV = "CLAUDE_AGENT_ID"
+REASON_BLIND_VANTAGE = "this-vantage-cannot-see-the-agent-processes"
+REASON_ENGINES_DISAGREE = "live-processes-disagree-on-the-engine"
 REASON_SPEC_DECLARES_NO_ENGINE = "spec-declares-no-engine"
-REASON_READ_ERROR = "process-environment-unreadable"
+REASON_READ_ERROR = "process-scan-failed"
+
+AGENT_ID_ENV = "CLAUDE_AGENT_ID"
+
+VANTAGE_HOST = "host"
+VANTAGE_CONTAINER = "container"
 
 _VERDICT_COLOUR = {
     VERDICT_MATCH: "green",
@@ -60,108 +69,146 @@ _VERDICT_COLOUR = {
 }
 
 
+@dataclass(frozen=True)
+class EngineScan:
+    """What the /proc walk actually saw. Travels with EVERY answer.
+
+    Published even on success: consulting the unreadable count only when
+    nothing was found makes a partial scan invisible the moment one
+    process happens to be readable, and the disagreement check below
+    then compares a subset while looking like it compared everything.
+    """
+
+    pids_scanned: int = 0
+    pids_matched: int = 0
+    pids_unreadable: int = 0
+    vantage: str = VANTAGE_HOST
+
+    @property
+    def could_have_seen_everything(self) -> bool:
+        """Absence is only meaningful when this is True."""
+        return self.pids_unreadable == 0 and self.vantage != VANTAGE_CONTAINER
+
+    def to_dict(self) -> dict:
+        return {
+            "pids_scanned": self.pids_scanned,
+            "pids_matched": self.pids_matched,
+            "pids_unreadable": self.pids_unreadable,
+            "vantage": self.vantage,
+            "complete": self.could_have_seen_everything,
+        }
+
+
+def _vantage() -> str:
+    """``container`` when this process runs inside an apptainer SIF.
+
+    Uses sac's existing marker set rather than a private heuristic.
+    """
+    import os
+
+    from .._maintenance._scratch_migrate_liveness import CONTAINER_MARKER_ENV
+
+    for marker in CONTAINER_MARKER_ENV:
+        if os.environ.get(marker):
+            return VANTAGE_CONTAINER
+    return VANTAGE_HOST
+
+
 def _read_running_engine(
     name: str, *, proc_root: Any = None
-) -> tuple[str | None, str | None, str | None]:
-    """``(engine, observed_at, reason)`` from ``name``'s RUNNING process.
+) -> tuple[str | None, EngineScan, str | None]:
+    """``(engine, scan, reason)`` for ``name``'s RUNNING processes.
 
-    ``engine`` is ``None`` whenever we could not read one, and ``reason``
-    then says which of the ways it failed. Never guesses.
+    ``engine`` is ``None`` whenever we could not read exactly one, and
+    ``reason`` then says which way it failed. Never guesses, and never
+    reports absence from a vantage that could not have seen presence.
     """
-    import datetime
     from pathlib import Path
 
     from ..runtimes._apptainer_provider import ENGINE_KEY_ENV
 
-    root = Path(proc_root) if proc_root is not None else Path("/proc")
-    agent_prefix = f"{AGENT_ID_ENV}="
+    fake_proc = proc_root is not None
+    root = Path(proc_root) if fake_proc else Path("/proc")
+    vantage = VANTAGE_HOST if fake_proc else _vantage()
+
+    agent_entry = f"{AGENT_ID_ENV}={name}"
     engine_prefix = f"{ENGINE_KEY_ENV}="
 
     engines: set[str] = set()
-    earliest: float | None = None
-    # Counted, never swallowed. A process whose environ we may not read is
-    # NOT evidence of absence, and reporting it as "nothing is running" is
-    # the same conflation this whole module exists to end — measured
-    # 2026-09-06, where a host-side run reported no engine for five agents
-    # that were all running, because the caller was not their owner.
-    unreadable = 0
+    scanned = matched = unreadable = 0
     try:
         entries = sorted(root.iterdir())
     except OSError as exc:
-        return None, None, f"{REASON_READ_ERROR} ({type(exc).__name__}: {exc})"
+        return (
+            None,
+            EngineScan(vantage=vantage),
+            f"{REASON_READ_ERROR} ({type(exc).__name__}: {exc})",
+        )
 
     for entry in entries:
         if not entry.name.isdigit():
             continue
+        scanned += 1
         try:
             block = (entry / "environ").read_bytes().decode("utf-8", errors="replace")
         except PermissionError:
             unreadable += 1
             continue
         except OSError:
-            # A process that exited between listing and reading is not an
-            # error: it simply is not one of ours to report on.
+            # Exited between listing and reading. Not ours, not an error.
             continue
         variables = block.split("\0")
-        if f"{agent_prefix}{name}" not in variables:
+        if agent_entry not in variables:
             continue
+        matched += 1
         for variable in variables:
             if variable.startswith(engine_prefix):
                 engines.add(variable[len(engine_prefix) :].strip())
-        try:
-            started = (entry / "environ").stat().st_mtime
-        except OSError:
-            started = None
-        if started is not None and (earliest is None or started < earliest):
-            earliest = started
 
-    observed_at = (
-        datetime.datetime.fromtimestamp(earliest, tz=datetime.timezone.utc).isoformat()
-        if earliest is not None
-        else None
+    scan = EngineScan(
+        pids_scanned=scanned,
+        pids_matched=matched,
+        pids_unreadable=unreadable,
+        vantage=vantage,
     )
-    if not engines:
-        if unreadable:
-            return (
-                None,
-                observed_at,
-                f"{REASON_ENVIRONS_UNREADABLE}: {unreadable} unreadable",
-            )
-        return None, observed_at, REASON_NO_RUNNING_PROCESS
+
     if len(engines) > 1:
-        # Two live processes of one agent disagreeing about the backend is
-        # a real condition, and averaging it away would hide it.
-        return (
-            None,
-            observed_at,
-            f"{REASON_ENGINES_DISAGREE}: {sorted(engines)}",
-        )
-    return engines.pop(), observed_at, None
+        # Two live processes of one agent disagreeing about the backend
+        # is a real condition; averaging it away would hide it.
+        return None, scan, f"{REASON_ENGINES_DISAGREE}: {sorted(engines)}"
+    if engines:
+        return engines.pop(), scan, None
+    if scan.vantage == VANTAGE_CONTAINER:
+        return None, scan, REASON_BLIND_VANTAGE
+    if unreadable:
+        return None, scan, f"{REASON_ENVIRONS_UNREADABLE}: {unreadable} unreadable"
+    return None, scan, REASON_NO_RUNNING_PROCESS
 
 
 def _declared_engine(config: Any) -> str | None:
-    """The engine key the SPEC selects, or ``None`` if it declares none.
+    """The engine the PRECEDENCE selects for this spec, or ``None``.
 
-    Reads ``AgentConfig`` the way the rest of the package does — an
-    explicit ``engine_key`` pin first, then the default among
-    ``config.engines`` (already the fleet library UNION the spec's own
-    block by the time load_config is done). The plain-mapping branch
-    below keeps a raw spec dict usable by callers and tests.
+    ONE source, and it is the one the START path uses.
+    ``AgentConfig.engine_key`` is written at load time from
+    ``_engine_precedence.resolve_default_for_spec``, so reading it makes
+    ``declared`` equal BY CONSTRUCTION to the engine a start would pick.
+    Empty means the precedence selected NOTHING, which is UNKNOWN.
+
+    A raw spec mapping (tests, callers holding parsed YAML) asks the SAME
+    precedence, so an ``engine:`` pin, the legacy block and the fleet
+    default are all honoured -- the previous version's private
+    ``parse_engines`` + ``resolve_default`` pair silently ignored the pin.
     """
-    from ..config._engine_types import parse_engines, resolve_default
-
-    pinned = str(getattr(config, "engine_key", "") or "").strip()
-    if pinned:
-        return pinned
-
-    engines = getattr(config, "engines", None)
-    if isinstance(engines, Mapping) and engines:
-        return getattr(resolve_default(engines), "key", None)
+    key = str(getattr(config, "engine_key", "") or "").strip()
+    if key:
+        return key
 
     if isinstance(config, Mapping):
-        parsed = parse_engines(config)
-        if parsed:
-            return getattr(resolve_default(parsed), "key", None)
+        from ..config._engine_library import resolve_engine_namespace
+        from ..config._engine_precedence import resolve_default_for_spec
+
+        selected = resolve_default_for_spec(config, resolve_engine_namespace(config))
+        return getattr(selected, "key", None)
     return None
 
 
@@ -169,27 +216,23 @@ def engine_payload(
     name: str,
     config: Any,
     *,
-    launch_engine_reader: Callable[[str], tuple[str | None, str | None, str | None]]
+    launch_engine_reader: Callable[[str], tuple[str | None, EngineScan, str | None]]
     | None = None,
 ) -> dict:
-    """JSON-ready engine verdict; any gather failure degrades to UNKNOWN.
-
-    ``launch_engine_reader`` is the test seam, matching the injected-reader
-    idiom used elsewhere in this package.
-    """
+    """JSON-ready engine verdict; any gather failure degrades to UNKNOWN."""
     reader = launch_engine_reader or _read_running_engine
     try:
-        running, observed_at, reason = reader(name)
+        running, scan, reason = reader(name)
     except Exception as exc:  # stx-allow: fallback (reason: an unreadable process environment is UNKNOWN with its reason — never a fabricated MATCH, and never a crashed health command)
-        running, observed_at, reason = (
+        running, scan, reason = (
             None,
-            None,
+            EngineScan(),
             f"{REASON_READ_ERROR} ({type(exc).__name__}: {exc})",
         )
 
     try:
         declared = _declared_engine(config)
-    except Exception as exc:  # stx-allow: fallback (reason: same rule — a spec we cannot parse is UNKNOWN, not a match)
+    except Exception as exc:  # stx-allow: fallback (reason: same rule — a spec whose engine namespace will not resolve is UNKNOWN, not a match)
         declared = None
         reason = reason or f"{REASON_READ_ERROR} ({type(exc).__name__}: {exc})"
 
@@ -208,7 +251,7 @@ def engine_payload(
         "running": running,
         "verdict": verdict,
         "reason": reason,
-        "observed_at": observed_at,
+        "scan": scan.to_dict(),
     }
 
 
@@ -218,6 +261,7 @@ def print_engine(console: Any, payload: dict) -> None:
     colour = _VERDICT_COLOUR.get(verdict, "yellow")
     declared = payload.get("declared") or "?"
     running = payload.get("running") or "?"
+    scan = payload.get("scan") or {}
     if verdict == VERDICT_MATCH:
         console.print(f"[{colour}]engine: {running} (matches spec)[/{colour}]")
         return
@@ -235,3 +279,10 @@ def print_engine(console: Any, payload: dict) -> None:
     console.print(
         f"[{colour}]engine: unknown — {payload.get('reason') or '?'}[/{colour}]"
     )
+    if not scan.get("complete", True):
+        console.print(
+            f"[dim]  scan was PARTIAL: {scan.get('pids_matched')} matched of "
+            f"{scan.get('pids_scanned')} scanned, {scan.get('pids_unreadable')} "
+            f"unreadable, vantage={scan.get('vantage')}. Absence here is not "
+            f"evidence of absence — run this on the agent's host as its owner.[/dim]"
+        )

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -477,6 +477,15 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
 
     overlay_masking = overlay_masking_payload(name, config)
 
+    # Observation-only like the two above. Answers the question no other
+    # surface answered: which backend is this agent ACTUALLY running on?
+    # Read from the running process, never re-derived from the spec — a
+    # reading derived from the spec would agree with the spec and could
+    # never report the disagreement. See :mod:`._health_engine`.
+    from ._health_engine import engine_payload, print_engine
+
+    engine = engine_payload(name, config)
+
     if use_json:
         click.echo(
             json_mod.dumps(
@@ -489,6 +498,7 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
                     "fault": inbox_fault,
                     "liveness": liveness,
                     "overlay_masking": overlay_masking,
+                    "engine": engine,
                 },
                 indent=2,
             )
@@ -504,6 +514,7 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
 
     print_liveness(console, liveness)
     print_overlay_masking(console, overlay_masking)
+    print_engine(console, engine)
     print_inbox(console, name, subscribers, reachable, inbox_fault)
 
     if not is_healthy:

--- a/tests/scitex_agent_container/cli_pkg/test__health_engine.py
+++ b/tests/scitex_agent_container/cli_pkg/test__health_engine.py
@@ -1,0 +1,248 @@
+"""``engine_payload`` must report the engine the process was LAUNCHED on.
+
+The defect these cover: nothing reported the resolved engine, so an agent
+could run 27 hours on a backend its own spec forbade and every surface
+still said it was fine.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.cli_pkg._health_engine import (
+    REASON_ENGINES_DISAGREE,
+    REASON_NO_RUNNING_PROCESS,
+    VERDICT_MATCH,
+    VERDICT_MISMATCH,
+    VERDICT_UNKNOWN,
+    _read_running_engine,
+    engine_payload,
+)
+
+SPEC_SELECTING_QWEN = {
+    "engines": {
+        "qwen38-27b": {"default": True},
+        "claude": {},
+    }
+}
+
+
+def _reader(engine, observed_at="2026-09-06T00:00:00+00:00", reason=None):
+    """Stand in for the launch-env snapshot read."""
+
+    def read(_name):
+        return engine, observed_at, reason
+
+    return read
+
+
+def test_an_agent_launched_on_a_different_engine_than_the_spec_selects_is_a_mismatch():
+    # Arrange
+    reader = _reader("claude")
+
+    # Act
+    payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=reader)
+
+    # Assert
+    assert payload["verdict"] == VERDICT_MISMATCH
+
+
+def test_an_agent_launched_on_the_engine_its_spec_selects_is_not_flagged():
+    # Arrange
+    reader = _reader("qwen38-27b")
+
+    # Act
+    payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=reader)
+
+    # Assert
+    assert payload["verdict"] == VERDICT_MATCH
+
+
+def test_an_agent_declared_on_claude_and_running_claude_is_not_flagged():
+    # Arrange
+    spec = {"engines": {"claude": {"default": True}}}
+
+    # Act
+    payload = engine_payload("cards", spec, launch_engine_reader=_reader("claude"))
+
+    # Assert
+    assert payload["verdict"] == VERDICT_MATCH
+
+
+def test_a_missing_launch_snapshot_is_unknown_rather_than_a_match():
+    # Arrange
+    reader = _reader(None, observed_at=None, reason="no-launch-env-snapshot")
+
+    # Act
+    payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=reader)
+
+    # Assert
+    assert payload["verdict"] == VERDICT_UNKNOWN
+
+
+def test_a_reader_that_raises_degrades_to_unknown_instead_of_crashing_health():
+    # Arrange
+    def exploding(_name):
+        raise OSError("snapshot volume went away")
+
+    # Act
+    payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=exploding)
+
+    # Assert
+    assert payload["verdict"] == VERDICT_UNKNOWN
+
+
+def test_the_running_engine_is_taken_from_the_launch_environment_not_the_spec():
+    # Arrange
+    reader = _reader("claude")
+
+    # Act
+    payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=reader)
+
+    # Assert
+    assert payload["running"] == "claude"
+
+
+def test_the_declared_engine_is_taken_from_the_spec():
+    # Arrange
+    reader = _reader("claude")
+
+    # Act
+    payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=reader)
+
+    # Assert
+    assert payload["declared"] == "qwen38-27b"
+
+
+def _proc(tmp_path, entries):
+    """Build a fake /proc: {pid: {VAR: value}} -> null-separated environ files."""
+    root = tmp_path / "proc"
+    root.mkdir()
+    for pid, variables in entries.items():
+        directory = root / str(pid)
+        directory.mkdir()
+        block = "\0".join(f"{k}={v}" for k, v in variables.items())
+        (directory / "environ").write_bytes(block.encode("utf-8"))
+    (root / "notapid").mkdir()
+    return root
+
+
+def test_the_real_reader_takes_the_engine_from_the_running_process(tmp_path):
+    # Arrange
+    root = _proc(tmp_path, {961961: {"CLAUDE_AGENT_ID": "business", "SAC_ENGINE": "claude"}})
+
+    # Act
+    engine, _observed_at, _reason = _read_running_engine("business", proc_root=root)
+
+    # Assert
+    assert engine == "claude"
+
+
+def test_a_process_belonging_to_another_agent_is_not_read():
+    # Arrange
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = _proc(
+            Path(directory),
+            {700: {"CLAUDE_AGENT_ID": "figrecipe", "SAC_ENGINE": "qwen38-27b"}},
+        )
+
+        # Act
+        engine, _observed_at, _reason = _read_running_engine("business", proc_root=root)
+
+        # Assert
+        assert engine is None
+
+
+def test_no_running_process_is_reported_as_such_rather_than_guessed(tmp_path):
+    # Arrange
+    root = _proc(tmp_path, {})
+
+    # Act
+    _engine, _observed_at, reason = _read_running_engine("never-started", proc_root=root)
+
+    # Assert
+    assert reason == REASON_NO_RUNNING_PROCESS
+
+
+def test_live_processes_disagreeing_on_the_engine_is_surfaced_not_averaged(tmp_path):
+    # Arrange
+    root = _proc(
+        tmp_path,
+        {
+            11: {"CLAUDE_AGENT_ID": "business", "SAC_ENGINE": "claude"},
+            12: {"CLAUDE_AGENT_ID": "business", "SAC_ENGINE": "qwen38-27b"},
+        },
+    )
+
+    # Act
+    _engine, _observed_at, reason = _read_running_engine("business", proc_root=root)
+
+    # Assert
+    assert reason.startswith(REASON_ENGINES_DISAGREE)
+
+
+def test_the_business_incident_would_now_be_reported_as_a_mismatch(tmp_path):
+    # Arrange
+    root = _proc(tmp_path, {961961: {"CLAUDE_AGENT_ID": "business", "SAC_ENGINE": "claude"}})
+
+    # Act
+    payload = engine_payload(
+        "business",
+        SPEC_SELECTING_QWEN,
+        launch_engine_reader=lambda n: _read_running_engine(n, proc_root=root),
+    )
+
+    # Assert
+    assert payload["verdict"] == VERDICT_MISMATCH
+
+
+class _AgentConfigLike:
+    """The shape `load_config` actually returns: engines + engine_key."""
+
+    def __init__(self, engines, engine_key=""):
+        self.engines = engines
+        self.engine_key = engine_key
+
+
+def test_the_declared_engine_is_read_from_a_real_agent_config_object():
+    # Arrange
+    from scitex_agent_container.config._engine_types import parse_engines
+
+    config = _AgentConfigLike(parse_engines(SPEC_SELECTING_QWEN))
+
+    # Act
+    payload = engine_payload("business", config, launch_engine_reader=_reader("claude"))
+
+    # Assert
+    assert payload["declared"] == "qwen38-27b"
+
+
+def test_an_explicit_engine_pin_on_the_config_wins_over_the_default():
+    # Arrange
+    from scitex_agent_container.config._engine_types import parse_engines
+
+    config = _AgentConfigLike(parse_engines(SPEC_SELECTING_QWEN), engine_key="claude")
+
+    # Act
+    payload = engine_payload("business", config, launch_engine_reader=_reader("claude"))
+
+    # Assert
+    assert payload["verdict"] == VERDICT_MATCH
+
+
+def test_unreadable_process_environments_are_reported_not_read_as_absence(tmp_path):
+    # Arrange
+    from scitex_agent_container.cli_pkg._health_engine import REASON_ENVIRONS_UNREADABLE
+
+    root = _proc(tmp_path, {})
+    denied = root / "4242"
+    denied.mkdir()
+    (denied / "environ").write_bytes(b"CLAUDE_AGENT_ID=business\0SAC_ENGINE=claude")
+    (denied / "environ").chmod(0o000)
+
+    # Act
+    _engine, _observed_at, reason = _read_running_engine("business", proc_root=root)
+
+    # Assert
+    assert reason.startswith(REASON_ENVIRONS_UNREADABLE)

--- a/tests/scitex_agent_container/cli_pkg/test__health_engine.py
+++ b/tests/scitex_agent_container/cli_pkg/test__health_engine.py
@@ -1,18 +1,22 @@
 """``engine_payload`` must report the engine the process was LAUNCHED on.
 
-The defect these cover: nothing reported the resolved engine, so an agent
-could run 27 hours on a backend its own spec forbade and every surface
-still said it was fine.
+Every test below either covers the original defect (nothing reported the
+resolved engine) or one of the six found in adversarial review of the
+first cut. The review's own reproductions are the fixtures.
 """
 
 from __future__ import annotations
 
 from scitex_agent_container.cli_pkg._health_engine import (
+    REASON_BLIND_VANTAGE,
     REASON_ENGINES_DISAGREE,
+    REASON_ENVIRONS_UNREADABLE,
     REASON_NO_RUNNING_PROCESS,
+    VANTAGE_CONTAINER,
     VERDICT_MATCH,
     VERDICT_MISMATCH,
     VERDICT_UNKNOWN,
+    EngineScan,
     _read_running_engine,
     engine_payload,
 )
@@ -25,13 +29,34 @@ SPEC_SELECTING_QWEN = {
 }
 
 
-def _reader(engine, observed_at="2026-09-06T00:00:00+00:00", reason=None):
-    """Stand in for the launch-env snapshot read."""
+def _reader(engine, reason=None, scan=None):
+    """Stand in for the /proc scan."""
 
     def read(_name):
-        return engine, observed_at, reason
+        return engine, scan or EngineScan(pids_scanned=1, pids_matched=1), reason
 
     return read
+
+
+class _AgentConfigLike:
+    """The shape `load_config` returns: a MERGED engines map + engine_key."""
+
+    def __init__(self, engines, engine_key=""):
+        self.engines = engines
+        self.engine_key = engine_key
+
+
+def _proc(tmp_path, entries):
+    """Fake /proc: {pid: {VAR: value}} -> NUL-separated environ files."""
+    root = tmp_path / "proc"
+    root.mkdir()
+    for pid, variables in entries.items():
+        directory = root / str(pid)
+        directory.mkdir()
+        block = "\0".join(f"{k}={v}" for k, v in variables.items())
+        (directory / "environ").write_bytes(block.encode("utf-8"))
+    (root / "notapid").mkdir()
+    return root
 
 
 def test_an_agent_launched_on_a_different_engine_than_the_spec_selects_is_a_mismatch():
@@ -67,21 +92,55 @@ def test_an_agent_declared_on_claude_and_running_claude_is_not_flagged():
     assert payload["verdict"] == VERDICT_MATCH
 
 
-def test_a_missing_launch_snapshot_is_unknown_rather_than_a_match():
+def test_a_spec_declaring_no_engine_never_inherits_one_from_the_fleet_library():
     # Arrange
-    reader = _reader(None, observed_at=None, reason="no-launch-env-snapshot")
+    merged_namespace = {"only-fleet-engine": object()}
+    config = _AgentConfigLike(merged_namespace, engine_key="")
 
     # Act
-    payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=reader)
+    payload = engine_payload("scitex-cards", config, launch_engine_reader=_reader("claude"))
+
+    # Assert
+    assert payload["declared"] is None
+
+
+def test_a_spec_declaring_no_engine_is_unknown_rather_than_a_mismatch():
+    # Arrange
+    config = _AgentConfigLike({"only-fleet-engine": object()}, engine_key="")
+
+    # Act
+    payload = engine_payload("scitex-cards", config, launch_engine_reader=_reader("claude"))
 
     # Assert
     assert payload["verdict"] == VERDICT_UNKNOWN
 
 
+def test_an_explicit_engine_pin_in_a_raw_spec_beats_the_default_flag():
+    # Arrange
+    spec = {"engine": "claude", "engines": {"qwen38-27b": {"default": True}, "claude": {}}}
+
+    # Act
+    payload = engine_payload("business", spec, launch_engine_reader=_reader("claude"))
+
+    # Assert
+    assert payload["declared"] == "claude"
+
+
+def test_the_declared_engine_is_read_from_a_real_agent_config_object():
+    # Arrange
+    config = _AgentConfigLike({}, engine_key="qwen38-27b")
+
+    # Act
+    payload = engine_payload("business", config, launch_engine_reader=_reader("claude"))
+
+    # Assert
+    assert payload["declared"] == "qwen38-27b"
+
+
 def test_a_reader_that_raises_degrades_to_unknown_instead_of_crashing_health():
     # Arrange
     def exploding(_name):
-        raise OSError("snapshot volume went away")
+        raise OSError("proc went away")
 
     # Act
     payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=exploding)
@@ -101,65 +160,34 @@ def test_the_running_engine_is_taken_from_the_launch_environment_not_the_spec():
     assert payload["running"] == "claude"
 
 
-def test_the_declared_engine_is_taken_from_the_spec():
-    # Arrange
-    reader = _reader("claude")
-
-    # Act
-    payload = engine_payload("business", SPEC_SELECTING_QWEN, launch_engine_reader=reader)
-
-    # Assert
-    assert payload["declared"] == "qwen38-27b"
-
-
-def _proc(tmp_path, entries):
-    """Build a fake /proc: {pid: {VAR: value}} -> null-separated environ files."""
-    root = tmp_path / "proc"
-    root.mkdir()
-    for pid, variables in entries.items():
-        directory = root / str(pid)
-        directory.mkdir()
-        block = "\0".join(f"{k}={v}" for k, v in variables.items())
-        (directory / "environ").write_bytes(block.encode("utf-8"))
-    (root / "notapid").mkdir()
-    return root
-
-
 def test_the_real_reader_takes_the_engine_from_the_running_process(tmp_path):
     # Arrange
     root = _proc(tmp_path, {961961: {"CLAUDE_AGENT_ID": "business", "SAC_ENGINE": "claude"}})
 
     # Act
-    engine, _observed_at, _reason = _read_running_engine("business", proc_root=root)
+    engine, _scan, _reason = _read_running_engine("business", proc_root=root)
 
     # Assert
     assert engine == "claude"
 
 
-def test_a_process_belonging_to_another_agent_is_not_read():
+def test_a_process_belonging_to_another_agent_is_not_read(tmp_path):
     # Arrange
-    import tempfile
-    from pathlib import Path
+    root = _proc(tmp_path, {700: {"CLAUDE_AGENT_ID": "figrecipe", "SAC_ENGINE": "qwen38-27b"}})
 
-    with tempfile.TemporaryDirectory() as directory:
-        root = _proc(
-            Path(directory),
-            {700: {"CLAUDE_AGENT_ID": "figrecipe", "SAC_ENGINE": "qwen38-27b"}},
-        )
+    # Act
+    engine, _scan, _reason = _read_running_engine("business", proc_root=root)
 
-        # Act
-        engine, _observed_at, _reason = _read_running_engine("business", proc_root=root)
-
-        # Assert
-        assert engine is None
+    # Assert
+    assert engine is None
 
 
-def test_no_running_process_is_reported_as_such_rather_than_guessed(tmp_path):
+def test_no_running_process_is_reported_as_such_when_the_scan_was_complete(tmp_path):
     # Arrange
     root = _proc(tmp_path, {})
 
     # Act
-    _engine, _observed_at, reason = _read_running_engine("never-started", proc_root=root)
+    _engine, _scan, reason = _read_running_engine("never-started", proc_root=root)
 
     # Assert
     assert reason == REASON_NO_RUNNING_PROCESS
@@ -176,10 +204,64 @@ def test_live_processes_disagreeing_on_the_engine_is_surfaced_not_averaged(tmp_p
     )
 
     # Act
-    _engine, _observed_at, reason = _read_running_engine("business", proc_root=root)
+    _engine, _scan, reason = _read_running_engine("business", proc_root=root)
 
     # Assert
     assert reason.startswith(REASON_ENGINES_DISAGREE)
+
+
+def test_unreadable_process_environments_are_reported_not_read_as_absence(tmp_path):
+    # Arrange
+    root = _proc(tmp_path, {})
+    denied = root / "4242"
+    denied.mkdir()
+    (denied / "environ").write_bytes(b"CLAUDE_AGENT_ID=business\0SAC_ENGINE=claude")
+    (denied / "environ").chmod(0o000)
+
+    # Act
+    _engine, _scan, reason = _read_running_engine("business", proc_root=root)
+
+    # Assert
+    assert reason.startswith(REASON_ENVIRONS_UNREADABLE)
+
+
+def test_a_container_vantage_cannot_claim_the_agent_is_absent():
+    # Arrange
+    scan = EngineScan(pids_scanned=18, pids_matched=0, vantage=VANTAGE_CONTAINER)
+
+    # Act
+    payload = engine_payload(
+        "business",
+        SPEC_SELECTING_QWEN,
+        launch_engine_reader=_reader(None, reason=REASON_BLIND_VANTAGE, scan=scan),
+    )
+
+    # Assert
+    assert payload["reason"] == REASON_BLIND_VANTAGE
+
+
+def test_a_partial_scan_is_never_reported_as_complete():
+    # Arrange
+    scan = EngineScan(pids_scanned=283, pids_matched=1, pids_unreadable=235)
+
+    # Act
+    complete = scan.to_dict()["complete"]
+
+    # Assert
+    assert complete is False
+
+
+def test_the_scan_census_travels_with_a_successful_answer_too():
+    # Arrange
+    scan = EngineScan(pids_scanned=283, pids_matched=13, pids_unreadable=235)
+
+    # Act
+    payload = engine_payload(
+        "business", SPEC_SELECTING_QWEN, launch_engine_reader=_reader("claude", scan=scan)
+    )
+
+    # Assert
+    assert payload["scan"]["pids_unreadable"] == 235
 
 
 def test_the_business_incident_would_now_be_reported_as_a_mismatch(tmp_path):
@@ -195,54 +277,3 @@ def test_the_business_incident_would_now_be_reported_as_a_mismatch(tmp_path):
 
     # Assert
     assert payload["verdict"] == VERDICT_MISMATCH
-
-
-class _AgentConfigLike:
-    """The shape `load_config` actually returns: engines + engine_key."""
-
-    def __init__(self, engines, engine_key=""):
-        self.engines = engines
-        self.engine_key = engine_key
-
-
-def test_the_declared_engine_is_read_from_a_real_agent_config_object():
-    # Arrange
-    from scitex_agent_container.config._engine_types import parse_engines
-
-    config = _AgentConfigLike(parse_engines(SPEC_SELECTING_QWEN))
-
-    # Act
-    payload = engine_payload("business", config, launch_engine_reader=_reader("claude"))
-
-    # Assert
-    assert payload["declared"] == "qwen38-27b"
-
-
-def test_an_explicit_engine_pin_on_the_config_wins_over_the_default():
-    # Arrange
-    from scitex_agent_container.config._engine_types import parse_engines
-
-    config = _AgentConfigLike(parse_engines(SPEC_SELECTING_QWEN), engine_key="claude")
-
-    # Act
-    payload = engine_payload("business", config, launch_engine_reader=_reader("claude"))
-
-    # Assert
-    assert payload["verdict"] == VERDICT_MATCH
-
-
-def test_unreadable_process_environments_are_reported_not_read_as_absence(tmp_path):
-    # Arrange
-    from scitex_agent_container.cli_pkg._health_engine import REASON_ENVIRONS_UNREADABLE
-
-    root = _proc(tmp_path, {})
-    denied = root / "4242"
-    denied.mkdir()
-    (denied / "environ").write_bytes(b"CLAUDE_AGENT_ID=business\0SAC_ENGINE=claude")
-    (denied / "environ").chmod(0o000)
-
-    # Act
-    _engine, _observed_at, reason = _read_running_engine("business", proc_root=root)
-
-    # Assert
-    assert reason.startswith(REASON_ENVIRONS_UNREADABLE)


### PR DESCRIPTION
## Why

`business` ran 27 hours on Claude while its own spec declares `qwen38-27b` with `default: true` and carries an operator ruling saying **Qwen ONLY**. No sac surface could have told anyone: `check` validates apptainer, binds and host and prints "Ready to deploy"; `status` reports ports, session and inbox. Neither says *engine*. Establishing it required reading `/proc/<pid>/environ` by hand.

**This is not a resolver bug.** Reproduced against the exact commit that host was running (`f7c9b975`, bracketed by its own reflog): business's spec resolves to `qwen38-27b` from every vantage, and a no-override start *raises* rather than falling back. The only way `SAC_ENGINE=claude` is emitted is an explicit `--engine claude`, which arrived on a restart. What was missing was any way to *see* the result.

## What

An observation-only `engine` payload on `agents health`, beside `liveness` and `overlay_masking`, never folded into the exit code:

```json
"engine": {
  "declared": "qwen38-27b", "running": "claude", "verdict": "mismatch", "reason": null,
  "scan": {"pids_scanned": 283, "pids_matched": 13, "pids_unreadable": 235,
           "vantage": "host", "complete": false}
}
```

Two rules it is built around:

1. **`declared` has exactly one source** — `AgentConfig.engine_key`, written at load time by the same `resolve_default_for_spec` the START path uses. It equals the engine a start would pick *by construction*, and is never re-derived from `config.engines`.
2. **Absence is claimable only from a vantage that could have seen presence.** The scan census travels with every answer, and "I could not look" never renders as "nothing is there".

## Six defects found in adversarial review of the first cut — all fixed

The first version would have shipped **129 false alarms** and **still missed the incident it was written for**. Every one of these was measured, not reasoned:

| # | Defect | Evidence |
|---|---|---|
| D1 | `declared` **fabricated** from the merged fleet∪spec namespace — `resolve_default` with no `local_keys` treats every fleet engine as spec-local | with a 1-entry library, a spec declaring no engines reported `declared=<library's lone key>`, `verdict=MISMATCH`. 129 of 130 deployed specs declare no engine (control: `harness:` matches 123). With a 2-entry library it *raises*, degrading all of them to UNKNOWN while blaming the process environment |
| D2 | raw-spec branch ignored the `engine:` **pin** | `{'engine':'claude', 'engines':{'qwen38-27b':{'default':True},…}}` → `'qwen38-27b'`; sac's own resolver → `'claude'` |
| D3 | definite "no process carries an engine" from a **container PID namespace** | 18 pids visible in-container while 13 business processes ran on the host |
| D4 | the two reasons **inverted on a real host** — `NO_RUNNING_PROCESS` unreachable | compute-01 as uid 1000: 283 pids, 235 PermissionError |
| D5 | `observed_at` was procfs **inode instantiation time**, neither start nor observation | pid 1 +11.4s; pid 203 +385.0s; five pids sharing one stamp. Removed rather than re-labelled |
| D6 | partial scan **invisible** once one process was readable | `unreadable` consulted only inside `if not engines:`, so the disagreement check silently compared a subset |

## Verification

End-to-end against business's **real** spec and **real** observed environ:

```
declared=qwen38-27b  running=claude  verdict=mismatch
```

The previous version returned `unknown` for that same input.

18 tests — one per fixed defect, plus the control that an agent declared on `claude` and running `claude` is **not** flagged (a version flagging every non-qwen agent would pass the mismatch tests and be useless), a fake `/proc` tree so the real reader is exercised rather than only the seam, and a chmod-000 `environ` so "may not read" is distinguished from "not there".

Full `cli_pkg` suite: **2793 passed, 813 skipped**. ruff clean.

## Scope this does *not* close

- **Provenance.** sac records the restart (`restart_decision.log`, 72 business lines) but not *who* passed `--engine claude`. Tracked separately.
- **Propagation.** business is the only spec in the fleet using `engines:` at all (1 of 130; 0 of 131 on compute-03), and compute-03 holds a 2026-08-31 copy of business's spec with zero qwen content. That must be fixed before any app agent is flipped, or the incident reproduces silently.
