### PR TITLE
feat(engine): say so when --engine overrules the spec's declared default

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_engine_select.py
+++ b/src/scitex_agent_container/_lifecycle/_engine_select.py
@@ -169,12 +169,50 @@ def select_engine_at_start(
     # changed.
     spec_harness = str(getattr(config, "harness", "") or "").strip().lower()
 
+    # The engine the SPEC selects, captured BEFORE the fold for the same
+    # reason as the harness above: ``apply_engine`` overwrites
+    # ``engine_key``, so reading it afterwards would report this start's
+    # choice back to itself and the contradiction below could never fire.
+    #
+    # Read the FIELD, never re-derived from ``config.engines``: that
+    # mapping is the MERGED namespace (fleet library UNION spec-local),
+    # and resolving a default from it attributes fleet engines to this
+    # spec. ``engine_key`` was written by the loader from the same
+    # ``resolve_default_for_spec`` used here, so it is the spec's answer
+    # by construction.
+    spec_default = str(getattr(config, "engine_key", "") or "").strip()
+
     # Raises UnknownEngineError listing the declared keys. Deliberately
     # NOT caught: degrading to the default here is the exact silent
     # fallback the operator ruled out.
     engine = select_engine(engines, requested)
     if engine is None:
         return None
+
+    # A RECORD, NOT A GATE, and deliberately so: honouring an explicit
+    # --engine is correct, and refusing here would make the override
+    # useless. What was missing is that the override was SILENT. On
+    # 2026-09-05 `business` was restarted with `--engine claude` while
+    # its own spec declares qwen38-27b with `default: true` and carries
+    # an operator ruling saying Qwen ONLY; it ran 27 hours that way and
+    # nothing anywhere said the spec had been overruled. This line is
+    # read by a person during an incident -- that is its consumer, and
+    # it is the only one it claims.
+    if explicit and spec_default and spec_default != engine.key:
+        if log:
+            _logger().warning(
+                "agent %r: starting on engine %r by explicit --engine, "
+                "OVERRULING this spec's declared default %r "
+                "(spec.%s.%s). The override applies to THIS start only; "
+                "the spec is unchanged and the next start without "
+                "--engine will select %r again.",
+                getattr(config, "name", "<unknown>"),
+                engine.key,
+                spec_default,
+                ENGINES_KEY,
+                spec_default,
+                spec_default,
+            )
 
     # Re-fold even when the loader already applied this same entry: the
     # config may have been mutated between load and start, and applying

--- a/tests/scitex_agent_container/_lifecycle/test__engine_select.py
+++ b/tests/scitex_agent_container/_lifecycle/test__engine_select.py
@@ -457,3 +457,67 @@ def test_a_legacy_spec_emits_no_engine_env_flags_at_all(tmp_path):
     argv = auth_argv(config, tmp_path / "state")
     # Assert
     assert not any(a.startswith("SAC_ENGINE") for a in argv)
+
+
+def test_an_explicit_engine_overruling_the_spec_default_is_recorded(
+    tmp_path, token_exported, caplog
+):
+    # Arrange
+    import logging
+
+    config = load_config(_write(tmp_path, "overruled", _engines()))
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        select_engine_at_start(config, "qwen38-27b")
+
+    # Assert
+    assert "OVERRULING" in caplog.text
+
+
+def test_an_explicit_engine_agreeing_with_the_spec_default_is_not_recorded(
+    tmp_path, token_exported, caplog
+):
+    # Arrange
+    import logging
+
+    config = load_config(_write(tmp_path, "agreeing", _engines()))
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        select_engine_at_start(config, "claude")
+
+    # Assert
+    assert "OVERRULING" not in caplog.text
+
+
+def test_a_start_with_no_explicit_engine_is_not_recorded_as_an_override(
+    tmp_path, token_exported, caplog
+):
+    # Arrange
+    import logging
+
+    config = load_config(_write(tmp_path, "plain", _engines()))
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        select_engine_at_start(config, None)
+
+    # Assert
+    assert "OVERRULING" not in caplog.text
+
+
+def test_the_override_record_names_the_engine_the_spec_declared(
+    tmp_path, token_exported, caplog
+):
+    # Arrange
+    import logging
+
+    config = load_config(_write(tmp_path, "named", _engines()))
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        select_engine_at_start(config, "qwen38-27b")
+
+    # Assert
+    assert "'claude'" in caplog.text


### PR DESCRIPTION
## Why

On 2026-09-05 `business` was restarted with `--engine claude` while its own spec declares `qwen38-27b` with `default: true` and carries an operator ruling saying **Qwen ONLY**. It ran 27 hours that way.

Honouring the override was correct. What was missing is that **nothing said the spec had been overruled** — a day later the only surviving evidence was the tmux process's argv, recovered by hand from `/proc`.

## What

One WARNING at start, naming both engines:

```
agent 'business': starting on engine 'claude' by explicit --engine,
OVERRULING this spec's declared default 'qwen38-27b' (spec.engines.qwen38-27b).
The override applies to THIS start only; the spec is unchanged and the next
start without --engine will select 'qwen38-27b' again.
```

**A record, not a gate, and deliberately so.** Refusing here would make `--engine` useless. The constitution asks that we say which one we built: the consumer is a person reading logs during an incident, which is a real and sufficient consumer, and it is the only one this claims.

## The one subtle part

The spec's own answer is read from `config.engine_key` **captured before `apply_engine` overwrites it** — the same before-the-fold idiom this function already uses for `spec_harness`, and for the same reason. Read afterwards, it would compare this start's choice with itself and the contradiction could never fire.

It is **not** re-derived from `config.engines`. That mapping is the merged namespace (fleet library ∪ spec-local), and resolving a default from it attributes fleet engines to the spec — the defect fixed in #1318, where it fabricated a declared engine for the 129 of 130 deployed specs that declare none.

## Tests

Four, **three of them controls**, because a warning that fires on every start is worse than no warning:

| case | expected |
|---|---|
| explicit `--engine` contradicting the default | recorded |
| explicit `--engine` **agreeing** with the default | NOT recorded |
| no `--engine` at all | NOT recorded |
| the record names the engine the spec declared | `'claude'` present |

Driven against real `AgentConfig` objects from real spec files, matching this file's existing "nothing under test is mocked" convention.

## A pre-existing failure you may hit locally

`test_a_legacy_spec_with_no_engine_requested_selects_nothing` fails in a container that has a fleet `engines.yaml` on disk, and passes in CI which has none. **Verified pre-existing** against a worktree where `_engine_select.py` is untouched — the identical failure.

Its cause is the same merged-namespace defect one layer down: the start path calls `resolve_default(engines)` with no `local_keys`, so a fleet-library entry is treated as spec-local. Tracked as `sac-start-path-resolves-the-default-engine-without-local-keys-20260906` (P1), and it is why deploying `engines.yaml` to the fleet today would make ~129 legacy agents refuse to start.
