### PR TITLE
fix(image): one bake-remote at a time — a second concurrent pull filled the disk

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_bake_lock.py
+++ b/src/scitex_agent_container/cli_pkg/_bake_lock.py
@@ -1,0 +1,136 @@
+"""Single-instance guard for ``sac image bake-remote``.
+
+MEASURED INCIDENT, 2026-09-06/07 on scitex-compute-03. Nothing stopped a
+second ``bake-remote`` starting while one was mid-transfer, so a
+supervisor restart began a SECOND ~7.6G rsync of the SAME artifact. Both
+used ``rsync --partial``, so the newcomer resumed from the incumbent's
+partial AND wrote its own temp — consuming more than it replaced. The
+host went 17G free -> 3.8G in fifteen minutes with THREE concurrent
+pulls of one artifact, and earlier the same evening the same loop had
+driven the disk to zero and the ecosystem supervisor to 273 restarts.
+
+Killing a duplicate does not help: the supervisor re-runs the job when
+it exits, so each kill starts a fresh full pull. The only thing that
+ends it is refusing the second START.
+
+WHY A LOCK RATHER THAN A SURVEY. Asking "is another bake running?" and
+then starting is two steps with a gap, and the gap is exactly where the
+second one gets in — measured here as a third bake appearing 55 seconds
+after the second was killed. ``flock(LOCK_EX | LOCK_NB)`` decides
+atomically: acquired means nobody else holds it AND nobody else can
+take it while we do.
+
+Mechanism follows ``_listen/_single_instance`` (flock-backed pidfile,
+holder PID in the body for diagnostics, kernel releases on any exit
+including SIGKILL, so a crashed bake never jams the pipeline). That
+module is correctly scoped to listen — it is parameterised on a TCP
+port — so this is a sibling rather than a caller. Unifying the two onto
+one primitive is worth doing and is deliberately NOT done here: the
+listen lock is on the daemon's critical path and this landed while a
+supervisor was stopped.
+
+SCOPED PER CONTAINERS DIR, not per host and not global. Two bakes into
+DIFFERENT containers dirs cannot collide (they write different files),
+and a global lock would make an unrelated dev bake block the timer.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "BakeLockHandle",
+    "BakeAlreadyRunningError",
+    "acquire_bake_lock",
+    "release_bake_lock",
+]
+
+
+@dataclass
+class BakeLockHandle:
+    """Opaque handle to an acquired bake lock.
+
+    ``fd`` holds the flock; closing it releases the lock. Keep the
+    handle alive for the whole bake.
+    """
+
+    fd: int
+    pid_file: Path
+
+
+class BakeAlreadyRunningError(RuntimeError):
+    """Another ``bake-remote`` holds the lock for this containers dir.
+
+    Carries the holding PID and the lock path so the operator can name
+    and clear the conflict without ``lsof``.
+    """
+
+
+def bake_lock_path(containers_dir: Path, lock_dir: Path) -> Path:
+    """Lock path for ``containers_dir``, hashed so it is filesystem-safe.
+
+    The absolute containers dir is the identity — a short digest of it
+    names the file, because the path itself contains separators and can
+    be long. Deterministic, so two invocations naming the same dir by
+    the same absolute path collide as intended.
+    """
+    digest = hashlib.sha256(str(containers_dir.resolve()).encode()).hexdigest()[:16]
+    return lock_dir / f"bake-remote-{digest}.pid"
+
+
+def _read_holding_pid(fd: int) -> str:
+    """Best-effort PID read for the diagnostic message only.
+
+    Never branched on — the flock is the source of truth.
+    """
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        return os.read(fd, 256).decode("utf-8", "replace").strip() or "<unknown>"
+    except OSError:  # stx-allow: fallback (reason: diagnostic-only — flock decision already made)
+        return "<unreadable>"
+
+
+def acquire_bake_lock(
+    *,
+    containers_dir: Path,
+    lock_dir: Path,
+) -> BakeLockHandle:
+    """Take the exclusive bake lock for ``containers_dir``.
+
+    ``lock_dir`` must exist; the caller owns creating it, so tests can
+    isolate without touching ``$HOME``.
+
+    Raises :class:`BakeAlreadyRunningError` when another bake holds it.
+    Refusing is correct: a second concurrent pull of a multi-GB artifact
+    cannot help and demonstrably fills the disk.
+    """
+    pid_file = bake_lock_path(containers_dir, lock_dir)
+    fd = os.open(str(pid_file), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        holding_pid = _read_holding_pid(fd)
+        os.close(fd)
+        raise BakeAlreadyRunningError(
+            f"another `sac image bake-remote` is already pulling into "
+            f"{containers_dir} (holding PID {holding_pid}, lock file "
+            f"{pid_file}). A second concurrent pull of the same multi-GB "
+            f"artifact cannot finish sooner and fills the disk — this one "
+            f"is declining, NOT failing. Wait for that bake, or stop it "
+            f"(`kill {holding_pid}`) if it is wedged."
+        ) from exc
+    os.ftruncate(fd, 0)
+    os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+    return BakeLockHandle(fd=fd, pid_file=pid_file)
+
+
+def release_bake_lock(handle: BakeLockHandle) -> None:
+    """Release on clean exit. The kernel handles dirty exit."""
+    try:
+        os.close(handle.fd)
+    except OSError:  # stx-allow: fallback (reason: fd already closed; the flock is gone either way)
+        pass

--- a/src/scitex_agent_container/cli_pkg/_image_remote_bake.py
+++ b/src/scitex_agent_container/cli_pkg/_image_remote_bake.py
@@ -41,6 +41,12 @@ from pathlib import Path
 
 import click
 
+from ._bake_lock import (
+    BakeAlreadyRunningError,
+    acquire_bake_lock,
+    release_bake_lock,
+)
+
 from . import _remote_bake_core as core
 from ._remote_bake_core import (
     BakeVerdict,
@@ -262,61 +268,98 @@ def image_bake_remote(
         # trap is a measured incident shape).
         containers_dir = Path.home() / ".scitex" / "agent-container" / "containers"
 
-    failures: list[str] = []
-    # One-line-per-failure summaries for the headline. The full reason is
-    # multi-line by design (remote stderr, remedy), and a headline that
-    # ends at the colon is unreadable in a journal: `bake-remote FAILED:`
-    # matched a grep and told the reader NOTHING.
-    failure_heads: list[str] = []
-    for layer in layers:
-        click.echo(f"=== bake-remote: layer={layer} host={host} ===")
-        try:
-            outcome = run_remote_bake(
-                host=host,
-                layer=layer,
-                lease_name=lease_name,
-                remote_workdir=remote_workdir,
-                branch=branch,
-                retain=retain,
-                force=force,
-                timeout=ssh_timeout,
-            )
-        except subprocess.TimeoutExpired:
-            failure_heads.append(
-                f"{layer}: remote bake exceeded --ssh-timeout={ssh_timeout}s"
-            )
-            failures.append(failure_heads[-1])
-            click.echo(failures[-1], err=True)
-            continue
-        if outcome.verdict in (BakeVerdict.FAILED, BakeVerdict.NO_RESULT):
-            failure_heads.append(
-                f"{layer}: bake {outcome.verdict.value} — {_first_line(outcome.detail)}"
-            )
-            failures.append(f"{layer}: bake {outcome.verdict.value}\n{outcome.detail}")
-            click.echo(failures[-1], err=True)
-            continue
-        click.echo(f"bake: {outcome.verdict.value} {outcome.sif}")
-        if bake_only:
-            continue
-        pull = core.pull_and_publish(
-            host=host, outcome=outcome, containers_dir=containers_dir, retain=retain
+    # ONE BAKE AT A TIME PER CONTAINERS DIR. Measured 2026-09-06/07: a
+    # supervisor restart began a SECOND ~7.6G pull of the same artifact
+    # while the first was mid-transfer; both used `rsync --partial`, so
+    # the newcomer resumed from the incumbent's partial AND wrote its own
+    # temp. scitex-compute-03 went 17G free -> 3.8G with three concurrent
+    # pulls, and earlier the same evening the identical loop drove the
+    # disk to zero and the ecosystem supervisor to 273 restarts.
+    #
+    # DECLINING IS EXIT 0, NOT A FAILURE. The caller is a supervised job
+    # under Restart=always: a non-zero exit here would be read as a crash
+    # and restarted, which is precisely the loop this prevents. Nothing
+    # went wrong when a second bake declines — the first one is doing the
+    # work.
+    lock_dir = Path.home() / ".scitex" / "agent-container" / "runtime"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        # Held for the lifetime of this one-shot command. The kernel
+        # releases the flock when the process exits — including SIGKILL
+        # and OOM — so a crashed bake never jams the pipeline and no
+        # stale-lock reconciliation is needed. Bound to a name so the fd
+        # is not garbage-collected (closing it would release the lock).
+        _bake_lock = acquire_bake_lock(
+            containers_dir=containers_dir, lock_dir=lock_dir
         )
-        click.echo(f"publish: {pull.verdict.value} — {pull.detail}")
-        if pull.verdict is PullVerdict.FAILED:
-            failure_heads.append(
-                f"{layer}: publish FAILED — {_first_line(pull.detail)}"
-            )
-            failures.append(f"{layer}: publish FAILED ({pull.detail})")
+    except BakeAlreadyRunningError as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(0) from exc
 
-    if failures:
-        # The headline itself names what broke. Anything less makes the
-        # whole message invisible to the grep that a tired operator at
-        # 03:00 actually runs.
-        click.echo(f"bake-remote FAILED: {'; '.join(failure_heads)}", err=True)
-        for f in failures:
-            click.echo(f"  - {f}", err=True)
-        raise SystemExit(1)
-    click.echo("bake-remote: all layers ok")
+    try:
+        failures: list[str] = []
+        # One-line-per-failure summaries for the headline. The full reason is
+        # multi-line by design (remote stderr, remedy), and a headline that
+        # ends at the colon is unreadable in a journal: `bake-remote FAILED:`
+        # matched a grep and told the reader NOTHING.
+        failure_heads: list[str] = []
+        for layer in layers:
+            click.echo(f"=== bake-remote: layer={layer} host={host} ===")
+            try:
+                outcome = run_remote_bake(
+                    host=host,
+                    layer=layer,
+                    lease_name=lease_name,
+                    remote_workdir=remote_workdir,
+                    branch=branch,
+                    retain=retain,
+                    force=force,
+                    timeout=ssh_timeout,
+                )
+            except subprocess.TimeoutExpired:
+                failure_heads.append(
+                    f"{layer}: remote bake exceeded --ssh-timeout={ssh_timeout}s"
+                )
+                failures.append(failure_heads[-1])
+                click.echo(failures[-1], err=True)
+                continue
+            if outcome.verdict in (BakeVerdict.FAILED, BakeVerdict.NO_RESULT):
+                failure_heads.append(
+                    f"{layer}: bake {outcome.verdict.value} — {_first_line(outcome.detail)}"
+                )
+                failures.append(f"{layer}: bake {outcome.verdict.value}\n{outcome.detail}")
+                click.echo(failures[-1], err=True)
+                continue
+            click.echo(f"bake: {outcome.verdict.value} {outcome.sif}")
+            if bake_only:
+                continue
+            pull = core.pull_and_publish(
+                host=host, outcome=outcome, containers_dir=containers_dir, retain=retain
+            )
+            click.echo(f"publish: {pull.verdict.value} — {pull.detail}")
+            if pull.verdict is PullVerdict.FAILED:
+                failure_heads.append(
+                    f"{layer}: publish FAILED — {_first_line(pull.detail)}"
+                )
+                failures.append(f"{layer}: publish FAILED ({pull.detail})")
+
+        if failures:
+            # The headline itself names what broke. Anything less makes the
+            # whole message invisible to the grep that a tired operator at
+            # 03:00 actually runs.
+            click.echo(f"bake-remote FAILED: {'; '.join(failure_heads)}", err=True)
+            for f in failures:
+                click.echo(f"  - {f}", err=True)
+            raise SystemExit(1)
+        click.echo("bake-remote: all layers ok")
+    finally:
+        # Explicit release so a second invocation IN THE SAME PROCESS
+        # (CliRunner, a future in-process caller) can acquire. Relying
+        # on process exit alone was measured wrong here: the existing
+        # CliRunner tests share one process, so the first invocation
+        # held the lock and every later one silently declined with
+        # exit 0. The kernel still covers dirty exit.
+        release_bake_lock(_bake_lock)
 
 
 __all__ = ["image_bake_remote", "run_remote_bake"]

--- a/tests/scitex_agent_container/cli_pkg/test__bake_lock.py
+++ b/tests/scitex_agent_container/cli_pkg/test__bake_lock.py
@@ -21,98 +21,175 @@ from scitex_agent_container.cli_pkg._bake_lock import (
 )
 
 
-def test_a_first_bake_acquires_the_lock(tmp_path: Path) -> None:
-    lock_dir = tmp_path / "runtime"
-    lock_dir.mkdir()
-    containers = tmp_path / "containers"
-    containers.mkdir()
+@pytest.fixture
+def lock_dir(tmp_path: Path) -> Path:
+    """Directory holding the pidfile; the caller owns creating it."""
+    path = tmp_path / "runtime"
+    path.mkdir()
+    return path
 
-    handle = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+
+@pytest.fixture
+def containers_dir(tmp_path: Path) -> Path:
+    """The bake destination the lock is scoped to."""
+    path = tmp_path / "containers"
+    path.mkdir()
+    return path
+
+
+def test_the_first_bake_creates_its_pidfile(
+    lock_dir: Path, containers_dir: Path
+) -> None:
+    # Arrange
+    handle = None
+    # Act
+    handle = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    # Assert
     try:
         assert handle.pid_file.is_file()
-        assert handle.pid_file.read_text().strip() == str(os.getpid())
     finally:
         release_bake_lock(handle)
 
 
-def test_a_second_bake_into_the_same_dir_is_REFUSED(tmp_path: Path) -> None:
+def test_the_first_bake_stamps_its_own_pid(
+    lock_dir: Path, containers_dir: Path
+) -> None:
+    # Arrange
+    expected = str(os.getpid())
+    # Act
+    handle = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    # Assert
+    try:
+        assert handle.pid_file.read_text().strip() == expected
+    finally:
+        release_bake_lock(handle)
+
+
+def test_a_second_bake_into_the_same_dir_is_refused(
+    lock_dir: Path, containers_dir: Path
+) -> None:
     """The whole point: the second concurrent pull must not start."""
-    lock_dir = tmp_path / "runtime"
-    lock_dir.mkdir()
-    containers = tmp_path / "containers"
-    containers.mkdir()
-
-    first = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+    # Arrange
+    first = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    # Act
+    # Assert
     try:
-        with pytest.raises(BakeAlreadyRunningError) as excinfo:
-            acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
-        message = str(excinfo.value)
-        # The refusal must be actionable: name the holder and the file.
-        assert str(os.getpid()) in message
-        assert str(first.pid_file) in message
-        assert "declining" in message
+        with pytest.raises(BakeAlreadyRunningError):
+            acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
     finally:
         release_bake_lock(first)
 
 
-def test_a_bake_into_a_DIFFERENT_containers_dir_is_allowed(tmp_path: Path) -> None:
+def test_the_refusal_names_the_holding_pid(
+    lock_dir: Path, containers_dir: Path
+) -> None:
+    """`kill <pid>` must be actionable without lsof."""
+    # Arrange
+    first = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    message = ""
+    # Act
+    try:
+        acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    except BakeAlreadyRunningError as exc:
+        message = str(exc)
+    finally:
+        release_bake_lock(first)
+    # Assert
+    assert str(os.getpid()) in message
+
+
+def test_the_refusal_says_it_is_declining_not_failing(
+    lock_dir: Path, containers_dir: Path
+) -> None:
+    """A supervised caller must not read this as a crash."""
+    # Arrange
+    first = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    message = ""
+    # Act
+    try:
+        acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    except BakeAlreadyRunningError as exc:
+        message = str(exc)
+    finally:
+        release_bake_lock(first)
+    # Assert
+    assert "declining" in message
+
+
+def test_a_bake_into_a_different_containers_dir_is_allowed(
+    lock_dir: Path, tmp_path: Path
+) -> None:
     """Scoped per containers dir — unrelated bakes must not block."""
-    lock_dir = tmp_path / "runtime"
-    lock_dir.mkdir()
+    # Arrange
     one = tmp_path / "containers-one"
     one.mkdir()
     two = tmp_path / "containers-two"
     two.mkdir()
-
     first = acquire_bake_lock(containers_dir=one, lock_dir=lock_dir)
+    # Act
+    second = acquire_bake_lock(containers_dir=two, lock_dir=lock_dir)
+    # Assert
     try:
-        second = acquire_bake_lock(containers_dir=two, lock_dir=lock_dir)
-        release_bake_lock(second)
+        assert second.pid_file != first.pid_file
     finally:
+        release_bake_lock(second)
         release_bake_lock(first)
 
 
-def test_the_lock_is_reacquirable_after_release(tmp_path: Path) -> None:
+def test_the_lock_is_reacquirable_after_release(
+    lock_dir: Path, containers_dir: Path
+) -> None:
     """A finished bake must not jam the next one."""
-    lock_dir = tmp_path / "runtime"
-    lock_dir.mkdir()
-    containers = tmp_path / "containers"
-    containers.mkdir()
-
-    first = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+    # Arrange
+    first = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
     release_bake_lock(first)
-    second = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
-    release_bake_lock(second)
+    # Act
+    second = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    # Assert
+    try:
+        assert second.pid_file.read_text().strip() == str(os.getpid())
+    finally:
+        release_bake_lock(second)
 
 
-def test_a_stale_pidfile_with_no_live_holder_does_not_jam(tmp_path: Path) -> None:
-    """A crashed bake leaves a PID behind but no flock — the next must proceed.
+def test_a_stale_pidfile_with_no_live_holder_does_not_jam(
+    lock_dir: Path, containers_dir: Path
+) -> None:
+    """A crashed bake leaves a PID behind but no flock — the next proceeds.
 
-    This is the case that would otherwise require stale-lock
-    reconciliation; the kernel releasing the flock on exit is what makes
-    that unnecessary.
+    The kernel releasing the flock on exit is what makes stale-lock
+    reconciliation unnecessary.
     """
-    lock_dir = tmp_path / "runtime"
-    lock_dir.mkdir()
-    containers = tmp_path / "containers"
-    containers.mkdir()
-
-    stale = bake_lock_path(containers, lock_dir)
-    stale.write_text("999999\n")  # a PID nothing holds a flock for
-
-    handle = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+    # Arrange
+    stale = bake_lock_path(containers_dir, lock_dir)
+    stale.write_text("999999\n")
+    # Act
+    handle = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    # Assert
     try:
         assert handle.pid_file.read_text().strip() == str(os.getpid())
     finally:
         release_bake_lock(handle)
 
 
-def test_the_lock_path_is_stable_and_dir_scoped(tmp_path: Path) -> None:
-    lock_dir = tmp_path / "runtime"
+def test_the_lock_path_is_stable_for_one_dir(
+    lock_dir: Path, containers_dir: Path
+) -> None:
+    # Arrange
+    first = bake_lock_path(containers_dir, lock_dir)
+    # Act
+    second = bake_lock_path(containers_dir, lock_dir)
+    # Assert
+    assert first == second
+
+
+def test_the_lock_path_differs_between_dirs(lock_dir: Path, tmp_path: Path) -> None:
+    # Arrange
     one = tmp_path / "containers-one"
     one.mkdir()
     two = tmp_path / "containers-two"
     two.mkdir()
-
-    assert bake_lock_path(one, lock_dir) == bake_lock_path(one, lock_dir)
-    assert bake_lock_path(one, lock_dir) != bake_lock_path(two, lock_dir)
+    # Act
+    paths = (bake_lock_path(one, lock_dir), bake_lock_path(two, lock_dir))
+    # Assert
+    assert paths[0] != paths[1]

--- a/tests/scitex_agent_container/cli_pkg/test__bake_lock.py
+++ b/tests/scitex_agent_container/cli_pkg/test__bake_lock.py
@@ -1,0 +1,118 @@
+"""Tests for the bake-remote single-instance lock.
+
+The incident these encode: a second `bake-remote` started while one was
+mid-transfer, resumed from the incumbent's partial, wrote its own temp,
+and drove scitex-compute-03 from 17G free to 3.8G with three concurrent
+pulls of one artifact.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg._bake_lock import (
+    BakeAlreadyRunningError,
+    acquire_bake_lock,
+    bake_lock_path,
+    release_bake_lock,
+)
+
+
+def test_a_first_bake_acquires_the_lock(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "runtime"
+    lock_dir.mkdir()
+    containers = tmp_path / "containers"
+    containers.mkdir()
+
+    handle = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+    try:
+        assert handle.pid_file.is_file()
+        assert handle.pid_file.read_text().strip() == str(os.getpid())
+    finally:
+        release_bake_lock(handle)
+
+
+def test_a_second_bake_into_the_same_dir_is_REFUSED(tmp_path: Path) -> None:
+    """The whole point: the second concurrent pull must not start."""
+    lock_dir = tmp_path / "runtime"
+    lock_dir.mkdir()
+    containers = tmp_path / "containers"
+    containers.mkdir()
+
+    first = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+    try:
+        with pytest.raises(BakeAlreadyRunningError) as excinfo:
+            acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+        message = str(excinfo.value)
+        # The refusal must be actionable: name the holder and the file.
+        assert str(os.getpid()) in message
+        assert str(first.pid_file) in message
+        assert "declining" in message
+    finally:
+        release_bake_lock(first)
+
+
+def test_a_bake_into_a_DIFFERENT_containers_dir_is_allowed(tmp_path: Path) -> None:
+    """Scoped per containers dir — unrelated bakes must not block."""
+    lock_dir = tmp_path / "runtime"
+    lock_dir.mkdir()
+    one = tmp_path / "containers-one"
+    one.mkdir()
+    two = tmp_path / "containers-two"
+    two.mkdir()
+
+    first = acquire_bake_lock(containers_dir=one, lock_dir=lock_dir)
+    try:
+        second = acquire_bake_lock(containers_dir=two, lock_dir=lock_dir)
+        release_bake_lock(second)
+    finally:
+        release_bake_lock(first)
+
+
+def test_the_lock_is_reacquirable_after_release(tmp_path: Path) -> None:
+    """A finished bake must not jam the next one."""
+    lock_dir = tmp_path / "runtime"
+    lock_dir.mkdir()
+    containers = tmp_path / "containers"
+    containers.mkdir()
+
+    first = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+    release_bake_lock(first)
+    second = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+    release_bake_lock(second)
+
+
+def test_a_stale_pidfile_with_no_live_holder_does_not_jam(tmp_path: Path) -> None:
+    """A crashed bake leaves a PID behind but no flock — the next must proceed.
+
+    This is the case that would otherwise require stale-lock
+    reconciliation; the kernel releasing the flock on exit is what makes
+    that unnecessary.
+    """
+    lock_dir = tmp_path / "runtime"
+    lock_dir.mkdir()
+    containers = tmp_path / "containers"
+    containers.mkdir()
+
+    stale = bake_lock_path(containers, lock_dir)
+    stale.write_text("999999\n")  # a PID nothing holds a flock for
+
+    handle = acquire_bake_lock(containers_dir=containers, lock_dir=lock_dir)
+    try:
+        assert handle.pid_file.read_text().strip() == str(os.getpid())
+    finally:
+        release_bake_lock(handle)
+
+
+def test_the_lock_path_is_stable_and_dir_scoped(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "runtime"
+    one = tmp_path / "containers-one"
+    one.mkdir()
+    two = tmp_path / "containers-two"
+    two.mkdir()
+
+    assert bake_lock_path(one, lock_dir) == bake_lock_path(one, lock_dir)
+    assert bake_lock_path(one, lock_dir) != bake_lock_path(two, lock_dir)


### PR DESCRIPTION
## The incident

`sac image bake-remote` had no mutual exclusion, so a supervisor restart could begin a **second ~7.6G pull of the same artifact** while the first was mid-transfer. Both use `rsync --partial`, so the newcomer resumed from the incumbent's partial **and** wrote its own temp — consuming more than it replaced.

Measured on scitex-compute-03, 2026-09-06/07:

```
17G free -> 3.8G in ~15 minutes, THREE concurrent pulls of one artifact
```

Earlier the same evening the identical loop drove that host's disk to **zero** and the ecosystem supervisor to **273 restarts** (it dies when its state write hits ENOSPC, systemd restarts it, it re-runs the bake job, repeat).

**Killing a duplicate makes it worse.** The supervisor re-runs the job when it exits, so each kill starts a fresh full pull — a third appeared 55 seconds after the second was killed. The only thing that ends it is refusing the second START.

## The change

A flock-backed pidfile lock, scoped per containers dir.

- **A lock, not a survey.** "Is another bake running?" then starting is two steps with a gap, and the gap is where the second one gets in. `flock(LOCK_EX | LOCK_NB)` decides atomically.
- **Follows `_listen/_single_instance`** — same mechanism (holder PID in the body for diagnostics, kernel releases on any exit including SIGKILL, so no stale-lock reconciliation). That module is correctly scoped to listen (parameterised on a TCP port), so this is a sibling rather than a caller. Unifying them onto one primitive is worth doing and is deliberately **not** done here: the listen lock is on the daemon's critical path and this landed while a supervisor was stopped.
- **Declining is exit 0.** The caller is a supervised job under `Restart=always`; a non-zero exit when a second bake declines would be read as a crash and restarted — the very loop this prevents.
- **Released explicitly**, not only at process exit (see below).

## What the existing tests caught

My first version held the lock for process lifetime and let the kernel release it. Correct for a one-shot CLI — but `CliRunner` invokes the command repeatedly in **one process**, so the first invocation held the lock and the next three declined with exit 0, breaking three existing tests (`assert 0 == 1`).

That was a real defect, not a test artifact: any future in-process caller would have silently no-opped with a success code. Fixed with an explicit release in `finally`; the kernel still covers dirty exit.

## Verification

- 6 new tests, including stale-pidfile-with-no-live-holder and per-dir scoping.
- **Proved the suite can go red**: with the `flock` call neutered, the refusal test reports `DID NOT RAISE`. Restored, green.
- `207 passed` across the bake surface (was 204 passed + 3 failed before the release fix).

## Deliberately NOT in this change

After reading `_remote_bake_core.py`, two things I had filed as defects are not:

- **Idempotency already exists** — `pull_and_publish` returns `UP_TO_DATE` when the SIF is present and its checksum matches the remote sidecar, and **refuses** on mismatch rather than guessing.
- **Partial retention is deliberate** — the `.incoming-*` file is kept for `--partial` resume, dot-named so it can never be mistaken for an artifact. Removing it on failure, as I had proposed, would turn every interrupted 7G transfer into a full re-transfer.

The free-space precheck (the card's other real item) is separate: it needs an artifact size from the remote before transfer, and is not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzNE6E8jqwVLXPUdAkDngd