### PR TITLE
fix(image): put the bake lock inside the containers dir — a $HOME-scoped lock reddened develop

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_bake_lock.py
+++ b/src/scitex_agent_container/cli_pkg/_bake_lock.py
@@ -37,7 +37,6 @@ and a global lock would make an unrelated dev bake block the timer.
 from __future__ import annotations
 
 import fcntl
-import hashlib
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -70,16 +69,23 @@ class BakeAlreadyRunningError(RuntimeError):
     """
 
 
-def bake_lock_path(containers_dir: Path, lock_dir: Path) -> Path:
-    """Lock path for ``containers_dir``, hashed so it is filesystem-safe.
+def bake_lock_path(containers_dir: Path) -> Path:
+    """The lock file for ``containers_dir`` — INSIDE it, deliberately.
 
-    The absolute containers dir is the identity — a short digest of it
-    names the file, because the path itself contains separators and can
-    be long. Deterministic, so two invocations naming the same dir by
-    the same absolute path collide as intended.
+    An earlier version put this under ``~/.scitex/.../runtime/`` keyed by
+    a digest of the containers dir. That was wrong in a way only CI
+    showed: the two matrix legs run CONCURRENTLY on the same self-hosted
+    runner, sharing one ``$HOME``, so their bake tests contended on one
+    real lock file and whichever started second DECLINED — turning a
+    correct guard into four red tests on develop. A local run passed
+    because only one suite ran at a time.
+
+    Putting the lock beside the artifacts it guards fixes both halves:
+    production still gets exactly one lock per containers dir, and a test
+    passing a ``tmp_path`` containers dir is isolated BY CONSTRUCTION
+    rather than by remembering to redirect ``$HOME``.
     """
-    digest = hashlib.sha256(str(containers_dir.resolve()).encode()).hexdigest()[:16]
-    return lock_dir / f"bake-remote-{digest}.pid"
+    return containers_dir / ".bake-remote.lock"
 
 
 def _read_holding_pid(fd: int) -> str:
@@ -94,21 +100,17 @@ def _read_holding_pid(fd: int) -> str:
         return "<unreadable>"
 
 
-def acquire_bake_lock(
-    *,
-    containers_dir: Path,
-    lock_dir: Path,
-) -> BakeLockHandle:
+def acquire_bake_lock(*, containers_dir: Path) -> BakeLockHandle:
     """Take the exclusive bake lock for ``containers_dir``.
 
-    ``lock_dir`` must exist; the caller owns creating it, so tests can
-    isolate without touching ``$HOME``.
+    ``containers_dir`` must exist — it is where the artifacts land, so
+    the caller has already created it.
 
     Raises :class:`BakeAlreadyRunningError` when another bake holds it.
     Refusing is correct: a second concurrent pull of a multi-GB artifact
     cannot help and demonstrably fills the disk.
     """
-    pid_file = bake_lock_path(containers_dir, lock_dir)
+    pid_file = bake_lock_path(containers_dir)
     fd = os.open(str(pid_file), os.O_CREAT | os.O_RDWR, 0o644)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/src/scitex_agent_container/cli_pkg/_image_remote_bake.py
+++ b/src/scitex_agent_container/cli_pkg/_image_remote_bake.py
@@ -281,17 +281,14 @@ def image_bake_remote(
     # and restarted, which is precisely the loop this prevents. Nothing
     # went wrong when a second bake declines — the first one is doing the
     # work.
-    lock_dir = Path.home() / ".scitex" / "agent-container" / "runtime"
-    lock_dir.mkdir(parents=True, exist_ok=True)
+    containers_dir.mkdir(parents=True, exist_ok=True)
     try:
         # Held for the lifetime of this one-shot command. The kernel
         # releases the flock when the process exits — including SIGKILL
         # and OOM — so a crashed bake never jams the pipeline and no
         # stale-lock reconciliation is needed. Bound to a name so the fd
         # is not garbage-collected (closing it would release the lock).
-        _bake_lock = acquire_bake_lock(
-            containers_dir=containers_dir, lock_dir=lock_dir
-        )
+        _bake_lock = acquire_bake_lock(containers_dir=containers_dir)
     except BakeAlreadyRunningError as exc:
         click.echo(str(exc), err=True)
         raise SystemExit(0) from exc

--- a/tests/scitex_agent_container/cli_pkg/test__bake_lock.py
+++ b/tests/scitex_agent_container/cli_pkg/test__bake_lock.py
@@ -22,14 +22,6 @@ from scitex_agent_container.cli_pkg._bake_lock import (
 
 
 @pytest.fixture
-def lock_dir(tmp_path: Path) -> Path:
-    """Directory holding the pidfile; the caller owns creating it."""
-    path = tmp_path / "runtime"
-    path.mkdir()
-    return path
-
-
-@pytest.fixture
 def containers_dir(tmp_path: Path) -> Path:
     """The bake destination the lock is scoped to."""
     path = tmp_path / "containers"
@@ -38,12 +30,12 @@ def containers_dir(tmp_path: Path) -> Path:
 
 
 def test_the_first_bake_creates_its_pidfile(
-    lock_dir: Path, containers_dir: Path
+    containers_dir: Path
 ) -> None:
     # Arrange
     handle = None
     # Act
-    handle = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    handle = acquire_bake_lock(containers_dir=containers_dir)
     # Assert
     try:
         assert handle.pid_file.is_file()
@@ -52,12 +44,12 @@ def test_the_first_bake_creates_its_pidfile(
 
 
 def test_the_first_bake_stamps_its_own_pid(
-    lock_dir: Path, containers_dir: Path
+    containers_dir: Path
 ) -> None:
     # Arrange
     expected = str(os.getpid())
     # Act
-    handle = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    handle = acquire_bake_lock(containers_dir=containers_dir)
     # Assert
     try:
         assert handle.pid_file.read_text().strip() == expected
@@ -66,30 +58,30 @@ def test_the_first_bake_stamps_its_own_pid(
 
 
 def test_a_second_bake_into_the_same_dir_is_refused(
-    lock_dir: Path, containers_dir: Path
+    containers_dir: Path
 ) -> None:
     """The whole point: the second concurrent pull must not start."""
     # Arrange
-    first = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    first = acquire_bake_lock(containers_dir=containers_dir)
     # Act
     # Assert
     try:
         with pytest.raises(BakeAlreadyRunningError):
-            acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+            acquire_bake_lock(containers_dir=containers_dir)
     finally:
         release_bake_lock(first)
 
 
 def test_the_refusal_names_the_holding_pid(
-    lock_dir: Path, containers_dir: Path
+    containers_dir: Path
 ) -> None:
     """`kill <pid>` must be actionable without lsof."""
     # Arrange
-    first = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    first = acquire_bake_lock(containers_dir=containers_dir)
     message = ""
     # Act
     try:
-        acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+        acquire_bake_lock(containers_dir=containers_dir)
     except BakeAlreadyRunningError as exc:
         message = str(exc)
     finally:
@@ -99,15 +91,15 @@ def test_the_refusal_names_the_holding_pid(
 
 
 def test_the_refusal_says_it_is_declining_not_failing(
-    lock_dir: Path, containers_dir: Path
+    containers_dir: Path
 ) -> None:
     """A supervised caller must not read this as a crash."""
     # Arrange
-    first = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    first = acquire_bake_lock(containers_dir=containers_dir)
     message = ""
     # Act
     try:
-        acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+        acquire_bake_lock(containers_dir=containers_dir)
     except BakeAlreadyRunningError as exc:
         message = str(exc)
     finally:
@@ -116,18 +108,16 @@ def test_the_refusal_says_it_is_declining_not_failing(
     assert "declining" in message
 
 
-def test_a_bake_into_a_different_containers_dir_is_allowed(
-    lock_dir: Path, tmp_path: Path
-) -> None:
+def test_a_bake_into_a_different_containers_dir_is_allowed(tmp_path: Path) -> None:
     """Scoped per containers dir — unrelated bakes must not block."""
     # Arrange
     one = tmp_path / "containers-one"
     one.mkdir()
     two = tmp_path / "containers-two"
     two.mkdir()
-    first = acquire_bake_lock(containers_dir=one, lock_dir=lock_dir)
+    first = acquire_bake_lock(containers_dir=one)
     # Act
-    second = acquire_bake_lock(containers_dir=two, lock_dir=lock_dir)
+    second = acquire_bake_lock(containers_dir=two)
     # Assert
     try:
         assert second.pid_file != first.pid_file
@@ -137,14 +127,14 @@ def test_a_bake_into_a_different_containers_dir_is_allowed(
 
 
 def test_the_lock_is_reacquirable_after_release(
-    lock_dir: Path, containers_dir: Path
+    containers_dir: Path
 ) -> None:
     """A finished bake must not jam the next one."""
     # Arrange
-    first = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    first = acquire_bake_lock(containers_dir=containers_dir)
     release_bake_lock(first)
     # Act
-    second = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    second = acquire_bake_lock(containers_dir=containers_dir)
     # Assert
     try:
         assert second.pid_file.read_text().strip() == str(os.getpid())
@@ -153,7 +143,7 @@ def test_the_lock_is_reacquirable_after_release(
 
 
 def test_a_stale_pidfile_with_no_live_holder_does_not_jam(
-    lock_dir: Path, containers_dir: Path
+    containers_dir: Path
 ) -> None:
     """A crashed bake leaves a PID behind but no flock — the next proceeds.
 
@@ -161,10 +151,10 @@ def test_a_stale_pidfile_with_no_live_holder_does_not_jam(
     reconciliation unnecessary.
     """
     # Arrange
-    stale = bake_lock_path(containers_dir, lock_dir)
+    stale = bake_lock_path(containers_dir)
     stale.write_text("999999\n")
     # Act
-    handle = acquire_bake_lock(containers_dir=containers_dir, lock_dir=lock_dir)
+    handle = acquire_bake_lock(containers_dir=containers_dir)
     # Assert
     try:
         assert handle.pid_file.read_text().strip() == str(os.getpid())
@@ -173,23 +163,41 @@ def test_a_stale_pidfile_with_no_live_holder_does_not_jam(
 
 
 def test_the_lock_path_is_stable_for_one_dir(
-    lock_dir: Path, containers_dir: Path
+    containers_dir: Path
 ) -> None:
     # Arrange
-    first = bake_lock_path(containers_dir, lock_dir)
+    first = bake_lock_path(containers_dir)
     # Act
-    second = bake_lock_path(containers_dir, lock_dir)
+    second = bake_lock_path(containers_dir)
     # Assert
     assert first == second
 
 
-def test_the_lock_path_differs_between_dirs(lock_dir: Path, tmp_path: Path) -> None:
+def test_the_lock_path_differs_between_dirs(tmp_path: Path) -> None:
     # Arrange
     one = tmp_path / "containers-one"
     one.mkdir()
     two = tmp_path / "containers-two"
     two.mkdir()
     # Act
-    paths = (bake_lock_path(one, lock_dir), bake_lock_path(two, lock_dir))
+    paths = (bake_lock_path(one), bake_lock_path(two))
     # Assert
     assert paths[0] != paths[1]
+
+
+def test_the_lock_lives_INSIDE_the_containers_dir_not_in_home(
+    containers_dir: Path,
+) -> None:
+    """Regression: a $HOME-scoped lock made CI's two matrix legs contend.
+
+    They run concurrently on the same self-hosted runner with one shared
+    home, so the second leg's bake tests DECLINED and develop went red on
+    four tests. Keeping the lock beside the artifacts it guards makes a
+    tmp_path containers dir isolated by construction.
+    """
+    # Arrange
+    expected_parent = containers_dir
+    # Act
+    path = bake_lock_path(containers_dir)
+    # Assert
+    assert path.parent == expected_parent


### PR DESCRIPTION
**develop is red on `f4ad60b6`** — my own #1320. This fixes it.

## What broke

Four failures in `test__image_remote_bake.py`, including `assert [] == [True]` — meaning **no ssh happened at all**, which is the command correctly *declining*.

The lock file lived under `~/.scitex/agent-container/runtime/`, keyed by a digest of the containers dir. CI's two matrix legs (py3.11, py3.13) run **concurrently on the same self-hosted runner sharing one `$HOME`**, so their bake tests contended on a single real lock file and whichever reached them second declined.

A correct guard, firing exactly as designed, on the wrong pair of processes.

That also explains the asymmetry: **#1320's own PR run was green while develop went red.** It's a race, so a green run was luck rather than proof.

## My first hypothesis was wrong

I assumed xdist workers contending. Reproducing under `-n 4` locally **passed** — 14 tests green.

What the failed reproduction surfaced was the actual evidence: a stray pidfile in my container's own `$HOME`, timestamped from my earlier test runs. The tests were reaching the real home directory. That pointed at two CI legs sharing one home on a persistent runner.

## The fix

The lock now lives **inside `containers_dir`** as `.bake-remote.lock`, beside the artifacts it guards.

- Production: still exactly one lock per containers dir.
- Tests: a `tmp_path` containers dir is isolated **by construction**, not by anyone remembering to redirect `$HOME`.
- Removes the `$HOME` dependency and the digest-naming entirely.

## Verified behaviourally, not just structurally

The regression test pins `path.parent == containers_dir`. But a structural test can pass while the leak persists, so the decisive check was behavioural: **clear `$HOME`, run the whole bake surface, confirm no lock file reappears there.** It doesn't. `212 passed`.

The regression test names the CI mechanism in its docstring, so whoever moves this path next knows what it cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzNE6E8jqwVLXPUdAkDngd