### PR TITLE
fix(a2a): a refused turn names the next step and says nothing was queued

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -454,8 +454,31 @@ def _build_on_turn(
                 "no reason available from this runtime — the session is absent, "
                 "or the pane would park the turn rather than run it"
             )
+            # NAME THE NEXT STEP, not only the cause. A refusal that explains
+            # itself and stops leaves the sender with nowhere to go: scitex-hub
+            # hit this on 2026-09-07, retried the same POST three times, got
+            # three identical 502s and reported "cannot reach sac" — correct
+            # behaviour against a contract that never told it what else to do.
+            #
+            # The two causes want OPPOSITE responses and the sender cannot act
+            # without being told which it is:
+            #   BUSY   -> the agent is working; the turn was NOT stored, so
+            #             resend later or use a durable rail
+            #   ABSENT -> nothing will drain; retrying forever is pointless and
+            #             someone must start it
+            #
+            # Explicit about the loss, because that is the part a sender gets
+            # wrong: a 502 here means NOTHING WAS QUEUED. Saying so is what
+            # stops a peer assuming the message is waiting somewhere.
             raise RuntimeError(
-                f"turn NOT delivered to agent {config.name!r}: {why}"
+                f"turn NOT delivered to agent {config.name!r}: {why}\n"
+                "NOTHING WAS QUEUED — this turn is not stored anywhere and "
+                "will not be retried by sac.\n"
+                "NEXT: if the agent is BUSY, resend when it idles, or use a "
+                "durable rail (scitex-cards DM) that survives a busy pane. "
+                "If the agent is ABSENT, resending cannot help — start it "
+                f"with `sac agents start {config.name}` and check "
+                f"`sac agents list {config.name}` first."
             )
 
     return on_turn

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -540,44 +540,56 @@ def test_build_on_turn_raises_when_session_absent() -> None:
 # failure anyway. These pin the two things a sender cannot act without.
 
 
-def test_the_refusal_says_NOTHING_WAS_QUEUED() -> None:
-    # Arrange — a pane that refuses the inject.
-    runtime = SimpleNamespace(send_turn=lambda config, text, wait_ready: False)
-    on_turn = bridge._build_on_turn(SimpleNamespace(name="busy"), runtime=runtime)
+@pytest.fixture()
+def refusal_message() -> str:
+    """The RuntimeError text a REFUSED turn produces.
 
-    # Act
-    with pytest.raises(RuntimeError) as exc:
-        on_turn("wake up")
-
-    # Assert — the sender must not assume the turn is waiting somewhere.
-    assert "NOTHING WAS QUEUED" in str(exc.value), str(exc.value)
-
-
-def test_the_refusal_names_the_BUSY_next_step() -> None:
-    # Arrange
-    runtime = SimpleNamespace(send_turn=lambda config, text, wait_ready: False)
-    on_turn = bridge._build_on_turn(SimpleNamespace(name="busy"), runtime=runtime)
-
-    # Act
-    with pytest.raises(RuntimeError) as exc:
-        on_turn("wake up")
-
-    # Assert — busy wants "resend later / use a durable rail".
-    assert "durable rail" in str(exc.value), str(exc.value)
-
-
-def test_the_refusal_names_the_ABSENT_next_step_with_the_agent_name() -> None:
-    # Arrange
+    Built once here so each test below asserts exactly one thing (STX-TQ007):
+    a `pytest.raises` block counts as an assertion, so raising and inspecting
+    in the same test is two.
+    """
     runtime = SimpleNamespace(send_turn=lambda config, text, wait_ready: False)
     on_turn = bridge._build_on_turn(SimpleNamespace(name="ghost"), runtime=runtime)
+    try:
+        on_turn("wake up")
+    except RuntimeError as exc:
+        return str(exc)
+    raise AssertionError("a refused turn must raise; it did not")
+
+
+def test_the_refusal_says_NOTHING_WAS_QUEUED(refusal_message: str) -> None:
+    # Arrange — the text a refused turn hands the sender.
+    message = refusal_message
 
     # Act
-    with pytest.raises(RuntimeError) as exc:
-        on_turn("wake up")
+    states_the_loss = "NOTHING WAS QUEUED" in message
 
-    # Assert — absent wants "start it", and the command must carry the NAME so
-    # the reader can run it without looking anything up.
-    assert "sac agents start ghost" in str(exc.value), str(exc.value)
+    # Assert — the sender must not assume the turn is waiting somewhere.
+    assert states_the_loss, message
+
+
+def test_the_refusal_names_the_BUSY_next_step(refusal_message: str) -> None:
+    # Arrange
+    message = refusal_message
+
+    # Act
+    names_the_alternative = "durable rail" in message
+
+    # Assert — busy wants "resend later / use a rail that survives a busy pane".
+    assert names_the_alternative, message
+
+
+def test_the_refusal_names_the_ABSENT_next_step_with_the_agent_name(
+    refusal_message: str,
+) -> None:
+    # Arrange
+    message = refusal_message
+
+    # Act — the command must carry the NAME so it is runnable as printed.
+    names_the_command = "sac agents start ghost" in message
+
+    # Assert
+    assert names_the_command, message
 
 
 def test_CONTROL_a_DELIVERED_turn_raises_nothing() -> None:

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -534,6 +534,65 @@ def test_build_on_turn_raises_when_session_absent() -> None:
         on_turn("wake up")
 
 
+# A refusal that explains itself and stops leaves the sender nowhere to go.
+# scitex-hub hit exactly that on 2026-09-07: three identical 502s, then it
+# reported "cannot reach sac" — correct against the old contract, and a system
+# failure anyway. These pin the two things a sender cannot act without.
+
+
+def test_the_refusal_says_NOTHING_WAS_QUEUED() -> None:
+    # Arrange — a pane that refuses the inject.
+    runtime = SimpleNamespace(send_turn=lambda config, text, wait_ready: False)
+    on_turn = bridge._build_on_turn(SimpleNamespace(name="busy"), runtime=runtime)
+
+    # Act
+    with pytest.raises(RuntimeError) as exc:
+        on_turn("wake up")
+
+    # Assert — the sender must not assume the turn is waiting somewhere.
+    assert "NOTHING WAS QUEUED" in str(exc.value), str(exc.value)
+
+
+def test_the_refusal_names_the_BUSY_next_step() -> None:
+    # Arrange
+    runtime = SimpleNamespace(send_turn=lambda config, text, wait_ready: False)
+    on_turn = bridge._build_on_turn(SimpleNamespace(name="busy"), runtime=runtime)
+
+    # Act
+    with pytest.raises(RuntimeError) as exc:
+        on_turn("wake up")
+
+    # Assert — busy wants "resend later / use a durable rail".
+    assert "durable rail" in str(exc.value), str(exc.value)
+
+
+def test_the_refusal_names_the_ABSENT_next_step_with_the_agent_name() -> None:
+    # Arrange
+    runtime = SimpleNamespace(send_turn=lambda config, text, wait_ready: False)
+    on_turn = bridge._build_on_turn(SimpleNamespace(name="ghost"), runtime=runtime)
+
+    # Act
+    with pytest.raises(RuntimeError) as exc:
+        on_turn("wake up")
+
+    # Assert — absent wants "start it", and the command must carry the NAME so
+    # the reader can run it without looking anything up.
+    assert "sac agents start ghost" in str(exc.value), str(exc.value)
+
+
+def test_CONTROL_a_DELIVERED_turn_raises_nothing() -> None:
+    # Arrange — the same seam, but the pane accepts. A "next step" that also
+    # appears on the success path would be noise, not guidance.
+    runtime = SimpleNamespace(send_turn=lambda config, text, wait_ready: True)
+    on_turn = bridge._build_on_turn(SimpleNamespace(name="ok"), runtime=runtime)
+
+    # Act
+    result = on_turn("wake up")
+
+    # Assert
+    assert result is None
+
+
 # ---------------------------------------------------------------------------
 # Launcher — spawn-failure + real SIGTERM teardown
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What happened

scitex-hub could not reach this agent on 2026-09-07. It POSTed three times, got three identical 502s, and reported "cannot reach sac". That was **correct behaviour** against a contract that told it the cause and never told it what else to do.

## The 502 itself is right and stays

The bridge refuses when the pane would *park* a turn rather than run it, because the alternative is a lie. The comment above that code carries the measurement it was built from:

> "claude queues keystrokes typed mid-turn, so a live wake … is never dropped" — **IS FALSE**. Measured 2026-08-18: four dispatches to live agents across four pane states produced **zero** completed tasks, one over a 35-minute window with no restart in it. Claude does queue them; **the queue does not reliably drain.**

A 200 there would tell the sender its message landed when it had not.

## What was missing

The half after the diagnosis. The refusal now states:

- **NOTHING WAS QUEUED** — the turn is not stored anywhere and sac will not retry it. This is the part a sender gets wrong, and getting it wrong means waiting for something that will never arrive.
- the **BUSY** next step — resend when it idles, or use a durable rail
- the **ABSENT** next step — resending cannot help; `sac agents start <name>`, with the name interpolated so the reader can run it without a lookup

Those two causes want *opposite* responses from the sender, which is precisely why naming only the cause was not enough.

## Tests

4 added (3 assertions + 1 control), 60 pass.

**The mutant is why they are trustworthy.** Reverting the message to its cause-only form turns exactly the three new assertions red and leaves 57 green — including the control asserting a *delivered* turn raises nothing, since a "next step" that also appeared on the success path would be noise rather than guidance. The mutant is gated on `py_compile` first, because one that cannot build proves nothing.

## Not fixed here, deliberately

a2a still has no durable queue, so a busy agent remains unreachable until it idles. That is the larger half and is tracked separately (`sac-a2a-has-no-durable-queue-a-busy-agent-is-unreachable-20260907`). This change makes the failure honest and actionable; it does not make it stop happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzNE6E8jqwVLXPUdAkDngd