### PR TITLE
fix(a2a): auto-port allocation skips a port something is LISTENING on

### DIFF
--- a/src/scitex_agent_container/_state/port_allocator.py
+++ b/src/scitex_agent_container/_state/port_allocator.py
@@ -74,6 +74,7 @@ DEFAULT_RANGE: tuple[int, int] = (19000, 19999)
 
 __all__ = [
     "DEFAULT_RANGE",
+    "port_is_bindable",
     "STORE_NAME",
     "claim_port",
     "get_port",
@@ -134,6 +135,31 @@ def get_port(agent_name: str) -> int | None:
         if holder == agent_name:
             return port
     return None
+
+
+def port_is_bindable(port: int, host: str = "127.0.0.1") -> bool:
+    """True when a fresh listener could bind ``host:port`` RIGHT NOW.
+
+    Deliberately a real bind rather than a connect: a connect probe answers
+    "is someone serving", which is a different question and misses a socket
+    held open without accepting. SO_REUSEADDR mirrors what the turn bridge
+    itself sets, so this answers the bridge's question and not an easier one.
+
+    Fails OPEN (returns True) on an unexpected error — a probe that cannot
+    run must not silently block every allocation. The claim table still
+    guards the common case.
+    """
+    import socket as _socket
+
+    try:
+        with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as sock:
+            sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+            sock.bind((host, port))
+        return True
+    except OSError:
+        return False
+    except Exception:  # stx-allow: fallback (reason: an unusable probe must not block every start)
+        return True
 
 
 def claim_port(
@@ -228,11 +254,35 @@ def claim_port(
     for candidate in range(lo, hi + 1):
         if candidate in held:
             continue
+        if not port_is_bindable(candidate):
+            # THE CLAIM TABLE IS NOT THE PORT.
+            #
+            # Measured 2026-09-07 by scitex-hub on compute-03:
+            # `sac agents stop handyman-c03-01` released the CLAIM but left the
+            # turn bridge LISTENING on 19003. figrecipe-qwen then started with
+            # `port: auto`, was handed 19003 because the table said free, and
+            # its claude launched with --turn-url http://127.0.0.1:19003/v1/turn.
+            # A turn sent to figrecipe-qwen appeared VERBATIM in the stopped
+            # agent's pane — different repo, different identity, different git
+            # credentials — and the sender was told {"ok": true, 200}.
+            #
+            # A MISDELIVERED turn reported as delivered is the exact inverse of
+            # the failure the bridge's 502 exists to prevent, and it is worse:
+            # a task that edited files would have edited the wrong tree.
+            #
+            # So the SOCKET arbitrates, not the table. Skipping costs one bind
+            # probe on the first unheld candidate — the loop returns on the
+            # first success, so the "thousand round trips" concern above (which
+            # is about STORE reads) is untouched.
+            continue
         if try_claim(store, port=candidate, agent_name=agent_name, now=now):
             return candidate
     raise RuntimeError(
-        f"no free a2a port in range [{lo}, {hi}] (all claimed); "
-        "extend a2a.port_range in ~/.scitex/agent-container/config.yaml"
+        f"no free a2a port in range [{lo}, {hi}] (every port is either claimed "
+        "in state.db or already has a live listener); extend a2a.port_range in "
+        "~/.scitex/agent-container/config.yaml, or find the stale listener with "
+        f"`ss -ltnp | grep -E ':{lo}|:{hi}'` — a stopped agent whose bridge was "
+        "never reaped holds a port that no claim row mentions"
     )
 
 

--- a/tests/scitex_agent_container/_state/test_port_allocator_socket_probe.py
+++ b/tests/scitex_agent_container/_state/test_port_allocator_socket_probe.py
@@ -1,0 +1,104 @@
+"""The auto-port scan must skip a port something is actually LISTENING on.
+
+MEASURED 2026-09-07 by scitex-hub on scitex-compute-03, and it is the reason
+this probe exists:
+
+  * handyman-c03-01 started; its turn bridge bound 127.0.0.1:19003.
+  * `sac agents stop handyman-c03-01` released the CLAIM and left the bridge,
+    the claude process, the mcp channel and the tmux session all running.
+  * figrecipe-qwen started with `a2a.port: auto`, was handed 19003 because the
+    claim table said free, and its claude launched with
+    --turn-url http://127.0.0.1:19003/v1/turn.
+  * A turn sent to figrecipe-qwen appeared VERBATIM in handyman-c03-01's pane —
+    different repo, different identity, different git credentials — and the
+    sender received {"ok": true, "http_status": 200}.
+
+A MISDELIVERED turn reported as delivered is the inverse of the failure the
+turn bridge's 502 exists to prevent, and worse: a task that edited files would
+have edited the wrong tree, authored as the wrong agent.
+
+The claim table and the socket had diverged, and only the table was consulted.
+These tests pin the socket as the arbiter.
+
+REAL SOCKETS, NO MOCKS — matching port_allocator's own stated contract. A
+mocked "port is busy" would prove the test's own bookkeeping, not the bind.
+"""
+
+from __future__ import annotations
+
+import socket
+
+from scitex_agent_container._state.port_allocator import port_is_bindable
+
+
+def _free_port() -> int:
+    """A port the OS just confirmed is free, released before returning."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def test_a_port_held_by_a_live_listener_is_NOT_bindable() -> None:
+    # Arrange — a real listener, exactly like a stopped agent's stray bridge.
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    held.bind(("127.0.0.1", 0))
+    held.listen(1)
+    port = int(held.getsockname()[1])
+
+    # Act
+    try:
+        verdict = port_is_bindable(port)
+    finally:
+        held.close()
+
+    # Assert
+    assert verdict is False, port
+
+
+def test_CONTROL_a_free_port_IS_bindable() -> None:
+    # Arrange — without this the test above passes for a probe that always
+    # says False, which would block every allocation instead of one port.
+    port = _free_port()
+
+    # Act
+    verdict = port_is_bindable(port)
+
+    # Assert
+    assert verdict is True, port
+
+
+def test_the_probe_reflects_RELEASE_rather_than_caching_a_verdict() -> None:
+    # Arrange — hold, then release. A probe that memoised would still say busy,
+    # and would strand a port permanently after one stray listener.
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    held.bind(("127.0.0.1", 0))
+    held.listen(1)
+    port = int(held.getsockname()[1])
+    port_is_bindable(port)
+    held.close()
+
+    # Act
+    after_release = port_is_bindable(port)
+
+    # Assert
+    assert after_release is True, port
+
+
+def test_the_probe_asks_about_BINDING_not_about_being_served() -> None:
+    # Arrange — a bound socket that never calls listen(). A connect-based probe
+    # would call this port free; a bind-based one must not, because the bridge
+    # binds and would collide.
+    bound = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    bound.bind(("127.0.0.1", 0))
+    port = int(bound.getsockname()[1])
+
+    # Act
+    try:
+        verdict = port_is_bindable(port)
+    finally:
+        bound.close()
+
+    # Assert
+    assert verdict is False, port


### PR DESCRIPTION
## The failure

scitex-hub measured a **misdelivered turn reported as delivered** — the exact inverse of what the turn bridge's 502 exists to prevent, and worse.

On scitex-compute-03, 2026-09-07:

```
handyman-c03-01's turn bridge bound 127.0.0.1:19003
`sac agents stop handyman-c03-01`  → claim released; bridge, claude,
                                     mcp channel and tmux ALL still alive
figrecipe-qwen started, a2a.port: auto → ALSO handed 19003
  its claude launched --turn-url http://127.0.0.1:19003/v1/turn
`sac agents send figrecipe-qwen '<task>'`
  → {"ok": true, "http_status": 200, "route": "live-runner"}
figrecipe-qwen's pane:   unchanged, idle
handyman-c03-01's pane:  THE FIGRECIPE PROMPT, VERBATIM
```

Different repo, different identity, different git credentials. hub's task was read-only; one that edited files would have edited the wrong tree, authored as the wrong agent.

## Root cause

The auto scan excluded only `held` — the state.db **claim table**. `agents stop` releases the claim but does not reap the bridge, so the table and the socket diverge and only the table was consulted.

## Fix

The socket arbitrates. A candidate that cannot be bound *right now* is skipped whatever the table believes.

`port_is_bindable` does a real bind with `SO_REUSEADDR`, mirroring what the bridge itself does — deliberately **not** a connect probe, which answers "is someone serving" and would call a bound-but-unlistening socket free.

Cost is one bind probe on the first unheld candidate, not per row: the loop returns on first success, so the module's existing "thousand round trips" concern (about *store* reads) is untouched. The probe **fails open** on an unexpected error — a probe that cannot run must not block every start.

The exhaustion message now distinguishes claimed-in-db from has-a-live-listener, and names `ss -ltnp` so the stale holder is findable.

## Tests, and their limits

4 new tests, **real sockets, no mocks** (the module's own stated contract). These run locally: held port not bindable; free port bindable (control); the verdict tracks release rather than caching; and a bound-but-not-listening socket reads as busy — which is what separates a bind probe from a connect probe.

**Mutant:** making the probe always answer "bindable" turns exactly the two busy-detecting tests red and leaves both controls green.

**Not covered locally:** the `claim_port` integration itself. Its suite is PostgreSQL-backed and this container skips it — measured **4 passed, 21 skipped** — so a green local run says nothing about that path. It runs in CI.

## Not fixed here

Tracked on hub's card (`sac-stopped-agent-keeps-its-a2a-port-and-steals-the-next-agents-turns-20260907`): `stop` still leaves the bridge, channel and tmux running; something respawns bridges for stopped agents; and the operator-**pinned** port path has the same table-vs-socket gap — there a live listener should fail loud rather than silently pick another port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzNE6E8jqwVLXPUdAkDngd