### PR TITLE
docs(env): effective_env does not mirror the identity onto both names

### DIFF
--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -344,11 +344,17 @@ def effective_env(
     under ``config.env`` (``spec.env`` wins), then the board-identity alias
     (:mod:`._board_identity_env`) is applied so a value declared under either
     ``SCITEX_TODO_AGENT_ID`` or ``SCITEX_CARDS_AGENT_ID`` — in ``spec.env`` or
-    in ``apptainer.raw_args`` — is mirrored onto BOTH names for the
-    scitex-cards rename transition window (INCIDENT 2026-07-19: cards were
-    written with the literal, unexpanded ``${SCITEX_CARDS_AGENT_ID}`` as
-    their author because sac injected only the old name — 7 rows when first
-    reported, 15 a few hours later, since every new card added one).
+    in ``apptainer.raw_args`` — resolves to an identity. Only the CANONICAL
+    ``SCITEX_CARDS_AGENT_ID`` is ever written: the retired spelling is READ,
+    so an un-migrated spec still launches able to say who it is, and is
+    deliberately NOT written back. Mirroring it would re-create the very
+    declarations the rename retires — which is why the twin writer pops it
+    rather than inheriting it (``_lifecycle/_twin.py``).
+
+    INCIDENT 2026-07-19: cards were written with the literal, unexpanded
+    ``${SCITEX_CARDS_AGENT_ID}`` as their author because sac injected only
+    the old name — 7 rows when first reported, 15 a few hours later, since
+    every new card added one.
 
     Every value — not just the identity vars — is validated: an env value
     that still looks like an unexpanded ``${VAR}`` substitution raises


### PR DESCRIPTION
## What

`effective_env`'s docstring said a declared board identity "is mirrored onto **BOTH** names for the scitex-cards rename transition window". The code beneath it writes only the canonical `SCITEX_CARDS_AGENT_ID`, and logs on this exact path: *"derived from the legacy SCITEX_TODO_AGENT_ID, which is read but deliberately NOT written back"*.

## Why it is worth a commit

proj-dotfiles asked tonight whether sac's twin/template writers still emit `SCITEX_TODO_AGENT_ID` — their fork-identity manifest lists sac as an emitter, and dropping the last read-side shim (a line in the `idle_guard` STOP hook shipped to every agent home) is gated on the answer. This sentence sits on the function every launch goes through (`_apptainer_build_argv.build_run_argv`) and is the most likely source of that belief.

## Measured, not re-read

- **Twin writer POPS the retired key.** Positive control: a parent spec that *does* declare `SCITEX_TODO_AGENT_ID` yields a twin env containing only `SCITEX_CARDS_AGENT_ID` and `SAC_TWIN_PARENT` — so the clean output is a removal, not a no-op.
- **Inline template**: its single occurrence is a comment reading *"is retired and must not be emitted into a new spec"*, directly above the canonical `env:` block.
- **Dir-templates**: the retired name appears 0 times, against a control of 20 files carrying the canonical name.
- Verified on three hosts' checkouts (compute-01/03/04); all three carry the strip.

## Tests

94 tests in `test__board_identity_env.py` + `test__fleet_env.py` pass, with `PYTHONPATH` pinned to the worktree (confirmed by importing the module and printing its path — otherwise pytest here runs the main checkout's code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzNE6E8jqwVLXPUdAkDngd