### PR TITLE
fix(image): refuse a bake-remote pull that cannot fit on the volume

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_bake_space.py
+++ b/src/scitex_agent_container/cli_pkg/_bake_space.py
@@ -1,0 +1,131 @@
+"""Will this pull fit? — the free-space decision for ``bake-remote``.
+
+MEASURED 2026-09-06/07 on scitex-compute-03: `bake-remote` started a
+~7.6G transfer onto a volume with 4.0G free. It could not finish, and
+what it left behind reduced the space available to the next attempt —
+so every failure made the next one likelier. A pull that cannot fit is
+not a pull; refusing is the correct answer and it must be said out loud.
+
+PURE ON PURPOSE. This module does no I/O: the caller measures (remote
+artifact size, existing partial, free bytes) and this decides. That
+keeps the arithmetic — which is where the resume subtlety lives —
+testable without a filesystem, a remote host, or a 7G file.
+
+THE RESUME SUBTLETY, which a naive check gets wrong. rsync runs with
+``--partial``, so an interrupted transfer leaves bytes that the next run
+RESUMES from. The requirement is therefore the REMAINDER, not the whole
+artifact: a 7.6G pull that already has 7.0G on disk needs 0.6G, and a
+checker that demands 7.6G would refuse a transfer that fits comfortably.
+Refusing work that would have succeeded is its own defect.
+
+THREE-VALUED, because the size can be UNKNOWN. If the remote size cannot
+be determined (ssh failed, stat unavailable, unparseable output), that is
+not "it fits" and not "it does not fit" — it is "cannot tell". Collapsing
+unknown into either pole is the constitution's most-shipped bug. Unknown
+PROCEEDS, because refusing every pull whenever a probe is flaky would be
+a worse failure than the one this prevents, and it SAYS SO, so a pull
+that later dies of space is not a mystery.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "SpaceVerdict",
+    "DEFAULT_MARGIN_BYTES",
+    "check_space",
+    "human_bytes",
+]
+
+#: Headroom demanded beyond the transfer itself. A pull that lands with
+#: zero bytes to spare leaves a host that cannot write its own logs — the
+#: 2026-09-06 incident put compute-03 at exactly that point twice.
+DEFAULT_MARGIN_BYTES = 2 * 1024**3
+
+
+@dataclass(frozen=True)
+class SpaceVerdict:
+    """Fixed shape, so a caller never has to guess which field exists.
+
+    ``proceed`` is the decision. ``known`` says whether it rests on a
+    measured size or on not being able to tell — the two are different
+    and a caller that conflates them is repeating the bug this guards.
+    """
+
+    proceed: bool
+    known: bool
+    needed: int
+    free: int
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not self.known and not self.proceed:
+            raise ValueError(
+                "an UNKNOWN size must PROCEED — refusing on 'cannot tell' "
+                "would block every pull whenever the size probe is flaky"
+            )
+
+
+def human_bytes(count: int) -> str:
+    """Render bytes for a message a tired operator reads at 03:00."""
+    value = float(count)
+    for unit in ("B", "K", "M", "G", "T"):
+        if abs(value) < 1024.0 or unit == "T":
+            return f"{value:.1f}{unit}"
+        value /= 1024.0
+    return f"{value:.1f}T"
+
+
+def check_space(
+    *,
+    remote_size: int | None,
+    existing_partial: int,
+    free: int,
+    margin: int = DEFAULT_MARGIN_BYTES,
+) -> SpaceVerdict:
+    """Decide whether the remaining transfer fits, with headroom.
+
+    ``remote_size`` is ``None`` when it could not be determined.
+    ``existing_partial`` is what ``--partial`` already left on disk (0
+    when there is none), and is subtracted because the transfer resumes.
+    """
+    if remote_size is None:
+        return SpaceVerdict(
+            proceed=True,
+            known=False,
+            needed=0,
+            free=free,
+            reason=(
+                "remote artifact size UNKNOWN (probe failed) — proceeding "
+                "without a space check. If this pull dies partway, disk is "
+                f"the first thing to check ({human_bytes(free)} free now)."
+            ),
+        )
+    remaining = max(0, remote_size - existing_partial)
+    needed = remaining + margin
+    if free >= needed:
+        return SpaceVerdict(
+            proceed=True,
+            known=True,
+            needed=needed,
+            free=free,
+            reason=(
+                f"{human_bytes(remaining)} to transfer "
+                f"+ {human_bytes(margin)} margin fits in "
+                f"{human_bytes(free)} free"
+            ),
+        )
+    return SpaceVerdict(
+        proceed=False,
+        known=True,
+        needed=needed,
+        free=free,
+        reason=(
+            f"REFUSING: needs {human_bytes(remaining)} to transfer "
+            f"+ {human_bytes(margin)} margin = {human_bytes(needed)}, but "
+            f"only {human_bytes(free)} is free. A pull that cannot fit "
+            f"leaves a partial that makes the NEXT attempt likelier to "
+            f"fail. Free space on this volume, or bake to another host."
+        ),
+    )

--- a/src/scitex_agent_container/cli_pkg/_image_remote_bake.py
+++ b/src/scitex_agent_container/cli_pkg/_image_remote_bake.py
@@ -282,81 +282,91 @@ def image_bake_remote(
     # went wrong when a second bake declines — the first one is doing the
     # work.
     containers_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        # Held for the lifetime of this one-shot command. The kernel
-        # releases the flock when the process exits — including SIGKILL
-        # and OOM — so a crashed bake never jams the pipeline and no
-        # stale-lock reconciliation is needed. Bound to a name so the fd
-        # is not garbage-collected (closing it would release the lock).
-        _bake_lock = acquire_bake_lock(containers_dir=containers_dir)
-    except BakeAlreadyRunningError as exc:
-        click.echo(str(exc), err=True)
-        raise SystemExit(0) from exc
 
-    try:
-        failures: list[str] = []
-        # One-line-per-failure summaries for the headline. The full reason is
-        # multi-line by design (remote stderr, remedy), and a headline that
-        # ends at the colon is unreadable in a journal: `bake-remote FAILED:`
-        # matched a grep and told the reader NOTHING.
-        failure_heads: list[str] = []
-        for layer in layers:
-            click.echo(f"=== bake-remote: layer={layer} host={host} ===")
-            try:
-                outcome = run_remote_bake(
-                    host=host,
-                    layer=layer,
-                    lease_name=lease_name,
-                    remote_workdir=remote_workdir,
-                    branch=branch,
-                    retain=retain,
-                    force=force,
-                    timeout=ssh_timeout,
-                )
-            except subprocess.TimeoutExpired:
-                failure_heads.append(
-                    f"{layer}: remote bake exceeded --ssh-timeout={ssh_timeout}s"
-                )
-                failures.append(failure_heads[-1])
-                click.echo(failures[-1], err=True)
-                continue
-            if outcome.verdict in (BakeVerdict.FAILED, BakeVerdict.NO_RESULT):
-                failure_heads.append(
-                    f"{layer}: bake {outcome.verdict.value} — {_first_line(outcome.detail)}"
-                )
-                failures.append(f"{layer}: bake {outcome.verdict.value}\n{outcome.detail}")
-                click.echo(failures[-1], err=True)
-                continue
-            click.echo(f"bake: {outcome.verdict.value} {outcome.sif}")
-            if bake_only:
-                continue
-            pull = core.pull_and_publish(
-                host=host, outcome=outcome, containers_dir=containers_dir, retain=retain
+    failures: list[str] = []
+    # One-line-per-failure summaries for the headline. The full reason is
+    # multi-line by design (remote stderr, remedy), and a headline that
+    # ends at the colon is unreadable in a journal: `bake-remote FAILED:`
+    # matched a grep and told the reader NOTHING.
+    failure_heads: list[str] = []
+    for layer in layers:
+        click.echo(f"=== bake-remote: layer={layer} host={host} ===")
+        try:
+            outcome = run_remote_bake(
+                host=host,
+                layer=layer,
+                lease_name=lease_name,
+                remote_workdir=remote_workdir,
+                branch=branch,
+                retain=retain,
+                force=force,
+                timeout=ssh_timeout,
             )
-            click.echo(f"publish: {pull.verdict.value} — {pull.detail}")
-            if pull.verdict is PullVerdict.FAILED:
-                failure_heads.append(
-                    f"{layer}: publish FAILED — {_first_line(pull.detail)}"
-                )
-                failures.append(f"{layer}: publish FAILED ({pull.detail})")
+        except subprocess.TimeoutExpired:
+            failure_heads.append(
+                f"{layer}: remote bake exceeded --ssh-timeout={ssh_timeout}s"
+            )
+            failures.append(failure_heads[-1])
+            click.echo(failures[-1], err=True)
+            continue
+        if outcome.verdict in (BakeVerdict.FAILED, BakeVerdict.NO_RESULT):
+            failure_heads.append(
+                f"{layer}: bake {outcome.verdict.value} — {_first_line(outcome.detail)}"
+            )
+            failures.append(f"{layer}: bake {outcome.verdict.value}\n{outcome.detail}")
+            click.echo(failures[-1], err=True)
+            continue
+        click.echo(f"bake: {outcome.verdict.value} {outcome.sif}")
+        if bake_only:
+            continue
+        # ONE PULL AT A TIME PER CONTAINERS DIR — the lock wraps the
+        # TRANSFER it guards, not the whole command. Measured: a supervisor
+        # restart began a SECOND ~7.6G rsync of the same artifact while the
+        # first ran; both use --partial, so the newcomer resumed from the
+        # incumbent's partial AND wrote its own temp. compute-03 went 17G
+        # free -> 3.8G with three concurrent pulls.
+        #
+        # WHY NOT AT THE TOP OF THE COMMAND, measured the hard way: `--bake
+        # -only` never pulls and a FAILED bake never reaches here, so an
+        # earlier lock guarded paths that touch no disk — and did it on the
+        # DEFAULT containers dir under $HOME, which CI's two matrix legs
+        # share on one self-hosted runner. Four unrelated tests declined and
+        # develop went red. Scoping to the transfer fixes both: nothing that
+        # does not pull ever waits, and every caller reaching here passes an
+        # explicit dir, so tests isolate by construction.
+        #
+        # DECLINING IS NOT FAILING — a supervised job under Restart=always
+        # must not read "someone else is fetching this" as a crash.
+        try:
+            _pull_lock = acquire_bake_lock(containers_dir=containers_dir)
+        except BakeAlreadyRunningError as exc:
+            click.echo(f"publish: SKIPPED — {exc}")
+            continue
+        try:
+            pull = core.pull_and_publish(
+                host=host,
+                outcome=outcome,
+                containers_dir=containers_dir,
+                retain=retain,
+            )
+        finally:
+            release_bake_lock(_pull_lock)
+        click.echo(f"publish: {pull.verdict.value} — {pull.detail}")
+        if pull.verdict is PullVerdict.FAILED:
+            failure_heads.append(
+                f"{layer}: publish FAILED — {_first_line(pull.detail)}"
+            )
+            failures.append(f"{layer}: publish FAILED ({pull.detail})")
 
-        if failures:
-            # The headline itself names what broke. Anything less makes the
-            # whole message invisible to the grep that a tired operator at
-            # 03:00 actually runs.
-            click.echo(f"bake-remote FAILED: {'; '.join(failure_heads)}", err=True)
-            for f in failures:
-                click.echo(f"  - {f}", err=True)
-            raise SystemExit(1)
-        click.echo("bake-remote: all layers ok")
-    finally:
-        # Explicit release so a second invocation IN THE SAME PROCESS
-        # (CliRunner, a future in-process caller) can acquire. Relying
-        # on process exit alone was measured wrong here: the existing
-        # CliRunner tests share one process, so the first invocation
-        # held the lock and every later one silently declined with
-        # exit 0. The kernel still covers dirty exit.
-        release_bake_lock(_bake_lock)
+    if failures:
+        # The headline itself names what broke. Anything less makes the
+        # whole message invisible to the grep that a tired operator at
+        # 03:00 actually runs.
+        click.echo(f"bake-remote FAILED: {'; '.join(failure_heads)}", err=True)
+        for f in failures:
+            click.echo(f"  - {f}", err=True)
+        raise SystemExit(1)
+    click.echo("bake-remote: all layers ok")
 
 
 __all__ = ["image_bake_remote", "run_remote_bake"]

--- a/src/scitex_agent_container/cli_pkg/_remote_bake_core.py
+++ b/src/scitex_agent_container/cli_pkg/_remote_bake_core.py
@@ -48,6 +48,8 @@ LAYERS = ("base", "scitex")
 
 # Timestamped artifact name, e.g. sac-scitex-2026-0717-092952.sif —
 # matches scitex-container's ``_store`` timestamp shape.
+from ._bake_space import check_space
+
 SIF_RE = re.compile(r"^sac-(?P<layer>base|scitex)-(?P<ts>\d{4}-\d{4}-\d{6})\.sif$")
 
 # Module-level seams (save/restore in tests, same pattern as image_group's
@@ -333,6 +335,35 @@ def prune_local(containers_dir: Path, layer: str, retain: int) -> list[str]:
     return pruned
 
 
+def _reference_size(layer_dir: Path, layer: str) -> int | None:
+    """Size of the newest SIF already present for ``layer``, or None.
+
+    An ESTIMATE, and deliberately a local one. The exact answer lives on
+    the remote, but fetching it would add an ssh round-trip to the hot
+    path of every pull — a new network dependency, and a new way for a
+    transfer to stall before it starts. Successive builds of one layer
+    are close in size (sac-scitex has sat near 7.1G across rebuilds), so
+    the previous artifact answers "roughly how much do we need?" well
+    enough to catch the case that actually bit us: 4.0G free, ~7.6G
+    wanted.
+
+    Returns None when no prior SIF exists (a first bake), which
+    :func:`check_space` treats as UNKNOWN and lets through rather than
+    blocking a legitimate first pull.
+
+    Being an estimate is the honest limit: an image that grows sharply
+    could pass this check and still exhaust the volume. It narrows the
+    failure, it does not eliminate it, and the margin is what covers
+    ordinary drift.
+    """
+    candidates = [
+        p for p in layer_dir.glob(f"sac-{layer}-*.sif") if SIF_RE.match(p.name)
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime).stat().st_size
+
+
 def pull_and_publish(
     *,
     host: str,
@@ -380,6 +411,25 @@ def pull_and_publish(
     if rsync is None:
         return PullOutcome(PullVerdict.FAILED, layer, "rsync not found on this host")
     incoming = layer_dir / f".incoming-{sif_name}"
+
+    # WILL THIS FIT? Measured 2026-09-06/07: a ~7.6G transfer started
+    # onto 4.0G free, could not finish, and the partial it left made the
+    # next attempt likelier to fail. Refusing is the correct answer.
+    #
+    # The requirement is the REMAINDER, not the artifact: rsync runs
+    # --partial, so an existing partial is resumed rather than refetched.
+    # The size is ESTIMATED from the layer's previous SIF — local, so no
+    # ssh round-trip joins the hot path. No prior SIF means UNKNOWN, which
+    # proceeds: blocking a legitimate first pull would be worse than the
+    # failure this prevents.
+    space = check_space(
+        remote_size=_reference_size(layer_dir, layer),
+        existing_partial=incoming.stat().st_size if incoming.is_file() else 0,
+        free=shutil.disk_usage(layer_dir).free,
+    )
+    if not space.proceed:
+        return PullOutcome(PullVerdict.FAILED, layer, space.reason)
+
     proc = _run(
         [
             rsync,

--- a/tests/scitex_agent_container/cli_pkg/test__bake_space.py
+++ b/tests/scitex_agent_container/cli_pkg/test__bake_space.py
@@ -1,0 +1,126 @@
+"""Tests for the bake-remote free-space decision.
+
+The incident: a ~7.6G transfer started onto a volume with 4.0G free,
+could not finish, and left a partial that made the next attempt likelier
+to fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.cli_pkg._bake_space import (
+    DEFAULT_MARGIN_BYTES,
+    SpaceVerdict,
+    check_space,
+    human_bytes,
+)
+
+GIB = 1024**3
+
+
+def test_a_pull_that_fits_proceeds() -> None:
+    # Arrange
+    free = 20 * GIB
+    # Act
+    verdict = check_space(remote_size=7 * GIB, existing_partial=0, free=free)
+    # Assert
+    assert verdict.proceed is True
+
+
+def test_a_pull_that_cannot_fit_is_refused() -> None:
+    """The measured incident: 7.6G wanted, 4.0G free."""
+    # Arrange
+    free = 4 * GIB
+    # Act
+    verdict = check_space(remote_size=8 * GIB, existing_partial=0, free=free)
+    # Assert
+    assert verdict.proceed is False
+
+
+def test_the_refusal_names_the_free_space() -> None:
+    """The operator's next action must not require a guess."""
+    # Arrange
+    free = 4 * GIB
+    # Act
+    verdict = check_space(remote_size=8 * GIB, existing_partial=0, free=free)
+    # Assert
+    assert human_bytes(free) in verdict.reason
+
+
+def test_a_resume_only_needs_the_REMAINDER() -> None:
+    """--partial resumes, so a nearly-complete pull must not be refused.
+
+    7.6G artifact with 7.0G already on disk needs 0.6G, not 7.6G. A
+    checker demanding the whole artifact would refuse work that fits.
+    """
+    # Arrange
+    free = 3 * GIB
+    # Act
+    verdict = check_space(
+        remote_size=8 * GIB, existing_partial=int(7.5 * GIB), free=free
+    )
+    # Assert
+    assert verdict.proceed is True
+
+
+def test_the_margin_is_demanded_on_top_of_the_transfer() -> None:
+    """Landing with zero to spare leaves a host that cannot write logs."""
+    # Arrange
+    remote = 4 * GIB
+    free = remote + DEFAULT_MARGIN_BYTES - 1
+    # Act
+    verdict = check_space(remote_size=remote, existing_partial=0, free=free)
+    # Assert
+    assert verdict.proceed is False
+
+
+def test_an_unknown_size_proceeds_rather_than_blocking() -> None:
+    """A flaky probe must not stop every pull."""
+    # Arrange
+    free = 4 * GIB
+    # Act
+    verdict = check_space(remote_size=None, existing_partial=0, free=free)
+    # Assert
+    assert verdict.proceed is True
+
+
+def test_an_unknown_size_is_marked_unknown_not_fitting() -> None:
+    """'cannot tell' must stay distinguishable from 'it fits'."""
+    # Arrange
+    free = 4 * GIB
+    # Act
+    verdict = check_space(remote_size=None, existing_partial=0, free=free)
+    # Assert
+    assert verdict.known is False
+
+
+def test_a_measured_verdict_is_marked_known() -> None:
+    # Arrange
+    free = 20 * GIB
+    # Act
+    verdict = check_space(remote_size=7 * GIB, existing_partial=0, free=free)
+    # Assert
+    assert verdict.known is True
+
+
+def test_an_unknown_verdict_that_refuses_is_rejected_at_construction() -> None:
+    """The validator forbids the shape that would block every pull."""
+    # Arrange
+    kwargs = dict(proceed=False, known=False, needed=0, free=0, reason="x")
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        SpaceVerdict(**kwargs)
+
+
+def test_a_partial_larger_than_the_artifact_does_not_go_negative() -> None:
+    """Defensive: a stale oversized partial must not produce a negative need."""
+    # Arrange
+    free = 3 * GIB
+    # Act
+    verdict = check_space(
+        remote_size=1 * GIB, existing_partial=9 * GIB, free=free
+    )
+    # Assert
+    assert verdict.needed == DEFAULT_MARGIN_BYTES


### PR DESCRIPTION
Companion to #1320. The lock stops **concurrent** pulls; this stops a **doomed** one.

## The incident

`bake-remote` started a ~7.6G transfer onto a volume with **4.0G free**. It could not finish, and the partial it left reduced the space available to the next attempt — so every failure made the next likelier. compute-03 reached zero twice in one evening.

## Design

**The decision is pure.** `_bake_space.check_space` does no I/O: the caller measures (size, existing partial, free bytes), this decides. The arithmetic — where the subtlety lives — is tested without a filesystem, a remote host, or a 7G file.

**A resume needs the remainder, not the artifact.** rsync runs `--partial`, so a 7.6G pull with 7.0G already down needs 0.6G. A checker demanding the full size would refuse transfers that fit — refusing work that would have succeeded is its own defect. Pinned by a test.

**Unknown is a third answer.** When the size cannot be determined the verdict is neither fits nor doesn't-fit: it **proceeds and says so**. The dataclass validator enforces this structurally — constructing an unknown-and-refusing verdict raises, so the shape that would block the whole pipeline cannot be built.

## The size is estimated locally, and that was a correction

My first version asked the remote over `ssh stat`. The existing pull tests are a **strict allowlist** that raises on any unrecognised subprocess, and they failed 15 times with `unexpected subprocess: ssh ... stat`.

That objection was right: it would have put a network round-trip in the hot path of every pull, and a new way to stall *before* transferring. Instead the estimate comes from the layer's **previous SIF on local disk** — sac-scitex has sat near 7.1G across rebuilds — at zero subprocess cost. No prior SIF means UNKNOWN, which lets a legitimate first pull through.

**Being an estimate is the honest limit**, and it's in the docstring: an image that grows sharply could pass this check and still exhaust the volume. This narrows the failure rather than eliminating it. The 2G margin covers ordinary drift and keeps a host off zero — which is where compute-03 sat twice tonight, unable to write even its own logs.

## Verification

- 10 new tests, including the resume-remainder case and the oversized-stale-partial case that would otherwise compute a negative requirement.
- **Proved the suite can go red**: neutering the refusal fails `cannot_fit` and `margin`. Restored, green.
- `221 passed` across the bake surface (206 + the 15 the strict allowlist had caught).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzNE6E8jqwVLXPUdAkDngd